### PR TITLE
feat: sync-v2 workspace sync-head heartbeat (dropped-emit detection)

### DIFF
--- a/apps/backend/src/features/sync/heartbeat-worker.test.ts
+++ b/apps/backend/src/features/sync/heartbeat-worker.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, spyOn, mock } from "bun:test"
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import { SyncHeartbeatWorker } from "./heartbeat-worker"
+import { SyncLogRepository } from "./repository"
+
+function makeIo(rooms: string[]) {
+  const emits: Array<{ room: string; eventType: string; payload: unknown }> = []
+  const io = {
+    sockets: { adapter: { rooms: new Map(rooms.map((room) => [room, new Set(["sock_1"])])) } },
+    local: {
+      to: (room: string) => ({
+        emit: (eventType: string, payload: unknown) => {
+          emits.push({ room, eventType, payload })
+        },
+      }),
+    },
+  }
+  return { io: io as unknown as Server, emits }
+}
+
+describe("SyncHeartbeatWorker.tickOnce", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("emits each workspace's head to its bare workspace room via the local operator", async () => {
+    const getHeads = spyOn(SyncLogRepository, "getHeads").mockResolvedValue(new Map([["workspace_a", 7n]]))
+    const { io, emits } = makeIo([
+      "ws:workspace_a",
+      "ws:workspace_a:stream:stream_1",
+      "ws:workspace_a:user:usr_1",
+      "socket_id_room",
+      "ws:workspace_b",
+    ])
+    const worker = new SyncHeartbeatWorker({ pool: {} as Pool, io })
+
+    await worker.tickOnce()
+
+    // Subrooms and socket-id rooms are excluded from the head query; a
+    // workspace with no log entries reports head 0.
+    expect(getHeads.mock.calls[0][1]).toEqual(["workspace_a", "workspace_b"])
+    expect(emits).toEqual([
+      {
+        room: "ws:workspace_a",
+        eventType: "sync:heartbeat",
+        payload: { workspaceId: "workspace_a", head: "7" },
+      },
+      {
+        room: "ws:workspace_b",
+        eventType: "sync:heartbeat",
+        payload: { workspaceId: "workspace_b", head: "0" },
+      },
+    ])
+  })
+
+  it("skips the head query entirely when no local workspace rooms exist", async () => {
+    const getHeads = spyOn(SyncLogRepository, "getHeads")
+    const { io, emits } = makeIo(["socket_id_room", "ws:workspace_a:stream:stream_1"])
+    const worker = new SyncHeartbeatWorker({ pool: {} as Pool, io })
+
+    await worker.tickOnce()
+
+    expect(getHeads).not.toHaveBeenCalled()
+    expect(emits).toEqual([])
+  })
+
+  it("survives a failing head query and emits nothing that tick", async () => {
+    spyOn(SyncLogRepository, "getHeads").mockRejectedValue(new Error("db down"))
+    const { io, emits } = makeIo(["ws:workspace_a"])
+    const worker = new SyncHeartbeatWorker({ pool: {} as Pool, io })
+
+    await worker.tickOnce()
+
+    expect(emits).toEqual([])
+  })
+})

--- a/apps/backend/src/features/sync/heartbeat-worker.ts
+++ b/apps/backend/src/features/sync/heartbeat-worker.ts
@@ -1,0 +1,93 @@
+import type { Pool } from "pg"
+import type { Server } from "socket.io"
+import type { SyncHeartbeatPayload } from "@threa/types"
+import { Ticker } from "@threa/backend-common"
+import { logger } from "../../lib/logger"
+import { SyncLogRepository } from "./repository"
+
+export interface SyncHeartbeatWorkerConfig {
+  intervalMs?: number
+}
+
+const DEFAULT_CONFIG = {
+  intervalMs: 15_000,
+}
+
+/** The bare workspace room (`ws:<id>`), not its `:stream:`/`:user:` subrooms. */
+const WORKSPACE_ROOM_PATTERN = /^ws:([^:]+)$/
+
+/**
+ * Periodically broadcasts each workspace's sync-log head to its workspace
+ * room (`sync:heartbeat`), so active-mode clients can detect a dropped emit
+ * by comparing the head against their cursor position and trigger catch-up —
+ * without waiting for a reconnect/resume. Design:
+ * docs/plans/sync-v2-heartbeat.md.
+ *
+ * Deliberately NOT an outbox event (INV-4 governs domain state changes): the
+ * heartbeat carries no state — it is a derived `MAX` over the very log whose
+ * head it reports, idempotent and periodic, so logging it would advance the
+ * head it measures.
+ *
+ * Emits with the `local` flag: the Socket.io Postgres adapter fans a plain
+ * room emit out through every backend instance, and each instance runs its
+ * own ticker for its own sockets — without `local`, N instances would deliver
+ * N copies per interval. `adapter.rooms` is node-local, so the room scan and
+ * the emit cover exactly this instance's connections.
+ */
+export class SyncHeartbeatWorker {
+  private readonly pool: Pool
+  private readonly io: Server
+  private readonly ticker: Ticker
+
+  constructor(deps: { pool: Pool; io: Server }, config?: SyncHeartbeatWorkerConfig) {
+    this.pool = deps.pool
+    this.io = deps.io
+    this.ticker = new Ticker({
+      name: "sync-heartbeat",
+      intervalMs: config?.intervalMs ?? DEFAULT_CONFIG.intervalMs,
+      maxConcurrency: 1,
+    })
+  }
+
+  start(): void {
+    this.ticker.start(() => this.tickOnce())
+    logger.info("SyncHeartbeatWorker started")
+  }
+
+  async stop(): Promise<void> {
+    this.ticker.stop()
+    await this.ticker.drain()
+    logger.info("SyncHeartbeatWorker stopped")
+  }
+
+  /** One heartbeat pass; the ticker calls this on its interval. */
+  async tickOnce(): Promise<void> {
+    try {
+      const workspaceIds: string[] = []
+      for (const room of this.io.sockets.adapter.rooms.keys()) {
+        const match = WORKSPACE_ROOM_PATTERN.exec(room)
+        if (match) {
+          workspaceIds.push(match[1])
+        }
+      }
+      if (workspaceIds.length === 0) {
+        return
+      }
+
+      const heads = await SyncLogRepository.getHeads(this.pool, workspaceIds)
+      for (const workspaceId of workspaceIds) {
+        const payload: SyncHeartbeatPayload = {
+          workspaceId,
+          // A workspace absent from sync_log has head 0; no client position
+          // sits below 0, so the emit is a harmless no-op compare.
+          head: (heads.get(workspaceId) ?? 0n).toString(),
+        }
+        this.io.local.to(`ws:${workspaceId}`).emit("sync:heartbeat", payload)
+      }
+    } catch (err) {
+      // Next tick retries with a fresh head; detection latency degrades,
+      // correctness doesn't — catch-up triggers on the following heartbeat.
+      logger.error({ err }, "sync heartbeat tick failed")
+    }
+  }
+}

--- a/apps/backend/src/features/sync/index.ts
+++ b/apps/backend/src/features/sync/index.ts
@@ -2,3 +2,4 @@ export { SyncLogRepository, type SyncLogEntryInput, type SyncLogEntry } from "./
 export { SyncService, type CatchUpResult } from "./service"
 export { createSyncHandlers } from "./handlers"
 export { SyncLogReconciliationWorker, type SyncLogReconciliationWorkerConfig } from "./reconciliation-worker"
+export { SyncHeartbeatWorker, type SyncHeartbeatWorkerConfig } from "./heartbeat-worker"

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -187,6 +187,24 @@ export const SyncLogRepository = {
     return result.rows.map(mapRowToEntry)
   },
 
+  /**
+   * Heads for a batch of workspaces in one statement (INV-56), for the
+   * heartbeat tick. Workspaces with no log entries are absent from the map;
+   * callers default them to 0.
+   */
+  async getHeads(db: Querier, workspaceIds: string[]): Promise<Map<string, bigint>> {
+    if (workspaceIds.length === 0) {
+      return new Map()
+    }
+    const result = await db.query<{ workspace_id: string; head: string }>(sql`
+      SELECT workspace_id, MAX(sync_id) AS head
+      FROM sync_log
+      WHERE workspace_id = ANY(${workspaceIds})
+      GROUP BY workspace_id
+    `)
+    return new Map(result.rows.map((row) => [row.workspace_id, BigInt(row.head)]))
+  },
+
   /** Max visible sync id for a workspace (0 when the log is empty). */
   async getHead(db: Querier, workspaceId: string): Promise<bigint> {
     const result = await db.query<{ head: string }>(sql`

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -110,7 +110,7 @@ import {
 import { EmojiUsageHandler } from "./features/emoji"
 import { SystemMessageService, SystemMessageOutboxHandler } from "./features/system-messages"
 import { ActivityService, ActivityFeedHandler } from "./features/activity"
-import { SyncService, SyncLogReconciliationWorker } from "./features/sync"
+import { SyncService, SyncLogReconciliationWorker, SyncHeartbeatWorker } from "./features/sync"
 import { BotInvocationOutboxHandler } from "./features/bot-runtimes/invocation-outbox-handler"
 import {
   BotRuntimeInstanceRepository,
@@ -1160,6 +1160,14 @@ export async function startServer(): Promise<ServerInstance> {
   )
   await syncLogReconciliationWorker.start()
 
+  // Broadcasts each workspace's sync-log head to its room so active-mode
+  // clients detect dropped emits between reconnect/resume triggers
+  const syncHeartbeatWorker = new SyncHeartbeatWorker(
+    { pool, io },
+    { intervalMs: Number(process.env.SYNC_HEARTBEAT_INTERVAL_MS) || undefined }
+  )
+  syncHeartbeatWorker.start()
+
   const orphanSessionCleanup = createOrphanSessionCleanup(pools.main, io)
   orphanSessionCleanup.start()
 
@@ -1200,6 +1208,7 @@ export async function startServer(): Promise<ServerInstance> {
     await cleanupWorker.stop()
     await outboxRetentionWorker.stop()
     await syncLogReconciliationWorker.stop()
+    await syncHeartbeatWorker.stop()
     await outboxDispatcher.stop()
     await jobQueue.stop()
     logger.info("Closing socket.io...")

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import type { Socket } from "socket.io-client"
 import { QueryClient } from "@tanstack/react-query"
 import { SyncEngine, isSyncEngineCurrent } from "./sync-engine"
@@ -1470,5 +1470,236 @@ describe("SyncEngine sync-v2 cursor mode wiring", () => {
 
     engine.destroy()
     expect(isSyncEngineCurrent(engine, "ws_1", "shadow")).toBe(false)
+  })
+})
+
+describe("SyncEngine sync:heartbeat (active mode)", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([
+      db.workspaces.clear(),
+      db.syncCursors.clear(),
+      db.workspaceUsers.clear(),
+      db.unreadState.clear(),
+    ])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeActiveDeps(catchUp: ReturnType<typeof vi.fn>) {
+    return {
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      syncCursorMode: "active" as const,
+    }
+  }
+
+  function emptyPage(head: string): SyncCatchUpResponse {
+    return { entries: [], head }
+  }
+
+  function userAddedEntry(syncId: string, userId: string): SyncCatchUpResponse["entries"][number] {
+    return {
+      syncId,
+      eventType: "workspace_user:added",
+      payload: { workspaceId: "ws_1", user: { id: userId, workspaceId: "ws_1", name: `User ${userId}` } },
+      createdAt: new Date().toISOString(),
+    }
+  }
+
+  function heartbeat(head: string) {
+    return { workspaceId: "ws_1", head }
+  }
+
+  /** Connect with a persisted cursor at 10 and let the connect catch-up
+   *  settle (one page), so heartbeat-triggered calls are distinguishable. */
+  async function connectSettledEngine(catchUp: ReturnType<typeof vi.fn>) {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const engine = new SyncEngine(makeActiveDeps(catchUp))
+    const socket = new MockSocket()
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(catchUp).toHaveBeenCalled())
+    // Drain the connect catch-up's remaining microtasks (gate resume).
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    return { engine, socket }
+  }
+
+  it("ignores a head already covered by max(cursor, lastSeenHead) — including invisible-entry inflation", async () => {
+    // Connect catch-up reports head 12 with nothing visible: the cursor stays
+    // at 10 but lastSeenHead records 12 as known-clean.
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("12"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("12"))
+    socket.trigger("sync:heartbeat", heartbeat("11"))
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(baseline)
+    engine.destroy()
+  })
+
+  it("triggers catch-up after the grace window when the head stays ahead, applying entries through the gate", async () => {
+    const catchUp = vi
+      .fn()
+      .mockResolvedValueOnce(emptyPage("10"))
+      .mockResolvedValueOnce({
+        entries: [userAddedEntry("11", "user_a"), userAddedEntry("12", "user_b")],
+        head: "12",
+      })
+      .mockResolvedValue(emptyPage("12"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("12"))
+    // Within grace: nothing fetched yet.
+    expect(catchUp.mock.calls.length).toBe(1)
+    vi.advanceTimersByTime(3_500)
+    vi.useRealTimers()
+
+    await vi.waitFor(async () => {
+      expect(await db.workspaceUsers.get("user_a")).toBeDefined()
+      expect(await db.workspaceUsers.get("user_b")).toBeDefined()
+    })
+    expect(engine.getSyncCursor()).toBe("12")
+    engine.destroy()
+  })
+
+  it("does not fetch when live events close the gap during the grace window", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("11"))
+    // The "missing" event arrives mid-grace; the gate applies it live and the
+    // cursor advances past the heartbeat head before the re-check fires.
+    socket.trigger("workspace_user:added", {
+      workspaceId: "ws_1",
+      syncId: "11",
+      user: { id: "user_live", workspaceId: "ws_1", name: "User live" },
+    })
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(baseline)
+    expect(engine.getSyncCursor()).toBe("11")
+    engine.destroy()
+  })
+
+  it("coalesces heartbeats during grace into one run and self-quiets once the head is seen", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    // The heartbeat-triggered run finds only entries invisible to this user.
+    catchUp.mockResolvedValue(emptyPage("15"))
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("12"))
+    socket.trigger("sync:heartbeat", heartbeat("15"))
+    vi.advanceTimersByTime(3_500)
+    vi.useRealTimers()
+    await vi.waitFor(() => expect(catchUp.mock.calls.length).toBeGreaterThan(baseline))
+    const afterRun = catchUp.mock.calls.length
+
+    // Same head again: lastSeenHead now covers it, so no second run.
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("15"))
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(afterRun)
+    engine.destroy()
+  })
+
+  it("does not mark a head clean when the drain fails mid-way — the next heartbeat finishes it", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    // First heartbeat-triggered run: page 1 applies entry 11 (head reports
+    // 15), then the next page's fetch fails — lastSeenHead must NOT record 15.
+    catchUp
+      .mockResolvedValueOnce({ entries: [userAddedEntry("11", "user_a")], head: "15" })
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValueOnce({ entries: [userAddedEntry("12", "user_b")], head: "15" })
+      .mockResolvedValue(emptyPage("15"))
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("15"))
+    vi.advanceTimersByTime(2_500)
+    vi.useRealTimers()
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("user_a")).toBeDefined())
+    // Let the failed run settle fully before the retry heartbeat.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("15"))
+    vi.advanceTimersByTime(2_500)
+    vi.useRealTimers()
+
+    await vi.waitFor(async () => expect(await db.workspaceUsers.get("user_b")).toBeDefined())
+    expect(engine.getSyncCursor()).toBe("12")
+    engine.destroy()
+  })
+
+  it("ignores other workspaces' heartbeats and malformed heads", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", { workspaceId: "ws_other", head: "99" })
+    socket.trigger("sync:heartbeat", { workspaceId: "ws_1", head: "not-a-number" })
+    socket.trigger("sync:heartbeat", undefined)
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(baseline)
+    engine.destroy()
+  })
+
+  it("does not react to heartbeats in shadow mode", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const engine = new SyncEngine({
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      syncCursorMode: "shadow" as const,
+    })
+    const socket = new MockSocket()
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(catchUp).toHaveBeenCalled())
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("99"))
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(baseline)
+    engine.destroy()
+  })
+
+  it("destroy during the grace window cancels the pending catch-up", async () => {
+    const catchUp = vi.fn().mockResolvedValue(emptyPage("10"))
+    const { engine, socket } = await connectSettledEngine(catchUp)
+    const baseline = catchUp.mock.calls.length
+
+    vi.useFakeTimers()
+    socket.trigger("sync:heartbeat", heartbeat("12"))
+    engine.destroy()
+    vi.advanceTimersByTime(10_000)
+    vi.useRealTimers()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp.mock.calls.length).toBe(baseline)
   })
 })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -73,6 +73,16 @@ interface SyncEngineDeps {
 const MAX_CATCHUP_PAGES = 20
 const CATCHUP_PAGE_LIMIT = 500
 
+/**
+ * How long a heartbeat-detected lag must persist before it triggers catch-up.
+ * The server reads the head from the log and sequence-before-emit means the
+ * matching emits can still be in flight when the heartbeat lands — during
+ * live traffic nearly every tick would otherwise pause the gate for a gap
+ * that closes itself. The re-check after this window only fetches if the
+ * client is still behind.
+ */
+const HEARTBEAT_GRACE_MS = 2_000
+
 // Unread counter events replay from the log like any other event since their
 // payloads went absolute (phase 2c) — EXCEPT legacy entries persisted before
 // the backend shipped the absolute fields, which still carry increments and
@@ -125,6 +135,17 @@ export class SyncEngine {
   private catchUpCycle = 0
   private activeCatchUpCycle = 0
   private queuedCatchUp: Promise<void> | null = null
+
+  // Heartbeat (active mode): the highest workspace head observed in catch-up
+  // responses. The cursor is per-user filtered and can sit permanently below
+  // the workspace-global head, so heartbeat comparisons run against
+  // max(cursor, lastSeenHead) — an empty catch-up page proves nothing visible
+  // exists in (cursor, head], without ever moving the cursor toward head.
+  private lastSeenHead: bigint | null = null
+  private heartbeatGraceTimer: ReturnType<typeof setTimeout> | null = null
+  /** Max behind-head among heartbeats received while the grace timer is armed. */
+  private pendingHeartbeatHead: bigint | null = null
+  private heartbeatCleanup: (() => void) | null = null
 
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
@@ -193,6 +214,7 @@ export class SyncEngine {
     if (this.syncCursorMode === "shadow") {
       this.trackSyncCursor(socket)
     } else if (this.syncCursorMode === "active") {
+      this.trackHeartbeat(socket)
       // Read-before-stamp: the cursor position (head, on a first run) must be
       // read BEFORE the bootstrap data fetch so any race falls on the
       // duplicate side (entry also present in the snapshot — idempotent),
@@ -815,6 +837,84 @@ export class SyncEngine {
     return this.eventGate ?? socket
   }
 
+  /**
+   * Active-mode heartbeat listener, on the RAW socket — the payload carries
+   * no syncId, is not an applied event, and must keep flowing while the gate
+   * is paused. The server broadcasts each workspace's sync-log head every
+   * SYNC_HEARTBEAT_INTERVAL_MS (see SyncHeartbeatWorker); a head beyond
+   * max(cursor, lastSeenHead) means events exist that this client neither
+   * applied live nor saw in a catch-up — a dropped emit, caught without
+   * waiting for a reconnect/resume trigger.
+   */
+  private trackHeartbeat(socket: Socket): void {
+    this.cleanupHeartbeatTracking()
+    const listener = (payload: { workspaceId?: unknown; head?: unknown } | undefined) => {
+      this.handleHeartbeat(payload)
+    }
+    socket.on("sync:heartbeat", listener)
+    this.heartbeatCleanup = () => socket.off("sync:heartbeat", listener)
+  }
+
+  private handleHeartbeat(payload: { workspaceId?: unknown; head?: unknown } | undefined): void {
+    if (this.isDestroyed) return
+    if (!payload || payload.workspaceId !== this.workspaceId || typeof payload.head !== "string") return
+    const head = parseHeartbeatHead(payload.head)
+    if (head === null) return
+    // No cursor yet: the connect-time seed/catch-up owns this window.
+    const position = this.heartbeatPosition()
+    if (position === null || head <= position) return
+
+    if (this.pendingHeartbeatHead === null || head > this.pendingHeartbeatHead) {
+      this.pendingHeartbeatHead = head
+    }
+    // One grace window at a time; repeat heartbeats coalesce onto it via the
+    // pending max above.
+    this.heartbeatGraceTimer ??= setTimeout(() => {
+      this.heartbeatGraceTimer = null
+      const pending = this.pendingHeartbeatHead
+      this.pendingHeartbeatHead = null
+      if (pending === null || this.isDestroyed) return
+      const current = this.heartbeatPosition()
+      // The gap closed during the grace window — in-flight delivery, not a
+      // dropped emit.
+      if (current !== null && pending <= current) return
+      // Same pause-before-catch-up rule as connect/resume: catch-up applies
+      // through the gate, and live events must buffer (then splice) so an
+      // older log entry can never regress a newer live LWW payload.
+      this.beginCatchUpCycle()
+      void this.runCatchUp("heartbeat")
+    }, HEARTBEAT_GRACE_MS)
+  }
+
+  /** Comparison baseline for heartbeats; null until the cursor is seeded. */
+  private heartbeatPosition(): bigint | null {
+    const cursor = this.syncLogCursor?.get()
+    if (cursor == null) return null
+    const cursorValue = BigInt(cursor)
+    return this.lastSeenHead !== null && this.lastSeenHead > cursorValue ? this.lastSeenHead : cursorValue
+  }
+
+  /** Max-merge a catch-up response's head into the heartbeat baseline. */
+  private noteSeenHead(head: string): void {
+    const value = parseHeartbeatHead(head)
+    if (value === null) return
+    if (this.lastSeenHead === null || value > this.lastSeenHead) {
+      this.lastSeenHead = value
+    }
+  }
+
+  private cleanupHeartbeatTracking(): void {
+    if (this.heartbeatCleanup) {
+      this.heartbeatCleanup()
+      this.heartbeatCleanup = null
+    }
+    if (this.heartbeatGraceTimer) {
+      clearTimeout(this.heartbeatGraceTimer)
+      this.heartbeatGraceTimer = null
+    }
+    this.pendingHeartbeatHead = null
+  }
+
   /** Active mode: pause the gate and open a new catch-up cycle. Each
    *  connect/resume trigger gets its own cycle so a catch-up run that was
    *  already in flight cannot reopen live delivery inside the new trigger's
@@ -841,6 +941,7 @@ export class SyncEngine {
       const { head } = await this.deps.syncService!.catchUp(this.workspaceId, { after: "0", limit: 1 }, abort.signal)
       if (this.isDestroyed) return
       cursorStore.advance(head)
+      this.noteSeenHead(head)
       console.info("Sync-v2 cursor seeded from head", { workspaceId: this.workspaceId, head })
     } catch (error) {
       if (this.isDestroyed) return
@@ -971,7 +1072,16 @@ export class SyncEngine {
         )
         if (this.isDestroyed) return
         head = response.head
-        if (response.entries.length === 0) break
+        if (response.entries.length === 0) {
+          // ONLY an empty page proves nothing visible exists in (cursor, head]
+          // — record the head so the next heartbeat at or below it is
+          // known-clean. Recording on a non-empty page would be premature: if
+          // a later page's fetch fails mid-drain, an inflated lastSeenHead
+          // suppresses the very heartbeat re-trigger that would finish the
+          // drain (truncation by MAX_CATCHUP_PAGES is healed the same way).
+          this.noteSeenHead(response.head)
+          break
+        }
 
         pages += 1
         fetched += response.entries.length
@@ -1113,6 +1223,19 @@ export class SyncEngine {
     this.cleanupWorkspaceHandlers()
     this.cleanupStreamHandlers()
     this.cleanupSyncCursorTracking()
+    this.cleanupHeartbeatTracking()
+  }
+}
+
+/** Wire heads are server-stamped, but tolerate malformed input like the
+ *  cursor does (see SyncLogCursor) — a rogue payload must not throw in a
+ *  socket listener. */
+function parseHeartbeatHead(value: string): bigint | null {
+  try {
+    return BigInt(value)
+  } catch {
+    console.warn("Sync-v2: ignoring malformed heartbeat head", { value })
+    return null
   }
 }
 

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -128,6 +128,20 @@ reconnect arrives, it can't retroactively upgrade the in-flight request (which a
 its stream set), so it **chains** a follow-up reconnect bootstrap to run after the current
 one. Repeated reconnects collapse onto that single queued promise.
 
+### The sync heartbeat catches dropped emits between triggers
+
+Every catch-up trigger above is connectivity-shaped (connect, reconnect, online
+flip, resume) — a client whose transport stays healthy for hours would never
+notice a dropped emit. The backend's `SyncHeartbeatWorker` therefore broadcasts
+each workspace's sync-log head to its room (`sync:heartbeat`, every 15s,
+node-local emits under the Postgres adapter). In active sync-v2 mode the engine
+compares the head against `max(cursor, lastSeenHead)` — the cursor is per-user
+filtered and can sit permanently below the workspace-global head, so catch-up
+responses' `head` is recorded as the known-clean high-water mark. A head still
+ahead after a short grace window (in-flight emits close themselves) pauses the
+gate and runs a normal catch-up. Design and decision record:
+`docs/plans/sync-v2-heartbeat.md`.
+
 ### Page resume and zombie sockets
 
 `handlePageResume` (e.g. phone unlocked after an app switch) pings the socket. If the ping

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -136,10 +136,12 @@ notice a dropped emit. The backend's `SyncHeartbeatWorker` therefore broadcasts
 each workspace's sync-log head to its room (`sync:heartbeat`, every 15s,
 node-local emits under the Postgres adapter). In active sync-v2 mode the engine
 compares the head against `max(cursor, lastSeenHead)` — the cursor is per-user
-filtered and can sit permanently below the workspace-global head, so catch-up
-responses' `head` is recorded as the known-clean high-water mark. A head still
-ahead after a short grace window (in-flight emits close themselves) pauses the
-gate and runs a normal catch-up. Design and decision record:
+filtered and can sit permanently below the workspace-global head, so a catch-up
+that drains to an empty page records that page's `head` as the known-clean
+high-water mark (`lastSeenHead`; non-empty pages don't move it, so a failed or
+truncated drain is retried by the next heartbeat). A head still ahead after a
+short grace window (in-flight emits close themselves) pauses the gate and runs
+a normal catch-up. Design and decision record:
 `docs/plans/sync-v2-heartbeat.md`.
 
 ### Page resume and zombie sockets

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -46,9 +46,10 @@ author-scoped; migrate if dismissal staleness is ever reported).
 
 ## Decision (2026-06-12): additive first
 
-The rollout isn't complete (no heartbeat, no sync_log retention), so the owner
-chose to finish wiring consumers into the sync system before deleting any more
-healing. PR E therefore ships the **additive** halves only:
+The rollout wasn't complete at decision time (no heartbeat, no sync_log
+retention — the heartbeat has since shipped, see the ground rules above;
+retention is still missing), so the owner chose to finish wiring consumers
+into the sync system before deleting any more healing. PR E therefore ships the **additive** halves only:
 
 - `use-conversations` registers through the engine's event gate (catch-up
   replay now reaches it); its reconnect invalidation **stays**.

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -9,7 +9,12 @@ the rollout sessions:
 - **One healing deletion per PR**, each with a test proving the cursor covers
   what the deleted healing covered.
 - **Never delete healing that covers dropped live emits** until a socket
-  heartbeat exists.
+  heartbeat exists. _The heartbeat now exists_
+  (`docs/plans/sync-v2-heartbeat.md`): the server broadcasts each workspace's
+  sync-log head every 15s and active-mode clients trigger catch-up when
+  behind, bounding dropped-emit detection to ~interval+grace. Deletions it
+  gates are unblocked on this axis — but the big ones (reconnect-bootstrap
+  slimming, `usePageResumeRefresh`) ALSO require sync_log retention.
 - Coverage proof method (established in #885): event type → scoping list in
   `apps/backend/src/lib/outbox/repository.ts` → delivery group
   (`delivery-groups.ts`, single source of truth for log + emit) → `sync_log`
@@ -161,8 +166,10 @@ treating such a flag as real healing — it may be dead code (labels was).
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**
-  (INV-61): the only healing with in-band dropped-emit _detection_ (a gap is
-  visible the moment the next event arrives). Keep until a heartbeat exists.
+  (INV-61): in-band dropped-emit _detection_ (a gap is visible the moment the
+  next event arrives). The heartbeat now exists but these stay anyway: their
+  detection is instant where the heartbeat's is a ≤interval+grace floor, and
+  the in-place placeholder rendering is UX, not just healing.
 - **Ephemeral raw-socket handlers** (`agent_session:activity_started`,
   `:progress`, `:step:*`, voice, `bot_runtime:presence`,
   `pointer:invalidated`): not outbox-routed, never in the log; no healing

--- a/docs/plans/sync-v2-heartbeat.md
+++ b/docs/plans/sync-v2-heartbeat.md
@@ -1,0 +1,227 @@
+# Sync v2 — workspace sync-head heartbeat
+
+Design for the periodic server→client sync-head heartbeat, the missing
+detection half of the sync-v2 cursor system. Decisions recorded here were made
+with the owner on 2026-06-12; the implementation ships as one PR with this doc
+as its plan.
+
+## Problem
+
+The sync log is populated independently of emit success (inventory doc,
+Mechanic 1): the BroadcastHandler sequences every client-routed outbox event
+into `sync_log` BEFORE the best-effort Socket.io emit, so a dropped emit always
+has a log entry and the client cursor stays behind it. Catch-up replays it —
+but only when a trigger fires, and today every trigger is connectivity-shaped:
+socket connect/reconnect, browser online flip, page resume. A client whose
+transport stays healthy for hours never fires any of them, so a dropped emit
+sits unhealed until the user happens to reconnect.
+
+Timeline contiguity (INV-61) closes this gap for stream message rows only — a
+missing `broadcastSequence` is visible the moment the next event arrives. All
+other gate-registered consumers (labels, saved, scheduled, memos, unread
+counters, conversations, workspace metadata) have **no detection at all**
+between a drop and the next connectivity trigger. That detection gap is what
+this heartbeat closes, and it is the precondition the deletion inventory's
+ground rule names: "never delete healing that covers dropped live emits until
+a socket heartbeat exists."
+
+## Decisions (owner, 2026-06-12)
+
+1. **Workspace head, room broadcast** — not per-user visible head. One
+   set-based `MAX(sync_id)` query across active workspaces per tick, one emit
+   per workspace room. The false-positive cost (a no-op catch-up when only
+   entries invisible to this user landed) is bounded to at most one cheap
+   request per client per interval and is rare in a solo-first product.
+2. **Detection only.** The heartbeat triggers catch-up when the client is
+   behind; it is NOT a transport-liveness mechanism. Dead transports stay
+   covered by socket.io's native pingTimeout and the page-resume probe
+   (`pingSocket`).
+3. **Rides `sync-v2-cursor` active mode.** The server emits unconditionally
+   (clients in `off`/`shadow` or on old builds ignore the event); the client
+   handler exists only in active mode, where the gate/cursor machinery lives.
+   No new feature flag; flipping `sync-v2-cursor` to `off` also kills
+   heartbeat-triggered catch-up.
+4. **One PR**: server emitter + client trigger + tests, no healing deletions
+   bundled in.
+5. **15s interval** (owner choice over the recommended 30s), env-configurable;
+   client grace window ~2s. Detection latency bound: ~17s.
+
+## Server design
+
+### `SyncHeartbeatWorker` (new, `apps/backend/src/features/sync/heartbeat-worker.ts`)
+
+Structural twin of `SyncLogReconciliationWorker` (INV-51 colocation): a
+`Ticker`-driven class with `start()`/`stop()`, constructed in `server.ts` next
+to the reconciliation worker, interval from `SYNC_HEARTBEAT_INTERVAL_MS`
+(default **15s**, decision 5).
+
+Each tick:
+
+1. Enumerate workspaces with locally connected sockets from
+   `io.sockets.adapter.rooms`, keeping keys matching `/^ws:([^:]+)$/` (the
+   bare workspace room, not `:stream:`/`:user:` subrooms or socket-id rooms).
+   With the Postgres adapter, `adapter.rooms` is node-local — exactly the set
+   this instance is responsible for.
+2. No rooms → no query, no emit (idle instances cost nothing).
+3. One set-based head query (INV-56) via the new `SyncLogRepository.getHeads`
+   beside `getHead`: one `MAX(sync_id)` grouped by workspace over the batch.
+   Workspaces absent from `sync_log` report head 0; emitting 0 is harmless
+   (no client sits below 0).
+4. Per workspace: emit `sync:heartbeat` with `{ workspaceId, head }` to the
+   workspace room through the `local` broadcast operator, `head` as a string
+   like sync ids everywhere on the wire.
+
+**Why `io.local`:** the backend runs the Socket.io Postgres adapter
+(`server.ts:612`), so a plain `io.to(room).emit` fans out through every
+instance. Each instance runs its own ticker for its own sockets; without the
+`local` flag, N instances would deliver N copies per interval. `local`
+restricts delivery to this node's sockets — no leader election, no
+duplication. (Duplicates would be _correct_ — the handler is a pure
+compare — just wasteful.)
+
+**Why not the outbox:** INV-4 routes domain events through the outbox so log
+and emit can't drift. The heartbeat is not a domain event — it carries no
+state, is derived (a `MAX` over the log), idempotent, and periodic. Writing it
+to the outbox would put one row per workspace per tick into the very log whose
+head it reports, advancing the head it measures. It is infrastructure
+signaling, same lane as the `health:ping` ack.
+
+**Wire type:** `SyncHeartbeatPayload { workspaceId: string; head: string }` in
+`packages/types/src/api.ts` next to `SyncCatchUpResponse`, exported from the
+barrel. Event name literal `"sync:heartbeat"`.
+
+### Membership and security
+
+The emit targets the workspace room, which `socket.ts` only admits after a
+`UserRepository.findByWorkosUserIdInWorkspace` check on join. The payload is a
+single integer that leaks nothing about content — the same number every member
+already receives in every catch-up response's `head`.
+
+## Client design
+
+All in `SyncEngine` (`apps/frontend/src/sync/sync-engine.ts`), active mode
+only.
+
+### State
+
+- `lastSeenHead: bigint | null` (in-memory, per engine): the highest workspace
+  head this client has **proven clean** from catch-up responses. It max-merges
+  `response.head` ONLY when a catch-up page comes back empty (plus the
+  first-run seed in `initializeActiveCursor`, where the cursor is advanced to
+  head anyway). Recording it on a non-empty page would be premature: if a
+  later page's fetch fails mid-drain, an inflated `lastSeenHead` would
+  suppress the very heartbeat re-trigger that finishes the drain — instead, a
+  failed or `MAX_CATCHUP_PAGES`-truncated run leaves `lastSeenHead` behind and
+  the next heartbeat retries. Not persisted: on reload, the connect catch-up
+  reseeds it before the first heartbeat can matter.
+
+  This is what makes workspace-head comparison sound despite the per-user
+  filtered cursor: the cursor advances only past entries visible to this user
+  and can sit permanently below workspace head ("head is a freshness hint,
+  not a cursor target" — the existing contract in `api.ts` and
+  `sync/service.ts` is unchanged). The comparison baseline is
+  `position = max(cursor, lastSeenHead)`: a catch-up that drains to an empty
+  page proves there is nothing visible in `(cursor, head]`, so heads at or
+  below `lastSeenHead` are known-clean without touching the cursor.
+
+### Handler
+
+Registered in `onConnect` on the **raw socket** (not the gate — the payload
+carries no `syncId`, must not be buffered during pause, and is not an applied
+event), cleaned up alongside the workspace handlers. Logic on
+`sync:heartbeat`:
+
+1. Ignore unless active mode, payload's `workspaceId` matches the engine's,
+   and `head` parses as a BigInt (same malformed-input tolerance as
+   `SyncLogCursor.parseSyncId`).
+2. Ignore when the cursor is still null (first connect before
+   `initializeActiveCursor` — the connect catch-up owns that window).
+3. `position = max(cursor, lastSeenHead)`. `head <= position` → done. This is
+   the steady-state path: in a live conversation the cursor tracks the latest
+   visible entries and every heartbeat is a no-op compare.
+4. Otherwise arm a **grace re-check** (~2s, constant): one pending timer per
+   engine, coalescing repeat heartbeats by keeping the max behind-head. When
+   it fires, recompute `position`; if it now covers the remembered head, the
+   gap was in-flight delivery — done, no fetch.
+5. Still behind → `beginCatchUpCycle()` then `runCatchUp("heartbeat")`. The
+   catch-up records `lastSeenHead` from its final empty page, so a head
+   inflated by entries invisible to this user self-quiets after one no-op
+   fetch instead of re-triggering every interval.
+
+**Why the grace window:** the worker reads head from the log, and
+sequence-before-emit means the matching emits can still be in flight to this
+client when the heartbeat lands (ms-scale, but every tick during active
+traffic). Acting immediately would pause the gate mid-conversation for a gap
+that closes itself; a 2s re-check absorbs the in-flight window at zero cost.
+
+**Why `beginCatchUpCycle()` (gate pause):** identical to the connect/resume
+triggers. Catch-up applies log entries through `gate.dispatch`, and absolute
+unread-counter payloads are LWW — a live event applying mid-replay could be
+regressed by an older log entry applied after it. Pausing buffers live events
+and the existing splice predicate (`appliedThrough`) replays them in order;
+the cycle counter already handles a heartbeat trigger landing while a
+connect/resume catch-up is in flight (the older run leaves the gate paused,
+`runCatchUp` chains one fresh run — `sync-engine.ts` runCatchUp doc).
+
+Teardown: `destroy()` clears the grace timer; the socket listener is removed
+with the other handlers. Disconnect during grace is harmless — the timer
+re-check compares positions only, and `runCatchUp` already no-ops on a
+destroyed engine; a reconnect supersedes via its own cycle.
+
+### Out of scope (deliberately)
+
+- **`shadow` mode**: no handler. Shadow owns no healing; adding parity logging
+  is scope creep on a mode that's past its validation purpose.
+- **Missed-heartbeat transport probing** (owner decision 2).
+- **Cursor jumps to head**: never. The existing contract stands.
+- **Deleting any healing**: heartbeat satisfies the inventory's precondition,
+  but each deletion remains its own PR with its own coverage proof, and the
+  big ones (reconnect-bootstrap slimming, `usePageResumeRefresh`) ALSO require
+  sync_log retention (`isLegacyUnreadCounterEntry` must die first). INV-61
+  contiguity stays regardless of the heartbeat: it is instant in-band
+  detection with placeholder UX; the heartbeat is a ≤interval+grace floor for
+  everything else, not a replacement.
+
+## Failure modes considered
+
+- **Worker tick fails** (DB blip): logged, next tick retries — same posture as
+  the reconciliation sweep. Detection latency degrades; nothing breaks.
+- **Heartbeat emit itself drops**: the next one (15s) carries a fresher head.
+  The mechanism is self-healing by repetition; no per-emit durability needed.
+- **Catch-up fails or truncates mid-drain**: `lastSeenHead` only advances on
+  an empty page, so the unproven head stays ahead of the baseline and the
+  next heartbeat re-triggers the drain (pinned by a test).
+- **Client behind on an invisible-only gap**: one no-op catch-up, then
+  `lastSeenHead` covers it (step 5 above). No loops.
+- **Two tabs / two devices**: each engine compares and fetches independently;
+  catch-up is idempotent and the cursor store is monotonic cross-tab.
+- **Burst of workspaces on one node**: the head query is one statement; emits
+  are in-memory fan-out. At Threa's scale (region-sharded, solo-first) this is
+  noise; if it ever isn't, the tick can shard the room list.
+
+## Testing plan
+
+Backend (`heartbeat-worker.test.ts`, colocated):
+
+- enumerates only bare `ws:<id>` rooms from a stubbed local adapter rooms map
+  (subrooms and socket-id rooms excluded), emits `sync:heartbeat` with the
+  per-workspace head via the `local` broadcast operator, skips the DB query
+  entirely when no workspace rooms exist, and survives a failing head query.
+- `getHeads` is exercised via a stubbed repo like every sibling
+  (`appendForWorkspace`, `listEntriesForUser`): the backend has no live-DB
+  test harness, so repo SQL is not integration-tested here either.
+
+Frontend (`sync-engine.test.ts` additions):
+
+- heartbeat `head` ≤ `max(cursor, lastSeenHead)` → no catch-up scheduled.
+- heartbeat behind → catch-up fires after grace; entries apply through the
+  gate (reuse the existing gate-dispatch assertion pattern from #891/#900/#901
+  tests).
+- gap closed by live events during grace → re-check cancels, no fetch.
+- repeat heartbeats during grace coalesce to one catch-up with the max head.
+- wrong-workspace payload, malformed head, null cursor, `off`/`shadow` mode →
+  ignored.
+- empty catch-up response still advances `lastSeenHead`, so the same head
+  doesn't re-trigger on the next heartbeat.
+- a drain that fails between pages does NOT advance `lastSeenHead`, so the
+  next heartbeat at the same head re-triggers and finishes the drain.

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -259,6 +259,18 @@ export interface SyncCatchUpResponse {
   head: string
 }
 
+/**
+ * Periodic `sync:heartbeat` socket payload: the workspace-global sync-log
+ * head, broadcast to the workspace room so clients can detect a dropped emit
+ * without waiting for a reconnect/resume trigger. Same head semantics as the
+ * catch-up response: a freshness hint to compare against, never a cursor
+ * target. See docs/plans/sync-v2-heartbeat.md.
+ */
+export interface SyncHeartbeatPayload {
+  workspaceId: string
+  head: string
+}
+
 // ============================================================================
 // Messages API
 // ============================================================================

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -397,6 +397,7 @@ export type {
   // Sync log catch-up
   SyncCatchUpEntry,
   SyncCatchUpResponse,
+  SyncHeartbeatPayload,
   // Messages
   CreateMessageInput,
   CreateMessageInputJson,


### PR DESCRIPTION
## Problem

The sync log is populated independently of emit success (BroadcastHandler sequences to `sync_log` BEFORE the best-effort socket emit), so a dropped emit always has a log entry and the client cursor stays behind it — but catch-up only runs on connectivity-shaped triggers (connect, reconnect, online flip, resume). A client whose transport stays healthy for hours never fires any of them, so a dropped emit sits unhealed until the user happens to reconnect. Timeline contiguity (INV-61) detects drops for stream message rows only; every other gate-registered consumer (labels, saved, scheduled, memos, unread counters, conversations) has **no detection at all** between a drop and the next trigger.

This is also the precondition the deletion inventory's ground rule names: "never delete healing that covers dropped live emits until a socket heartbeat exists."

## Solution

A periodic server→client sync-head heartbeat. Full design and decision record: `docs/plans/sync-v2-heartbeat.md` (committed in this PR).

### How it works

- **Server** (`SyncHeartbeatWorker`, colocated in `features/sync`): every 15s (`SYNC_HEARTBEAT_INTERVAL_MS`), enumerate workspaces with locally connected sockets from `adapter.rooms`, fetch their heads in one set-based query (`SyncLogRepository.getHeads`, INV-56), and emit `sync:heartbeat { workspaceId, head }` to each workspace room with the `local` flag — under the Postgres adapter each instance heartbeats its own sockets, so no leader election and no duplicate delivery.
- **Client** (`SyncEngine`, active sync-v2 mode only, raw-socket listener): compare the head against `max(cursor, lastSeenHead)`. If still ahead after a 2s grace re-check (sequence-before-emit means heads legitimately lead delivery by the in-flight window), pause the gate (`beginCatchUpCycle`) and run the normal catch-up — the same pause/splice invariants as connect/resume.

### Key design decisions (made with the owner, recorded in the design doc)

**1. Workspace head, not per-user visible head.** The cursor is per-user filtered and can sit permanently below the workspace-global head, so the client tracks `lastSeenHead`: the head of a catch-up that drained to an empty page — which proves nothing visible exists in `(cursor, head]`. Recorded ONLY on the empty page: a drain that fails or truncates mid-way leaves `lastSeenHead` behind so the next heartbeat retries (pinned by a test). The cursor itself never jumps to head; the existing "head is a freshness hint, not a cursor target" contract is unchanged.

**2. Detection only.** Not a transport-liveness mechanism — dead transports stay covered by socket.io's native pingTimeout and the page-resume probe.

**3. Rides `sync-v2-cursor` active mode.** Server emits unconditionally (off/shadow/old clients ignore the event); no new feature flag, and the existing `off` kill switch also kills heartbeat-triggered catch-up.

**4. Not an outbox event.** The heartbeat carries no domain state — it is a derived `MAX` over the very log whose head it reports; logging it would advance the head it measures. Same lane as the `health:ping` ack.

**5. No healing deletions bundled in.** This PR only adds the detection floor (~17s). The inventory deletions it gates remain one-per-PR, and the big ones (reconnect-bootstrap slimming, `usePageResumeRefresh`) also require sync_log retention.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/sync/heartbeat-worker.ts` | Ticker-driven per-instance heartbeat emitter |
| `apps/backend/src/features/sync/heartbeat-worker.test.ts` | Room enumeration, local emits, head-0 default, failure tolerance |
| `docs/plans/sync-v2-heartbeat.md` | Design doc and owner decision record |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/sync/repository.ts` | New `getHeads` batch query beside `getHead` |
| `apps/backend/src/features/sync/index.ts` | Barrel export |
| `apps/backend/src/server.ts` | Construct/start the worker next to the reconciliation worker; stop on shutdown |
| `apps/frontend/src/sync/sync-engine.ts` | Heartbeat listener, `lastSeenHead`, grace re-check, catch-up trigger |
| `apps/frontend/src/sync/sync-engine.test.ts` | 8 heartbeat tests (see test plan) |
| `packages/types/src/api.ts`, `index.ts` | `SyncHeartbeatPayload` wire type |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Ground rule updated: the heartbeat now exists |
| `docs/features/architecture/sync-engine.md` | New subsection on the heartbeat |

## Test plan

- [x] Backend: `bun test src/features/sync` — worker emits per-workspace heads to bare `ws:<id>` rooms only via the local operator, skips the query with no rooms, survives a failing query
- [x] Frontend: `bunx vitest run src/sync` (189 tests) — covered-head no-op (including invisible-entry inflation), grace-window trigger with gate-dispatched entries, gap closed mid-grace cancels, coalescing + self-quieting, mid-drain failure retried by next heartbeat, wrong-workspace/malformed/shadow-mode ignored, destroy-during-grace cancels
- [x] Full monorepo lint + typecheck + OpenAPI check (pre-commit)

<details>
<summary>📋 Full implementation plan</summary>

The plan is the committed design doc: [`docs/plans/sync-v2-heartbeat.md`](https://github.com/threahq/threa/blob/claude/sync-v2-healing-deletions-handover-07i4mw/docs/plans/sync-v2-heartbeat.md).

**Goal:** close the dropped-emit detection gap in sync v2 (the precondition for the remaining healing deletions in `docs/plans/sync-v2-healing-deletion-inventory.md`).

**What was built:** server heartbeat worker (15s, node-local room emits, set-based head query) + active-mode client trigger (`max(cursor, lastSeenHead)` compare, 2s grace, gate-paused catch-up) + wire type + tests.

**Design evolution:** initial draft used a 30s interval and 3s grace; owner chose 15s, and the grace option as specified was ~2s. Self-review found and fixed a `lastSeenHead` inflation bug (originally recorded on every catch-up page; a mid-drain failure would then suppress the retry — now recorded only on a proven-clean empty page, with a regression test).

**What's NOT included:** transport-liveness probing, shadow-mode handling, any healing deletion, sync_log retention.

**Status:** complete; all tests green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01VvvCaFyXHjVzpEysVRwBm8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvvCaFyXHjVzpEysVRwBm8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783892561&installation_id=129946197&pr_number=904&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F904&signature=6daf41fddde5ec47bff2aee693d9baa90be13a3e2e49066fa7c2bafc68a894ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->