### PR TITLE
fix: revive re-wraps every owner-openable enclave generation (E2EE-7)

### DIFF
--- a/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
+++ b/apps/backend/src/features/e2e-streams/key-wrap-repository.ts
@@ -101,4 +101,28 @@ export const StreamE2eKeyWrapsRepository = {
     `)
     return result.rows.map(mapRow)
   },
+
+  /**
+   * Distinct key generations that already have a wrap for the given recipient
+   * kind. Scopes the read to exactly the rows the caller consumes — the revive
+   * path needs only the generations the (singleton) enclave actor provably
+   * held to gate an older-generation re-wrap, never the full wrap set — so the
+   * `recipient_kind` filter is pushed into SQL rather than scanning every row
+   * for the stream and filtering in JS.
+   */
+  async listGenerationsForRecipientKind(
+    db: Querier,
+    workspaceId: string,
+    streamId: string,
+    recipientKind: E2eKeyWrapRecipientKind
+  ): Promise<number[]> {
+    const result = await db.query<{ key_generation: number }>(sql`
+      SELECT DISTINCT key_generation
+      FROM stream_e2e_key_wraps
+      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
+        AND recipient_kind = ${recipientKind}
+      ORDER BY key_generation
+    `)
+    return result.rows.map((r) => r.key_generation)
+  },
 }

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -202,16 +202,21 @@ const rollKeySchema = z.object({
 })
 
 /**
- * Actor-wrap revive body: re-wraps of the *current* SSK (generation 0 is
- * valid — an owner-only stream that never rolled) to invited actors' live
- * keys. Same per-wrap caps as `rollKeySchema`; the service rejects `user`
- * recipients and keys that aren't live actor keys.
+ * Actor-wrap revive body: re-wraps of already-granted SSK generations
+ * (generation 0 is valid — an owner-only stream that never rolled) to
+ * invited actors' live keys. The top-level generation is the client's view
+ * of current; a wrap's own `keyGeneration` (defaulting to it) may name an
+ * older one — the service allows that only for the enclave actor, and only
+ * for a generation it already held (E2EE-7). Same per-wrap caps as
+ * `rollKeySchema`; the service rejects `user` recipients and keys that
+ * aren't live actor keys.
  */
 const actorRewrapSchema = z.object({
   keyGeneration: z.number().int().min(0),
   wraps: z
     .array(
       z.object({
+        keyGeneration: z.number().int().min(0).optional(),
         recipientKeyId: z.string().min(1).max(128),
         recipientKind: z.enum(E2E_KEY_WRAP_RECIPIENT_KINDS),
         wrapEnc: z.string().min(1).max(1024),

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -870,8 +870,10 @@ describe("StreamService.reviveActorKeyWraps", () => {
 
   const mockGetByStreamId = spyOn(E2eStreamsRepository, "getByStreamId")
   const mockInsertManyWraps = spyOn(StreamE2eKeyWrapsRepository, "insertMany")
+  const mockListWraps = spyOn(StreamE2eKeyWrapsRepository, "listForStream")
   const mockListActors = spyOn(E2eStreamActorsRepository, "listForStream")
   const mockListLiveEiks = spyOn(EnclaveRuntimesRepository, "listLive")
+  const mockFindLiveBiks = spyOn(BotRuntimeInstanceRepository, "findLiveWithKeyForBot")
 
   // A transaction client that answers the advisory-lock query the revive
   // issues before any repo call (same serialization as rollStreamKey).
@@ -892,8 +894,10 @@ describe("StreamService.reviveActorKeyWraps", () => {
     spyOn(db, "withTransaction").mockImplementation((_pool, fn) => fn(lockClient))
     mockGetByStreamId.mockReset().mockResolvedValue(ownedStream)
     mockInsertManyWraps.mockReset().mockResolvedValue(undefined as never)
+    mockListWraps.mockReset().mockResolvedValue([])
     mockListActors.mockReset().mockResolvedValue([{ kind: "enclave", actorId: "enclave", keyId: null }])
     mockListLiveEiks.mockReset().mockResolvedValue([{ keyId: "eik_fresh", publicKey: new Uint8Array([1]) }] as never)
+    mockFindLiveBiks.mockReset().mockResolvedValue([] as never)
   })
 
   afterAll(() => {
@@ -969,6 +973,104 @@ describe("StreamService.reviveActorKeyWraps", () => {
 
     expect((error as HttpError).status).toBe(400)
     expect((error as HttpError).code).toBe("E2E_RECIPIENT_NOT_LIVE_ACTOR")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  // E2EE-7: an enclave restart that follows a key roll leaves the parked turn
+  // (and old history/digests) sealed under generations the fresh EIK has no
+  // wrap for — revive must be able to re-address those generations too.
+  test("stores an older-generation wrap for the enclave when a prior enclave wrap proves it held that generation", async () => {
+    mockListWraps.mockResolvedValue([
+      { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+      { keyGeneration: 1, recipientKeyId: "e2ek_owner", recipientKind: "user", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+    ] as never)
+
+    await service.reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+      keyGeneration: 1,
+      wraps: [enclaveWrap, { ...enclaveWrap, keyGeneration: 0 }] as never,
+    })
+
+    expect(mockInsertManyWraps).toHaveBeenCalledWith(lockClient, [
+      expect.objectContaining({ keyGeneration: 1, recipientKeyId: "eik_fresh" }),
+      expect.objectContaining({ keyGeneration: 0, recipientKeyId: "eik_fresh" }),
+    ])
+  })
+
+  test("throws 400 for an older generation no enclave wrap ever existed at", async () => {
+    // Only the owner's user wrap exists at generation 0 — the enclave never held it.
+    mockListWraps.mockResolvedValue([
+      { keyGeneration: 0, recipientKeyId: "e2ek_owner", recipientKind: "user", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+    ] as never)
+
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        wraps: [{ ...enclaveWrap, keyGeneration: 0 }] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_GENERATION_NOT_HELD")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 400 for an older-generation wrap addressed to a bot key (no per-bot history attribution)", async () => {
+    mockListActors.mockResolvedValue([{ kind: "bot", actorId: "bot_1", keyId: null }] as never)
+    mockFindLiveBiks.mockResolvedValue([{ publicKeyId: "bik_live", publicKey: "AA==" }] as never)
+    mockListLiveEiks.mockResolvedValue([] as never)
+    // Even with a bot wrap on file at generation 0, old generations don't revive for bots.
+    mockListWraps.mockResolvedValue([
+      { keyGeneration: 0, recipientKeyId: "bik_dead", recipientKind: "bot", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+    ] as never)
+
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        wraps: [
+          { keyGeneration: 0, recipientKeyId: "bik_live", recipientKind: "bot", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+        ] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_GENERATION_NOT_HELD")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 400 when a wrap's kind doesn't match the live key's server-resolved kind", async () => {
+    mockListActors.mockResolvedValue([{ kind: "bot", actorId: "bot_1", keyId: null }] as never)
+    mockFindLiveBiks.mockResolvedValue([{ publicKeyId: "bik_live", publicKey: "AA==" }] as never)
+    mockListLiveEiks.mockResolvedValue([] as never)
+    mockListWraps.mockResolvedValue([
+      { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+    ] as never)
+
+    // A live bot key relabeled "enclave" must not unlock the enclave-only
+    // older-generation rule.
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        wraps: [
+          { keyGeneration: 0, recipientKeyId: "bik_live", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+        ] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_RECIPIENT_NOT_LIVE_ACTOR")
+    expect(mockInsertManyWraps).not.toHaveBeenCalled()
+  })
+
+  test("throws 400 when a wrap names a generation above current", async () => {
+    const error = await service
+      .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
+        keyGeneration: 1,
+        wraps: [{ ...enclaveWrap, keyGeneration: 2 }] as never,
+      })
+      .catch((e) => e)
+
+    expect((error as HttpError).status).toBe(400)
+    expect((error as HttpError).code).toBe("E2E_GENERATION_NOT_HELD")
     expect(mockInsertManyWraps).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -870,7 +870,7 @@ describe("StreamService.reviveActorKeyWraps", () => {
 
   const mockGetByStreamId = spyOn(E2eStreamsRepository, "getByStreamId")
   const mockInsertManyWraps = spyOn(StreamE2eKeyWrapsRepository, "insertMany")
-  const mockListWraps = spyOn(StreamE2eKeyWrapsRepository, "listForStream")
+  const mockEnclaveGenerations = spyOn(StreamE2eKeyWrapsRepository, "listGenerationsForRecipientKind")
   const mockListActors = spyOn(E2eStreamActorsRepository, "listForStream")
   const mockListLiveEiks = spyOn(EnclaveRuntimesRepository, "listLive")
   const mockFindLiveBiks = spyOn(BotRuntimeInstanceRepository, "findLiveWithKeyForBot")
@@ -894,7 +894,7 @@ describe("StreamService.reviveActorKeyWraps", () => {
     spyOn(db, "withTransaction").mockImplementation((_pool, fn) => fn(lockClient))
     mockGetByStreamId.mockReset().mockResolvedValue(ownedStream)
     mockInsertManyWraps.mockReset().mockResolvedValue(undefined as never)
-    mockListWraps.mockReset().mockResolvedValue([])
+    mockEnclaveGenerations.mockReset().mockResolvedValue([])
     mockListActors.mockReset().mockResolvedValue([{ kind: "enclave", actorId: "enclave", keyId: null }])
     mockListLiveEiks.mockReset().mockResolvedValue([{ keyId: "eik_fresh", publicKey: new Uint8Array([1]) }] as never)
     mockFindLiveBiks.mockReset().mockResolvedValue([] as never)
@@ -980,10 +980,9 @@ describe("StreamService.reviveActorKeyWraps", () => {
   // (and old history/digests) sealed under generations the fresh EIK has no
   // wrap for — revive must be able to re-address those generations too.
   test("stores an older-generation wrap for the enclave when a prior enclave wrap proves it held that generation", async () => {
-    mockListWraps.mockResolvedValue([
-      { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
-      { keyGeneration: 1, recipientKeyId: "e2ek_owner", recipientKind: "user", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
-    ] as never)
+    // The (dead) enclave EIK held generation 0; the owner's own gen-1 wrap is
+    // not an enclave row, so the scoped read returns only [0].
+    mockEnclaveGenerations.mockResolvedValue([0])
 
     await service.reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
       keyGeneration: 1,
@@ -997,10 +996,9 @@ describe("StreamService.reviveActorKeyWraps", () => {
   })
 
   test("throws 400 for an older generation no enclave wrap ever existed at", async () => {
-    // Only the owner's user wrap exists at generation 0 — the enclave never held it.
-    mockListWraps.mockResolvedValue([
-      { keyGeneration: 0, recipientKeyId: "e2ek_owner", recipientKind: "user", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
-    ] as never)
+    // No enclave wrap exists at generation 0 (only the owner's user wrap), so
+    // the scoped read returns no held generations — the enclave never held it.
+    mockEnclaveGenerations.mockResolvedValue([])
 
     const error = await service
       .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
@@ -1018,10 +1016,9 @@ describe("StreamService.reviveActorKeyWraps", () => {
     mockListActors.mockResolvedValue([{ kind: "bot", actorId: "bot_1", keyId: null }] as never)
     mockFindLiveBiks.mockResolvedValue([{ publicKeyId: "bik_live", publicKey: "AA==" }] as never)
     mockListLiveEiks.mockResolvedValue([] as never)
-    // Even with a bot wrap on file at generation 0, old generations don't revive for bots.
-    mockListWraps.mockResolvedValue([
-      { keyGeneration: 0, recipientKeyId: "bik_dead", recipientKind: "bot", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
-    ] as never)
+    // Older generations are enclave-only: the scoped read returns enclave rows,
+    // so a bot recipient can never satisfy the older-generation rule.
+    mockEnclaveGenerations.mockResolvedValue([])
 
     const error = await service
       .reviveActorKeyWraps("ws_1", "stream_e2e", "usr_owner", {
@@ -1041,9 +1038,9 @@ describe("StreamService.reviveActorKeyWraps", () => {
     mockListActors.mockResolvedValue([{ kind: "bot", actorId: "bot_1", keyId: null }] as never)
     mockFindLiveBiks.mockResolvedValue([{ publicKeyId: "bik_live", publicKey: "AA==" }] as never)
     mockListLiveEiks.mockResolvedValue([] as never)
-    mockListWraps.mockResolvedValue([
-      { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
-    ] as never)
+    // The enclave genuinely held generation 0 — but that must not help a live
+    // bot key that merely relabels itself "enclave".
+    mockEnclaveGenerations.mockResolvedValue([0])
 
     // A live bot key relabeled "enclave" must not unlock the enclave-only
     // older-generation rule.

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1046,20 +1046,29 @@ export class StreamService {
   }
 
   /**
-   * Re-wrap the *current* SSK to invited actors' live keys that lost their
-   * wrap — the revive path for an actor whose key changed after the invite
-   * (an enclave restart mints a fresh EIK, orphaning every stream wrapped to
-   * the old one; until revived, enclave turns for the stream park in the
-   * queue). No fresh SSK and no generation bump: the actor already held this
-   * generation, so re-addressing the same key to its new instance restores
-   * exactly the prior access — and keeps a parked turn (sealed under the
-   * current generation) decryptable, which a roll would strand.
+   * Re-wrap already-granted SSK generations to invited actors' live keys that
+   * lost their wrap — the revive path for an actor whose key changed after
+   * the invite (an enclave restart mints a fresh EIK, orphaning every stream
+   * wrapped to the old one; until revived, enclave turns for the stream park
+   * in the queue). No fresh SSK and no generation bump: the actor already
+   * held these generations, so re-addressing the same keys to its new
+   * instance restores exactly the prior access — and keeps a parked turn
+   * decryptable, which a roll would strand.
    *
-   * Owner-only, generation must be exactly current (same advisory lock as
-   * `rollStreamKey` so a concurrent roll can't slip a stale-generation wrap
-   * in), and every wrap must address a currently-live key of a currently-
-   * invited actor — never a `user` wrap, so this can't become a side door
-   * for adding readers.
+   * Owner-only, and the top-level generation must be exactly current (same
+   * advisory lock as `rollStreamKey` so a concurrent roll can't slip a
+   * stale-generation wrap in). Each wrap defaults to that generation; it may
+   * name an older one only for the enclave — a singleton actor, so any
+   * existing enclave wrap at that generation proves the actor held it. That
+   * is what un-strands a turn parked under a pre-roll generation, and what
+   * keeps old sealed history and turn digests readable after an enclave
+   * restart (E2EE-7). Bots stay current-generation-only: their wraps carry
+   * no per-bot identity, so an older generation can't be attributed to the
+   * specific bot that held it — and widening one bot's revive to another's
+   * history would breach the invite-time boundary `rekeyStream` documents.
+   * Every wrap must address a currently-live key of a currently-invited
+   * actor, matching the server-resolved kind — never a `user` wrap, so this
+   * can't become a side door for adding readers.
    */
   async reviveActorKeyWraps(
     workspaceId: string,
@@ -1090,12 +1099,48 @@ export class StreamService {
       }
 
       const live = await this.resolveActorRecipients(client, e2e)
-      const liveKeyIds = new Set(live.map((r) => r.recipientKeyId))
+      const liveByKeyId = new Map(live.map((r) => [r.recipientKeyId, r]))
+
+      // Generations the enclave actor already held, proven by an existing
+      // enclave wrap row at that generation (wraps are immutable, so a dead
+      // EIK's rows remain as the record). Fetched only when some wrap asks
+      // for an older generation — the common current-only heal skips it.
+      const wantsOlderGeneration = input.wraps.some(
+        (w) => (w.keyGeneration ?? input.keyGeneration) !== e2e.currentKeyGeneration
+      )
+      const enclaveHeldGenerations = wantsOlderGeneration
+        ? new Set(
+            (await StreamE2eKeyWrapsRepository.listForStream(client, workspaceId, streamId))
+              .filter((w) => w.recipientKind === E2eKeyWrapRecipientKinds.ENCLAVE)
+              .map((w) => w.keyGeneration)
+          )
+        : new Set<number>()
+
       for (const wrap of input.wraps) {
-        if (wrap.recipientKind === E2eKeyWrapRecipientKinds.USER || !liveKeyIds.has(wrap.recipientKeyId)) {
+        // Kind is taken from the server-resolved live entry, never the
+        // client's label — a relabeled key id must not widen what the
+        // generation rule below allows.
+        const liveRecipient = liveByKeyId.get(wrap.recipientKeyId)
+        if (
+          wrap.recipientKind === E2eKeyWrapRecipientKinds.USER ||
+          !liveRecipient ||
+          liveRecipient.recipientKind !== wrap.recipientKind
+        ) {
           throw new HttpError("Wrap recipient is not a live key of an invited actor", {
             status: 400,
             code: "E2E_RECIPIENT_NOT_LIVE_ACTOR",
+          })
+        }
+        const generation = wrap.keyGeneration ?? input.keyGeneration
+        if (generation === e2e.currentKeyGeneration) continue
+        if (
+          generation > e2e.currentKeyGeneration ||
+          liveRecipient.recipientKind !== E2eKeyWrapRecipientKinds.ENCLAVE ||
+          !enclaveHeldGenerations.has(generation)
+        ) {
+          throw new HttpError("Wrap generation was never granted to this actor", {
+            status: 400,
+            code: "E2E_GENERATION_NOT_HELD",
           })
         }
       }
@@ -1108,7 +1153,7 @@ export class StreamService {
         input.wraps.map((w) => ({
           workspaceId,
           streamId,
-          keyGeneration: input.keyGeneration,
+          keyGeneration: w.keyGeneration ?? input.keyGeneration,
           recipientKeyId: w.recipientKeyId,
           recipientKind: w.recipientKind,
           wrapEnc: w.wrapEnc,

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1103,16 +1103,20 @@ export class StreamService {
 
       // Generations the enclave actor already held, proven by an existing
       // enclave wrap row at that generation (wraps are immutable, so a dead
-      // EIK's rows remain as the record). Fetched only when some wrap asks
-      // for an older generation — the common current-only heal skips it.
+      // EIK's rows remain as the record). The repo scopes the read to enclave
+      // rows in SQL; fetched only when some wrap asks for an older generation —
+      // the common current-only heal skips it.
       const wantsOlderGeneration = input.wraps.some(
         (w) => (w.keyGeneration ?? input.keyGeneration) !== e2e.currentKeyGeneration
       )
       const enclaveHeldGenerations = wantsOlderGeneration
         ? new Set(
-            (await StreamE2eKeyWrapsRepository.listForStream(client, workspaceId, streamId))
-              .filter((w) => w.recipientKind === E2eKeyWrapRecipientKinds.ENCLAVE)
-              .map((w) => w.keyGeneration)
+            await StreamE2eKeyWrapsRepository.listGenerationsForRecipientKind(
+              client,
+              workspaceId,
+              streamId,
+              E2eKeyWrapRecipientKinds.ENCLAVE
+            )
           )
         : new Set<number>()
 

--- a/apps/frontend/src/api/e2e-key-wraps.ts
+++ b/apps/frontend/src/api/e2e-key-wraps.ts
@@ -33,10 +33,11 @@ export const e2eKeyWrapsApi = {
   },
 
   /**
-   * Re-wrap the *current* SSK to invited actors' live keys that lost their
-   * wrap (an enclave restart mints a fresh EIK). No generation bump — the
-   * actor already held this generation, so the new instance gets exactly the
-   * prior access, and a turn parked on the missing wrap revives.
+   * Re-wrap already-granted SSK generations to invited actors' live keys
+   * that lost their wrap (an enclave restart mints a fresh EIK). No
+   * generation bump — the actor already held these generations, so the new
+   * instance gets exactly the prior access, and a turn parked on a missing
+   * wrap revives (including one sealed under a pre-roll generation, E2EE-7).
    */
   async reviveActorWraps(workspaceId: string, streamId: string, input: E2eActorRewrapInput): Promise<void> {
     await api.post<void>(`/api/workspaces/${workspaceId}/streams/${streamId}/e2e/actor-key-wraps`, input)

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
-import { provisionOwnerStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
+import { computeMissingActorWraps, provisionOwnerStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { useE2eSession } from "@/stores/e2e-session-store"
@@ -154,17 +154,16 @@ function useActorWrapRevive(workspaceId: string, streamId: string): void {
     if (!sessionReady || !data || !userId || !ownerKeyId || !ownerPrivateKey || !rootStreamId) return
     if (data.ownerUserId !== userId) return
 
-    const live = data.liveActorRecipients ?? []
-    const missing = live.filter(
-      (r) =>
-        !data.wraps.some((w) => w.keyGeneration === data.currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
-    )
+    // The shared slot computation (current generation for every actor, plus
+    // the enclave's already-held older generations — E2EE-7) so this probe
+    // can't drift from what `reviveStaleActorWraps` actually heals.
+    const missing = computeMissingActorWraps(data)
     if (missing.length === 0) return
 
-    const signature = `${data.currentKeyGeneration}:${missing
-      .map((r) => r.recipientKeyId)
+    const signature = missing
+      .map((m) => `${m.keyGeneration}:${m.recipient.recipientKeyId}`)
       .sort()
-      .join(",")}`
+      .join(",")
     if (attemptedRef.current === signature) return
     attemptedRef.current = signature
 

--- a/apps/frontend/src/lib/crypto/__tests__/stream-key-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-key-cache.test.ts
@@ -10,6 +10,7 @@ import {
 import { generateUIK, type UserIdentityKey } from "../keys"
 import {
   clearStreamKeyCache,
+  computeMissingActorWraps,
   putStreamKey,
   rekeyStream,
   resolveCurrentStreamKey,
@@ -242,6 +243,76 @@ describe("putStreamKey + resolveCurrentStreamKey", () => {
   })
 })
 
+describe("computeMissingActorWraps", () => {
+  const eik = { recipientKeyId: "eik_fresh", recipientKind: "enclave" as const, publicKey: "AA==" }
+  const bik = { recipientKeyId: "bik_fresh", recipientKind: "bot" as const, publicKey: "AA==" }
+  const wrap = (keyGeneration: number, recipientKeyId: string, recipientKind: "user" | "enclave" | "bot") => ({
+    keyGeneration,
+    recipientKeyId,
+    recipientKind,
+    wrapEnc: "ZW5j",
+    wrapCt: "Y3Q=",
+  })
+
+  it("returns nothing when every live actor key has its current wrap and no older enclave generations exist", () => {
+    const missing = computeMissingActorWraps({
+      currentKeyGeneration: 0,
+      wraps: [wrap(0, "eik_fresh", "enclave")],
+      liveActorRecipients: [eik],
+    })
+    expect(missing).toEqual([])
+  })
+
+  it("flags the current generation for any live actor key without a wrap", () => {
+    const missing = computeMissingActorWraps({
+      currentKeyGeneration: 0,
+      wraps: [wrap(0, "eik_dead", "enclave")],
+      liveActorRecipients: [eik, bik],
+    })
+    expect(missing).toEqual([
+      { recipient: eik, keyGeneration: 0 },
+      { recipient: bik, keyGeneration: 0 },
+    ])
+  })
+
+  // E2EE-7: a restart after a key roll orphans the enclave's OLDER generations
+  // too — a parked turn or digest sealed under them is unreadable until the
+  // fresh EIK gets those wraps back.
+  it("flags the enclave's already-held older generations, but never a bot's", () => {
+    const missing = computeMissingActorWraps({
+      currentKeyGeneration: 2,
+      wraps: [
+        // The dead keys' wraps prove which generations each actor held.
+        wrap(0, "eik_dead", "enclave"),
+        wrap(1, "eik_dead", "enclave"),
+        wrap(1, "bik_dead", "bot"),
+        wrap(2, "eik_fresh", "enclave"),
+        wrap(2, "bik_fresh", "bot"),
+        // The owner's user wraps must not count as actor-held generations.
+        wrap(0, "e2ek_owner", "user"),
+      ],
+      liveActorRecipients: [eik, bik],
+    })
+    expect(missing).toEqual([
+      { recipient: eik, keyGeneration: 0 },
+      { recipient: eik, keyGeneration: 1 },
+    ])
+  })
+
+  it("does not re-flag an older generation the live EIK already holds", () => {
+    const missing = computeMissingActorWraps({
+      currentKeyGeneration: 1,
+      wraps: [wrap(0, "eik_fresh", "enclave"), wrap(1, "eik_fresh", "enclave")],
+      liveActorRecipients: [eik],
+    })
+    expect(missing).toEqual([])
+  })
+
+  it("tolerates a backend that omits liveActorRecipients", () => {
+    expect(computeMissingActorWraps({ currentKeyGeneration: 0, wraps: [], liveActorRecipients: undefined })).toEqual([])
+  })
+})
+
 describe("reviveStaleActorWraps", () => {
   it("re-wraps the current SSK to a live actor key that is missing its wrap (enclave restart)", async () => {
     const owner = await generateUIK()
@@ -301,7 +372,9 @@ describe("reviveStaleActorWraps", () => {
     const owner = await generateUIK()
     vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
       currentKeyGeneration: 0,
-      wraps: [{ keyGeneration: 0, recipientKeyId: "eik_live", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" }],
+      wraps: [
+        { keyGeneration: 0, recipientKeyId: "eik_live", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+      ],
       ownerUserId: "user_owner",
       liveActorRecipients: [{ recipientKeyId: "eik_live", recipientKind: "enclave", publicKey: "AA==" }],
     })
@@ -317,6 +390,80 @@ describe("reviveStaleActorWraps", () => {
 
     expect(result).toBe("none-missing")
     expect(revive).not.toHaveBeenCalled()
+  })
+
+  // E2EE-7: enclave restart after a key roll — the fresh EIK needs BOTH
+  // generations back (a turn parked under generation 0 plus current sends),
+  // and a generation the owner can't open is skipped, not fatal.
+  it("re-wraps every owner-openable generation the enclave held, skipping unopenable ones", async () => {
+    const owner = await generateUIK()
+    const enclave = await generateUIK()
+    const sskGen0 = generateStreamKey()
+    const sskGen2 = generateStreamKey()
+    const ownerWrapGen0 = await wrapStreamKey({
+      key: sskGen0,
+      recipientPublicKey: owner.publicKey,
+      aad: buildWrapAad({ streamId: STREAM, keyGeneration: 0, recipientKeyId: KEY_ID }),
+    })
+    const ownerWrapGen2 = await wrapStreamKey({
+      key: sskGen2,
+      recipientPublicKey: owner.publicKey,
+      aad: buildWrapAad({ streamId: STREAM, keyGeneration: 2, recipientKeyId: KEY_ID }),
+    })
+    const asWire = (w: { enc: Uint8Array; ct: Uint8Array }) => ({
+      wrapEnc: bytesToBase64(w.enc),
+      wrapCt: bytesToBase64(w.ct),
+    })
+    vi.spyOn(e2eKeyWrapsApi, "get").mockResolvedValue({
+      currentKeyGeneration: 2,
+      wraps: [
+        { keyGeneration: 0, recipientKeyId: KEY_ID, recipientKind: "user", ...asWire(ownerWrapGen0) },
+        { keyGeneration: 2, recipientKeyId: KEY_ID, recipientKind: "user", ...asWire(ownerWrapGen2) },
+        // The dead EIK held generations 0, 1, and 2 — but the owner has no
+        // generation-1 wrap of its own, so that one is unopenable and skipped.
+        { keyGeneration: 0, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+        { keyGeneration: 1, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+        { keyGeneration: 2, recipientKeyId: "eik_dead", recipientKind: "enclave", wrapEnc: "ZW5j", wrapCt: "Y3Q=" },
+      ],
+      ownerUserId: "user_owner",
+      liveActorRecipients: [
+        { recipientKeyId: "eik_fresh", recipientKind: "enclave", publicKey: bytesToBase64(enclave.publicKey) },
+      ],
+    })
+    const revive = vi.spyOn(e2eKeyWrapsApi, "reviveActorWraps").mockResolvedValue(undefined)
+
+    const result = await reviveStaleActorWraps({
+      workspaceId: WS,
+      streamId: STREAM,
+      userId: "user_owner",
+      ownerKeyId: KEY_ID,
+      ownerPrivateKey: owner.privateKey,
+    })
+
+    expect(result).toBe("revived")
+    const [, , input] = revive.mock.calls[0]!
+    expect(input.keyGeneration).toBe(2)
+    expect(input.wraps.map((w) => `${w.keyGeneration}:${w.recipientKeyId}`).sort()).toEqual([
+      "0:eik_fresh",
+      "2:eik_fresh",
+    ])
+
+    // Each posted wrap must open to ITS generation's SSK under the fresh
+    // EIK's key, with the AAD bound to that generation's slot.
+    const opened = new Map<number, Uint8Array>()
+    for (const w of input.wraps) {
+      opened.set(
+        w.keyGeneration!,
+        await unwrapStreamKey({
+          enc: base64ToBytes(w.wrapEnc),
+          ct: base64ToBytes(w.wrapCt),
+          recipientPrivateKey: enclave.privateKey,
+          aad: buildWrapAad({ streamId: STREAM, keyGeneration: w.keyGeneration!, recipientKeyId: "eik_fresh" }),
+        })
+      )
+    }
+    expect(opened.get(0)).toEqual(sskGen0)
+    expect(opened.get(2)).toEqual(sskGen2)
   })
 
   it("short-circuits for a non-owner without touching the SSK", async () => {

--- a/apps/frontend/src/lib/crypto/stream-key-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-key-cache.ts
@@ -6,7 +6,7 @@ import {
   unwrapStreamKey,
   wrapStreamKey,
 } from "@threa/crypto"
-import type { E2eKeyRollRecipient } from "@threa/types"
+import type { E2eKeyRollRecipient, E2eKeyWrapsResponse } from "@threa/types"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
 
 /**
@@ -178,22 +178,79 @@ export interface ReviveActorWrapsInput {
 
 export type ReviveActorWrapsResult = "revived" | "none-missing" | "not-owner" | "no-key"
 
+/** One (live actor key, generation) slot whose SSK wrap is missing. */
+export interface MissingActorWrap {
+  recipient: E2eKeyRollRecipient
+  keyGeneration: number
+}
+
+/**
+ * Which wrap slots a revive must fill, from one key-wraps fetch. Every live
+ * actor key needs the current generation (the classic enclave-restart heal).
+ * Enclave recipients additionally need every older generation some enclave
+ * wrap already exists at: the enclave is a singleton actor, so a prior
+ * enclave wrap at a generation proves the actor held it — and a restart
+ * orphans ALL of its generations, not just the current one. Healing only the
+ * current generation leaves a turn parked under a pre-roll generation
+ * stranded until DLQ (E2EE-7), and old sealed history and turn digests
+ * unreadable. Bots stay current-only: their wraps carry no per-bot identity,
+ * so older generations can't be attributed to the specific bot that held
+ * them (the server rejects the attempt).
+ *
+ * Shared by the revive itself and the affordance probe that decides whether
+ * to fire it, so "is anything missing" can't drift from "what gets healed".
+ */
+export function computeMissingActorWraps(
+  data: Pick<E2eKeyWrapsResponse, "currentKeyGeneration" | "wraps"> & {
+    /** `undefined` tolerates a not-yet-redeployed backend that omits the field. */
+    liveActorRecipients: E2eKeyRollRecipient[] | undefined
+  }
+): MissingActorWrap[] {
+  const { currentKeyGeneration, wraps } = data
+  const hasWrap = (recipientKeyId: string, keyGeneration: number) =>
+    wraps.some((w) => w.keyGeneration === keyGeneration && w.recipientKeyId === recipientKeyId)
+  const enclaveHeldGenerations = [
+    ...new Set(
+      wraps
+        .filter((w) => w.recipientKind === "enclave" && w.keyGeneration < currentKeyGeneration)
+        .map((w) => w.keyGeneration)
+    ),
+  ]
+
+  const missing: MissingActorWrap[] = []
+  for (const recipient of data.liveActorRecipients ?? []) {
+    if (!hasWrap(recipient.recipientKeyId, currentKeyGeneration)) {
+      missing.push({ recipient, keyGeneration: currentKeyGeneration })
+    }
+    if (recipient.recipientKind !== "enclave") continue
+    for (const keyGeneration of enclaveHeldGenerations) {
+      if (!hasWrap(recipient.recipientKeyId, keyGeneration)) {
+        missing.push({ recipient, keyGeneration })
+      }
+    }
+  }
+  return missing
+}
+
 /** De-dupes concurrent revives per stream (header probe + send firing together). */
 const reviveInflight = new Map<string, Promise<ReviveActorWrapsResult>>()
 
 /**
- * Re-wrap the *current* SSK to invited actors' live keys that are missing a
- * wrap at the current generation — the heal for an enclave restart, whose
- * fresh EIK orphans every stream wrapped to its predecessor (parking enclave
- * turns server-side until this runs). Unlike `rekeyStream`, no fresh SSK and
- * no generation bump: the actor already held this generation, so the new
- * instance gets exactly the prior access — and a parked turn (sealed under
- * the current generation) stays decryptable, which a roll would strand.
+ * Re-wrap already-granted SSK generations to invited actors' live keys that
+ * are missing their wrap — the heal for an enclave restart, whose fresh EIK
+ * orphans every stream wrapped to its predecessor (parking enclave turns
+ * server-side until this runs). Unlike `rekeyStream`, no fresh SSK and no
+ * generation bump: the actor already held these generations, so the new
+ * instance gets exactly the prior access — and a parked turn stays
+ * decryptable, which a roll would strand. `computeMissingActorWraps` decides
+ * the slots; every generation the owner can open is re-wrapped, and one it
+ * can't is skipped rather than failing the rest.
  *
  * Owner-only (the server enforces it; `"not-owner"` short-circuits everyone
  * else). Returns `"none-missing"` when every live actor key already has its
- * wrap, `"no-key"` when the owner's own wrap can't be recovered (nothing to
- * re-wrap), `"revived"` after storing the missing wraps.
+ * wraps, `"no-key"` when no missing generation's SSK can be recovered from
+ * the owner's own wraps (nothing to re-wrap), `"revived"` after storing the
+ * missing wraps.
  */
 export async function reviveStaleActorWraps(input: ReviveActorWrapsInput): Promise<ReviveActorWrapsResult> {
   const slot = streamSlot(input.workspaceId, input.streamId)
@@ -210,45 +267,42 @@ export async function reviveStaleActorWraps(input: ReviveActorWrapsInput): Promi
 async function doReviveStaleActorWraps(input: ReviveActorWrapsInput): Promise<ReviveActorWrapsResult> {
   // Always a fresh fetch: the point is to see an EIK that registered after
   // whatever the UI has cached.
-  const { currentKeyGeneration, wraps, liveActorRecipients, ownerUserId } = await e2eKeyWrapsApi.get(
-    input.workspaceId,
-    input.streamId
-  )
+  const data = await e2eKeyWrapsApi.get(input.workspaceId, input.streamId)
+  const { currentKeyGeneration, ownerUserId } = data
   currentGenerations.set(streamSlot(input.workspaceId, input.streamId), currentKeyGeneration)
 
   if (ownerUserId !== input.userId) return "not-owner"
 
-  // `?? []` tolerates a not-yet-redeployed backend that omits the field.
-  const missing = (liveActorRecipients ?? []).filter(
-    (r) => !wraps.some((w) => w.keyGeneration === currentKeyGeneration && w.recipientKeyId === r.recipientKeyId)
-  )
+  const missing = computeMissingActorWraps(data)
   if (missing.length === 0) return "none-missing"
 
-  // At send time the seal path has already cached this generation's SSK, so
-  // this is normally a cache hit; on a cold open it unwraps the owner's slot.
-  const ssk = await resolveStreamKey({
-    workspaceId: input.workspaceId,
-    streamId: input.streamId,
-    keyGeneration: currentKeyGeneration,
-    recipientKeyId: input.ownerKeyId,
-    privateKey: input.ownerPrivateKey,
-  })
-  if (!ssk) return "no-key"
+  // Recover each missing generation's SSK from the owner's own wrap in the
+  // response we already hold (at send time the current generation is normally
+  // already cached). A generation the owner can't open — no owner wrap, or an
+  // unwrap failure — is skipped so it can't block healing the rest.
+  const sskByGeneration = new Map<number, Uint8Array>()
+  for (const keyGeneration of new Set(missing.map((m) => m.keyGeneration))) {
+    const ssk = await unwrapOwnerGeneration(input, data, keyGeneration)
+    if (ssk) sskByGeneration.set(keyGeneration, ssk)
+  }
+  const wrappable = missing.filter((m) => sskByGeneration.has(m.keyGeneration))
+  if (wrappable.length === 0) return "no-key"
 
   const rewraps = await Promise.all(
-    missing.map(async (r) => {
+    wrappable.map(async ({ recipient, keyGeneration }) => {
       const wrap = await wrapStreamKey({
-        key: ssk,
-        recipientPublicKey: base64ToBytes(r.publicKey),
+        key: sskByGeneration.get(keyGeneration)!,
+        recipientPublicKey: base64ToBytes(recipient.publicKey),
         aad: buildWrapAad({
           streamId: input.streamId,
-          keyGeneration: currentKeyGeneration,
-          recipientKeyId: r.recipientKeyId,
+          keyGeneration,
+          recipientKeyId: recipient.recipientKeyId,
         }),
       })
       return {
-        recipientKeyId: r.recipientKeyId,
-        recipientKind: r.recipientKind,
+        keyGeneration,
+        recipientKeyId: recipient.recipientKeyId,
+        recipientKind: recipient.recipientKind,
         wrapEnc: bytesToBase64(wrap.enc),
         wrapCt: bytesToBase64(wrap.ct),
       }
@@ -260,6 +314,36 @@ async function doReviveStaleActorWraps(input: ReviveActorWrapsInput): Promise<Re
     wraps: rewraps,
   })
   return "revived"
+}
+
+/**
+ * Unwrap the owner's SSK for one generation from an already-fetched wrap set,
+ * serving the in-memory cache first and seeding it on success. Returns `null`
+ * (never throws) when the owner holds no wrap at the generation or the unwrap
+ * fails — revive callers treat that generation as unopenable and move on.
+ */
+async function unwrapOwnerGeneration(
+  input: ReviveActorWrapsInput,
+  data: Pick<E2eKeyWrapsResponse, "wraps">,
+  keyGeneration: number
+): Promise<Uint8Array | null> {
+  const cached = keys.get(keySlot(input.workspaceId, input.streamId, keyGeneration))
+  if (cached) return cached
+
+  const ownerWrap = data.wraps.find((w) => w.keyGeneration === keyGeneration && w.recipientKeyId === input.ownerKeyId)
+  if (!ownerWrap) return null
+  try {
+    const key = await unwrapStreamKey({
+      enc: base64ToBytes(ownerWrap.wrapEnc),
+      ct: base64ToBytes(ownerWrap.wrapCt),
+      recipientPrivateKey: input.ownerPrivateKey,
+      aad: buildWrapAad({ streamId: input.streamId, keyGeneration, recipientKeyId: input.ownerKeyId }),
+    })
+    keys.set(keySlot(input.workspaceId, input.streamId, keyGeneration), key)
+    return key
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -751,7 +751,9 @@ ship earlier as the UX-12 fix without inverting turn start.
    the former; read-path simplicity suggests the latter.
 4. **`sources: []` willful defeat** (prior doc's spike #3): add the test that
    a turn whose tool results carried sources commits non-empty sources, so the
-   required-field guarantee isn't quietly defeated.
+   required-field guarantee isn't quietly defeated. _Resolved: the test
+   shipped with #818 (`agent-runtime.test.ts`, "AgentRuntime source
+   commitment")._
 5. **Digest authorship and trust (C-1):** the turn digest is model-generated
    text that future turns treat as ground truth. Does it need the same
    trust-boundary wrap as tool output, and should the trace UI render it so
@@ -760,7 +762,13 @@ ship earlier as the UX-12 fix without inverting turn start.
    sealed under generation N must be re-wrapped or rebuilt when the stream
    key rolls, or it becomes the same stranded-data class as parked turns.
    Decide: re-wrap on revive (preferred) or rebuild from scratch on
-   generation mismatch.
+   generation mismatch. _Resolved as re-wrap on revive: the actor-wrap revive
+   path re-wraps every owner-openable generation the enclave already held
+   (proven by a prior enclave wrap row at that generation; bots stay
+   current-only — no per-bot generation attribution), so a parked turn, old
+   sealed history, and turn digests survive an enclave restart that follows a
+   key roll (E2EE-7). Sealed rolling summaries don't exist yet; when they do,
+   the same generation wraps cover them._
 7. **Where does the budgeted window live for mentions/channels?** Scratchpads
    want deep continuity; a channel mention probably still wants the shallow
    window. The `ContextWindowPolicy` should be per-trigger-kind (deep for

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -447,6 +447,19 @@ complete.**
 | 1.3 | Per-tool `promptBlock` + `categories` on `AgentToolConfig`; both assemblers become data-driven                                                                             | toolset/prompt drift |
 | 1.4 | Generalize `allowed_tool_categories` to all streams; `negotiateCapabilities` enforces it via `isToolAllowedByPolicy` for companion + enclave                               | #8, N-1              |
 
+**Phase 1 status (verified on `main`, 2026-06-12):** complete. 1.1 — shared
+`TraceProjector` with injected sinks for all three surfaces (#838). 1.2 —
+`AgentRuntime` emits `context:received` at run start from `initialContext`;
+`EnclaveTraceObserver.emitContext` deleted; reply-only bot invocations get a
+reconstructed `context_received` + `message_sent` trace written through the
+projector in the `/complete` transaction (#841). 1.3 — per-tool `promptBlock`
+
+- `categories` on `AgentToolConfig`, both hosts assemble tool prose via
+  `buildToolPromptSections` over the real toolset (#845). 1.4 — `stream_policies`
+  table generalizes `allowed_tool_categories` to all streams (resolving §2.8 Q3
+  as the tracking-table option); `negotiateCapabilities` folds the policy over
+  companion and enclave toolsets identically (#847).
+
 **Phase 2 — The contract**
 
 | #   | Change                                                                                                                                           | Closes                               |
@@ -455,6 +468,23 @@ complete.**
 | 2.2 | `EnclaveTurnDriver` over the existing HTTP callbacks; interjection implemented-or-declared                                                       | UX-12                                |
 | 2.3 | `ExternalTurnDriver` wraps claim/complete; `bot:hello` manifest; `/complete` sources; context handle; reject-undeclared at boundary              | N-4, N-5, external parallel universe |
 | 2.4 | Trust-tier rule in `negotiateCapabilities` replaces scattered E2E guards; per-runner identity + real attestation before the tier is load-bearing | E2EE-21/22 precondition              |
+
+**Phase 2 status (verified on `main`, 2026-06-12):** complete. 2.1 —
+`TurnDriver`/`TurnSink`/`TurnRequest` spine, companion on
+`InProcessTurnDriver` (#848). 2.2 — `EnclaveTurnDriver` runs the sealed loop
+through the turn contract; interjection resolved as `declaredUnsupported`
+(renderable, not silent — §2.8 Q1's "declare" half; implementation remains
+the §2.7 observation-1 option) (#853). 2.3 — `/complete` accepts `sources`
+(#861), `bot:hello` output manifest + reject-undeclared at the verb boundary
+(#865), `ExternalTurnDriver` + synchronous/dispatched interface split (#870),
+inline context handle on the claim response (#871). 2.4 — trust tiers +
+delivery-verdict gate and session-bound enclave callbacks (#882, token
+requirement flipped on in #899), dedicated enclave credential +
+wrap-eligibility boundary (#889); real TEE attestation remains the documented
+upgrade path. **The §2.4 migration plan is fully shipped.** Remaining from
+this doc: the §2.7 transport inversion (and/or its standalone interjection
+poll), the deliberately-deferred items below, and the unresolved §2.8
+questions.
 
 **Deferred deliberately (INV-36):** a published versioned wire contract
 (`taipVersion`) until the first non-Threa harness we don't control ships;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -454,21 +454,26 @@ export interface E2eKeyRollInput {
 }
 
 /**
- * Body for `POST …/e2e/actor-key-wraps`: re-wraps of the *current* SSK to
- * invited actors' live keys that are missing a wrap at that generation —
+ * Body for `POST …/e2e/actor-key-wraps`: re-wraps of already-granted SSK
+ * generations to invited actors' live keys that are missing their wrap —
  * the revive path for an actor whose key changed after the invite (an
  * enclave restart mints a fresh EIK, orphaning every stream wrapped to the
  * old one). Unlike a key roll, no fresh SSK is minted and the generation
- * does not advance: the actor was already granted this generation, so
- * re-addressing the same key to its new instance preserves exactly the
- * prior access — and keeps a pending turn (sealed under the current
- * generation) decryptable, which a roll would strand. `keyGeneration` must
- * equal the stream's current generation; recipients must be live keys of
- * currently-invited actors (never `user` wraps).
+ * does not advance: the actor was already granted these generations, so
+ * re-addressing the same keys to its new instance preserves exactly the
+ * prior access — and keeps a pending turn decryptable, which a roll would
+ * strand. The top-level `keyGeneration` must equal the stream's current
+ * generation (the client's freshness assertion); each wrap defaults to it.
+ * A wrap may name an older generation only for the enclave actor (a
+ * singleton, so any prior enclave wrap at that generation proves the actor
+ * held it) — re-wrapping every generation the owner can open is what
+ * un-strands a parked turn, sealed history, and turn digests after an
+ * enclave restart that follows a key roll (E2EE-7). Recipients must be
+ * live keys of currently-invited actors (never `user` wraps).
  */
 export interface E2eActorRewrapInput {
   keyGeneration: number
-  wraps: E2eKeyWrapInput[]
+  wraps: (E2eKeyWrapInput & { keyGeneration?: number })[]
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Closes **E2EE-7** from the enclave audit (`docs/audits/e2ee-enclave-audit-2026-06.md`) and resolves the agent-runtimes redesign's §2.8 Q6 as **re-wrap on revive**.

A parked enclave turn sealed under a **pre-roll** key generation could never revive. Dispatch (`request-builder.ts:96`) requires the chosen live EIK to hold wraps for **both** the current and the trigger generation, but the actor-wrap revive path only ever re-wrapped the *current* one. So this sequence stranded the turn until DLQ:

1. Owner invites the enclave → roll to gen N (enclave wrap at gen N).
2. Owner sends a message → turn parked, sealed at gen N.
3. Owner invites a bot (or otherwise rolls) → gen N+1.
4. Enclave restarts → fresh EIK; the old EIK's wraps at gen N and N+1 are orphaned.
5. Revive re-wraps only gen N+1 to the fresh EIK. The turn parked at gen N never becomes decryptable → DLQ. Old sealed history and turn digests at gen N stay unreadable too.

## How

- **Wire + schema** (`packages/types`, `streams/handlers.ts`): `POST …/e2e/actor-key-wraps` accepts an optional per-wrap `keyGeneration` (defaulting to the top-level current-generation assertion). The top-level generation is still the client's freshness check (409 on mismatch).
- **Service** (`streams/service.ts`): older generations are **enclave-only** — the enclave is a singleton actor, so an existing enclave wrap row at a generation proves the actor held it (wraps are immutable; a dead EIK's rows remain as the record). The recipient kind is matched against the **server-resolved** live entry, so a relabeled bot key can't unlock the enclave rule. Bots stay current-only: their wraps carry no per-bot identity, and widening one bot's revive to another's history would breach the invite-time boundary `rekeyStream` documents.
- **Frontend** (`stream-key-cache.ts`): new shared `computeMissingActorWraps` is the single slot computation for both the revive itself and the header affordance probe (current-generation gaps for all actors + the enclave's already-held older generations), so "is anything missing" can't drift from "what gets healed". The revive recovers each missing generation's SSK from the owner's own wrap in the one fetch it already makes (down from two round-trips), re-wraps every generation the owner can open, and skips one it can't rather than failing the batch.

## Invariant / boundary notes

- **Invite-boundary preserved** (the load-bearing E2EE property): older generations only re-wrap for the enclave, gated on an existing enclave wrap at that generation — an actor invited at gen N still can't be granted gen <N.
- **No `user` side-door**: rejected by kind; a relabeled user key id fails the live-actor lookup.
- **Race-safe** (INV-20): advisory lock serializes with rolls; `e2e` and the held-generations snapshot are read post-lock; insert stays `ON CONFLICT DO NOTHING`.

Also closes §2.8 Q4 in the doc (it was already shipped by #818's source-commitment test — marked resolved, not re-implemented).

## Tests

- Backend `streams/service.test.ts` (+5): older-generation enclave revive with a proving wrap; rejection when no enclave wrap ever existed at that generation; bot older-generation rejection; kind-mismatch rejection; above-current rejection.
- Frontend `stream-key-cache.test.ts` (+6): `computeMissingActorWraps` unit cases (enclave older generations flagged, bots never, owner-user wraps not counted) and a full-HPKE multi-generation revive that opens each posted wrap under its generation's SSK and skips an unopenable generation.
- Full monorepo lint + typecheck green (pre-commit); `bun test` across streams / e2e-streams / enclave-runtimes (185) and frontend crypto + affordance (30) green.

<details><summary>📋 Context — agent-runtimes redesign</summary>

This branch also adds verified Phase 1/2 status notes to `docs/plans/agent-runtimes-unification-redesign.md`: both phases of the §2.4 migration plan are fully shipped on `main` (Phase 1: #838/#841/#845/#847; Phase 2: #848/#853/#861/#865/#870/#871/#882/#889/#899). What remains from that doc is the §2.7 transport inversion, the deliberately-deferred items, and the open §2.8 questions — of which this PR closes Q4 and Q6.
</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_014B8DTthgWfuetPdtbJdt7n)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783923222&installation_id=129946197&pr_number=905&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F905&signature=3c8e88f43ad4eb478c6a662edaad639813c073d9e87a27854f72d8cc3b414eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->