### PR TITLE
feat: sweep legacy unread-counter entries from sync_log

### DIFF
--- a/apps/backend/src/db/migrations/20260613083239_prune_legacy_counter_entries.sql
+++ b/apps/backend/src/db/migrations/20260613083239_prune_legacy_counter_entries.sql
@@ -1,0 +1,43 @@
+-- One-time sweep of legacy unread-counter entries from sync_log.
+-- (sync engine v2; docs/plans/sync-v2-log-retention.md, "What this unblocks".)
+--
+-- The four unread-counter events (stream:activity, stream:read, stream:read_all,
+-- activity:created) carry ABSOLUTE fields since the phase-2c backend deploy
+-- (#872). Entries written before that deploy lack those fields; catch-up replay
+-- of them is unsafe, so the client guard `isLegacyUnreadCounterEntry`
+-- (apps/frontend/src/sync/unread-counters.ts) skips them on apply and leans on
+-- the workspace bootstrap as their authority (INV-53). That guard can only be
+-- deleted once no legacy entry can reach catch-up.
+--
+-- Pure time-based retention does not get us there reliably: a quiet workspace
+-- with fewer than minKeep (2,000) lifetime sync events never trips the count
+-- floor, so its legacy rows would persist indefinitely. This sweep removes them
+-- directly, by CONTENT rather than a hardcoded deploy timestamp: it deletes
+-- exactly the rows the guard already skips (the same per-type absent-field
+-- predicate, mirrored in SQL), so it can never touch a valid post-#872 row.
+--
+-- Safety: the guard is client-side and the workspace sync cursor advances to
+-- head with no per-sync_id contiguity check (contiguity is a separate
+-- per-stream broadcastSequence mechanism, INV-61). Deleting a legacy row is
+-- therefore identical to the client skipping it — surviving entries still apply
+-- and the cursor still climbs to head. The deleted set is SPARSE (legacy
+-- counter rows interleaved among non-counter rows), so `retained_from` is
+-- deliberately NOT advanced: advancing the floor past surviving lower-id rows
+-- would falsely mark them pruned and force needless bootstraps. A sparse
+-- removal of skipped-anyway rows opens no gap, so no floor signal is owed.
+--
+-- Idempotent: re-running finds no legacy rows. No FKs (INV-1); workspace-scoped
+-- by table (INV-8). Runs before the server accepts connections, so no outbox
+-- events are emitted.
+
+DELETE FROM sync_log
+WHERE
+  (event_type = 'stream:activity'
+    AND jsonb_typeof(payload -> 'messageOrdinal') IS DISTINCT FROM 'number')
+  OR (event_type = 'stream:read'
+    AND jsonb_typeof(payload -> 'lastReadOrdinal') IS DISTINCT FROM 'number')
+  OR (event_type = 'stream:read_all'
+    AND jsonb_typeof(payload -> 'reads') IS DISTINCT FROM 'array')
+  OR (event_type = 'activity:created'
+    AND (jsonb_typeof(payload -> 'counts' -> 'mentionCount') IS DISTINCT FROM 'number'
+      OR jsonb_typeof(payload -> 'counts' -> 'activityCount') IS DISTINCT FROM 'number'));

--- a/apps/backend/tests/integration/prune-legacy-counter-entries.test.ts
+++ b/apps/backend/tests/integration/prune-legacy-counter-entries.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import path from "path"
+import { setupTestDatabase } from "./setup"
+import { SyncLogRepository, type SyncLogEntryInput } from "../../src/features/sync"
+
+// Exercises the real migration artifact (the same SQL that ships) against
+// seeded sync_log rows: the content-based sweep must delete exactly the legacy
+// counter entries the client guard `isLegacyUnreadCounterEntry` skips, leave
+// every non-legacy and non-counter row intact, and never advance the retention
+// floor (the deleted set is sparse, so a floor advance would falsely mark
+// surviving lower-id rows as pruned).
+const MIGRATION_PATH = path.join(
+  import.meta.dir,
+  "../../src/db/migrations/20260613083239_prune_legacy_counter_entries.sql"
+)
+
+describe("prune_legacy_counter_entries migration", () => {
+  let pool: Pool
+  let migrationSql: string
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    migrationSql = await Bun.file(MIGRATION_PATH).text()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  function uniqueId(prefix: string): string {
+    return `${prefix}_${crypto.randomUUID().replaceAll("-", "").slice(0, 20)}`
+  }
+
+  async function reserveOutboxIds(count: number): Promise<bigint[]> {
+    const result = await pool.query<{ id: string }>(
+      `SELECT nextval('outbox_id_seq') AS id FROM generate_series(1, $1)`,
+      [count]
+    )
+    return result.rows.map((r) => BigInt(r.id))
+  }
+
+  async function append(
+    workspaceId: string,
+    entries: Array<Omit<SyncLogEntryInput, "outboxEventId">>
+  ): Promise<bigint[]> {
+    const outboxIds = await reserveOutboxIds(entries.length)
+    const withIds = entries.map((e, i) => ({ ...e, outboxEventId: outboxIds[i] }))
+    const assigned = await SyncLogRepository.appendForWorkspace(pool, workspaceId, withIds)
+    return outboxIds.map((id) => assigned.get(id)!)
+  }
+
+  async function survivingSyncIds(workspaceId: string): Promise<Set<string>> {
+    const result = await pool.query<{ sync_id: string }>(
+      `SELECT sync_id FROM sync_log WHERE workspace_id = $1 ORDER BY sync_id`,
+      [workspaceId]
+    )
+    return new Set(result.rows.map((r) => r.sync_id))
+  }
+
+  test("deletes only field-less counter entries, keeps survivors and floor", async () => {
+    const workspaceId = uniqueId("ws")
+    const streamId = uniqueId("stream")
+    const group = `stream:${streamId}`
+
+    // Legacy: the four counter types missing their absolute fields (and a
+    // wrong-typed variant), exactly what isLegacyUnreadCounterEntry returns true on.
+    const legacyIds = await append(workspaceId, [
+      { eventType: "stream:activity", groups: [group], payload: { streamId } },
+      { eventType: "stream:activity", groups: [group], payload: { streamId, messageOrdinal: "5" } },
+      { eventType: "stream:read", groups: [group], payload: { streamId } },
+      { eventType: "stream:read_all", groups: [group], payload: {} },
+      { eventType: "activity:created", groups: [group], payload: { streamId } },
+      { eventType: "activity:created", groups: [group], payload: { streamId, counts: { mentionCount: 1 } } },
+    ])
+
+    // Survivors: non-legacy counter entries (absolute fields present) plus a
+    // non-counter entry, all interleaved so the deleted set is sparse.
+    const survivorIds = await append(workspaceId, [
+      { eventType: "stream:activity", groups: [group], payload: { streamId, messageOrdinal: 5 } },
+      { eventType: "stream:read", groups: [group], payload: { streamId, lastReadOrdinal: 3 } },
+      {
+        eventType: "stream:read_all",
+        groups: [group],
+        payload: { reads: [{ streamId, lastReadOrdinal: 2 }] },
+      },
+      {
+        eventType: "activity:created",
+        groups: [group],
+        payload: { streamId, counts: { mentionCount: 1, activityCount: 2 } },
+      },
+      { eventType: "message:created", groups: [group], payload: { messageId: uniqueId("msg") } },
+    ])
+
+    // Seed a retention floor to prove the sweep leaves it untouched.
+    await pool.query(`INSERT INTO sync_log_retention_state (workspace_id, retained_from) VALUES ($1, $2)`, [
+      workspaceId,
+      "7",
+    ])
+
+    await pool.query(migrationSql)
+
+    const surviving = await survivingSyncIds(workspaceId)
+    for (const id of legacyIds) {
+      expect(surviving.has(id.toString())).toBe(false)
+    }
+    for (const id of survivorIds) {
+      expect(surviving.has(id.toString())).toBe(true)
+    }
+
+    const floor = await pool.query<{ retained_from: string }>(
+      `SELECT retained_from FROM sync_log_retention_state WHERE workspace_id = $1`,
+      [workspaceId]
+    )
+    expect(floor.rows[0].retained_from).toBe("7")
+  })
+
+  test("is idempotent — a second run deletes nothing", async () => {
+    const workspaceId = uniqueId("ws")
+    const streamId = uniqueId("stream")
+    const group = `stream:${streamId}`
+
+    await append(workspaceId, [
+      { eventType: "stream:activity", groups: [group], payload: { streamId } },
+      { eventType: "stream:activity", groups: [group], payload: { streamId, messageOrdinal: 9 } },
+    ])
+
+    await pool.query(migrationSql)
+    const afterFirst = await survivingSyncIds(workspaceId)
+    await pool.query(migrationSql)
+    const afterSecond = await survivingSyncIds(workspaceId)
+
+    expect([...afterSecond].sort()).toEqual([...afterFirst].sort())
+    expect(afterSecond.size).toBe(1)
+  })
+})

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -18,9 +18,13 @@ the rollout sessions:
   30-day horizon (keeping a per-workspace recent floor) and catch-up returns
   `requiresBootstrap` for cursors below the pruned floor, so the big deletions
   (reconnect-bootstrap slimming, `usePageResumeRefresh`) lose their retention
-  blocker — they still each ship as their own PR with a coverage proof, and
-  `isLegacyUnreadCounterEntry` dies only once pre-field entries age out below
-  the floor.
+  blocker — they still each ship as their own PR with a coverage proof.
+  `isLegacyUnreadCounterEntry` dies in two steps: a one-time content-based sweep
+  migration (`20260613083239_prune_legacy_counter_entries.sql`) removes the
+  legacy entries the guard skips — by content, not a hardcoded boundary, because
+  pure time+count retention leaves a quiet workspace's legacy rows in place
+  indefinitely (its history never exceeds the `minKeep` floor) — and then a
+  follow-up PR deletes the guard once the sweep has deployed to prod.
 - Coverage proof method (established in #885): event type → scoping list in
   `apps/backend/src/lib/outbox/repository.ts` → delivery group
   (`delivery-groups.ts`, single source of truth for log + emit) → `sync_log`

--- a/docs/plans/sync-v2-log-retention.md
+++ b/docs/plans/sync-v2-log-retention.md
@@ -127,9 +127,25 @@ authority the inventory keeps for the below-floor case.
 
 ## What this unblocks (NOT in this PR)
 
-- **`isLegacyUnreadCounterEntry`** can die once pre-field entries age out below
-  the 30-day floor — a follow-up PR (and its own coverage proof) per the
-  inventory's one-deletion-per-PR rule.
+- **`isLegacyUnreadCounterEntry`** can die once no legacy entry can reach
+  catch-up. Waiting for the 30-day floor does NOT get us there reliably: a quiet
+  workspace with fewer than `minKeep` (2,000) lifetime sync events never trips
+  the count floor (`head - minKeep` is negative), so its legacy rows would
+  persist indefinitely and the guard could never be deleted by waiting. Instead,
+  a one-time **content-based sweep migration**
+  (`20260613083239_prune_legacy_counter_entries.sql`) deletes exactly the rows
+  the guard skips — the same per-type absent-field predicate, mirrored in SQL —
+  by content, not a hardcoded deploy timestamp. It deliberately does NOT advance
+  `retained_from`: the legacy set is sparse (counter rows interleaved among
+  non-counter rows), so a floor advance would falsely mark surviving lower-id
+  rows as pruned and force needless bootstraps. Safe because the guard is
+  client-side and the workspace cursor advances to head with no per-sync_id
+  contiguity check (INV-61 contiguity is per-stream `broadcastSequence`), so
+  deleting a skipped-anyway row opens no gap. Deleting the guard itself is a
+  separate follow-up PR, sequenced AFTER the sweep deploys to prod (the sweep
+  runs at backend startup before serving, so once deployed every backend is
+  legacy-free; removing the guard before then would let a pre-sweep backend feed
+  field-less payloads to the appliers).
 - **Engine reconnect-bootstrap slimming** and the **`usePageResumeRefresh`
   redesign** lose their "retention is still missing" blocker; they remain their
   own follow-ups.


### PR DESCRIPTION
## What

A one-time, content-based data migration that deletes the legacy unread-counter
entries from `sync_log` — the rows the client guard
`isLegacyUnreadCounterEntry` (`apps/frontend/src/sync/unread-counters.ts`)
currently skips on catch-up.

This is **PR 1 of 2**. It unblocks deleting the guard itself, which follows as a
separate PR once this sweep has deployed to prod.

## Why

The four unread-counter events (`stream:activity`, `stream:read`,
`stream:read_all`, `activity:created`) carry absolute fields since the phase-2c
backend deploy (#872). Entries written before it lack those fields; catch-up
replay of them is unsafe, so the client guard skips them and leans on the
workspace bootstrap as their authority (INV-53). The guard can only die once no
legacy entry can reach catch-up.

**Pure time+count retention (#907) never reliably gets us there:** a quiet
workspace with fewer than `minKeep` (2,000) lifetime sync events never trips the
count floor (`head − minKeep` is negative), so its legacy rows would persist
*indefinitely* and the guard could never be deleted by waiting.

## How

`20260613083239_prune_legacy_counter_entries.sql` deletes exactly the rows the
guard skips, using the **same per-type absent-field predicate, mirrored in
SQL** — keyed on payload **content**, not a hardcoded deploy timestamp, so it
can never touch a valid post-#872 row.

## Design decisions

- **Content-based, not timestamp-based.** No hardcoded boundary; the predicate
  mirrors `isLegacyUnreadCounterEntry` exactly (`jsonb_typeof(...) IS DISTINCT
  FROM 'number'/'array'`), so it deletes precisely what the guard skips.
- **A migration, not a worker + marker table.** Run-once-then-inert is free from
  the migrator; no throwaway-table/second-deploy-removal machinery needed.
  Matches existing one-time data migrations (`backfill_system_streams`,
  `fix_persona_model`).
- **Does NOT advance `retained_from`.** The legacy set is *sparse* (counter rows
  interleaved among non-counter rows). Advancing the floor to the max deleted id
  would falsely mark surviving lower-id rows as pruned and force needless
  bootstraps. Retention's floor is for its contiguous time-prefix; a sparse
  removal owes no floor signal.

## Safety

The guard is **client-side** (`sync-engine.ts:1113`) and the workspace sync
cursor advances to `head` with **no per-sync_id contiguity check** (INV-61
contiguity is a separate per-stream `broadcastSequence` mechanism). So deleting a
legacy row server-side is byte-for-byte equivalent to the client skipping it:
surviving entries still apply, the cursor still climbs to `head`, and the deleted
row opens no gap. Idempotent; runs before the server accepts connections.

## Sequencing

PR 2 (deleting `isLegacyUnreadCounterEntry` + its sync-engine call sites) is safe
only **after this sweep deploys to prod** — the migration runs at backend startup
before serving, so once deployed every backend is legacy-free. Removing the guard
before then would let a pre-sweep backend feed field-less payloads to the
appliers.

## Testing

`apps/backend/tests/integration/prune-legacy-counter-entries.test.ts` runs the
**actual shipped migration SQL** (read from the file — no duplication) against
seeded legacy / survivor / non-counter rows, asserting only legacy rows are
deleted, survivors + non-counter rows remain, and `retained_from` is untouched.
Plus an idempotency case. (Live-DB integration suite is CI-only; verified here by
typecheck + reasoning.)

<details>
<summary>📋 Full implementation plan</summary>

See `docs/plans/sync-v2-log-retention.md` ("What this unblocks") and
`docs/plans/sync-v2-healing-deletion-inventory.md` (ground rules), both updated
in this PR.

Approach: one-time content-based sweep migration removes the legacy entries the
guard skips (by content, because pure retention leaves a quiet workspace's legacy
rows in place forever), then a follow-up PR deletes the guard once the sweep has
deployed. No floor advance (sparse set). Tested against the real migration SQL in
the live-DB integration harness.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7rV7XXFhxzS7QAZMCaByJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783932268&installation_id=129946197&pr_number=908&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F908&signature=d6dfa8dd7d5d858b94144dacf61fe4de105f857d3a1e5635c210eaad582e0ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->