### PR TITLE
fix: guard enclave numeric env vars and cap per-instance turn concurrency (agent-runtimes §2.7)

### DIFF
--- a/apps/enclave/README.md
+++ b/apps/enclave/README.md
@@ -65,15 +65,16 @@ What the enclave does not do:
 
 ## Environment
 
-| Variable                         | Required             | Purpose                                                                                                                                                                                  |
-| -------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                           | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation` (read-only metadata — there are no content routes).                                                                                |
-| `BACKEND_BASE_URL`               | yes                  | Regional backend base URL — target for register/heartbeat/revoke, the claim poll, and the per-session heartbeat/messages/complete/fail callbacks.                                        |
-| `ENCLAVE_INTERNAL_API_KEY`       | yes                  | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY` and must NOT equal the shared `INTERNAL_API_KEY`. |
-| `OPENROUTER_API_KEY`             | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                                                |
-| `OPENROUTER_BASE_URL`            | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                                                   |
-| `ENCLAVE_HEARTBEAT_INTERVAL_MS`  | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                                                          |
-| `ENCLAVE_CLAIM_POLL_INTERVAL_MS` | no (default `1500`)  | Idle claim-poll interval — the turn-start latency floor when no work is flowing (a win re-polls immediately).                                                                            |
+| Variable                          | Required             | Purpose                                                                                                                                                                                  |
+| --------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                            | no (default `3011`)  | Listen port for `/pubkey`, `/healthz`, `/attestation` (read-only metadata — there are no content routes).                                                                                |
+| `BACKEND_BASE_URL`                | yes                  | Regional backend base URL — target for register/heartbeat/revoke, the claim poll, and the per-session heartbeat/messages/complete/fail callbacks.                                        |
+| `ENCLAVE_INTERNAL_API_KEY`        | yes                  | Dedicated secret for the enclave↔backend channel (`/internal/enclave-runtimes/*`). Must match the backend's `ENCLAVE_INTERNAL_API_KEY` and must NOT equal the shared `INTERNAL_API_KEY`. |
+| `OPENROUTER_API_KEY`              | yes                  | The enclave's only outbound LLM credential; calls OpenRouter with zero-retention routing.                                                                                                |
+| `OPENROUTER_BASE_URL`             | no                   | Override OpenRouter base URL (default `https://openrouter.ai/api/v1`).                                                                                                                   |
+| `ENCLAVE_HEARTBEAT_INTERVAL_MS`   | no (default `30000`) | Heartbeat cadence; the backend's staleness window is 2 minutes.                                                                                                                          |
+| `ENCLAVE_CLAIM_POLL_INTERVAL_MS`  | no (default `1500`)  | Idle claim-poll interval — the turn-start latency floor when no work is flowing (a win re-polls immediately).                                                                            |
+| `ENCLAVE_MAX_CONCURRENT_SESSIONS` | no (default `8`)     | Per-instance ceiling on concurrently-running turns. At capacity the claim loop stops claiming until a turn settles, bounding per-box memory and OpenRouter spend. Scale with replicas.   |
 
 ## Egress allow-list (operational)
 

--- a/apps/enclave/src/claim-loop.test.ts
+++ b/apps/enclave/src/claim-loop.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { INTERNAL_API_KEY_HEADER } from "@threa/types"
 import type { EnclaveConfig } from "./config"
 import type { EnclaveKeyPair } from "./keystore"
-import { claimOnce } from "./claim-loop"
+import { claimOnce, startClaimLoop } from "./claim-loop"
 
 const config: EnclaveConfig = {
   port: 3011,
@@ -57,6 +57,7 @@ function stubFetch(captured: Captured, status: number, body?: unknown): void {
 afterEach(() => {
   globalThis.fetch = originalFetch
   vi.restoreAllMocks()
+  vi.useRealTimers()
 })
 
 describe("claimOnce", () => {
@@ -130,23 +131,20 @@ describe("claimOnce", () => {
   })
 
   it("does not claim at the per-instance concurrency ceiling, leaving the turn for a free slot", async () => {
-    const captured: Captured = { url: null, headers: null, body: null }
     const fetchSpy = vi.fn(async () => new Response(null, { status: 204 }))
     globalThis.fetch = fetchSpy as unknown as typeof fetch
     const runSession = vi.fn(async () => {})
-    const atCapacity = new Set(["session_a", "session_b"])
 
     const result = await claimOnce({
       config: { ...config, maxConcurrentSessions: 2 },
       keyPair,
-      inFlight: atCapacity,
+      inFlight: new Set(["session_a", "session_b"]),
       runSession,
     })
 
     expect(result.claimed).toBe(false)
     expect(fetchSpy).not.toHaveBeenCalled()
     expect(runSession).not.toHaveBeenCalled()
-    expect(captured.url).toBeNull()
   })
 
   it("treats a tombstoned registration (404) as no work, leaving re-registration to the heartbeat", async () => {
@@ -157,5 +155,33 @@ describe("claimOnce", () => {
 
     expect(result.claimed).toBe(false)
     expect(runSession).not.toHaveBeenCalled()
+  })
+})
+
+describe("startClaimLoop", () => {
+  it("at capacity, idles for the poll interval instead of busy-spinning, then resumes when a slot frees", async () => {
+    vi.useFakeTimers()
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 204 }))
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const inFlight = new Set(["session_a", "session_b"])
+
+    const loop = startClaimLoop({
+      config: { ...config, maxConcurrentSessions: 2 },
+      keyPair,
+      inFlight,
+      runSession: vi.fn(async () => {}),
+    })
+
+    // The first tick runs on start; at capacity it must not poll, and must not
+    // hot-loop — advancing nearly a full interval still triggers no claim.
+    await vi.advanceTimersByTimeAsync(config.claimPollIntervalMs - 1)
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    // A turn settles; the next idle tick finds a free slot and claims.
+    inFlight.delete("session_a")
+    await vi.advanceTimersByTimeAsync(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    loop.stop()
   })
 })

--- a/apps/enclave/src/claim-loop.test.ts
+++ b/apps/enclave/src/claim-loop.test.ts
@@ -10,6 +10,7 @@ const config: EnclaveConfig = {
   internalApiKey: "enclave-secret",
   heartbeatIntervalMs: 30_000,
   claimPollIntervalMs: 1_500,
+  maxConcurrentSessions: 8,
   sourceCommitSha: "unknown",
   buildHash: "unknown",
   openRouterApiKey: "sk-test",
@@ -126,6 +127,26 @@ describe("claimOnce", () => {
 
     expect(result.claimed).toBe(false)
     expect(runSession).not.toHaveBeenCalled()
+  })
+
+  it("does not claim at the per-instance concurrency ceiling, leaving the turn for a free slot", async () => {
+    const captured: Captured = { url: null, headers: null, body: null }
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 204 }))
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    const runSession = vi.fn(async () => {})
+    const atCapacity = new Set(["session_a", "session_b"])
+
+    const result = await claimOnce({
+      config: { ...config, maxConcurrentSessions: 2 },
+      keyPair,
+      inFlight: atCapacity,
+      runSession,
+    })
+
+    expect(result.claimed).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(runSession).not.toHaveBeenCalled()
+    expect(captured.url).toBeNull()
   })
 
   it("treats a tombstoned registration (404) as no work, leaving re-registration to the heartbeat", async () => {

--- a/apps/enclave/src/claim-loop.ts
+++ b/apps/enclave/src/claim-loop.ts
@@ -14,8 +14,9 @@ const logger = baseLogger.child({ name: "enclave-claim-loop" })
  *
  * Pacing: a winning claim polls again immediately (drain a backlog without
  * waiting out the interval); an empty poll (204) or an error waits
- * `claimPollIntervalMs`. Sessions run detached — the loop keeps claiming
- * while turns are in flight, same concurrency the push transport allowed.
+ * `claimPollIntervalMs`. Sessions run detached — the loop keeps claiming while
+ * turns are in flight, up to `maxConcurrentSessions`; at that ceiling it stops
+ * claiming until a turn settles, bounding per-box memory and OpenRouter spend.
  */
 
 /** Claim responses carry the full assignment (inline attachment ciphertext can be tens of MB), so allow a slow transfer. */
@@ -41,6 +42,15 @@ export interface ClaimLoopDeps {
  */
 export async function claimOnce(deps: ClaimLoopDeps): Promise<{ claimed: boolean }> {
   const { config, keyPair, inFlight, runSession } = deps
+
+  // Per-instance ceiling. Turns run detached, so at capacity we stop claiming
+  // rather than pile on — each in-flight turn pins its history + inline
+  // attachment ciphertext (tens of MB) and burns OpenRouter spend. Reported as
+  // "no work won" so the loop settles to the idle interval; a settling turn
+  // frees the slot for the next poll. The loop serializes claimOnce, so this
+  // check-then-add never overshoots the cap.
+  if (inFlight.size >= config.maxConcurrentSessions) return { claimed: false }
+
   const res = await fetch(`${config.backendBaseUrl}/internal/enclave-runtimes/claims`, {
     method: "POST",
     headers: {

--- a/apps/enclave/src/claim-loop.ts
+++ b/apps/enclave/src/claim-loop.ts
@@ -47,9 +47,16 @@ export async function claimOnce(deps: ClaimLoopDeps): Promise<{ claimed: boolean
   // rather than pile on — each in-flight turn pins its history + inline
   // attachment ciphertext (tens of MB) and burns OpenRouter spend. Reported as
   // "no work won" so the loop settles to the idle interval; a settling turn
-  // frees the slot for the next poll. The loop serializes claimOnce, so this
-  // check-then-add never overshoots the cap.
-  if (inFlight.size >= config.maxConcurrentSessions) return { claimed: false }
+  // frees the slot, picked up on the next idle tick. The loop serializes
+  // claimOnce, so this check-then-add never overshoots the cap. The log keeps
+  // "throttling at capacity" distinguishable from "genuinely idle".
+  if (inFlight.size >= config.maxConcurrentSessions) {
+    logger.debug(
+      { inFlight: inFlight.size, max: config.maxConcurrentSessions },
+      "At concurrency ceiling; deferring claim to the next idle poll"
+    )
+    return { claimed: false }
+  }
 
   const res = await fetch(`${config.backendBaseUrl}/internal/enclave-runtimes/claims`, {
     method: "POST",

--- a/apps/enclave/src/config.test.ts
+++ b/apps/enclave/src/config.test.ts
@@ -30,3 +30,36 @@ describe("loadEnclaveConfig credential resolution (Phase 2.4c, E2EE-22)", () => 
     expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_INTERNAL_API_KEY")
   })
 })
+
+describe("loadEnclaveConfig numeric guards", () => {
+  function withKey() {
+    setBaseEnv()
+    process.env.ENCLAVE_INTERNAL_API_KEY = "enclave-key"
+  }
+
+  it("accepts a valid positive override", () => {
+    withKey()
+    process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "3000"
+
+    expect(loadEnclaveConfig().claimPollIntervalMs).toBe(3000)
+  })
+
+  it("falls back rather than passing a negative interval to setTimeout (hot-loop guard)", () => {
+    withKey()
+    process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "-5"
+
+    expect(loadEnclaveConfig().claimPollIntervalMs).toBe(1_500)
+  })
+
+  it("falls back on zero, non-integer, and non-numeric values", () => {
+    withKey()
+    process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS = "0"
+    process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "1.5"
+    process.env.ENCLAVE_MAX_CONCURRENT_SESSIONS = "lots"
+
+    const config = loadEnclaveConfig()
+    expect(config.heartbeatIntervalMs).toBe(30_000)
+    expect(config.claimPollIntervalMs).toBe(1_500)
+    expect(config.maxConcurrentSessions).toBe(8)
+  })
+})

--- a/apps/enclave/src/config.test.ts
+++ b/apps/enclave/src/config.test.ts
@@ -44,22 +44,38 @@ describe("loadEnclaveConfig numeric guards", () => {
     expect(loadEnclaveConfig().claimPollIntervalMs).toBe(3000)
   })
 
-  it("falls back rather than passing a negative interval to setTimeout (hot-loop guard)", () => {
+  it("uses the documented default when the var is unset", () => {
     withKey()
-    process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "-5"
+    delete process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS
 
     expect(loadEnclaveConfig().claimPollIntervalMs).toBe(1_500)
   })
 
-  it("falls back on zero, non-integer, and non-numeric values", () => {
+  it("throws rather than passing a negative interval to setTimeout (hot-loop guard)", () => {
+    withKey()
+    process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "-5"
+
+    expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_CLAIM_POLL_INTERVAL_MS")
+  })
+
+  it("throws on a zero override", () => {
     withKey()
     process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS = "0"
+
+    expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_HEARTBEAT_INTERVAL_MS")
+  })
+
+  it("throws on a non-integer override", () => {
+    withKey()
     process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS = "1.5"
+
+    expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_CLAIM_POLL_INTERVAL_MS")
+  })
+
+  it("throws on a non-numeric override", () => {
+    withKey()
     process.env.ENCLAVE_MAX_CONCURRENT_SESSIONS = "lots"
 
-    const config = loadEnclaveConfig()
-    expect(config.heartbeatIntervalMs).toBe(30_000)
-    expect(config.claimPollIntervalMs).toBe(1_500)
-    expect(config.maxConcurrentSessions).toBe(8)
+    expect(() => loadEnclaveConfig()).toThrow("ENCLAVE_MAX_CONCURRENT_SESSIONS")
   })
 })

--- a/apps/enclave/src/config.ts
+++ b/apps/enclave/src/config.ts
@@ -16,6 +16,14 @@ export interface EnclaveConfig {
    * floor when no work is flowing. A winning claim re-polls immediately.
    */
   claimPollIntervalMs: number
+  /**
+   * Per-instance ceiling on concurrently-running turns. Turns run detached, so
+   * without a cap a backlog would let one box claim unboundedly — each in-flight
+   * turn pins its history plus inline attachment ciphertext (tens of MB) in
+   * memory and burns OpenRouter spend. At capacity the claim loop stops claiming
+   * until a turn settles. Scaling stays "run more replicas".
+   */
+  maxConcurrentSessions: number
   /** Source commit the image was built from, surfaced via /attestation. */
   sourceCommitSha: string
   /** Build hash of the running image, surfaced via /attestation. */
@@ -32,6 +40,18 @@ export interface EnclaveConfig {
   tavilyApiKey?: string
 }
 
+/**
+ * Parse a positive-integer env var, falling back to `fallback` for anything
+ * that isn't one. The dangerous case is a negative interval: `Number(env) || x`
+ * passes it straight through to `setTimeout`, which clamps to 0 and turns the
+ * idle claim poll into a hot loop hammering the backend. 0/NaN/empty already
+ * fall back; this additionally rejects negatives and non-integers.
+ */
+function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  const n = Number(raw)
+  return Number.isInteger(n) && n > 0 ? n : fallback
+}
+
 export function loadEnclaveConfig(): EnclaveConfig {
   const required = ["ENCLAVE_INTERNAL_API_KEY", "BACKEND_BASE_URL", "OPENROUTER_API_KEY"]
   const missing = required.filter((k) => !process.env[k])
@@ -40,11 +60,12 @@ export function loadEnclaveConfig(): EnclaveConfig {
   }
 
   return {
-    port: Number(process.env.PORT) || 3011,
+    port: parsePositiveIntEnv(process.env.PORT, 3011),
     backendBaseUrl: process.env.BACKEND_BASE_URL!.replace(/\/$/, ""),
     internalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY!,
-    heartbeatIntervalMs: Number(process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS) || 30_000,
-    claimPollIntervalMs: Number(process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS) || 1_500,
+    heartbeatIntervalMs: parsePositiveIntEnv(process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS, 30_000),
+    claimPollIntervalMs: parsePositiveIntEnv(process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS, 1_500),
+    maxConcurrentSessions: parsePositiveIntEnv(process.env.ENCLAVE_MAX_CONCURRENT_SESSIONS, 8),
     sourceCommitSha: process.env.GIT_SHA || "unknown",
     buildHash: process.env.BUILD_HASH || "unknown",
     openRouterApiKey: process.env.OPENROUTER_API_KEY!,

--- a/apps/enclave/src/config.ts
+++ b/apps/enclave/src/config.ts
@@ -22,6 +22,10 @@ export interface EnclaveConfig {
    * turn pins its history plus inline attachment ciphertext (tens of MB) in
    * memory and burns OpenRouter spend. At capacity the claim loop stops claiming
    * until a turn settles. Scaling stays "run more replicas".
+   *
+   * Default 8 is a conservative ceiling for a small instance: at tens of MB
+   * pinned per in-flight turn, 8 keeps peak memory in the low hundreds of MB.
+   * Raise it on larger boxes; lower it under memory pressure.
    */
   maxConcurrentSessions: number
   /** Source commit the image was built from, surfaced via /attestation. */
@@ -41,15 +45,24 @@ export interface EnclaveConfig {
 }
 
 /**
- * Parse a positive-integer env var, falling back to `fallback` for anything
- * that isn't one. The dangerous case is a negative interval: `Number(env) || x`
- * passes it straight through to `setTimeout`, which clamps to 0 and turns the
- * idle claim poll into a hot loop hammering the backend. 0/NaN/empty already
- * fall back; this additionally rejects negatives and non-integers.
+ * Resolve an optional positive-integer env var. Unset (or empty) uses
+ * `fallback`; a value that is set but not a positive integer throws rather than
+ * silently degrading to the default — a malformed override is a deployment
+ * mistake the operator should see at boot, not a quietly-ignored setting
+ * (INV-11), and `loadEnclaveConfig` already throws for missing required vars.
+ *
+ * The motivating bug: `Number(env) || fallback` is truthy for a negative value,
+ * so `ENCLAVE_CLAIM_POLL_INTERVAL_MS=-5` would pass straight to setTimeout
+ * (clamped to 0) and turn the idle claim poll into a hot loop.
  */
-function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+function positiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (raw === undefined || raw === "") return fallback
   const n = Number(raw)
-  return Number.isInteger(n) && n > 0 ? n : fallback
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`${name} must be a positive integer, got: ${raw}`)
+  }
+  return n
 }
 
 export function loadEnclaveConfig(): EnclaveConfig {
@@ -60,12 +73,12 @@ export function loadEnclaveConfig(): EnclaveConfig {
   }
 
   return {
-    port: parsePositiveIntEnv(process.env.PORT, 3011),
+    port: positiveIntEnv("PORT", 3011),
     backendBaseUrl: process.env.BACKEND_BASE_URL!.replace(/\/$/, ""),
     internalApiKey: process.env.ENCLAVE_INTERNAL_API_KEY!,
-    heartbeatIntervalMs: parsePositiveIntEnv(process.env.ENCLAVE_HEARTBEAT_INTERVAL_MS, 30_000),
-    claimPollIntervalMs: parsePositiveIntEnv(process.env.ENCLAVE_CLAIM_POLL_INTERVAL_MS, 1_500),
-    maxConcurrentSessions: parsePositiveIntEnv(process.env.ENCLAVE_MAX_CONCURRENT_SESSIONS, 8),
+    heartbeatIntervalMs: positiveIntEnv("ENCLAVE_HEARTBEAT_INTERVAL_MS", 30_000),
+    claimPollIntervalMs: positiveIntEnv("ENCLAVE_CLAIM_POLL_INTERVAL_MS", 1_500),
+    maxConcurrentSessions: positiveIntEnv("ENCLAVE_MAX_CONCURRENT_SESSIONS", 8),
     sourceCommitSha: process.env.GIT_SHA || "unknown",
     buildHash: process.env.BUILD_HASH || "unknown",
     openRouterApiKey: process.env.OPENROUTER_API_KEY!,

--- a/apps/enclave/src/register.test.ts
+++ b/apps/enclave/src/register.test.ts
@@ -10,6 +10,7 @@ const config: EnclaveConfig = {
   internalApiKey: "shared-secret",
   heartbeatIntervalMs: 30_000,
   claimPollIntervalMs: 1_500,
+  maxConcurrentSessions: 8,
   sourceCommitSha: "unknown",
   buildHash: "unknown",
   openRouterApiKey: "sk-test",


### PR DESCRIPTION
Two small hardening follow-ups on the §2.7 enclave pull transport (`apps/enclave`).

## 1. Positive-integer guard for numeric env vars (`config.ts`)

The old `Number(env) || default` pattern accepted a **negative** value: it's truthy, so `ENCLAVE_CLAIM_POLL_INTERVAL_MS=-5` would pass straight to `setTimeout`, which clamps negatives to `0` and turns the idle claim poll into a hot loop hammering the backend. (`0`/`NaN`/empty already fell back safely.)

`positiveIntEnv(name, fallback)` replaces it for `PORT`, `ENCLAVE_HEARTBEAT_INTERVAL_MS`, `ENCLAVE_CLAIM_POLL_INTERVAL_MS`, and the new `ENCLAVE_MAX_CONCURRENT_SESSIONS`:

- **Unset (or empty) → documented default.**
- **Set but not a positive integer → throws at boot**, rather than silently degrading to the default. A malformed override is a deployment mistake the operator should see immediately (INV-11, fail loudly); `loadEnclaveConfig` already throws for missing required vars, so this is consistent with the existing fail-loud path. The error names the offending var.

Applied uniformly to all numeric knobs rather than just the claim-poll interval — `PORT=0` (ephemeral) isn't relied on anywhere (only read in `config.ts`; Railway injects the port).

## 2. Per-instance concurrency ceiling (`claim-loop.ts`)

Turns run detached, so the claim loop had no upper bound on concurrent turns — `inFlight.size` was limited only by available work plus the per-*stream* one-running guard, not a per-*instance* cap. Each in-flight turn pins its history plus inline attachment ciphertext (tens of MB) and burns OpenRouter spend, so an unbounded backlog let one box run away.

New `ENCLAVE_MAX_CONCURRENT_SESSIONS` (default `8`). At the top of `claimOnce`, when `inFlight.size >= maxConcurrentSessions` it returns `{ claimed: false }` (with a debug log so "throttling at capacity" is distinguishable from "genuinely idle"), so the loop settles to the idle poll interval and resumes claiming when a turn settles. The loop serializes `claimOnce`, so the check-then-add never overshoots the cap. Scaling stays "run more replicas."

## Self-review hardening (second commit)

Three review agents (correctness / spec+invariants / design) ran on the diff. Applied: the INV-11 throw-on-malformed behavior above; the capacity debug log; a sizing rationale for the default of 8; split bundled config-guard tests into distinct throw assertions; added a `startClaimLoop` fake-timer test proving at-capacity idle pacing (no busy-spin) and resume-on-free-slot; removed a dead assertion in the cap test.

## Tests

`apps/enclave`: typecheck + lint clean, **83 tests pass** (vitest). README env table updated. No DB-touching changes.

https://claude.ai/code/session_016j2RorTWfinxXKnCGTs6PY

---
_Generated by [Claude Code](https://claude.ai/code/session_016j2RorTWfinxXKnCGTs6PY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783932300&installation_id=129946197&pr_number=909&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F909&signature=d88b435e66d7d8f2c54264913975cd030776f06facbba9f6367f9fb4df92008b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->