### PR TITLE
feat: rework create-pr skill — self-review flow + Fable-style dense prose

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -5,121 +5,142 @@ description: Create a well-structured pull request with proper description, desi
 
 # Create Pull Request
 
-Create a pull request with a comprehensive description that explains the problem, solution, design decisions, and changes.
+Self-review the change, write a dense and verifiable description, open the PR, and subscribe to it. This skill bakes in the full "self-review, then create a PR, then subscribe" flow — you do not need to be asked for the review or the subscribe separately.
 
-## Instructions
+## The flow (do these in order)
 
-### 1. Gather context
+1. **Gather context** — commits, diff, ticket id, plan.
+2. **Draft the prose** — high-level but dense (see Prose style). Write the Problem / Solution / How it works / Key design decisions first, from your understanding of the change.
+3. **Self-review and verify every claim against the code** — this is the load-bearing step. Walk the diff for correctness *and* check that each factual claim in your draft is actually true of the code. Fix what you find; record the findings in the description.
+4. **Finalize the file tables and test plan** — with real, run counts.
+5. **Create the PR.**
+6. **Subscribe to PR activity.**
 
-Run these commands in parallel to understand the current state:
+The point of ordering it this way: writing the prose first forces you to state precisely what you believe the change does, and the verify pass then holds those statements against the actual code. A claim like "the prune is atomic" or "catch-up reads entries first" is both a description and a correctness assertion — verifying it catches prose drift and real bugs in the same pass. Reviewers can then trust the description to match the diff, which is the whole point.
+
+---
+
+## 1. Gather context
+
+Run in parallel:
 
 ```bash
-# Current branch
-git branch --show-current
-
-# Check if tracking remote
-git status -sb
-
-# All commits on this branch (not on main)
-git log main..HEAD --oneline
-
-# Full diff from main
-git diff main...HEAD --stat
+git branch --show-current          # current branch
+git status -sb                     # tracking + dirty state
+git log main..HEAD --oneline       # commits on this branch
+git diff main...HEAD --stat        # files touched
+git diff main...HEAD               # the actual change (read it)
 ```
 
-### 2. Extract Linear ticket ID
-
-Check the branch name for a Linear ticket ID (format: `thr-XX` or `THR-XX`):
+Extract a Linear ticket id from the branch name if present:
 
 ```bash
-# Extract ticket ID from branch name
 git branch --show-current | grep -oiE 'thr-[0-9]+' | tr '[:lower:]' '[:upper:]'
 ```
 
-If found, this ticket ID **must** be included in:
+If found, it **must** appear in the PR title (`feat(THR-19): …`) and as a link in the body. Many changes here are tracked by an audit-finding or design-doc id instead (`E2EE-22`, `agent-runtimes §2.7`, `INV-62`) — cite those the same way when there's no Linear ticket.
 
-- The PR title (e.g., `feat(THR-19): implement agent loop`)
-- The PR description (link to Linear issue)
+The implementation plan lives in the PR description, **not** the repo (`.claude/plans/` is gitignored). Run `/sync-plan` or `/find-plan` to compose the plan before writing the body; it goes in a collapsible `<details>` block at the end.
 
-### 3. Analyze the changes
+## 2. Draft the prose
 
-For each commit, understand:
+Write the **Problem**, **Solution**, **How it works**, and **Key design decisions** sections now, before verifying — you're stating what you believe the change does so the next step can hold it against the code. Follow the Prose style section below. Don't fill in the file tables or test counts yet; those come after the review.
 
-- What problem does it solve?
-- What design decisions were made?
-- What alternatives were considered?
+## 3. Self-review and verify every claim against the code
 
-Read relevant files if needed:
+Two passes over the same diff. Do them together.
 
-- Design docs in `docs/plans/` (intentional, long-lived design docs — distinct from branch plans)
-- Work notes if they exist
-- The actual code changes
+**Correctness pass.** Read the diff as a reviewer would. Look for the things this codebase cares about: race-safe write paths (INV-20), workspace scoping (INV-8), outbox-in-transaction (INV-4/7), access via the canonical predicates (INV-62), no silent fallbacks (INV-11), Zod-validated inputs (INV-55), dead code left behind (INV-38). For a substantial change, spawning a few parallel review agents over the diff is the established move here (see the "Pre-PR review (N reviewer agents)" line in recent merged PRs). The `/code-review` command reviews the current diff and is a good fit.
 
-**The implementation plan lives in the PR description, not the repo.** Branch plans are
-never committed (`.claude/plans/` is gitignored). The title and prose give the high-level
-summary; the full plan goes in a collapsible `<details>` block near the end of the body.
-Run `/sync-plan` (or `/find-plan`) to compose the plan content before writing the body.
+**Claim-verification pass.** Go through your draft sentence by sentence and confirm each concrete claim against the actual code:
 
-### 4. Structure the PR description
+- Every `path/to/file.ts`, function name, and symbol you named exists and does what you said.
+- Every behavioral claim ("atomic", "race-safe", "reads X before Y", "one transaction", "no schema change", "required at boot") is literally true of the diff — open the lines and check.
+- Every invariant reference (INV-XX) actually applies to what you changed.
+- Every number (timeouts, counts, sizes, limits) matches a constant or default in the code.
+- Every "out of scope / NOT included" claim is real — you didn't actually touch that thing.
 
-The title and the prose sections are the **high-level summary** — keep them tight so a
-reviewer can size up the change at a glance. The **full plan** is collapsed in the
-`<details>` block at the end, so a long plan never bloats the visible description.
+When the review turns up a finding, **fix it in the branch**, then reflect it in the description honestly rather than hiding it:
 
-The PR must include these sections:
+- A correctness fix found mid-review → note it inline where relevant (`(caught in self-review; see commit N)`) or in a short **Design evolution (self-review)** note that says what the first version got wrong and how it's fixed. Recent PRs do exactly this — e.g. "Initial version read the floor before the entries query … a concurrent prune could silently drop entries. Fixed by folding the floor advance into the prune DELETE."
+- A review pass with findings → a one-line tally in the test plan: "Pre-PR review (3 reviewer agents): 2 findings fixed (…), 3 dismissed as pre-existing/misapplied."
+
+A clean review is a real outcome too — but only claim it after you've actually done the passes.
+
+## 4. Finalize file tables and test plan
+
+Now fill in the **New / Modified / Deleted files** tables and the **Test plan** — after the review, so the counts and per-file notes are accurate.
+
+Run the relevant suites and record real numbers. Use checked boxes for what passed with counts, and **unchecked boxes for what genuinely wasn't done**, with the honest reason:
+
+```markdown
+- [x] Backend `bun test src/features/sync` — 14 pass
+- [x] `tsc --noEmit` across types / backend / frontend clean
+- [ ] No live-DB harness, so the prune SQL is covered via stubbed repo like its siblings — not integration-tested
+```
+
+Never check a box you didn't run. An honest unchecked box with a reason is worth more than a green checkmark a reviewer can't trust.
+
+## 5. Structure of the description
 
 ```markdown
 **Linear:** [THR-XX](https://linear.app/threa/issue/THR-XX) _(if applicable)_
 
 ## Problem
 
-[What issue or limitation exists? Why does this change need to happen?]
+[The concrete defect or limitation, with the specific files/symbols/ids involved.
+Why it matters, and why it isn't trivial if that's relevant.]
 
 ## Solution
 
-[High-level description of the approach taken]
+[One tight framing sentence — the shape of the approach, an analogy if it helps.
+Then the substance.]
 
 ### How it works
 
-[Architecture diagram or flow explanation if applicable]
+[Numbered or bulleted mechanism. Each point names the real function/file and the
+actual mechanism. Concrete numbers, not "configurable".]
 
 ### Key design decisions
 
-[For each significant decision:]
-**1. [Decision title]**
-
-[What was chosen and why. Include alternatives considered if relevant.]
+**1. [Decision]** — [what was chosen, the alternatives rejected and their failure
+modes, the invariant or user ruling behind it.]
 
 ## New files
 
-| File              | Purpose           |
-| ----------------- | ----------------- |
-| `path/to/file.ts` | Brief description |
+| File | Purpose |
+| ---- | ------- |
+| `path/to/file.ts` | What it's for |
 
 ## Modified files
 
-| File              | Change       |
-| ----------------- | ------------ |
+| File | Change |
+| ---- | ------ |
 | `path/to/file.ts` | What changed |
 
 ## Deleted files (if any)
 
-| File              | Reason      |
-| ----------------- | ----------- |
+| File | Reason |
+| ---- | ------ |
 | `path/to/file.ts` | Why removed |
+
+## Out of scope (deliberate)
+
+[What you consciously didn't do and why — names follow-up PRs / audit items.
+Mark deliberate deviations so a reviewer doesn't "fix" them.]
 
 ## Test plan
 
-- [x] Completed tests
-- [ ] Manual verification steps
+- [x] [suite] — [N pass]
+- [ ] [genuinely not done] — [honest reason]
 
 <details>
 <summary>📋 Full implementation plan</summary>
 
-[Full plan from /sync-plan or /find-plan: Goal, What Was Built, Design Decisions,
-Design Evolution, Schema Changes, What's NOT Included, Status. Use the exact summary
-line above so tooling (CodeRabbit, /code-review, /update-pr) can locate the block.
-Omit this block only if there is genuinely no plan beyond the prose above.]
+[From /sync-plan or /find-plan: Goal, What Was Built, Design Decisions, Design
+Evolution, Schema Changes, What's NOT Included, Status. Keep the exact summary
+line above so tooling (CodeRabbit, /code-review, /update-pr) can find the block.
+Omit only if there's genuinely no plan beyond the prose.]
 
 </details>
 
@@ -128,70 +149,62 @@ Omit this block only if there is genuinely no plan beyond the prose above.]
 🤖 _PR by [Claude Code](https://claude.com/claude-code)_
 ```
 
-### 5. Create the PR
+Small PRs collapse this: a docs-only or one-file change uses **Problem / Solution / Files changed / Test plan** and skips the decision matrix and the plan block. Match the section weight to the change — don't pad a one-liner into the heavyweight shape, and don't crush a layout rewrite into three sentences.
+
+## Prose style
+
+The description should read high-level but stay dense and detail-oriented — a reviewer skims the prose to size up the change, then trusts it enough not to re-derive the diff. The benchmark is the recently merged feature PRs in this repo; open a couple before writing if you're unsure of the register.
+
+**Lead with altitude, immediately land in specifics.** State the shape in one sentence ("a generic, URL-driven multi-panel layout in the spirit of VS Code editor groups"), then the very next clause is concrete — the real function, the real file, the real mechanism.
+
+**Name real things.** `streamAccessPredicateSql`, `20260613064500_sync_log_retention.sql`, `resolveActorRecipients`, `?panel=`. Never "the relevant helper", "a config value", "some logic". If you can't name it, you haven't verified it.
+
+**Concrete over vague, always.** "30-day horizon + per-workspace ~2,000-row floor", "below 420px the action bar collapses", "200ms skeleton delay" — not "a configurable retention window" or "small viewports".
+
+**Explain the why and the rejected alternatives.** Decisions carry their tradeoff: "Time and count have opposite failure modes — pure time grows unbounded for a firehose workspace, pure count shrinks the healing window." A decision with no alternative stated reads like there was no choice to make.
+
+**Quote the source of truth.** Audit findings, design-doc sections, and user rulings get quoted or cited verbatim ("the audit's words (E2EE-22): …", "Kris's call"). Cite invariants by id where they bind.
+
+**Understated and factual — no slop.** No "comprehensive", "robust", "seamless"(unless literally describing a no-flash transition you verified), "powerful", "simply", "just", emoji-as-decoration, or marketing cadence. Active voice. Confident where the code earns it, honest where it doesn't. If a copy pass would help, the `/deslopify` skill targets exactly this register.
+
+**Honesty is part of the style.** The strongest sections in this repo's PRs say what's *not* covered, what's deferred, what the first attempt got wrong. That candor is what makes the rest trustworthy. Don't sand it off.
+
+## 6. Create the PR
+
+Push, then create. In web/remote sessions `gh` is **not installed** — use the GitHub MCP tool.
 
 ```bash
-# Push branch if needed
-git push -u origin $(git branch --show-current)
-
-# Create PR (write body to temp file first to avoid heredoc issues)
-# If ticket ID exists, include it: "[type](THR-XX): [short description]"
-gh pr create --base main --title "[type](THR-XX): [short description]" --body-file /tmp/claude/pr-body.md
+git push -u origin "$(git branch --show-current)"
 ```
 
-If `gh pr create` fails with GraphQL errors, use the API directly:
+Write the body to a temp file first (avoids heredoc/quoting issues), then create via, in order of preference for this environment:
 
-```bash
-gh api repos/{owner}/{repo}/pulls --method POST \
-  -f title="[type]: [short description]" \
-  -f head="$(git branch --show-current)" \
-  -f base="main" \
-  -f body="$(cat /tmp/claude/pr-body.md)"
-```
+1. **MCP (web/remote sessions):** `mcp__github__create_pull_request` with `owner`, `repo`, `head` (current branch), `base: main`, `title`, and `body` (contents of the temp file).
+2. **`gh` (local sessions where it exists):**
+   ```bash
+   gh pr create --base main --title "<type>(THR-XX): <short description>" --body-file /tmp/claude/pr-body.md
+   ```
+3. **REST fallback** if `gh` errors: `gh api repos/{owner}/{repo}/pulls --method POST -f title=… -f head=… -f base=main -f body="$(cat /tmp/claude/pr-body.md)"`.
 
-### 6. Return the PR URL
+### Title conventions
 
-Always provide the PR URL to the user when done.
+Conventional-commit type, optional scope, Linear id when there is one, and a **specific** summary — the title alone should say what changed:
 
-Use this URL capture order:
+- `feat(THR-XX): …`, `fix: …`, `refactor(backend): …`, `docs: …`, `test: …`, `chore: …`
+- Good: `feat: sync_log retention with below-floor bootstrap fallback`. Weak: `feat: update sync`.
+- Omit the parenthetical when there's no ticket. Cite audit/design ids (`E2EE-22`, `INV-62`) in the body instead.
 
-1. If `gh pr create` succeeds, capture and return the URL printed by `gh`.
-2. If using the GitHub REST API, parse `html_url` from the response body and return it.
-3. If using the `make_pr` MCP tool, return the URL from tool output when available.
-4. If URL cannot be determined (e.g., missing remote/token/tool does not return URL), explicitly say so and include:
-   - the exact reason (for example, "no `origin` remote configured in this checkout")
-   - the PR title used
-   - the branch name used
-   - the next command/API call required to fetch the URL once connectivity/remote is available
+### Return the URL
 
-## PR Title Conventions
+Always return the PR URL. Capture it from the MCP tool output / `gh` stdout / REST `html_url`. If it genuinely can't be determined, say so explicitly and give the title, branch, and the exact command to fetch it once resolved.
 
-Use conventional commit format with Linear ticket ID when available:
+## 7. Subscribe to PR activity
 
-- `feat(THR-XX):` - New feature
-- `fix(THR-XX):` - Bug fix
-- `refactor(THR-XX):` - Code restructuring without behavior change
-- `docs(THR-XX):` - Documentation only
-- `test(THR-XX):` - Test additions/changes
-- `chore(THR-XX):` - Maintenance tasks
+This is part of the skill, not a separate ask. After the PR exists, call `mcp__github__subscribe_pr_activity` for it so the session wakes on CI results, review comments, and CodeRabbit findings, and follow through on those events (see the harness's PR-activity guidance). Tell the user you've subscribed and will watch it. If the user has said they don't want it watched, skip this step.
 
-If no Linear ticket exists, omit the parenthetical: `feat: description`
+## Important
 
-## Examples
-
-**User says:** "Create a PR"
-**Action:** Analyze current branch, gather context from task docs, create comprehensive PR
-
-**User says:** "Open a PR for this feature"
-**Action:** Same as above, ensuring all design decisions are documented
-
-**User says:** "Submit this for review"
-**Action:** Create PR, return URL for user to review
-
-## Important Notes
-
-- **Always include Linear ticket ID** in title and description when working from a ticket
-- Never create a PR with an empty or minimal description
-- Always explain the "why" not just the "what"
-- Include divergences from original plans if applicable
-- Reference task docs or issues when relevant
+- Do not create a PR unless asked — but invoking this skill *is* the explicit request, so the create + subscribe steps proceed.
+- Never ship an empty or minimal description, and never ship one whose claims you haven't checked against the code.
+- Explain the why, not only the what. Surface divergences from the original plan.
+- Run the tests you claim to have run.


### PR DESCRIPTION
## Problem

The `create-pr` skill produced a correct-but-generic description shape (Problem / Solution / decisions / file tables) and stopped at "create the PR". Two things it didn't do are the two things that actually happen every time by hand:

1. **Self-review and claim verification.** Kris types "can you please self review and then create a pull request and subscribe to it" on essentially every PR. The skill didn't bake that in, so the review and the subscribe were re-typed each time and easy to skip.
2. **A house prose register.** The descriptions Fable 5 wrote over the last day and a half (#878–#907) are the benchmark Kris wants matched — high-level but dense, detail-oriented enough that the description can be trusted to match the diff without re-deriving it. The old skill had no guidance pointing writers at that register, so density and trustworthiness drifted per-session.

## Solution

Restructure the skill around the exact sequence Kris runs by hand — **draft the dense prose first, then a combined correctness + claim-verification pass against the code, then create the PR, then subscribe** — and add a Prose style section that codifies the register from the recent merged PRs.

The ordering is the point: writing the prose first forces a precise statement of what the change does, and the verify pass then holds each statement against the actual code. A claim like "the prune is atomic" or "required at boot" is simultaneously a description and a correctness assertion, so one pass catches prose drift and real bugs together — which is what makes the finished description trustworthy.

### The new flow

1. Gather context (commits, diff, ticket id, plan).
2. **Draft the prose** (Problem / Solution / How it works / Key design decisions) before verifying.
3. **Self-review + verify every claim against the code** — a correctness pass (race-safety, workspace-scoping, access predicates, no silent fallbacks, dead code) and a claim-verification pass (every named symbol, behavioral claim, invariant ref, and number checked against the diff). Findings get fixed and recorded honestly via `(caught in self-review)` / "Design evolution (self-review)" notes — mirroring what #907 and #903 already do.
4. **Finalize file tables + test plan** after the review, with real run counts and honest unchecked boxes for what wasn't done.
5. **Create the PR** — prefers `mcp__github__create_pull_request` (since `gh` isn't installed in web/remote sessions), with `gh` and the REST API as fallbacks.
6. **Subscribe** via `mcp__github__subscribe_pr_activity` — a skill step, not a separate ask.

### Prose style section

New section codifying the register observed across the Fable-written PRs: lead with altitude then immediately land in specifics; name real symbols (never "the relevant helper"); concrete over vague; state rejected alternatives and their failure modes; quote the source of truth (audit findings, design-doc sections, invariant ids); understated and factual with no slop (points at `/deslopify`); and treat honesty about what's *not* covered as part of the style. Small PRs are told to collapse the heavy structure so a one-liner isn't padded.

## Files changed

| File | Change |
| ---- | ------ |
| `.agents/skills/create-pr/SKILL.md` | Reworked: draft-prose-first flow, self-review + claim-verification step, baked-in `subscribe_pr_activity`, Prose style section, MCP-first PR creation, Out-of-scope + honest-test-plan guidance |

## Out of scope (deliberate)

- No change to `/sync-plan`, `/find-plan`, `/code-review`, or `/deslopify` — the skill references them as-is.
- The harness's global "ask before watching a PR" guidance still stands; the skill auto-subscribes per Kris's explicit request and notes it, skipping only if told not to watch. Flagged in chat in case the preference should instead be "ask each time".

## Test plan

- [x] Pre-commit hook on push — full-monorepo eslint, per-package `tsc --noEmit`, `astro check`, Dockerfile-workspace check, and OpenAPI `--check` all green
- [x] Frontmatter (`name` + trigger-phrase `description`) matches sibling skills; harness lists `create-pr`
- [x] Cross-checked every tool/skill the body references (`mcp__github__create_pull_request`, `mcp__github__subscribe_pr_activity`, `/code-review`, `/deslopify`, `/sync-plan`, `/find-plan`) against the available tool + skill lists
- [ ] No executable test covers a skill markdown file — verification is the frontmatter/format check above plus the pre-commit lint pass

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuLTQiuGDt2KjamBPTGmym)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783934986&installation_id=129946197&pr_number=910&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F910&signature=3eb44b8d03ae697554b2b29057c1f5b5b9f36335ff10962b27f83844b5e5ce0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->