### PR TITLE
refactor: delete isLegacyUnreadCounterEntry now that legacy entries are swept

### DIFF
--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1087,39 +1087,6 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
     engine.destroy()
   })
 
-  it("skips LEGACY unread-counter entries (no absolute fields) but still advances the cursor past them", async () => {
-    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
-    const catchUp = vi
-      .fn()
-      .mockResolvedValueOnce({
-        entries: [
-          {
-            syncId: "11",
-            eventType: "activity:created",
-            payload: {
-              workspaceId: "ws_1",
-              activity: { id: "act_1", streamId: "stream_x", activityType: "message", isSelf: false },
-            },
-            createdAt: new Date().toISOString(),
-          },
-          userAddedEntry("12", "user_a"),
-        ],
-        head: "12",
-      })
-      .mockResolvedValue(emptyPage("12"))
-    const engine = new SyncEngine(makeActiveDeps(catchUp))
-
-    await engine.onConnect(asSocket(new MockSocket()))
-
-    await vi.waitFor(async () => expect(await db.workspaceUsers.get("user_a")).toBeDefined())
-    expect(engine.getSyncCursor()).toBe("12")
-    // The bootstrap wrote zeroed unread state; the skipped log entry must not
-    // have incremented it (bootstrap stays the counter authority in 2b).
-    const unread = await db.unreadState.get("ws_1")
-    expect(unread?.unreadActivityCount).toBe(0)
-    engine.destroy()
-  })
-
   it("re-bootstraps and jumps the cursor to head when catch-up reports the cursor is below the retention floor", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     // The cursor (10) predates the pruned span, so the log can't heal the gap:
@@ -1163,51 +1130,6 @@ describe("SyncEngine sync-v2 cursor (active mode)", () => {
       expect(await db.workspaceUsers.get("user_live")).toBeDefined()
     })
     expect(engine.getSyncCursor()).toBe("12")
-    engine.destroy()
-  })
-
-  it("applies buffered LEGACY counter events at the splice even when at or below the catch-up position", async () => {
-    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
-    let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined
-    const catchUp = vi
-      .fn()
-      .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
-      .mockResolvedValue(emptyPage("12"))
-    const engine = new SyncEngine(makeActiveDeps(catchUp))
-    const socket = new MockSocket()
-
-    await engine.onConnect(asSocket(socket))
-    await vi.waitFor(() => expect(resolveFirstPage).toBeDefined())
-    // Bootstrap has applied by now (onConnect awaited it) with zeroed counts.
-    expect((await db.unreadState.get("ws_1"))?.unreadActivityCount).toBe(0)
-
-    const activityPayload = {
-      workspaceId: "ws_1",
-      syncId: "11",
-      activity: { id: "act_1", streamId: "stream_x", activityType: "message", isSelf: false },
-    }
-    socket.trigger("activity:created", activityPayload)
-
-    // The same legacy event is also in the log (duplicate by design) —
-    // catch-up skips it there; the buffered live copy applies exactly once
-    // at splice.
-    resolveFirstPage!({
-      entries: [
-        {
-          syncId: "11",
-          eventType: "activity:created",
-          payload: activityPayload,
-          createdAt: new Date().toISOString(),
-        },
-        userAddedEntry("12", "user_a"),
-      ],
-      head: "12",
-    })
-
-    await vi.waitFor(async () => {
-      expect((await db.unreadState.get("ws_1"))?.unreadActivityCount).toBe(1)
-    })
-    expect((await db.unreadState.get("ws_1"))?.activityCounts["stream_x"]).toBe(1)
     engine.destroy()
   })
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -21,7 +21,6 @@ import { processOperationQueue } from "./operation-queue"
 import { waitForInitialReveal } from "./reveal-gate"
 import { SyncLogCursor } from "./sync-log-cursor"
 import type { SyncV2CursorMode } from "./sync-v2-mode"
-import { isLegacyUnreadCounterEntry } from "./unread-counters"
 import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
@@ -82,14 +81,6 @@ const CATCHUP_PAGE_LIMIT = 500
  * client is still behind.
  */
 const HEARTBEAT_GRACE_MS = 2_000
-
-// Unread counter events replay from the log like any other event since their
-// payloads went absolute (phase 2c) — EXCEPT legacy entries persisted before
-// the backend shipped the absolute fields, which still carry increments and
-// must be skipped (the cursor advances past them; the bootstrap remains their
-// authority, INV-53). `isLegacyUnreadCounterEntry` is that per-entry check;
-// it replaces the phase-2b CATCHUP_SKIPPED_UNREAD_EVENT_TYPES set and dies
-// when sync-log retention ships and pre-field entries age out.
 
 /**
  * Owns the full sync lifecycle for a workspace:
@@ -1017,18 +1008,15 @@ export class SyncEngine {
    * by design (sweep + dispatcher can both emit; snapshot/log overlap is the
    * safe side of read-before-stamp) and are absorbed by the handlers'
    * idempotency — including the unread counter family, whose absolute
-   * payloads max-merge/LWW-set (phase 2c). Only LEGACY counter entries
-   * (pre-field payloads, still increments) are skipped; see
-   * isLegacyUnreadCounterEntry.
+   * payloads max-merge/LWW-set (phase 2c).
    *
    * While catch-up pages, the gate buffers live syncId-bearing events; the
-   * finally-splice applies buffered events above the catch-up position (plus
-   * legacy counter events at any position, since catch-up never applies
-   * those) and reopens live flow. A buffered ABSOLUTE counter event at or
-   * below the position must NOT re-apply: its log copy already applied, and
-   * activity counts are LWW — re-applying it after a newer log entry would
-   * regress them. The cursor advances only past entries that were handed to
-   * handlers (or policy-skipped), never by jumping to head.
+   * finally-splice applies buffered events above the catch-up position and
+   * reopens live flow. A buffered ABSOLUTE counter event at or below the
+   * position must NOT re-apply: its log copy already applied, and activity
+   * counts are LWW — re-applying it after a newer log entry would regress
+   * them. The cursor advances only past entries that were handed to handlers,
+   * never by jumping to head.
    */
   private async performActiveCatchUp(trigger: string, signal: AbortSignal, cycle: number): Promise<void> {
     const syncService = this.deps.syncService!
@@ -1061,7 +1049,6 @@ export class SyncEngine {
       let head = cursorBefore
       let pages = 0
       let fetched = 0
-      let skipped = 0
       const byEventType: Record<string, number> = {}
 
       while (pages < MAX_CATCHUP_PAGES) {
@@ -1110,17 +1097,13 @@ export class SyncEngine {
         for (const entry of response.entries) {
           if (this.isDestroyed) return
           byEventType[entry.eventType] = (byEventType[entry.eventType] ?? 0) + 1
-          if (isLegacyUnreadCounterEntry(entry.eventType, entry.payload)) {
-            skipped += 1
-          } else {
-            // Mirror the live wire shape exactly: emits carry the syncId
-            // spread onto the outbox payload (see emitToGroups).
-            const payload =
-              typeof entry.payload === "object" && entry.payload !== null
-                ? { ...entry.payload, syncId: entry.syncId }
-                : entry.payload
-            await gate.dispatch(entry.eventType, payload)
-          }
+          // Mirror the live wire shape exactly: emits carry the syncId
+          // spread onto the outbox payload (see emitToGroups).
+          const payload =
+            typeof entry.payload === "object" && entry.payload !== null
+              ? { ...entry.payload, syncId: entry.syncId }
+              : entry.payload
+          await gate.dispatch(entry.eventType, payload)
           cursorStore.advance(entry.syncId)
           appliedThrough = BigInt(entry.syncId)
           cursor = entry.syncId
@@ -1135,7 +1118,6 @@ export class SyncEngine {
           cursorAfter: cursor,
           head,
           fetched,
-          skipped,
           pages,
           byEventType,
           truncated: pages >= MAX_CATCHUP_PAGES,
@@ -1148,15 +1130,10 @@ export class SyncEngine {
       // this run was in flight, its bootstrap window is still open; leave the
       // gate paused and let that cycle's own run (chained by runCatchUp) do
       // the splice. Buffered events at or below the applied position were
-      // already applied from the log — except legacy counter events, which
-      // only ever apply via live delivery and so splice regardless of
-      // position.
+      // already applied from the log.
       if (!this.isDestroyed && this.catchUpCycle === cycle) {
         const through = appliedThrough
-        await gate.resume(
-          (eventType, syncId, payload) =>
-            through === null || syncId > through || isLegacyUnreadCounterEntry(eventType, payload)
-        )
+        await gate.resume((_eventType, syncId) => through === null || syncId > through)
       }
     }
   }

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -4,7 +4,6 @@ import {
   applyStreamReadOrdinal,
   applyStreamsReadAllOrdinals,
   applyActivityCounts,
-  isLegacyUnreadCounterEntry,
   type UnreadCounterState,
 } from "./unread-counters"
 
@@ -177,25 +176,5 @@ describe("applyActivityCounts", () => {
     const once = applyActivityCounts(state, "s1", { mentionCount: 0, activityCount: 2 })
     expect(applyActivityCounts(once, "s1", { mentionCount: 0, activityCount: 2 })).toEqual(once)
     expect(once.unreadActivityCount).toBe(2)
-  })
-})
-
-describe("isLegacyUnreadCounterEntry", () => {
-  it("detects missing absolute fields per counter event type", () => {
-    expect(isLegacyUnreadCounterEntry("stream:activity", { streamId: "s1" })).toBe(true)
-    expect(isLegacyUnreadCounterEntry("stream:activity", { streamId: "s1", messageOrdinal: 3 })).toBe(false)
-    expect(isLegacyUnreadCounterEntry("stream:read", { streamId: "s1" })).toBe(true)
-    expect(isLegacyUnreadCounterEntry("stream:read", { streamId: "s1", lastReadOrdinal: 0 })).toBe(false)
-    expect(isLegacyUnreadCounterEntry("stream:read_all", { streamIds: [] })).toBe(true)
-    expect(isLegacyUnreadCounterEntry("stream:read_all", { streamIds: [], reads: [] })).toBe(false)
-    expect(isLegacyUnreadCounterEntry("activity:created", { activity: {} })).toBe(true)
-    expect(isLegacyUnreadCounterEntry("activity:created", { counts: { mentionCount: 1, activityCount: 2 } })).toBe(
-      false
-    )
-  })
-
-  it("never marks non-counter events legacy", () => {
-    expect(isLegacyUnreadCounterEntry("message:created", {})).toBe(false)
-    expect(isLegacyUnreadCounterEntry("workspace_user:added", undefined)).toBe(false)
   })
 })

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -22,13 +22,6 @@ import type { WorkspaceBootstrap } from "@threa/types"
  *   compensating event), so a plain set is the only safe apply.
  * - `unreadActivityCount` is never on the wire: it is derived as
  *   Σ activityCounts whenever an absolute apply touches activity counts.
- *
- * Events missing the absolute fields are legacy: sync-log entries that predate
- * the absolute fields. `isLegacyUnreadCounterEntry` detects them so catch-up
- * skips them (the bootstrap is their authority) while live handlers fall back
- * to the old increment/zero behavior. Such entries are bounded, not permanent:
- * they fall below the sync_log retention floor
- * (docs/plans/sync-v2-log-retention.md) and age out of catch-up.
  */
 
 export interface UnreadCounterState {
@@ -165,34 +158,5 @@ export function withCounterState(bootstrap: WorkspaceBootstrap, state: UnreadCou
     activityCounts: state.activityCounts,
     unreadActivityCount: state.unreadActivityCount,
     messageCounts: state.latestOrdinals,
-  }
-}
-
-/**
- * True when this is one of the four unread counter events AND its payload
- * lacks the absolute fields — a sync-log entry persisted before the backend
- * shipped them (or a live emit from a not-yet-upgraded backend). Catch-up
- * skips these (the cursor still advances past them; the bootstrap remains
- * their authority, INV-53) and the gate splice applies their buffered live
- * copies regardless of position, exactly as the phase-2b skip set did.
- * Non-counter event types are never legacy. These entries are bounded: they
- * fall below the sync_log retention floor (docs/plans/sync-v2-log-retention.md)
- * and age out of catch-up.
- */
-export function isLegacyUnreadCounterEntry(eventType: string, payload: unknown): boolean {
-  const p = payload as Record<string, unknown> | null | undefined
-  switch (eventType) {
-    case "stream:activity":
-      return typeof p?.messageOrdinal !== "number"
-    case "stream:read":
-      return typeof p?.lastReadOrdinal !== "number"
-    case "stream:read_all":
-      return !Array.isArray(p?.reads)
-    case "activity:created": {
-      const counts = p?.counts as Record<string, unknown> | null | undefined
-      return typeof counts?.mentionCount !== "number" || typeof counts?.activityCount !== "number"
-    }
-    default:
-      return false
   }
 }

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -108,10 +108,10 @@ interface WorkspaceUserUpdatedPayload {
   user: WorkspaceUserPayload
 }
 
-// The unread counter payloads carry absolute fields (sync-v2 phase 2c).
-// They are optional on the wire: sync-log entries persisted before the
-// backend shipped them replay without them forever, and handlers fall back
-// to the legacy increment/zero behavior (see sync/unread-counters.ts).
+// The unread counter payloads carry absolute fields (sync-v2 phase 2c); every
+// current payload has them. The fields stay optional on the wire and the
+// handlers below tolerate their absence (increment/zero fallback) as a
+// defensive guard.
 interface StreamReadPayload {
   workspaceId: string
   authorId: string

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -19,12 +19,14 @@ the rollout sessions:
   `requiresBootstrap` for cursors below the pruned floor, so the big deletions
   (reconnect-bootstrap slimming, `usePageResumeRefresh`) lose their retention
   blocker — they still each ship as their own PR with a coverage proof.
-  `isLegacyUnreadCounterEntry` dies in two steps: a one-time content-based sweep
-  migration (`20260613083239_prune_legacy_counter_entries.sql`) removes the
-  legacy entries the guard skips — by content, not a hardcoded boundary, because
-  pure time+count retention leaves a quiet workspace's legacy rows in place
-  indefinitely (its history never exceeds the `minKeep` floor) — and then a
-  follow-up PR deletes the guard once the sweep has deployed to prod.
+  `isLegacyUnreadCounterEntry` died in two steps (both DONE): a one-time
+  content-based sweep migration (`20260613083239_prune_legacy_counter_entries.sql`)
+  removed the legacy entries the guard skips — by content, not a hardcoded
+  boundary, because pure time+count retention leaves a quiet workspace's legacy
+  rows in place indefinitely (its history never exceeds the `minKeep` floor) —
+  and then, once the sweep deployed to prod (verified by a read-only prod check:
+  zero legacy counter entries remained), a follow-up PR deleted the guard and its
+  sync-engine call sites.
 - Coverage proof method (established in #885): event type → scoping list in
   `apps/backend/src/lib/outbox/repository.ts` → delivery group
   (`delivery-groups.ts`, single source of truth for log + emit) → `sync_log`
@@ -173,10 +175,10 @@ treating such a flag as real healing — it may be dead code (labels was).
   authority, but its blocker has lifted. `sync_log` retention has shipped
   (`docs/plans/sync-v2-log-retention.md`) and the below-floor fallback now
   routes through this very `runBootstrap(true)`, so it is also the explicit
-  recovery for a pruned cursor. It stays authoritative until
-  `isLegacyUnreadCounterEntry` dies (once pre-field entries age out below the
-  floor), and it still heals the accepted #874 drift and seeds active-mode
-  read-before-stamp against this fetch. Slimming it is a follow-up PR.
+  recovery for a pruned cursor. `isLegacyUnreadCounterEntry` is now gone (its
+  sweep deployed), so that gate has lifted too; it still heals the accepted #874
+  drift and seeds active-mode read-before-stamp against this fetch. Slimming it
+  is a now-fully-unblocked follow-up PR.
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**

--- a/docs/plans/sync-v2-log-retention.md
+++ b/docs/plans/sync-v2-log-retention.md
@@ -141,11 +141,15 @@ authority the inventory keeps for the below-floor case.
   rows as pruned and force needless bootstraps. Safe because the guard is
   client-side and the workspace cursor advances to head with no per-sync_id
   contiguity check (INV-61 contiguity is per-stream `broadcastSequence`), so
-  deleting a skipped-anyway row opens no gap. Deleting the guard itself is a
-  separate follow-up PR, sequenced AFTER the sweep deploys to prod (the sweep
+  deleting a skipped-anyway row opens no gap. Deleting the guard itself was a
+  separate follow-up PR, sequenced AFTER the sweep deployed to prod (the sweep
   runs at backend startup before serving, so once deployed every backend is
   legacy-free; removing the guard before then would let a pre-sweep backend feed
-  field-less payloads to the appliers).
+  field-less payloads to the appliers). **DONE** — the sweep deployed, a prod
+  read-only check confirmed zero legacy counter entries remained, and
+  `isLegacyUnreadCounterEntry` + its sync-engine call sites were deleted; catch-up
+  now applies every counter entry (all absolute) idempotently, covered by the
+  existing absolute-counter catch-up tests in `sync-engine.test.ts`.
 - **Engine reconnect-bootstrap slimming** and the **`usePageResumeRefresh`
   redesign** lose their "retention is still missing" blocker; they remain their
   own follow-ups.

--- a/docs/plans/sync-v2-log-retention.md
+++ b/docs/plans/sync-v2-log-retention.md
@@ -116,7 +116,7 @@ a page comes back with `requiresBootstrap`:
    duplicate side, never the gap side — same rule as `initializeActiveCursor`).
 2. `noteSeenHead(response.head)`, `appliedThrough = head`, then
    `void this.runBootstrap(true)` and return. The `finally` splice
-   (`syncId > head || legacy`) drops buffered events `<= head` — the snapshot
+   (`syncId > head`) drops buffered events `<= head` — the snapshot
    covers them, and re-applying an older LWW counter would regress it — and
    applies only those above.
 


### PR DESCRIPTION
## What

Deletes `isLegacyUnreadCounterEntry` (`apps/frontend/src/sync/unread-counters.ts`)
and its three sync-engine call sites. This is **PR 2 of 2** — the cleanup that
#908 (the legacy sweep) unblocked.

## Why it's safe now

The guard skipped pre-absolute-field counter entries during catch-up so they
couldn't corrupt counters. #908's content-based sweep migration deleted every
such row from `sync_log`, and **a read-only prod check confirmed zero legacy
counter entries remain** (399 total rows, 0 legacy). With no legacy entry able to
reach catch-up — and all backends emitting absolute fields since #872 — the guard
is dead code (INV-38).

The sequencing gate (guard removal must follow the sweep's **prod deploy**, not
just its merge) is satisfied: #908 is merged and deployed, verified empirically.

## Changes

- Remove `isLegacyUnreadCounterEntry` + its frontend tests.
- **Catch-up apply loop** (`sync-engine.ts`): drop the legacy skip branch —
  catch-up now dispatches every entry (all absolute) through the gate. The
  always-zero `skipped` counter is removed from the catch-up log line.
- **Resume splice**: the predicate is now purely position-based
  (`through === null || syncId > through`); the legacy term that force-spliced
  field-less buffered events is gone.
- Obsolete explanatory comments removed; plan docs marked DONE.

## Coverage

The post-guard behavior is already covered in `sync-engine.test.ts`:
- "applies absolute counter entries from the log without double-counting the
  bootstrap snapshot"
- "replays a read-zero between two absolute activity entries in log order"
- "does not re-apply a buffered ABSOLUTE counter duplicate at or below the
  catch-up position" (proves the position-only splice)

The two legacy-specific tests are removed — they exercised a payload shape that
can no longer occur in prod. Full `src/sync` suite: **186 passing**; typecheck +
lint clean.

<details>
<summary>📋 Full implementation plan</summary>

Per `docs/plans/sync-v2-healing-deletion-inventory.md` (one-deletion-per-PR) and
`docs/plans/sync-v2-log-retention.md` ("What this unblocks"), both updated here to
mark this DONE.

The guard died in two steps: (1) #908 swept the legacy rows by content; (2) once
that deployed to prod (verified: 0 legacy rows), this PR deletes the guard. The
coverage proof is the sweep (no legacy rows reach catch-up) plus the existing
absolute-counter catch-up tests.

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7rV7XXFhxzS7QAZMCaByJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783935417&installation_id=129946197&pr_number=911&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F911&signature=25269a7b80e60281d2c5bed3a4a6b65dd884e2691fbe0aadc5b1f5a39eb1f2ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->