### PR TITLE
refactor: slim the active-mode reconnect bootstrap to per-stream deltas + label reconcile

### DIFF
--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -27,6 +27,7 @@ import {
   useStreamService,
   useMessageService,
   useScheduledService,
+  useLabelService,
   PanelProvider,
   QuickSwitcherProvider,
   PreferencesProvider,
@@ -192,6 +193,7 @@ function WorkspaceSyncHandler({
   const streamService = useStreamService()
   const messageService = useMessageService()
   const scheduledService = useScheduledService()
+  const labelService = useLabelService()
   const syncStatusStore = useContext(SyncStatusContext)
   const { user } = useAuth()
   const isOnline = useOnlineStatus()
@@ -228,6 +230,7 @@ function WorkspaceSyncHandler({
         delete: scheduledService.delete,
         sendNow: scheduledService.sendNow,
       },
+      labelService: { list: labelService.list },
       syncService: syncApi,
       syncCursorMode: syncV2Mode,
     })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1834,4 +1834,21 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
     expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
     engine.destroy()
   })
+
+  it("keeps the full bootstrap on an active-mode resume — only the socket reconnect is slimmed", async () => {
+    const deps = makeReconnectDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    deps.workspaceService.bootstrap.mockClear()
+
+    // The resume / online-flip path stays full (forceFull): it is the
+    // usePageResumeRefresh follow-up's territory, not this PR's slimming.
+    await engine.refreshAfterConnectivityResume()
+
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    expect(deps.labelService.list).not.toHaveBeenCalled()
+    engine.destroy()
+  })
 })

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -5,6 +5,7 @@ import { SyncEngine, isSyncEngineCurrent } from "./sync-engine"
 import { SyncStatusStore } from "./sync-status"
 import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import { assignmentId } from "@/hooks/use-labels"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
@@ -12,9 +13,13 @@ import {
   defaultFeatureFlags,
   defaultFeatureFlagValue,
   DEFAULT_SIDEBAR_CONFIG,
+  LabelableResourceTypes,
   type WorkspaceBootstrap,
   type StreamBootstrap,
   type SyncCatchUpResponse,
+  type Label,
+  type LabelMember,
+  type LabelAssignment,
 } from "@threa/types"
 
 type EventHandler = (...args: unknown[]) => void
@@ -1642,5 +1647,191 @@ describe("SyncEngine sync:heartbeat (active mode)", () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(catchUp.mock.calls.length).toBe(baseline)
+  })
+})
+
+describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([
+      db.workspaces.clear(),
+      db.syncCursors.clear(),
+      db.workspaceUsers.clear(),
+      db.streams.clear(),
+      db.streamMemberships.clear(),
+      db.unreadState.clear(),
+      db.labels.clear(),
+      db.labelMemberships.clear(),
+      db.labelAssignments.clear(),
+      db.events.clear(),
+    ])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function emptyPage(head: string): SyncCatchUpResponse {
+    return { entries: [], head }
+  }
+
+  /** A public-stream assignment on a stream the viewer can see but isn't a
+   *  member of — the slice `listEntriesForUser` (stream_members scoped) can't
+   *  replay, so only the label reconcile heals it. */
+  function publicStreamAssignment(overrides?: Partial<LabelAssignment>): LabelAssignment {
+    return {
+      labelId: "label_1",
+      resourceType: LabelableResourceTypes.STREAM,
+      resourceId: "stream_public",
+      userId: "user_1",
+      workspaceId: "ws_1",
+      assignedAt: new Date().toISOString(),
+      ...overrides,
+    }
+  }
+
+  function makeReconnectDeps(assignments: LabelAssignment[] = []) {
+    const catchUp = vi.fn(async () => emptyPage("0"))
+    const list = vi.fn(async () => ({
+      labels: [] as Label[],
+      memberships: [] as LabelMember[],
+      assignments,
+    }))
+    return {
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      labelService: { list },
+      syncCursorMode: "active" as const,
+    }
+  }
+
+  it("skips the full workspace snapshot on an active reconnect and reconciles viewer labels instead", async () => {
+    const deps = makeReconnectDeps([publicStreamAssignment()])
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    // First connect runs the full bootstrap and does not touch labelService.
+    await engine.onConnect(asSocket(socket))
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    expect(deps.labelService.list).not.toHaveBeenCalled()
+    deps.workspaceService.bootstrap.mockClear()
+
+    // Reconnect: no full snapshot fetch; the viewer label reconcile runs and
+    // lands the non-member public-stream assignment in IDB (the render source).
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.workspaceService.bootstrap).not.toHaveBeenCalled()
+    expect(deps.labelService.list).toHaveBeenCalledWith("ws_1")
+    await vi.waitFor(async () =>
+      expect(
+        await db.labelAssignments.get(
+          assignmentId("ws_1", LabelableResourceTypes.STREAM, "stream_public", "label_1", "user_1")
+        )
+      ).toBeDefined()
+    )
+    engine.destroy()
+  })
+
+  it("re-subscribes member rooms from cached membership on a slim reconnect", async () => {
+    const deps = makeReconnectDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    // Seed the membership AFTER the first bootstrap so its stale-delete reconcile
+    // (the empty test bootstrap carries no memberships) can't clear it.
+    await db.streamMemberships.put({
+      id: "ws_1:stream_member",
+      workspaceId: "ws_1",
+      streamId: "stream_member",
+      memberId: "user_1",
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+    socket.emittedEvents.length = 0
+
+    await engine.onConnect(asSocket(socket))
+
+    await vi.waitFor(() =>
+      expect(socket.emittedEvents.some((e) => e.event === "join" && e.args[0] === "ws:ws_1:stream:stream_member")).toBe(
+        true
+      )
+    )
+    engine.destroy()
+  })
+
+  it("still fetches per-stream data for visible streams on a slim reconnect (per-stream cursor mechanism kept)", async () => {
+    const deps = makeReconnectDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    // Mark a stream visible after the first connect; the slim reconnect must
+    // still heal its timeline (a per-stream sequence, not the workspace
+    // sync-log), so the per-stream bootstrap fetch fires for it.
+    engine.setVisibleStreamIds(["stream_v"])
+    deps.streamService.bootstrap.mockClear()
+
+    await engine.onConnect(asSocket(socket))
+
+    await vi.waitFor(() =>
+      expect(deps.streamService.bootstrap.mock.calls.some((call) => call[1] === "stream_v")).toBe(true)
+    )
+    engine.destroy()
+  })
+
+  it("forces a full bootstrap when an active reconnect catch-up reports below the retention floor", async () => {
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi.fn().mockResolvedValue({ entries: [], head: "500", requiresBootstrap: true })
+    const deps = { ...makeReconnectDeps(), syncService: { catchUp } }
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    // First connect: full bootstrap, then the below-floor fallback fires a
+    // second full bootstrap and jumps the cursor to head.
+    await engine.onConnect(asSocket(socket))
+    await vi.waitFor(() => expect(engine.getSyncCursor()).toBe("500"))
+    deps.workspaceService.bootstrap.mockClear()
+
+    // Reconnect: the slim path itself never fetches the snapshot, so a call
+    // here proves the below-floor fallback ran as a forced full bootstrap.
+    await engine.onConnect(asSocket(socket))
+
+    await vi.waitFor(() => expect(deps.workspaceService.bootstrap).toHaveBeenCalled())
+    engine.destroy()
+  })
+
+  it("keeps the full reconnect bootstrap in off mode", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    deps.workspaceService.bootstrap.mockClear()
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    engine.destroy()
+  })
+
+  it("keeps the full reconnect bootstrap in active mode when no labelService is wired", async () => {
+    const catchUp = vi.fn(async () => emptyPage("0"))
+    const deps = {
+      ...makeDeps(),
+      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
+      syncCursorMode: "active" as const,
+    }
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    await engine.onConnect(asSocket(socket))
+    deps.workspaceService.bootstrap.mockClear()
+    await engine.onConnect(asSocket(socket))
+
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    engine.destroy()
   })
 })

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -114,6 +114,10 @@ export class SyncEngine {
   private workspaceHandlerCleanup: (() => void) | null = null
   private activeBootstrap: Promise<void> | null = null
   private queuedReconnectBootstrap: Promise<void> | null = null
+  /** Whether the queued reconnect bootstrap must run as a full snapshot. A
+   *  below-floor `forceFull` request arriving while a slim reconnect is already
+   *  queued upgrades the queued run rather than being collapsed away. */
+  private queuedReconnectForceFull = false
   private activeStreamRefreshes = new Map<string, Promise<void>>()
   private activeGapBackfills = new Map<string, { cursor: string; promise: Promise<void> }>()
   /** Lowest gap cursor reported per stream while a backfill was in flight —
@@ -262,7 +266,11 @@ export class SyncEngine {
     // Same pause-before-bootstrap rule as onConnect: the catch-up position
     // must not move between this trigger and the catch-up fetch.
     this.beginCatchUpCycle()
-    await this.runBootstrap(true)
+    // forceFull: only the socket-reconnect path (onConnect) is slimmed. The
+    // resume / online-flip window is the `usePageResumeRefresh` redesign's
+    // territory (a separate follow-up); until that lands it keeps the full
+    // snapshot, the only blanket cover for the socket-healthy-but-throttled gap.
+    await this.runBootstrap(true, { forceFull: true })
     void this.runCatchUp("resume")
   }
 
@@ -685,24 +693,36 @@ export class SyncEngine {
     const { workspaceId, syncStatus } = this.deps
     syncStatus.set(`workspace:${workspaceId}`, "syncing")
 
-    if (this.socket) {
-      await joinRoomBestEffort(this.socket, `ws:${workspaceId}`, "SyncEngine")
+    // Mirror the full path's swallow-everything discipline. This runs inside
+    // the awaited `runBootstrap` in onConnect; if it rejected, the await would
+    // throw and `runCatchUp` — the only path that resumes the paused gate —
+    // would never run, stranding every buffered live event. So an unexpected
+    // failure (e.g. an IDB read in cachedMemberStreamIds) sets the workspace
+    // stale (cached data is already on screen on a reconnect) and returns;
+    // catch-up still runs and the next reconnect bootstrap closes the gap.
+    try {
+      if (this.socket) {
+        await joinRoomBestEffort(this.socket, `ws:${workspaceId}`, "SyncEngine")
+      }
+      if (this.isDestroyed) return
+
+      // Per-stream deltas (each refresh owns its own status + error handling)
+      // and the label reconcile run together; neither depends on the other.
+      await Promise.all([
+        ...this.getVisibleServerStreamIds().map((streamId) => this.refreshStreamAfterNavigation(streamId)),
+        this.reconcileViewerLabels(),
+      ])
+      if (this.isDestroyed) return
+
+      await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
+      if (this.isDestroyed) return
+
+      this.lastWorkspaceError = null
+      syncStatus.set(`workspace:${workspaceId}`, "synced")
+    } catch (error) {
+      this.lastWorkspaceError = error
+      syncStatus.set(`workspace:${workspaceId}`, "stale")
     }
-    if (this.isDestroyed) return
-
-    // Per-stream deltas (each refresh owns its own status + error handling) and
-    // the label reconcile run together; neither depends on the other.
-    await Promise.all([
-      ...this.getVisibleServerStreamIds().map((streamId) => this.refreshStreamAfterNavigation(streamId)),
-      this.reconcileViewerLabels(),
-    ])
-    if (this.isDestroyed) return
-
-    await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
-    if (this.isDestroyed) return
-
-    this.lastWorkspaceError = null
-    syncStatus.set(`workspace:${workspaceId}`, "synced")
   }
 
   /**
@@ -740,16 +760,26 @@ export class SyncEngine {
       // bootstrap so the visible streams get their delta fetch once the
       // current bootstrap finishes. Repeat reconnect triggers collapse onto
       // the same queued promise.
-      if (isReconnect && !this.queuedReconnectBootstrap) {
-        const chained = this.activeBootstrap
-          .catch(() => {
-            // Swallow — the follow-up reconnect will retry whatever failed.
-          })
-          .then(() => {
-            this.queuedReconnectBootstrap = null
-            return this.runBootstrap(true, { forceFull })
-          })
-        this.queuedReconnectBootstrap = chained
+      if (isReconnect) {
+        // forceFull is a strictly stronger request than a slim reconnect, so it
+        // must survive collapsing onto an already-queued reconnect: the chain
+        // reads this flag at execution time rather than capturing `forceFull`,
+        // so a below-floor forceFull arriving after a slim reconnect is queued
+        // upgrades the single queued run to a full snapshot.
+        if (forceFull) this.queuedReconnectForceFull = true
+        if (!this.queuedReconnectBootstrap) {
+          const chained = this.activeBootstrap
+            .catch(() => {
+              // Swallow — the follow-up reconnect will retry whatever failed.
+            })
+            .then(() => {
+              const queuedForceFull = this.queuedReconnectForceFull
+              this.queuedReconnectBootstrap = null
+              this.queuedReconnectForceFull = false
+              return this.runBootstrap(true, { forceFull: queuedForceFull })
+            })
+          this.queuedReconnectBootstrap = chained
+        }
       }
       return this.queuedReconnectBootstrap ?? this.activeBootstrap
     }

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -25,6 +25,7 @@ import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import { reconcileLabels } from "@/hooks/use-labels"
 import { defaultFeatureFlagValue, type WorkspaceBootstrap } from "@threa/types"
 
 interface SyncEngineDeps {
@@ -38,6 +39,19 @@ interface SyncEngineDeps {
       streamId: string,
       params?: { after?: string }
     ) => Promise<import("@threa/types").StreamBootstrap>
+  }
+  /** Viewer-scoped label catalog + assignments (`listForViewer`). Used by the
+   *  active-mode slim reconnect bootstrap to reconcile the one label slice
+   *  workspace catch-up can't replay: assignments on public streams the viewer
+   *  can see (INV-62) but has no `stream_members` row for, so the
+   *  stream-group-scoped `label:*` event never reaches their sync-log cursor.
+   *  Absent (off/shadow/test deps) → the reconnect bootstrap stays full. */
+  labelService?: {
+    list: (workspaceId: string) => Promise<{
+      labels: import("@threa/types").Label[]
+      memberships: import("@threa/types").LabelMember[]
+      assignments: import("@threa/types").LabelAssignment[]
+    }>
   }
   messageService?: {
     update: (workspaceId: string, messageId: string, data: any) => Promise<any>
@@ -436,7 +450,21 @@ export class SyncEngine {
   // Internal
   // =========================================================================
 
-  private async bootstrapWorkspace(_isReconnect: boolean): Promise<void> {
+  private async bootstrapWorkspace(_isReconnect: boolean, forceFull = false): Promise<void> {
+    // Active-mode reconnect slimming: catch-up replay (which runs right after
+    // this) re-seeds every workspace-scoped projection through the
+    // gate-registered handlers, so re-fetching the full workspace snapshot on
+    // every reconnect is redundant. Skip it and instead do only what catch-up
+    // can't: the per-stream message deltas (the per-stream cursor mechanism,
+    // unchanged) and a reconcile of the viewer's label assignments (the one
+    // non-member public-stream slice the sync-log can't carry). `forceFull`
+    // (below-floor fallback) and the first connect / off / shadow / no-label-
+    // service cases keep the full snapshot.
+    if (_isReconnect && !forceFull && this.syncCursorMode === "active" && this.deps.labelService) {
+      await this.slimReconnectBootstrap()
+      return
+    }
+
     const { workspaceId, syncStatus, queryClient, workspaceService, streamService } = this.deps
 
     syncStatus.set(`workspace:${workspaceId}`, "syncing")
@@ -628,7 +656,82 @@ export class SyncEngine {
     }
   }
 
-  private runBootstrap(isReconnect: boolean): Promise<void> {
+  /**
+   * The active-mode reconnect bootstrap, minus the full workspace-snapshot
+   * fetch + reconcile. Everything here is what workspace catch-up replay can't
+   * cover on its own:
+   *
+   * - Per-stream message deltas for the visible streams. Timeline events ride a
+   *   per-stream sequence (INV-61), not the workspace sync-log, so they heal
+   *   through `bootstrap?after=` (cursor-before-join), never catch-up. Same
+   *   mechanism the full path and post-navigation refresh use.
+   * - The viewer's label assignments. `listEntriesForUser` scopes the sync-log
+   *   to `stream_members` rows, so a `label:assigned/unassigned` on a public
+   *   stream the viewer can see (INV-62) but isn't a member of never replays.
+   *   `labelService.list` returns `listForViewer` (gated through
+   *   `listAccessibleStreamIds`, which includes those streams) and
+   *   `reconcileLabels` bulkPuts + stale-deletes it into IDB — the render
+   *   source. Member-stream label events still replay through catch-up; this
+   *   only backstops the non-member public slice.
+   * - Re-subscribing member rooms from the cached membership list, so
+   *   `stream:activity` keeps flowing onto the sidebar. Membership added/removed
+   *   while offline is replayed by catch-up (`stream:member_*` → subscribe).
+   *
+   * The workspace gate is paused (begun in `onConnect`) for the whole window,
+   * so the IDB writes here land before catch-up applies its delta and before
+   * buffered live events splice in on top — newest state wins, no regression.
+   */
+  private async slimReconnectBootstrap(): Promise<void> {
+    const { workspaceId, syncStatus } = this.deps
+    syncStatus.set(`workspace:${workspaceId}`, "syncing")
+
+    if (this.socket) {
+      await joinRoomBestEffort(this.socket, `ws:${workspaceId}`, "SyncEngine")
+    }
+    if (this.isDestroyed) return
+
+    // Per-stream deltas (each refresh owns its own status + error handling) and
+    // the label reconcile run together; neither depends on the other.
+    await Promise.all([
+      ...this.getVisibleServerStreamIds().map((streamId) => this.refreshStreamAfterNavigation(streamId)),
+      this.reconcileViewerLabels(),
+    ])
+    if (this.isDestroyed) return
+
+    await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
+    if (this.isDestroyed) return
+
+    this.lastWorkspaceError = null
+    syncStatus.set(`workspace:${workspaceId}`, "synced")
+  }
+
+  /**
+   * Reconcile the viewer's label catalog + assignments into IDB. Non-fatal:
+   * member-stream label events still heal through catch-up, so a failed fetch
+   * only leaves the non-member public-stream slice stale until the next
+   * reconnect — never a hard error on the connect path.
+   */
+  private async reconcileViewerLabels(): Promise<void> {
+    const { workspaceId, labelService } = this.deps
+    if (!labelService) return
+    try {
+      const { labels, memberships, assignments } = await labelService.list(workspaceId)
+      if (this.isDestroyed) return
+      await reconcileLabels(workspaceId, labels, memberships, assignments)
+    } catch {
+      // Swallow — catch-up covers member streams; the next reconnect retries.
+    }
+  }
+
+  /**
+   * @param forceFull Run the full workspace-snapshot bootstrap even on an
+   *   active-mode reconnect (where it would otherwise be slimmed to per-stream
+   *   deltas + a label reconcile). The below-floor catch-up fallback sets this:
+   *   a cursor below the retained sync-log floor has no log to replay, so only
+   *   the full snapshot is authoritative for everything `<= head`.
+   */
+  private runBootstrap(isReconnect: boolean, opts?: { forceFull?: boolean }): Promise<void> {
+    const forceFull = opts?.forceFull ?? false
     if (this.activeBootstrap) {
       // If a reconnect arrives while a non-reconnect bootstrap (e.g.
       // retryWorkspace) is in flight, we can't mutate the in-flight request
@@ -644,14 +747,14 @@ export class SyncEngine {
           })
           .then(() => {
             this.queuedReconnectBootstrap = null
-            return this.runBootstrap(true)
+            return this.runBootstrap(true, { forceFull })
           })
         this.queuedReconnectBootstrap = chained
       }
       return this.queuedReconnectBootstrap ?? this.activeBootstrap
     }
 
-    const bootstrapPromise = this.bootstrapWorkspace(isReconnect).finally(() => {
+    const bootstrapPromise = this.bootstrapWorkspace(isReconnect, forceFull).finally(() => {
       if (this.activeBootstrap === bootstrapPromise) {
         this.activeBootstrap = null
       }
@@ -1078,7 +1181,11 @@ export class SyncEngine {
           cursorStore.advance(response.head)
           this.noteSeenHead(response.head)
           appliedThrough = BigInt(response.head)
-          void this.runBootstrap(true)
+          // forceFull: the cursor is below the retained floor, so catch-up has
+          // no entries to replay — only the full workspace snapshot is
+          // authoritative for everything <= head. The slim reconnect path
+          // (per-stream deltas + label reconcile) would leave the rest stale.
+          void this.runBootstrap(true, { forceFull: true })
           return
         }
         if (response.entries.length === 0) {

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -172,29 +172,32 @@ treating such a flag as real healing — it may be dead code (labels was).
   change here is a redesign (threshold alignment / engine-owned resume
   catch-up), not a one-line deletion. Owner decision; not next.
 - **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): **slimmed for
-  active mode (DONE).** The full-snapshot fetch was redundant on a reconnect —
-  catch-up replay (which runs right after) re-seeds every workspace-scoped
-  projection through the gate-registered handlers, patching both IDB and the
-  TanStack bootstrap cache exactly as live events do. On an active-mode
-  reconnect the engine now runs `slimReconnectBootstrap()` instead: per-stream
-  message deltas (the per-stream cursor mechanism, unchanged), a
-  `reconcileViewerLabels()` reconcile (`labelService.list` → `reconcileLabels`,
-  the one slice catch-up can't carry — assignments on public streams the viewer
+  the active-mode socket reconnect (DONE).** The full-snapshot fetch was
+  redundant there — catch-up replay (which runs right after) re-seeds every
+  workspace-scoped projection through the gate-registered handlers, patching
+  both IDB and the TanStack bootstrap cache exactly as live events do. On an
+  active-mode reconnect the engine now runs `slimReconnectBootstrap()` instead:
+  per-stream message deltas (the per-stream cursor mechanism, unchanged), a
+  `reconcileViewerLabels()` reconcile (`labelService.list` → `reconcileLabels` —
+  the one slice catch-up can't carry, assignments on public streams the viewer
   can see per INV-62 but isn't a `stream_members` row for), and member-room
   re-subscription from the cached membership list. The full snapshot is kept
-  for: the first connect (cold load), off/shadow modes, a missing
-  `labelService` (defensive fallback), and the **below-floor `requiresBootstrap`
-  fallback** — which now passes `runBootstrap(true, { forceFull: true })`
-  because a cursor below the retained floor has no log to replay and only the
-  full snapshot is authoritative for everything `<= head`. Static bootstrap-only
-  state (personas, emojis, commands, invitations, viewer permissions,
-  muted-stream ids) has no live event today, so a reconnect was only ever an
-  incidental refresh of it — not a guarantee; it stays fresh until the next cold
-  load, same as a long-lived connection that never reconnects. Read-before-stamp
-  is moot on the slim path: there is no snapshot for the cursor to race, and the
-  cursor + unread IDB persist across the reconnect, so absolute LWW catch-up
-  converges the counters. Covered by `sync-engine.test.ts` ("active-mode
-  reconnect bootstrap slimming").
+  for: the first connect (cold load), off/shadow modes, a missing `labelService`
+  (defensive fallback), the **resume / online-flip path**
+  (`refreshAfterConnectivityResume` passes `forceFull: true` — that window is
+  the `usePageResumeRefresh` follow-up's territory, see below), and the
+  **below-floor `requiresBootstrap` fallback** (also `forceFull: true` — a
+  cursor below the retained floor has no log to replay, so only the full
+  snapshot is authoritative for everything `<= head`; `forceFull` upgrades an
+  already-queued slim reconnect so it can't be collapsed away). Static
+  bootstrap-only state (personas, emojis, commands, invitations, permissions,
+  muted ids) has no live event, so a reconnect was only ever an incidental
+  refresh of it, not a guarantee — no regression. Read-before-stamp is moot on
+  the slim path (no snapshot for the cursor to race; cursor + unread IDB persist
+  across the reconnect, so absolute LWW catch-up converges the counters). The
+  slim path swallows its own errors (sets the workspace stale) so it can never
+  reject and strand the paused gate. Covered by `sync-engine.test.ts`
+  ("active-mode reconnect bootstrap slimming").
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -171,14 +171,30 @@ treating such a flag as real healing — it may be dead code (labels was).
   "socket-healthy but tab-throttled" gaps below the probe threshold. Any
   change here is a redesign (threshold alignment / engine-owned resume
   catch-up), not a one-line deletion. Owner decision; not next.
-- **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): still the
-  authority, but its blocker has lifted. `sync_log` retention has shipped
-  (`docs/plans/sync-v2-log-retention.md`) and the below-floor fallback now
-  routes through this very `runBootstrap(true)`, so it is also the explicit
-  recovery for a pruned cursor. `isLegacyUnreadCounterEntry` is now gone (its
-  sweep deployed), so that gate has lifted too; it still heals the accepted #874
-  drift and seeds active-mode read-before-stamp against this fetch. Slimming it
-  is a now-fully-unblocked follow-up PR.
+- **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): **slimmed for
+  active mode (DONE).** The full-snapshot fetch was redundant on a reconnect —
+  catch-up replay (which runs right after) re-seeds every workspace-scoped
+  projection through the gate-registered handlers, patching both IDB and the
+  TanStack bootstrap cache exactly as live events do. On an active-mode
+  reconnect the engine now runs `slimReconnectBootstrap()` instead: per-stream
+  message deltas (the per-stream cursor mechanism, unchanged), a
+  `reconcileViewerLabels()` reconcile (`labelService.list` → `reconcileLabels`,
+  the one slice catch-up can't carry — assignments on public streams the viewer
+  can see per INV-62 but isn't a `stream_members` row for), and member-room
+  re-subscription from the cached membership list. The full snapshot is kept
+  for: the first connect (cold load), off/shadow modes, a missing
+  `labelService` (defensive fallback), and the **below-floor `requiresBootstrap`
+  fallback** — which now passes `runBootstrap(true, { forceFull: true })`
+  because a cursor below the retained floor has no log to replay and only the
+  full snapshot is authoritative for everything `<= head`. Static bootstrap-only
+  state (personas, emojis, commands, invitations, viewer permissions,
+  muted-stream ids) has no live event today, so a reconnect was only ever an
+  incidental refresh of it — not a guarantee; it stays fresh until the next cold
+  load, same as a long-lived connection that never reconnects. Read-before-stamp
+  is moot on the slim path: there is no snapshot for the cursor to race, and the
+  cursor + unread IDB persist across the reconnect, so absolute LWW catch-up
+  converges the counters. Covered by `sync-engine.test.ts` ("active-mode
+  reconnect bootstrap slimming").
 - **Per-stream reconnect delta** (`joinStreamForCatchUp` + `bootstrap?after=`):
   this _is_ the per-stream cursor mechanism, already delta-shaped. Keep.
 - **`backfillStreamGap` / `detectSequenceGap` / `computeTimelineHoles`**


### PR DESCRIPTION
## What

On an active-mode reconnect the engine re-fetched the **full** workspace
snapshot (`workspaceService.bootstrap`) and reconciled it across ~12 IDB
stores — then `runCatchUp("reconnect")` ran immediately after and re-seeded
every workspace-scoped projection through the gate-registered handlers anyway
(patching both IDB **and** the TanStack bootstrap cache, exactly as live
events do). The snapshot fetch was redundant.

This replaces it, on an **active-mode reconnect only**, with
`slimReconnectBootstrap()`, which does only what catch-up replay structurally
can't:

- **Per-stream message deltas** for visible streams. Timeline events ride a
  per-stream sequence (INV-61), not the workspace sync-log, so they heal
  through `bootstrap?after=` (cursor-before-join) — never catch-up. Unchanged
  mechanism, reused via `refreshStreamAfterNavigation`.
- **Viewer label reconcile** (`labelService.list` → existing `reconcileLabels`).
  `listEntriesForUser` scopes the sync-log to `stream_members` rows, so a
  `label:assigned/unassigned` on a public stream the viewer can see (INV-62)
  but isn't a member of never replays. `labelService.list` returns
  `listForViewer` (gated through `listAccessibleStreamIds`, which includes
  those streams). This is the slice a prior merged PR (the `useLabelsSync`
  deletion) explicitly deferred to "the kept reconnect bootstrap reconcile".
- **Member-room re-subscription** from the cached membership list, so
  `stream:activity` keeps flowing onto the sidebar. Membership added/removed
  while offline is replayed by catch-up (`stream:member_*` → subscribe).

## What stays full

The full snapshot is kept for the **first connect** (cold load), **off/shadow**
modes, a **missing `labelService`** (defensive fallback → no silent gap), and
the **below-floor `requiresBootstrap` fallback** — which now passes
`runBootstrap(true, { forceFull: true })` because a cursor below the retained
sync-log floor has no log to replay and only the full snapshot is
authoritative for everything `<= head`.

## Why it's safe

- **Render source is IDB** (`useLiveQuery` stores). Catch-up replay patches
  both IDB and the TanStack bootstrap cache incrementally for every
  member-scoped projection; the label reconcile patches IDB for the
  non-member public-stream slice catch-up can't carry.
- **Read-before-stamp is moot** on the slim path: there is no snapshot for the
  cursor to race, and the cursor + unread IDB persist across the reconnect, so
  absolute LWW catch-up converges the counters.
- **Gate ordering**: the workspace gate is paused (begun in `onConnect`) for
  the whole slim window, so the reconcile IDB writes land before catch-up
  applies its delta and before buffered live events splice in on top — newest
  state wins, no regression.
- **Static bootstrap-only state** (personas, emojis, commands, invitations,
  permissions, muted ids) has no live event today, so a reconnect was only ever
  an *incidental* refresh of it — not a guarantee. It stays fresh until the
  next cold load, same as a long-lived connection that never reconnects.

## Tests

New `describe("SyncEngine active-mode reconnect bootstrap slimming")` in
`sync-engine.test.ts`:

- active reconnect skips the full snapshot and reconciles viewer labels (the
  non-member public-stream assignment lands in IDB);
- member rooms re-subscribed from cached membership;
- per-stream data still fetched for visible streams;
- below-floor catch-up forces a full bootstrap on reconnect;
- off mode and active-without-`labelService` keep the full reconnect bootstrap.

Full `src/sync` suite green (192), frontend typecheck + lint clean, pre-commit
hook (full monorepo lint + per-package tsc + astro + dockerfiles + OpenAPI
`--check`) green.

Plan: `docs/plans/sync-v2-healing-deletion-inventory.md` "Not deletable /
keep as-is" → "Engine reconnect workspace bootstrap" entry updated to DONE.

Follow-up still open: `usePageResumeRefresh` redesign (its own PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_013aN89rrbjFv6YCVh2rmWc5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783939434&installation_id=129946197&pr_number=912&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F912&signature=a3f77470d4496e6a85bca2c17a0cc35818e0e7da5e308970ae519feffe2269ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->