### PR TITLE
feat: enclave pulls mid-turn messages to reconsider in flight (agent-runtimes §2.7, UX-12)

### DIFF
--- a/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.test.ts
@@ -5,7 +5,8 @@ import type { Server } from "socket.io"
 import { AuthorTypes, ENCLAVE_CALLBACK_TOKEN_HEADER } from "@threa/types"
 import * as db from "../../db"
 import { HttpError } from "../../lib/errors"
-import { AgentSessionRepository, SessionStatuses } from "../agents"
+import { AgentSessionRepository, PersonaRepository, SessionStatuses } from "../agents"
+import { UserRepository } from "../workspaces"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { OutboxRepository } from "../../lib/outbox"
@@ -161,6 +162,107 @@ describe("createEnclaveSessionHandlers.message", () => {
       e2eVersion: 2,
       accessibleStreamIds: ["stream_1"],
       clientMessageId: "enclave-reply:session_1:msg_a",
+    })
+  })
+})
+
+describe("createEnclaveSessionHandlers.pollMessages (interjection pull)", () => {
+  function getReq(id: string | undefined, after?: string): Request {
+    return {
+      params: { id },
+      query: after !== undefined ? { after } : {},
+      header: (name: string) => (name === ENCLAVE_CALLBACK_TOKEN_HEADER ? CB_TOKEN : undefined),
+    } as unknown as Request
+  }
+
+  it("404s when the session is gone", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(null)
+    const { handlers } = makeHandlers()
+    await expect(handlers.pollMessages(getReq("session_1"), fakeRes())).rejects.toMatchObject({ status: 404 })
+  })
+
+  it("409s when the session is no longer running", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...SESSION!, status: SessionStatuses.FAILED })
+    const { handlers } = makeHandlers()
+    await expect(handlers.pollMessages(getReq("session_1"), fakeRes())).rejects.toMatchObject({ status: 409 })
+  })
+
+  it("returns no messages (never replays history) when the trigger sequence can't be resolved", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    // The trigger's message_created event isn't found — no safe floor to clamp to.
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(null)
+    const list = spyOn(StreamEventRepository, "list")
+    const { handlers } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.pollMessages(getReq("session_1", "0"), res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonBody).toEqual({ messages: [] })
+    // The window is never widened to all history — we don't even list.
+    expect(list).not.toHaveBeenCalled()
+  })
+
+  it("returns sealed rows after the trigger-clamped boundary, excluding the persona's own replies", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    // Trigger at 5; the enclave asked for messages after 3, so the floor clamps up.
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
+    const list = spyOn(StreamEventRepository, "list").mockResolvedValue([
+      {
+        sequence: 6n,
+        actorId: "usr_owner",
+        actorType: "user",
+        createdAt: new Date("2026-06-13T10:00:00.000Z"),
+        payload: { messageId: "msg_a" },
+      },
+      // The session's own persona reply — must be dropped, never re-injected.
+      {
+        sequence: 7n,
+        actorId: "persona_ariadne",
+        actorType: "persona",
+        createdAt: new Date("2026-06-13T10:00:01.000Z"),
+        payload: { messageId: "msg_self" },
+      },
+    ] as never)
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_a",
+          {
+            id: "msg_a",
+            authorId: "usr_owner",
+            authorType: "user",
+            ciphertext: Buffer.from("opaque"),
+            envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
+          },
+        ],
+      ]) as never
+    )
+    spyOn(UserRepository, "findByIds").mockResolvedValue([{ id: "usr_owner", name: "Owner" }] as never)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([] as never)
+    const { handlers } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.pollMessages(getReq("session_1", "3"), res)
+
+    // Clamped to the trigger sequence (5), not the requested 3.
+    expect(list.mock.calls[0]![2]).toMatchObject({ afterSequence: 5n, types: ["message_created"] })
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonBody).toEqual({
+      messages: [
+        {
+          messageId: "msg_a",
+          sequence: "6",
+          authorId: "usr_owner",
+          authorType: "user",
+          authorName: "Owner",
+          createdAt: "2026-06-13T10:00:00.000Z",
+          ciphertext: Buffer.from("opaque").toString("base64"),
+          envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
+        },
+      ],
     })
   })
 })
@@ -367,6 +469,31 @@ describe("createEnclaveSessionHandlers.complete", () => {
       messageId: "msg_new",
       triggeredBy: "usr_1",
     })
+  })
+
+  it("advances the catch-up boundary past a message the turn already incorporated (UX-12)", async () => {
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+    spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(SESSION)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ workspaceId: "ws_1" } as never)
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+    const tx = {} as never
+    spyOn(db, "withTransaction").mockImplementation((async (_pool: unknown, fn: (client: never) => unknown) =>
+      fn(tx)) as never)
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    // Trigger at 5; the loop reported it reached 9 via the interjection poll.
+    spyOn(StreamEventRepository, "getMessageSequence").mockResolvedValue(5n)
+    const unseen = spyOn(StreamEventRepository, "getLatestUnseenUserMessage").mockResolvedValue(null)
+    const { handlers, enqueueCatchUp } = makeHandlers()
+    const res = fakeRes()
+
+    await handlers.complete(req("session_1", { ...COMPLETE_BODY, lastProcessedSequence: "9" }), res)
+
+    expect(res.statusCode).toBe(204)
+    // The boundary is the reported sequence (9), not the trigger (5), so the
+    // message the reply already addressed isn't re-triggered.
+    expect(unseen.mock.calls[0]![2]).toBe(9n)
+    expect(enqueueCatchUp).not.toHaveBeenCalled()
   })
 
   it("does not emit the completed event when the session raced to a terminal state", async () => {

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -8,7 +8,10 @@ import {
   AuthorTypes,
   E2E_PLACEHOLDER_CONTENT_MARKDOWN,
   ENCLAVE_CALLBACK_TOKEN_HEADER,
+  type EnclaveMidTurnMessage,
+  type EnclaveMidTurnMessagesResponse,
   type EnclaveSessionHeartbeatResponse,
+  type EnclaveStreamEnvelope,
   type JSONContent,
 } from "@threa/types"
 import { withTransaction } from "../../db"
@@ -18,11 +21,13 @@ import { OutboxRepository } from "../../lib/outbox"
 import { HttpError } from "../../lib/errors"
 import {
   AgentSessionRepository,
+  PersonaRepository,
   SessionStatuses,
   getBuiltInAgentConfig,
   failSessionWithLifecycle,
   type AgentSession,
 } from "../agents"
+import { UserRepository } from "../workspaces"
 import { StreamRepository, StreamEventRepository } from "../streams"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { serializeTraceStep } from "../public-api"
@@ -41,6 +46,7 @@ import { parseModelId } from "@threa/agent-runtime"
  *
  *   POST /internal/enclave-runtimes/sessions/:id/heartbeat  — liveness refresh
  *   POST /internal/enclave-runtimes/sessions/:id/messages   — one sealed reply, streamed
+ *   GET  /internal/enclave-runtimes/sessions/:id/messages   — sealed mid-turn messages (interjection pull)
  *   POST /internal/enclave-runtimes/sessions/:id/steps      — one sealed trace step, streamed
  *   POST /internal/enclave-runtimes/sessions/:id/complete   — ack (ids + metadata)
  *   POST /internal/enclave-runtimes/sessions/:id/fail       — terminate on loop error
@@ -88,6 +94,10 @@ const completeSchema = z.object({
       cost: z.number().optional(),
     })
     .optional(),
+  // The highest stream sequence the turn incorporated via the interjection pull
+  // (UX-12), base-10. Advances the catch-up boundary so a mid-turn message the
+  // reply already addressed isn't re-triggered. Absent → trigger boundary.
+  lastProcessedSequence: z.string().regex(/^\d+$/).optional(),
 })
 
 // The enclave's scrubbed failure classification — `errorName` is the thrown
@@ -133,6 +143,13 @@ const sealedSubstepSchema = z.object({
   stepId: z.string().min(1).optional(),
   snapshotCiphertext: z.base64().min(1).optional(),
   snapshotEnvelope: streamEnvelopeSchema.optional(),
+})
+
+// The interjection pull's only input: the base-10 sequence the enclave has seen
+// up to. Optional — absent means "from the floor" (the trigger boundary the
+// handler clamps to regardless), so a first poll with no cursor is well-defined.
+const pollAfterSchema = z.object({
+  after: z.string().regex(/^\d+$/).optional(),
 })
 
 interface Dependencies {
@@ -293,6 +310,113 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
       })
 
       res.status(204).end()
+    },
+
+    /**
+     * GET /internal/enclave-runtimes/sessions/:id/messages?after=<seq>
+     * The interjection pull (UX-12): hand the enclave the user messages that
+     * landed since `after`, sealed, so its turn loop can reconsider mid-flight
+     * instead of only catching up after completion. The enclave already holds the
+     * SSK from the assignment's wraps, so the body is ciphertext + envelope it
+     * opens itself — the backend never decrypts (INV-E7). Only newly created,
+     * sealed messages are returned, and the session's own persona replies are
+     * excluded so the enclave never re-injects its own streamed output.
+     *
+     * `after` is clamped UP to the trigger's sequence: the enclave was given
+     * history up to its trigger and nothing after it, so a low/absent cursor must
+     * never replay pre-trigger rows it already holds. The enclave seeds its loop
+     * boundary at 0 and lets this floor define the real start.
+     */
+    async pollMessages(req: Request, res: Response) {
+      const id = req.params.id
+      if (!id) throw new HttpError("Missing session id", { status: 400, code: "VALIDATION_ERROR" })
+
+      const parsed = pollAfterSchema.safeParse(req.query)
+      if (!parsed.success) throw new HttpError("Invalid query", { status: 400, code: "VALIDATION_ERROR" })
+
+      const session = await AgentSessionRepository.findById(pool, id)
+      assertRunning(session)
+      assertCallbackBound(session, req)
+      const stream = await StreamRepository.findById(pool, session.streamId)
+      if (!stream) throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+
+      const triggerSeq = session.triggerMessageId
+        ? await StreamEventRepository.getMessageSequence(pool, session.streamId, session.triggerMessageId)
+        : null
+      // No resolvable trigger sequence → no safe floor. Returning rows from 0
+      // would replay the enclave's entire pre-trigger history, so degrade to
+      // "nothing new" rather than silently widening the window (INV-11). The next
+      // turn re-reads settled history anyway; this is observable via the log.
+      if (triggerSeq === null) {
+        logger.warn(
+          { sessionId: id, streamId: session.streamId },
+          "Interjection poll: no trigger sequence; returning no messages"
+        )
+        const empty: EnclaveMidTurnMessagesResponse = { messages: [] }
+        res.status(200).json(empty)
+        return
+      }
+
+      const requested = parsed.data.after ? BigInt(parsed.data.after) : 0n
+      const effectiveAfter = requested > triggerSeq ? requested : triggerSeq
+
+      // Same seam the in-process companion's `check` walks (persona-agent.ts):
+      // list message_created events after the boundary, then hydrate the rows.
+      const events = await StreamEventRepository.list(pool, session.streamId, {
+        types: ["message_created"],
+        afterSequence: effectiveAfter,
+        limit: 50,
+      })
+      // Drop the session's own persona replies — they stream back over /messages
+      // and must not re-enter the loop as fresh user context.
+      const incoming = events.filter((event) => event.actorId !== session.personaId)
+
+      const messageIds = incoming
+        .map((event) => (event.payload as { messageId?: string }).messageId)
+        .filter((messageId): messageId is string => typeof messageId === "string")
+      const messagesById = await MessageRepository.findByIds(pool, messageIds)
+
+      // Resolve author display names (non-secret) so the enclave can render the
+      // same "new context arrived" trace the companion does — mirrors the
+      // companion's check, split by actor kind.
+      const userIds = [...new Set(incoming.filter((e) => e.actorType === "user" && e.actorId).map((e) => e.actorId!))]
+      const personaIds = [
+        ...new Set(incoming.filter((e) => e.actorType === "persona" && e.actorId).map((e) => e.actorId!)),
+      ]
+      const [members, personas] = await Promise.all([
+        userIds.length > 0 ? UserRepository.findByIds(pool, stream.workspaceId, userIds) : Promise.resolve([]),
+        personaIds.length > 0 ? PersonaRepository.findByIds(pool, personaIds, stream.workspaceId) : Promise.resolve([]),
+      ])
+      const names = new Map<string, string>()
+      for (const m of members) names.set(m.id, m.name)
+      for (const p of personas) names.set(p.id, p.name)
+
+      const messages = incoming.flatMap<EnclaveMidTurnMessage>((event) => {
+        const messageId = (event.payload as { messageId?: string }).messageId
+        if (!messageId) return []
+        const message = messagesById.get(messageId)
+        // Only sealed rows are meaningful to the enclave; a non-E2E row in an E2E
+        // stream (shouldn't happen) carries no ciphertext to open, so skip it.
+        if (!message?.ciphertext || !message.envelope) return []
+        const authorId = event.actorId ?? message.authorId ?? "system"
+        const authorType = event.actorType ?? message.authorType ?? AuthorTypes.SYSTEM
+        const authorName = names.get(authorId) ?? (authorType === AuthorTypes.SYSTEM ? "System" : "Unknown")
+        return [
+          {
+            messageId,
+            sequence: event.sequence.toString(),
+            authorId,
+            authorType,
+            authorName,
+            createdAt: event.createdAt.toISOString(),
+            ciphertext: message.ciphertext.toString("base64"),
+            envelope: message.envelope as EnclaveStreamEnvelope,
+          },
+        ]
+      })
+
+      const response: EnclaveMidTurnMessagesResponse = { messages }
+      res.status(200).json(response)
     },
 
     /**
@@ -660,7 +784,14 @@ export function createEnclaveSessionHandlers({ pool, eventService, io, costServi
             session.triggerMessageId
           )
           if (triggerSeq !== null) {
-            const unseen = await StreamEventRepository.getLatestUnseenUserMessage(pool, session.streamId, triggerSeq)
+            // Advance the "seen" boundary past any message the turn already
+            // incorporated mid-flight via the interjection pull (UX-12): the loop
+            // reports its final sequence here, so a message the reply addressed
+            // isn't re-triggered as a redundant follow-up turn. Falls back to the
+            // trigger boundary when the turn saw nothing past its trigger.
+            const reported = parsed.data.lastProcessedSequence ? BigInt(parsed.data.lastProcessedSequence) : 0n
+            const seenBoundary = reported > triggerSeq ? reported : triggerSeq
+            const unseen = await StreamEventRepository.getLatestUnseenUserMessage(pool, session.streamId, seenBoundary)
             if (unseen) {
               await enqueueEnclaveInvocation(pool, {
                 workspaceId: stream.workspaceId,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -329,6 +329,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     })
     app.post("/internal/enclave-runtimes/sessions/:id/heartbeat", enclaveAuth, enclaveSession.heartbeat)
     app.post("/internal/enclave-runtimes/sessions/:id/messages", enclaveAuth, enclaveSession.message)
+    app.get("/internal/enclave-runtimes/sessions/:id/messages", enclaveAuth, enclaveSession.pollMessages)
     app.post("/internal/enclave-runtimes/sessions/:id/sealed-name", enclaveAuth, enclaveSession.sealedName)
     app.post("/internal/enclave-runtimes/sessions/:id/steps/started", enclaveAuth, enclaveSession.stepStarted)
     app.post("/internal/enclave-runtimes/sessions/:id/steps", enclaveAuth, enclaveSession.steps)

--- a/apps/enclave/src/agent/backend-callbacks.test.ts
+++ b/apps/enclave/src/agent/backend-callbacks.test.ts
@@ -45,3 +45,43 @@ describe("createBackendCallbacks callback-token binding (Phase 2.4b)", () => {
     expect(ENCLAVE_CALLBACK_TOKEN_HEADER in calls[0]!.headers).toBe(false)
   })
 })
+
+describe("createBackendCallbacks.pollMessages (interjection pull)", () => {
+  it("GETs the after-cursor URL and returns the sealed rows", async () => {
+    const row = {
+      messageId: "msg_a",
+      sequence: "42",
+      authorId: "usr_owner",
+      authorType: "user",
+      authorName: "Owner",
+      createdAt: "2026-06-13T10:00:00.000Z",
+      ciphertext: "Y3Q=",
+      envelope: { v: 2, keyGeneration: 0, iv: "aXY=", aad: "YWFk" },
+    }
+    const calls: { url: string; method?: string }[] = []
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: RequestInit) => {
+        calls.push({ url, method: init.method })
+        return { ok: true, status: 200, json: async () => ({ messages: [row] }) } as Response
+      })
+    )
+    const callbacks = createBackendCallbacks(config, "cbtok_1")
+
+    const messages = await callbacks.pollMessages("session_1", 7n)
+
+    expect(calls[0]!.method).toBe("GET")
+    expect(calls[0]!.url).toBe("http://backend.test/internal/enclave-runtimes/sessions/session_1/messages?after=7")
+    expect(messages).toEqual([row])
+  })
+
+  it("throws on a malformed body so a protocol fault never reads as 'no messages'", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }) as Response)
+    )
+    const callbacks = createBackendCallbacks(config, "cbtok_1")
+
+    await expect(callbacks.pollMessages("session_1", 0n)).rejects.toThrow(/invalid body/)
+  })
+})

--- a/apps/enclave/src/agent/backend-callbacks.ts
+++ b/apps/enclave/src/agent/backend-callbacks.ts
@@ -1,6 +1,8 @@
 import {
   ENCLAVE_CALLBACK_TOKEN_HEADER,
   INTERNAL_API_KEY_HEADER,
+  type EnclaveMidTurnMessage,
+  type EnclaveMidTurnMessagesResponse,
   type EnclaveSessionHeartbeatResponse,
   type SealedReply,
   type EnclaveSealedName,
@@ -28,6 +30,15 @@ export interface BackendCallbacks {
   heartbeat(sessionId: string): Promise<EnclaveSessionHeartbeatResponse>
   /** Stream one sealed reply back the moment the loop sends it (written + broadcast now). */
   message(sessionId: string, reply: SealedReply): Promise<void>
+  /**
+   * Pull the sealed messages that landed since `afterSequence` (the interjection
+   * poll, UX-12). The loop calls this at its reconsider boundaries so a message
+   * arriving mid-turn reaches the turn in flight, not only via post-completion
+   * catch-up. The backend clamps the floor to the trigger, so a `0` cursor is
+   * safe; the rows come back sealed and the enclave opens them with the SSK it
+   * already holds.
+   */
+  pollMessages(sessionId: string, afterSequence: bigint): Promise<EnclaveMidTurnMessage[]>
   /** Open one in-flight sealed trace step the moment the loop starts it (persisted + broadcast now). */
   stepStarted(sessionId: string, step: SealedStepStart): Promise<void>
   /** Finalize one sealed trace step in place the moment it completes (persisted + broadcast now). */
@@ -81,6 +92,19 @@ export function createBackendCallbacks(config: EnclaveConfig, callbackToken?: st
         signal: AbortSignal.timeout(MESSAGE_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`session message failed: ${res.status}`)
+    },
+
+    async pollMessages(sessionId, afterSequence) {
+      const url = `${base}/internal/enclave-runtimes/sessions/${sessionId}/messages?after=${afterSequence.toString()}`
+      const res = await fetch(url, {
+        method: "GET",
+        headers,
+        signal: AbortSignal.timeout(MESSAGE_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`session poll-messages failed: ${res.status}`)
+      const body = (await res.json()) as EnclaveMidTurnMessagesResponse
+      if (!Array.isArray(body?.messages)) throw new Error("session poll-messages returned an invalid body")
+      return body.messages
     },
 
     async stepStarted(sessionId, step) {

--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -15,6 +15,7 @@ import {
   type AttachmentRef,
 } from "@threa/crypto"
 import type {
+  EnclaveMidTurnMessage,
   SealedReply,
   SealedStep,
   SealedStepStart,
@@ -188,6 +189,87 @@ describe("runEnclaveTurn", () => {
       ciphertext: Buffer.from(messageStep!.ciphertext, "base64"),
     })
     expect(stepText).toBe("Paris.")
+  })
+
+  it("pulls a mid-turn message, reconsiders the draft, and reports the advanced boundary (UX-12)", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "Plan a weekend in France.", "msg_user", "usr_owner")
+
+    // A follow-up the owner sends mid-turn, sealed under the same SSK — the
+    // enclave opens it with the wrap it already holds, no new key machinery.
+    const followUp = await sealUnder(ssk, "Actually, also cover Lyon.", "msg_followup", "usr_owner")
+    const midTurn: EnclaveMidTurnMessage = {
+      messageId: "msg_followup",
+      sequence: "42",
+      authorId: "usr_owner",
+      authorType: "user",
+      authorName: "Owner",
+      createdAt: "2026-06-13T10:00:00.000Z",
+      ciphertext: followUp.ciphertext,
+      envelope: followUp.envelope,
+    }
+
+    // First poll hands back the follow-up; subsequent polls are empty. Record the
+    // `after` cursor so we can prove it advances past the injected sequence.
+    const pollAfter: bigint[] = []
+    let polls = 0
+    const pollNewMessages = async (afterSequence: bigint): Promise<EnclaveMidTurnMessage[]> => {
+      pollAfter.push(afterSequence)
+      return polls++ === 0 ? [midTurn] : []
+    }
+
+    // Draft, then revise after the interjection lands.
+    const chat = stubChat([sendMessageReply("A two-day Paris plan."), sendMessageReply("A Paris + Lyon plan.")])
+    const { onMessage, onStepStarted, onStep, onSubstep, sent } = collector()
+
+    const result = await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep, pollNewMessages },
+      baseRequest({ wraps: [wrap], prompt })
+    )
+
+    // The loop saw the decrypted follow-up injected as user context before it
+    // committed — never ciphertext — so the revised reply is what ships.
+    const reconsiderTurn = chat.seen.at(-1)
+    const injected = reconsiderTurn?.messages.some(
+      (m) => m.role === "user" && String(m.content).includes("Actually, also cover Lyon.")
+    )
+    expect(injected).toBe(true)
+
+    expect(sent).toHaveLength(1)
+    const replyText = await openMessageAsString({
+      key: ssk,
+      envelope: sent[0]!.envelope,
+      ciphertext: Buffer.from(sent[0]!.ciphertext, "base64"),
+    })
+    expect(replyText).toBe("A Paris + Lyon plan.")
+
+    // The boundary seeds at 0 (the backend clamps the floor to the trigger), then
+    // advances past the injected message so the second poll asks for newer rows.
+    expect(pollAfter[0]).toBe(0n)
+    expect(pollAfter.at(-1)).toBe(42n)
+    // The advanced boundary is reported so the backend's catch-up skips the
+    // follow-up the reply already addressed.
+    expect(result.lastProcessedSequence).toBe("42")
+  })
+
+  it("reports no boundary when nothing lands mid-turn", async () => {
+    const keyPair = await createEnclaveKeyPair()
+    const ssk = generateStreamKey()
+    const wrap = await wrapSskToEnclave(keyPair, ssk)
+    const prompt = await sealUnder(ssk, "What's the capital of France?", "msg_user", "usr_owner")
+    const chat = stubChat(textReply("Paris."))
+    const { onMessage, onStepStarted, onStep, onSubstep } = collector()
+
+    const result = await runEnclaveTurn(
+      { keyPair, rawChat: chat.fn, onMessage, onStepStarted, onStep, onSubstep, pollNewMessages: async () => [] },
+      baseRequest({ wraps: [wrap], prompt })
+    )
+
+    // A turn that saw nothing past its trigger omits the field entirely — the
+    // wire stays byte-identical to before the poll existed.
+    expect(result.lastProcessedSequence).toBeUndefined()
   })
 
   it("seals an auto-title the owner's SSK can recover when autoTitle is set", async () => {

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -1,5 +1,6 @@
 import type { LanguageModel, ModelMessage } from "ai"
 import { ulid } from "ulid"
+import { logger as baseLogger } from "@threa/agent-runtime/logger"
 import {
   base64ToBytes,
   buildMessageAad,
@@ -16,6 +17,7 @@ import {
 } from "@threa/crypto"
 import { AgentToolNames } from "@threa/types"
 import type {
+  EnclaveMidTurnMessage,
   EnclaveSessionAssignment,
   EnclaveSessionResult,
   SealedReply,
@@ -34,6 +36,8 @@ import {
   formatTurnDigestsForPrompt,
   generateTurnDigest,
   parseTurnDigestStepContent,
+  type NewMessageAwareness,
+  type NewMessageInfo,
   type TurnDigestPromptEntry,
   type TurnRequest,
   type TurnSink,
@@ -63,8 +67,14 @@ import { generateTitle } from "./auto-title"
  * `EnclaveTraceObserver` seals every step the loop emits (the LLM's reasoning,
  * each tool call, each reply) under the SSK and streams it back, so the owner
  * sees Ariadne's work in real time without the server ever reading it.
- * Durability and mid-turn reconsideration land in later slices.
+ *
+ * Mid-turn messages reach the loop by pulling (UX-12): when `pollNewMessages` is
+ * wired, the turn's interjection edge opens each sealed message that landed since
+ * its boundary with the SSK it already holds, so a fast follow-up is reconsidered
+ * in flight rather than only caught up after completion.
  */
+
+const logger = baseLogger.child({ name: "enclave-interjection" })
 
 /** Marks a caller/data fault so the Express layer can answer 400 instead of 500. */
 export class InvokeError extends Error {}
@@ -108,6 +118,16 @@ export interface EnclaveTurnDeps {
    */
   abortSignal?: AbortSignal
   /**
+   * Mid-turn interjection pull (UX-12): fetch the sealed messages that landed
+   * since `afterSequence` so the loop can reconsider a draft when new context
+   * arrives mid-turn, instead of only catching up after completion. When wired,
+   * the turn's `newMessages` sink becomes a real provider that opens each row
+   * with the SSK the enclave already holds; when omitted, the enclave declares
+   * interjection unsupported (the pre-poll behavior) and the loop runs straight
+   * through.
+   */
+  pollNewMessages?: (afterSequence: bigint) => Promise<EnclaveMidTurnMessage[]>
+  /**
    * Web-tool configuration. Absent or keyless degrades gracefully: no Tavily key
    * means no `web_search` (URL reads + research still work). Omitting `tools`
    * entirely runs the loop with `read_url` + research only.
@@ -124,6 +144,7 @@ export async function runEnclaveTurn(
   request: EnclaveSessionAssignment
 ): Promise<EnclaveSessionResult> {
   const { keyPair, rawChat, onMessage, onStepStarted, onStep, onSubstep, onSealedName, tools, abortSignal } = deps
+  const { pollNewMessages } = deps
 
   // Recover the SSK for every generation the backend wrapped to us. The wrap AAD
   // binds to our own keyId — a wrap addressed elsewhere simply won't open.
@@ -306,12 +327,21 @@ export async function runEnclaveTurn(
       return { messageId }
     },
     observers: [traceObserver, digestCollector],
-    // Interjection is declared unsupported, not silently omitted (UX-12 / §2.2.4):
-    // the enclave reads sealed history once at assignment time and has no channel
-    // to see messages that land mid-turn, so the loop's reconsider path has no
-    // provider here. The reason rides the seam for rendering; the sealed mid-turn
-    // pull (§2.7) is the future "implement" alternative.
-    newMessages: declaredUnsupported("Ariadne can't see mid-turn messages in encrypted scratchpads"),
+    // Interjection (UX-12 / §2.7): when the host wired the mid-turn pull, give the
+    // loop a real provider that opens each sealed message arriving mid-turn with
+    // the SSK we already hold — the same reconsider seam the in-process companion
+    // uses. Without the pull we declare it unsupported, not silently omit it
+    // (§2.2.4): the reason rides the seam for rendering.
+    newMessages: pollNewMessages
+      ? buildInterjectionAwareness({
+          sskByGeneration,
+          refsById,
+          streamId: request.streamId,
+          sessionId: request.sessionId,
+          replySenderId: request.reply.senderId,
+          pollNewMessages,
+        })
+      : declaredUnsupported("Ariadne can't see mid-turn messages in encrypted scratchpads"),
     // Hand ONLY the long-running research sub-loop the session's cancel signal so
     // a user "Stop research" aborts it gracefully (partial findings, the turn
     // still replies). Gated by tool name exactly like the in-process path, so a
@@ -325,7 +355,7 @@ export async function runEnclaveTurn(
   }
 
   // Per turn because the enclave AI is per turn (it accumulates THIS turn's usage).
-  await new EnclaveTurnDriver({ ai }).runTurn(turnRequest, turnSink)
+  const loopResult = await new EnclaveTurnDriver({ ai }).runTurn(turnRequest, turnSink)
 
   // Turn digest (C-1): condense the turn's tool work with one cheap completion
   // over the same pinned model, seal it as a trailing turn_digest step (the
@@ -376,6 +406,14 @@ export async function runEnclaveTurn(
     messageIds,
     model: request.model,
     usage: { promptTokens: usage.promptTokens, completionTokens: usage.completionTokens, cost: usage.cost },
+    // Report the boundary the loop advanced to via the interjection pull so the
+    // backend's post-completion catch-up skips a message this turn already
+    // addressed. The awareness seeds at 0 (the backend clamps the floor to the
+    // trigger), so a turn that saw nothing past its trigger reports nothing —
+    // byte-identical to before the poll existed.
+    ...(loopResult.lastProcessedSequence > 0n
+      ? { lastProcessedSequence: loopResult.lastProcessedSequence.toString() }
+      : {}),
   }
 }
 
@@ -452,6 +490,84 @@ function withAttachmentNote(contentMarkdown: string, refs: AttachmentRef[]): str
   if (refs.length === 0) return contentMarkdown
   const note = refs.map((r) => `[Attached: "${r.filename}" (${r.attachmentId})]`).join("\n")
   return contentMarkdown.length > 0 ? `${contentMarkdown}\n\n${note}` : note
+}
+
+/**
+ * The enclave's mid-turn interjection provider (UX-12), mirroring the in-process
+ * companion's `NewMessageAwareness` but over sealed input: `check` pulls the
+ * messages that landed since the loop's boundary and opens each with the SSK the
+ * enclave already holds (skipping any generation it has no wrap for, exactly as
+ * history opening does), so no new key machinery is involved. `updateSequence`
+ * and `awaitAttachments` are no-ops — the enclave never persists a mid-turn
+ * cursor (the loop holds the boundary and reports it at `/complete`), and it
+ * injects decrypted markdown with attachment notes rather than awaiting
+ * server-side extraction it can't read. The boundary seeds at 0: the backend
+ * clamps the floor to the trigger, so pre-trigger history is never replayed.
+ */
+function buildInterjectionAwareness(params: {
+  sskByGeneration: Map<number, Uint8Array>
+  refsById: Map<string, AttachmentRef>
+  streamId: string
+  sessionId: string
+  replySenderId: string
+  pollNewMessages: (afterSequence: bigint) => Promise<EnclaveMidTurnMessage[]>
+}): NewMessageAwareness {
+  const { sskByGeneration, refsById, streamId, sessionId, replySenderId, pollNewMessages } = params
+  return {
+    streamId,
+    sessionId,
+    // Passed to `check` as `excludeAuthorId`; the backend also drops the persona's
+    // own replies, so excluding it here is belt-and-suspenders.
+    personaId: replySenderId,
+    lastProcessedSequence: 0n,
+    check: async (_streamId, sinceSequence) => {
+      // A transient pull failure (network blip, 5xx) must not kill an otherwise
+      // healthy turn — unlike the in-process companion's `check`, this one crosses
+      // an HTTP boundary mid-turn. Treat the boundary as "nothing new" and let the
+      // next poll retry the same cursor; any message missed this way is still
+      // recovered by the post-completion catch-up, so nothing is permanently
+      // dropped. Scrubbed classification only — the enclave never logs payloads.
+      let rows: EnclaveMidTurnMessage[]
+      try {
+        rows = await pollNewMessages(sinceSequence)
+      } catch (err) {
+        const errorName = err instanceof Error ? err.name : typeof err
+        logger.warn({ errorName }, "Interjection poll failed; continuing without mid-turn messages")
+        return []
+      }
+      const infos: NewMessageInfo[] = []
+      for (const row of rows) {
+        const ssk = sskByGeneration.get(row.envelope.keyGeneration)
+        if (!ssk) continue // no wrap for this generation — can't open, skip
+        try {
+          const raw = await openMessageAsString({
+            key: ssk,
+            envelope: row.envelope,
+            ciphertext: base64ToBytes(row.ciphertext),
+          })
+          const { contentMarkdown, attachmentRefs } = parseSealedPayload(raw)
+          for (const ref of attachmentRefs) refsById.set(ref.attachmentId, ref)
+          infos.push({
+            sequence: BigInt(row.sequence),
+            messageId: row.messageId,
+            changeType: "message_created",
+            content: withAttachmentNote(contentMarkdown, attachmentRefs),
+            authorId: row.authorId,
+            authorName: row.authorName,
+            authorType: row.authorType,
+            createdAt: row.createdAt,
+          })
+        } catch {
+          // An unopenable/malformed row is skipped, never fatal — parity with how
+          // history items are opened above.
+          continue
+        }
+      }
+      return infos
+    },
+    updateSequence: async () => {},
+    awaitAttachments: async () => {},
+  }
 }
 
 async function unwrap(keyPair: EnclaveKeyPair, streamId: string, wrap: EnclaveSskWrap): Promise<Uint8Array> {

--- a/apps/enclave/src/agent/session-runner.test.ts
+++ b/apps/enclave/src/agent/session-runner.test.ts
@@ -50,6 +50,7 @@ function noopCallbacks(overrides: Partial<BackendCallbacks>): BackendCallbacks {
   return {
     heartbeat: async () => ({ abort: false }),
     message: async () => {},
+    pollMessages: async () => [],
     stepStarted: async () => {},
     step: async () => {},
     substep: async () => {},

--- a/apps/enclave/src/agent/session-runner.ts
+++ b/apps/enclave/src/agent/session-runner.ts
@@ -69,6 +69,10 @@ export async function runEnclaveSession(deps: SessionRunnerDeps, assignment: Enc
         onSubstep: (substep) => deps.callbacks.substep(sessionId, substep),
         // Persist a sealed auto-title when the backend flagged this turn for it.
         onSealedName: (sealed) => deps.callbacks.sealedName(sessionId, sealed),
+        // Mid-turn interjection (UX-12): let the loop pull the sealed messages
+        // that land while it runs, so a follow-up reaches the turn in flight
+        // rather than only via post-completion catch-up.
+        pollNewMessages: (afterSequence) => deps.callbacks.pollMessages(sessionId, afterSequence),
         tools: deps.toolConfig ? { tavilyApiKey: deps.toolConfig.tavilyApiKey } : undefined,
         abortSignal: abortController.signal,
       },

--- a/docs/features/architecture/agent-runtime.md
+++ b/docs/features/architecture/agent-runtime.md
@@ -211,11 +211,15 @@ step, then hands both to an `EnclaveTurnDriver` — the same `runTurnOnAgentRunt
 the plaintext driver uses, differing only by delivery and sealing. The driver is exported
 from the curated barrel (no OTEL, no `createAI`) and is constructed per turn because the
 enclave's `AgentRuntimeAI` is per turn (it accumulates that turn's token usage). The enclave
-cannot see messages that arrive mid-turn — it reads sealed history once at assignment time —
-so its sink passes `declaredUnsupported("…")` for the interjection edge rather than omitting
-it: the gap (UX-12) is a named, renderable product decision, not a silent hole. Implementing
-a sealed mid-turn pull is a later option (`docs/plans/agent-runtimes-unification-redesign.md`
-§2.7).
+sees messages that arrive mid-turn by _pulling_ them (UX-12): its sink's interjection edge is
+a real `NewMessageAwareness` that, at each reconsider boundary, calls
+`GET /internal/enclave-runtimes/sessions/:id/messages?after=<seq>` and opens the sealed rows
+with the SSK it already holds — the same reconsider seam the in-process companion uses, no new
+key machinery. The backend clamps the pull's floor to the trigger so pre-trigger history is
+never replayed, and the loop reports the boundary it advanced to at `/complete` so the
+post-completion catch-up skips a follow-up the reply already addressed. When the host doesn't
+wire the pull, the sink falls back to `declaredUnsupported("…")` — a named, renderable product
+decision, not a silent hole (`docs/plans/agent-runtimes-unification-redesign.md` §2.7).
 
 ## Boundaries
 

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -746,18 +746,35 @@ minted per-claim. The enclave's inbound listener is metadata-only
 validation, the forwarder, and the `ENCLAVE_INVOKE` queue are deleted.
 Cancellation collapsed into the session heartbeat (`abort_requested_at` on
 `agent_sessions`, returned as `{ abort }`), closing the N-3 divergence on
-the abort side. Still open from this section: the **interjection poll**
-(observation 1, UX-12) — mid-turn messages still reach the enclave only via
-the post-completion catch-up, which now reopens the suppressed message's own
-invocation; and the wake-up nudge (the idle poll interval, default 1.5s, is
-the turn-start latency floor).
+the abort side.
+
+**The interjection poll (observation 1, UX-12) has now shipped too.** The
+enclave's sink no longer declares interjection unsupported: it provides a real
+`NewMessageAwareness` that, at each reconsider boundary, calls
+`GET /internal/enclave-runtimes/sessions/:id/messages?after=<seq>` and opens the
+sealed rows with the SSK it already holds — no new key machinery, the same
+reconsider seam the in-process companion uses. The pull's floor is clamped
+server-side to the trigger sequence (pre-trigger history is never replayed), and
+the loop reports the boundary it advanced to on `/complete` (`lastProcessedSequence`)
+so the post-completion catch-up skips a follow-up the reply already addressed
+instead of re-triggering a redundant turn. Scope: newly created messages only (a
+mid-turn edit/delete of an older row isn't an interjection; the next turn re-reads
+settled history); mid-turn attachment _bytes_ aren't shipped (the message's
+markdown + an attachment note are injected, matching how the companion injects
+mid-turn context). Still open from this section: the wake-up nudge (the idle poll
+interval, default 1.5s, is the turn-start latency floor).
 
 ## 2.8 Open questions
 
 1. **Enclave interjection: implement or declare?** Implementing sealed
    mid-turn message push is real work (new callback direction, wrap handling);
    declaring it unsupported is honest and cheap. Recommend: declare in Phase 0
-   timeframe, decide on implementation after the contract lands.
+   timeframe, decide on implementation after the contract lands. _Resolved as
+   implement (the pull, not a push): the enclave's interjection edge is a real
+   `NewMessageAwareness` over `GET .../sessions/:id/messages?after=<seq>`,
+   opening sealed rows with the SSK it already holds — no new wrap machinery,
+   no new callback direction beyond the one pull. See the §2.7 status note. The
+   `declaredUnsupported` fallback remains for a host that doesn't wire the pull._
 2. **Context handle shape for bots (N-4):** inline last-N history in the
    invocation vs. a fetch-back ref. Inline is simpler and matches the
    enclave's assignment shape (30 messages); a ref scales better and keeps

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -745,6 +745,17 @@ export interface EnclaveSessionResult {
   messageIds: string[]
   model: string
   usage?: { promptTokens?: number; completionTokens?: number; cost?: number }
+  /**
+   * The highest stream sequence the turn's loop incorporated, as a base-10
+   * bigint string (UX-12 interjection poll). The loop seeds its boundary at the
+   * trigger and advances it each time the mid-turn pull (`GET .../messages`)
+   * hands it a newer message; reporting the final value lets the backend's
+   * post-completion catch-up skip a message the reply already addressed instead
+   * of re-triggering a redundant turn for it. Omitted (or ≤ the trigger's
+   * sequence) means the turn incorporated nothing past its trigger — the catch-up
+   * then falls back to the trigger boundary, exactly as before the poll existed.
+   */
+  lastProcessedSequence?: string
 }
 
 /**
@@ -783,6 +794,41 @@ export interface EnclaveClaimResponse {
  */
 export interface EnclaveSessionHeartbeatResponse {
   abort: boolean
+}
+
+/**
+ * One message that landed mid-turn, handed back over the enclave's interjection
+ * pull (`GET .../sessions/:id/messages?after=<seq>`, UX-12). The body is sealed —
+ * ciphertext + envelope, opened with the SSK the enclave already holds from the
+ * assignment's wraps, so no new key machinery is involved; only the routing
+ * metadata travels in clear. The sequence is a base-10 bigint string (per-stream
+ * sequences are bigints), so the enclave's loop can advance its "seen up to here"
+ * boundary and report the final value at `/complete`. The author's display name
+ * is non-secret (it already rides the assignment's trigger metadata), and lets
+ * the enclave render the same "new context arrived" trace the in-process
+ * companion does. Only newly created messages are reported — a mid-turn edit or
+ * delete of an older row isn't an interjection, and the next turn re-reads the
+ * settled history anyway.
+ */
+export interface EnclaveMidTurnMessage {
+  messageId: string
+  sequence: string
+  authorId: string
+  authorType: AuthorType
+  authorName: string
+  createdAt: string
+  ciphertext: string
+  envelope: EnclaveStreamEnvelope
+}
+
+/**
+ * Response of the enclave's interjection pull (`GET .../sessions/:id/messages`):
+ * the sealed messages that arrived after the requested sequence, oldest→newest,
+ * with the session's own persona replies excluded (the enclave must not re-inject
+ * its own output). An empty array means nothing landed since the last poll.
+ */
+export interface EnclaveMidTurnMessagesResponse {
+  messages: EnclaveMidTurnMessage[]
 }
 
 export type CreateDmMessageInput = CreateDmMessageInputJson | CreateDmMessageInputMarkdown

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -385,6 +385,8 @@ export type {
   EnclaveSessionFailure,
   EnclaveClaimResponse,
   EnclaveSessionHeartbeatResponse,
+  EnclaveMidTurnMessage,
+  EnclaveMidTurnMessagesResponse,
   UpdateStreamInput,
   UpdateCompanionModeInput,
   StreamBootstrap,


### PR DESCRIPTION
**Design doc:** `docs/plans/agent-runtimes-unification-redesign.md` §2.7 (observation 1) / §2.8 Q1 — audit finding **UX-12**.

## Problem

The enclave (Ariadne's E2EE runtime) read a stream's sealed history exactly once, at assignment time, and never again for the rest of the turn. A message that landed mid-turn reached it only through the post-completion catch-up, which reopens the suppressed message's own invocation and runs a *whole second turn* for it. So a fast follow-up to an encrypted scratchpad produced two separate replies instead of one reconsidered answer — the divergence the audit tracked as UX-12.

The seam to fix it already existed: `TurnSink.newMessages` (the loop's reconsider edge, `packages/agent-runtime/src/runtime/turn-driver.ts`). The in-process companion (`persona-agent.ts:702`) supplies a real `NewMessageAwareness` there; the enclave passed `declaredUnsupported("Ariadne can't see mid-turn messages in encrypted scratchpads")`. The loop's entire reconsider path was dead code in the enclave.

## Solution

Invert it to a pull, the way §2.7 specifies: the enclave fetches the messages that landed mid-turn over an outbound callback and opens them with the SSK it already holds. No new key machinery — mid-turn messages are sealed under the stream SSK by the sender's client, and the enclave already unwrapped that SSK from the assignment. The enclave's `newMessages` edge becomes a real `NewMessageAwareness`, landing on the identical reconsider seam the plaintext companion uses.

### How it works

1. **Backend pull endpoint** — `GET /internal/enclave-runtimes/sessions/:id/messages?after=<seq>` (`session-handlers.ts`, `pollMessages`). Walks the same path the companion's `check` does — `StreamEventRepository.list({ types: ["message_created"], afterSequence })` then `MessageRepository.findByIds` — and returns sealed `EnclaveMidTurnMessage` rows (ciphertext + envelope + clear author metadata), oldest→newest, with the session's own persona replies filtered out. Same callback-token binding (`assertCallbackBound`) and `assertRunning` gate as every other session callback; ciphertext only crosses, never plaintext (INV-E7).
2. **Floor clamp** — `after` is clamped *up* to the trigger message's sequence (`getMessageSequence`): the enclave was handed history up to its trigger and nothing after, so a low/absent cursor must never replay pre-trigger history it already holds. The enclave seeds its loop boundary at `0` and lets the server define the real floor.
3. **Enclave awareness** — `buildInterjectionAwareness` (`run-turn.ts`) wires `check` to `pollMessages`, opens each row with `sskByGeneration` (skipping any generation it has no wrap for, exactly as history opening does), and injects decrypted markdown + attachment notes. `updateSequence`/`awaitAttachments` are no-ops: the enclave holds the boundary in the loop and reports it at `/complete`, and it injects markdown rather than awaiting server-side extraction it can't read. Gated on a wired `pollNewMessages` — without it the sink still falls back to `declaredUnsupported`.
4. **Boundary report** — `runEnclaveTurn` captures the loop's final `lastProcessedSequence` and reports it on `EnclaveSessionResult`; `/complete` advances its catch-up boundary to `max(triggerSeq, reported)` so a follow-up the reply already addressed is not re-triggered as a redundant turn. A turn that saw nothing past its trigger reports nothing — byte-identical to before the poll existed.

### Key design decisions

**1. Created-messages only.** A mid-turn edit or delete of an *older* row isn't an interjection (the loop re-reads settled history on the next turn anyway), so the endpoint returns only `message_created`. Keeps the decrypt path and the wire shape minimal.

**2. Server-side clamp + report-at-complete, not a new assignment field or update-sequence endpoint.** The boundary lives in two cheap places already on the wire: the server clamps the GET floor to the trigger, and the enclave reports the loop's final sequence on the existing `/complete` body. Shipping the trigger sequence on the assignment, or a separate "advance cursor" POST per the companion's `updateSequence`, were both rejected as more surface for no behavioral gain — the enclave never persists a mid-turn cursor (a crash falls back to the next user message re-triggering, same as today).

**3. The clamp runs on every poll, deliberately.** A self-review pass floated skipping `getMessageSequence` once the cursor advanced. Rejected: a caller sending a small nonzero `after` (e.g. `after=1`, trigger at `5`) would replay history `1..5`, so the floor must be enforced on every request regardless of cursor — the lookup is one indexed query riding alongside the `list` the poll runs anyway.

**4. Mid-turn attachment *bytes* aren't shipped.** History/trigger attachment ciphertext rides the assignment; mid-turn messages inject markdown + an `[Attached: …]` note (same shape the companion injects for mid-turn context) rather than widening the pull to carry blobs. Noted in §2.7's status as the one scoped gap.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts` | `EnclaveMidTurnMessage` + `EnclaveMidTurnMessagesResponse` wire types; optional `lastProcessedSequence` (base-10 string) on `EnclaveSessionResult` |
| `packages/types/src/index.ts` | Barrel-export the two new types |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | New `pollMessages` GET handler (clamp, persona-exclusion, sealed rows, author-name resolution); `/complete` catch-up boundary advanced by reported sequence; `completeSchema` + `pollAfterSchema` |
| `apps/backend/src/routes.ts` | Register `GET .../sessions/:id/messages` |
| `apps/enclave/src/agent/backend-callbacks.ts` | `pollMessages` GET callback with malformed-body guard |
| `apps/enclave/src/agent/run-turn.ts` | `buildInterjectionAwareness`; `pollNewMessages` dep; real `newMessages` edge when wired; capture + report `lastProcessedSequence`; poll-failure resilience |
| `apps/enclave/src/agent/session-runner.ts` | Thread `pollNewMessages` → `callbacks.pollMessages` |
| `docs/features/architecture/agent-runtime.md`, `docs/plans/agent-runtimes-unification-redesign.md` | §2.7 status + §2.8 Q1 resolved; feature-doc enclave section updated |

## Out of scope (deliberate)

- **Mid-turn edits/deletes** of older rows, and **mid-turn attachment bytes** — see decisions 1 and 4.
- **The wake-up nudge** (turn-start latency floor, default 1.5s idle poll) — still open in §2.7, untouched here.
- **Heartbeat piggyback.** §2.7 notes the poll *could* share the heartbeat channel; the honest implementation is a per-`check` GET (matching the companion's per-check DB query). Not coupled to the heartbeat.

## Test plan

- [x] Enclave `bun run test` — **87 pass** (+4: interjection reconsider + boundary report, no-boundary-when-nothing-lands, `pollMessages` GET URL/parse, malformed-body throw)
- [x] Backend `bun test src/features/enclave-runtimes/` — **99 pass**, incl. new `pollMessages` cases (404/409, trigger-clamped sealed rows + persona exclusion, null-trigger → no history replay) and the `/complete` boundary-advancement case
- [x] `tsc --noEmit` clean across `packages/types`, `apps/backend` (+ tests config), `apps/enclave` — and the full 14-workspace typecheck + api-docs `--check` + astro check via the pre-commit hook
- [x] Lint clean (enclave `eslint src/`, backend touched files)
- [x] Pre-PR self-review (3 reviewer agents: correctness / spec+invariants / design) — **2 findings fixed**, 2 dismissed with reasoning (see below)

### Design evolution (self-review)

- **Poll failure killed the turn.** First version called `pollNewMessages` unguarded inside `check`; a transient network blip would propagate up and fail an otherwise-healthy turn (unlike the companion's local DB query, this crosses HTTP mid-turn). Fixed: catch, log a scrubbed `errorName`, return `[]` — the next poll retries the same cursor and the post-completion catch-up backstops anything permanently missed.
- **Null trigger sequence replayed all history.** First version used `floor = triggerSeq ?? 0n`; an unresolvable trigger event would silently widen the window to sequence 0 and re-ship the entire pre-trigger history. Fixed to gate on `triggerSeq !== null` and degrade to `{ messages: [] }` with a log (INV-11) — the companion's `check` gates the same way.
- **Dismissed:** per-poll `getMessageSequence` (perf) — one indexed lookup atop an unavoidable `list`, and the clamp *must* run every poll (decision 3); a session-column cache is scope creep. Unbounded reported `lastProcessedSequence` (trust) — the value is always a real in-stream sequence the backend itself handed back, and the enclave is the trusted plaintext-handling component, so "suppress all follow-ups" needs a malicious enclave that already sees far more.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Implement §2.7 observation 1 (UX-12): let the enclave see messages that arrive mid-turn and reconsider its draft, instead of only catching up after completion. Chosen by Kris over the alternative (declare it unsupported, §2.8 Q1).

**What was built.** A pull-shaped interjection channel: a backend `GET .../sessions/:id/messages?after=<seq>` returning sealed created-message rows after a trigger-clamped boundary, and an enclave `NewMessageAwareness` that opens them with the SSK it already holds and injects them at the loop's reconsider boundaries. The loop reports the boundary it reached at `/complete`, which advances the post-completion catch-up so a message already incorporated isn't re-triggered.

**Design decisions.** (1) created-only; (2) server-side clamp + report-at-complete rather than an assignment field or update-sequence endpoint; (3) clamp every poll (skipping it is unsafe); (4) inject markdown + attachment notes, don't ship mid-turn attachment bytes. No new key machinery — the SSK from the assignment opens mid-turn messages.

**Design evolution.** Two self-review fixes: poll-failure resilience (catch → `[]`), and null-trigger floor (degrade to empty rather than replay history).

**Schema changes.** None — no migration, no new columns. The boundary lives on the existing `/complete` body + the GET's server-side clamp.

**What's NOT included.** Mid-turn edits/deletes, mid-turn attachment bytes, the wake-up nudge, heartbeat piggyback.

**Status.** Implemented, self-reviewed, tests green, typecheck/lint/api-docs/astro clean. §2.7 status note and §2.8 Q1 updated to reflect shipped.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfWTRc2HrEdPsheuDvu1J5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783942758&installation_id=129946197&pr_number=913&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F913&signature=4858cfbedf4ca51063e216b39bb568405905284612eecd2c9f0155d047aa2734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->