### PR TITLE
fix: stack list-page header tabs onto a second row on mobile

### DIFF
--- a/apps/frontend/src/components/layout/index.ts
+++ b/apps/frontend/src/components/layout/index.ts
@@ -1,5 +1,6 @@
 export { AppShell } from "./app-shell"
 export { Sidebar } from "./sidebar"
 export { SidebarToggle } from "./sidebar-toggle"
+export { PageHeaderTabs, type PageHeaderTab } from "./page-header-tabs"
 export { ThreadPanelSlot } from "./thread-panel-slot"
 export { PanelResizeHandle } from "./panel-resize-handle"

--- a/apps/frontend/src/components/layout/page-header-tabs.tsx
+++ b/apps/frontend/src/components/layout/page-header-tabs.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react"
+import { Link } from "react-router-dom"
+import { ArrowLeft, type LucideIcon } from "lucide-react"
+import { buttonVariants } from "@/components/ui/button"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { SidebarToggle } from "@/components/layout/sidebar-toggle"
+import { cn } from "@/lib/utils"
+
+export interface PageHeaderTab {
+  /** Matches the active `value` to drive the selected styling. */
+  value: string
+  label: string
+  /** Destination URL — tabs are navigation, so each trigger renders an <a> (INV-40). */
+  href: string
+  /** Optional trailing adornment (e.g. an unread count pill). */
+  badge?: ReactNode
+}
+
+interface PageHeaderTabsProps {
+  /** Back-arrow destination (the workspace home). */
+  backTo: string
+  icon: LucideIcon
+  title: string
+  /** The active tab's `value`. */
+  value: string
+  tabs: PageHeaderTab[]
+  /** Optional right-aligned actions (e.g. a "Mark all read" button). */
+  actions?: ReactNode
+}
+
+/**
+ * Shared header for the list pages (Saved, Activity, Scheduled): a back arrow,
+ * an icon + title, and a chip-style tab strip.
+ *
+ * On desktop the title and the tab strip share one row (`justify-between`). On
+ * mobile there isn't room for both — the non-shrinking chips would otherwise
+ * swallow the title — so the header stacks into two rows: title on top, the tab
+ * strip on its own full-width row below. The strip scrolls horizontally rather
+ * than wrapping, so adding tabs never pushes the title off-screen.
+ */
+export function PageHeaderTabs({ backTo, icon: Icon, title, value, tabs, actions }: PageHeaderTabsProps) {
+  return (
+    <header className="flex flex-col gap-2 border-b px-4 py-2 sm:h-12 sm:flex-row sm:items-center sm:justify-between sm:gap-2 sm:py-0">
+      <div className="flex items-center gap-2 min-w-0">
+        <SidebarToggle location="page" />
+        <Link
+          to={backTo}
+          className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "h-8 w-8 shrink-0")}
+          aria-label="Back to workspace"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <div className="flex items-center gap-2 min-w-0">
+          <Icon className="h-5 w-5 text-muted-foreground shrink-0" />
+          <h1 className="font-semibold truncate">{title}</h1>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 min-w-0 sm:min-w-fit sm:shrink-0">
+        <div className="min-w-0 overflow-x-auto scrollbar-none">
+          <Tabs value={value}>
+            <TabsList className="h-8 w-max">
+              {tabs.map((t) => (
+                <TabsTrigger key={t.value} value={t.value} asChild>
+                  <Link to={t.href} className="text-xs px-2.5 py-1">
+                    {t.label}
+                    {t.badge}
+                  </Link>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        </div>
+        {actions}
+      </div>
+    </header>
+  )
+}

--- a/apps/frontend/src/components/layout/page-header-tabs.tsx
+++ b/apps/frontend/src/components/layout/page-header-tabs.tsx
@@ -56,7 +56,7 @@ export function PageHeaderTabs({ backTo, icon: Icon, title, value, tabs, actions
         </div>
       </div>
 
-      <div className="flex items-center gap-2 min-w-0 sm:min-w-fit sm:shrink-0">
+      <div className="flex items-center justify-center gap-2 min-w-0 sm:justify-start sm:min-w-fit sm:shrink-0">
         <div className="min-w-0 overflow-x-auto scrollbar-none">
           <Tabs value={value}>
             <TabsList className="h-8 w-max">

--- a/apps/frontend/src/pages/activity.tsx
+++ b/apps/frontend/src/pages/activity.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react"
-import { Navigate, useParams, Link } from "react-router-dom"
-import { Bell, ArrowLeft, Check } from "lucide-react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { Navigate, useParams } from "react-router-dom"
+import { Bell, Check } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { cn } from "@/lib/utils"
 import { useActivityFeed, useMarkActivityRead, useMarkAllActivityRead, useActors } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
@@ -13,7 +11,7 @@ import { getStreamName, streamFallbackLabel } from "@/lib/streams"
 import { ActivityItem } from "@/components/activity/activity-item"
 import { ActivityEmpty } from "@/components/activity/activity-empty"
 import { ActivitySkeleton } from "@/components/activity/activity-skeleton"
-import { SidebarToggle } from "@/components/layout"
+import { PageHeaderTabs } from "@/components/layout"
 import type { AuthorType, Activity } from "@threa/types"
 
 type ActivityFilter = "all" | "unread" | "me"
@@ -136,58 +134,32 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 items-center justify-between border-b px-4 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <SidebarToggle location="page" />
-          <Link
-            to={`/w/${workspaceId}`}
-            className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "h-8 w-8 shrink-0")}
-            aria-label="Back to workspace"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-          <div className="flex items-center gap-2 min-w-0">
-            <Bell className="h-5 w-5 text-muted-foreground shrink-0" />
-            <h1 className="font-semibold truncate">Activity</h1>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2 shrink-0">
-          <Tabs value={filter}>
-            <TabsList className="h-8">
-              <TabsTrigger value="all" asChild>
-                <Link to={filterHref("all")} className="text-xs px-2.5 py-1">
-                  All
-                </Link>
-              </TabsTrigger>
-              <TabsTrigger value="unread" asChild>
-                <Link to={filterHref("unread")} className="text-xs px-2.5 py-1">
-                  Unread
-                </Link>
-              </TabsTrigger>
-              <TabsTrigger value="me" asChild>
-                <Link to={filterHref("me")} className="text-xs px-2.5 py-1">
-                  Me
-                </Link>
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          {unreadActivityCount > 0 && (
+      <PageHeaderTabs
+        backTo={`/w/${workspaceId}`}
+        icon={Bell}
+        title="Activity"
+        value={filter}
+        tabs={[
+          { value: "all", label: "All", href: filterHref("all") },
+          { value: "unread", label: "Unread", href: filterHref("unread") },
+          { value: "me", label: "Me", href: filterHref("me") },
+        ]}
+        actions={
+          unreadActivityCount > 0 ? (
             <Button
               variant="ghost"
               size="sm"
               onClick={() => markAllRead.mutate()}
               disabled={markAllRead.isPending}
-              className="text-xs gap-1.5 max-sm:h-8 max-sm:w-8 max-sm:p-0"
+              className="text-xs gap-1.5 shrink-0 max-sm:h-8 max-sm:w-8 max-sm:p-0"
               title="Mark all read"
             >
               <Check className="h-3.5 w-3.5" />
               <span className="max-sm:hidden">Mark all read</span>
             </Button>
-          )}
-        </div>
-      </header>
+          ) : undefined
+        }
+      />
 
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
         <main className="py-2">{content}</main>

--- a/apps/frontend/src/pages/saved.tsx
+++ b/apps/frontend/src/pages/saved.tsx
@@ -1,11 +1,8 @@
-import { Navigate, useParams, Link } from "react-router-dom"
-import { ArrowLeft, Bookmark } from "lucide-react"
+import { Navigate, useParams } from "react-router-dom"
+import { Bookmark } from "lucide-react"
 import { toast } from "sonner"
 import { SAVED_STATUSES } from "@threa/types"
-import { buttonVariants } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { cn } from "@/lib/utils"
 import { useSavedList, useUpdateSaved, useDeleteSaved } from "@/hooks"
 import { useSuggestedCount } from "@/hooks/use-saved-suggestions"
 import { SavedItem } from "@/components/saved/saved-item"
@@ -13,7 +10,7 @@ import { SavedEmpty } from "@/components/saved/saved-empty"
 import { SavedSkeleton } from "@/components/saved/saved-skeleton"
 import { SavedQuickAdd } from "@/components/saved/saved-quick-add"
 import { SuggestedTab } from "@/components/saved/suggested-tab"
-import { SidebarToggle } from "@/components/layout"
+import { PageHeaderTabs } from "@/components/layout"
 import type { SavedStatus } from "@threa/types"
 
 // "suggested" is a view, not a saved status — it reads from a separate data
@@ -69,39 +66,23 @@ function SavedPageInner({ workspaceId, tab }: InnerProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 items-center justify-between border-b px-4 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <SidebarToggle location="page" />
-          <Link
-            to={`/w/${workspaceId}`}
-            className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "h-8 w-8 shrink-0")}
-            aria-label="Back to workspace"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-          <div className="flex items-center gap-2 min-w-0">
-            <Bookmark className="h-5 w-5 text-muted-foreground shrink-0" />
-            <h1 className="font-semibold truncate">Saved</h1>
-          </div>
-        </div>
-
-        <Tabs value={tab}>
-          <TabsList className="h-8">
-            {TABS.map((t) => (
-              <TabsTrigger key={t.value} value={t.value} asChild>
-                <Link to={tabHref(t.value)} className="text-xs px-2.5 py-1">
-                  {t.label}
-                  {t.value === "suggested" && suggestedCount > 0 && (
-                    <span className="ml-1.5 rounded-full bg-amber-500/15 px-1.5 text-[10px] font-medium text-amber-600 tabular-nums">
-                      {suggestedCount}
-                    </span>
-                  )}
-                </Link>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-      </header>
+      <PageHeaderTabs
+        backTo={`/w/${workspaceId}`}
+        icon={Bookmark}
+        title="Saved"
+        value={tab}
+        tabs={TABS.map((t) => ({
+          value: t.value,
+          label: t.label,
+          href: tabHref(t.value),
+          badge:
+            t.value === "suggested" && suggestedCount > 0 ? (
+              <span className="ml-1.5 rounded-full bg-amber-500/15 px-1.5 text-[10px] font-medium text-amber-600 tabular-nums">
+                {suggestedCount}
+              </span>
+            ) : undefined,
+        }))}
+      />
 
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
         <main className="py-1">

--- a/apps/frontend/src/pages/scheduled.tsx
+++ b/apps/frontend/src/pages/scheduled.tsx
@@ -1,18 +1,15 @@
 import { useState } from "react"
-import { Link, Navigate, useParams } from "react-router-dom"
-import { ArrowLeft, CalendarClock } from "lucide-react"
+import { Navigate, useParams } from "react-router-dom"
+import { CalendarClock } from "lucide-react"
 import { toast } from "sonner"
 import type { ScheduledMessageView } from "@threa/types"
-import { buttonVariants } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { cn } from "@/lib/utils"
 import { useScheduledList, useCancelScheduled, useSendScheduledNow } from "@/hooks"
 import { ScheduledEmpty } from "@/components/scheduled/scheduled-empty"
 import { ScheduledItem } from "@/components/scheduled/scheduled-item"
 import { ScheduledSkeleton } from "@/components/scheduled/scheduled-skeleton"
 import { ScheduledEditDialog } from "@/components/scheduled/scheduled-edit-dialog"
-import { SidebarToggle } from "@/components/layout"
+import { PageHeaderTabs } from "@/components/layout"
 
 type PageTabValue = "pending" | "sent"
 const TABS: { value: PageTabValue; label: string }[] = [
@@ -107,34 +104,13 @@ function ScheduledPageInner({ workspaceId, tab }: InnerProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <header className="flex h-12 items-center justify-between border-b px-4 gap-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <SidebarToggle location="page" />
-          <Link
-            to={`/w/${workspaceId}`}
-            className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "h-8 w-8 shrink-0")}
-            aria-label="Back to workspace"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-          <div className="flex items-center gap-2 min-w-0">
-            <CalendarClock className="h-5 w-5 text-muted-foreground shrink-0" />
-            <h1 className="font-semibold truncate">Scheduled</h1>
-          </div>
-        </div>
-
-        <Tabs value={tab}>
-          <TabsList className="h-8">
-            {TABS.map((t) => (
-              <TabsTrigger key={t.value} value={t.value} asChild>
-                <Link to={tabHref(t.value)} className="text-xs px-2.5 py-1">
-                  {t.label}
-                </Link>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-      </header>
+      <PageHeaderTabs
+        backTo={`/w/${workspaceId}`}
+        icon={CalendarClock}
+        title="Scheduled"
+        value={tab}
+        tabs={TABS.map((t) => ({ value: t.value, label: t.label, href: tabHref(t.value) }))}
+      />
 
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
         <main className="py-1">{content}</main>


### PR DESCRIPTION
## Problem

The Saved, Activity, and Scheduled list pages shared a header that placed the title group (back arrow + icon + title) and the chip-style tab strip on a single row via `justify-between`. The chips are `whitespace-nowrap` and don't shrink; the title group carries `min-w-0`. On a narrow (mobile) viewport the chips win the space contest and the title truncates to nothing — on `/saved`, the four-tab strip (Saved / Suggested / Done / Archived) covered the left side entirely, leaving the "Saved" heading invisible. Desktop has the width to fit both, so the bug only showed on mobile.

The three headers were also copy-pasted, so the layout could (and did) drift between pages.

## Solution

Extract a single `PageHeaderTabs` component and route all three pages through it. On desktop the title and tab strip keep the existing one-row `justify-between` layout. On mobile the header stacks into two rows — title on top, the tab strip on its own full-width row below — and the strip scrolls horizontally (`overflow-x-auto scrollbar-none`) instead of wrapping or overrunning the title.

### How it works

- The header root is `flex flex-col` by default and `sm:flex-row sm:items-center sm:justify-between` at the `sm` breakpoint, so it stacks on mobile and sits on one row on desktop. Height goes from a fixed `h-12` (desktop) to auto with `py-2` padding on mobile (two rows).
- The tab cluster wraps the `Tabs`/`TabsList` in a `min-w-0 overflow-x-auto scrollbar-none` div, with `TabsList` set to `w-max` so the chips keep their natural width and scroll within the row rather than compressing. `scrollbar-none` is the existing utility already used in `pages/memory.tsx`.
- Page-specific bits are passed as props rather than special-cased inside the component: each tab takes an optional `badge` ReactNode (Saved uses it for the amber suggestion count), and the header takes an optional `actions` ReactNode (Activity uses it for the "Mark all read" button). Scheduled passes neither.
- Tabs remain `<Link>`s wrapped by `TabsTrigger asChild`, preserving cmd-click / middle-click / context-menu navigation (INV-40). The active-state styling is still driven by the `Tabs` `value`.

### Key design decisions

**1. Shared component over three parallel edits** — the headers were near-identical and had already been hand-maintained in three places. A single `PageHeaderTabs` keeps them from drifting again and matches the reuse-over-duplication direction in CLAUDE.md (INV-35/37). Page-specific affordances (badge, actions) are injected as props so the component stays generic.

**2. Second row + horizontal scroll on mobile, not a dropdown or one-row scroll** — this was the user's explicit pick. It preserves the chip aesthetic the desktop layout already uses (no new control to learn), keeps every tab visible at a glance, and degrades gracefully: the four Saved chips fit a typical phone width without scrolling, and anything narrower scrolls instead of clipping the title. A dropdown would have hidden the tab row; a single-row scroll would have kept the title cramped.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/layout/page-header-tabs.tsx` | Shared list-page header: back arrow, icon + title, chip tab strip; stacks to two rows on mobile with a horizontally scrollable strip. Exposes `PageHeaderTab` (`value`/`label`/`href`/optional `badge`) and an optional `actions` slot. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/index.ts` | Export `PageHeaderTabs` and the `PageHeaderTab` type. |
| `apps/frontend/src/pages/saved.tsx` | Replace the inline header with `PageHeaderTabs`; move the amber suggestion-count pill into the `suggested` tab's `badge`. Drop now-unused `Link`/`ArrowLeft`/`Tabs*`/`buttonVariants`/`cn`/`SidebarToggle` imports. |
| `apps/frontend/src/pages/activity.tsx` | Replace the inline header with `PageHeaderTabs`; pass the "Mark all read" button via `actions` (kept its `max-sm:` icon-only collapse, added `shrink-0`). Drop now-unused imports. |
| `apps/frontend/src/pages/scheduled.tsx` | Replace the inline header with `PageHeaderTabs` (no badge, no actions). Drop now-unused imports. |

## Out of scope (deliberate)

- The chip strip is left-aligned on its mobile row, matching the desktop look. Full-width / evenly-distributed mobile chips would be a separate styling choice — flagged to the user as an easy follow-up if they want it.
- No change to the page bodies, routing (INV-59 segments unchanged), data hooks, or the empty states.

## Test plan

- [x] `bun run typecheck` (full monorepo) — clean, exit 0
- [x] Pre-commit hook (lint-staged: eslint + prettier across all apps, monorepo `tsc --noEmit`, dockerfile + OpenAPI checks) — passed on commit
- [x] `apps/frontend` `bun run test suggested-tab` — 4 pass (only existing test touching these surfaces; mounts `SuggestedTab` directly, unaffected by the header change)
- [ ] No automated visual/responsive test harness in the repo, so the two-row mobile breakpoint was verified by reading the resulting Tailwind classes, not rendered at width — worth an eyeball on a phone-width viewport before merge

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XusCzW3btYw85k5DTnTs2L)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783947782&installation_id=129946197&pr_number=915&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F915&signature=97a27bd17e5339f75d56c10eb04a4c210882dd7fe6a8e3f07587b25ebc217549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->