### PR TITLE
feat: fold quiet "show when active" quick links under a "more" divider

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
@@ -71,8 +71,8 @@ describe("SidebarQuickLinks", () => {
     expect(screen.queryByText("Threads")).not.toBeInTheDocument()
   })
 
-  it("hides links the viewer has hidden and honors the configured order", () => {
-    stubSidebar("open")
+  it("keeps hidden links out of the main list and honors the configured order", () => {
+    stubSidebar("open", "collapsed")
     renderQuickLinks({
       quickLinks: [
         { key: "activity", visibility: "show" },
@@ -81,10 +81,12 @@ describe("SidebarQuickLinks", () => {
       ],
     })
 
-    // Hidden link is gone; the rest render in the order given.
+    // Hidden link is tucked under the collapsed fold, not in the main list; the
+    // shown links render in the order given.
     expect(screen.queryByText("Labels")).not.toBeInTheDocument()
     const rendered = screen.getAllByRole("link").map((l) => l.textContent)
     expect(rendered).toEqual(["Activity", "Drafts"])
+    expect(screen.getByRole("button", { name: /1 more/i })).toBeInTheDocument()
   })
 
   it("renders a 'show when active' link in the main list only when it carries a signal", () => {
@@ -116,11 +118,37 @@ describe("SidebarQuickLinks", () => {
     expect(screen.getByText("Drafts")).toBeInTheDocument()
   })
 
-  it("renders nothing when every link is hidden", () => {
+  it("folds hidden links under the divider instead of dropping them", () => {
+    stubSidebar("open", "open")
+    renderQuickLinks({ quickLinks: [{ key: "drafts", visibility: "hidden" }] })
+
+    // A link the viewer hid still appears under the (open) fold, never gone.
+    expect(screen.getByText("Quick Links")).toBeInTheDocument()
+    expect(screen.getByText("Drafts")).toBeInTheDocument()
+  })
+
+  it("renders nothing when there are no links at all", () => {
     stubSidebar("open")
-    const { container } = renderQuickLinks({ quickLinks: [{ key: "drafts", visibility: "hidden" }] })
+    const { container } = renderQuickLinks({ quickLinks: [] })
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it("folds hidden and quiet 'active' links together in configured order", () => {
+    stubSidebar("open", "open")
+    renderQuickLinks({
+      quickLinks: [
+        { key: "files", visibility: "show" },
+        { key: "labels", visibility: "hidden" },
+        { key: "drafts", visibility: "active" },
+      ],
+      draftCount: 0,
+    })
+
+    // Files (show) leads the main list; the hidden and quiet-active links fall
+    // under the fold in their configured order.
+    const rendered = screen.getAllByRole("link").map((l) => l.textContent)
+    expect(rendered).toEqual(["Files", "Labels", "Drafts"])
   })
 
   it("tucks quiet 'show when active' links under a collapsed 'more' fold", () => {

--- a/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
@@ -8,12 +8,18 @@ import { SidebarQuickLinks } from "./quick-links"
 
 type SidebarValue = ReturnType<typeof Contexts.useSidebar>
 
-function stubSidebar(quickLinksState: CollapseState = "open"): { toggleSectionState: ReturnType<typeof vi.fn> } {
+function stubSidebar(
+  quickLinksState: CollapseState = "open",
+  moreState: CollapseState = "collapsed"
+): { toggleSectionState: ReturnType<typeof vi.fn> } {
   const toggleSectionState = vi.fn()
   const value = {
     collapseOnMobile: vi.fn(),
-    getSectionState: (section: string, defaultState: CollapseState = "open") =>
-      section === "quick-links" ? quickLinksState : defaultState,
+    getSectionState: (section: string, defaultState: CollapseState = "open") => {
+      if (section === "quick-links") return quickLinksState
+      if (section === "quick-links:more") return moreState
+      return defaultState
+    },
     toggleSectionState,
   } as unknown as SidebarValue
   vi.spyOn(Contexts, "useSidebar").mockReturnValue(value)
@@ -81,9 +87,10 @@ describe("SidebarQuickLinks", () => {
     expect(rendered).toEqual(["Activity", "Drafts"])
   })
 
-  it("renders a 'show when active' link only when it carries a signal", () => {
+  it("renders a 'show when active' link in the main list only when it carries a signal", () => {
     stubSidebar("open")
-    // Drafts is "active" — hidden with no count, shown once a draft exists.
+    // Drafts is "active" — tucked under the collapsed fold with no count, then
+    // promoted into the main list once a draft exists.
     const { rerender } = renderQuickLinks({ quickLinks: [{ key: "drafts", visibility: "active" }], draftCount: 0 })
     expect(screen.queryByText("Drafts")).not.toBeInTheDocument()
 
@@ -114,6 +121,68 @@ describe("SidebarQuickLinks", () => {
     const { container } = renderQuickLinks({ quickLinks: [{ key: "drafts", visibility: "hidden" }] })
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it("tucks quiet 'show when active' links under a collapsed 'more' fold", () => {
+    stubSidebar("open", "collapsed")
+    renderQuickLinks({
+      quickLinks: [
+        { key: "files", visibility: "show" },
+        { key: "drafts", visibility: "active" },
+        { key: "saved", visibility: "active" },
+      ],
+      draftCount: 0,
+      savedCount: 0,
+    })
+
+    // The always-on link shows; the two quiet ones hide behind the fold.
+    expect(screen.getByText("Files")).toBeInTheDocument()
+    expect(screen.queryByText("Drafts")).not.toBeInTheDocument()
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /2 more/i })).toBeInTheDocument()
+  })
+
+  it("reveals folded links in configured order when the 'more' fold is open", () => {
+    stubSidebar("open", "open")
+    renderQuickLinks({
+      quickLinks: [
+        { key: "files", visibility: "show" },
+        { key: "saved", visibility: "active" },
+        { key: "drafts", visibility: "active" },
+      ],
+      draftCount: 0,
+      savedCount: 0,
+    })
+
+    const rendered = screen.getAllByRole("link").map((l) => l.textContent)
+    expect(rendered).toEqual(["Files", "Saved", "Drafts"])
+    expect(screen.getByRole("button", { name: /less/i })).toBeInTheDocument()
+  })
+
+  it("toggles the 'more' fold when its divider is clicked", async () => {
+    const user = userEvent.setup()
+    const { toggleSectionState } = stubSidebar("open", "collapsed")
+    renderQuickLinks({ quickLinks: [{ key: "drafts", visibility: "active" }], draftCount: 0 })
+
+    await user.click(screen.getByRole("button", { name: /1 more/i }))
+    expect(toggleSectionState).toHaveBeenCalledWith("quick-links:more", "collapsed")
+  })
+
+  it("still renders the section when every link is quiet so links stay reachable", () => {
+    stubSidebar("open", "collapsed")
+    renderQuickLinks({
+      quickLinks: [
+        { key: "drafts", visibility: "active" },
+        { key: "saved", visibility: "active" },
+      ],
+      draftCount: 0,
+      savedCount: 0,
+    })
+
+    // Nothing carries a signal, but the section persists with its fold so the
+    // links are one click away instead of disappearing entirely.
+    expect(screen.getByText("Quick Links")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /2 more/i })).toBeInTheDocument()
   })
 
   it("renders only the header when collapsed", () => {

--- a/apps/frontend/src/components/layout/sidebar/quick-links.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.tsx
@@ -114,18 +114,16 @@ export function SidebarQuickLinks({
   }
 
   // A link renders above the fold when it's set to "show", or "show when active"
-  // and it currently carries a signal. A "show when active" link with no signal
-  // is tucked under the fold instead of vanishing, so it stays one click away.
-  // "hidden" links are an explicit editor choice and render nowhere.
+  // and it currently carries a signal. Everything else — a quiet "show when
+  // active" link, or one the viewer set to "hidden" — is tucked under the fold
+  // rather than vanishing, so every configured link stays one click away.
   const isVisible = (link: SidebarQuickLink): boolean => {
     if (link.visibility === "show") return true
     if (link.visibility === "active") return itemByKey[link.key].unreadCount > 0
     return false
   }
-  const isFolded = (link: SidebarQuickLink): boolean =>
-    link.visibility === "active" && itemByKey[link.key].unreadCount === 0
   const visible = quickLinks.filter(isVisible)
-  const folded = quickLinks.filter(isFolded)
+  const folded = quickLinks.filter((link) => !isVisible(link))
 
   // Aggregate only "real" attention-worthy signals — drafts and saved counts
   // are persistent artifacts, not unread activity. The activity feed is the
@@ -137,7 +135,7 @@ export function SidebarQuickLinks({
   const isOpen = state === "open"
   const isMoreOpen = moreState === "open"
 
-  // Nothing to show and nothing tucked away (every link hidden / empty list).
+  // Render nothing only when there are no links at all to show or fold.
   if (visible.length === 0 && folded.length === 0) return null
 
   const renderLink = ({ key }: SidebarQuickLink) => {

--- a/apps/frontend/src/components/layout/sidebar/quick-links.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.tsx
@@ -6,7 +6,7 @@ import { QUICK_LINKS_SECTION_ID } from "@threa/types"
 import { UnreadBadge } from "@/components/unread-badge"
 import { useSidebar } from "@/contexts"
 import { cn } from "@/lib/utils"
-import { SectionHeader } from "./sections"
+import { MoreDivider, SectionHeader } from "./sections"
 
 /**
  * Per-key label + icon for the quick links. Single source of truth shared by the
@@ -52,6 +52,12 @@ interface QuickLinkItem {
 const SECTION_KEY = QUICK_LINKS_SECTION_ID
 const DEFAULT_STATE = "open"
 
+// Inline "more" expander for the quiet tail: links set to "show when active"
+// that currently carry no signal. Mirrors the stream sections' `${parent}:more`
+// key and collapsed default so the two reveals behave identically.
+const MORE_KEY = `${QUICK_LINKS_SECTION_ID}:more`
+const MORE_DEFAULT = "collapsed"
+
 function countSlot(count: number): ReactNode {
   return count > 0 ? <span className="ml-auto text-xs text-muted-foreground">({count})</span> : null
 }
@@ -73,6 +79,7 @@ export function SidebarQuickLinks({
 }: SidebarQuickLinksProps) {
   const { collapseOnMobile, getSectionState, toggleSectionState } = useSidebar()
   const state = getSectionState(SECTION_KEY, DEFAULT_STATE)
+  const moreState = getSectionState(MORE_KEY, MORE_DEFAULT)
 
   // The route/count signal data per key; presentation (label/icon) comes from
   // QUICK_LINK_META so the editor and the list stay in sync.
@@ -106,14 +113,19 @@ export function SidebarQuickLinks({
     },
   }
 
-  // A link renders when it's set to "show", or "show when active" and it
-  // currently carries a signal (a count / unread badge). "hidden" never renders.
+  // A link renders above the fold when it's set to "show", or "show when active"
+  // and it currently carries a signal. A "show when active" link with no signal
+  // is tucked under the fold instead of vanishing, so it stays one click away.
+  // "hidden" links are an explicit editor choice and render nowhere.
   const isVisible = (link: SidebarQuickLink): boolean => {
     if (link.visibility === "show") return true
     if (link.visibility === "active") return itemByKey[link.key].unreadCount > 0
     return false
   }
+  const isFolded = (link: SidebarQuickLink): boolean =>
+    link.visibility === "active" && itemByKey[link.key].unreadCount === 0
   const visible = quickLinks.filter(isVisible)
+  const folded = quickLinks.filter(isFolded)
 
   // Aggregate only "real" attention-worthy signals — drafts and saved counts
   // are persistent artifacts, not unread activity. The activity feed is the
@@ -123,9 +135,31 @@ export function SidebarQuickLinks({
   const unreadAggregate = activityVisible ? unreadActivityCount : 0
 
   const isOpen = state === "open"
+  const isMoreOpen = moreState === "open"
 
-  // Every link can be hidden from the editor; render nothing when none remain.
-  if (visible.length === 0) return null
+  // Nothing to show and nothing tucked away (every link hidden / empty list).
+  if (visible.length === 0 && folded.length === 0) return null
+
+  const renderLink = ({ key }: SidebarQuickLink) => {
+    const { label, icon: Icon } = QUICK_LINK_META[key]
+    const { to, isActive, unreadCount, signalSlot } = itemByKey[key]
+    return (
+      <Link
+        key={key}
+        to={to}
+        onClick={collapseOnMobile}
+        className={cn(
+          "flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+          isActive ? "bg-primary/10" : "hover:bg-muted/50",
+          !isActive && unreadCount === 0 && "text-muted-foreground"
+        )}
+      >
+        <Icon className="h-4 w-4" />
+        {label}
+        {signalSlot}
+      </Link>
+    )
+  }
 
   return (
     <div className="mb-2 space-y-1">
@@ -136,27 +170,19 @@ export function SidebarQuickLinks({
         unreadAggregate={unreadAggregate}
       />
 
-      {isOpen &&
-        visible.map(({ key }) => {
-          const { label, icon: Icon } = QUICK_LINK_META[key]
-          const { to, isActive, unreadCount, signalSlot } = itemByKey[key]
-          return (
-            <Link
-              key={key}
-              to={to}
-              onClick={collapseOnMobile}
-              className={cn(
-                "flex items-center gap-2.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
-                isActive ? "bg-primary/10" : "hover:bg-muted/50",
-                !isActive && unreadCount === 0 && "text-muted-foreground"
-              )}
-            >
-              <Icon className="h-4 w-4" />
-              {label}
-              {signalSlot}
-            </Link>
-          )
-        })}
+      {isOpen && (
+        <>
+          {visible.map(renderLink)}
+          {folded.length > 0 && (
+            <MoreDivider
+              isOpen={isMoreOpen}
+              hiddenCount={folded.length}
+              onToggle={() => toggleSectionState(MORE_KEY, MORE_DEFAULT)}
+            />
+          )}
+          {isMoreOpen && folded.map(renderLink)}
+        </>
+      )}
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -489,7 +489,7 @@ interface MoreDividerProps {
  * flush with stream items via matching horizontal padding so it feels like a
  * peer of the list, not a separate control.
  */
-function MoreDivider({ isOpen, hiddenCount, onToggle }: MoreDividerProps) {
+export function MoreDivider({ isOpen, hiddenCount, onToggle }: MoreDividerProps) {
   const Chevron = isOpen ? ChevronUp : ChevronDown
   const label = isOpen ? "less" : `${hiddenCount} more`
   return (


### PR DESCRIPTION
## Problem

Quick links set to **"show when active"** in the sidebar editor disappear entirely when they carry no signal — Drafts with zero drafts, Saved with nothing saved, Scheduled/Activity when quiet — and links set to **"hidden"** vanish with no way back except reopening the editor. The editor's three states are `show` (always), `active` (only with a live count), and `hidden`. Whenever a link wasn't in the main list there was no affordance pointing to it, so a user couldn't tell it existed, let alone reach it. `apps/frontend/src/components/layout/sidebar/quick-links.tsx` simply filtered those links out (`isVisible`), and when nothing remained visible the whole section returned `null`.

## Solution

Tuck every not-currently-shown link under the same collapsible **"N more" / "less"** divider the long stream lists already use, instead of dropping them. Any quick link that isn't in the main list is one click away rather than gone.

### How it works

- `quick-links.tsx` splits the configured links into two lists, both preserving config order: `visible` (`show`, or `active` with `unreadCount > 0`) renders in the main list; `folded` is **every other link** (`folded = quickLinks.filter((link) => !isVisible(link))`) — quiet `active` links and `hidden` ones alike — rendered below the divider.
- The divider is the existing `MoreDivider` from `sections.tsx`, now exported rather than file-private, so the quick links reuse the identical control (centered "`N` more" / "less" label, chevron, flush padding) — no parallel implementation.
- Fold state persists under section key `quick-links:more` (`${QUICK_LINKS_SECTION_ID}:more`), defaulting to `"collapsed"` — mirroring the stream sections' `${parent}:more` key and `MORE_DEFAULT`. It toggles via `toggleSectionState`, the same `useSidebar` mechanism as every other collapsible section.
- The empty guard is `visible.length === 0 && folded.length === 0`, so the section renders (header + fold) whenever any link is configured, and returns `null` only for a genuinely empty list — exactly the cases where links were previously unreachable now keep the fold.

### Key design decisions

**1. Everything not in the main list folds — `active`-without-signal and `hidden` alike.** Per the requester's call, a link the viewer hid should still be reachable one click away rather than gone. The three editor states stay distinct by *where* a link sits, not whether it exists: `show` = always in the main list; `active` = main list when it has a signal, under the fold when quiet; `hidden` = always under the fold. (This reverses an earlier iteration that kept `hidden` links out entirely; the requester opted for "all should end up there.")

**2. Reuse `MoreDivider`, don't reimplement.** The request was explicitly "the same mechanism as for very long stream lists." Exporting the existing component satisfies that literally and avoids INV-35/37 parallel-implementation drift, rather than cloning the divider markup into the quick links.

**3. Aggregate-unread logic unchanged.** The collapsed-header badge still keys off `activity` being in `visible`; an `active` Activity link with unread is visible (not folded), so the existing aggregate behavior is untouched.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/quick-links.tsx` | Split links into `visible` / `folded` (folded = everything not visible, incl. `hidden`); render the folded tail under a `MoreDivider` keyed on `quick-links:more` (collapsed by default); extract a `renderLink` helper; guard `null` only on a truly empty list. |
| `apps/frontend/src/components/layout/sidebar/sections.tsx` | Export `MoreDivider` (was file-private) for reuse by the quick links. |
| `apps/frontend/src/components/layout/sidebar/quick-links.test.tsx` | Extend `stubSidebar` to drive the `quick-links:more` state; cover folding of quiet `active` and `hidden` links, config-order under the fold, divider toggling, section reachability when all links are quiet, and the empty-list `null` case. |

## Out of scope (deliberate)

- No change to the sidebar editor or the `SidebarQuickLink` type/visibility model — the three states keep their existing meaning; only where a non-visible link renders changed.

## Test plan

- [x] `bun run test quick-links` (frontend) — 17 pass
- [x] `bun run typecheck` (frontend `tsc --noEmit`) — clean
- [ ] No visual/Playwright pass — the fold reuses the already-shipped `MoreDivider` styling verbatim, so behavior is covered by the unit tests rather than a screenshot diff.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_