### PR TITLE
refactor: sync-v2 unread-counter cleanup + scope invitation events to members:write

### DIFF
--- a/apps/backend/src/features/sync/handlers.test.ts
+++ b/apps/backend/src/features/sync/handlers.test.ts
@@ -4,9 +4,9 @@ import { createSyncHandlers } from "./handlers"
 import { HttpError } from "../../lib/errors"
 import type { SyncService } from "./service"
 
-function makeReqRes(query: Record<string, string>) {
+function makeReqRes(query: Record<string, string>, role: string = "member") {
   const req = {
-    user: { id: "usr_alice" },
+    user: { id: "usr_alice", role },
     workspaceId: "ws_1",
     query,
   } as unknown as Request
@@ -33,7 +33,13 @@ describe("createSyncHandlers.catchUp", () => {
     const { req, res, json } = makeReqRes({ after: "5", limit: "50" })
     await handlers.catchUp(req, res)
 
-    expect(catchUp.mock.calls[0][0]).toEqual({ workspaceId: "ws_1", userId: "usr_alice", after: 5n, limit: 50 })
+    expect(catchUp.mock.calls[0][0]).toEqual({
+      workspaceId: "ws_1",
+      userId: "usr_alice",
+      permissionGroups: [],
+      after: 5n,
+      limit: 50,
+    })
     expect(json.mock.calls[0][0]).toEqual({
       entries: [
         {
@@ -68,7 +74,29 @@ describe("createSyncHandlers.catchUp", () => {
     const { req, res } = makeReqRes({})
     await handlers.catchUp(req, res)
 
-    expect(catchUp.mock.calls[0][0]).toEqual({ workspaceId: "ws_1", userId: "usr_alice", after: 0n, limit: 200 })
+    expect(catchUp.mock.calls[0][0]).toEqual({
+      workspaceId: "ws_1",
+      userId: "usr_alice",
+      permissionGroups: [],
+      after: 0n,
+      limit: 200,
+    })
+  })
+
+  it("derives permission delivery groups from the member role (admin → members:write)", async () => {
+    const catchUp = mock(async (_params: Parameters<SyncService["catchUp"]>[0]) => ({ entries: [], head: 0n }))
+    const handlers = createSyncHandlers({ syncService: { catchUp } as unknown as SyncService })
+
+    const { req, res } = makeReqRes({}, "admin")
+    await handlers.catchUp(req, res)
+
+    expect(catchUp.mock.calls[0][0]).toEqual({
+      workspaceId: "ws_1",
+      userId: "usr_alice",
+      permissionGroups: ["permission:members:write"],
+      after: 0n,
+      limit: 200,
+    })
   })
 
   it("rejects a non-numeric cursor with a 400", async () => {

--- a/apps/backend/src/features/sync/handlers.test.ts
+++ b/apps/backend/src/features/sync/handlers.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, mock } from "bun:test"
 import type { Request, Response } from "express"
+import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { createSyncHandlers } from "./handlers"
 import { HttpError } from "../../lib/errors"
+import { permissionGroup } from "../../lib/outbox"
 import type { SyncService } from "./service"
 
 function makeReqRes(query: Record<string, string>, role: string = "member") {
@@ -93,7 +95,7 @@ describe("createSyncHandlers.catchUp", () => {
     expect(catchUp.mock.calls[0][0]).toEqual({
       workspaceId: "ws_1",
       userId: "usr_alice",
-      permissionGroups: ["permission:members:write"],
+      permissionGroups: [permissionGroup(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)],
       after: 0n,
       limit: 200,
     })

--- a/apps/backend/src/features/sync/handlers.ts
+++ b/apps/backend/src/features/sync/handlers.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express"
 import { z } from "zod"
 import type { SyncCatchUpResponse } from "@threa/types"
 import { HttpError } from "../../lib/errors"
+import { permissionGroupsForRole } from "../../lib/outbox"
 import type { SyncService } from "./service"
 
 const catchUpQuerySchema = z.object({
@@ -18,6 +19,10 @@ export function createSyncHandlers({ syncService }: Dependencies) {
     async catchUp(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
+      // Permission-scoped log entries (e.g. invitation lifecycle) replay only to
+      // holders. Derived from role to stay congruent with the socket join, which
+      // joins the same permission rooms off the same role.
+      const permissionGroups = permissionGroupsForRole(req.user!.role)
 
       const parsed = catchUpQuerySchema.safeParse(req.query)
       if (!parsed.success) {
@@ -27,6 +32,7 @@ export function createSyncHandlers({ syncService }: Dependencies) {
       const { entries, head, requiresBootstrap } = await syncService.catchUp({
         workspaceId,
         userId,
+        permissionGroups,
         after: BigInt(parsed.data.after),
         limit: parsed.data.limit,
       })

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -119,8 +119,12 @@ export const SyncLogRepository = {
 
   /**
    * Lists log entries after a cursor, filtered to what the requesting user is
-   * allowed to see: workspace-group entries, their own user-group entries, and
-   * stream-group entries for streams they can read.
+   * allowed to see: workspace-group entries, their own user-group entries,
+   * entries for any permission group they hold (`permissionGroups`, e.g.
+   * invitation lifecycle → members:write), and stream-group entries for streams
+   * they can read. The permission groups are role-derived by the caller, the
+   * same source the socket join uses, so catch-up admits exactly what live
+   * delivery reached.
    *
    * A stream is readable when the user is a member of it OR a member of its
    * root stream (INV-62) — threads never carry their own access;
@@ -142,9 +146,9 @@ export const SyncLogRepository = {
    */
   async listEntriesForUser(
     db: Querier,
-    params: { workspaceId: string; userId: string; after: bigint; limit: number }
+    params: { workspaceId: string; userId: string; permissionGroups: string[]; after: bigint; limit: number }
   ): Promise<SyncLogEntry[]> {
-    const { workspaceId, userId, after, limit } = params
+    const { workspaceId, userId, permissionGroups, after, limit } = params
     const result = await db.query<SyncLogEntryRow>(sql`
       WITH join_bounds AS (
         SELECT DISTINCT ON (payload->>'streamId') payload->>'streamId' AS stream_id, sync_id AS join_sync_id
@@ -173,7 +177,7 @@ export const SyncLogRepository = {
       WHERE l.workspace_id = ${workspaceId}
         AND l.sync_id > ${after.toString()}
         AND (
-          l.groups && ARRAY['workspace', 'user:' || ${userId}]
+          l.groups && (ARRAY['workspace', 'user:' || ${userId}]::text[] || ${permissionGroups}::text[])
           OR EXISTS (
             SELECT 1
             FROM visible_streams vs

--- a/apps/backend/src/features/sync/service.test.ts
+++ b/apps/backend/src/features/sync/service.test.ts
@@ -10,7 +10,7 @@ function setupService() {
   return new SyncService({ pool: {} as Pool })
 }
 
-const baseParams = { workspaceId: "ws_1", userId: "usr_alice", limit: 50 }
+const baseParams = { workspaceId: "ws_1", userId: "usr_alice", permissionGroups: [], limit: 50 }
 
 describe("SyncService.catchUp retention floor", () => {
   afterEach(() => {

--- a/apps/backend/src/features/sync/service.ts
+++ b/apps/backend/src/features/sync/service.ts
@@ -28,7 +28,13 @@ export class SyncService {
    * (never by jumping to `head`) and page until a fetch comes back empty —
    * `head` is a freshness hint, not a cursor target.
    */
-  async catchUp(params: { workspaceId: string; userId: string; after: bigint; limit: number }): Promise<CatchUpResult> {
+  async catchUp(params: {
+    workspaceId: string
+    userId: string
+    permissionGroups: string[]
+    after: bigint
+    limit: number
+  }): Promise<CatchUpResult> {
     return withClient(this.pool, async (client) => {
       // Read entries FIRST, then head + retention floor in one query. Order
       // matters for race-safety: if a prune advanced the floor past `after`,

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test"
+import { resolveDeliveryGroups, permissionGroupsForRole, permissionGroup } from "./delivery-groups"
+import type { OutboxEvent, OutboxEventType } from "./repository"
+
+function event<T extends OutboxEventType>(eventType: T, payload: Record<string, unknown>): OutboxEvent<T> {
+  return { id: 1n, eventType, payload, createdAt: new Date() } as unknown as OutboxEvent<T>
+}
+
+const MEMBERS_WRITE_GROUP = permissionGroup("members:write")
+
+describe("resolveDeliveryGroups — invitation events", () => {
+  const invitationEvents = [
+    "invitation:sent",
+    "invitation:accepted",
+    "invitation:revoked",
+    "invitation:link-created",
+    "invitation:link-claimed",
+  ] as const
+
+  for (const eventType of invitationEvents) {
+    it(`scopes ${eventType} to members:write, never the workspace`, () => {
+      const groups = resolveDeliveryGroups(event(eventType, { workspaceId: "ws_1", invitationId: "inv_1" }))
+      expect(groups).toEqual([MEMBERS_WRITE_GROUP])
+      expect(groups).not.toContain("workspace")
+    })
+  }
+})
+
+describe("permissionGroupsForRole", () => {
+  it("grants the members:write delivery group to admins and owners", () => {
+    expect(permissionGroupsForRole("admin")).toEqual([MEMBERS_WRITE_GROUP])
+    expect(permissionGroupsForRole("owner")).toEqual([MEMBERS_WRITE_GROUP])
+  })
+
+  it("grants no permission delivery groups to plain members", () => {
+    expect(permissionGroupsForRole("member")).toEqual([])
+  })
+})

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { resolveDeliveryGroups, permissionGroupsForRole, permissionGroup } from "./delivery-groups"
 import type { OutboxEvent, OutboxEventType } from "./repository"
 
@@ -6,7 +7,14 @@ function event<T extends OutboxEventType>(eventType: T, payload: Record<string, 
   return { id: 1n, eventType, payload, createdAt: new Date() } as unknown as OutboxEvent<T>
 }
 
-const MEMBERS_WRITE_GROUP = permissionGroup("members:write")
+const MEMBERS_WRITE_GROUP = permissionGroup(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)
+
+describe("permissionGroup", () => {
+  it("names the members:write delivery group on the wire", () => {
+    // Pins the group string format once; other suites derive via the helper.
+    expect(MEMBERS_WRITE_GROUP).toBe("permission:members:write")
+  })
+})
 
 describe("resolveDeliveryGroups — invitation events", () => {
   const invitationEvents = [

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -1,5 +1,13 @@
 import type { Server } from "socket.io"
-import { LabelableResourceTypes, StreamTypes, Visibilities } from "@threa/types"
+import {
+  LabelableResourceTypes,
+  StreamTypes,
+  Visibilities,
+  WORKSPACE_PERMISSION_SCOPES,
+  permissionsForRole,
+  type WorkspacePermissionSlug,
+  type WorkspaceRoleSlug,
+} from "@threa/types"
 import {
   isStreamScopedEvent,
   isOutboxEventType,
@@ -44,6 +52,33 @@ export function streamGroup(streamId: string): string {
 
 export function userGroup(userId: string): string {
   return `user:${userId}`
+}
+
+/**
+ * Delivery group for everyone who holds a workspace permission slug. Events
+ * routed here (invitation lifecycle → members:write) reach only holders, not
+ * the whole workspace. Sockets join the matching room on workspace join and
+ * catch-up admits the group for holders — both derive the holder set from the
+ * member's role, so live and replay delivery stay congruent.
+ */
+export function permissionGroup(slug: WorkspacePermissionSlug): string {
+  return `permission:${slug}`
+}
+
+/**
+ * Permission scopes that get their own delivery group. Keep in sync with the
+ * permission branches in `resolveDeliveryGroups`: a scope listed here without a
+ * routing branch puts members in a room nothing emits to, and an event routed
+ * to a `permission:<slug>` group whose scope is absent here reaches no holder.
+ */
+export const DELIVERED_PERMISSION_SCOPES: readonly WorkspacePermissionSlug[] = [
+  WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE,
+]
+
+/** The permission delivery groups a member with `role` belongs to. */
+export function permissionGroupsForRole(role: WorkspaceRoleSlug): string[] {
+  const held = permissionsForRole(role)
+  return DELIVERED_PERMISSION_SCOPES.filter((slug) => held.includes(slug)).map(permissionGroup)
 }
 
 /**
@@ -207,6 +242,23 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
       "delivery groups: no mapping for public-label resource type"
     )
     return []
+  }
+
+  // Invitation lifecycle carries invitee identity (email, link token hash):
+  // scope it to members:write holders instead of letting it fall through to the
+  // whole workspace below. Mirrors the bootstrap gate (workspaces/handlers.ts
+  // includes `invitations` only for members:write) and the invitation routes'
+  // requireWorkspacePermission(members:write).
+  if (
+    isOneOfOutboxEventType(event, [
+      "invitation:sent",
+      "invitation:accepted",
+      "invitation:revoked",
+      "invitation:link-created",
+      "invitation:link-claimed",
+    ])
+  ) {
+    return [permissionGroup(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)]
   }
 
   if (isStreamScopedEvent(event)) {

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -16,6 +16,7 @@ import {
   isUserScopedEvent,
   isBotScopedEvent,
   type OutboxEvent,
+  type OutboxEventType,
   type StreamCreatedOutboxPayload,
   type StreamMemberAddedOutboxPayload,
   type ActivityCreatedOutboxPayload,
@@ -66,14 +67,38 @@ export function permissionGroup(slug: WorkspacePermissionSlug): string {
 }
 
 /**
- * Permission scopes that get their own delivery group. Keep in sync with the
- * permission branches in `resolveDeliveryGroups`: a scope listed here without a
- * routing branch puts members in a room nothing emits to, and an event routed
- * to a `permission:<slug>` group whose scope is absent here reaches no holder.
+ * Single source of truth for permission-scoped event routing: each permission
+ * scope maps to the outbox event types delivered only to holders of that scope.
+ * `resolveDeliveryGroups` routes an event by reverse-lookup here, and sockets +
+ * catch-up derive room membership from the same keys (via
+ * `DELIVERED_PERMISSION_SCOPES` → `permissionGroupsForRole`), so routing and
+ * membership cannot drift. `satisfies` pins the keys to real permission slugs
+ * and the values to real outbox event types.
+ *
+ * Invitation lifecycle carries invitee identity (email, link token hash), so it
+ * is scoped to members:write — mirroring the bootstrap gate (workspaces/handlers
+ * includes `invitations` only for members:write) and the invitation routes'
+ * requireWorkspacePermission(members:write).
  */
-export const DELIVERED_PERMISSION_SCOPES: readonly WorkspacePermissionSlug[] = [
-  WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE,
-]
+const PERMISSION_SCOPED_EVENTS = {
+  [WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE]: [
+    "invitation:sent",
+    "invitation:accepted",
+    "invitation:revoked",
+    "invitation:link-created",
+    "invitation:link-claimed",
+  ],
+} as const satisfies Partial<Record<WorkspacePermissionSlug, readonly OutboxEventType[]>>
+
+/** Permission scopes that get their own delivery group (keys of the routing map). */
+const DELIVERED_PERMISSION_SCOPES = Object.keys(PERMISSION_SCOPED_EVENTS) as WorkspacePermissionSlug[]
+
+/** Reverse index built once at load: outbox event type → its permission group. */
+const PERMISSION_GROUP_BY_EVENT = new Map<string, string>(
+  Object.entries(PERMISSION_SCOPED_EVENTS).flatMap(([scope, eventTypes]) =>
+    eventTypes.map((eventType) => [eventType, permissionGroup(scope as WorkspacePermissionSlug)] as const)
+  )
+)
 
 /** The permission delivery groups a member with `role` belongs to. */
 export function permissionGroupsForRole(role: WorkspaceRoleSlug): string[] {
@@ -244,21 +269,11 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
     return []
   }
 
-  // Invitation lifecycle carries invitee identity (email, link token hash):
-  // scope it to members:write holders instead of letting it fall through to the
-  // whole workspace below. Mirrors the bootstrap gate (workspaces/handlers.ts
-  // includes `invitations` only for members:write) and the invitation routes'
-  // requireWorkspacePermission(members:write).
-  if (
-    isOneOfOutboxEventType(event, [
-      "invitation:sent",
-      "invitation:accepted",
-      "invitation:revoked",
-      "invitation:link-created",
-      "invitation:link-claimed",
-    ])
-  ) {
-    return [permissionGroup(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)]
+  // Permission-scoped events (e.g. invitation lifecycle → members:write) go to
+  // their scope's delivery group instead of the whole-workspace fallthrough.
+  const permissionScopedGroup = PERMISSION_GROUP_BY_EVENT.get(event.eventType)
+  if (permissionScopedGroup) {
+    return [permissionScopedGroup]
   }
 
   if (isStreamScopedEvent(event)) {

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -12,6 +12,9 @@ export {
   WORKSPACE_GROUP,
   streamGroup,
   userGroup,
+  permissionGroup,
+  permissionGroupsForRole,
+  DELIVERED_PERMISSION_SCOPES,
 } from "./delivery-groups"
 export { parseMessagePayload, type NormalizedMessagePayload } from "./payload-parsers"
 export {

--- a/apps/backend/src/lib/outbox/index.ts
+++ b/apps/backend/src/lib/outbox/index.ts
@@ -14,7 +14,6 @@ export {
   userGroup,
   permissionGroup,
   permissionGroupsForRole,
-  DELIVERED_PERMISSION_SCOPES,
 } from "./delivery-groups"
 export { parseMessagePayload, type NormalizedMessagePayload } from "./payload-parsers"
 export {

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -128,8 +128,16 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         // Auto-join permission rooms for permission-scoped delivery (e.g.
         // invitation lifecycle → members:write). Derived from the member's role,
         // mirroring requireWorkspacePermission's role fallback, so a non-admin
-        // never receives invitee identity. Demotion heals on the next join.
+        // never receives invitee identity. A re-join on the same socket
+        // re-derives the set and leaves rooms the member no longer qualifies for,
+        // so an in-connection role change heals on the next join (a fresh
+        // connection always re-derives from scratch). The catch-up path derives
+        // the role per request, so it is always current.
         const permissionRooms = permissionGroupsForRole(workspaceUser.role).map((group) => groupToRoom(wsId, group))
+        const stalePermissionRooms = userRooms.get(wsId)?.permissionRooms ?? []
+        for (const stale of stalePermissionRooms) {
+          if (!permissionRooms.includes(stale)) socket.leave(stale)
+        }
         for (const permissionRoom of permissionRooms) {
           socket.join(permissionRoom)
         }

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -9,6 +9,7 @@ import type { UserSocketRegistry } from "./lib/user-socket-registry"
 import { AgentSessionRepository, PersonaRepository } from "./features/agents"
 import type { SessionAbortRegistry } from "./features/agents"
 import { UserRepository } from "./features/workspaces"
+import { groupToRoom, permissionGroupsForRole } from "./lib/outbox"
 import { HttpError } from "./lib/errors"
 import { logger } from "./lib/logger"
 import { wsConnectionsActive, wsConnectionDuration, wsMessagesTotal } from "./lib/observability"
@@ -91,8 +92,8 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
       joinedRooms: new Map(),
     }
 
-    // Track user rooms per workspace for auto-leave on workspace leave
-    const userRooms = new Map<string, { userId: string; userRoom: string }>()
+    // Track user + permission rooms per workspace for auto-leave on workspace leave
+    const userRooms = new Map<string, { userId: string; userRoom: string; permissionRooms: string[] }>()
 
     // =========================================================================
     // Room management
@@ -123,7 +124,16 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
         // Auto-join user room for targeted event delivery (activity, commands, read state)
         const userRoom = `ws:${wsId}:user:${workspaceUser.id}`
         socket.join(userRoom)
-        userRooms.set(wsId, { userId: workspaceUser.id, userRoom })
+
+        // Auto-join permission rooms for permission-scoped delivery (e.g.
+        // invitation lifecycle → members:write). Derived from the member's role,
+        // mirroring requireWorkspacePermission's role fallback, so a non-admin
+        // never receives invitee identity. Demotion heals on the next join.
+        const permissionRooms = permissionGroupsForRole(workspaceUser.role).map((group) => groupToRoom(wsId, group))
+        for (const permissionRoom of permissionRooms) {
+          socket.join(permissionRoom)
+        }
+        userRooms.set(wsId, { userId: workspaceUser.id, userRoom, permissionRooms })
 
         // Upsert session for push notification suppression (only when push is enabled).
         // Don't set focused — the first heartbeat (emitted immediately on connect)
@@ -258,13 +268,16 @@ export function registerSocketHandlers(io: Server, deps: Dependencies) {
 
       socket.leave(room)
 
-      // Auto-leave user room when leaving a workspace room
+      // Auto-leave user + permission rooms when leaving a workspace room
       const wsMatch = room.match(/^ws:([^:]+)$/)
       if (wsMatch) {
         const wsId = wsMatch[1]
         const entry = userRooms.get(wsId)
         if (entry) {
           socket.leave(entry.userRoom)
+          for (const permissionRoom of entry.permissionRooms) {
+            socket.leave(permissionRoom)
+          }
           userRooms.delete(wsId)
         }
       }

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -49,8 +49,8 @@ describe("SyncLogRepository catch-up reads", () => {
     return assigned.get(outboxEventId)!
   }
 
-  function listFor(workspaceId: string, userId: string, after = 0n, limit = 100) {
-    return SyncLogRepository.listEntriesForUser(pool, { workspaceId, userId, after, limit })
+  function listFor(workspaceId: string, userId: string, after = 0n, limit = 100, permissionGroups: string[] = []) {
+    return SyncLogRepository.listEntriesForUser(pool, { workspaceId, userId, permissionGroups, after, limit })
   }
 
   /**
@@ -97,6 +97,26 @@ describe("SyncLogRepository catch-up reads", () => {
 
     const bobEntries = await listFor(workspaceId, bob)
     expect(bobEntries.map((e) => e.syncId)).toEqual([workspaceWide, bobStreamEntry])
+  })
+
+  test("admits permission-group entries only for holders of the permission", async () => {
+    const workspaceId = uniqueId("ws")
+    const admin = uniqueId("usr")
+    const member = uniqueId("usr")
+
+    const invite = await appendEntry(workspaceId, {
+      eventType: "invitation:sent",
+      groups: ["permission:members:write"],
+      payload: { workspaceId, invitationId: uniqueId("inv"), email: "invitee@example.com" },
+    })
+
+    // The admin holds members:write (passes its permission group); the member
+    // does not, so the invitation entry never reaches them.
+    const adminEntries = await listFor(workspaceId, admin, 0n, 100, ["permission:members:write"])
+    expect(adminEntries.map((e) => e.syncId)).toEqual([invite])
+
+    const memberEntries = await listFor(workspaceId, member, 0n, 100, [])
+    expect(memberEntries.map((e) => e.syncId)).toEqual([])
   })
 
   test("bounds stream groups by the member_added join position — no pre-join history", async () => {

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -1,7 +1,11 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test"
 import { Pool } from "pg"
+import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import { setupTestDatabase } from "./setup"
 import { SyncLogRepository, type SyncLogEntryInput } from "../../src/features/sync"
+import { permissionGroup } from "../../src/lib/outbox"
+
+const MEMBERS_WRITE_GROUP = permissionGroup(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)
 
 describe("SyncLogRepository catch-up reads", () => {
   let pool: Pool
@@ -106,13 +110,13 @@ describe("SyncLogRepository catch-up reads", () => {
 
     const invite = await appendEntry(workspaceId, {
       eventType: "invitation:sent",
-      groups: ["permission:members:write"],
+      groups: [MEMBERS_WRITE_GROUP],
       payload: { workspaceId, invitationId: uniqueId("inv"), email: "invitee@example.com" },
     })
 
     // The admin holds members:write (passes its permission group); the member
     // does not, so the invitation entry never reaches them.
-    const adminEntries = await listFor(workspaceId, admin, 0n, 100, ["permission:members:write"])
+    const adminEntries = await listFor(workspaceId, admin, 0n, 100, [MEMBERS_WRITE_GROUP])
     expect(adminEntries.map((e) => e.syncId)).toEqual([invite])
 
     const memberEntries = await listFor(workspaceId, member, 0n, 100, [])

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1366,26 +1366,6 @@ describe("unread counter events (absolute payloads, sync-v2 phase 2c)", () => {
     cleanup()
   })
 
-  it("falls back to the legacy increment when stream:activity lacks an ordinal", async () => {
-    const queryClient = new QueryClient()
-    await seedCounterFixture(queryClient)
-    const { emit, cleanup } = register(queryClient)
-
-    emit("stream:activity", {
-      workspaceId: "ws_1",
-      streamId: "stream_1",
-      authorId: "member_2",
-      lastMessagePreview: preview,
-    })
-
-    expect(queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))?.unreadCounts.stream_1).toBe(2)
-    await vi.waitFor(async () => {
-      expect((await db.unreadState.get("ws_1"))?.unreadCounts.stream_1).toBe(2)
-    })
-
-    cleanup()
-  })
-
   it("applies stream:read absolute positions — newer messages stay unread", async () => {
     const queryClient = new QueryClient()
     await seedCounterFixture(queryClient)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -899,7 +899,8 @@ export function registerWorkspaceSocketHandlers(
   }
 
   // Handle stream activity (when a new message is created in any stream)
-  // Always updates the preview, but only increments unread for others' messages
+  // Always updates the preview; sets unread from the absolute message ordinal
+  // (own messages and viewing advance the read position instead of raising it).
   const handleStreamActivity = (payload: StreamActivityPayload) => {
     // Only update if it's for this workspace
     if (payload.workspaceId !== workspaceId) return

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -108,10 +108,10 @@ interface WorkspaceUserUpdatedPayload {
   user: WorkspaceUserPayload
 }
 
-// The unread counter payloads carry absolute fields (sync-v2 phase 2c); every
-// current payload has them. The fields stay optional on the wire and the
-// handlers below tolerate their absence (increment/zero fallback) as a
-// defensive guard.
+// The unread counter payloads carry absolute fields (sync-v2 phase 2c): the
+// backend always emits them, so clients set counters from
+// latestOrdinal − lastReadOrdinal instead of incrementing and replayed or
+// duplicated events converge.
 interface StreamReadPayload {
   workspaceId: string
   authorId: string
@@ -120,7 +120,7 @@ interface StreamReadPayload {
   /** The read event's per-stream sequence (bigint as string). */
   lastReadSequence?: string
   /** Message ordinal of the read position. */
-  lastReadOrdinal?: number
+  lastReadOrdinal: number
 }
 
 interface StreamsReadAllPayload {
@@ -128,7 +128,7 @@ interface StreamsReadAllPayload {
   authorId: string
   streamIds: string[]
   /** Absolute read position per updated stream. */
-  reads?: Array<{ streamId: string; lastReadOrdinal: number }>
+  reads: Array<{ streamId: string; lastReadOrdinal: number }>
 }
 
 interface StreamActivityPayload {
@@ -138,7 +138,7 @@ interface StreamActivityPayload {
   /** The message event's per-stream sequence (bigint as string). */
   sequence?: string
   /** Count of message_created events with sequence ≤ this one. */
-  messageOrdinal?: number
+  messageOrdinal: number
   lastMessagePreview: LastMessagePreview
 }
 
@@ -798,8 +798,6 @@ export function registerWorkspaceSocketHandlers(
 
     const current = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
     const hadActivity = (current?.activityCounts[payload.streamId] ?? 0) > 0
-    // Absolute read position (sync-v2 phase 2c); null on legacy payloads.
-    const readOrdinal = typeof payload.lastReadOrdinal === "number" ? payload.lastReadOrdinal : null
 
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
@@ -811,29 +809,10 @@ export function registerWorkspaceSocketHandlers(
             : membership
         ),
       }
-      if (readOrdinal !== null) {
-        return withCounterState(
-          withMembership,
-          applyStreamReadOrdinal(toCounterState(old), payload.streamId, readOrdinal)
-        )
-      }
-      const clearedActivity = old.activityCounts[payload.streamId] ?? 0
-      return {
-        ...withMembership,
-        unreadCounts: {
-          ...old.unreadCounts,
-          [payload.streamId]: 0,
-        },
-        mentionCounts: {
-          ...old.mentionCounts,
-          [payload.streamId]: 0,
-        },
-        activityCounts: {
-          ...old.activityCounts,
-          [payload.streamId]: 0,
-        },
-        unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - clearedActivity),
-      }
+      return withCounterState(
+        withMembership,
+        applyStreamReadOrdinal(toCounterState(old), payload.streamId, payload.lastReadOrdinal)
+      )
     })
 
     queryClient.setQueryData<import("@threa/types").StreamBootstrap | undefined>(
@@ -853,25 +832,13 @@ export function registerWorkspaceSocketHandlers(
       const now = Date.now()
       const state = await db.unreadState.get(workspaceId)
       if (state) {
-        if (readOrdinal !== null) {
-          // Read-merge-write inside one transaction so concurrent tabs
-          // max-merge instead of clobbering each other (INV-20 analogue).
-          await db.unreadState.put({
-            ...state,
-            ...applyStreamReadOrdinal(state, payload.streamId, readOrdinal),
-            _cachedAt: now,
-          })
-        } else {
-          const clearedActivity = state.activityCounts[payload.streamId] ?? 0
-          await db.unreadState.put({
-            ...state,
-            unreadCounts: { ...state.unreadCounts, [payload.streamId]: 0 },
-            mentionCounts: { ...state.mentionCounts, [payload.streamId]: 0 },
-            activityCounts: { ...state.activityCounts, [payload.streamId]: 0 },
-            unreadActivityCount: Math.max(0, state.unreadActivityCount - clearedActivity),
-            _cachedAt: now,
-          })
-        }
+        // Read-merge-write inside one transaction so concurrent tabs
+        // max-merge instead of clobbering each other (INV-20 analogue).
+        await db.unreadState.put({
+          ...state,
+          ...applyStreamReadOrdinal(state, payload.streamId, payload.lastReadOrdinal),
+          _cachedAt: now,
+        })
       }
 
       await db.streams.update(payload.streamId, { lastReadEventId: payload.lastReadEventId, _cachedAt: now })
@@ -904,63 +871,20 @@ export function registerWorkspaceSocketHandlers(
   const handleStreamReadAll = (payload: StreamsReadAllPayload) => {
     if (payload.workspaceId !== workspaceId) return
 
-    // Absolute read positions (sync-v2 phase 2c); null on legacy payloads.
-    const reads = Array.isArray(payload.reads) ? payload.reads : null
-
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
-
-      if (reads !== null) {
-        return withCounterState(old, applyStreamsReadAllOrdinals(toCounterState(old), reads))
-      }
-
-      const newUnreadCounts = { ...old.unreadCounts }
-      const newMentionCounts = { ...old.mentionCounts }
-      const newActivityCounts = { ...old.activityCounts }
-      let clearedActivity = 0
-      for (const streamId of payload.streamIds) {
-        newUnreadCounts[streamId] = 0
-        newMentionCounts[streamId] = 0
-        clearedActivity += newActivityCounts[streamId] ?? 0
-        newActivityCounts[streamId] = 0
-      }
-      return {
-        ...old,
-        unreadCounts: newUnreadCounts,
-        mentionCounts: newMentionCounts,
-        activityCounts: newActivityCounts,
-        unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - clearedActivity),
-      }
+      return withCounterState(old, applyStreamsReadAllOrdinals(toCounterState(old), payload.reads))
     })
 
     // Update IDB unread state
     db.transaction("rw", [db.unreadState], async () => {
       const state = await db.unreadState.get(workspaceId)
       if (!state) return
-      if (reads !== null) {
-        await db.unreadState.put({
-          ...state,
-          ...applyStreamsReadAllOrdinals(state, reads),
-          _cachedAt: Date.now(),
-        })
-        return
-      }
-      const updated = { ...state, _cachedAt: Date.now() }
-      const newUnread = { ...state.unreadCounts }
-      const newMention = { ...state.mentionCounts }
-      const newActivity = { ...state.activityCounts }
-      let cleared = 0
-      for (const sid of payload.streamIds) {
-        newUnread[sid] = 0
-        newMention[sid] = 0
-        cleared += newActivity[sid] ?? 0
-        newActivity[sid] = 0
-      }
-      updated.unreadCounts = newUnread
-      updated.mentionCounts = newMention
-      updated.activityCounts = newActivity
-      updated.unreadActivityCount = Math.max(0, state.unreadActivityCount - cleared)
-      await db.unreadState.put(updated)
+      await db.unreadState.put({
+        ...state,
+        ...applyStreamsReadAllOrdinals(state, payload.reads),
+        _cachedAt: Date.now(),
+      })
     })
 
     queryClient.invalidateQueries({ queryKey: ["activity", workspaceId] })
@@ -993,9 +917,6 @@ export function registerWorkspaceSocketHandlers(
       })
     }
 
-    // Absolute message ordinal (sync-v2 phase 2c); null on legacy payloads.
-    const messageOrdinal = typeof payload.messageOrdinal === "number" ? payload.messageOrdinal : null
-
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
 
@@ -1018,27 +939,13 @@ export function registerWorkspaceSocketHandlers(
         ),
       }
 
-      if (messageOrdinal !== null) {
-        return withCounterState(
-          withPreview,
-          applyStreamActivityOrdinal(toCounterState(old), payload.streamId, messageOrdinal, {
-            isOwnMessage,
-            isViewing: isViewingStream,
-          })
-        )
-      }
-
-      // Legacy payload: increment unread for others' messages when not viewing.
-      const shouldIncrementUnread = !isOwnMessage && !isViewingStream
-      return shouldIncrementUnread
-        ? {
-            ...withPreview,
-            unreadCounts: {
-              ...withPreview.unreadCounts,
-              [payload.streamId]: (withPreview.unreadCounts[payload.streamId] ?? 0) + 1,
-            },
-          }
-        : withPreview
+      return withCounterState(
+        withPreview,
+        applyStreamActivityOrdinal(toCounterState(old), payload.streamId, payload.messageOrdinal, {
+          isOwnMessage,
+          isViewing: isViewingStream,
+        })
+      )
     })
 
     // Always persist lastMessagePreview to IDB so the cached sort order
@@ -1049,8 +956,7 @@ export function registerWorkspaceSocketHandlers(
     })
 
     // Update IDB unread state. We check membership via IDB to avoid dependency
-    // on the TanStack closure. Unlike the legacy increment (skipped for own
-    // messages and while viewing), the absolute path always writes: own sends
+    // on the TanStack closure. The absolute path always writes: own sends
     // advance the implied read position and viewing pins it to latest.
     void (async () => {
       const membership = await db.streamMemberships.get(`${workspaceId}:${payload.streamId}`)
@@ -1064,30 +970,18 @@ export function registerWorkspaceSocketHandlers(
             .first()
         : null
       const isOwnMessage = Boolean(currentMember && payload.authorId === currentMember.id)
-      if (messageOrdinal === null && (isOwnMessage || isViewingStream)) return
 
       await db.transaction("rw", [db.unreadState], async () => {
         const state = await db.unreadState.get(workspaceId)
         if (!state) return
-        if (messageOrdinal !== null) {
-          // Read-merge-write inside one transaction so concurrent tabs
-          // max-merge instead of clobbering each other (INV-20 analogue).
-          await db.unreadState.put({
-            ...state,
-            ...applyStreamActivityOrdinal(state, payload.streamId, messageOrdinal, {
-              isOwnMessage,
-              isViewing: isViewingStream,
-            }),
-            _cachedAt: Date.now(),
-          })
-          return
-        }
+        // Read-merge-write inside one transaction so concurrent tabs
+        // max-merge instead of clobbering each other (INV-20 analogue).
         await db.unreadState.put({
           ...state,
-          unreadCounts: {
-            ...state.unreadCounts,
-            [payload.streamId]: (state.unreadCounts[payload.streamId] ?? 0) + 1,
-          },
+          ...applyStreamActivityOrdinal(state, payload.streamId, payload.messageOrdinal, {
+            isOwnMessage,
+            isViewing: isViewingStream,
+          }),
           _cachedAt: Date.now(),
         })
       })

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -226,27 +226,31 @@ treating such a flag as real healing — it may be dead code (labels was).
   queries, so live emits and catch-up replays both heal it now. In-situ
   capture rides `stream:memos_captured` through stream-sync.
 - **`invitation:*` (sent / accepted / revoked / link-created / link-claimed)** —
-  bootstrap-only on the client today; the next additive candidate the owner
-  flagged (interest expressed, not yet scheduled). The five events are real
-  outbox events (`features/invitations/service.ts`), and because they match no
-  scoping list in `lib/outbox/repository.ts`, `resolveDeliveryGroups` routes
-  them through its `WORKSPACE_GROUP` fallthrough — so they are **already**
-  appended to `sync_log` and broadcast workspace-wide. What is missing is purely
+  bootstrap-only on the client; the next additive candidate the owner flagged.
+  The five events are real outbox events (`features/invitations/service.ts`).
+  They used to fall through `resolveDeliveryGroups` to `WORKSPACE_GROUP` — logged
+  and broadcast to every member's socket even though the payloads carry invitee
+  `email`, link `tokenHash`, and accepted-user identity (inert only because no
+  client read them). **Now permission-scoped (DONE):** `resolveDeliveryGroups`
+  routes them to `permissionGroup(members:write)`, so they are logged and emitted
+  to the `permission:members:write` group only. Sockets join that room on
+  workspace join via `permissionGroupsForRole(role)` (role-derived, mirroring
+  `requireWorkspacePermission`'s fallback), and catch-up admits the group for
+  holders — the catch-up handler passes the same role-derived `permissionGroups`
+  into `listEntriesForUser`, so live and replay delivery stay congruent. This
+  mirrors the bootstrap gate (`workspaces/handlers.ts` includes `invitations`
+  only for `members:write`). Pre-change `sync_log` rows keep their old
+  `['workspace']` groups until they age out of retention, but they are inert (no
+  client handler reads invitation events yet). What remains is purely
   client-side: there is no `invitation:*` handler in `sync/workspace-sync.ts`,
   and the only frontend surface — the `["invitations", workspaceId]` query in
   `components/workspace-settings/users-tab.tsx` (settings → users) — refreshes
   only on the viewer's own send/revoke/resend mutations and on a full workspace
-  bootstrap. So an invitation another admin sends or revokes in another session
-  never updates a viewer's open list until they remount or re-bootstrap.
-  Wiring it is **not** a drop-in `memo:created` clone: those payloads carry
-  invitee `email`, link `tokenHash`, and accepted-user identity, and the
-  workspace-wide fallthrough already puts them on _every_ member's socket (inert
-  only because nothing reads them). Before adding a client handler, scope the
-  events to admins / `members:manage` (move them onto an author- or
-  permission-scoped delivery group) rather than invalidating off a broadcast
-  ordinary members also receive. Once a gate-registered handler invalidates
-  `["invitations", workspaceId]`, live emits and catch-up replays both heal the
-  list and the standard coverage-proof chain applies.
+  bootstrap, so an invitation another admin sends or revokes in another session
+  never updates a viewer's open list until they remount or re-bootstrap. Once a
+  gate-registered handler invalidates `["invitations", workspaceId]`, live emits
+  and catch-up replays both heal the list and the standard coverage-proof chain
+  applies.
 - **`refetchOnMount: true`** on saved/scheduled/labels/activity: mount-time
   freshness, not reconnect healing. Out of scope.
 - **`useBackgroundBootstrapSync`** (SW prefetch) and **`useAppUpdate`**

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -163,14 +163,20 @@ treating such a flag as real healing — it may be dead code (labels was).
 
 ## Not deletable / keep as-is
 
-- **`usePageResumeRefresh`** (workspace + visible-stream bootstrap
-  invalidation on ≥5s resume): overlaps `SyncEngine.handlePageResume` (≥10s
-  away → probe → full reconnect bootstrap + catch-up), and on a ≥10s resume
-  the two run _duplicate_ full bootstrap fetches in every mode — but it is the
-  only healing in the 5–10s window and the only blanket cover for
-  "socket-healthy but tab-throttled" gaps below the probe threshold. Any
-  change here is a redesign (threshold alignment / engine-owned resume
-  catch-up), not a one-line deletion. Owner decision; not next.
+- **`usePageResumeRefresh`** (workspace + visible-stream bootstrap invalidation
+  on ≥5s resume): **deleted; resume is now engine-owned (#917).** It overlapped
+  `SyncEngine.handlePageResume` and on a ≥10s resume the two ran _duplicate_
+  full bootstrap fetches — the only thing it covered alone was the 5–10s window
+  below the old probe threshold. #917 unified the trigger at a single 5s
+  `PAGE_RESUME_THRESHOLD_MS` (one engine-owned entry point covers the whole
+  window, including the former 5–10s gap) and slimmed
+  `refreshAfterConnectivityResume` to `runBootstrap(true)` — so an active-mode
+  resume / online flip now runs `slimReconnectBootstrap()` + `runCatchUp("resume")`
+  instead of a full snapshot, the same slim path the socket reconnect uses. The
+  engine already tracks the identical visible-stream set the hook computed
+  (`currentStreamId` + `visibleStreamIds`), so per-stream deltas cover what the
+  hook's `streamKeys.bootstrap` invalidations did. Full snapshot still kept for
+  off/shadow/cold-connect and the below-floor `requiresBootstrap` fallback.
 - **Engine reconnect workspace bootstrap** (`runBootstrap(true)`): **slimmed for
   the active-mode socket reconnect (DONE).** The full-snapshot fetch was
   redundant there — catch-up replay (which runs right after) re-seeds every
@@ -190,9 +196,13 @@ treating such a flag as real healing — it may be dead code (labels was).
   cursor below the retained floor has no log to replay, so only the full
   snapshot is authoritative for everything `<= head`; `forceFull` upgrades an
   already-queued slim reconnect so it can't be collapsed away). Static
-  bootstrap-only state (personas, emojis, commands, invitations, permissions,
-  muted ids) has no live event, so a reconnect was only ever an incidental
-  refresh of it, not a guarantee — no regression. Read-before-stamp is moot on
+  bootstrap-only state (personas, emojis, commands, permissions, muted ids) has
+  no live event, so a reconnect was only ever an incidental refresh of it, not a
+  guarantee — no regression. (Invitations are bootstrap-only on the client too
+  but for a different reason — their events _are_ logged and broadcast
+  workspace-wide, just unhandled on the client; see the `invitation:*` follow-up
+  below. Earlier inventory text lumping invitations in with the static "no live
+  event" set was imprecise.) Read-before-stamp is moot on
   the slim path (no snapshot for the cursor to race; cursor + unread IDB persist
   across the reconnect, so absolute LWW catch-up converges the counters). The
   slim path swallows its own errors (sets the workspace stale) so it can never
@@ -215,6 +225,28 @@ treating such a flag as real healing — it may be dead code (labels was).
   handler in workspace-sync that invalidates the memory-explorer search
   queries, so live emits and catch-up replays both heal it now. In-situ
   capture rides `stream:memos_captured` through stream-sync.
+- **`invitation:*` (sent / accepted / revoked / link-created / link-claimed)** —
+  bootstrap-only on the client today; the next additive candidate the owner
+  flagged (interest expressed, not yet scheduled). The five events are real
+  outbox events (`features/invitations/service.ts`), and because they match no
+  scoping list in `lib/outbox/repository.ts`, `resolveDeliveryGroups` routes
+  them through its `WORKSPACE_GROUP` fallthrough — so they are **already**
+  appended to `sync_log` and broadcast workspace-wide. What is missing is purely
+  client-side: there is no `invitation:*` handler in `sync/workspace-sync.ts`,
+  and the only frontend surface — the `["invitations", workspaceId]` query in
+  `components/workspace-settings/users-tab.tsx` (settings → users) — refreshes
+  only on the viewer's own send/revoke/resend mutations and on a full workspace
+  bootstrap. So an invitation another admin sends or revokes in another session
+  never updates a viewer's open list until they remount or re-bootstrap.
+  Wiring it is **not** a drop-in `memo:created` clone: those payloads carry
+  invitee `email`, link `tokenHash`, and accepted-user identity, and the
+  workspace-wide fallthrough already puts them on _every_ member's socket (inert
+  only because nothing reads them). Before adding a client handler, scope the
+  events to admins / `members:manage` (move them onto an author- or
+  permission-scoped delivery group) rather than invalidating off a broadcast
+  ordinary members also receive. Once a gate-registered handler invalidates
+  `["invitations", workspaceId]`, live emits and catch-up replays both heal the
+  list and the standard coverage-proof chain applies.
 - **`refetchOnMount: true`** on saved/scheduled/labels/activity: mount-time
   freshness, not reconnect healing. Out of scope.
 - **`useBackgroundBootstrapSync`** (SW prefetch) and **`useAppUpdate`**


### PR DESCRIPTION
Two sync-v2 healing follow-ups on top of #917, plus the inventory doc that tracks this line of work. They are independent; grouped here because they share the inventory entry and were done in one sitting.

---

## 1. Require absolute unread-counter payload fields, drop legacy fallbacks (frontend)

### Problem

The three unread-counter socket payloads — `stream:read`, `stream:read_all`, `stream:activity` — have carried absolute fields (`lastReadOrdinal`, `reads[]`, `messageOrdinal`) since sync-v2 phase 2c. The backend emits them unconditionally (`messaging/event-service.ts` for `messageOrdinal`; `streams/service.ts` for `lastReadOrdinal` and `reads[]`). The frontend handlers in `apps/frontend/src/sync/workspace-sync.ts` still carried the pre-2c increment/zero fallback for absent fields as a defensive guard — dead code now that every live and replayed payload has the fields.

### Solution

Make the three fields required on the payload interfaces and delete the absent-field branches in `handleStreamRead` / `handleStreamReadAll` / `handleStreamActivity` (both the TanStack query-cache update and the IndexedDB write), so each handler routes straight through the absolute appliers (`applyStreamReadOrdinal` / `applyStreamsReadAllOrdinals` / `applyStreamActivityOrdinal`).

The absolute path is byte-for-byte unchanged — the deleted code only ran when a field was missing, which the backend never does. The obsolete `"falls back to the legacy increment when stream:activity lacks an ordinal"` test is removed (it covered a path that no longer exists).

---

## 2. Scope invitation events to `members:write` instead of the whole workspace (backend)

### Problem

Invitation outbox events (`invitation:sent` / `accepted` / `revoked` / `link-created` / `link-claimed`) matched no scoping list in `lib/outbox/repository.ts`, so `resolveDeliveryGroups` routed them through its final `WORKSPACE_GROUP` fallthrough. That meant they were appended to `sync_log` and broadcast to **every** workspace member's socket — even though the payloads carry invitee `email`, invite-link `tokenHash`, and accepted-user identity (`InvitationSentOutboxPayload` etc.). Inert today only because no client reads invitation events, but a leak waiting for the first `invitation:*` listener. The workspace bootstrap already gates the `invitations` field on `members:write` (`workspaces/handlers.ts`), so the broadcast was strictly broader than the REST surface.

### Solution

Introduce a permission-scoped delivery group and route the five invitation events to it, applied congruently to both the live socket path and catch-up replay.

### How it works

1. **`delivery-groups.ts`** — `permissionGroup(slug)` → `permission:<slug>`; `DELIVERED_PERMISSION_SCOPES` (currently just `MEMBERS_WRITE`) is the set of scopes that get their own group; `permissionGroupsForRole(role)` derives a member's permission groups via `permissionsForRole` from `@threa/types`. `resolveDeliveryGroups` gains a branch returning `[permissionGroup(MEMBERS_WRITE)]` for the five invitation events, before the workspace fallthrough.
2. **Live (`socket.ts`)** — on workspace join, after the existing user-room join, the socket auto-joins the role-derived permission rooms (`permissionGroupsForRole(workspaceUser.role).map(groupToRoom)`) and leaves them on workspace leave. The `userRooms` bookkeeping map now tracks `permissionRooms` alongside `userRoom`. A re-join on the same socket re-derives the set and leaves rooms the member no longer qualifies for.
3. **Catch-up (`sync/handlers.ts` → `service.ts` → `repository.ts`)** — the catch-up handler derives `permissionGroups` from `req.user.role` (the same role source the socket join uses) and threads it into `listEntriesForUser`, whose group-overlap test becomes `l.groups && (ARRAY['workspace', 'user:' || $userId]::text[] || $permissionGroups::text[])`. So replay admits exactly what live delivery reached.

### Key design decisions

**1. Role-derived permissions, not the JWT claim.** Socket auth carries only `workosUserId` (no permissions claim), and using one source in both paths keeps live and catch-up congruent by construction — no gap or duplicate for any custom-permission edge. `requireWorkspacePermission` honors a JWT `permissions` claim when present and falls back to `permissionsForRole(role)`; this change uses the role fallback in both delivery paths. Both `workspaceUser.role` (socket) and `req.user.role` (catch-up) come from the same mirror-aware `mapRowToUser` read, so they agree. Consequence: a hypothetical user with a custom JWT grant of `members:write` but `member` role would see `invitations` in bootstrap (JWT) but not get live/catch-up invitation updates (role) — strictly better than today (nobody gets live updates) and never a leak to a non-privileged member.

**2. Scope is `members:write`, mirroring the bootstrap gate.** `workspaces/handlers.ts` already includes the bootstrap `invitations` field only for `members:write` holders, and the invitation routes gate on `requireWorkspacePermission(members:write)`. The delivery scope now matches the REST surface exactly.

**3. All five invitation events, not just sent/accepted/revoked.** `link-created` and `link-claimed` carry `tokenHash` / `email` too, so scoping anything less would leave a leak.

### Self-review (2 Sonnet reviewer agents)

- **Re-join leak (fixed before push).** First version joined the new permission rooms on every workspace `join` but never left previously-joined ones. Since the frontend re-joins the workspace room on the same socket (`sync-engine.ts` joins at two sites), a role change mid-connection would have left a demoted admin in the stale `members:write` room. Fixed in `socket.ts`: on re-join the handler leaves any tracked permission room not in the freshly-derived set.
- **Live-path demotion window (accepted limitation).** After the re-join fix, a demoted admin whose socket stays connected and never re-joins still receives live invitation events until reconnect. This matches the system's existing permission model — `requireWorkspacePermission` itself accepts "a demoted member loses access on next session refresh (≤ access-token TTL)." Catch-up is always current (role derived per request). Reacting to role-change events on the socket to close the window fully is a possible follow-up, not done here.
- Remaining reviewer notes (permission rooms not metered in `wsConnectionsActive`, `userRooms` not cleared on disconnect) are pre-existing and match the existing user-room treatment; socket.io drops rooms on disconnect, so no live leak. Not changed.

## Out of scope (deliberate)

- **The frontend `invitation:*` client handler.** Wiring `sync/workspace-sync.ts` to invalidate `["invitations", workspaceId]` so the settings invitations list heals live remains the separate follow-up logged in the inventory. This PR only closes the broadcast leak so that wiring is safe to add later.
- **Backfilling historical `sync_log` rows.** Pre-change invitation entries keep their old `['workspace']` groups until retention (30-day horizon) ages them out, so catch-up still returns them to all members until then. They are inert — no client handler reads invitation events — so no rewrite here; if the client handler lands before those rows expire, add a one-time migration to rewrite their `groups` (INV-17 allows a new append-only migration).
- **The unconsumed `lastReadSequence?` / `sequence?` wire fields** on the unread payload interfaces — declared but never read, dead before this PR. Left untouched; a separate dead-code question, not part of the fallback cleanup.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/lib/outbox/delivery-groups.test.ts` | Unit tests: invitation events route to `members:write`; `permissionGroupsForRole` (admin/owner→group, member→none) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/workspace-sync.ts` | Make `lastReadOrdinal`/`reads`/`messageOrdinal` required; delete legacy fallback branches in the three handlers (cache + IDB); correct the `handleStreamActivity` comment |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Remove the obsolete legacy-increment test |
| `apps/backend/src/lib/outbox/delivery-groups.ts` | Add `permissionGroup`, `DELIVERED_PERMISSION_SCOPES`, `permissionGroupsForRole`; route invitation events to `permission:members:write` |
| `apps/backend/src/lib/outbox/index.ts` | Export the three new delivery-group symbols |
| `apps/backend/src/socket.ts` | Auto-join/leave role-derived permission rooms on workspace join/leave; drop stale rooms on re-join |
| `apps/backend/src/features/sync/handlers.ts` | Derive `permissionGroups` from `req.user.role`, pass to catch-up |
| `apps/backend/src/features/sync/service.ts` | Thread `permissionGroups` through `catchUp` |
| `apps/backend/src/features/sync/repository.ts` | Admit the viewer's permission groups in the `listEntriesForUser` overlap test |
| `apps/backend/src/features/sync/{handlers,service}.test.ts` | Supply/assert `permissionGroups` (incl. admin→members:write derivation) |
| `apps/backend/tests/integration/sync-catch-up.test.ts` | Integration case: holders get permission-group entries, members don't |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Log the `invitation:*` entry, mark it scoped (done) and `usePageResumeRefresh` done (#917) |

## Test plan

- [x] Frontend `bunx vitest run src/sync` — 193 pass
- [x] Backend `bun test src/lib/outbox src/features/sync` — 64 pass
- [x] `tsc --noEmit` clean across frontend and backend; eslint + prettier clean on changed files
- [x] Self-review: 2 Sonnet reviewer agents (backend security/correctness, frontend correctness) — 1 correctness fix applied (re-join room leak), 1 limitation documented (demotion window), 1 comment nit fixed; remaining notes dismissed as pre-existing/by-design
- [ ] `tests/integration/sync-catch-up.test.ts` permission-group case — not run locally (live-DB harness is CI-only, `ECONNREFUSED 127.0.0.1`); runs in CI

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_