### PR TITLE
feat(drafts): stage 2 frontend — unified local draft store + composer-loaded pointer

### DIFF
--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -8,13 +8,13 @@ import { stripMarkdownToInline } from "@/lib/markdown"
 import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
-import type { StashedDraft } from "@/hooks"
+import type { CachedDraft } from "@/hooks"
 
 /** Keystroke hint for the "Save current" action. Rendered only on non-mobile (no hardware keyboard). */
 const MOD_SYMBOL = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? "⌘" : "Ctrl+"
 
 interface StashedDraftsPickerProps {
-  drafts: StashedDraft[]
+  drafts: CachedDraft[]
   /** True when the composer has something worth stashing (controls "Save current" enablement). */
   canStashCurrent: boolean
   /** Called when the user clicks "Save current draft" or presses Enter on the save affordance. */
@@ -32,7 +32,7 @@ interface StashedDraftsPickerProps {
   size?: "compact" | "fab"
 }
 
-function getPreview(draft: StashedDraft): string {
+function getPreview(draft: CachedDraft): string {
   try {
     const md = serializeToMarkdown(draft.contentJson)
     const stripped = stripMarkdownToInline(md).trim()
@@ -164,7 +164,7 @@ export function StashedDraftsPicker({
                     >
                       <p className="text-sm line-clamp-2 break-words">{preview}</p>
                       <p className="text-[11px] text-muted-foreground mt-0.5">
-                        {formatRelativeTime(new Date(draft.createdAt), now, undefined, { terse: true })}
+                        {formatRelativeTime(new Date(draft.clientUpdatedAt), now, undefined, { terse: true })}
                         {attachmentCount > 0 && <span className="ml-1.5">· {attachmentCount} 📎</span>}
                       </p>
                     </button>

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -173,6 +173,18 @@ export function sequenceToNum(sequence: string): number {
   return Number(sequence)
 }
 
+/**
+ * Generate a client-side draft id. Mirrors the backend `draft_` ULID prefix so
+ * the same id can stand in until (Stage 3) the server confirms it. Lives here,
+ * at the data layer, so both the Dexie upgrade and the draft hooks mint ids the
+ * same way without the hooks→db layering inverting.
+ */
+export function generateLocalDraftId(): string {
+  const timestamp = Date.now().toString(36)
+  const random = Math.random().toString(36).substring(2, 10)
+  return `draft_${timestamp}${random}`
+}
+
 export interface CachedBot {
   id: string
   workspaceId: string
@@ -319,34 +331,43 @@ export interface DraftAttachment {
   sizeBytes: number
 }
 
-export interface DraftMessage {
-  // Key format: "stream:{streamId}" or "thread:{parentMessageId}" for new threads
+/**
+ * A single composer payload — the unit that (from Stage 3 on) mirrors to the
+ * backend `drafts` table. Folds the former `DraftMessage` (one ambient
+ * auto-save per scope) and `StashedDraft` (many explicit saves per scope) into
+ * one entity: every draft is a first-class row keyed by its own `draft_` id,
+ * and a scope may hold any number of them. Which one (if any) is currently
+ * checked out into the composer is tracked separately, and device-locally, by
+ * `ComposerLoaded` — "loaded" is never a property of the draft itself.
+ */
+export interface CachedDraft {
+  /** "draft_" prefixed id; client-generated until the first server confirm. */
   id: string
   workspaceId: string
+  /** "stream:{streamId}" or "thread:{parentMessageId}". */
+  scope: string
   /** ProseMirror JSON content */
   contentJson: JSONContent
   /** Attachments that have been uploaded and are ready to attach to the message */
-  attachments?: DraftAttachment[]
+  attachments: DraftAttachment[]
   /** Context refs attached to this draft (populated by "Discuss with Ariadne"). */
   contextRefs?: DraftContextRef[]
-  updatedAt: number
+  /** Authoring-device clock (ms); drives recency ordering. */
+  clientUpdatedAt: number
 }
 
 /**
- * An explicitly-stashed draft, created by the user pressing Cmd+S or the save
- * button in the composer. Unlike `DraftMessage` (one per scope, auto-saved as
- * the user types), any number of stashed drafts can coexist for the same scope
- * — they're a sidelined pile the user can restore later. Scope mirrors the
- * `DraftMessage` key format: "stream:{streamId}" or "thread:{parentMessageId}".
+ * Device-local pointer: which draft (if any) is checked out into the composer
+ * for a scope. Persisted so a reload restores it, but never synced — a fresh
+ * device opens the composer empty and the user picks a draft from the stash to
+ * load it. One row per scope; `workspaceId` is carried for workspace-scoped
+ * cache seeding, not because the pointer is shared.
  */
-export interface StashedDraft {
-  /** ULID with "stash_" prefix. Distinct from "draft_" which is claimed by DraftScratchpad. */
-  id: string
-  workspaceId: string
+export interface ComposerLoaded {
+  /** Primary key: "stream:{streamId}" or "thread:{parentMessageId}". */
   scope: string
-  contentJson: JSONContent
-  attachments?: DraftAttachment[]
-  createdAt: number
+  workspaceId: string
+  draftId: string | null
 }
 
 export interface CachedUnreadState {
@@ -697,8 +718,8 @@ export class ThreaDatabase extends Dexie {
   pendingMessages!: EntityTable<PendingMessage, "clientId">
   syncCursors!: EntityTable<SyncCursor, "key">
   draftScratchpads!: EntityTable<DraftScratchpad, "id">
-  draftMessages!: EntityTable<DraftMessage, "id">
-  stashedDrafts!: EntityTable<StashedDraft, "id">
+  drafts!: EntityTable<CachedDraft, "id">
+  composerLoaded!: EntityTable<ComposerLoaded, "scope">
   unreadState!: EntityTable<CachedUnreadState, "id">
   userPreferences!: EntityTable<CachedUserPreferences, "id">
   workspaceMetadata!: EntityTable<CachedWorkspaceMetadata, "id">
@@ -1008,6 +1029,80 @@ export class ThreaDatabase extends Dexie {
       sidebarConfigs: "id, workspaceId",
     })
 
+    // v34: Centralized drafts — fold the two local draft tables into one.
+    // `draftMessages` (one ambient auto-save per scope) and `stashedDrafts`
+    // (many explicit Cmd+S saves per scope) become rows in a single `drafts`
+    // store, each with its own `draft_` id and a `scope`. A device-local
+    // `composerLoaded` pointer records which draft is checked out per scope.
+    // The upgrade migrates every ambient draft to a draft + a loaded pointer,
+    // and every stash to a (not-loaded) draft, then drops the old stores.
+    // [workspaceId+scope] backs the per-scope stash picker; clientUpdatedAt
+    // backs recency ordering.
+    this.version(34)
+      .stores({
+        drafts: "id, workspaceId, scope, [workspaceId+scope], clientUpdatedAt",
+        composerLoaded: "scope, workspaceId",
+        draftMessages: null,
+        stashedDrafts: null,
+      })
+      .upgrade(async (tx) => {
+        const [messages, stashes] = await Promise.all([
+          tx.table("draftMessages").toArray(),
+          tx.table("stashedDrafts").toArray(),
+        ])
+
+        const draftRows: CachedDraft[] = []
+        const loadedRows: ComposerLoaded[] = []
+
+        // Ambient auto-saved drafts: one draft each, set as the loaded pointer
+        // for their scope so the composer restores them exactly as before. The
+        // old row's `id` IS the scope ("stream:…" / "thread:…").
+        for (const message of messages) {
+          const row = message as {
+            id: string
+            workspaceId: string
+            contentJson: JSONContent
+            attachments?: DraftAttachment[]
+            contextRefs?: DraftContextRef[]
+            updatedAt?: number
+          }
+          const id = generateLocalDraftId()
+          draftRows.push({
+            id,
+            workspaceId: row.workspaceId,
+            scope: row.id,
+            contentJson: row.contentJson,
+            attachments: row.attachments ?? [],
+            contextRefs: row.contextRefs,
+            clientUpdatedAt: row.updatedAt ?? Date.now(),
+          })
+          loadedRows.push({ scope: row.id, workspaceId: row.workspaceId, draftId: id })
+        }
+
+        // Stashed drafts: one draft each, left unloaded so they surface in the
+        // stash list rather than the composer.
+        for (const stash of stashes) {
+          const row = stash as {
+            workspaceId: string
+            scope: string
+            contentJson: JSONContent
+            attachments?: DraftAttachment[]
+            createdAt?: number
+          }
+          draftRows.push({
+            id: generateLocalDraftId(),
+            workspaceId: row.workspaceId,
+            scope: row.scope,
+            contentJson: row.contentJson,
+            attachments: row.attachments ?? [],
+            clientUpdatedAt: row.createdAt ?? Date.now(),
+          })
+        }
+
+        if (draftRows.length > 0) await tx.table("drafts").bulkPut(draftRows)
+        if (loadedRows.length > 0) await tx.table("composerLoaded").bulkPut(loadedRows)
+      })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -1065,7 +1160,11 @@ export async function clearAllCachedData(): Promise<void> {
       db.linkPreviewCollapse.clear(),
       db.savedMessages.clear(),
       db.scheduledMessages.clear(),
-      db.stashedDrafts.clear(),
+      // Drafts (the unified `drafts` store) and the device-local
+      // `composerLoaded` pointer are intentionally NOT cleared on logout —
+      // mirroring the pre-unification behavior where ambient drafts survived a
+      // sign-out so in-progress work isn't lost across a re-login. They are
+      // workspace+user scoped within this account's database.
       // Wrapped private bundles are tied to the logging-out identity — drop
       // them so the next account starts without inherited key material.
       db.e2eKeys.clear(),

--- a/apps/frontend/src/db/drafts-migration.test.ts
+++ b/apps/frontend/src/db/drafts-migration.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import Dexie from "dexie"
+import { ThreaDatabase } from "./database"
+
+const doc = (text: string) => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+describe("v34 drafts migration", () => {
+  it("folds draftMessages + stashedDrafts into drafts + composerLoaded", async () => {
+    const name = `threa_test_${Math.random().toString(36).slice(2)}`
+
+    // Seed an old-schema database carrying the two pre-unification draft tables.
+    const legacy = new Dexie(name)
+    legacy.version(33).stores({
+      draftMessages: "id, workspaceId, updatedAt",
+      stashedDrafts: "id, workspaceId, scope, [workspaceId+scope], createdAt",
+    })
+    await legacy.open()
+    await legacy.table("draftMessages").put({
+      id: "stream:stream_1",
+      workspaceId: "ws_1",
+      contentJson: doc("ambient"),
+      attachments: [{ id: "a1", filename: "f", mimeType: "text/plain", sizeBytes: 1 }],
+      updatedAt: 1000,
+    })
+    await legacy.table("stashedDrafts").put({
+      id: "stash_1",
+      workspaceId: "ws_1",
+      scope: "stream:stream_1",
+      contentJson: doc("stashed"),
+      createdAt: 2000,
+    })
+    legacy.close()
+
+    // Reopen through the app schema — runs the v34 upgrade.
+    const db = new ThreaDatabase(name)
+    await db.open()
+
+    const drafts = await db.drafts.toArray()
+    const loaded = await db.composerLoaded.toArray()
+
+    // One draft per old row; the ambient becomes the loaded pointer, the stash stays unloaded.
+    expect(drafts).toHaveLength(2)
+    expect(loaded).toHaveLength(1)
+
+    const pointer = loaded[0]
+    expect(pointer.scope).toBe("stream:stream_1")
+    expect(pointer.workspaceId).toBe("ws_1")
+
+    const ambient = drafts.find((d) => d.id === pointer.draftId)
+    expect(ambient).toMatchObject({ scope: "stream:stream_1", workspaceId: "ws_1", clientUpdatedAt: 1000 })
+    expect(ambient!.contentJson).toEqual(doc("ambient"))
+    expect(ambient!.attachments).toHaveLength(1)
+    expect(ambient!.id.startsWith("draft_")).toBe(true)
+
+    const stash = drafts.find((d) => d.id !== pointer.draftId)
+    expect(stash).toMatchObject({ scope: "stream:stream_1", workspaceId: "ws_1", clientUpdatedAt: 2000 })
+    expect(stash!.contentJson).toEqual(doc("stashed"))
+
+    // The old stores are dropped.
+    expect(db.tables.some((t) => t.name === "draftMessages")).toBe(false)
+    expect(db.tables.some((t) => t.name === "stashedDrafts")).toBe(false)
+
+    db.close()
+    await Dexie.delete(name)
+  })
+})

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -1,4 +1,11 @@
-export { db, ThreaDatabase, clearAllCachedData, clearPendingMessages, sequenceToNum } from "./database"
+export {
+  db,
+  ThreaDatabase,
+  clearAllCachedData,
+  clearPendingMessages,
+  sequenceToNum,
+  generateLocalDraftId,
+} from "./database"
 export type {
   CachedWorkspace,
   CachedWorkspaceUser,
@@ -17,9 +24,9 @@ export type {
   PendingStreamCreation,
   SyncCursor,
   DraftScratchpad,
-  DraftMessage,
+  CachedDraft,
+  ComposerLoaded,
   DraftAttachment,
-  StashedDraft,
   CachedSavedMessage,
   CachedScheduledMessage,
   CachedE2eKey,

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -55,10 +55,9 @@ export { useDraftMessage, getDraftMessageKey } from "./use-draft-message"
 
 export {
   useStashedDrafts,
-  generateStashId,
   type UseStashedDraftsResult,
   type StashDraftInput,
-  type StashedDraft,
+  type CachedDraft,
 } from "./use-stashed-drafts"
 
 export { useStashComposer, type UseStashComposerResult } from "./use-stash-composer"

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -1,30 +1,21 @@
 import { useLiveQuery } from "dexie-react-hooks"
 import { useCallback, useMemo } from "react"
-import { db, type CachedStream } from "@/db"
+import { db, type CachedDraft, type CachedStream } from "@/db"
 import {
-  deleteDraftMessageFromCache,
   deleteDraftScratchpadFromCache,
-  useDraftMessagesFromStore,
+  useComposerLoadedFromStore,
+  useDraftsFromStore,
   useDraftScratchpadsFromStore,
 } from "@/stores/draft-store"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { isDraftId } from "./use-draft-scratchpads"
+import { clearLoadedDraft, purgeScopeDrafts } from "./use-draft-message"
 import { deleteStashedDraftById } from "./use-stashed-drafts"
 import { serializeToMarkdown } from "@threa/prosemirror"
 import type { CompanionMode, JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
-
-/**
- * Defensive ceiling on the workspace-wide stash scan that powers the /drafts
- * explorer. `useLiveQuery` re-fires on every Dexie change in the table, so we
- * want to avoid re-materialising an unbounded number of rows into React state
- * on each write. 500 is well above any realistic user's stash pile; if the
- * explorer ever needs more, switch to cursor-based pagination instead of
- * raising this number.
- */
-const WORKSPACE_STASH_SCAN_LIMIT = 500
 
 export type DraftType = "scratchpad" | "channel" | "dm" | "thread"
 
@@ -34,12 +25,8 @@ function isValidDraftType(type: string): type is DraftType {
   return VALID_DRAFT_TYPES.includes(type as DraftType)
 }
 
-function isStashId(id: string): boolean {
-  return id.startsWith("stash_")
-}
-
 export interface UnifiedDraft {
-  /** Original draft ID (e.g., "draft_xxx" / "stream:xxx" / "thread:xxx" / "stash_xxx") */
+  /** Row id: a scratchpad id (`draft_xxx`) for scratchpad rows, otherwise the unified draft's own `draft_xxx` id. */
   id: string
   /** Type of stream/draft */
   type: DraftType
@@ -123,8 +110,8 @@ interface ResolvedDraftLocation {
 }
 
 /**
- * Shared location resolution used by both DraftMessage and StashedDraft rows
- * so their rendering stays in sync (same display name, same href, same
+ * Shared location resolution used by both loaded (ambient) and stashed draft
+ * rows so their rendering stays in sync (same display name, same href, same
  * group clustering). For thread-scope rows we resolve the parent stream via
  * cached events; if the parent isn't in cache yet we degrade to a generic
  * label with a null href.
@@ -186,56 +173,36 @@ function resolveDraftLocation(
  */
 export function useAllDrafts(workspaceId: string) {
   const draftScratchpads = useDraftScratchpadsFromStore(workspaceId)
-  const draftMessages = useDraftMessagesFromStore(workspaceId)
+  const allDrafts = useDraftsFromStore(workspaceId)
+  const composerLoaded = useComposerLoadedFromStore(workspaceId)
   const cachedStreams = useWorkspaceStreams(workspaceId)
 
-  // Stashed drafts live in a sibling pile (see `useStashedDrafts`). The
-  // workspace-wide query powers the /drafts explorer — the per-scope picker
-  // in the composer uses its own scoped query. `.reverse().limit(…)` takes
-  // the newest rows in the (ULID-based) primary-key order: ULIDs sort
-  // chronologically, so reversing the index iteration and taking N
-  // truncates from the old end, not the new one. Without `.reverse()` a
-  // power user past the cap would silently lose recently-stashed drafts
-  // from /drafts.
-  const stashedDrafts =
-    useLiveQuery(
-      () => {
-        if (!workspaceId) return []
-        return db.stashedDrafts
-          .where("workspaceId")
-          .equals(workspaceId)
-          .reverse()
-          .limit(WORKSPACE_STASH_SCAN_LIMIT)
-          .toArray()
-      },
-      [workspaceId],
-      []
-    ) ?? []
+  // scope -> loaded draft id, the device-local "checked out into the composer"
+  // pointer. A draft is "stashed" (vs. ambient/loaded) when it is not the one
+  // its scope points at.
+  const loadedByScope = useMemo(() => {
+    const map = new Map<string, string | null>()
+    for (const row of composerLoaded) map.set(row.scope, row.draftId)
+    return map
+  }, [composerLoaded])
 
-  // `useLiveQuery` returns a fresh array reference on every Dexie re-fire,
-  // even when the row set is unchanged. Deriving a stable signature from the
-  // set of scopes present turns identity-based churn into value-based
-  // invalidation for downstream memos (`hasThreadDrafts` →
-  // `cachedEvents` subscription → rebuild), so an unrelated stash write
-  // doesn't force event re-fetch.
-  const stashedScopesSignature = useMemo(() => {
+  // Stable signature over the set of draft scopes so the events query below
+  // (which is gated on whether any thread-scoped drafts exist) doesn't re-fire
+  // on every unrelated draft write — `useDraftsFromStore` hands back a fresh
+  // array reference each time.
+  const scopesSignature = useMemo(() => {
     const scopes = new Set<string>()
-    for (const row of stashedDrafts) scopes.add(row.scope)
+    for (const draft of allDrafts) scopes.add(draft.scope)
     return [...scopes].sort().join("|")
-  }, [stashedDrafts])
+  }, [allDrafts])
 
-  // Check if we have any thread drafts that need parent message resolution.
-  // Includes stashed drafts because a thread's parent-message resolution path
-  // is identical regardless of whether the row is auto-saved or stashed.
-  // Splitting on `|` and prefix-checking each segment avoids false positives
-  // on any scope that contained the literal substring `thread:` in a
-  // non-prefix position — cheap since the signature is capped by the scan
-  // limit above.
+  // Check if we have any thread drafts that need parent message resolution, so
+  // we only run the (expensive) events query when there are thread-scoped
+  // drafts. Prefix-checking each `|`-split segment avoids false positives on a
+  // scope that merely contains the substring `thread:` in a non-prefix spot.
   const hasThreadDrafts = useMemo(
-    () =>
-      (draftMessages ?? []).some((m) => m.id.startsWith("thread:")) ||
-      stashedScopesSignature.split("|").some((scope) => scope.startsWith("thread:")),
-    [draftMessages, stashedScopesSignature]
+    () => scopesSignature.split("|").some((scope) => scope.startsWith("thread:")),
+    [scopesSignature]
   )
 
   // Stable stream ID key — only changes when the set of IDs changes, not on
@@ -288,93 +255,73 @@ export function useAllDrafts(workspaceId: string) {
   // Combine and transform drafts
   const drafts = useMemo((): UnifiedDraft[] => {
     const result: UnifiedDraft[] = []
+    const draftsById = new Map<string, CachedDraft>()
+    for (const draft of allDrafts) draftsById.set(draft.id, draft)
 
-    // Add draft scratchpads (these are scratchpads that haven't been created on server yet)
-    for (const draft of draftScratchpads ?? []) {
-      // Check if there's a corresponding draft message with content
-      const draftMessageKey = `stream:${draft.id}`
-      const draftMessage = (draftMessages ?? []).find((m) => m.id === draftMessageKey)
+    // Scratchpads (streams not yet created on the server). Their content is the
+    // loaded draft for the `stream:{scratchpadId}` scope.
+    for (const scratchpad of draftScratchpads ?? []) {
+      const scope = `stream:${scratchpad.id}`
+      const loadedId = loadedByScope.get(scope) ?? null
+      const loadedDraft = loadedId ? draftsById.get(loadedId) : undefined
 
-      // Only include if there's content or attachments
-      const hasContent = !isEmptyContent(draftMessage?.contentJson)
-      const hasAttachments = (draftMessage?.attachments?.length ?? 0) > 0
+      const hasContent = !isEmptyContent(loadedDraft?.contentJson)
+      const hasAttachments = (loadedDraft?.attachments?.length ?? 0) > 0
 
       if (hasContent || hasAttachments) {
-        const displayName = draft.displayName ?? streamFallbackLabel("scratchpad", "sidebar")
+        const displayName = scratchpad.displayName ?? streamFallbackLabel("scratchpad", "sidebar")
         result.push({
-          id: draft.id,
+          id: scratchpad.id,
           type: "scratchpad",
-          streamId: draft.id,
+          streamId: scratchpad.id,
           displayName,
-          preview: truncatePreview(getContentPreview(draftMessage?.contentJson)),
-          attachmentCount: draftMessage?.attachments?.length ?? 0,
-          updatedAt: draftMessage?.updatedAt ?? draft.createdAt,
-          href: `/w/${workspaceId}/s/${draft.id}`,
+          preview: truncatePreview(getContentPreview(loadedDraft?.contentJson)),
+          attachmentCount: loadedDraft?.attachments?.length ?? 0,
+          updatedAt: loadedDraft?.clientUpdatedAt ?? scratchpad.createdAt,
+          href: `/w/${workspaceId}/s/${scratchpad.id}`,
           groupLabel: displayName,
           isStashed: false,
-          companionMode: draft.companionMode,
+          companionMode: scratchpad.companionMode,
         })
       }
     }
 
-    // Add draft messages for existing streams (channels, DMs, threads)
-    for (const draftMessage of draftMessages ?? []) {
-      const parsed = parseDraftMessageKey(draftMessage.id)
+    // Every other draft — channels, DMs, threads — loaded (ambient) or stashed.
+    for (const draft of allDrafts) {
+      const parsed = parseDraftMessageKey(draft.scope)
       if (!parsed) continue
 
-      // Skip if this is for a draft scratchpad (already handled above)
+      // Scratchpad-scoped drafts: the loaded one is handled above; any stash
+      // siblings are skipped in the explorer until the scratchpad flow itself
+      // supports them.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
 
-      // Only include if there's content or attachments
-      const hasContent = !isEmptyContent(draftMessage.contentJson)
-      const hasAttachments = (draftMessage.attachments?.length ?? 0) > 0
+      const hasContent = !isEmptyContent(draft.contentJson)
+      const hasAttachments = (draft.attachments?.length ?? 0) > 0
       if (!hasContent && !hasAttachments) continue
 
       const resolved = resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
+      const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
+
+      // A stashed row deep-links via `?stash=<draftId>` so the composer host
+      // pops + restores it on mount; the loaded (ambient) row navigates plainly
+      // since its content is already checked out.
+      const href =
+        isStashed && resolved.href
+          ? resolved.href + (resolved.href.includes("?") ? "&" : "?") + `stash=${encodeURIComponent(draft.id)}`
+          : resolved.href
 
       result.push({
-        id: draftMessage.id,
+        id: draft.id,
         type: resolved.draftType,
         streamId: resolved.streamId,
         displayName: resolved.displayName,
-        preview: truncatePreview(getContentPreview(draftMessage.contentJson)),
-        attachmentCount: draftMessage.attachments?.length ?? 0,
-        updatedAt: draftMessage.updatedAt,
-        href: resolved.href,
-        groupLabel: resolved.groupLabel,
-        isStashed: false,
-      })
-    }
-
-    // Stashed drafts: one row per saved snapshot. Clicking the row navigates
-    // to the stream with `?stash=<id>`; `MessageInput` / `StreamPanel` picks
-    // up that param on mount and restores into the composer (stashing any
-    // current content first, mirroring the picker's swap behavior).
-    for (const stashed of stashedDrafts) {
-      const parsed = parseDraftMessageKey(stashed.scope)
-      if (!parsed) continue
-      if (parsed.type === "stream" && isDraftId(parsed.id)) {
-        // Scratchpad-scoped stashes are rare but conceptually valid; skip in
-        // the /drafts explorer until the scratchpad flow itself supports them.
-        continue
-      }
-
-      const resolved = resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
-      const href = resolved.href
-        ? resolved.href + (resolved.href.includes("?") ? "&" : "?") + `stash=${encodeURIComponent(stashed.id)}`
-        : null
-
-      result.push({
-        id: stashed.id,
-        type: resolved.draftType,
-        streamId: resolved.streamId,
-        displayName: resolved.displayName,
-        preview: truncatePreview(getContentPreview(stashed.contentJson)),
-        attachmentCount: stashed.attachments?.length ?? 0,
-        updatedAt: stashed.createdAt,
+        preview: truncatePreview(getContentPreview(draft.contentJson)),
+        attachmentCount: draft.attachments?.length ?? 0,
+        updatedAt: draft.clientUpdatedAt,
         href,
         groupLabel: resolved.groupLabel,
-        isStashed: true,
+        isStashed,
       })
     }
 
@@ -384,29 +331,29 @@ export function useAllDrafts(workspaceId: string) {
     result.sort((a, b) => b.updatedAt - a.updatedAt)
 
     return result
-  }, [draftScratchpads, draftMessages, stashedDrafts, streamMap, messageToStreamMap, workspaceId])
+  }, [draftScratchpads, allDrafts, loadedByScope, streamMap, messageToStreamMap, workspaceId])
 
-  // Delete a draft by id — dispatches to the correct table by id prefix.
-  // Handles three shapes: "stash_xxx" (stashed pile), "draft_xxx" (scratchpad
-  // + its ambient draft message), and "stream:..." / "thread:..." (ambient
-  // draft message).
+  // Delete a draft by its `UnifiedDraft.id`. Scratchpad rows carry a scratchpad
+  // id; every other row carries a unified draft id — both `draft_`-prefixed, so
+  // we disambiguate by table lookup rather than prefix.
   const deleteDraft = useCallback(
     async (draftId: string) => {
-      if (isStashId(draftId)) {
-        await deleteStashedDraftById(draftId)
-        return
-      }
-
-      if (isDraftId(draftId)) {
+      const scratchpad = await db.draftScratchpads.get(draftId)
+      if (scratchpad) {
         await db.draftScratchpads.delete(draftId)
-        await db.draftMessages.delete(`stream:${draftId}`)
         deleteDraftScratchpadFromCache(workspaceId, draftId)
-        deleteDraftMessageFromCache(workspaceId, `stream:${draftId}`)
+        await purgeScopeDrafts(workspaceId, `stream:${draftId}`)
         return
       }
 
-      await db.draftMessages.delete(draftId)
-      deleteDraftMessageFromCache(workspaceId, draftId)
+      const draft = await db.drafts.get(draftId)
+      if (!draft) return
+      const loadedId = (await db.composerLoaded.get(draft.scope))?.draftId ?? null
+      if (loadedId === draftId) {
+        await clearLoadedDraft(workspaceId, draft.scope)
+      } else {
+        await deleteStashedDraftById(draftId)
+      }
     },
     [workspaceId]
   )

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -62,7 +62,7 @@ export interface DraftComposerState {
   /**
    * Hydrate attachments from a snapshot (e.g. when restoring a stashed draft).
    * Pushes them into the pending-attachments list; the persistence effect
-   * then writes them into the active DraftMessage on next flush.
+   * then writes them into the scope's loaded draft on next flush.
    */
   restoreAttachments: (
     attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -1,86 +1,50 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
-import { useDraftMessage, getDraftMessageKey } from "./use-draft-message"
-import type { JSONContent } from "@threa/types"
-import * as dbModule from "@/db"
-import * as draftStoreModule from "@/stores/draft-store"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { useDraftMessage, getDraftMessageKey, upsertLoadedDraft } from "./use-draft-message"
+import { ContextRefKinds, type JSONContent } from "@threa/types"
+import type { DraftContextRef } from "@/lib/context-bag/types"
+import { db } from "@/db"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const makeDoc = (text: string): JSONContent => ({
   type: "doc",
   content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
 })
-// Mock Dexie database
-const mockGet = vi.fn()
-const mockPut = vi.fn()
-const mockDelete = vi.fn()
-const mockUpsertDraftMessageInCache = vi.fn()
-const mockDeleteDraftMessageFromCache = vi.fn()
 
-let seededDraftCache = false
-let draftMessages: Array<{
-  id: string
-  workspaceId: string
-  contentJson: JSONContent
-  attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>
-  updatedAt: number
-}> = []
+const workspaceId = "ws_123"
+const draftKey = "stream:stream_456"
+
+/** Read back the single loaded draft for a scope (or undefined). */
+async function loadedDraft(scope: string) {
+  const id = (await db.composerLoaded.get(scope))?.draftId ?? null
+  return id ? db.drafts.get(id) : undefined
+}
 
 describe("getDraftMessageKey", () => {
   it("should return stream key format for stream type", () => {
-    const key = getDraftMessageKey({ type: "stream", streamId: "stream_123" })
-    expect(key).toBe("stream:stream_123")
+    expect(getDraftMessageKey({ type: "stream", streamId: "stream_123" })).toBe("stream:stream_123")
   })
 
   it("should return thread key format for thread type", () => {
-    const key = getDraftMessageKey({ type: "thread", parentMessageId: "msg_456" })
-    expect(key).toBe("thread:msg_456")
+    expect(getDraftMessageKey({ type: "thread", parentMessageId: "msg_456" })).toBe("thread:msg_456")
   })
 })
 
 describe("useDraftMessage", () => {
-  const workspaceId = "ws_123"
-  const draftKey = "stream:stream_456"
-
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.restoreAllMocks()
-    mockGet.mockReset()
-    mockPut.mockReset()
-    mockDelete.mockReset()
-    mockUpsertDraftMessageInCache.mockReset()
-    mockDeleteDraftMessageFromCache.mockReset()
-    vi.useFakeTimers()
-    seededDraftCache = false
-    draftMessages = []
-    mockGet.mockResolvedValue(undefined)
-    mockPut.mockResolvedValue(undefined)
-    mockDelete.mockResolvedValue(undefined)
-
-    vi.spyOn(dbModule.db.draftMessages, "get").mockImplementation(((...args: unknown[]) =>
-      mockGet(...args)) as unknown as typeof dbModule.db.draftMessages.get)
-    vi.spyOn(dbModule.db.draftMessages, "put").mockImplementation(((...args: unknown[]) =>
-      mockPut(...args)) as unknown as typeof dbModule.db.draftMessages.put)
-    vi.spyOn(dbModule.db.draftMessages, "delete").mockImplementation(((...args: unknown[]) =>
-      mockDelete(...args)) as unknown as typeof dbModule.db.draftMessages.delete)
-
-    vi.spyOn(draftStoreModule, "hasSeededDraftCache").mockImplementation(() => seededDraftCache)
-    vi.spyOn(draftStoreModule, "useDraftMessagesFromStore").mockImplementation(
-      () => draftMessages as ReturnType<typeof draftStoreModule.useDraftMessagesFromStore>
-    )
-    vi.spyOn(draftStoreModule, "upsertDraftMessageInCache").mockImplementation(((...args: unknown[]) =>
-      mockUpsertDraftMessageInCache(...args)) as unknown as typeof draftStoreModule.upsertDraftMessageInCache)
-    vi.spyOn(draftStoreModule, "deleteDraftMessageFromCache").mockImplementation(((...args: unknown[]) =>
-      mockDeleteDraftMessageFromCache(...args)) as unknown as typeof draftStoreModule.deleteDraftMessageFromCache)
+    resetDraftStoreCache()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   describe("isLoaded state", () => {
-    it("should return isLoaded=false while Dexie is loading", () => {
-      seededDraftCache = false
-
+    it("should return isLoaded=false while the draft cache is unseeded", () => {
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
       expect(result.current.isLoaded).toBe(false)
@@ -88,28 +52,24 @@ describe("useDraftMessage", () => {
       expect(result.current.attachments).toEqual([])
     })
 
-    it("should return isLoaded=true after Dexie finishes loading with no data", () => {
-      seededDraftCache = true
-
+    it("should return isLoaded=true after the cache is seeded with no data", async () => {
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+
+      await act(async () => {
+        await seedDraftCacheFromIdb(workspaceId)
+      })
 
       expect(result.current.isLoaded).toBe(true)
       expect(result.current.contentJson).toEqual(EMPTY_DOC)
       expect(result.current.attachments).toEqual([])
     })
 
-    it("should return isLoaded=true with saved content after Dexie loads", () => {
-      seededDraftCache = true
+    it("should surface the loaded draft's saved content once seeded", async () => {
       const savedContentJson = makeDoc("Hello world")
-      draftMessages = [
-        {
-          id: draftKey,
-          workspaceId,
-          contentJson: savedContentJson,
-          attachments: [{ id: "attach_1", filename: "test.txt", mimeType: "text/plain", sizeBytes: 100 }],
-          updatedAt: Date.now(),
-        },
-      ]
+      await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: savedContentJson,
+        attachments: [{ id: "attach_1", filename: "test.txt", mimeType: "text/plain", sizeBytes: 100 }],
+      })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -119,40 +79,29 @@ describe("useDraftMessage", () => {
       expect(result.current.attachments[0].filename).toBe("test.txt")
     })
 
-    it("should return empty state for a different draft key once the workspace cache is loaded", () => {
-      seededDraftCache = true
+    it("should return empty state for a scope with no loaded draft", async () => {
       const oldDraftKey = "stream:stream_old"
       const newDraftKey = "stream:stream_new"
-
-      draftMessages = [
-        {
-          id: oldDraftKey,
-          workspaceId,
-          contentJson: makeDoc("Old draft"),
-          attachments: [{ id: "attach_old", filename: "old.txt", mimeType: "text/plain", sizeBytes: 100 }],
-          updatedAt: Date.now(),
-        },
-      ]
-
-      const { result, rerender } = renderHook(({ currentDraftKey }) => useDraftMessage(workspaceId, currentDraftKey), {
-        initialProps: { currentDraftKey: oldDraftKey },
+      await upsertLoadedDraft(workspaceId, oldDraftKey, {
+        contentJson: makeDoc("Old draft"),
+        attachments: [{ id: "attach_old", filename: "old.txt", mimeType: "text/plain", sizeBytes: 100 }],
       })
 
-      expect(result.current.isLoaded).toBe(true)
+      const { result, rerender } = renderHook(({ key }) => useDraftMessage(workspaceId, key), {
+        initialProps: { key: oldDraftKey },
+      })
+
       expect(result.current.attachments).toHaveLength(1)
 
-      rerender({ currentDraftKey: newDraftKey })
+      rerender({ key: newDraftKey })
 
-      expect(result.current.isLoaded).toBe(true)
       expect(result.current.contentJson).toEqual(EMPTY_DOC)
       expect(result.current.attachments).toEqual([])
     })
   })
 
   describe("saveDraft", () => {
-    it("should save content to database", async () => {
-      seededDraftCache = true
-
+    it("should persist content as a draft_ row scoped to the key + a loaded pointer", async () => {
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
       const newContent = makeDoc("New content")
 
@@ -160,18 +109,14 @@ describe("useDraftMessage", () => {
         await result.current.saveDraft(newContent)
       })
 
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: draftKey,
-          workspaceId,
-          contentJson: newContent,
-          attachments: [],
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted).toMatchObject({ scope: draftKey, workspaceId, contentJson: newContent, attachments: [] })
+      expect(persisted!.id.startsWith("draft_")).toBe(true)
     })
 
     it("never persists a draft for an E2E stream and purges any on disk (E2EE-4)", async () => {
-      seededDraftCache = true
+      // A plaintext draft written before the gate existed...
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("secret"), attachments: [] })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, true))
 
@@ -181,15 +126,12 @@ describe("useDraftMessage", () => {
         await result.current.addAttachment({ id: "att_1", filename: "f", mimeType: "text/plain", sizeBytes: 1 })
       })
 
-      // Nothing written to disk through any persistence entry point...
-      expect(mockPut).not.toHaveBeenCalled()
-      // ...and a pre-existing on-disk draft is cleared on mount.
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
+      // ...is purged on mount, and nothing new is written to disk.
+      await waitFor(async () => expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0))
+      expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
     })
 
     it("cancels a debounced plaintext save when the stream becomes encrypted mid-flight (E2EE-4 race)", async () => {
-      seededDraftCache = true
-
       const { result, rerender } = renderHook(
         ({ e2e }: { e2e: boolean }) => useDraftMessage(workspaceId, draftKey, e2e),
         {
@@ -197,26 +139,18 @@ describe("useDraftMessage", () => {
         }
       )
 
-      // Queue a debounced save while the stream is still plaintext...
       act(() => {
         result.current.saveDraftDebounced(makeDoc("typed before the stream was encrypted"))
       })
-      // ...then the stream becomes encrypted before the debounce window elapses.
       rerender({ e2e: true })
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1000)
-      })
-
-      // The in-flight save must NOT re-persist plaintext after the purge.
-      expect(mockPut).not.toHaveBeenCalled()
-      // The encrypt transition purged any on-disk draft.
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
+      // Past the debounce window: the in-flight save must NOT persist plaintext.
+      await new Promise((r) => setTimeout(r, 700))
+      expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
     })
 
-    it("should delete draft when content is empty and no attachments", async () => {
-      seededDraftCache = true
-      mockGet.mockResolvedValue({ attachments: [] })
+    it("should delete the loaded draft when content is empty and no attachments", async () => {
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("something"), attachments: [] })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -224,14 +158,13 @@ describe("useDraftMessage", () => {
         await result.current.saveDraft(EMPTY_DOC)
       })
 
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
-      expect(mockPut).not.toHaveBeenCalled()
+      expect(await loadedDraft(draftKey)).toBeUndefined()
+      expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
     })
 
     it("should preserve existing attachments when saving content", async () => {
-      seededDraftCache = true
       const existingAttachments = [{ id: "attach_1", filename: "file.txt", mimeType: "text/plain", sizeBytes: 50 }]
-      mockGet.mockResolvedValue({ attachments: existingAttachments })
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("x"), attachments: existingAttachments })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
       const updatedContent = makeDoc("Updated content")
@@ -240,28 +173,28 @@ describe("useDraftMessage", () => {
         await result.current.saveDraft(updatedContent)
       })
 
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          contentJson: updatedContent,
-          attachments: existingAttachments,
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted).toMatchObject({ contentJson: updatedContent, attachments: existingAttachments })
     })
 
     it("should preserve existing contextRefs sidecar when saving content (regression: typing wiped the chip)", async () => {
-      seededDraftCache = true
-      const existingRefs = [
+      const existingRefs: DraftContextRef[] = [
         {
-          refKind: "thread",
+          refKind: ContextRefKinds.THREAD,
           streamId: "stream_src",
           fromMessageId: null,
           toMessageId: null,
-          status: "ready" as const,
+          originMessageId: null,
+          status: "ready",
           fingerprint: null,
           errorMessage: null,
         },
       ]
-      mockGet.mockResolvedValue({ attachments: [], contextRefs: existingRefs })
+      await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        contextRefs: existingRefs,
+      })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
       const updatedContent = makeDoc("user is typing")
@@ -270,29 +203,28 @@ describe("useDraftMessage", () => {
         await result.current.saveDraft(updatedContent)
       })
 
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          contentJson: updatedContent,
-          attachments: [],
-          contextRefs: existingRefs,
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted).toMatchObject({ contentJson: updatedContent, attachments: [], contextRefs: existingRefs })
     })
 
     it("should keep the draft alive when content goes empty but contextRefs is non-empty", async () => {
-      seededDraftCache = true
-      const existingRefs = [
+      const existingRefs: DraftContextRef[] = [
         {
-          refKind: "thread",
+          refKind: ContextRefKinds.THREAD,
           streamId: "stream_src",
           fromMessageId: null,
           toMessageId: null,
-          status: "ready" as const,
+          originMessageId: null,
+          status: "ready",
           fingerprint: null,
           errorMessage: null,
         },
       ]
-      mockGet.mockResolvedValue({ attachments: [], contextRefs: existingRefs })
+      await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: makeDoc("x"),
+        attachments: [],
+        contextRefs: existingRefs,
+      })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -300,20 +232,14 @@ describe("useDraftMessage", () => {
         await result.current.saveDraft(EMPTY_DOC)
       })
 
-      expect(mockDelete).not.toHaveBeenCalled()
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          contentJson: EMPTY_DOC,
-          contextRefs: existingRefs,
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted).toMatchObject({ contentJson: EMPTY_DOC, contextRefs: existingRefs })
     })
   })
 
   describe("saveDraftDebounced", () => {
-    it("should debounce saves", async () => {
-      seededDraftCache = true
-
+    it("should debounce saves, persisting only the last value", async () => {
+      const putSpy = vi.spyOn(db.drafts, "put")
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
       const thirdContent = makeDoc("Third")
 
@@ -323,70 +249,49 @@ describe("useDraftMessage", () => {
         result.current.saveDraftDebounced(thirdContent)
       })
 
-      // Nothing saved yet
-      expect(mockPut).not.toHaveBeenCalled()
+      expect(putSpy).not.toHaveBeenCalled()
 
-      // Advance past debounce delay
-      await act(async () => {
-        vi.advanceTimersByTime(600)
-      })
-
-      // Only the last value should be saved
-      expect(mockPut).toHaveBeenCalledTimes(1)
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          contentJson: thirdContent,
-        })
-      )
+      await waitFor(() => expect(putSpy).toHaveBeenCalledTimes(1))
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted?.contentJson).toEqual(thirdContent)
     })
   })
 
   describe("addAttachment", () => {
-    it("should add attachment to empty draft", async () => {
-      seededDraftCache = true
-      mockGet.mockResolvedValue(undefined)
-
+    it("should add attachment to an empty (absent) draft", async () => {
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
-
       const attachment = { id: "attach_1", filename: "new.txt", mimeType: "text/plain", sizeBytes: 100 }
 
       await act(async () => {
         await result.current.addAttachment(attachment)
       })
 
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: draftKey,
-          workspaceId,
-          contentJson: EMPTY_DOC,
-          attachments: [attachment],
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted).toMatchObject({ scope: draftKey, contentJson: EMPTY_DOC, attachments: [attachment] })
     })
 
-    it("should not add duplicate attachment", async () => {
-      seededDraftCache = true
+    it("should not add a duplicate attachment", async () => {
       const existingAttachment = { id: "attach_1", filename: "existing.txt", mimeType: "text/plain", sizeBytes: 50 }
-      mockGet.mockResolvedValue({ contentJson: EMPTY_DOC, attachments: [existingAttachment] })
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: EMPTY_DOC, attachments: [existingAttachment] })
 
+      const putSpy = vi.spyOn(db.drafts, "put")
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
       await act(async () => {
         await result.current.addAttachment(existingAttachment)
       })
 
-      expect(mockPut).not.toHaveBeenCalled()
+      expect(putSpy).not.toHaveBeenCalled()
     })
   })
 
   describe("removeAttachment", () => {
-    it("should remove attachment from draft", async () => {
-      seededDraftCache = true
+    it("should remove an attachment from the draft", async () => {
       const attachments = [
         { id: "attach_1", filename: "file1.txt", mimeType: "text/plain", sizeBytes: 50 },
         { id: "attach_2", filename: "file2.txt", mimeType: "text/plain", sizeBytes: 100 },
       ]
-      mockGet.mockResolvedValue({ id: draftKey, contentJson: makeDoc("Some content"), attachments })
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("Some content"), attachments })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -394,17 +299,15 @@ describe("useDraftMessage", () => {
         await result.current.removeAttachment("attach_1")
       })
 
-      expect(mockPut).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attachments: [{ id: "attach_2", filename: "file2.txt", mimeType: "text/plain", sizeBytes: 100 }],
-        })
-      )
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted?.attachments).toEqual([
+        { id: "attach_2", filename: "file2.txt", mimeType: "text/plain", sizeBytes: 100 },
+      ])
     })
 
-    it("should delete draft when removing last attachment and content is empty", async () => {
-      seededDraftCache = true
+    it("should delete the draft when removing the last attachment and content is empty", async () => {
       const attachment = { id: "attach_1", filename: "file.txt", mimeType: "text/plain", sizeBytes: 50 }
-      mockGet.mockResolvedValue({ id: draftKey, contentJson: EMPTY_DOC, attachments: [attachment] })
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: EMPTY_DOC, attachments: [attachment] })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -412,14 +315,13 @@ describe("useDraftMessage", () => {
         await result.current.removeAttachment("attach_1")
       })
 
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
-      expect(mockPut).not.toHaveBeenCalled()
+      expect(await loadedDraft(draftKey)).toBeUndefined()
     })
   })
 
   describe("clearDraft", () => {
-    it("should delete the draft", async () => {
-      seededDraftCache = true
+    it("should delete the loaded draft and its pointer", async () => {
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("x"), attachments: [] })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
@@ -427,12 +329,12 @@ describe("useDraftMessage", () => {
         await result.current.clearDraft()
       })
 
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
+      expect(await loadedDraft(draftKey)).toBeUndefined()
+      expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
     })
 
-    it("should cancel pending debounced save", async () => {
-      seededDraftCache = true
-
+    it("should cancel a pending debounced save", async () => {
+      const putSpy = vi.spyOn(db.drafts, "put")
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
 
       act(() => {
@@ -443,14 +345,9 @@ describe("useDraftMessage", () => {
         await result.current.clearDraft()
       })
 
-      // Advance past debounce
-      await act(async () => {
-        vi.advanceTimersByTime(600)
-      })
-
-      // Only delete should have been called, not put
-      expect(mockDelete).toHaveBeenCalledWith(draftKey)
-      expect(mockPut).not.toHaveBeenCalled()
+      await new Promise((r) => setTimeout(r, 700))
+      expect(putSpy).not.toHaveBeenCalled()
+      expect(await loadedDraft(draftKey)).toBeUndefined()
     })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useRef } from "react"
-import { db, type DraftAttachment, type DraftMessage } from "@/db"
+import { db, generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import {
-  deleteDraftMessageFromCache,
+  deleteDraftFromCache,
   hasSeededDraftCache,
-  upsertDraftMessageInCache,
-  useDraftMessagesFromStore,
+  setComposerLoadedInCache,
+  upsertDraftInCache,
+  useComposerLoadedFromStore,
+  useDraftsFromStore,
 } from "@/stores/draft-store"
 import type { JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 
-// Key formats:
+// Key formats (a draft's `scope`):
 // - "stream:{streamId}" for messages in existing streams
 // - "thread:{parentMessageId}" for new threads (reply to a message that doesn't have a thread yet)
 export function getDraftMessageKey(
@@ -24,6 +26,76 @@ export function getDraftMessageKey(
 
 const DEBOUNCE_MS = import.meta.env.VITE_DRAFT_DEBOUNCE_MS ? Number(import.meta.env.VITE_DRAFT_DEBOUNCE_MS) : 500
 
+const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
+
+/** Resolve the draft id currently checked out into the composer for a scope. */
+async function getLoadedDraftId(scope: string): Promise<string | null> {
+  const row = await db.composerLoaded.get(scope)
+  return row?.draftId ?? null
+}
+
+export interface DraftFields {
+  contentJson: JSONContent
+  attachments: DraftAttachment[]
+  contextRefs?: DraftContextRef[]
+}
+
+/**
+ * Create or update the draft currently loaded into the composer for `scope`,
+ * setting the loaded pointer when a fresh draft is minted. Writes IDB and the
+ * in-memory cache together so the composer reflects the change on next paint.
+ * Shared by `useDraftMessage` and the context-bag / share-target seeders so a
+ * scope never ends up with a draft that no pointer references.
+ */
+export async function upsertLoadedDraft(workspaceId: string, scope: string, fields: DraftFields): Promise<CachedDraft> {
+  const loadedId = await getLoadedDraftId(scope)
+  const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+  const id = existing?.id ?? generateLocalDraftId()
+  const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
+  const row: CachedDraft = {
+    id,
+    workspaceId,
+    scope,
+    contentJson: fields.contentJson,
+    attachments: fields.attachments,
+    contextRefs,
+    clientUpdatedAt: Date.now(),
+  }
+  await db.drafts.put(row)
+  upsertDraftInCache(workspaceId, row)
+  if (!existing) {
+    await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+    setComposerLoadedInCache(workspaceId, scope, id)
+  }
+  return row
+}
+
+/** Delete the loaded draft for `scope` and clear its pointer (stashes survive). */
+export async function clearLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+  const loadedId = await getLoadedDraftId(scope)
+  if (loadedId) {
+    await db.drafts.delete(loadedId)
+    deleteDraftFromCache(workspaceId, loadedId)
+  }
+  await db.composerLoaded.delete(scope)
+  setComposerLoadedInCache(workspaceId, scope, null)
+}
+
+/**
+ * Delete every draft for `scope` and clear its pointer. Used by the E2E gate to
+ * ensure no plaintext draft (loaded or stashed) for a sealed stream stays at
+ * rest (E2EE-4).
+ */
+export async function purgeScopeDrafts(workspaceId: string, scope: string): Promise<void> {
+  const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
+  for (const row of rows) {
+    await db.drafts.delete(row.id)
+    deleteDraftFromCache(workspaceId, row.id)
+  }
+  await db.composerLoaded.delete(scope)
+  setComposerLoadedInCache(workspaceId, scope, null)
+}
+
 /**
  * @param e2eEnabled When the draft belongs to an end-to-end-encrypted stream,
  *   persistence and restore are disabled (E2EE-4): the composer keeps content in
@@ -36,8 +108,10 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
   // Read inside the debounced timer so a save scheduled while the stream was
   // plaintext can't write after the stream becomes encrypted (E2EE-4).
   const e2eEnabledRef = useRef(e2eEnabled)
-  const draftMessages = useDraftMessagesFromStore(workspaceId)
-  const resolvedDraft = e2eEnabled ? undefined : draftMessages.find((draft) => draft.id === draftKey)
+  const drafts = useDraftsFromStore(workspaceId)
+  const loaded = useComposerLoadedFromStore(workspaceId)
+  const loadedId = e2eEnabled ? null : (loaded.find((row) => row.scope === draftKey)?.draftId ?? null)
+  const resolvedDraft = loadedId ? drafts.find((draft) => draft.id === loadedId) : undefined
 
   // When a stream becomes encrypted, cancel any debounced plaintext save still
   // in flight — otherwise it fires after the purge below and re-persists the
@@ -54,7 +128,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
   // before this gate landed, or carried over when a stream is encrypted).
   useEffect(() => {
     if (!e2eEnabled) return
-    void db.draftMessages.delete(draftKey).then(() => deleteDraftMessageFromCache(workspaceId, draftKey))
+    void purgeScopeDrafts(workspaceId, draftKey)
   }, [e2eEnabled, draftKey, workspaceId])
 
   const saveDraft = useCallback(
@@ -71,29 +145,24 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
       // sidecar must survive a content-only save (e.g. user typing into a
       // bag-attached scratchpad) — without this preservation the chip would
       // vanish from the composer the moment the first keystroke fires.
-      const currentDraft = await db.draftMessages.get(draftKey)
+      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const finalAttachments = attachments ?? currentDraft?.attachments ?? []
       const finalContextRefs = currentDraft?.contextRefs ?? []
 
       // Delete draft only when content + attachments + contextRefs are all empty.
       if (isEmptyContent(contentJson) && finalAttachments.length === 0 && finalContextRefs.length === 0) {
-        await db.draftMessages.delete(draftKey)
-        deleteDraftMessageFromCache(workspaceId, draftKey)
+        await clearLoadedDraft(workspaceId, draftKey)
         return
       }
 
-      const nextDraft: DraftMessage = {
-        id: draftKey,
-        workspaceId,
+      await upsertLoadedDraft(workspaceId, draftKey, {
         contentJson,
         attachments: finalAttachments,
-        contextRefs: finalContextRefs.length > 0 ? finalContextRefs : undefined,
-        updatedAt: Date.now(),
-      }
-      await db.draftMessages.put(nextDraft)
-      upsertDraftMessageInCache(workspaceId, nextDraft)
+        contextRefs: finalContextRefs,
+      })
     },
-    [draftKey, workspaceId, resolvedDraft, e2eEnabled]
+    [draftKey, workspaceId, e2eEnabled]
   )
 
   const saveDraftDebounced = useCallback(
@@ -123,7 +192,8 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
     async (attachment: DraftAttachment) => {
       // E2EE-4: encrypted-stream drafts (incl. attachment metadata) stay in memory.
       if (e2eEnabled) return
-      const currentDraft = await db.draftMessages.get(draftKey)
+      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const currentAttachments = currentDraft?.attachments ?? []
 
       // Don't add duplicates
@@ -131,20 +201,12 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
         return
       }
 
-      // Default empty document
-      const emptyDoc: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
-
-      const nextDraft: DraftMessage = {
-        id: draftKey,
-        workspaceId,
-        contentJson: currentDraft?.contentJson ?? emptyDoc,
+      await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: currentDraft?.contentJson ?? EMPTY_DOC,
         attachments: [...currentAttachments, attachment],
         // Preserve sidecar so a paste/upload doesn't wipe an attached chip.
         contextRefs: currentDraft?.contextRefs,
-        updatedAt: Date.now(),
-      }
-      await db.draftMessages.put(nextDraft)
-      upsertDraftMessageInCache(workspaceId, nextDraft)
+      })
     },
     [draftKey, workspaceId, e2eEnabled]
   )
@@ -156,27 +218,25 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
   const removeAttachment = useCallback(
     async (attachmentId: string) => {
       if (e2eEnabled) return
-      const currentDraft = await db.draftMessages.get(draftKey)
+      const currentLoadedId = await getLoadedDraftId(draftKey)
+      const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       if (!currentDraft) return
 
       const remainingAttachments = (currentDraft.attachments ?? []).filter((a) => a.id !== attachmentId)
 
       // Delete draft if both content and attachments are empty
       if (isEmptyContent(currentDraft.contentJson) && remainingAttachments.length === 0) {
-        await db.draftMessages.delete(draftKey)
-        deleteDraftMessageFromCache(workspaceId, draftKey)
+        await clearLoadedDraft(workspaceId, draftKey)
         return
       }
 
-      const nextDraft: DraftMessage = {
-        ...currentDraft,
+      await upsertLoadedDraft(workspaceId, draftKey, {
+        contentJson: currentDraft.contentJson,
         attachments: remainingAttachments,
-        updatedAt: Date.now(),
-      }
-      await db.draftMessages.put(nextDraft)
-      upsertDraftMessageInCache(workspaceId, nextDraft)
+        contextRefs: currentDraft.contextRefs,
+      })
     },
-    [draftKey, workspaceId]
+    [draftKey, workspaceId, e2eEnabled]
   )
 
   const clearDraft = useCallback(async () => {
@@ -186,8 +246,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
       debounceRef.current = null
     }
 
-    await db.draftMessages.delete(draftKey)
-    deleteDraftMessageFromCache(workspaceId, draftKey)
+    await clearLoadedDraft(workspaceId, draftKey)
   }, [draftKey, workspaceId])
 
   // Cleanup timeout on unmount
@@ -199,13 +258,10 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
     }
   }, [])
 
-  // Default empty document
-  const emptyDoc: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
-
   return {
     /** Whether Dexie has finished loading the draft (true even if no draft exists) */
     isLoaded: hasSeededDraftCache(workspaceId),
-    contentJson: resolvedDraft?.contentJson ?? emptyDoc,
+    contentJson: resolvedDraft?.contentJson ?? EMPTY_DOC,
     attachments: resolvedDraft?.attachments ?? [],
     /** Sidecar context refs attached to the draft (see DraftContextRef). */
     contextRefs: (resolvedDraft?.contextRefs ?? []) as DraftContextRef[],

--- a/apps/frontend/src/hooks/use-draft-scratchpads.ts
+++ b/apps/frontend/src/hooks/use-draft-scratchpads.ts
@@ -1,11 +1,11 @@
 import { useCallback } from "react"
 import { db, type DraftScratchpad } from "@/db"
 import {
-  deleteDraftMessageFromCache,
   deleteDraftScratchpadFromCache,
   upsertDraftScratchpadInCache,
   useDraftScratchpadsFromStore,
 } from "@/stores/draft-store"
+import { purgeScopeDrafts } from "./use-draft-message"
 import type { CompanionMode } from "@threa/types"
 
 export function generateDraftId(): string {
@@ -51,12 +51,10 @@ export function useDraftScratchpads(workspaceId: string) {
 
   const deleteDraft = useCallback(
     async (id: string) => {
-      await db.transaction("rw", db.draftScratchpads, db.draftMessages, async () => {
-        await db.draftScratchpads.delete(id)
-        await db.draftMessages.delete(`stream:${id}`)
-      })
+      await db.draftScratchpads.delete(id)
       deleteDraftScratchpadFromCache(workspaceId, id)
-      deleteDraftMessageFromCache(workspaceId, `stream:${id}`)
+      // Drop the scratchpad scope's drafts (loaded + any stashes) and pointer.
+      await purgeScopeDrafts(workspaceId, `stream:${id}`)
     },
     [workspaceId]
   )

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -8,6 +8,7 @@ import * as prosemirrorModule from "@threa/prosemirror"
 import * as draftPromotionsModule from "@/lib/draft-promotions"
 import * as streamSyncModule from "@/sync/stream-sync"
 import * as draftStoreModule from "@/stores/draft-store"
+import * as useDraftMessageModule from "./use-draft-message"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
 
@@ -125,7 +126,6 @@ describe("useMessageQueue", () => {
 
     vi.spyOn(dbModule.db.streams, "put").mockResolvedValue(undefined as never)
     vi.spyOn(dbModule.db.draftScratchpads, "delete").mockResolvedValue(undefined as never)
-    vi.spyOn(dbModule.db.draftMessages, "delete").mockResolvedValue(undefined as never)
 
     vi.spyOn(dbModule.db, "transaction").mockImplementation(((
       _mode: string,
@@ -152,7 +152,8 @@ describe("useMessageQueue", () => {
 
     // Draft store
     vi.spyOn(draftStoreModule, "deleteDraftScratchpadFromCache").mockImplementation(() => {})
-    vi.spyOn(draftStoreModule, "deleteDraftMessageFromCache").mockImplementation(() => {})
+    // Post-promotion draft cleanup is exercised via its own tests; stub it here.
+    vi.spyOn(useDraftMessageModule, "purgeScopeDrafts").mockResolvedValue(undefined)
   })
 
   it("should register its notify callback on mount", () => {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -6,7 +6,8 @@ import { db, sequenceToNum } from "@/db"
 import { parseMarkdown } from "@threa/prosemirror"
 import { emitDraftPromoted } from "@/lib/draft-promotions"
 import { setParentThreadId } from "@/sync/stream-sync"
-import { deleteDraftScratchpadFromCache, deleteDraftMessageFromCache } from "@/stores/draft-store"
+import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
+import { purgeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
 import { StreamTypes, ShareErrorCodes } from "@threa/types"
 import type { PendingMessage } from "@/db"
@@ -123,15 +124,16 @@ async function promoteDraft(
   // Also delete the optimistic scratchpad stream entry that was created at
   // queue time — the real stream now replaces it in the sidebar.
   if (next.draftId) {
-    await db.transaction("rw", db.draftScratchpads, db.draftMessages, db.streams, async () => {
+    await db.transaction("rw", db.draftScratchpads, db.streams, async () => {
       await db.draftScratchpads.delete(next.draftId!)
-      await db.draftMessages.delete(`stream:${next.draftId!}`)
       if (draftStreamId !== realStreamId) {
         await db.streams.delete(draftStreamId)
       }
     })
     deleteDraftScratchpadFromCache(next.workspaceId, next.draftId)
-    deleteDraftMessageFromCache(next.workspaceId, `stream:${next.draftId}`)
+    // Drop the scratchpad scope's drafts (the just-sent loaded draft plus any
+    // stash siblings) and its loaded pointer.
+    await purgeScopeDrafts(next.workspaceId, `stream:${next.draftId}`)
   }
 
   // Notify UI to navigate from draft to real stream

--- a/apps/frontend/src/hooks/use-share-target.ts
+++ b/apps/frontend/src/hooks/use-share-target.ts
@@ -3,8 +3,9 @@ import { db } from "@/db"
 import type { DraftAttachment } from "@/db/database"
 import type { JSONContent } from "@threa/types"
 import { generateDraftId } from "@/hooks/use-draft-scratchpads"
+import { getDraftMessageKey, upsertLoadedDraft } from "@/hooks/use-draft-message"
 import { attachmentsApi } from "@/api/attachments"
-import { upsertDraftMessageInCache, upsertDraftScratchpadInCache } from "@/stores/draft-store"
+import { upsertDraftScratchpadInCache } from "@/stores/draft-store"
 import { SHARE_TARGET_CACHE } from "@/lib/sw-messages"
 
 /** Data stashed by the service worker from a Web Share Target POST. */
@@ -170,20 +171,16 @@ export function useShareTarget() {
         companionMode: "on" as const,
         createdAt,
       }
-      const draftMessage = {
-        id: `stream:${draftId}`,
-        workspaceId,
-        contentJson: content,
-        attachments,
-        updatedAt: createdAt,
-      }
 
-      await db.transaction("rw", db.draftScratchpads, db.draftMessages, async () => {
-        await db.draftScratchpads.add(scratchpad)
-        await db.draftMessages.put(draftMessage)
-      })
+      await db.draftScratchpads.add(scratchpad)
       upsertDraftScratchpadInCache(workspaceId, scratchpad)
-      upsertDraftMessageInCache(workspaceId, draftMessage)
+
+      // The shared content becomes the scratchpad's loaded draft so the
+      // composer shows it when the user lands on the freshly-created scratchpad.
+      await upsertLoadedDraft(workspaceId, getDraftMessageKey({ type: "stream", streamId: draftId }), {
+        contentJson: content,
+        attachments: attachments ?? [],
+      })
 
       return { draftId, path: `/w/${workspaceId}/s/${draftId}` }
     },
@@ -195,20 +192,15 @@ export function useShareTarget() {
       const content = buildSharedContent(shared.title, shared.text, shared.url)
       const uploadedAttachments = shared.files.length > 0 ? await uploadSharedFiles(workspaceId, shared.files) : []
 
-      // Transaction ensures the read-then-put is atomic — a concurrent write
-      // between get and put can't silently drop attachments.
-      await db.transaction("rw", db.draftMessages, async () => {
-        const existing = await db.draftMessages.get(`stream:${streamId}`)
-        const mergedAttachments = [...(existing?.attachments ?? []), ...uploadedAttachments]
-        const nextDraft = {
-          id: `stream:${streamId}`,
-          workspaceId,
-          contentJson: content,
-          attachments: mergedAttachments.length > 0 ? mergedAttachments : undefined,
-          updatedAt: Date.now(),
-        }
-        await db.draftMessages.put(nextDraft)
-        upsertDraftMessageInCache(workspaceId, nextDraft)
+      // Merge the shared files into the scope's loaded draft (or mint one).
+      const scope = getDraftMessageKey({ type: "stream", streamId })
+      const loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
+      const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+      const mergedAttachments = [...(existing?.attachments ?? []), ...uploadedAttachments]
+      await upsertLoadedDraft(workspaceId, scope, {
+        contentJson: content,
+        attachments: mergedAttachments,
+        contextRefs: existing?.contextRefs,
       })
     },
     []

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
-import { useStashedDrafts, type StashedDraft } from "./use-stashed-drafts"
+import { useStashedDrafts, type CachedDraft } from "./use-stashed-drafts"
 import type { DraftComposerState } from "./use-draft-composer"
 import type { DraftAttachment } from "@/db"
 import type { PendingAttachment } from "./use-attachments"
@@ -16,7 +16,7 @@ function snapshotUploadedAttachments(pending: PendingAttachment[]): DraftAttachm
 
 export interface UseStashComposerResult {
   /** Stashed drafts for the current scope, newest first. Empty when `scope` is undefined. */
-  drafts: StashedDraft[]
+  drafts: CachedDraft[]
   /** Snapshot the current composer content + attachments into the stash, clear the editor, toast. Empty composer → silent no-op. */
   handleStashDraft: () => Promise<void>
   /** Swap: stash current content first (if any), then load the chosen stashed row into the composer. */

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { generateStashId, createStashedDraft, popStashedDraft, deleteStashedDraftById } from "./use-stashed-drafts"
+import { describe, it, expect, beforeEach } from "vitest"
+import { createStashedDraft, popStashedDraft, deleteStashedDraftById } from "./use-stashed-drafts"
+import { upsertLoadedDraft } from "./use-draft-message"
 import type { JSONContent } from "@threa/types"
-import * as dbModule from "@/db"
+import { db } from "@/db"
+import { resetDraftStoreCache } from "@/stores/draft-store"
 
 const makeDoc = (text: string): JSONContent => ({
   type: "doc",
@@ -9,37 +11,17 @@ const makeDoc = (text: string): JSONContent => ({
 })
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 
-const mockAdd = vi.fn()
-const mockGet = vi.fn()
-const mockDelete = vi.fn()
+const workspaceId = "ws_123"
+const scope = "stream:stream_456"
 
-describe("generateStashId", () => {
-  it("uses the stash_ prefix (distinct from draft_)", () => {
-    const id = generateStashId()
-    expect(id.startsWith("stash_")).toBe(true)
-    expect(id.startsWith("draft_")).toBe(false)
-  })
-
-  it("produces unique ids across calls", () => {
-    const ids = new Set([generateStashId(), generateStashId(), generateStashId()])
-    expect(ids.size).toBe(3)
-  })
+beforeEach(async () => {
+  resetDraftStoreCache()
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
 })
 
 describe("createStashedDraft", () => {
-  const workspaceId = "ws_123"
-  const scope = "stream:stream_456"
-
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    mockAdd.mockReset()
-    mockAdd.mockResolvedValue(undefined)
-
-    vi.spyOn(dbModule.db.stashedDrafts, "add").mockImplementation(((...args: unknown[]) =>
-      mockAdd(...args)) as unknown as typeof dbModule.db.stashedDrafts.add)
-  })
-
-  it("persists a row with workspaceId, scope, and contentJson", async () => {
+  it("persists a draft_-prefixed row with workspaceId, scope, and contentJson", async () => {
     const content = makeDoc("Hello saved world")
 
     const row = await createStashedDraft(workspaceId, scope, { contentJson: content })
@@ -48,20 +30,17 @@ describe("createStashedDraft", () => {
     expect(row!.workspaceId).toBe(workspaceId)
     expect(row!.scope).toBe(scope)
     expect(row!.contentJson).toEqual(content)
-    expect(row!.id.startsWith("stash_")).toBe(true)
-    expect(mockAdd).toHaveBeenCalledTimes(1)
-    expect(mockAdd.mock.calls[0][0]).toMatchObject({
-      workspaceId,
-      scope,
-      contentJson: content,
-    })
+    expect(row!.id.startsWith("draft_")).toBe(true)
+
+    const persisted = await db.drafts.get(row!.id)
+    expect(persisted).toMatchObject({ workspaceId, scope, contentJson: content })
   })
 
   it("no-ops on empty content with no attachments", async () => {
     const row = await createStashedDraft(workspaceId, scope, { contentJson: EMPTY_DOC })
 
     expect(row).toBeNull()
-    expect(mockAdd).not.toHaveBeenCalled()
+    expect(await db.drafts.count()).toBe(0)
   })
 
   it("stashes attachment-only drafts (empty body + attachments)", async () => {
@@ -71,77 +50,58 @@ describe("createStashedDraft", () => {
 
     expect(row).not.toBeNull()
     expect(row!.attachments).toEqual(attachments)
-    expect(mockAdd).toHaveBeenCalledTimes(1)
+    expect(await db.drafts.count()).toBe(1)
   })
 
   it("no-ops when scope is undefined (host still resolving)", async () => {
     const row = await createStashedDraft(workspaceId, undefined, { contentJson: makeDoc("x") })
 
     expect(row).toBeNull()
-    expect(mockAdd).not.toHaveBeenCalled()
+    expect(await db.drafts.count()).toBe(0)
   })
 
   it("no-ops when workspaceId is empty", async () => {
     const row = await createStashedDraft("", scope, { contentJson: makeDoc("x") })
 
     expect(row).toBeNull()
-    expect(mockAdd).not.toHaveBeenCalled()
+    expect(await db.drafts.count()).toBe(0)
+  })
+
+  it("never resurrects the loaded draft — a stash is a separate row", async () => {
+    const loaded = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("loaded"), attachments: [] })
+    const stash = await createStashedDraft(workspaceId, scope, { contentJson: makeDoc("stashed") })
+
+    expect(stash!.id).not.toBe(loaded.id)
+    expect(await db.drafts.count()).toBe(2)
+    // The loaded pointer is untouched by stashing.
+    expect((await db.composerLoaded.get(scope))?.draftId).toBe(loaded.id)
   })
 })
 
 describe("popStashedDraft", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    mockGet.mockReset()
-    mockDelete.mockReset()
-    mockGet.mockResolvedValue(undefined)
-    mockDelete.mockResolvedValue(undefined)
-
-    vi.spyOn(dbModule.db.stashedDrafts, "get").mockImplementation(((...args: unknown[]) =>
-      mockGet(...args)) as unknown as typeof dbModule.db.stashedDrafts.get)
-    vi.spyOn(dbModule.db.stashedDrafts, "delete").mockImplementation(((...args: unknown[]) =>
-      mockDelete(...args)) as unknown as typeof dbModule.db.stashedDrafts.delete)
-  })
-
   it("returns the row and deletes it from the table", async () => {
-    const existing = {
-      id: "stash_abc",
-      workspaceId: "ws_123",
-      scope: "stream:stream_456",
-      contentJson: makeDoc("Saved earlier"),
-      createdAt: 1000,
-    }
-    mockGet.mockResolvedValue(existing)
+    const created = await createStashedDraft(workspaceId, scope, { contentJson: makeDoc("Saved earlier") })
 
-    const restored = await popStashedDraft("stash_abc")
+    const restored = await popStashedDraft(created!.id)
 
-    expect(restored).toEqual(existing)
-    expect(mockDelete).toHaveBeenCalledWith("stash_abc")
+    expect(restored?.id).toBe(created!.id)
+    expect(restored?.contentJson).toEqual(makeDoc("Saved earlier"))
+    expect(await db.drafts.get(created!.id)).toBeUndefined()
   })
 
   it("returns null when the row is missing (no-op delete)", async () => {
-    mockGet.mockResolvedValue(undefined)
-
-    const restored = await popStashedDraft("stash_missing")
+    const restored = await popStashedDraft("draft_missing")
 
     expect(restored).toBeNull()
-    expect(mockDelete).not.toHaveBeenCalled()
   })
 })
 
 describe("deleteStashedDraftById", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    mockDelete.mockReset()
-    mockDelete.mockResolvedValue(undefined)
-
-    vi.spyOn(dbModule.db.stashedDrafts, "delete").mockImplementation(((...args: unknown[]) =>
-      mockDelete(...args)) as unknown as typeof dbModule.db.stashedDrafts.delete)
-  })
-
   it("deletes the row by id", async () => {
-    await deleteStashedDraftById("stash_xyz")
+    const created = await createStashedDraft(workspaceId, scope, { contentJson: makeDoc("x") })
 
-    expect(mockDelete).toHaveBeenCalledWith("stash_xyz")
+    await deleteStashedDraftById(created!.id)
+
+    expect(await db.drafts.get(created!.id)).toBeUndefined()
   })
 })

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -1,24 +1,20 @@
 import { useCallback, useMemo } from "react"
-import { useLiveQuery } from "dexie-react-hooks"
-import { db, type DraftAttachment, type StashedDraft } from "@/db"
+import { db, generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
+import {
+  deleteDraftFromCache,
+  hasSeededDraftCache,
+  upsertDraftInCache,
+  useComposerLoadedFromStore,
+  useDraftsFromStore,
+} from "@/stores/draft-store"
 import type { JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 
 // Re-exported so components (which cannot import from `@/db` per INV-15) can
 // still get the row type they render without reaching into the data layer.
-export type { StashedDraft }
-
-/**
- * Generate a stashed-draft ID. The "stash_" prefix is distinct from the
- * "draft_" prefix used by `DraftScratchpad`, so the existing `isDraftId`
- * check in `use-draft-scratchpads` doesn't confuse stashed rows for
- * scratchpads.
- */
-export function generateStashId(): string {
-  const timestamp = Date.now().toString(36)
-  const random = Math.random().toString(36).substring(2, 10)
-  return `stash_${timestamp}${random}`
-}
+// A "stashed" draft is just a `CachedDraft` that isn't the loaded one for its
+// scope.
+export type { CachedDraft }
 
 export interface StashDraftInput {
   contentJson: JSONContent
@@ -26,9 +22,9 @@ export interface StashDraftInput {
 }
 
 export interface UseStashedDraftsResult {
-  /** Stashed drafts for the current scope, newest first. Empty while `scope` is undefined. */
-  drafts: StashedDraft[]
-  /** True once Dexie has resolved the initial query (used to suppress empty-flash in the picker). */
+  /** Stashed drafts for the current scope (every draft except the loaded one), newest first. */
+  drafts: CachedDraft[]
+  /** True once the draft cache has been seeded (used to suppress empty-flash in the picker). */
   isLoaded: boolean
   /**
    * Persist a new stashed draft. Refuses to save when the content is empty
@@ -36,88 +32,93 @@ export interface UseStashedDraftsResult {
    * locally (e.g. skip the toast) so the UX doesn't confirm a save that
    * didn't happen.
    */
-  stashDraft: (input: StashDraftInput) => Promise<StashedDraft | null>
+  stashDraft: (input: StashDraftInput) => Promise<CachedDraft | null>
   /** Fetch-and-delete: returns the row so the caller can load it into the composer. */
-  restoreStashedDraft: (id: string) => Promise<StashedDraft | null>
+  restoreStashedDraft: (id: string) => Promise<CachedDraft | null>
   /** Delete without restoring. */
   deleteStashedDraft: (id: string) => Promise<void>
 }
 
 /**
- * Persist a new stashed draft. Returns `null` (no DB write) when both the
- * content is empty and there are no attachments — callers should treat the
- * null return as a silent no-op (e.g. skip the confirmation toast).
+ * Persist a new stashed draft (a `CachedDraft` left unloaded). Returns `null`
+ * (no DB write) when both the content is empty and there are no attachments —
+ * callers should treat the null return as a silent no-op (e.g. skip the
+ * confirmation toast).
  */
 export async function createStashedDraft(
   workspaceId: string,
   scope: string | undefined,
   input: StashDraftInput
-): Promise<StashedDraft | null> {
+): Promise<CachedDraft | null> {
   if (!workspaceId || !scope) return null
   const hasContent = !isEmptyContent(input.contentJson)
   const hasAttachments = (input.attachments?.length ?? 0) > 0
   if (!hasContent && !hasAttachments) return null
 
-  const row: StashedDraft = {
-    id: generateStashId(),
+  const row: CachedDraft = {
+    id: generateLocalDraftId(),
     workspaceId,
     scope,
     contentJson: input.contentJson,
-    attachments: input.attachments && input.attachments.length > 0 ? input.attachments : undefined,
-    createdAt: Date.now(),
+    attachments: input.attachments ?? [],
+    clientUpdatedAt: Date.now(),
   }
-  await db.stashedDrafts.add(row)
+  await db.drafts.add(row)
+  upsertDraftInCache(workspaceId, row)
   return row
 }
 
 /**
- * Fetch-and-delete a stashed draft by id. Returns the row so the caller can
- * hydrate the composer; returns `null` if the id is missing (idempotent).
+ * Fetch-and-delete a draft by id. Returns the row so the caller can hydrate the
+ * composer; returns `null` if the id is missing (idempotent).
  *
  * Wrapped in a Dexie rw transaction so the get + delete are atomic against
  * concurrent tabs — without it, two tabs opening the same `?stash=` link
  * could both read the row before either deletes, and both would restore
  * the same content into their composers.
  */
-export async function popStashedDraft(id: string): Promise<StashedDraft | null> {
-  return db.transaction("rw", db.stashedDrafts, async () => {
-    const row = await db.stashedDrafts.get(id)
-    if (!row) return null
-    await db.stashedDrafts.delete(id)
-    return row
+export async function popStashedDraft(id: string): Promise<CachedDraft | null> {
+  const row = await db.transaction("rw", db.drafts, async () => {
+    const found = await db.drafts.get(id)
+    if (!found) return null
+    await db.drafts.delete(id)
+    return found
   })
+  if (row) deleteDraftFromCache(row.workspaceId, id)
+  return row
 }
 
-/** Delete a stashed draft without restoring it. */
+/** Delete a draft without restoring it. */
 export async function deleteStashedDraftById(id: string): Promise<void> {
-  await db.stashedDrafts.delete(id)
+  const row = await db.drafts.get(id)
+  await db.drafts.delete(id)
+  if (row) deleteDraftFromCache(row.workspaceId, id)
 }
 
 /**
- * Query + mutate stashed drafts for a specific scope (a stream or a thread's
- * parent message). Pass `undefined` for `scope` when the host is still
- * resolving what scope to target — the hook will return an empty list and
- * silently no-op mutations rather than throw.
+ * Query + mutate the stashed drafts for a specific scope (a stream or a thread's
+ * parent message) — every draft for the scope except the one loaded into the
+ * composer. Pass `undefined` for `scope` when the host is still resolving what
+ * scope to target — the hook returns an empty list and silently no-ops
+ * mutations rather than throw.
  *
  * The mutation methods are thin wrappers over the module-level helpers
  * (`createStashedDraft`, `popStashedDraft`, `deleteStashedDraftById`) so the
- * mutation behavior is testable without `renderHook` or mocking
- * `useLiveQuery`.
+ * mutation behavior is testable without `renderHook`.
  */
 export function useStashedDrafts(workspaceId: string, scope: string | undefined): UseStashedDraftsResult {
-  const live = useLiveQuery(
-    async () => {
-      if (!workspaceId || !scope) return [] as StashedDraft[]
-      const rows = await db.stashedDrafts.where("[workspaceId+scope]").equals([workspaceId, scope]).sortBy("createdAt")
-      // Dexie sorts ascending; reverse so newest is first (what the picker wants).
-      return rows.reverse()
-    },
-    [workspaceId, scope],
-    undefined
-  )
+  const allDrafts = useDraftsFromStore(workspaceId)
+  const loaded = useComposerLoadedFromStore(workspaceId)
+  const loadedId = scope ? (loaded.find((row) => row.scope === scope)?.draftId ?? null) : null
 
-  const drafts = useMemo(() => live ?? [], [live])
-  const isLoaded = live !== undefined
+  const drafts = useMemo(() => {
+    if (!workspaceId || !scope) return []
+    return allDrafts
+      .filter((draft) => draft.scope === scope && draft.id !== loadedId)
+      .sort((a, b) => b.clientUpdatedAt - a.clientUpdatedAt)
+  }, [allDrafts, workspaceId, scope, loadedId])
+
+  const isLoaded = hasSeededDraftCache(workspaceId)
 
   const stashDraft = useCallback(
     (input: StashDraftInput) => createStashedDraft(workspaceId, scope, input),

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -14,7 +14,8 @@ import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { useWorkspaceUsers, useWorkspaceStreams, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useSyncEngine } from "@/sync/sync-engine"
-import { deleteDraftMessageFromCache, hasSeededDraftCache, upsertDraftMessageInCache } from "@/stores/draft-store"
+import { hasSeededDraftCache } from "@/stores/draft-store"
+import { getDraftMessageKey, purgeScopeDrafts, upsertLoadedDraft } from "./use-draft-message"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import { resolveDmDisplayName } from "@/lib/streams"
 import { serializeToMarkdown } from "@threa/prosemirror"
@@ -243,16 +244,23 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
 
     const migrateDraftAndNavigate = async () => {
       if (draftKey !== realStreamKey) {
-        const draft = await db.draftMessages.get(draftKey)
-        if (draft) {
-          const existingDraft = await db.draftMessages.get(realStreamKey)
-          if (!existingDraft || existingDraft.updatedAt < draft.updatedAt) {
-            const migratedDraft = { ...draft, id: realStreamKey }
-            await db.draftMessages.put(migratedDraft)
-            upsertDraftMessageInCache(workspaceId, migratedDraft)
+        // Move the virtual DM scope's loaded draft onto the real DM stream's
+        // scope, keeping whichever side is newer so a draft already started in
+        // the real DM isn't clobbered. The virtual scope's drafts are then
+        // purged. (Stash piles on the virtual scope are rare and dropped here.)
+        const fromLoadedId = (await db.composerLoaded.get(draftKey))?.draftId ?? null
+        const fromDraft = fromLoadedId ? await db.drafts.get(fromLoadedId) : undefined
+        if (fromDraft) {
+          const toLoadedId = (await db.composerLoaded.get(realStreamKey))?.draftId ?? null
+          const toDraft = toLoadedId ? await db.drafts.get(toLoadedId) : undefined
+          if (!toDraft || toDraft.clientUpdatedAt < fromDraft.clientUpdatedAt) {
+            await upsertLoadedDraft(workspaceId, realStreamKey, {
+              contentJson: fromDraft.contentJson,
+              attachments: fromDraft.attachments,
+              contextRefs: fromDraft.contextRefs,
+            })
           }
-          await db.draftMessages.delete(draftKey)
-          deleteDraftMessageFromCache(workspaceId, draftKey)
+          await purgeScopeDrafts(workspaceId, draftKey)
         }
       }
 
@@ -287,8 +295,7 @@ function useDraftDmStream(workspaceId: string, streamId: string, enabled: boolea
   const rename = useCallback(async () => {}, [])
 
   const archive = useCallback(async () => {
-    await db.draftMessages.delete(`stream:${streamId}`)
-    deleteDraftMessageFromCache(workspaceId, `stream:${streamId}`)
+    await purgeScopeDrafts(workspaceId, getDraftMessageKey({ type: "stream", streamId }))
     navigate(`/w/${workspaceId}`)
   }, [streamId, workspaceId, navigate])
 

--- a/apps/frontend/src/lib/context-bag/seed-draft.test.ts
+++ b/apps/frontend/src/lib/context-bag/seed-draft.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach } from "vitest"
 import { ContextRefKinds } from "@threa/types"
 import { seedDraftWithContextRef } from "./seed-draft"
-import * as dbModule from "@/db"
-import * as draftStoreModule from "@/stores/draft-store"
+import { db } from "@/db"
+import { resetDraftStoreCache } from "@/stores/draft-store"
 import type { DraftContextRef } from "./types"
 
 function makeRef(overrides: Partial<DraftContextRef> = {}): DraftContextRef {
@@ -20,42 +20,32 @@ function makeRef(overrides: Partial<DraftContextRef> = {}): DraftContextRef {
 }
 
 describe("seedDraftWithContextRef", () => {
-  const put = vi.fn()
-  const upsert = vi.fn()
-
-  beforeEach(() => {
-    vi.restoreAllMocks()
-    put.mockReset()
-    upsert.mockReset()
-    put.mockResolvedValue(undefined)
-    vi.spyOn(dbModule.db.draftMessages, "put").mockImplementation(((...args: unknown[]) =>
-      put(...args)) as unknown as typeof dbModule.db.draftMessages.put)
-    vi.spyOn(draftStoreModule, "upsertDraftMessageInCache").mockImplementation(((...args: unknown[]) =>
-      upsert(...args)) as unknown as typeof draftStoreModule.upsertDraftMessageInCache)
+  beforeEach(async () => {
+    resetDraftStoreCache()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
   })
 
-  it("writes a DraftMessage with the ref under contextRefs and an empty body", async () => {
+  it("writes a loaded draft with the ref under contextRefs and an empty body", async () => {
     await seedDraftWithContextRef({ workspaceId: "ws_1", streamId: "stream_new", ref: makeRef() })
 
-    expect(put).toHaveBeenCalledTimes(1)
-    const [draft] = put.mock.calls[0] as [Record<string, unknown>]
-    expect(draft).toMatchObject({
-      id: "stream:stream_new",
-      workspaceId: "ws_1",
-      attachments: [],
-    })
-    const refs = draft.contextRefs as DraftContextRef[]
+    const scope = "stream:stream_new"
+    const loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
+    expect(loadedId).not.toBeNull()
+
+    const draft = await db.drafts.get(loadedId!)
+    expect(draft).toMatchObject({ scope, workspaceId: "ws_1", attachments: [] })
+    const refs = draft!.contextRefs as DraftContextRef[]
     expect(refs).toHaveLength(1)
     expect(refs[0].streamId).toBe("stream_src")
     expect(refs[0].status).toBe("ready")
   })
 
-  it("primes the in-memory draft cache so the composer picks it up without waiting on Dexie", async () => {
+  it("sets the loaded pointer so the composer picks the draft up on first paint", async () => {
     await seedDraftWithContextRef({ workspaceId: "ws_1", streamId: "stream_new", ref: makeRef() })
 
-    expect(upsert).toHaveBeenCalledTimes(1)
-    const [workspaceId, draft] = upsert.mock.calls[0] as [string, { id: string }]
-    expect(workspaceId).toBe("ws_1")
-    expect(draft.id).toBe("stream:stream_new")
+    const pointer = await db.composerLoaded.get("stream:stream_new")
+    expect(pointer?.workspaceId).toBe("ws_1")
+    expect(pointer?.draftId?.startsWith("draft_")).toBe(true)
   })
 })

--- a/apps/frontend/src/lib/context-bag/seed-draft.ts
+++ b/apps/frontend/src/lib/context-bag/seed-draft.ts
@@ -1,8 +1,6 @@
 import type { JSONContent } from "@threa/types"
-import { db, type DraftMessage } from "@/db"
 import type { DraftContextRef } from "./types"
-import { upsertDraftMessageInCache } from "@/stores/draft-store"
-import { getDraftMessageKey } from "@/hooks/use-draft-message"
+import { getDraftMessageKey, upsertLoadedDraft } from "@/hooks/use-draft-message"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 
@@ -31,17 +29,15 @@ export async function seedDraftWithContextRef(params: {
   ref: DraftContextRef
 }): Promise<void> {
   const { workspaceId, streamId, ref } = params
-  const draftKey = getDraftMessageKey({ type: "stream", streamId })
+  const scope = getDraftMessageKey({ type: "stream", streamId })
 
-  const draft: DraftMessage = {
-    id: draftKey,
-    workspaceId,
+  // Seeds an (otherwise empty) loaded draft carrying just the context-ref
+  // sidecar, so the composer renders the attached chip when the user lands on
+  // the freshly-created scratchpad. `upsertLoadedDraft` mints the draft and the
+  // loaded pointer together and writes IDB + cache.
+  await upsertLoadedDraft(workspaceId, scope, {
     contentJson: EMPTY_DOC,
     attachments: [],
     contextRefs: [ref],
-    updatedAt: Date.now(),
-  }
-
-  await db.draftMessages.put(draft)
-  upsertDraftMessageInCache(workspaceId, draft)
+  })
 }

--- a/apps/frontend/src/lib/context-bag/types.ts
+++ b/apps/frontend/src/lib/context-bag/types.ts
@@ -1,6 +1,6 @@
 /**
  * Sidecar entry on a draft for an attached context ref. Lives next to
- * `attachments` on the `DraftMessage` row so the composer surface (uploads
+ * `attachments` on the `CachedDraft` row so the composer surface (uploads
  * + context refs) is atomic with the user's typed content.
  *
  * Status reflects the precompute lifecycle:

--- a/apps/frontend/src/stores/draft-store.test.tsx
+++ b/apps/frontend/src/stores/draft-store.test.tsx
@@ -3,7 +3,8 @@ import { renderHook, act } from "@testing-library/react"
 import {
   resetDraftStoreCache,
   seedDraftCache,
-  useDraftMessagesFromStore,
+  useComposerLoadedFromStore,
+  useDraftsFromStore,
   useDraftScratchpadsFromStore,
 } from "./draft-store"
 
@@ -12,30 +13,48 @@ describe("draft store cache subscriptions", () => {
     resetDraftStoreCache()
   })
 
-  it("rerenders existing message readers when the draft cache is seeded", () => {
-    const { result } = renderHook(() => useDraftMessagesFromStore("workspace_1"))
+  it("rerenders draft readers when the draft cache is seeded", () => {
+    const { result } = renderHook(() => useDraftsFromStore("workspace_1"))
 
     expect(result.current).toEqual([])
 
     act(() => {
       seedDraftCache("workspace_1", {
         scratchpads: [],
-        messages: [
+        loaded: [],
+        drafts: [
           {
-            id: "stream:stream_1",
+            id: "draft_1",
             workspaceId: "workspace_1",
+            scope: "stream:stream_1",
             contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] },
             attachments: [],
-            updatedAt: Date.now(),
+            clientUpdatedAt: Date.now(),
           },
         ],
       })
     })
 
-    expect(result.current.map((draft) => draft.id)).toEqual(["stream:stream_1"])
+    expect(result.current.map((draft) => draft.id)).toEqual(["draft_1"])
   })
 
-  it("rerenders existing scratchpad readers when the draft cache is seeded", () => {
+  it("rerenders composer-loaded readers when the draft cache is seeded", () => {
+    const { result } = renderHook(() => useComposerLoadedFromStore("workspace_1"))
+
+    expect(result.current).toEqual([])
+
+    act(() => {
+      seedDraftCache("workspace_1", {
+        scratchpads: [],
+        drafts: [],
+        loaded: [{ scope: "stream:stream_1", workspaceId: "workspace_1", draftId: "draft_1" }],
+      })
+    })
+
+    expect(result.current.map((row) => row.draftId)).toEqual(["draft_1"])
+  })
+
+  it("rerenders scratchpad readers when the draft cache is seeded", () => {
     const { result } = renderHook(() => useDraftScratchpadsFromStore("workspace_1"))
 
     expect(result.current).toEqual([])
@@ -51,7 +70,8 @@ describe("draft store cache subscriptions", () => {
             createdAt: Date.now(),
           },
         ],
-        messages: [],
+        drafts: [],
+        loaded: [],
       })
     })
 

--- a/apps/frontend/src/stores/draft-store.ts
+++ b/apps/frontend/src/stores/draft-store.ts
@@ -1,10 +1,11 @@
 import { useSyncExternalStore } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
-import { db, type DraftMessage, type DraftScratchpad } from "@/db"
+import { db, type CachedDraft, type ComposerLoaded, type DraftScratchpad } from "@/db"
 
 const cache = {
   scratchpads: new Map<string, DraftScratchpad[]>(),
-  messages: new Map<string, DraftMessage[]>(),
+  drafts: new Map<string, CachedDraft[]>(),
+  loaded: new Map<string, ComposerLoaded[]>(),
 }
 
 const readyWorkspaces = new Set<string>()
@@ -60,13 +61,19 @@ function useArrayStoreHook<T>(queryFn: () => Promise<T[]> | T[], deps: unknown[]
 }
 
 export function hasSeededDraftCache(workspaceId: string): boolean {
-  return readyWorkspaces.has(workspaceId) && cache.scratchpads.has(workspaceId) && cache.messages.has(workspaceId)
+  return (
+    readyWorkspaces.has(workspaceId) &&
+    cache.scratchpads.has(workspaceId) &&
+    cache.drafts.has(workspaceId) &&
+    cache.loaded.has(workspaceId)
+  )
 }
 
 export function resetDraftStoreCache(): void {
   const workspaceIds = new Set([...cacheVersion.keys(), ...cacheListeners.keys()])
   cache.scratchpads.clear()
-  cache.messages.clear()
+  cache.drafts.clear()
+  cache.loaded.clear()
   readyWorkspaces.clear()
   cacheVersion.clear()
   for (const workspaceId of workspaceIds) {
@@ -76,28 +83,27 @@ export function resetDraftStoreCache(): void {
 
 export function seedDraftCache(
   workspaceId: string,
-  data: { scratchpads: DraftScratchpad[]; messages: DraftMessage[] }
+  data: { scratchpads: DraftScratchpad[]; drafts: CachedDraft[]; loaded: ComposerLoaded[] }
 ): void {
   bumpVersion(workspaceId)
   cache.scratchpads.set(workspaceId, data.scratchpads)
-  cache.messages.set(workspaceId, data.messages)
+  cache.drafts.set(workspaceId, data.drafts)
+  cache.loaded.set(workspaceId, data.loaded)
   readyWorkspaces.add(workspaceId)
   emitDraftCacheChange(workspaceId)
 }
 
 export async function seedDraftCacheFromIdb(workspaceId: string): Promise<void> {
   const versionBefore = cacheVersion.get(workspaceId) ?? 0
-  const [scratchpads, messages] = await Promise.all([
+  const [scratchpads, drafts, loaded] = await Promise.all([
     db.draftScratchpads.where("workspaceId").equals(workspaceId).toArray(),
-    db.draftMessages.where("workspaceId").equals(workspaceId).toArray(),
+    db.drafts.where("workspaceId").equals(workspaceId).toArray(),
+    db.composerLoaded.where("workspaceId").equals(workspaceId).toArray(),
   ])
 
   if ((cacheVersion.get(workspaceId) ?? 0) !== versionBefore) return
 
-  seedDraftCache(workspaceId, {
-    scratchpads,
-    messages,
-  })
+  seedDraftCache(workspaceId, { scratchpads, drafts, loaded })
 }
 
 export function useDraftScratchpadsFromStore(workspaceId: string | undefined): DraftScratchpad[] {
@@ -110,11 +116,21 @@ export function useDraftScratchpadsFromStore(workspaceId: string | undefined): D
   )
 }
 
-export function useDraftMessagesFromStore(workspaceId: string | undefined): DraftMessage[] {
+export function useDraftsFromStore(workspaceId: string | undefined): CachedDraft[] {
   useDraftCacheSignal(workspaceId)
-  const cached = workspaceId ? (cache.messages.get(workspaceId) ?? []) : []
+  const cached = workspaceId ? (cache.drafts.get(workspaceId) ?? []) : []
   return useArrayStoreHook(
-    () => (workspaceId ? db.draftMessages.where("workspaceId").equals(workspaceId).toArray() : []),
+    () => (workspaceId ? db.drafts.where("workspaceId").equals(workspaceId).toArray() : []),
+    [workspaceId],
+    cached
+  )
+}
+
+export function useComposerLoadedFromStore(workspaceId: string | undefined): ComposerLoaded[] {
+  useDraftCacheSignal(workspaceId)
+  const cached = workspaceId ? (cache.loaded.get(workspaceId) ?? []) : []
+  return useArrayStoreHook(
+    () => (workspaceId ? db.composerLoaded.where("workspaceId").equals(workspaceId).toArray() : []),
     [workspaceId],
     cached
   )
@@ -131,20 +147,22 @@ export function upsertDraftScratchpadInCache(workspaceId: string, draft: DraftSc
   }
   seedDraftCache(workspaceId, {
     scratchpads: next,
-    messages: cache.messages.get(workspaceId) ?? [],
+    drafts: cache.drafts.get(workspaceId) ?? [],
+    loaded: cache.loaded.get(workspaceId) ?? [],
   })
 }
 
 export function deleteDraftScratchpadFromCache(workspaceId: string, draftId: string): void {
   seedDraftCache(workspaceId, {
     scratchpads: (cache.scratchpads.get(workspaceId) ?? []).filter((draft) => draft.id !== draftId),
-    messages: cache.messages.get(workspaceId) ?? [],
+    drafts: cache.drafts.get(workspaceId) ?? [],
+    loaded: cache.loaded.get(workspaceId) ?? [],
   })
 }
 
-export function upsertDraftMessageInCache(workspaceId: string, draft: DraftMessage): void {
-  const messages = cache.messages.get(workspaceId) ?? []
-  const next = [...messages]
+export function upsertDraftInCache(workspaceId: string, draft: CachedDraft): void {
+  const drafts = cache.drafts.get(workspaceId) ?? []
+  const next = [...drafts]
   const index = next.findIndex((candidate) => candidate.id === draft.id)
   if (index === -1) {
     next.push(draft)
@@ -153,13 +171,31 @@ export function upsertDraftMessageInCache(workspaceId: string, draft: DraftMessa
   }
   seedDraftCache(workspaceId, {
     scratchpads: cache.scratchpads.get(workspaceId) ?? [],
-    messages: next,
+    drafts: next,
+    loaded: cache.loaded.get(workspaceId) ?? [],
   })
 }
 
-export function deleteDraftMessageFromCache(workspaceId: string, draftId: string): void {
+export function deleteDraftFromCache(workspaceId: string, draftId: string): void {
   seedDraftCache(workspaceId, {
     scratchpads: cache.scratchpads.get(workspaceId) ?? [],
-    messages: (cache.messages.get(workspaceId) ?? []).filter((draft) => draft.id !== draftId),
+    drafts: (cache.drafts.get(workspaceId) ?? []).filter((draft) => draft.id !== draftId),
+    loaded: cache.loaded.get(workspaceId) ?? [],
+  })
+}
+
+/**
+ * Set (or clear, with `draftId: null`) the composer-loaded pointer for a scope
+ * in the in-memory cache. Mirrors the `composerLoaded` IDB row so the composer
+ * resolves its checked-out draft synchronously on first paint.
+ */
+export function setComposerLoadedInCache(workspaceId: string, scope: string, draftId: string | null): void {
+  const loaded = cache.loaded.get(workspaceId) ?? []
+  const next = loaded.filter((row) => row.scope !== scope)
+  next.push({ scope, workspaceId, draftId })
+  seedDraftCache(workspaceId, {
+    scratchpads: cache.scratchpads.get(workspaceId) ?? [],
+    drafts: cache.drafts.get(workspaceId) ?? [],
+    loaded: next,
   })
 }


### PR DESCRIPTION
**Design doc:** `docs/plans/centralized-draft-system.md` → §"Stage Sequence" → "Stage 2 — Frontend unified local store". Stage 1 (backend feature) shipped in #919.

## Problem

Drafts lived in two local Dexie tables with different shapes and lifecycles: `draftMessages` (one ambient auto-save per scope, keyed by the scope string `stream:{id}` / `thread:{messageId}`) and `stashedDrafts` (many explicit Cmd+S saves per scope, `stash_`-prefixed). The centralized-draft design (Stage 1 already landed the backend `drafts` table + endpoints + outbox) treats a draft as one first-class entity — but the frontend still modeled "the ambient draft" and "a stashed draft" as two different kinds of row in two different stores. Before any sync can be wired (Stage 3), the local model has to become the single entity the backend mirrors: every draft is a `draft_`-prefixed row with a `scope`, and "which one is open in the composer" is separate, device-local state.

## Solution

Fold `draftMessages` + `stashedDrafts` into one Dexie `drafts` store, and add a device-local `composerLoaded` pointer (`scope → draftId | null`) that records which draft is checked out into the composer. The ambient draft is no longer privileged by being the scope-keyed row — it's just "the loaded one." Stash = a scope's drafts minus the loaded one. Frontend-only: no backend calls, no socket handlers, no queue ops yet (those are Stage 3). The app behaves exactly as before, routed through the unified model.

### How it works

- **Schema (`db/database.ts`).** New `CachedDraft` (`id` `draft_xxx`, `workspaceId`, `scope`, `contentJson`, `attachments`, `contextRefs?`, `clientUpdatedAt`) and `ComposerLoaded` (`scope` PK, `workspaceId`, `draftId`). Dexie **v34** adds the `drafts` (`id, workspaceId, scope, [workspaceId+scope], clientUpdatedAt`) and `composerLoaded` (`scope, workspaceId`) stores; its `.upgrade()` reads the old tables and writes each `draftMessages` row → a draft **plus** a loaded pointer, and each `stashedDrafts` row → an unloaded draft, then drops both old stores (`: null`). This is the same read-the-table-being-deleted-in-the-same-version pattern the existing v22 migration uses. `generateLocalDraftId()` mints `draft_`-prefixed ids so they line up with the backend `draft_` prefix for Stage 3.
- **Cache (`stores/draft-store.ts`).** The synchronous-first-paint cache now holds `scratchpads` + `drafts` + `loaded`; `useDraftsFromStore` / `useComposerLoadedFromStore` replace `useDraftMessagesFromStore`; `upsertDraftInCache` / `deleteDraftFromCache` / `setComposerLoadedInCache` keep IDB and cache in step. `seedDraftCacheFromIdb` / `hasSeededDraftCache` / `resetDraftStoreCache` keep their signatures (callers in `coordinated-loading-context` / `account-scope` unchanged).
- **`use-draft-message.ts`.** `useDraftMessage` resolves the loaded draft via the pointer and keeps its exact public surface (`isLoaded`, `contentJson`, `attachments`, `contextRefs`, `saveDraft`, `saveDraftDebounced`, `addAttachment`, `removeAttachment`, `clearDraft`). Three shared pure helpers do the writes — `upsertLoadedDraft` (create-or-update the loaded draft + set the pointer when minting), `clearLoadedDraft` (delete loaded draft + pointer; stashes survive), `purgeScopeDrafts` (delete every draft for a scope + pointer, used by the E2EE-4 gate and cleanup paths). The E2E no-plaintext-at-rest gate and the encrypt-mid-flight debounce-cancel race are preserved.
- **Stash (`use-stashed-drafts.ts`).** `drafts` = scope drafts minus the loaded one, newest-first by `clientUpdatedAt`. `createStashedDraft` adds an unloaded draft; `popStashedDraft` / `deleteStashedDraftById` operate by id. `useStashComposer`'s copy-then-clear stash and pop-then-reload restore flows are unchanged, so the two composer hosts (`message-input`, `stream-panel`) need no behavioral edits.
- **Explorer (`use-all-drafts.ts`).** Joins the one table: scratchpad rows read their scope's loaded draft; every other draft renders with `isStashed` derived from the pointer; stash rows still deep-link via `?stash=<draftId>`. `deleteDraft` disambiguates a scratchpad id from a unified-draft id by table lookup (both share `draft_`), rather than by prefix.
- **Writers/cleanup** (`seed-draft`, `use-share-target`, `use-stream-or-draft`, `use-draft-scratchpads`, `use-message-queue`) all go through the unified helpers — context-ref seeding and share drafts create a loaded draft; DM-draft migration re-scopes the loaded draft (keep-newer) then purges the source; scratchpad delete / promotion purge the scope.

### Key design decisions

**1. `composerLoaded` is device-local and never synced.** Per the design's non-goals, which draft is checked out is UI state. A fresh device/scope opens the composer **empty** — only a migrated or explicitly-set pointer restores content. The v34 migration sets the pointer for each existing ambient draft so reload-restores-your-draft keeps working across the upgrade.

**2. Restore stays copy-then-pop, not a pure pointer move.** `handleRestoreStashed` reads the live editor state (current to the keystroke) when snapshotting, then pops the chosen row and reloads it. A pure pointer move would be cleaner but could drop up to the 500ms debounce window of unsaved typing on the draft being switched away from. Kept the behavior-preserving path for Stage 2; Stage 3 can revisit for id stability once sync makes id churn matter.

**3. `CachedDraft` is kept lean — no `version` / `baseVersion` / `_syncStatus` / `rootStreamId` / E2E fields yet.** Those appear in the design's full Dexie shape but nothing in Stage 2 reads them, and adding non-indexed fields to a Dexie row needs no migration — so they land in Stage 3/4 when a consumer exists, honoring INV-36 (no speculative fields).

**4. `ComposerLoaded` carries `workspaceId` (a small deviation from the doc's shape).** The doc lists only `scope` + `draftId`. Adding `workspaceId` lets the cache seed and clear per workspace like every other store; without it there's no workspace-scoped query for the pointer rows.

**5. Drafts now survive logout.** `clearAllCachedData` used to clear `stashedDrafts` but not `draftMessages`. Unified, both can't have separate fates; chose to **not** clear `drafts` / `composerLoaded` on logout, matching the dominant prior behavior (ambient drafts survived) — no draft loss, and Stage 3 re-pulls from the server anyway.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/database.ts` | `CachedDraft` + `ComposerLoaded` types; `drafts` + `composerLoaded` stores; v34 migration; `generateLocalDraftId`; drop `DraftMessage`/`StashedDraft`; `clearAllCachedData` no longer clears the (gone) `stashedDrafts` |
| `apps/frontend/src/db/index.ts` | Export `CachedDraft` / `ComposerLoaded` / `generateLocalDraftId`; drop `DraftMessage` / `StashedDraft` |
| `apps/frontend/src/stores/draft-store.ts` | Cache scratchpads + drafts + loaded; new selectors + cache mutators |
| `apps/frontend/src/hooks/use-draft-message.ts` | Loaded-draft semantics; `upsertLoadedDraft` / `clearLoadedDraft` / `purgeScopeDrafts` helpers |
| `apps/frontend/src/hooks/use-stashed-drafts.ts` | Stash = scope drafts minus loaded; backed by `drafts`; remove `generateStashId` |
| `apps/frontend/src/hooks/use-stash-composer.ts` | `StashedDraft` → `CachedDraft` type only |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Join the unified table; pointer-derived `isStashed`; table-lookup delete routing |
| `apps/frontend/src/hooks/use-draft-scratchpads.ts` | `deleteDraft` purges the scope's drafts + pointer |
| `apps/frontend/src/hooks/use-message-queue.ts` | Post-promotion cleanup via `purgeScopeDrafts` |
| `apps/frontend/src/hooks/use-stream-or-draft.ts` | DM-draft re-scope (keep-newer) + archive via unified helpers |
| `apps/frontend/src/hooks/use-share-target.ts` | Share draft / merge-attachments via `upsertLoadedDraft` |
| `apps/frontend/src/lib/context-bag/seed-draft.ts` | Context-ref seed via `upsertLoadedDraft` |
| `apps/frontend/src/hooks/index.ts` | Barrel: drop `generateStashId` / `StashedDraft`, export `CachedDraft` |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | Row type `CachedDraft`; `createdAt` → `clientUpdatedAt` |
| `apps/frontend/src/hooks/use-draft-composer.ts`, `lib/context-bag/types.ts` | Comment accuracy after the rename |
| `*.test.ts(x)` (draft-message, stashed-drafts, draft-store, seed-draft, message-queue) | Rewritten against the real fake-indexeddb db |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/db/drafts-migration.test.ts` | v34 upgrade: ambient → draft + pointer, stash → unloaded draft, old stores dropped |

## Out of scope (deliberate)

- **No backend calls / sync / socket handlers / queue ops** — Stage 3.
- **Resolve-on-send, thread re-pointing, E2E seal-before-push** — Stage 4.
- **No merge UI / "from another device" badge** — design non-goal.
- Sync-only `CachedDraft` fields (`version`, `baseVersion`, `_syncStatus`, …) — deferred to the stage that reads them (decision 3).

## Test plan

- [x] `bunx vitest run` (full frontend) — **2653 pass** / 237 files
- [x] Rewritten draft suites against real fake-indexeddb — `use-draft-message`, `use-stashed-drafts`, `draft-store`, `seed-draft`, `drafts-migration` — 35 pass
- [x] Consumer suites — `use-message-queue`, `use-draft-composer`, `message-input`, `use-queue-draft-message`, `coordinated-loading-context` — 88 pass
- [x] `tsc --noEmit` clean (frontend + all packages, via pre-commit hook); ESLint clean on changed files; Prettier clean
- [ ] No Playwright E2E run — Stage 2 adds no send/sync path, so the E2E suite isn't exercised here (Stage 3/4 territory)

<details>
<summary>📋 Full implementation plan</summary>

**Goal (Stage 2 of `docs/plans/centralized-draft-system.md`).** Fold the two local draft tables into one unified `drafts` store + a device-local `composerLoaded` pointer, and rewrite the draft hooks against it. Frontend-only, local-first, no backend calls. App keeps working exactly as today.

**What was built.**
- Dexie v34: `drafts` + `composerLoaded` stores; upgrade migrates `draftMessages` → draft + loaded pointer and `stashedDrafts` → unloaded draft, then drops the old stores.
- `use-draft-message` / `draft-store` / `use-stash-composer` rewritten to the unified model: load = read `composerLoaded[scope]` (empty on fresh device); save = upsert local draft + set loaded pointer; stash = scope's drafts minus the loaded one.
- Necessary collaborators (`use-stashed-drafts`, `use-all-drafts`, `seed-draft`, `use-share-target`, `use-stream-or-draft`, `use-draft-scratchpads`, `use-message-queue`, picker) moved onto the shared unified helpers.

**Design decisions / evolution.** See "Key design decisions" above — loaded pointer device-local; copy-then-pop restore kept for behavior parity; lean `CachedDraft`; `ComposerLoaded.workspaceId` added; drafts survive logout.

**Schema changes.** Dexie v34 (frontend IndexedDB only — no backend SQL migration in this stage).

**What's NOT included.** Sync, socket handlers, queue ops (Stage 3); resolve-on-send, thread re-pointing, E2E seal (Stage 4).

**Status.** Complete; full frontend suite green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_