### PR TITLE
feat(streams): scratchpad owner-set agent tool policy

### DIFF
--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, mock } from "bun:test"
 import type { LinkPreviewSummary } from "@threa/types"
+import type { Request, Response } from "express"
 import type { StreamEvent } from "./event-repository"
-import { applyLinkPreviewStateToEvents } from "./handlers"
+import { applyLinkPreviewStateToEvents, createStreamHandlers } from "./handlers"
+import type { StreamService } from "./service"
 
 function createMessageEvent(messageId: string): StreamEvent {
   return {
@@ -75,5 +77,99 @@ describe("applyLinkPreviewStateToEvents", () => {
     )
 
     expect((event.payload as { linkPreviews?: LinkPreviewSummary[] }).linkPreviews).toEqual([visiblePreview])
+  })
+})
+
+describe("createStreamHandlers.updateToolPolicy", () => {
+  const scratchpad = { id: "stream_sp", workspaceId: "ws_1", type: "scratchpad", createdBy: "user_owner" }
+
+  function makeRes() {
+    const captured: { status: number; body: unknown } = { status: 200, body: undefined }
+    const res = {
+      status(code: number) {
+        captured.status = code
+        return res
+      },
+      json(body: unknown) {
+        captured.body = body
+        return res
+      },
+    }
+    return { res: res as unknown as Response, captured }
+  }
+
+  function makeHandlers(streamService: Partial<StreamService>) {
+    return createStreamHandlers({ streamService } as unknown as Parameters<typeof createStreamHandlers>[0])
+  }
+
+  function makeReq(body: unknown, callerId = "user_owner"): Request {
+    return {
+      user: { id: callerId },
+      workspaceId: "ws_1",
+      params: { streamId: "stream_sp" },
+      body,
+    } as unknown as Request
+  }
+
+  it("lets the scratchpad owner set the policy and echoes it back", async () => {
+    const setStreamToolPolicy = mock(async (_ws: string, _s: string, policy: unknown) => policy)
+    const handlers = makeHandlers({
+      validateStreamAccess: mock(async () => scratchpad) as unknown as StreamService["validateStreamAccess"],
+      setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
+
+    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", ["web"])
+    expect(captured.body).toEqual({ data: { allowedToolCategories: ["web"] } })
+  })
+
+  it("clears the policy when allowedCategories is null", async () => {
+    const setStreamToolPolicy = mock(async (_ws: string, _s: string, policy: unknown) => policy)
+    const handlers = makeHandlers({
+      validateStreamAccess: mock(async () => scratchpad) as unknown as StreamService["validateStreamAccess"],
+      setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.updateToolPolicy(makeReq({ allowedCategories: null }), res)
+
+    expect(setStreamToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", null)
+    expect(captured.body).toEqual({ data: { allowedToolCategories: null } })
+  })
+
+  it("rejects a non-owner with 403 and never writes", async () => {
+    const setStreamToolPolicy = mock(async () => null)
+    const handlers = makeHandlers({
+      validateStreamAccess: mock(async () => ({
+        ...scratchpad,
+        createdBy: "user_other",
+      })) as unknown as StreamService["validateStreamAccess"],
+      setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
+
+    expect(captured.status).toBe(403)
+    expect(setStreamToolPolicy).not.toHaveBeenCalled()
+  })
+
+  it("rejects a non-scratchpad stream with 400 and never writes", async () => {
+    const setStreamToolPolicy = mock(async () => null)
+    const handlers = makeHandlers({
+      validateStreamAccess: mock(async () => ({
+        ...scratchpad,
+        type: "channel",
+      })) as unknown as StreamService["validateStreamAccess"],
+      setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
+    })
+    const { res, captured } = makeRes()
+
+    await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
+
+    expect(captured.status).toBe(400)
+    expect(setStreamToolPolicy).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -148,11 +148,11 @@ describe("createStreamHandlers.updateToolPolicy", () => {
       })) as unknown as StreamService["validateStreamAccess"],
       setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
     })
-    const { res, captured } = makeRes()
+    const { res } = makeRes()
 
-    await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
-
-    expect(captured.status).toBe(403)
+    await expect(handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)).rejects.toMatchObject({
+      status: 403,
+    })
     expect(setStreamToolPolicy).not.toHaveBeenCalled()
   })
 
@@ -165,11 +165,11 @@ describe("createStreamHandlers.updateToolPolicy", () => {
       })) as unknown as StreamService["validateStreamAccess"],
       setStreamToolPolicy: setStreamToolPolicy as unknown as StreamService["setStreamToolPolicy"],
     })
-    const { res, captured } = makeRes()
+    const { res } = makeRes()
 
-    await handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)
-
-    expect(captured.status).toBe(400)
+    await expect(handlers.updateToolPolicy(makeReq({ allowedCategories: ["web"] }), res)).rejects.toMatchObject({
+      status: 400,
+    })
     expect(setStreamToolPolicy).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -173,3 +173,51 @@ describe("createStreamHandlers.updateToolPolicy", () => {
     expect(setStreamToolPolicy).not.toHaveBeenCalled()
   })
 })
+
+describe("createStreamHandlers.create — allowedToolCategories", () => {
+  function makeRes() {
+    const captured: { status: number; body: unknown } = { status: 200, body: undefined }
+    const res = {
+      status(code: number) {
+        captured.status = code
+        return res
+      },
+      json(body: unknown) {
+        captured.body = body
+        return res
+      },
+    }
+    return { res: res as unknown as Response, captured }
+  }
+
+  function makeHandlers(streamService: Partial<StreamService>) {
+    return createStreamHandlers({ streamService } as unknown as Parameters<typeof createStreamHandlers>[0])
+  }
+
+  function makeCreateReq(body: unknown): Request {
+    return { user: { id: "user_owner" }, workspaceId: "ws_1", params: {}, body } as unknown as Request
+  }
+
+  it("threads allowedToolCategories to the service when creating a scratchpad", async () => {
+    const create = mock(async (_params: { allowedToolCategories?: unknown }) => ({ id: "stream_sp" }))
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res, captured } = makeRes()
+
+    await handlers.create(makeCreateReq({ type: "scratchpad", allowedToolCategories: ["web"] }), res)
+
+    expect(captured.status).toBe(201)
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create.mock.calls[0]![0].allowedToolCategories).toEqual(["web"])
+  })
+
+  it("rejects allowedToolCategories on a non-scratchpad and never creates", async () => {
+    const create = mock(async () => ({ id: "stream_ch" }))
+    const handlers = makeHandlers({ create: create as unknown as StreamService["create"] })
+    const { res } = makeRes()
+
+    await expect(
+      handlers.create(makeCreateReq({ type: "channel", slug: "general", allowedToolCategories: ["web"] }), res)
+    ).rejects.toMatchObject({ status: 400 })
+    expect(create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -714,10 +714,16 @@ export function createStreamHandlers({
       // guardrail on a solo surface, not a shared channel admin setting.
       const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
       if (stream.type !== StreamTypes.SCRATCHPAD) {
-        return res.status(400).json({ error: "Tool policy can only be set on a scratchpad" })
+        throw new HttpError("Tool policy can only be set on a scratchpad", {
+          status: 400,
+          code: "INVALID_STREAM_TYPE",
+        })
       }
       if (stream.createdBy !== userId) {
-        return res.status(403).json({ error: "Only the scratchpad owner can change its tool policy" })
+        throw new HttpError("Only the scratchpad owner can change its tool policy", {
+          status: 403,
+          code: "FORBIDDEN",
+        })
       }
 
       const allowedToolCategories = await streamService.setStreamToolPolicy(workspaceId, streamId, allowedCategories)

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -16,6 +16,7 @@ import {
   CompanionModes,
   E2E_ACTOR_KINDS,
   E2E_KEY_WRAP_RECIPIENT_KINDS,
+  TOOL_PRIVACY_CATEGORIES,
 } from "@threa/types"
 import type { Pool } from "pg"
 import { PersonaRepository, getResolver, fetchStreamBag, contextBagSchema } from "../agents"
@@ -23,6 +24,7 @@ import { UserE2eKeysRepository } from "../user-e2e-keys"
 import { HttpError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
 import { streamTypeSchema, visibilitySchema, companionModeSchema, notificationLevelSchema } from "../../lib/schemas"
+import { StreamPoliciesRepository } from "./policy-repository"
 
 const createStreamSchema = z
   .object({
@@ -137,6 +139,13 @@ const updateStreamSchema = z
 const updateCompanionModeSchema = z.object({
   companionMode: companionModeSchema,
   companionPersonaId: z.string().nullable().optional(),
+})
+
+// `null` = no restriction (clears the policy row); an array (including `[]` =
+// no tools) restricts the agent to exactly those categories. `messaging` is
+// always allowed regardless, so the picker never offers it.
+const updateToolPolicySchema = z.object({
+  allowedCategories: z.array(z.enum(TOOL_PRIVACY_CATEGORIES)).nullable(),
 })
 
 const setNotificationLevelSchema = z.object({
@@ -691,6 +700,27 @@ export function createStreamHandlers({
       res.json({ stream: updated })
     },
 
+    async updateToolPolicy(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { streamId } = req.params
+
+      const { allowedCategories } = validateRequest(updateToolPolicySchema, req.body)
+
+      // Scoped to scratchpads, owner-only: the tool policy is a personal
+      // guardrail on a solo surface, not a shared channel admin setting.
+      const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
+      if (stream.type !== StreamTypes.SCRATCHPAD) {
+        return res.status(400).json({ error: "Tool policy can only be set on a scratchpad" })
+      }
+      if (stream.createdBy !== userId) {
+        return res.status(403).json({ error: "Only the scratchpad owner can change its tool policy" })
+      }
+
+      const allowedToolCategories = await streamService.setStreamToolPolicy(workspaceId, streamId, allowedCategories)
+      res.json({ data: { allowedToolCategories } })
+    },
+
     async setNotificationLevel(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
@@ -861,6 +891,14 @@ export function createStreamHandlers({
       // `fetchStreamBag` via the resolver.
       const contextBag = await fetchStreamBag(pool, { workspaceId, streamId, userId }, { skipAccessCheck: true })
 
+      // Only scratchpads can carry a tool policy (the only surface that can set
+      // one); omit it elsewhere so the settings control renders only where it
+      // applies.
+      const allowedToolCategories =
+        stream.type === StreamTypes.SCRATCHPAD
+          ? await StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id)
+          : null
+
       res.json({
         data: {
           stream,
@@ -879,6 +917,7 @@ export function createStreamHandlers({
           mentionCount: activityCounts?.mentionCount ?? 0,
           activityCount: activityCounts?.totalCount ?? 0,
           contextBag,
+          allowedToolCategories,
         },
       })
     },

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -33,7 +33,6 @@ import { UserE2eKeysRepository } from "../user-e2e-keys"
 import { HttpError } from "../../lib/errors"
 import { validateRequest } from "../../lib/validation"
 import { streamTypeSchema, visibilitySchema, companionModeSchema, notificationLevelSchema } from "../../lib/schemas"
-import { StreamPoliciesRepository } from "./policy-repository"
 
 const createStreamSchema = z
   .object({
@@ -844,7 +843,7 @@ export function createStreamHandlers({
       const toolPolicyReads: Promise<[ToolPrivacyPolicy, ToolPrivacyCategory[] | undefined]> =
         stream.type === StreamTypes.SCRATCHPAD
           ? Promise.all([
-              StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id),
+              streamService.getStreamToolPolicy(workspaceId, stream.id),
               workspaceIntegrationService.getAvailableToolCategories(workspaceId),
             ])
           : Promise.resolve([null, undefined])

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -7,6 +7,7 @@ import type { ActivityService } from "../activity"
 import type { LinkPreviewService } from "../link-previews"
 import type { BotRuntimeService } from "../bot-runtimes"
 import type { CommandAvailabilityService } from "../commands"
+import type { WorkspaceIntegrationService } from "../workspace-integrations"
 import type { StreamEvent } from "./event-repository"
 import type { EventType, JSONContent, LinkPreviewSummary, StreamType, E2eKeyWrapsResponse } from "@threa/types"
 import {
@@ -321,6 +322,7 @@ interface Dependencies {
   linkPreviewService: LinkPreviewService
   botRuntimeService: BotRuntimeService
   commandAvailabilityService: CommandAvailabilityService
+  workspaceIntegrationService: WorkspaceIntegrationService
 }
 
 /**
@@ -454,6 +456,7 @@ export function createStreamHandlers({
   linkPreviewService,
   botRuntimeService,
   commandAvailabilityService,
+  workspaceIntegrationService,
 }: Dependencies) {
   return {
     async list(req: Request, res: Response) {
@@ -892,12 +895,17 @@ export function createStreamHandlers({
       const contextBag = await fetchStreamBag(pool, { workspaceId, streamId, userId }, { skipAccessCheck: true })
 
       // Only scratchpads can carry a tool policy (the only surface that can set
-      // one); omit it elsewhere so the settings control renders only where it
-      // applies.
-      const allowedToolCategories =
-        stream.type === StreamTypes.SCRATCHPAD
-          ? await StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id)
-          : null
+      // one); omit elsewhere so the settings control renders only where it
+      // applies. `configuredToolCategories` tells the owner's picker which
+      // toggles to show — a workspace without GitHub/Linear connected never
+      // offers those categories.
+      const isScratchpad = stream.type === StreamTypes.SCRATCHPAD
+      const [allowedToolCategories, configuredToolCategories] = isScratchpad
+        ? await Promise.all([
+            StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id),
+            workspaceIntegrationService.getAvailableToolCategories(workspaceId),
+          ])
+        : [null, undefined]
 
       res.json({
         data: {
@@ -918,6 +926,7 @@ export function createStreamHandlers({
           activityCount: activityCounts?.totalCount ?? 0,
           contextBag,
           allowedToolCategories,
+          configuredToolCategories,
         },
       })
     },

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -65,6 +65,13 @@ const createStreamSchema = z
      */
     e2eEnabled: z.literal(true).optional(),
     e2eOwnerKeyId: z.string().min(1).optional(),
+    /**
+     * Optional tool-privacy policy set at creation time (scratchpads only).
+     * `null`/absent = unrestricted; an array (incl. `[]`) restricts the agent
+     * to those categories. Persisted to `stream_policies` in the create
+     * transaction, like the E2E flag and context bag.
+     */
+    allowedToolCategories: z.array(z.enum(TOOL_PRIVACY_CATEGORIES)).nullable().optional(),
   })
   .refine((data) => data.type !== "channel" || data.slug, {
     message: "Slug is required for channels",
@@ -89,6 +96,10 @@ const createStreamSchema = z
   .refine((data) => !data.e2eEnabled || !data.contextBag, {
     message: "contextBag and E2E are mutually exclusive in Phase 1",
     path: ["e2eEnabled"],
+  })
+  .refine((data) => data.allowedToolCategories === undefined || data.type === "scratchpad", {
+    message: "allowedToolCategories is only supported on scratchpad creation",
+    path: ["allowedToolCategories"],
   })
 
 // Canonical base64 (correct alphabet + padding/length). Rejects e.g. "!!!!" or
@@ -496,6 +507,7 @@ export function createStreamHandlers({
         contextBag,
         e2eEnabled,
         e2eOwnerKeyId,
+        allowedToolCategories,
       } = data
 
       // Verify the caller owns the referenced E2E key BEFORE we hand off to
@@ -578,6 +590,7 @@ export function createStreamHandlers({
         createdBy: userId,
         contextBag,
         e2e: resolvedE2eOwnerKeyId ? { ownerKeyId: resolvedE2eOwnerKeyId } : undefined,
+        allowedToolCategories,
       })
 
       res.status(201).json({ stream })

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -9,7 +9,15 @@ import type { BotRuntimeService } from "../bot-runtimes"
 import type { CommandAvailabilityService } from "../commands"
 import type { WorkspaceIntegrationService } from "../workspace-integrations"
 import type { StreamEvent } from "./event-repository"
-import type { EventType, JSONContent, LinkPreviewSummary, StreamType, E2eKeyWrapsResponse } from "@threa/types"
+import type {
+  EventType,
+  JSONContent,
+  LinkPreviewSummary,
+  StreamType,
+  E2eKeyWrapsResponse,
+  ToolPrivacyPolicy,
+  ToolPrivacyCategory,
+} from "@threa/types"
 import {
   ARIADNE_PERSONA_SLUG,
   StreamTypes,
@@ -828,6 +836,19 @@ export function createStreamHandlers({
 
       const stream = await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
+      // Start the scratchpad tool-policy reads now so they run alongside the
+      // rest of bootstrap instead of serially after enrichment. Only scratchpads
+      // carry a policy; other types resolve to [null, undefined]. The picker uses
+      // `configuredToolCategories` to show only the categories the workspace has
+      // tooling for (GitHub/Linear only when connected).
+      const toolPolicyReads: Promise<[ToolPrivacyPolicy, ToolPrivacyCategory[] | undefined]> =
+        stream.type === StreamTypes.SCRATCHPAD
+          ? Promise.all([
+              StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id),
+              workspaceIntegrationService.getAvailableToolCategories(workspaceId),
+            ])
+          : Promise.resolve([null, undefined])
+
       // Captured BEFORE the parallel queries fire. Shipped on the wire as the
       // bootstrap's freshness watermark. The frontend stamps `_patchedAt` on
       // any IDB row mutated by a socket handler, and at apply time skips
@@ -913,18 +934,9 @@ export function createStreamHandlers({
       // `fetchStreamBag` via the resolver.
       const contextBag = await fetchStreamBag(pool, { workspaceId, streamId, userId }, { skipAccessCheck: true })
 
-      // Only scratchpads can carry a tool policy (the only surface that can set
-      // one); omit elsewhere so the settings control renders only where it
-      // applies. `configuredToolCategories` tells the owner's picker which
-      // toggles to show — a workspace without GitHub/Linear connected never
-      // offers those categories.
-      const isScratchpad = stream.type === StreamTypes.SCRATCHPAD
-      const [allowedToolCategories, configuredToolCategories] = isScratchpad
-        ? await Promise.all([
-            StreamPoliciesRepository.getToolPolicy(pool, workspaceId, stream.id),
-            workspaceIntegrationService.getAvailableToolCategories(workspaceId),
-          ])
-        : [null, undefined]
+      // Resolve the tool-policy reads started up front (parallel with the rest
+      // of bootstrap, not serial after enrichment).
+      const [allowedToolCategories, configuredToolCategories] = await toolPolicyReads
 
       res.json({
         data: {

--- a/apps/backend/src/features/streams/policy-repository.test.ts
+++ b/apps/backend/src/features/streams/policy-repository.test.ts
@@ -51,3 +51,40 @@ describe("StreamPoliciesRepository.getToolPolicy", () => {
     expect(result).toEqual([])
   })
 })
+
+describe("StreamPoliciesRepository.setToolPolicy", () => {
+  afterEach(() => mock.restore())
+
+  it("upserts a non-null policy race-safely, keyed on the stream PK (INV-20)", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    await StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", ["web", "workspace"])
+
+    expect(captured.text).toContain("INSERT INTO stream_policies")
+    expect(captured.text).toContain("ON CONFLICT (stream_id)")
+    expect(captured.text).toContain("DO UPDATE SET allowed_tool_categories = EXCLUDED.allowed_tool_categories")
+    expect(captured.values).toEqual(["stream_01", "ws_1", ["web", "workspace"]])
+  })
+
+  it("persists an empty array as a real policy (no tools), still an upsert not a delete", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    await StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", [])
+
+    expect(captured.text).toContain("INSERT INTO stream_policies")
+    expect(captured.values).toEqual(["stream_01", "ws_1", []])
+  })
+
+  it("expresses 'no restriction' (null) by deleting the row, never storing NULL", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    await StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", null)
+
+    expect(captured.text).toContain("DELETE FROM stream_policies")
+    expect(captured.text).not.toContain("INSERT")
+    expect(captured.values).toEqual(["ws_1", "stream_01"])
+  })
+})

--- a/apps/backend/src/features/streams/policy-repository.test.ts
+++ b/apps/backend/src/features/streams/policy-repository.test.ts
@@ -8,13 +8,13 @@ interface Captured {
   values: unknown[] | null
 }
 
-function createQuerier(captured: Captured, rows: unknown[]): Querier {
+function createQuerier(captured: Captured, rows: unknown[], rowCount?: number): Querier {
   return {
     query: mock(async (q) => {
       const config = q as QueryConfig
       captured.text = config.text
       captured.values = config.values ?? []
-      return { rows, rowCount: rows.length } as QueryResult
+      return { rows, rowCount: rowCount ?? rows.length } as QueryResult
     }),
   }
 }
@@ -55,26 +55,36 @@ describe("StreamPoliciesRepository.getToolPolicy", () => {
 describe("StreamPoliciesRepository.setToolPolicy", () => {
   afterEach(() => mock.restore())
 
-  it("upserts a non-null policy race-safely, keyed on the stream PK (INV-20)", async () => {
+  it("upserts a non-null policy race-safely, keyed on the stream PK (INV-20), asserting the workspace (INV-8)", async () => {
     const captured: Captured = { text: null, values: null }
-    const db = createQuerier(captured, [])
+    const db = createQuerier(captured, [], 1)
 
     await StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", ["web", "workspace"])
 
     expect(captured.text).toContain("INSERT INTO stream_policies")
     expect(captured.text).toContain("ON CONFLICT (stream_id)")
     expect(captured.text).toContain("DO UPDATE SET allowed_tool_categories = EXCLUDED.allowed_tool_categories")
+    expect(captured.text).toContain("WHERE stream_policies.workspace_id = EXCLUDED.workspace_id")
     expect(captured.values).toEqual(["stream_01", "ws_1", ["web", "workspace"]])
   })
 
   it("persists an empty array as a real policy (no tools), still an upsert not a delete", async () => {
     const captured: Captured = { text: null, values: null }
-    const db = createQuerier(captured, [])
+    const db = createQuerier(captured, [], 1)
 
     await StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", [])
 
     expect(captured.text).toContain("INSERT INTO stream_policies")
     expect(captured.values).toEqual(["stream_01", "ws_1", []])
+  })
+
+  it("fails loudly when the upsert matches no row (workspace mismatch, INV-11)", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [], 0)
+
+    await expect(StreamPoliciesRepository.setToolPolicy(db, "ws_1", "stream_01", ["web"])).rejects.toThrow(
+      /workspace mismatch/i
+    )
   })
 
   it("expresses 'no restriction' (null) by deleting the row, never storing NULL", async () => {

--- a/apps/backend/src/features/streams/policy-repository.ts
+++ b/apps/backend/src/features/streams/policy-repository.ts
@@ -27,4 +27,29 @@ export const StreamPoliciesRepository = {
     `)
     return (result.rows[0]?.allowed_tool_categories as ToolPrivacyPolicy) ?? null
   },
+
+  /**
+   * Set or clear a stream's tool-privacy policy. `null` means "no restriction",
+   * which this store expresses by row ABSENCE — so a null policy DELETEs any
+   * existing row rather than writing a NULL (the column is `NOT NULL`). A
+   * non-null policy is upserted race-safely (INV-20); note `[]` ("no tools at
+   * all") is a real, persisted policy, distinct from the deleted/null case.
+   * Keyed by the non-thread root stream, mirroring `getToolPolicy` — callers
+   * resolve thread → `rootStreamId` before writing.
+   */
+  async setToolPolicy(db: Querier, workspaceId: string, streamId: string, policy: ToolPrivacyPolicy): Promise<void> {
+    if (policy === null) {
+      await db.query(sql`
+        DELETE FROM stream_policies
+        WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId}
+      `)
+      return
+    }
+    await db.query(sql`
+      INSERT INTO stream_policies (stream_id, workspace_id, allowed_tool_categories, updated_at)
+      VALUES (${streamId}, ${workspaceId}, ${policy}, NOW())
+      ON CONFLICT (stream_id)
+      DO UPDATE SET allowed_tool_categories = EXCLUDED.allowed_tool_categories, updated_at = NOW()
+    `)
+  },
 }

--- a/apps/backend/src/features/streams/policy-repository.ts
+++ b/apps/backend/src/features/streams/policy-repository.ts
@@ -45,11 +45,20 @@ export const StreamPoliciesRepository = {
       `)
       return
     }
-    await db.query(sql`
+    // `stream_id` is the PK, so the conflict target can't carry `workspace_id`;
+    // the `WHERE` on the update path asserts the existing row's workspace matches
+    // the caller's (INV-8). A mismatch — which the access checks upstream already
+    // prevent — updates zero rows and fails loudly here (INV-11) instead of
+    // silently mutating another workspace's policy.
+    const result = await db.query(sql`
       INSERT INTO stream_policies (stream_id, workspace_id, allowed_tool_categories, updated_at)
       VALUES (${streamId}, ${workspaceId}, ${policy}, NOW())
       ON CONFLICT (stream_id)
       DO UPDATE SET allowed_tool_categories = EXCLUDED.allowed_tool_categories, updated_at = NOW()
+      WHERE stream_policies.workspace_id = EXCLUDED.workspace_id
     `)
+    if ((result.rowCount ?? 0) !== 1) {
+      throw new Error(`stream_policies workspace mismatch for stream ${streamId}`)
+    }
   },
 }

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -85,6 +85,12 @@ export type CreateScratchpadParams = z.infer<typeof createScratchpadParamsSchema
    * the owner can decrypt.
    */
   e2e?: E2eCreateParams
+  /**
+   * Optional tool-privacy policy set at creation. `undefined` leaves the
+   * scratchpad unrestricted (no row); a `ToolPrivacyPolicy` is written to
+   * `stream_policies` in the same transaction.
+   */
+  allowedToolCategories?: ToolPrivacyPolicy
 }
 
 const createChannelParamsSchema = z.object({
@@ -347,7 +353,13 @@ export class StreamService {
     })
   }
 
-  async create(params: CreateStreamParams & { contextBag?: ContextBag; e2e?: E2eCreateParams }): Promise<Stream> {
+  async create(
+    params: CreateStreamParams & {
+      contextBag?: ContextBag
+      e2e?: E2eCreateParams
+      allowedToolCategories?: ToolPrivacyPolicy
+    }
+  ): Promise<Stream> {
     switch (params.type) {
       case StreamTypes.SCRATCHPAD:
         return this.createScratchpad({
@@ -359,6 +371,7 @@ export class StreamService {
           createdBy: params.createdBy,
           contextBag: params.contextBag,
           e2e: params.e2e,
+          allowedToolCategories: params.allowedToolCategories,
         })
       case StreamTypes.CHANNEL:
         if (!params.slug) {
@@ -435,6 +448,18 @@ export class StreamService {
         stream.e2eEnabled = true
         stream.e2eOwnerKeyId = params.e2e.ownerKeyId
         stream.e2eActors = []
+      }
+
+      // Persist an at-creation tool policy in the same transaction, so the
+      // very first turn already respects it. `undefined` = unrestricted (no
+      // row); a policy (incl. `[]`) is written via the shared upsert.
+      if (params.allowedToolCategories !== undefined) {
+        await StreamPoliciesRepository.setToolPolicy(
+          client,
+          params.workspaceId,
+          stream.id,
+          params.allowedToolCategories
+        )
       }
 
       // Publish to outbox for real-time delivery

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -710,6 +710,15 @@ export class StreamService {
     return policy
   }
 
+  /**
+   * The stream's tool-privacy policy (or `null` for no restriction). Single read
+   * on the tracking table, so `pool` is passed directly (INV-30). Keeps the
+   * bootstrap handler thin — data access stays behind the service (INV-5/INV-34).
+   */
+  async getStreamToolPolicy(workspaceId: string, streamId: string): Promise<ToolPrivacyPolicy> {
+    return StreamPoliciesRepository.getToolPolicy(this.pool, workspaceId, streamId)
+  }
+
   async archiveStream(streamId: string, archivedBy: string): Promise<Stream | null> {
     return withTransaction(this.pool, async (client) => {
       const stream = await StreamRepository.update(client, streamId, { archivedAt: new Date() })

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -36,6 +36,7 @@ import {
   type E2eKeyRollRecipient,
   type E2eKeyRollInput,
   type E2eActorRewrapInput,
+  type ToolPrivacyPolicy,
 } from "@threa/types"
 import { ContextBagRepository } from "../agents"
 import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepository } from "../e2e-streams"
@@ -49,6 +50,7 @@ import { BotRuntimeInstanceRepository, BOT_RUNTIME_BIK_STALENESS_MS } from "../b
 import { BotRepository } from "../public-api/bot-repository"
 import { streamTypeSchema, visibilitySchema, companionModeSchema } from "../../lib/schemas"
 import { isAllowedLevel } from "./notification-config"
+import { StreamPoliciesRepository } from "./policy-repository"
 
 const DM_UNIQUENESS_KEY_PREFIX = "dm"
 
@@ -664,6 +666,23 @@ export class StreamService {
       })
       return stream
     })
+  }
+
+  /**
+   * Set or clear a scratchpad's tool-privacy policy. A single write on the
+   * `stream_policies` tracking table, so `pool` is passed directly (INV-30) and
+   * there is no outbox event: enforcement reads the policy fresh at the next
+   * turn's claim/dispatch (`negotiateCapabilities`), so a change takes effect on
+   * the next agent turn without a broadcast. Returns the policy as stored, for
+   * the caller's optimistic cache.
+   */
+  async setStreamToolPolicy(
+    workspaceId: string,
+    streamId: string,
+    policy: ToolPrivacyPolicy
+  ): Promise<ToolPrivacyPolicy> {
+    await StreamPoliciesRepository.setToolPolicy(this.pool, workspaceId, streamId, policy)
+    return policy
   }
 
   async archiveStream(streamId: string, archivedBy: string): Promise<Stream | null> {

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -83,3 +83,31 @@ describe("getGithubClient unauthenticated fallback", () => {
     expect(client).toBeNull()
   })
 })
+
+describe("getAvailableToolCategories", () => {
+  it("returns web + workspace only when no integrations are enabled, without touching the DB", async () => {
+    const service = makeService()
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace"])
+  })
+
+  it("includes github when its integration is enabled and connected (active)", async () => {
+    const service = makeServiceWithRow({
+      id: "wsi_1",
+      workspace_id: "ws_1",
+      provider: "github",
+      status: "active",
+      credentials: {},
+      metadata: {},
+      installed_by: "user_1",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace", "github"])
+  })
+
+  it("omits github when enabled for the deployment but not connected for the workspace", async () => {
+    const pool = { query: async () => ({ rows: [] }) } as unknown as Pool
+    const service = new WorkspaceIntegrationService({ pool, github: githubEnabled, linear: linearDisabled })
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace"])
+  })
+})

--- a/apps/backend/src/features/workspace-integrations/service.test.ts
+++ b/apps/backend/src/features/workspace-integrations/service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn } from "bun:test"
 import type { Pool } from "pg"
 import { GitHubClient, WorkspaceIntegrationService } from "./service"
 import type { GitHubAppConfig, LinearOAuthConfig } from "../../lib/env"
@@ -16,6 +16,14 @@ const linearDisabled: LinearOAuthConfig = {
   clientId: "",
   clientSecret: "",
   redirectUri: "",
+  integrationSecret: "secret",
+}
+
+const linearEnabled: LinearOAuthConfig = {
+  enabled: true,
+  clientId: "client",
+  clientSecret: "secret",
+  redirectUri: "https://example.test/callback",
   integrationSecret: "secret",
 }
 
@@ -108,6 +116,46 @@ describe("getAvailableToolCategories", () => {
   it("omits github when enabled for the deployment but not connected for the workspace", async () => {
     const pool = { query: async () => ({ rows: [] }) } as unknown as Pool
     const service = new WorkspaceIntegrationService({ pool, github: githubEnabled, linear: linearDisabled })
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace"])
+  })
+
+  it("includes linear when its integration is enabled and connected (active)", async () => {
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubDisabled,
+      linear: linearEnabled,
+    })
+    spyOn(service, "getLinearIntegration").mockResolvedValue({
+      status: "active",
+    } as Awaited<ReturnType<WorkspaceIntegrationService["getLinearIntegration"]>>)
+
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace", "linear"])
+  })
+
+  it("includes both github and linear when both are enabled and active", async () => {
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubEnabled,
+      linear: linearEnabled,
+    })
+    spyOn(service, "getGithubIntegration").mockResolvedValue({
+      status: "active",
+    } as Awaited<ReturnType<WorkspaceIntegrationService["getGithubIntegration"]>>)
+    spyOn(service, "getLinearIntegration").mockResolvedValue({
+      status: "active",
+    } as Awaited<ReturnType<WorkspaceIntegrationService["getLinearIntegration"]>>)
+
+    expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace", "github", "linear"])
+  })
+
+  it("omits linear when enabled for the deployment but not connected for the workspace", async () => {
+    const service = new WorkspaceIntegrationService({
+      pool: explodingPool,
+      github: githubDisabled,
+      linear: linearEnabled,
+    })
+    spyOn(service, "getLinearIntegration").mockResolvedValue(null)
+
     expect(await service.getAvailableToolCategories("ws_1")).toEqual(["web", "workspace"])
   })
 })

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -15,6 +15,7 @@ import {
   type LinearAuthorizedUser,
   type LinearRateLimit,
   type LinearWorkspaceIntegration,
+  type ToolPrivacyCategory,
 } from "@threa/types"
 import {
   decryptJson,
@@ -181,6 +182,27 @@ export class WorkspaceIntegrationService {
 
   isLinearEnabled(): boolean {
     return this.deps.linear.enabled
+  }
+
+  /**
+   * The tool-privacy categories whose backing tools are actually available in
+   * this workspace, for the per-stream tool-policy UI to show only relevant
+   * toggles. `web` and `workspace` primitives are always present; `github` /
+   * `linear` only when their integration is enabled for the deployment AND
+   * connected (active) for the workspace. `messaging` is omitted — it is always
+   * allowed and never offered as a toggle.
+   */
+  async getAvailableToolCategories(workspaceId: string): Promise<ToolPrivacyCategory[]> {
+    const categories: ToolPrivacyCategory[] = ["web", "workspace"]
+    if (this.isGitHubEnabled()) {
+      const github = await this.getGithubIntegration(workspaceId)
+      if (github?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("github")
+    }
+    if (this.isLinearEnabled()) {
+      const linear = await this.getLinearIntegration(workspaceId)
+      if (linear?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("linear")
+    }
+    return categories
   }
 
   async getGithubIntegration(workspaceId: string): Promise<GitHubWorkspaceIntegration | null> {

--- a/apps/backend/src/features/workspace-integrations/service.ts
+++ b/apps/backend/src/features/workspace-integrations/service.ts
@@ -193,15 +193,16 @@ export class WorkspaceIntegrationService {
    * allowed and never offered as a toggle.
    */
   async getAvailableToolCategories(workspaceId: string): Promise<ToolPrivacyCategory[]> {
+    // GitHub and Linear are independent lookups — fan them out so they don't
+    // serialize on the bootstrap path. Each short-circuits (no query) when its
+    // integration is disabled for the deployment.
+    const [github, linear] = await Promise.all([
+      this.isGitHubEnabled() ? this.getGithubIntegration(workspaceId) : Promise.resolve(null),
+      this.isLinearEnabled() ? this.getLinearIntegration(workspaceId) : Promise.resolve(null),
+    ])
     const categories: ToolPrivacyCategory[] = ["web", "workspace"]
-    if (this.isGitHubEnabled()) {
-      const github = await this.getGithubIntegration(workspaceId)
-      if (github?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("github")
-    }
-    if (this.isLinearEnabled()) {
-      const linear = await this.getLinearIntegration(workspaceId)
-      if (linear?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("linear")
-    }
+    if (github?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("github")
+    if (linear?.status === WorkspaceIntegrationStatuses.ACTIVE) categories.push("linear")
     return categories
   }
 

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -8,6 +8,7 @@ import type { FeatureFlagService } from "../feature-flags"
 import type { PlatformAdminService } from "../platform-admin"
 import type { SidebarConfigService } from "../sidebar-config"
 import type { InvitationService } from "../invitations"
+import type { WorkspaceIntegrationService } from "../workspace-integrations"
 import type { ActivityService } from "../activity"
 import type { CommandAvailabilityService } from "../commands"
 import type { AvatarService } from "./avatar-service"
@@ -60,6 +61,7 @@ interface Dependencies {
   platformAdminService: PlatformAdminService
   sidebarConfigService: SidebarConfigService
   invitationService: InvitationService
+  workspaceIntegrationService: WorkspaceIntegrationService
   activityService?: ActivityService
   commandAvailabilityService: CommandAvailabilityService
   avatarService: AvatarService
@@ -78,6 +80,7 @@ export function createWorkspaceHandlers({
   platformAdminService,
   sidebarConfigService,
   invitationService,
+  workspaceIntegrationService,
   activityService,
   commandAvailabilityService,
   avatarService,
@@ -153,6 +156,7 @@ export function createWorkspaceHandlers({
         labels,
         labelMemberships,
         labelAssignments,
+        configuredToolCategories,
       ] = await Promise.all([
         workspaceService.getWorkspaceById(workspaceId),
         workspaceService.getUsers(workspaceId),
@@ -169,6 +173,10 @@ export function createWorkspaceHandlers({
         labelService.listVisibleTo(workspaceId, userId),
         labelService.listMembershipsForUser(workspaceId, userId),
         labelAssignmentService.listForViewer(workspaceId, userId),
+        // Which agent tool categories the workspace has tooling for — drives the
+        // scratchpad tool-policy picker (including the at-creation control, which
+        // has no stream bootstrap yet).
+        workspaceIntegrationService.getAvailableToolCategories(workspaceId),
       ])
 
       if (!workspace) {
@@ -263,6 +271,7 @@ export function createWorkspaceHandlers({
           invitations,
           viewerPermissions,
           viewerIsPlatformAdmin,
+          configuredToolCategories,
         },
       })
     },

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -233,6 +233,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     platformAdminService,
     sidebarConfigService,
     invitationService,
+    workspaceIntegrationService,
     activityService,
     commandAvailabilityService,
     avatarService,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -249,6 +249,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     linkPreviewService,
     botRuntimeService,
     commandAvailabilityService,
+    workspaceIntegrationService,
   })
   const message = createMessageHandlers({
     pool,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -416,6 +416,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.patch("/api/workspaces/:workspaceId/streams/:streamId", ...authed, stream.update)
   app.get("/api/workspaces/:workspaceId/streams/:streamId/bootstrap", ...authed, stream.bootstrap)
   app.patch("/api/workspaces/:workspaceId/streams/:streamId/companion", ...authed, stream.updateCompanionMode)
+  app.patch("/api/workspaces/:workspaceId/streams/:streamId/tool-policy", ...authed, stream.updateToolPolicy)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/notification-level", ...authed, stream.setNotificationLevel)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/join", ...authed, stream.join)
   app.post("/api/workspaces/:workspaceId/streams/:streamId/e2e/actors", ...authed, stream.inviteActor)

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -11,6 +11,7 @@ import type {
   NotificationLevel,
   SharedMessageHydration,
   CompanionMode,
+  ToolPrivacyPolicy,
 } from "@threa/types"
 
 /**
@@ -76,6 +77,23 @@ export const streamsApi = {
       data
     )
     return res.stream
+  },
+
+  /**
+   * Set (or clear) a scratchpad's tool-privacy policy. `null` clears the
+   * restriction; an array (including `[]` = no tools) restricts the agent to
+   * those categories. Returns the policy as stored.
+   */
+  async updateToolPolicy(
+    workspaceId: string,
+    streamId: string,
+    allowedCategories: ToolPrivacyPolicy
+  ): Promise<ToolPrivacyPolicy> {
+    const res = await api.patch<{ data: { allowedToolCategories: ToolPrivacyPolicy } }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/tool-policy`,
+      { allowedCategories }
+    )
+    return res.data.allowedToolCategories
   },
 
   archive(workspaceId: string, streamId: string): Promise<void> {

--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -1,0 +1,100 @@
+import type { ComponentType } from "react"
+import { Moon, Sparkles } from "lucide-react"
+import { CompanionModes, type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { ToolPolicyControl } from "./tool-policy-picker"
+
+export interface AgentToolPolicyBinding {
+  value: ToolPrivacyPolicy
+  onChange: (next: ToolPrivacyPolicy) => void
+  configuredCategories?: ToolPrivacyCategory[]
+  /** Encrypted scratchpad: non-web categories render disabled, with a reason. */
+  e2e: boolean
+  busy?: boolean
+}
+
+interface AgentSettingsPanelProps {
+  companionMode: CompanionMode
+  onCompanionModeChange: (mode: CompanionMode) => void
+  companionBusy?: boolean
+  /** Tool-access section; omit to hide it (e.g. the viewer isn't the owner). */
+  toolPolicy?: AgentToolPolicyBinding
+}
+
+/**
+ * The compact agent-settings panel shown from the scratchpad pill — companion
+ * mode and (for the owner) tool access. One presentational surface for both
+ * drafts (writes to the local draft) and live scratchpads (live mutations); the
+ * caller wires the handlers.
+ */
+export function AgentSettingsPanel({
+  companionMode,
+  onCompanionModeChange,
+  companionBusy,
+  toolPolicy,
+}: AgentSettingsPanelProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Companion mode</Label>
+        <div role="radiogroup" aria-label="Companion mode" className="grid grid-cols-2 gap-2">
+          <ModeButton
+            selected={companionMode === CompanionModes.ON}
+            onSelect={() => onCompanionModeChange(CompanionModes.ON)}
+            icon={Sparkles}
+            label="Companion"
+            disabled={companionBusy}
+          />
+          <ModeButton
+            selected={companionMode === CompanionModes.OFF}
+            onSelect={() => onCompanionModeChange(CompanionModes.OFF)}
+            icon={Moon}
+            label="Quiet"
+            disabled={companionBusy}
+          />
+        </div>
+      </div>
+
+      {toolPolicy && (
+        <div className="border-t pt-4">
+          <ToolPolicyControl
+            value={toolPolicy.value}
+            onChange={toolPolicy.onChange}
+            configuredCategories={toolPolicy.configuredCategories}
+            e2e={toolPolicy.e2e}
+            disabled={toolPolicy.busy}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ModeButtonProps {
+  selected: boolean
+  onSelect: () => void
+  icon: ComponentType<{ className?: string }>
+  label: string
+  disabled?: boolean
+}
+
+function ModeButton({ selected, onSelect, icon: Icon, label, disabled }: ModeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      role="radio"
+      aria-checked={selected}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-sm transition-colors",
+        disabled && "opacity-50",
+        selected ? "border-primary bg-primary/5" : "border-border hover:bg-accent"
+      )}
+    >
+      <Icon className={cn("h-3.5 w-3.5", selected ? "text-primary" : "text-muted-foreground")} />
+      <span className={cn("font-medium", selected ? "text-foreground" : "text-muted-foreground")}>{label}</span>
+    </button>
+  )
+}

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -3,7 +3,13 @@ import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
-import { CompanionModes, type CompanionMode, type Stream, type ToolPrivacyPolicy } from "@threa/types"
+import {
+  CompanionModes,
+  type CompanionMode,
+  type Stream,
+  type ToolPrivacyCategory,
+  type ToolPrivacyPolicy,
+} from "@threa/types"
 import { ToolPolicyPicker } from "./tool-policy-picker"
 
 interface CompanionTabProps {
@@ -11,11 +17,19 @@ interface CompanionTabProps {
   stream: Stream
   /** The scratchpad's current tool policy (from the bootstrap envelope). */
   allowedToolCategories: ToolPrivacyPolicy
+  /** Tool categories the workspace has configured, so the picker hides unconnected integrations. */
+  configuredToolCategories?: ToolPrivacyCategory[]
   /** True only when the viewer can manage this stream's tool policy (scratchpad owner). */
   canManageToolPolicy: boolean
 }
 
-export function CompanionTab({ workspaceId, stream, allowedToolCategories, canManageToolPolicy }: CompanionTabProps) {
+export function CompanionTab({
+  workspaceId,
+  stream,
+  allowedToolCategories,
+  configuredToolCategories,
+  canManageToolPolicy,
+}: CompanionTabProps) {
   const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
 
   // On encrypted scratchpads Ariadne runs in the enclave (never the plaintext
@@ -76,7 +90,13 @@ export function CompanionTab({ workspaceId, stream, allowedToolCategories, canMa
       )}
 
       {canManageToolPolicy && (
-        <ToolPolicyPicker workspaceId={workspaceId} streamId={stream.id} value={allowedToolCategories} />
+        <ToolPolicyPicker
+          workspaceId={workspaceId}
+          streamId={stream.id}
+          value={allowedToolCategories}
+          configuredCategories={configuredToolCategories}
+          e2e={isE2e}
+        />
       )}
     </div>
   )

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -3,14 +3,19 @@ import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
-import { CompanionModes, type CompanionMode, type Stream } from "@threa/types"
+import { CompanionModes, type CompanionMode, type Stream, type ToolPrivacyPolicy } from "@threa/types"
+import { ToolPolicyPicker } from "./tool-policy-picker"
 
 interface CompanionTabProps {
   workspaceId: string
   stream: Stream
+  /** The scratchpad's current tool policy (from the bootstrap envelope). */
+  allowedToolCategories: ToolPrivacyPolicy
+  /** True only when the viewer can manage this stream's tool policy (scratchpad owner). */
+  canManageToolPolicy: boolean
 }
 
-export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
+export function CompanionTab({ workspaceId, stream, allowedToolCategories, canManageToolPolicy }: CompanionTabProps) {
   const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
 
   // On encrypted scratchpads Ariadne runs in the enclave (never the plaintext
@@ -68,6 +73,10 @@ export function CompanionTab({ workspaceId, stream }: CompanionTabProps) {
           On encrypted scratchpads Ariadne replies from inside the encryption enclave, so your content stays end-to-end
           encrypted either way. Companion lets her reply; Quiet keeps this a silent, encrypted dump.
         </p>
+      )}
+
+      {canManageToolPolicy && (
+        <ToolPolicyPicker workspaceId={workspaceId} streamId={stream.id} value={allowedToolCategories} />
       )}
     </div>
   )

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
+import * as draftHook from "@/hooks/use-draft-scratchpads"
+import { DraftAgentSettings } from "./draft-agent-settings"
+
+const updateDraft = vi.fn()
+
+beforeEach(() => {
+  updateDraft.mockReset()
+  vi.spyOn(draftHook, "useDraftScratchpads").mockReturnValue({
+    drafts: [],
+    createDraft: vi.fn(),
+    updateDraft,
+    deleteDraft: vi.fn(),
+    getDraft: vi.fn(),
+  } as unknown as ReturnType<typeof draftHook.useDraftScratchpads>)
+})
+
+function renderSettings(opts: {
+  companionMode?: "on" | "off"
+  allowedToolCategories?: ToolPrivacyPolicy
+  configuredCategories?: ToolPrivacyCategory[]
+}) {
+  return render(
+    <TooltipProvider>
+      <DraftAgentSettings
+        workspaceId="ws_1"
+        draftId="draft_1"
+        companionMode={opts.companionMode ?? "on"}
+        allowedToolCategories={opts.allowedToolCategories ?? null}
+        configuredCategories={opts.configuredCategories}
+      />
+    </TooltipProvider>
+  )
+}
+
+describe("DraftAgentSettings", () => {
+  it("writes the companion mode choice to the draft", async () => {
+    renderSettings({ companionMode: "on" })
+
+    await userEvent.click(screen.getByRole("radio", { name: /quiet/i }))
+
+    expect(updateDraft).toHaveBeenCalledWith("draft_1", { companionMode: "off" })
+  })
+
+  it("writes a restricted (empty) policy to the draft when restriction is turned on", async () => {
+    renderSettings({ allowedToolCategories: null })
+
+    await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
+
+    expect(updateDraft).toHaveBeenCalledWith("draft_1", { allowedToolCategories: [] })
+  })
+
+  it("only offers the categories the workspace has configured", () => {
+    renderSettings({ allowedToolCategories: [], configuredCategories: ["web", "workspace"] })
+
+    expect(screen.getByRole("checkbox", { name: /web/i })).toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: /github/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: /linear/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -1,10 +1,6 @@
-import type { ComponentType } from "react"
-import { Moon, Sparkles } from "lucide-react"
-import { CompanionModes, type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
 import { useDraftScratchpads } from "@/hooks/use-draft-scratchpads"
-import { ToolPolicyControl } from "./tool-policy-picker"
+import { AgentSettingsPanel } from "./agent-settings-panel"
 
 interface DraftAgentSettingsProps {
   workspaceId: string
@@ -18,7 +14,8 @@ interface DraftAgentSettingsProps {
  * In-flow agent settings for a not-yet-created scratchpad: companion mode and
  * tool access, written to the local draft and threaded into the create request
  * on the first message. Drafts are always plaintext (encrypted scratchpads skip
- * the draft system), so the enclave "not yet" gating never applies here.
+ * the draft system), so the enclave "not yet" gating never applies here. The
+ * draft author is always the owner, so the tool section is always shown.
  */
 export function DraftAgentSettings({
   workspaceId,
@@ -30,58 +27,15 @@ export function DraftAgentSettings({
   const { updateDraft } = useDraftScratchpads(workspaceId)
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Companion mode</Label>
-        <div role="radiogroup" aria-label="Companion mode" className="grid grid-cols-2 gap-2">
-          <ModeButton
-            selected={companionMode === CompanionModes.ON}
-            onSelect={() => updateDraft(draftId, { companionMode: CompanionModes.ON })}
-            icon={Sparkles}
-            label="Companion"
-          />
-          <ModeButton
-            selected={companionMode === CompanionModes.OFF}
-            onSelect={() => updateDraft(draftId, { companionMode: CompanionModes.OFF })}
-            icon={Moon}
-            label="Quiet"
-          />
-        </div>
-      </div>
-
-      <div className="border-t pt-4">
-        <ToolPolicyControl
-          value={allowedToolCategories}
-          onChange={(next) => updateDraft(draftId, { allowedToolCategories: next })}
-          configuredCategories={configuredCategories}
-          e2e={false}
-        />
-      </div>
-    </div>
-  )
-}
-
-interface ModeButtonProps {
-  selected: boolean
-  onSelect: () => void
-  icon: ComponentType<{ className?: string }>
-  label: string
-}
-
-function ModeButton({ selected, onSelect, icon: Icon, label }: ModeButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      role="radio"
-      aria-checked={selected}
-      className={cn(
-        "flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-sm transition-colors",
-        selected ? "border-primary bg-primary/5" : "border-border hover:bg-accent"
-      )}
-    >
-      <Icon className={cn("h-3.5 w-3.5", selected ? "text-primary" : "text-muted-foreground")} />
-      <span className={cn("font-medium", selected ? "text-foreground" : "text-muted-foreground")}>{label}</span>
-    </button>
+    <AgentSettingsPanel
+      companionMode={companionMode}
+      onCompanionModeChange={(mode) => updateDraft(draftId, { companionMode: mode })}
+      toolPolicy={{
+        value: allowedToolCategories,
+        onChange: (next) => updateDraft(draftId, { allowedToolCategories: next }),
+        configuredCategories,
+        e2e: false,
+      }}
+    />
   )
 }

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -1,0 +1,87 @@
+import type { ComponentType } from "react"
+import { Moon, Sparkles } from "lucide-react"
+import { CompanionModes, type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+import { useDraftScratchpads } from "@/hooks/use-draft-scratchpads"
+import { ToolPolicyControl } from "./tool-policy-picker"
+
+interface DraftAgentSettingsProps {
+  workspaceId: string
+  draftId: string
+  companionMode: CompanionMode
+  allowedToolCategories: ToolPrivacyPolicy
+  configuredCategories?: ToolPrivacyCategory[]
+}
+
+/**
+ * In-flow agent settings for a not-yet-created scratchpad: companion mode and
+ * tool access, written to the local draft and threaded into the create request
+ * on the first message. Drafts are always plaintext (encrypted scratchpads skip
+ * the draft system), so the enclave "not yet" gating never applies here.
+ */
+export function DraftAgentSettings({
+  workspaceId,
+  draftId,
+  companionMode,
+  allowedToolCategories,
+  configuredCategories,
+}: DraftAgentSettingsProps) {
+  const { updateDraft } = useDraftScratchpads(workspaceId)
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Companion mode</Label>
+        <div role="radiogroup" aria-label="Companion mode" className="grid grid-cols-2 gap-2">
+          <ModeButton
+            selected={companionMode === CompanionModes.ON}
+            onSelect={() => updateDraft(draftId, { companionMode: CompanionModes.ON })}
+            icon={Sparkles}
+            label="Companion"
+          />
+          <ModeButton
+            selected={companionMode === CompanionModes.OFF}
+            onSelect={() => updateDraft(draftId, { companionMode: CompanionModes.OFF })}
+            icon={Moon}
+            label="Quiet"
+          />
+        </div>
+      </div>
+
+      <div className="border-t pt-4">
+        <ToolPolicyControl
+          value={allowedToolCategories}
+          onChange={(next) => updateDraft(draftId, { allowedToolCategories: next })}
+          configuredCategories={configuredCategories}
+          e2e={false}
+        />
+      </div>
+    </div>
+  )
+}
+
+interface ModeButtonProps {
+  selected: boolean
+  onSelect: () => void
+  icon: ComponentType<{ className?: string }>
+  label: string
+}
+
+function ModeButton({ selected, onSelect, icon: Icon, label }: ModeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      role="radio"
+      aria-checked={selected}
+      className={cn(
+        "flex items-center gap-1.5 rounded-md border px-2.5 py-2 text-sm transition-colors",
+        selected ? "border-primary bg-primary/5" : "border-border hover:bg-accent"
+      )}
+    >
+      <Icon className={cn("h-3.5 w-3.5", selected ? "text-primary" : "text-muted-foreground")} />
+      <span className={cn("font-medium", selected ? "text-foreground" : "text-muted-foreground")}>{label}</span>
+    </button>
+  )
+}

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -1,0 +1,76 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createElement, type ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
+import { streamKeys } from "@/hooks"
+import * as streamsHooks from "@/hooks/use-streams"
+import * as workspacesHooks from "@/hooks/use-workspaces"
+import { LiveAgentSettings } from "./live-agent-settings"
+
+const companionMutate = vi.fn(async () => {})
+const toolMutate = vi.fn(async () => {})
+
+beforeEach(() => {
+  companionMutate.mockClear()
+  toolMutate.mockClear()
+  vi.spyOn(streamsHooks, "useUpdateCompanionMode").mockReturnValue({
+    mutateAsync: companionMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof streamsHooks.useUpdateCompanionMode>)
+  vi.spyOn(streamsHooks, "useUpdateToolPolicy").mockReturnValue({
+    mutateAsync: toolMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof streamsHooks.useUpdateToolPolicy>)
+  vi.spyOn(workspacesHooks, "useCurrentWorkspaceUser").mockReturnValue({
+    id: "user_owner",
+  } as unknown as ReturnType<typeof workspacesHooks.useCurrentWorkspaceUser>)
+})
+
+function seedAndRender(opts: {
+  createdBy?: string
+  allowed?: ToolPrivacyPolicy
+  configured?: ToolPrivacyCategory[]
+  e2e?: boolean
+}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_sp"), {
+    stream: { createdBy: opts.createdBy ?? "user_owner" },
+    allowedToolCategories: opts.allowed ?? null,
+    configuredToolCategories: opts.configured,
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, createElement(TooltipProvider, null, children))
+  }
+  return render(
+    <LiveAgentSettings workspaceId="ws_1" streamId="stream_sp" companionMode="on" e2e={opts.e2e ?? false} />,
+    { wrapper: Wrapper }
+  )
+}
+
+describe("LiveAgentSettings", () => {
+  it("changes companion mode via the live mutation", async () => {
+    seedAndRender({})
+
+    await userEvent.click(screen.getByRole("radio", { name: /quiet/i }))
+
+    expect(companionMutate).toHaveBeenCalledWith("off")
+  })
+
+  it("lets the owner restrict tools via the live mutation", async () => {
+    seedAndRender({ allowed: null, configured: ["web", "workspace"] })
+
+    await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
+
+    expect(toolMutate).toHaveBeenCalledWith([])
+  })
+
+  it("hides the tool section from a non-owner but still shows companion mode", () => {
+    seedAndRender({ createdBy: "someone_else" })
+
+    expect(screen.queryByRole("switch", { name: /restrict tool access/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /companion/i })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -1,0 +1,74 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import type { CompanionMode, StreamBootstrap, ToolPrivacyPolicy } from "@threa/types"
+import { streamKeys } from "@/hooks"
+import { useUpdateCompanionMode, useUpdateToolPolicy } from "@/hooks/use-streams"
+import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
+import { AgentSettingsPanel } from "./agent-settings-panel"
+
+interface LiveAgentSettingsProps {
+  workspaceId: string
+  streamId: string
+  companionMode: CompanionMode
+  e2e: boolean
+}
+
+/**
+ * The same agent-settings panel as drafts, for a persisted scratchpad: companion
+ * mode and (owner-only) tool access wired to live mutations. The current policy
+ * and configured categories come from the stream bootstrap the stream view
+ * already loaded; the tool section is gated to the scratchpad owner, mirroring
+ * the settings dialog.
+ */
+export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }: LiveAgentSettingsProps) {
+  const queryClient = useQueryClient()
+  const { mutateAsync: updateCompanionMode, isPending: companionBusy } = useUpdateCompanionMode(workspaceId, streamId)
+  const { mutateAsync: updateToolPolicy, isPending: toolBusy } = useUpdateToolPolicy(workspaceId, streamId)
+  const currentUser = useCurrentWorkspaceUser(workspaceId)
+
+  // Cache-only observer: re-renders when a mutation patches the bootstrap.
+  const { data: bootstrap } = useQuery({
+    queryKey: streamKeys.bootstrap(workspaceId, streamId),
+    queryFn: () => queryClient.getQueryData<StreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId)) ?? null,
+    enabled: false,
+    staleTime: Infinity,
+  })
+
+  const isOwner = !!bootstrap?.stream && bootstrap.stream.createdBy === currentUser?.id
+
+  const handleCompanion = async (mode: CompanionMode) => {
+    if (mode === companionMode) return
+    try {
+      await updateCompanionMode(mode)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update companion mode")
+    }
+  }
+
+  const handleToolPolicy = async (next: ToolPrivacyPolicy) => {
+    try {
+      await updateToolPolicy(next)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update tool access")
+    }
+  }
+
+  return (
+    <AgentSettingsPanel
+      companionMode={companionMode}
+      onCompanionModeChange={handleCompanion}
+      companionBusy={companionBusy}
+      toolPolicy={
+        isOwner
+          ? {
+              value: bootstrap?.allowedToolCategories ?? null,
+              onChange: handleToolPolicy,
+              configuredCategories: bootstrap?.configuredToolCategories,
+              e2e,
+              busy: toolBusy,
+            }
+          : undefined
+      }
+    />
+  )
+}

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -144,6 +144,7 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
                     workspaceId={workspaceId}
                     stream={resolvedStream}
                     allowedToolCategories={bootstrap?.allowedToolCategories ?? null}
+                    configuredToolCategories={bootstrap?.configuredToolCategories}
                     canManageToolPolicy={
                       resolvedStream.type === StreamTypes.SCRATCHPAD && resolvedStream.createdBy === currentUserId
                     }

--- a/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
+++ b/apps/frontend/src/components/stream-settings/stream-settings-dialog.tsx
@@ -140,7 +140,14 @@ export function StreamSettingsDialog({ workspaceId }: StreamSettingsDialogProps)
                   />
                 </TabsContent>
                 <TabsContent value="companion" className="mt-0">
-                  <CompanionTab workspaceId={workspaceId} stream={resolvedStream} />
+                  <CompanionTab
+                    workspaceId={workspaceId}
+                    stream={resolvedStream}
+                    allowedToolCategories={bootstrap?.allowedToolCategories ?? null}
+                    canManageToolPolicy={
+                      resolvedStream.type === StreamTypes.SCRATCHPAD && resolvedStream.createdBy === currentUserId
+                    }
+                  />
                 </TabsContent>
                 <TabsContent value="members" className="mt-0">
                   <MembersTab workspaceId={workspaceId} streamId={streamId} currentUserId={currentUserId} />

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
@@ -4,13 +4,17 @@ import userEvent from "@testing-library/user-event"
 import { createElement, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
-import type { ToolPrivacyPolicy } from "@threa/types"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import { ToolPolicyPicker } from "./tool-policy-picker"
 
 const updateToolPolicy =
   vi.fn<(workspaceId: string, streamId: string, policy: ToolPrivacyPolicy) => Promise<ToolPrivacyPolicy>>()
 
-function renderPicker(value: ToolPrivacyPolicy) {
+function renderPicker(
+  value: ToolPrivacyPolicy,
+  opts: { configuredCategories?: ToolPrivacyCategory[]; e2e?: boolean } = {}
+) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   function Wrapper({ children }: { children: ReactNode }) {
     return createElement(
@@ -18,11 +22,20 @@ function renderPicker(value: ToolPrivacyPolicy) {
       { client: queryClient },
       createElement(ServicesProvider, {
         services: { streams: { updateToolPolicy } as unknown as StreamService },
-        children,
+        children: createElement(TooltipProvider, null, children),
       })
     )
   }
-  return render(<ToolPolicyPicker workspaceId="ws_1" streamId="stream_sp" value={value} />, { wrapper: Wrapper })
+  return render(
+    <ToolPolicyPicker
+      workspaceId="ws_1"
+      streamId="stream_sp"
+      value={value}
+      configuredCategories={opts.configuredCategories}
+      e2e={opts.e2e ?? false}
+    />,
+    { wrapper: Wrapper }
+  )
 }
 
 describe("ToolPolicyPicker", () => {
@@ -61,5 +74,21 @@ describe("ToolPolicyPicker", () => {
     await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
 
     expect(updateToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", null)
+  })
+
+  it("hides categories the workspace has not configured (e.g. unconnected GitHub/Linear)", () => {
+    renderPicker([], { configuredCategories: ["web", "workspace"] })
+
+    expect(screen.getByRole("checkbox", { name: /web/i })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: /workspace/i })).toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: /github/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: /linear/i })).not.toBeInTheDocument()
+  })
+
+  it("disables non-web categories on an encrypted scratchpad (enclave is web-only)", () => {
+    renderPicker([], { configuredCategories: ["web", "workspace"], e2e: true })
+
+    expect(screen.getByRole("checkbox", { name: /web/i })).not.toBeDisabled()
+    expect(screen.getByRole("checkbox", { name: /workspace/i })).toBeDisabled()
   })
 })

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { createElement, type ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ServicesProvider, type StreamService } from "@/contexts"
+import type { ToolPrivacyPolicy } from "@threa/types"
+import { ToolPolicyPicker } from "./tool-policy-picker"
+
+const updateToolPolicy =
+  vi.fn<(workspaceId: string, streamId: string, policy: ToolPrivacyPolicy) => Promise<ToolPrivacyPolicy>>()
+
+function renderPicker(value: ToolPrivacyPolicy) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ServicesProvider, {
+        services: { streams: { updateToolPolicy } as unknown as StreamService },
+        children,
+      })
+    )
+  }
+  return render(<ToolPolicyPicker workspaceId="ws_1" streamId="stream_sp" value={value} />, { wrapper: Wrapper })
+}
+
+describe("ToolPolicyPicker", () => {
+  beforeEach(() => {
+    updateToolPolicy.mockReset()
+    updateToolPolicy.mockImplementation(async (_w, _s, policy) => policy)
+  })
+
+  it("is unrestricted by default and hides the category checkboxes", () => {
+    renderPicker(null)
+
+    expect(screen.getByRole("switch", { name: /restrict tool access/i })).not.toBeChecked()
+    expect(screen.queryByRole("checkbox", { name: /web/i })).not.toBeInTheDocument()
+  })
+
+  it("turning restriction on persists an empty policy — no tools until categories are chosen", async () => {
+    renderPicker(null)
+
+    await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
+
+    expect(updateToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", [])
+  })
+
+  it("adds a category to an existing policy without dropping the current ones", async () => {
+    renderPicker(["web"])
+
+    expect(screen.getByRole("checkbox", { name: /web/i })).toBeChecked()
+    await userEvent.click(screen.getByRole("checkbox", { name: /workspace/i }))
+
+    expect(updateToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", ["web", "workspace"])
+  })
+
+  it("turning restriction off clears the policy back to unrestricted (null)", async () => {
+    renderPicker(["web"])
+
+    await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
+
+    expect(updateToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", null)
+  })
+})

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
@@ -24,50 +24,45 @@ const ENCLAVE_TOOL_CATEGORIES = new Set<ToolPrivacyCategory>(["web"])
 const NOT_IN_ENCLAVE_REASON =
   "Not yet available in encrypted scratchpads — inside the enclave Ariadne only has web tools today."
 
-interface ToolPolicyPickerProps {
-  workspaceId: string
-  streamId: string
+interface ToolPolicyControlProps {
   /** Current policy: `null` = unrestricted; an array (incl. `[]`) = restricted to those categories. */
   value: ToolPrivacyPolicy
+  /** Apply a new policy — live mutation in settings, a local draft write at creation. */
+  onChange: (next: ToolPrivacyPolicy) => void
   /**
    * Categories the workspace actually has configured (so unconnected GitHub /
-   * Linear never show). Undefined (older cached bootstrap) falls back to all.
+   * Linear never show). Undefined falls back to all gateable categories.
    */
   configuredCategories?: ToolPrivacyCategory[]
   /** Encrypted scratchpad: non-web categories render disabled, with a reason. */
   e2e: boolean
+  /** Disables all inputs while a change is in flight. */
+  disabled?: boolean
 }
 
-export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCategories, e2e }: ToolPolicyPickerProps) {
-  const { mutateAsync, isPending } = useUpdateToolPolicy(workspaceId, streamId)
-
-  // The cache (via `value`) is the source of truth — no local state, so a
-  // success re-renders from the patched bootstrap and an error leaves the prior
-  // value untouched.
+/**
+ * Presentational, controlled tool-policy editor. Owns no persistence — the
+ * caller maps `onChange` to a live mutation (settings) or a draft write
+ * (at-creation). `value` is the single source of truth, so there is no local
+ * state to drift.
+ */
+export function ToolPolicyControl({ value, onChange, configuredCategories, e2e, disabled }: ToolPolicyControlProps) {
   const restricted = value !== null
   const allowed = new Set(value ?? [])
   const shown = configuredCategories ?? ALL_GATEABLE
   const options = CATEGORY_OPTIONS.filter((option) => shown.includes(option.value))
 
-  const apply = async (next: ToolPrivacyPolicy) => {
-    try {
-      await mutateAsync(next)
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to update tool access")
-    }
-  }
-
-  const handleRestrictToggle = (on: boolean) => apply(on ? [] : null)
+  const handleRestrictToggle = (on: boolean) => onChange(on ? [] : null)
 
   const handleCategoryToggle = (category: ToolPrivacyCategory) => {
     const next = new Set(allowed)
     if (next.has(category)) next.delete(category)
     else next.add(category)
-    apply([...next])
+    onChange([...next])
   }
 
   return (
-    <div className="space-y-3 border-t pt-6">
+    <div className="space-y-3">
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
           <Label className="text-sm font-medium">Restrict tool access</Label>
@@ -79,7 +74,7 @@ export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCateg
         <Switch
           checked={restricted}
           onCheckedChange={handleRestrictToggle}
-          disabled={isPending}
+          disabled={disabled}
           aria-label="Restrict tool access"
         />
       </div>
@@ -93,7 +88,7 @@ export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCateg
               description={option.description}
               checked={allowed.has(option.value)}
               notImplementedReason={e2e && !ENCLAVE_TOOL_CATEGORIES.has(option.value) ? NOT_IN_ENCLAVE_REASON : null}
-              disabled={isPending}
+              disabled={disabled ?? false}
               onToggle={() => handleCategoryToggle(option.value)}
             />
           ))}
@@ -105,6 +100,43 @@ export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCateg
           No tool groups selected — Ariadne can only read this scratchpad and reply.
         </p>
       )}
+    </div>
+  )
+}
+
+interface ToolPolicyPickerProps {
+  workspaceId: string
+  streamId: string
+  /** Current policy: `null` = unrestricted; an array (incl. `[]`) = restricted to those categories. */
+  value: ToolPrivacyPolicy
+  configuredCategories?: ToolPrivacyCategory[]
+  e2e: boolean
+}
+
+/**
+ * Settings wrapper: binds the controlled `ToolPolicyControl` to the live
+ * `useUpdateToolPolicy` mutation for an existing stream.
+ */
+export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCategories, e2e }: ToolPolicyPickerProps) {
+  const { mutateAsync, isPending } = useUpdateToolPolicy(workspaceId, streamId)
+
+  const handleChange = async (next: ToolPrivacyPolicy) => {
+    try {
+      await mutateAsync(next)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update tool access")
+    }
+  }
+
+  return (
+    <div className="border-t pt-6">
+      <ToolPolicyControl
+        value={value}
+        onChange={handleChange}
+        configuredCategories={configuredCategories}
+        e2e={e2e}
+        disabled={isPending}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
@@ -7,16 +7,25 @@ import { cn } from "@/lib/utils"
 import { useUpdateToolPolicy } from "@/hooks/use-streams"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 
-// `messaging` is intentionally absent: the agent's own reply tool is always
-// allowed, so it is never offered as a toggle. These are the gateable groups.
-const CATEGORY_OPTIONS: { value: ToolPrivacyCategory; label: string; description: string }[] = [
-  { value: "web", label: "Web", description: "Web search and fetching public URLs." },
-  { value: "workspace", label: "Workspace", description: "Search this workspace's messages, streams, and memos." },
-  { value: "github", label: "GitHub", description: "Read from connected GitHub." },
-  { value: "linear", label: "Linear", description: "Read from connected Linear." },
-]
+// `messaging` is intentionally excluded: the agent's own reply tool is always
+// allowed, so it is never offered as a toggle. The copy is keyed by a `Record`
+// over every *other* category, so adding a new `ToolPrivacyCategory` is a
+// compile error here until it's given picker copy (or excluded) — the picker can
+// never silently drop a category the backend reports as configured.
+type GateableCategory = Exclude<ToolPrivacyCategory, "messaging">
 
-const ALL_GATEABLE = CATEGORY_OPTIONS.map((option) => option.value)
+const CATEGORY_META: Record<GateableCategory, { label: string; description: string }> = {
+  web: { label: "Web", description: "Web search and fetching public URLs." },
+  workspace: { label: "Workspace", description: "Search this workspace's messages, streams, and memos." },
+  github: { label: "GitHub", description: "Read from connected GitHub." },
+  linear: { label: "Linear", description: "Read from connected Linear." },
+}
+
+const CATEGORY_OPTIONS: { value: GateableCategory; label: string; description: string }[] = (
+  Object.keys(CATEGORY_META) as GateableCategory[]
+).map((value) => ({ value, ...CATEGORY_META[value] }))
+
+const ALL_GATEABLE: ToolPrivacyCategory[] = CATEGORY_OPTIONS.map((option) => option.value)
 
 // Inside the enclave Ariadne only builds web tools, so on an encrypted
 // scratchpad the other categories exist as toggles but aren't wired yet.

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
@@ -1,0 +1,93 @@
+import { toast } from "sonner"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { useUpdateToolPolicy } from "@/hooks/use-streams"
+import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
+
+// `messaging` is intentionally absent: the agent's own reply tool is always
+// allowed, so it is never offered as a toggle. These are the gateable groups.
+const CATEGORY_OPTIONS: { value: ToolPrivacyCategory; label: string; description: string }[] = [
+  { value: "web", label: "Web", description: "Web search and fetching public URLs." },
+  { value: "workspace", label: "Workspace", description: "Search this workspace's messages, streams, and memos." },
+  { value: "github", label: "GitHub", description: "Read from connected GitHub." },
+  { value: "linear", label: "Linear", description: "Read from connected Linear." },
+]
+
+interface ToolPolicyPickerProps {
+  workspaceId: string
+  streamId: string
+  /** Current policy: `null` = unrestricted; an array (incl. `[]`) = restricted to those categories. */
+  value: ToolPrivacyPolicy
+}
+
+export function ToolPolicyPicker({ workspaceId, streamId, value }: ToolPolicyPickerProps) {
+  const { mutateAsync, isPending } = useUpdateToolPolicy(workspaceId, streamId)
+
+  // The cache (via `value`) is the source of truth — no local state, so a
+  // success re-renders from the patched bootstrap and an error leaves the prior
+  // value untouched.
+  const restricted = value !== null
+  const allowed = new Set(value ?? [])
+
+  const apply = async (next: ToolPrivacyPolicy) => {
+    try {
+      await mutateAsync(next)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update tool access")
+    }
+  }
+
+  const handleRestrictToggle = (on: boolean) => apply(on ? [] : null)
+
+  const handleCategoryToggle = (category: ToolPrivacyCategory) => {
+    const next = new Set(allowed)
+    if (next.has(category)) next.delete(category)
+    else next.add(category)
+    apply([...next])
+  }
+
+  return (
+    <div className="space-y-3 border-t pt-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Label className="text-sm font-medium">Restrict tool access</Label>
+          <p className="text-xs text-muted-foreground">
+            By default Ariadne can use every tool she has. Restrict her to only the tool groups you choose. She can
+            always reply.
+          </p>
+        </div>
+        <Switch
+          checked={restricted}
+          onCheckedChange={handleRestrictToggle}
+          disabled={isPending}
+          aria-label="Restrict tool access"
+        />
+      </div>
+
+      {restricted && (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {CATEGORY_OPTIONS.map((option) => (
+            <label key={option.value} className="flex items-start gap-2 rounded-md border px-2.5 py-2 text-sm">
+              <Checkbox
+                checked={allowed.has(option.value)}
+                onCheckedChange={() => handleCategoryToggle(option.value)}
+                disabled={isPending}
+              />
+              <span>
+                <span className="block font-medium">{option.label}</span>
+                <span className="block text-xs text-muted-foreground">{option.description}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      {restricted && allowed.size === 0 && (
+        <p className="text-xs text-muted-foreground">
+          No tool groups selected — Ariadne can only read this scratchpad and reply.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
@@ -2,6 +2,8 @@ import { toast } from "sonner"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
 import { useUpdateToolPolicy } from "@/hooks/use-streams"
 import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 
@@ -14,14 +16,29 @@ const CATEGORY_OPTIONS: { value: ToolPrivacyCategory; label: string; description
   { value: "linear", label: "Linear", description: "Read from connected Linear." },
 ]
 
+const ALL_GATEABLE = CATEGORY_OPTIONS.map((option) => option.value)
+
+// Inside the enclave Ariadne only builds web tools, so on an encrypted
+// scratchpad the other categories exist as toggles but aren't wired yet.
+const ENCLAVE_TOOL_CATEGORIES = new Set<ToolPrivacyCategory>(["web"])
+const NOT_IN_ENCLAVE_REASON =
+  "Not yet available in encrypted scratchpads — inside the enclave Ariadne only has web tools today."
+
 interface ToolPolicyPickerProps {
   workspaceId: string
   streamId: string
   /** Current policy: `null` = unrestricted; an array (incl. `[]`) = restricted to those categories. */
   value: ToolPrivacyPolicy
+  /**
+   * Categories the workspace actually has configured (so unconnected GitHub /
+   * Linear never show). Undefined (older cached bootstrap) falls back to all.
+   */
+  configuredCategories?: ToolPrivacyCategory[]
+  /** Encrypted scratchpad: non-web categories render disabled, with a reason. */
+  e2e: boolean
 }
 
-export function ToolPolicyPicker({ workspaceId, streamId, value }: ToolPolicyPickerProps) {
+export function ToolPolicyPicker({ workspaceId, streamId, value, configuredCategories, e2e }: ToolPolicyPickerProps) {
   const { mutateAsync, isPending } = useUpdateToolPolicy(workspaceId, streamId)
 
   // The cache (via `value`) is the source of truth — no local state, so a
@@ -29,6 +46,8 @@ export function ToolPolicyPicker({ workspaceId, streamId, value }: ToolPolicyPic
   // value untouched.
   const restricted = value !== null
   const allowed = new Set(value ?? [])
+  const shown = configuredCategories ?? ALL_GATEABLE
+  const options = CATEGORY_OPTIONS.filter((option) => shown.includes(option.value))
 
   const apply = async (next: ToolPrivacyPolicy) => {
     try {
@@ -67,18 +86,16 @@ export function ToolPolicyPicker({ workspaceId, streamId, value }: ToolPolicyPic
 
       {restricted && (
         <div className="grid gap-2 sm:grid-cols-2">
-          {CATEGORY_OPTIONS.map((option) => (
-            <label key={option.value} className="flex items-start gap-2 rounded-md border px-2.5 py-2 text-sm">
-              <Checkbox
-                checked={allowed.has(option.value)}
-                onCheckedChange={() => handleCategoryToggle(option.value)}
-                disabled={isPending}
-              />
-              <span>
-                <span className="block font-medium">{option.label}</span>
-                <span className="block text-xs text-muted-foreground">{option.description}</span>
-              </span>
-            </label>
+          {options.map((option) => (
+            <ToolCategoryRow
+              key={option.value}
+              label={option.label}
+              description={option.description}
+              checked={allowed.has(option.value)}
+              notImplementedReason={e2e && !ENCLAVE_TOOL_CATEGORIES.has(option.value) ? NOT_IN_ENCLAVE_REASON : null}
+              disabled={isPending}
+              onToggle={() => handleCategoryToggle(option.value)}
+            />
           ))}
         </div>
       )}
@@ -89,5 +106,49 @@ export function ToolPolicyPicker({ workspaceId, streamId, value }: ToolPolicyPic
         </p>
       )}
     </div>
+  )
+}
+
+interface ToolCategoryRowProps {
+  label: string
+  description: string
+  checked: boolean
+  /** When set, the category isn't wired in this runtime: render disabled with this hover reason. */
+  notImplementedReason: string | null
+  disabled: boolean
+  onToggle: () => void
+}
+
+function ToolCategoryRow({
+  label,
+  description,
+  checked,
+  notImplementedReason,
+  disabled,
+  onToggle,
+}: ToolCategoryRowProps) {
+  const notImplemented = notImplementedReason !== null
+  const row = (
+    <label
+      className={cn("flex items-start gap-2 rounded-md border px-2.5 py-2 text-sm", notImplemented && "opacity-60")}
+    >
+      <Checkbox checked={checked} onCheckedChange={onToggle} disabled={disabled || notImplemented} />
+      <span>
+        <span className="flex items-center gap-1.5 font-medium">
+          {label}
+          {notImplemented && <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Soon</span>}
+        </span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </label>
+  )
+
+  if (!notImplemented) return row
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{row}</TooltipTrigger>
+      <TooltipContent>{notImplementedReason}</TooltipContent>
+    </Tooltip>
   )
 }

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -36,6 +36,7 @@ export interface StreamService {
   create: typeof streamsApi.create
   update: typeof streamsApi.update
   updateCompanionMode: typeof streamsApi.updateCompanionMode
+  updateToolPolicy: typeof streamsApi.updateToolPolicy
   archive: typeof streamsApi.archive
   unarchive: typeof streamsApi.unarchive
   getEvents: typeof streamsApi.getEvents

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -9,6 +9,8 @@ import type {
   SidebarConfig,
   StreamContextBagPayload,
   StreamType,
+  ToolPrivacyCategory,
+  ToolPrivacyPolicy,
   WorkspaceRoleSlug,
 } from "@threa/types"
 import type { KdfParams } from "@/lib/crypto/passphrase"
@@ -215,6 +217,8 @@ export interface PendingStreamCreation {
   companionMode?: CompanionMode
   parentStreamId?: string
   parentMessageId?: string
+  /** At-creation tool policy carried from the draft; threaded into the create request. */
+  allowedToolCategories?: ToolPrivacyPolicy
 }
 
 export interface PendingMessage {
@@ -306,6 +310,13 @@ export interface DraftScratchpad {
   workspaceId: string
   displayName: string | null
   companionMode: "off" | "on"
+  /**
+   * Tool-privacy policy chosen before the scratchpad is server-created.
+   * `undefined` = unrestricted; threaded into the create request when the
+   * first message promotes the draft. Drafts are always plaintext, so the
+   * enclave "not yet" gating never applies here.
+   */
+  allowedToolCategories?: ToolPrivacyPolicy
   createdAt: number
 }
 
@@ -663,6 +674,13 @@ export interface CachedWorkspaceMetadata {
   workspaceId: string
   emojis: Array<{ shortcode: string; emoji: string; type: string; group: string; order: number; aliases: string[] }>
   emojiWeights: Record<string, number>
+  /**
+   * Agent tool categories the workspace has tooling configured for (`web` +
+   * `workspace` always, `github`/`linear` when connected). Drives the
+   * at-creation scratchpad tool-policy picker. Optional for rows cached before
+   * the field shipped — absent reads as "all gateable".
+   */
+  configuredToolCategories?: ToolPrivacyCategory[]
   /**
    * Commands surfaced in the slash-command menu. `kind` defaults to "server"
    * for backwards compatibility with older cached rows; "client-action" items

--- a/apps/frontend/src/hooks/use-draft-scratchpads.ts
+++ b/apps/frontend/src/hooks/use-draft-scratchpads.ts
@@ -39,7 +39,10 @@ export function useDraftScratchpads(workspaceId: string) {
   )
 
   const updateDraft = useCallback(
-    async (id: string, data: Partial<Pick<DraftScratchpad, "displayName" | "companionMode">>) => {
+    async (
+      id: string,
+      data: Partial<Pick<DraftScratchpad, "displayName" | "companionMode" | "allowedToolCategories">>
+    ) => {
       await db.draftScratchpads.update(id, data)
       const existingDraft = drafts.find((draft) => draft.id === id)
       if (existingDraft) {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -56,6 +56,7 @@ async function promoteDraft(
       companionMode: creation.companionMode,
       parentStreamId: creation.parentStreamId,
       parentMessageId: creation.parentMessageId,
+      allowedToolCategories: creation.allowedToolCategories,
     })
     realStreamId = newStream.id
 

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -29,6 +29,7 @@ import type {
   WorkspaceBootstrap,
   StreamWithPreview,
   E2eActor,
+  ToolPrivacyPolicy,
 } from "@threa/types"
 import { StreamTypes, Visibilities, CompanionModes } from "@threa/types"
 
@@ -112,6 +113,13 @@ export interface VirtualStream {
    * streams (treated as an empty set).
    */
   e2eActors?: E2eActor[]
+  /**
+   * Tool-privacy policy chosen at creation. On drafts this is the local,
+   * not-yet-persisted choice (threaded into the create request on the first
+   * message); on server streams it is the current policy. `undefined` =
+   * unrestricted.
+   */
+  allowedToolCategories?: ToolPrivacyPolicy
 }
 
 export interface SendMessageInput {
@@ -154,6 +162,7 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
         parentMessageId: null,
         rootStreamId: null,
         archivedAt: null,
+        allowedToolCategories: draft.allowedToolCategories,
       }
     : undefined
 
@@ -194,6 +203,7 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
           type: StreamTypes.SCRATCHPAD,
           displayName: draftData?.displayName ?? undefined,
           companionMode,
+          allowedToolCategories: draftData?.allowedToolCategories,
         },
         draftId: streamId,
       })

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -14,6 +14,7 @@ import type {
   WorkspaceBootstrap,
   NotificationLevel,
   CompanionMode,
+  ToolPrivacyPolicy,
 } from "@threa/types"
 import type { CreateStreamInput, UpdateStreamInput } from "@/api"
 import { workspaceKeys } from "./use-workspaces"
@@ -246,6 +247,28 @@ export function useUpdateCompanionMode(workspaceId: string, streamId: string) {
       })
 
       db.streams.put({ ...updatedStream, _cachedAt: Date.now() })
+    },
+  })
+}
+
+/**
+ * Set or clear a scratchpad's tool-privacy policy. The value lives on the
+ * stream bootstrap envelope (`allowedToolCategories`), not on the `Stream` row,
+ * so the success path patches only that cache — there is nothing to update in
+ * the workspace sidebar or IDB stream rows.
+ */
+export function useUpdateToolPolicy(workspaceId: string, streamId: string) {
+  const streamService = useStreamService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (allowedCategories: ToolPrivacyPolicy) =>
+      streamService.updateToolPolicy(workspaceId, streamId, allowedCategories),
+    onSuccess: (allowedToolCategories) => {
+      queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {
+        if (!old || typeof old !== "object") return old
+        return { ...old, allowedToolCategories }
+      })
     },
   })
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -19,9 +19,9 @@ import {
   Layers,
   ChevronDown,
 } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { DraftAgentSettings } from "@/components/stream-settings/draft-agent-settings"
+import { LiveAgentSettings } from "@/components/stream-settings/live-agent-settings"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
@@ -311,7 +311,6 @@ export function StreamPage() {
     let hoverVariant: string
     let iconTint: string
     let interactiveAria: string
-    let tooltipBody: string
 
     if (isEncrypted) {
       Icon = Lock
@@ -319,52 +318,49 @@ export function StreamPage() {
       pillVariant = "border-border bg-secondary text-foreground"
       hoverVariant = "hover:bg-accent"
       iconTint = "text-muted-foreground"
-      interactiveAria = "End-to-end encrypted. Open companion settings."
-      tooltipBody = "End-to-end encrypted — Companion is disabled. Click for details."
+      interactiveAria = "End-to-end encrypted. Companion and tool settings."
     } else if (isOn) {
       Icon = Sparkles
       modeLabel = "Companion"
       pillVariant = "border-primary/30 bg-primary/5 text-foreground"
       hoverVariant = "hover:bg-primary/10"
       iconTint = "text-primary"
-      interactiveAria = "Companion is on. Click to change."
-      tooltipBody = "Ariadne replies to new messages. Click to change."
+      interactiveAria = "Companion is on. Click to change companion mode and tool access."
     } else {
       Icon = Moon
       modeLabel = "Quiet"
       pillVariant = "border-border bg-secondary text-muted-foreground"
       hoverVariant = "hover:bg-accent hover:text-foreground"
       iconTint = ""
-      interactiveAria = "Quiet mode. Click to change."
-      tooltipBody = "Silent capture — no AI replies. Click to change."
+      interactiveAria = "Quiet mode. Click to change companion mode and tool access."
     }
 
     const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
 
-    if (isDraft) {
-      // The draft pill is live: it opens an in-flow popover to set companion
-      // mode and tool access before the scratchpad is server-created. The
-      // settings dialog can't be used yet (it reads caches with no draft row),
-      // so the choices are written to the local draft and threaded into the
-      // create request on the first message.
-      companionModeIndicator = (
-        <Popover>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              aria-label="Companion mode and tool access. Click to change."
-              className={cn(
-                pillBase,
-                pillVariant,
-                "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                hoverVariant
-              )}
-            >
-              <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
-              <span>{modeLabel}</span>
-            </button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-80">
+    // One in-flow popover for both drafts and live scratchpads: companion mode
+    // and (owner-only) tool access. The trailing chevron + hover state make the
+    // pill read as a control. Drafts write to the local draft (the settings
+    // dialog can't be used pre-create); live scratchpads use live mutations.
+    companionModeIndicator = (
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={interactiveAria}
+            className={cn(
+              pillBase,
+              pillVariant,
+              "cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+              hoverVariant
+            )}
+          >
+            <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
+            <span>{modeLabel}</span>
+            <ChevronDown className="h-3 w-3 -mr-0.5 opacity-60" aria-hidden="true" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-80">
+          {isDraft ? (
             <DraftAgentSettings
               workspaceId={workspaceId!}
               draftId={streamId!}
@@ -372,32 +368,17 @@ export function StreamPage() {
               allowedToolCategories={stream.allowedToolCategories ?? null}
               configuredCategories={workspaceMetadata?.configuredToolCategories}
             />
-          </PopoverContent>
-        </Popover>
-      )
-    } else {
-      companionModeIndicator = (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => openStreamSettings(streamId, "companion")}
-              aria-label={interactiveAria}
-              className={cn(
-                pillBase,
-                pillVariant,
-                "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                hoverVariant
-              )}
-            >
-              <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
-              <span>{modeLabel}</span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>{tooltipBody}</TooltipContent>
-        </Tooltip>
-      )
-    }
+          ) : (
+            <LiveAgentSettings
+              workspaceId={workspaceId!}
+              streamId={streamId!}
+              companionMode={stream.companionMode}
+              e2e={isEncrypted}
+            />
+          )}
+        </PopoverContent>
+      </Popover>
+    )
   }
 
   let headerTitle: React.ReactNode

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -20,6 +20,8 @@ import {
   ChevronDown,
 } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { DraftAgentSettings } from "@/components/stream-settings/draft-agent-settings"
 import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
@@ -31,7 +33,7 @@ import {
 } from "@/components/layout/sidebar/sidebar-actions"
 import { cn } from "@/lib/utils"
 import { useStreamOrDraft, useStreamError, usePanelLayout, isDmDraftId, useTypeToFocus } from "@/hooks"
-import { useWorkspaceDmPeers } from "@/stores/workspace-store"
+import { useWorkspaceDmPeers, useWorkspaceMetadata } from "@/stores/workspace-store"
 import { usePanel, useSidebar } from "@/contexts"
 import { useUserProfile } from "@/components/user-profile"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
@@ -134,6 +136,7 @@ export function StreamPage() {
   const { openStreamSettings } = useStreamSettings()
   const { open: openExplorer } = useExplorerUrlState()
   const dmPeers = useWorkspaceDmPeers(workspaceId ?? "")
+  const workspaceMetadata = useWorkspaceMetadata(workspaceId ?? "")
   // For an unlocked encrypted stream, the tamper-evident decrypted name; null
   // otherwise (plaintext stream, locked, or not yet decrypted) → plaintext label.
   const decryptedStreamName = useDecryptedStreamName(workspaceId ?? "", stream)
@@ -308,7 +311,6 @@ export function StreamPage() {
     let hoverVariant: string
     let iconTint: string
     let interactiveAria: string
-    let inertAria: string
     let tooltipBody: string
 
     if (isEncrypted) {
@@ -318,7 +320,6 @@ export function StreamPage() {
       hoverVariant = "hover:bg-accent"
       iconTint = "text-muted-foreground"
       interactiveAria = "End-to-end encrypted. Open companion settings."
-      inertAria = "End-to-end encrypted"
       tooltipBody = "End-to-end encrypted — Companion is disabled. Click for details."
     } else if (isOn) {
       Icon = Sparkles
@@ -327,7 +328,6 @@ export function StreamPage() {
       hoverVariant = "hover:bg-primary/10"
       iconTint = "text-primary"
       interactiveAria = "Companion is on. Click to change."
-      inertAria = "Companion on"
       tooltipBody = "Ariadne replies to new messages. Click to change."
     } else {
       Icon = Moon
@@ -336,18 +336,44 @@ export function StreamPage() {
       hoverVariant = "hover:bg-accent hover:text-foreground"
       iconTint = ""
       interactiveAria = "Quiet mode. Click to change."
-      inertAria = "Quiet mode"
       tooltipBody = "Silent capture — no AI replies. Click to change."
     }
 
     const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
 
     if (isDraft) {
+      // The draft pill is live: it opens an in-flow popover to set companion
+      // mode and tool access before the scratchpad is server-created. The
+      // settings dialog can't be used yet (it reads caches with no draft row),
+      // so the choices are written to the local draft and threaded into the
+      // create request on the first message.
       companionModeIndicator = (
-        <span className={cn(pillBase, pillVariant)} aria-label={inertAria}>
-          <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
-          <span>{modeLabel}</span>
-        </span>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Companion mode and tool access. Click to change."
+              className={cn(
+                pillBase,
+                pillVariant,
+                "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                hoverVariant
+              )}
+            >
+              <Icon className={cn("h-3 w-3", iconTint)} aria-hidden="true" />
+              <span>{modeLabel}</span>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80">
+            <DraftAgentSettings
+              workspaceId={workspaceId!}
+              draftId={streamId!}
+              companionMode={stream.companionMode}
+              allowedToolCategories={stream.allowedToolCategories ?? null}
+              configuredCategories={workspaceMetadata?.configuredToolCategories}
+            />
+          </PopoverContent>
+        </Popover>
       )
     } else {
       companionModeIndicator = (

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1995,6 +1995,7 @@ export async function applyWorkspaceBootstrap(
       emojis: bootstrap.emojis,
       emojiWeights: bootstrap.emojiWeights,
       commands: bootstrap.commands,
+      configuredToolCategories: bootstrap.configuredToolCategories,
       _cachedAt: now,
     }),
   ])
@@ -2210,6 +2211,7 @@ export async function applyReconnectBootstrapBatch(
           emojis: finalBootstrap.emojis,
           emojiWeights: finalBootstrap.emojiWeights,
           commands: finalBootstrap.commands,
+          configuredToolCategories: finalBootstrap.configuredToolCategories,
           _cachedAt: now,
         }),
       ])

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -2078,6 +2078,7 @@ export async function applyWorkspaceBootstrap(
       emojis: bootstrap.emojis,
       emojiWeights: bootstrap.emojiWeights,
       commands: bootstrap.commands,
+      configuredToolCategories: bootstrap.configuredToolCategories,
       _cachedAt: now,
     },
   })
@@ -2318,6 +2319,7 @@ export async function applyReconnectBootstrapBatch(
       emojis: finalBootstrap.emojis,
       emojiWeights: finalBootstrap.emojiWeights,
       commands: finalBootstrap.commands,
+      configuredToolCategories: finalBootstrap.configuredToolCategories,
       _cachedAt: now,
     },
   })

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -796,7 +796,34 @@ no schema change.
 2. **Context handle shape for bots (N-4):** inline last-N history in the
    invocation vs. a fetch-back ref. Inline is simpler and matches the
    enclave's assignment shape (30 messages); a ref scales better and keeps
-   invocation payloads small. Leaning inline-first.
+   invocation payloads small. Leaning inline-first. _Resolved as inline-first,
+   and it has already shipped (Phase 2.3, #871). The claim response carries an
+   `ExternalContextHandle` — `{ kind: "inline", messages }` — built by
+   `buildClaimContext` (`public-api/handlers.ts`): the last
+   `CLAIM_CONTEXT_MAX_MESSAGES` (30, mirroring the enclave's
+   `MAX_HISTORY_MESSAGES`) preceding the trigger, oldest → newest, the trigger
+   excluded (it rides as `promptMarkdown`), the runner's own prior replies
+   tagged `role: "assistant"` so a harness can rebuild a turn-taking transcript.
+   Inline wins now because the claim is already a round-trip: attaching 30
+   messages costs no extra call, no new authenticated read endpoint, and no
+   standing read scope — the very surface N-4 set out to avoid ("so a useful
+   third-party agent doesn't need broad standing read scopes"). A `ref` would
+   defer no access decision either: per-location scoping (INV-62) makes the
+   invocation's location the grant, so `buildClaimContext` runs the same
+   `resolveDeliveryVerdict` predicate regardless of handle shape — and withholds
+   the handle entirely for E2E / cross-workspace / missing-stream, where
+   plaintext history never leaves the enclave path. A ref would only move that
+   identical decision behind a second round-trip. Hydration is at claim time,
+   never double-stored on the invocation row (INV-57); `ExternalTurnDriver`
+   rejects a pre-resolved `contextHandle` loudly (INV-11) rather than dropping
+   it. The type is a discriminated union and `TurnDispatchBinding.contextHandle`
+   is a forward-compat slot, so the deferred `{ kind: "ref" }` variant — a
+   short-lived, invocation-scoped cursor the runner exchanges for paginated
+   history — is a non-breaking wire addition. Build it only when a concrete
+   payload-size trigger forces it: a deep-continuity window (§2.5 C-2, and Q7
+   below) or rolling summary too large for one claim response, or attachment
+   bytes that can't ride inline. Until then, inline is the entire contract
+   (INV-36)._
 3. **Where does the generalized stream tool policy live** — widen
    `e2e_streams.allowed_tool_categories`'s pattern to a `stream_policies`
    table vs. a column on `streams`? Tracking-table instinct (INV-57) suggests

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -827,7 +827,30 @@ no schema change.
 3. **Where does the generalized stream tool policy live** — widen
    `e2e_streams.allowed_tool_categories`'s pattern to a `stream_policies`
    table vs. a column on `streams`? Tracking-table instinct (INV-57) suggests
-   the former; read-path simplicity suggests the latter.
+   the former; read-path simplicity suggests the latter. _Resolved as the
+   tracking table, and it has already shipped (Phase 1.4, #847; see the Phase 1
+   status note above). Migration `20260611193158_stream_policies.sql` creates
+   `stream_policies (stream_id PK, workspace_id, allowed_tool_categories TEXT[],
+timestamps)`, carries the non-null `e2e_streams` rows over, and **drops**
+   `e2e_streams.allowed_tool_categories` — one source of truth for plaintext and
+   E2E alike, not two. `StreamPoliciesRepository.getToolPolicy`
+   (`streams/policy-repository.ts`) reads it; companion (`persona-agent.ts`) and
+   enclave (`enclave-runtimes/claim-service.ts` → the assignment) both fold it
+   over their toolsets through the same `negotiateCapabilities` /
+   `isToolAllowedByPolicy` predicate, so the gate is identical across hosts
+   (external bots bring their own tools and aren't gated here). The tracking
+   table won for the reasons INV-57 predicts: the policy is sparse and optional
+   (**a row exists only to RESTRICT — absence means "no restriction"**, so most
+   streams store nothing), and it is transient agent-policy state that doesn't
+   belong on the core `streams` identity row. Read-path simplicity, the column's
+   only edge, is a single keyed `SELECT` either way. Policy rows are keyed by
+   **non-thread root** streams; threads inherit via `rootStreamId` (INV-62), so
+   callers resolve thread → root before the lookup. Categories are validated in
+   code, not a DB enum (INV-3): `TOOL_PRIVACY_CATEGORIES` (`messaging` | `web` |
+   `workspace` | `github` | `linear` in `packages/types/src/tool-privacy.ts`),
+   with `messaging` always allowed. The "per-workspace policy" the category
+   comment gestures at is a future widening the same table absorbs (add a
+   workspace-scoped row or a sibling table) without revisiting this choice._
 4. **`sources: []` willful defeat** (prior doc's spike #3): add the test that
    a turn whose tool results carried sources commits non-empty sources, so the
    required-field guarantee isn't quietly defeated. _Resolved: the test

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -40,7 +40,7 @@ import type { UserPreferences } from "./preferences"
 import type { WorkspaceSettings } from "./workspace-settings"
 import type { FeatureFlags } from "./feature-flags"
 import type { SidebarConfig } from "./sidebar"
-import type { ToolPrivacyCategory } from "./tool-privacy"
+import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "./tool-privacy"
 import type { WorkspacePermissionSlug } from "./workspace-permissions"
 
 // ============================================================================
@@ -185,6 +185,14 @@ export interface StreamBootstrap {
    * `{bag: null, refs: []}` for streams without a bag.
    */
   contextBag?: StreamContextBagPayload
+  /**
+   * The scratchpad's tool-privacy policy: the tool categories its agent may use
+   * (`null` = no restriction). Only populated for scratchpads — the only
+   * surface that can set one; other stream types omit it. Drives the owner's
+   * tool-policy control in stream settings. Optional so older cached bootstrap
+   * payloads still validate.
+   */
+  allowedToolCategories?: ToolPrivacyPolicy
 }
 
 /**

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -60,6 +60,12 @@ interface CreateStreamInputBase {
   memberIds?: string[]
   /** Context bag attached to a new scratchpad (triggers summary pre-compute). */
   contextBag?: ContextBag
+  /**
+   * Tool-privacy policy to apply at creation (scratchpads only). Omitted =
+   * unrestricted; an array (incl. `[]`) restricts the agent to those
+   * categories. Persisted to `stream_policies` in the create transaction.
+   */
+  allowedToolCategories?: ToolPrivacyPolicy
 }
 
 /**
@@ -1183,6 +1189,14 @@ export interface WorkspaceBootstrap {
    * operator actions and take effect on the next bootstrap.
    */
   viewerIsPlatformAdmin?: boolean
+  /**
+   * Agent tool categories the workspace has tooling configured for: `web` and
+   * `workspace` always, `github`/`linear` only when connected. Drives the
+   * scratchpad tool-policy picker — chiefly the at-creation control, which has
+   * no per-stream bootstrap to read from yet. Optional for older cached
+   * payloads (absent reads as "all gateable").
+   */
+  configuredToolCategories?: ToolPrivacyCategory[]
 }
 
 // ============================================================================

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -193,6 +193,13 @@ export interface StreamBootstrap {
    * payloads still validate.
    */
   allowedToolCategories?: ToolPrivacyPolicy
+  /**
+   * Which tool categories the owner's policy picker should offer for this
+   * scratchpad: `web` and `workspace` are always present; `github` / `linear`
+   * appear only when that integration is connected for the workspace. Scratchpad
+   * bootstraps only; absent elsewhere (and on older cached payloads).
+   */
+  configuredToolCategories?: ToolPrivacyCategory[]
 }
 
 /**


### PR DESCRIPTION
**Tracking:** agent-runtimes unification §2.8 Q2/Q3, and the product follow-on to the `stream_policies` table (Phase 1.4, #847).

## Problem

The per-stream agent tool policy shipped its hard half — the `stream_policies` table and enforcement — in Phase 1.4 (#847): `StreamPoliciesRepository.getToolPolicy` is read at every turn and folded over the toolset via `negotiateCapabilities` on both the companion (`persona-agent.ts`) and enclave (`enclave-runtimes/claim-service.ts`) paths. But nothing could **write** a policy. The repository exposed only `getToolPolicy`; there was no service method, no endpoint, and no UI. A grep for `INSERT INTO stream_policies` / `setToolPolicy` came back empty — the only rows that could exist were the one-time carry-over the Phase 1.4 migration moved off the dropped `e2e_streams.allowed_tool_categories` column. So a scratchpad owner had no way to say "Ariadne may only use web tools here," even via the API.

This branch also settles two open §2.8 design questions whose answers turned out to already be shipped (Q2 inline context handle, Q3 the `stream_policies` tracking table) — recorded as rulings in the redesign doc.

## Solution

Add the owner-only write path and the settings control, scoped — per Kris's call — to **scratchpads only, owner-only**, then extend it so the policy can also be chosen **at creation, in-flow** (see the Update section). The storage model and enforcement are untouched; this is the write + read-back + UI slice on top of them, mirroring the existing `/companion` sub-resource almost exactly.

### How it works

- **Write (`PATCH /api/workspaces/:workspaceId/streams/:streamId/tool-policy`).** `handlers.ts:updateToolPolicy` validates the body with Zod against `TOOL_PRIVACY_CATEGORIES` (INV-55), then `validateStreamAccess` → reject non-scratchpad (400, `HttpError`) → reject non-owner via `stream.createdBy !== userId` (403, `HttpError`). `StreamService.setStreamToolPolicy` calls the new `StreamPoliciesRepository.setToolPolicy` on `pool` directly (single statement, INV-30) with **no outbox event**: enforcement re-reads the policy at the next turn's claim/dispatch, so a change takes effect on the next agent turn without a broadcast.
- **The `null`/`[]`/list distinction is load-bearing.** `setToolPolicy` branches: `null` (no restriction) **DELETEs** the row — the column is `NOT NULL`, so absence, not a stored NULL, expresses "unrestricted"; a non-null policy is upserted race-safely (`ON CONFLICT (stream_id) DO UPDATE`, INV-20), and `[]` ("no tools, reply only") persists as a real row distinct from the deleted case.
- **Read-back rides the owner's own bootstrap.** The scratchpad bootstrap returns `allowedToolCategories` (current policy) and `configuredToolCategories` (which categories the workspace has tooling for), computed in parallel with the existing bootstrap queries, scratchpad-only. Both sit on the `StreamBootstrap` envelope — deliberately **off** the core `Stream` type and the `StreamWithPreview` sidebar projection, consistent with the Q3 tracking-table ruling.
- **`configuredToolCategories` hides unconnected integrations.** `WorkspaceIntegrationService.getAvailableToolCategories` returns `web` + `workspace` always, and `github` / `linear` only when that integration is enabled for the deployment **and** connected (`status === ACTIVE`) for the workspace — short-circuiting the DB when the provider is env-disabled. So a workspace without GitHub connected never offers the GitHub toggle.
- **The picker reflects the runtime.** `ToolPolicyPicker` (rendered in the companion tab, gated to the scratchpad owner) shows a "Restrict tool access" switch — off → `null`, on → reveal the configured-category checkboxes (empty = reply-only). On an **encrypted** scratchpad, the categories the enclave doesn't build yet (everything but `web` — the enclave is web-only) render disabled with a "Soon" tag and a hover tooltip explaining they aren't available inside the enclave today.

### Key design decisions

**1. Scratchpads only, owner-only.** Kris's call: the tool policy is a personal guardrail on the solo surface, not a shared-channel admin setting. The handler rejects non-scratchpads (400) and non-owners (403); the companion-mode sibling control uses member-level auth, but this one is stricter by intent.

**2. No outbox, no real-time broadcast (INV-36).** Enforcement re-reads the policy from the DB at each turn's claim/dispatch, so correctness needs no event. The editing client patches its own bootstrap cache; other clients pick the value up on their next bootstrap/reconnect (INV-53).

**3. Value on the bootstrap envelope, not the `Stream` type.** Keeps policy off the identity row on the read side too (matching the Q3 ruling), and avoids a LEFT JOIN on every sidebar row.

**4. Surface integration state via the bootstrap, not the integrations API.** The `GET /integrations/{provider}` endpoints are admin-gated (`routes.ts`, `requireWorkspaceAdmin`), so a regular scratchpad owner can't call them. Folding the booleans onto a bootstrap the owner already loads is the member-visible path that needs no auth change.

**5. Enclave-unimplemented categories are shown-disabled, not hidden.** On E2E they're real future capabilities, so the owner should see them coming. The enclave-implemented set is a single frontend constant (`ENCLAVE_TOOL_CATEGORIES = {"web"}`).

## Update — set the policy at creation, in-flow (commit `df5357f`)

The settings control above only applies after the scratchpad exists. This adds setting the policy **before** creation, without leaving the flow. Scratchpad creation is form-less (a local draft lands you in the stream; the server `POST /streams` fires on the first message), so the choice rides the draft:

- **The draft companion pill goes live.** It was an inert `<span>` on drafts (the settings dialog reads caches with no draft row yet). It now opens a popover (`DraftAgentSettings`) with **companion mode + tool access**. Choices write to the local `DraftScratchpad` (`allowedToolCategories`) and thread into `CreateStreamInput` when the first message promotes the draft (`use-stream-or-draft` → `PendingStreamCreation` → `promoteDraft`). The backend persists the policy in the **same create transaction** as the stream row (`createScratchpad`), like the E2E flag and context bag — so the first turn already respects it. Drafts are always plaintext, so the enclave "Soon" gating never applies here.
- **`createStreamSchema`** accepts an optional `allowedToolCategories` (scratchpad-only refinement, INV-55); the handler threads it through `streamService.create`.
- **The picker splits** into a presentational, controlled `ToolPolicyControl` (`value` + `onChange`) shared by the settings wrapper (live mutation) and the draft popover (local draft write). `ToolPolicyPicker`'s external API is unchanged, so the settings path and its test are untouched.
- **Connected integrations are wired into the workspace bootstrap** (`configuredToolCategories`, via `getAvailableToolCategories`) and cached in `workspaceMetadata`, so the at-creation picker — which has no stream bootstrap to read — can hide unconnected GitHub/Linear. (The stream bootstrap keeps its own copy for the open-stream settings context.)

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/stream-settings/tool-policy-picker.tsx` | `ToolPolicyControl` (presentational, controlled) + `ToolPolicyPicker` (settings wrapper). |
| `apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx` | Picker behavior: toggle on→`[]`, add category, toggle off→`null`, hide unconfigured, disable non-web on E2E. |
| `apps/frontend/src/components/stream-settings/draft-agent-settings.tsx` | At-creation popover: companion mode + tool access, written to the draft. |
| `apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx` | Draft popover writes companion mode + policy; hides unconfigured categories. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/policy-repository.ts` | Add `setToolPolicy`: `null`→DELETE, else race-safe upsert. |
| `apps/backend/src/features/streams/service.ts` | Add `setStreamToolPolicy`; thread `allowedToolCategories` into `create`/`createScratchpad` (same transaction). |
| `apps/backend/src/features/streams/handlers.ts` | Add `updateToolPolicy` (scratchpad+owner gate, `HttpError`); accept `allowedToolCategories` in `createStreamSchema`; stream bootstrap returns `allowedToolCategories` + `configuredToolCategories`. |
| `apps/backend/src/features/workspaces/handlers.ts` | Workspace bootstrap returns `configuredToolCategories`. |
| `apps/backend/src/routes.ts` | Mount `PATCH …/tool-policy`; pass `workspaceIntegrationService` to stream + workspace handlers. |
| `apps/backend/src/features/workspace-integrations/service.ts` | Add `getAvailableToolCategories`. |
| `packages/types/src/api.ts` | `StreamBootstrap` + `WorkspaceBootstrap` gain the optional fields; `CreateStreamInput` gains `allowedToolCategories`. |
| `apps/frontend/src/api/streams.ts`, `hooks/use-streams.ts`, `contexts/services-context.tsx` | `updateToolPolicy` API + mutation + interface. |
| `apps/frontend/src/components/stream-settings/{companion-tab,stream-settings-dialog}.tsx` | Render the settings picker for the scratchpad owner. |
| `apps/frontend/src/db/database.ts` | `DraftScratchpad.allowedToolCategories`, `PendingStreamCreation.allowedToolCategories`, `CachedWorkspaceMetadata.configuredToolCategories`. |
| `apps/frontend/src/sync/workspace-sync.ts` | Cache `configuredToolCategories` into `workspaceMetadata`. |
| `apps/frontend/src/hooks/{use-draft-scratchpads,use-stream-or-draft,use-message-queue}.ts` | Carry the draft policy through to the create request. |
| `apps/frontend/src/pages/stream.tsx` | Draft companion pill → in-flow popover. |
| `apps/backend/src/features/streams/{policy-repository,handlers}.test.ts`, `workspace-integrations/service.test.ts` | Repo null/`[]`/list; handler auth + create threading; `getAvailableToolCategories`. |
| `docs/plans/agent-runtimes-unification-redesign.md` | §2.8 Q2 + Q3 resolution notes. |

## Out of scope (deliberate)

- **Persona-level `enabledTools` UI** — no UI exists today; the same picker pattern could be reused later.
- **Per-workspace default policy** — the same table absorbs it without revisiting this choice.
- **Building the missing enclave tools** so non-`web` categories bite on E2E — until then they're shown-disabled.
- **Real-time `stream:updated` for policy changes** — see decision 2.

## Test plan

- [x] Backend `bun test src/features/streams` — 86 pass; `workspace-integrations/service.test.ts` green
- [x] Frontend stream-settings folder (picker + draft popover + dialog) + touched hooks/sync — green (`use-stream-or-draft`, `use-streams`, `use-message-queue`, `workspace-sync` — 41 pass)
- [x] `bun run typecheck` clean across all 14 workspaces
- [x] `generate-api-docs --check` clean (app's own API, not the public OpenAPI surface)
- [x] Pre-PR self-review (2 reviewer agents) on the first slice: claim-verification 11/11 TRUE; correctness 0 bugs; 1 finding fixed (INV-32 `HttpError`), 1 dismissed (Zod accepts `"messaging"`, harmless)
- [ ] No live-DB harness in the backend unit suites, so the upsert/delete + create-transaction SQL is covered via stubbed `Querier`/service mocks, not integration-tested against Postgres.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Let a scratchpad owner set which tool categories its agent may use — in stream settings (after creation) and **in-flow at creation** — persisted to the existing `stream_policies` table. Closes the write/UI gap left when Phase 1.4 (#847) shipped storage + enforcement but no writer.

**What was built.**
- Backend: `setToolPolicy` (null→DELETE / upsert), `setStreamToolPolicy`, `PATCH …/tool-policy` (scratchpad+owner), `createScratchpad` persists an at-creation policy in the create transaction, `getAvailableToolCategories`, stream + workspace bootstraps expose `configuredToolCategories`.
- Types: `StreamBootstrap`/`WorkspaceBootstrap` optional fields; `CreateStreamInput.allowedToolCategories`.
- Frontend: presentational `ToolPolicyControl` shared by the settings `ToolPolicyPicker` and the at-creation `DraftAgentSettings` popover (live draft companion pill); draft carries the policy through to create; `workspaceMetadata` caches `configuredToolCategories`.

**Design decisions.** (1) Scratchpad-only, owner-only (Kris). (2) No outbox — re-read at turn time. (3) Bootstrap envelope, not `Stream` type. (4) Integration state via bootstrap (integrations API is admin-gated). (5) Enclave-unimplemented categories shown-disabled. (6) Form-less creation → the choice rides the local draft, threaded into the create transaction.

**Design evolution.** Picker first showed all four categories unconditionally and ignored E2E → refined (`3ff1acc`) to hide unconfigured integrations + disable enclave-unimplemented on E2E. Self-review converted the handler guards to `HttpError` (INV-32). At-creation flow added (`df5357f`) after exploring in-flow options — the live draft pill popover (Option A), with connected integrations moved onto the workspace bootstrap.

**Schema changes.** None — `stream_policies` already exists (Phase 1.4); no migration. No IDB schema bump (new fields are non-indexed).

**What's NOT included.** Persona `enabledTools` UI; per-workspace default; the missing enclave tools; real-time policy broadcast.

**Status.** Backend + frontend + types complete; tests green; typecheck clean. Also carries the §2.8 Q2/Q3 doc rulings.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_