### PR TITLE
feat(sync-v2): invitation:* client handler + sync_log backlog rescope

### DIFF
--- a/apps/backend/src/db/migrations/20260613192319_scope_invitation_sync_log_groups.sql
+++ b/apps/backend/src/db/migrations/20260613192319_scope_invitation_sync_log_groups.sql
@@ -1,0 +1,38 @@
+-- One-time rescope of pre-existing invitation entries in sync_log.
+-- (sync engine v2; docs/plans/sync-v2-healing-deletion-inventory.md, the
+-- `invitation:*` follow-up.)
+--
+-- Invitation lifecycle events carry invitee identity (email) and invite-link
+-- token hashes. They are now permission-scoped to members:write holders
+-- (apps/backend/src/lib/outbox/delivery-groups.ts → permission:members:write),
+-- so both the live socket emit and catch-up replay reach only privileged
+-- members. Entries written BEFORE that scoping deployed fell through to the
+-- workspace fallback and were logged with groups = ['workspace'], so catch-up's
+-- group-overlap filter (features/sync/repository.ts:listEntriesForUser) would
+-- still return them — and replay their payloads — to any member, not just
+-- members:write holders.
+--
+-- This was inert while no client read invitation events. The frontend now
+-- registers an `invitation:*` handler (apps/frontend/src/sync/workspace-sync.ts),
+-- so those backlog rows would deliver invitee email + token hash to a
+-- non-privileged member's browser on catch-up until 30-day retention ages them
+-- out (docs/plans/sync-v2-log-retention.md). Rewriting their groups to the
+-- members:write permission group closes that window: the catch-up filter then
+-- admits them only for holders, exactly like a post-scoping row.
+--
+-- Idempotent: post-scoping rows already carry ['permission:members:write'] and
+-- do not match the ['workspace'] predicate, so re-running is a no-op. No FKs
+-- (INV-1); workspace-scoped by table (INV-8). Runs before the server accepts
+-- connections, so no outbox events are emitted. Group membership is identity,
+-- not order, so rewriting groups opens no sync-id gap and owes no floor signal.
+
+UPDATE sync_log
+SET groups = ARRAY['permission:members:write']
+WHERE event_type IN (
+    'invitation:sent',
+    'invitation:accepted',
+    'invitation:revoked',
+    'invitation:link-created',
+    'invitation:link-claimed'
+  )
+  AND groups = ARRAY['workspace']::text[];

--- a/apps/frontend/src/api/invitations.ts
+++ b/apps/frontend/src/api/invitations.ts
@@ -10,6 +10,13 @@ import type {
   ClaimInvitationLinkResponse,
 } from "@threa/types"
 
+export const invitationKeys = {
+  all: ["invitations"] as const,
+  /** The pending-invitations list for one workspace — the invalidation target
+   *  when an `invitation:*` event lands (workspace-sync). */
+  list: (workspaceId: string) => [...invitationKeys.all, workspaceId] as const,
+}
+
 export const invitationsApi = {
   async list(workspaceId: string): Promise<WorkspaceInvitation[]> {
     const res = await api.get<{ invitations: WorkspaceInvitation[] }>(`/api/workspaces/${workspaceId}/invitations`)

--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -23,7 +23,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { ActorAvatar } from "@/components/actor-avatar"
-import { invitationsApi } from "@/api/invitations"
+import { invitationsApi, invitationKeys } from "@/api/invitations"
 import { ApiError } from "@/api/client"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { useFormattedDate } from "@/hooks"
@@ -113,7 +113,7 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
   const removeMutation = useRemoveWorkspaceMember(workspaceId)
 
   const invitationsQuery = useQuery({
-    queryKey: ["invitations", workspaceId],
+    queryKey: invitationKeys.list(workspaceId),
     queryFn: () => invitationsApi.list(workspaceId),
   })
 

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -12,6 +12,7 @@ import { SocketEventGate } from "./socket-event-gate"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
 import { memoKeys } from "@/hooks/use-memos"
+import { invitationKeys } from "@/api/invitations"
 import {
   DEFAULT_SIDEBAR_CONFIG,
   DEFAULT_QUICK_LINKS,
@@ -836,6 +837,57 @@ describe("registerWorkspaceSocketHandlers", () => {
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_other") })
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })
     cleanup()
+  })
+
+  const invitationEventTypes = [
+    "invitation:sent",
+    "invitation:accepted",
+    "invitation:revoked",
+    "invitation:link-created",
+    "invitation:link-claimed",
+  ] as const
+
+  it.each(invitationEventTypes)("invalidates the invitations list when %s lands", (eventType) => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, "active")
+
+    emit(eventType, { workspaceId: "ws_1", invitationId: "invite_1" })
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: invitationKeys.list("ws_1") })
+    cleanup()
+  })
+
+  it("ignores invitation events from other workspaces", () => {
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs, "active")
+
+    emit("invitation:sent", { workspaceId: "ws_other", invitationId: "invite_1" })
+
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: invitationKeys.list("ws_other") })
+    expect(invalidate).not.toHaveBeenCalledWith({ queryKey: invitationKeys.list("ws_1") })
+    cleanup()
+  })
+
+  it("invalidates the invitations list on a gate-dispatched catch-up replay", async () => {
+    // The coverage proof: in active mode the invitation handler registers on
+    // the engine's event gate, so a catch-up replay (gate.dispatch, never the
+    // raw socket) heals an open list through the same path as a live emit —
+    // this is what lets another admin's invite/revoke reach a viewer who was
+    // disconnected when it happened.
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const gate = new SocketEventGate("ws_1")
+    const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs, "active")
+
+    await gate.dispatch("invitation:revoked", { workspaceId: "ws_1", invitationId: "invite_1" })
+
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: invitationKeys.list("ws_1") })
+    cleanup()
+    gate.dispose()
   })
 
   it("subscribes the creator when a new stream is created at runtime", async () => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -35,6 +35,7 @@ import type {
 } from "@threa/types"
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
 import { memoKeys } from "@/hooks/use-memos"
+import { invitationKeys } from "@/api/invitations"
 import { savedSuggestionKeys } from "@/hooks/use-saved-suggestions"
 import { persistScheduledRows, removeScheduledRow, scheduledKeys } from "@/hooks/use-scheduled"
 import { assignmentToCached, assignmentId } from "@/hooks/use-labels"
@@ -1346,6 +1347,20 @@ export function registerWorkspaceSocketHandlers(
     queryClient.invalidateQueries({ queryKey: memoKeys.searches(workspaceId) })
   }
 
+  // Invitation lifecycle (sent / accepted / revoked / link-created /
+  // link-claimed): heal the settings → users invitation list for every admin,
+  // not just the one who performed the mutation. The five events are
+  // permission-scoped to members:write holders (delivery-groups.ts) — logged and
+  // emitted to that group only — so registering here both updates an open list
+  // live and replays through the sync-v2 catch-up cursor on reconnect, the same
+  // query a viewer's own send/revoke/resend mutation already invalidates. Every
+  // payload carries workspaceId; the differing per-event fields are unused since
+  // we only invalidate.
+  const handleInvitationChanged = (payload: { workspaceId: string }) => {
+    if (payload.workspaceId !== workspaceId) return
+    queryClient.invalidateQueries({ queryKey: invitationKeys.list(workspaceId) })
+  }
+
   // Handle attachment transcoded (video processing completed or failed)
   const handleAttachmentTranscoded = async (payload: {
     workspaceId: string
@@ -1688,6 +1703,11 @@ export function registerWorkspaceSocketHandlers(
   socket.on("bot:updated", handleBotUpdated)
   socket.on("activity:created", handleActivityCreated)
   socket.on("memo:created", handleMemoCreated)
+  socket.on("invitation:sent", handleInvitationChanged)
+  socket.on("invitation:accepted", handleInvitationChanged)
+  socket.on("invitation:revoked", handleInvitationChanged)
+  socket.on("invitation:link-created", handleInvitationChanged)
+  socket.on("invitation:link-claimed", handleInvitationChanged)
   socket.on("saved:upserted", handleSavedUpserted)
   socket.on("saved:deleted", handleSavedDeleted)
   socket.on("saved_reminder:fired", handleSavedReminderFired)
@@ -1730,6 +1750,11 @@ export function registerWorkspaceSocketHandlers(
     socket.off("bot:updated", handleBotUpdated)
     socket.off("activity:created", handleActivityCreated)
     socket.off("memo:created", handleMemoCreated)
+    socket.off("invitation:sent", handleInvitationChanged)
+    socket.off("invitation:accepted", handleInvitationChanged)
+    socket.off("invitation:revoked", handleInvitationChanged)
+    socket.off("invitation:link-created", handleInvitationChanged)
+    socket.off("invitation:link-claimed", handleInvitationChanged)
     socket.off("saved:upserted", handleSavedUpserted)
     socket.off("saved:deleted", handleSavedDeleted)
     socket.off("saved_reminder:fired", handleSavedReminderFired)

--- a/docs/plans/sync-v2-healing-deletion-inventory.md
+++ b/docs/plans/sync-v2-healing-deletion-inventory.md
@@ -239,18 +239,22 @@ treating such a flag as real healing — it may be dead code (labels was).
   holders — the catch-up handler passes the same role-derived `permissionGroups`
   into `listEntriesForUser`, so live and replay delivery stay congruent. This
   mirrors the bootstrap gate (`workspaces/handlers.ts` includes `invitations`
-  only for `members:write`). Pre-change `sync_log` rows keep their old
-  `['workspace']` groups until they age out of retention, but they are inert (no
-  client handler reads invitation events yet). What remains is purely
-  client-side: there is no `invitation:*` handler in `sync/workspace-sync.ts`,
-  and the only frontend surface — the `["invitations", workspaceId]` query in
-  `components/workspace-settings/users-tab.tsx` (settings → users) — refreshes
-  only on the viewer's own send/revoke/resend mutations and on a full workspace
-  bootstrap, so an invitation another admin sends or revokes in another session
-  never updates a viewer's open list until they remount or re-bootstrap. Once a
-  gate-registered handler invalidates `["invitations", workspaceId]`, live emits
-  and catch-up replays both heal the list and the standard coverage-proof chain
-  applies.
+  only for `members:write`). **Client handler now landed (DONE):** a
+  gate-registered `invitation:*` handler in `sync/workspace-sync.ts` invalidates
+  `invitationKeys.list(workspaceId)` (`api/invitations.ts`; the
+  `["invitations", workspaceId]` query the only frontend surface —
+  `components/workspace-settings/users-tab.tsx`, settings → users — reads). The
+  list used to refresh only on the viewer's own send/revoke/resend mutations and
+  on a full workspace bootstrap; now an invitation another admin sends or revokes
+  in another session heals a viewer's open list live, and a catch-up replay heals
+  it after a disconnect — the standard coverage-proof chain (event type → group
+  → `sync_log` → `gate.dispatch`) applies. Pre-change `sync_log` rows that fell
+  through to `['workspace']` would have replayed their payloads to non-holders on
+  catch-up once a handler existed, so the same change ships a one-time migration
+  (`20260613192319_scope_invitation_sync_log_groups.sql`) rewriting their groups
+  to `['permission:members:write']` — idempotent (post-scoping rows already carry
+  it) and aligned with the live routing, closing the backlog window the 30-day
+  retention would otherwise leave open.
 - **`refetchOnMount: true`** on saved/scheduled/labels/activity: mount-time
   freshness, not reconnect healing. Out of scope.
 - **`useBackgroundBootstrapSync`** (SW prefetch) and **`useAppUpdate`**


### PR DESCRIPTION
## Problem

Invitation lifecycle events (`invitation:sent` / `accepted` / `revoked` / `link-created` / `link-claimed`) had no frontend consumer. The only surface that shows them — the `["invitations", workspaceId]` query in `apps/frontend/src/components/workspace-settings/users-tab.tsx` (settings → users) — refreshed only on the viewer's *own* send/revoke/resend mutations (via `invitationsQuery.refetch()`) and on a full workspace bootstrap. So an invitation another admin sent or revoked in a different session never updated a viewer's open list until they remounted or re-bootstrapped.

This was the last open follow-up from #920, which scoped these events to `permission:members:write` holders on the backend (`apps/backend/src/lib/outbox/delivery-groups.ts`) but documented the client handler as the remaining additive work (`docs/plans/sync-v2-healing-deletion-inventory.md`).

A second, latent issue surfaces the moment a client *does* read these events: `sync_log` rows written **before** the #920 scoping deployed carry `groups = ['workspace']` (the old `resolveDeliveryGroups` workspace fallback). The catch-up filter `listEntriesForUser` (`apps/backend/src/features/sync/repository.ts:180`) is `l.groups && (ARRAY['workspace', 'user:'||userId]::text[] || permissionGroups::text[])` — an array-overlap test — so a `['workspace']` row matches *every* member, not just `members:write` holders. Those backlog rows carry invitee `email` and invite-link `tokenHash` in their payloads. Inert while nothing read invitation events; a real catch-up exposure to non-holders once a handler exists.

## Solution

Mirror the `memo:created` additive (#891): a gate-registered `invitation:*` handler in `apps/frontend/src/sync/workspace-sync.ts` that invalidates the invitations list. Because handlers register on the `SyncEventSource` (the engine's event gate in active mode), the same handler is reached by both live socket emits and catch-up replay (`gate.dispatch`) — so the list heals live *and* after a disconnect, for every `members:write` holder. Pair it with a one-time migration that rescopes the pre-#920 `sync_log` backlog so it can't replay payloads to non-holders.

### How it works

1. **`handleInvitationChanged`** (`workspace-sync.ts`) — one closure registered for all five event types. Guards `payload.workspaceId === workspaceId`, then `queryClient.invalidateQueries({ queryKey: invitationKeys.list(workspaceId) })`. Every invitation payload carries `workspaceId`; the differing per-event fields (email, role, tokenHash) are never read — the handler only invalidates, so it discloses nothing itself, and the re-fetch hits `/api/workspaces/:id/invitations`, which is gated by `requireWorkspacePermission(members:write)`.
2. **Key centralization** — `invitationKeys.list(workspaceId)` in `apps/frontend/src/api/invitations.ts` replaces the inline `["invitations", workspaceId]` magic array, so the handler and the consumer share one source of truth (INV-33). `list()` produces the identical key shape, so no cache-key migration.
3. **Backlog migration** — `20260613192319_scope_invitation_sync_log_groups.sql` runs at boot (before connections), one `UPDATE sync_log SET groups = ARRAY['permission:members:write'] WHERE event_type IN (…5 types…) AND groups = ARRAY['workspace']::text[]`. The equality predicate (not containment) means post-scoping rows already holding `['permission:members:write']` don't match — idempotent. After the rewrite, a non-holder's `permissionGroups` no longer overlaps the row's groups, so catch-up excludes it — exactly the live routing #920 established, applied to the backlog.

### Key design decisions

**1. Rescope, don't delete, the backlog rows.** Group membership is identity, not order — the workspace sync cursor advances by syncId with no per-syncId contiguity check (contiguity is the separate per-stream `broadcastSequence` mechanism, INV-61), so rewriting `groups` opens no gap and owes no floor signal. Deleting would have worked too but discards an audit row a holder *should* still receive on catch-up. The migration keeps holders' replay intact while removing only the non-holder overlap.

**2. One handler for five events, no debounce.** Invitation events are human-paced (an admin sends/revokes), so a bursty re-invalidation storm isn't a realistic load; TanStack already dedupes concurrent in-flight refetches. A single shared closure matches how sibling multi-event groups (`saved:*`, `label:*`) are wired in this file.

**3. Migration shipped alongside the handler, not separately.** The exposure is only reachable once a client reads these events — this PR is what activates it — so the fix and its safety belong in the same change to keep the #920 security property intact atomically. This was the handover's settled call ("if the client handler lands before they expire, add a one-time append-only migration").

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260613192319_scope_invitation_sync_log_groups.sql` | Rewrite pre-#920 invitation `sync_log` rows from `['workspace']` to `['permission:members:write']` so catch-up no longer replays invitee email / token hash to non-holders. Idempotent, append-only (INV-17). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/workspace-sync.ts` | Add `handleInvitationChanged`; register/unregister all five `invitation:*` events. |
| `apps/frontend/src/api/invitations.ts` | Add `invitationKeys` factory (`all`, `list(workspaceId)`). |
| `apps/frontend/src/components/workspace-settings/users-tab.tsx` | Use `invitationKeys.list(workspaceId)` instead of the inline key. |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Tests: per-event invalidation, cross-workspace guard, gate-dispatched catch-up replay. |
| `docs/plans/sync-v2-healing-deletion-inventory.md` | Mark the `invitation:*` follow-up DONE; document the migration. |

## Out of scope (deliberate)

- **The live-path demotion window** (a demoted admin whose socket never re-joins keeps receiving live invitation events until reconnect) — an accepted limitation from #920, matching the system's JWT-TTL permission model; catch-up is always current. Closing it fully (reacting to role-change events) is an unrequested follow-up.
- **Invitation list rendering / pagination** — unchanged; this only wires real-time + catch-up healing into the existing list.

## Test plan

- [x] Frontend `bunx vitest run src/sync` — 200 pass (9 files), incl. `workspace-sync.test.ts` 37 pass with 6 new invitation tests (5× per-event invalidation, cross-workspace ignore, gate-dispatched catch-up replay)
- [x] `tsc --noEmit` (frontend) + eslint on changed files — clean
- [x] Full pre-commit hook (monorepo lint, per-package tsc, astro check, OpenAPI `--check`) — passed
- [x] Pre-PR review (3 Sonnet reviewers: spec, correctness, design) — no issues; migration idempotency + leak-closure and listener-lifecycle verified
- [ ] Migration not integration-tested locally — no local DB in this web session; it's a static idempotent `UPDATE` validated by inspection and runs at server boot, so CI integration tests exercise it against a real DB

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9F3kkksxwJJevvWQABrQX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783971603&installation_id=129946197&pr_number=924&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F924&signature=4beb8f9fe2028df19ca42de75b54bc96b28bfda2f3db2492e2cdcf14f3aee38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->