### PR TITLE
fix(streams): keep granted-but-unconfigured tool categories revokable

### DIFF
--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx
@@ -85,6 +85,20 @@ describe("ToolPolicyPicker", () => {
     expect(screen.queryByRole("checkbox", { name: /linear/i })).not.toBeInTheDocument()
   })
 
+  it("still shows a granted category the workspace no longer configures, so it can be revoked", async () => {
+    renderPicker(["web", "github"], { configuredCategories: ["web", "workspace"] })
+
+    // GitHub is no longer configured but remains granted — it must stay visible
+    // and checked so the owner can turn it off.
+    const github = screen.getByRole("checkbox", { name: /github/i })
+    expect(github).toBeInTheDocument()
+    expect(github).toBeChecked()
+
+    await userEvent.click(github)
+
+    expect(updateToolPolicy).toHaveBeenCalledWith("ws_1", "stream_sp", ["web"])
+  })
+
   it("disables non-web categories on an encrypted scratchpad (enclave is web-only)", () => {
     renderPicker([], { configuredCategories: ["web", "workspace"], e2e: true })
 

--- a/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
+++ b/apps/frontend/src/components/stream-settings/tool-policy-picker.tsx
@@ -58,8 +58,14 @@ interface ToolPolicyControlProps {
 export function ToolPolicyControl({ value, onChange, configuredCategories, e2e, disabled }: ToolPolicyControlProps) {
   const restricted = value !== null
   const allowed = new Set(value ?? [])
-  const shown = configuredCategories ?? ALL_GATEABLE
-  const options = CATEGORY_OPTIONS.filter((option) => shown.includes(option.value))
+  // Show the configured categories *plus* anything already granted — a category
+  // can be stored (e.g. GitHub) and later un-configured (the integration is
+  // disconnected). Dropping it from the picker would strand the grant on,
+  // invisible and unrevokable; the union keeps it editable so the owner can turn
+  // it off. (The stored grant is already inert — no tools are built for it — so
+  // this is display-only, not an enforcement change.)
+  const shown = new Set<ToolPrivacyCategory>([...(configuredCategories ?? ALL_GATEABLE), ...allowed])
+  const options = CATEGORY_OPTIONS.filter((option) => shown.has(option.value))
 
   const handleRestrictToggle = (on: boolean) => onChange(on ? [] : null)
 


### PR DESCRIPTION
## Problem

The scratchpad agent tool-policy picker (`ToolPolicyControl` in `apps/frontend/src/components/stream-settings/tool-policy-picker.tsx`) built its visible category rows from the workspace's *configured* categories only:

```ts
const shown = configuredCategories ?? ALL_GATEABLE
const options = CATEGORY_OPTIONS.filter((option) => shown.includes(option.value))
```

A category can be granted to a scratchpad (stored in `stream_policies.allowed_tool_categories`) and *later* un-configured at the workspace level — e.g. the owner restricts the agent to `["web", "github"]`, then the GitHub integration is disconnected. `configuredToolCategories` then drops `github`, so the picker no longer renders the GitHub row. The grant stays stored, but the owner has no way to see or revoke it from the UI — it's stuck on and invisible.

This is the read-side cosmetic gap left open by #923's decision 5 (the write path deliberately does **not** validate granted categories against the configured set, because a stored-but-unconfigured grant is inert — no tools are built for it — and a hard reject would risk blocking scratchpad creation on a stale-cache disconnect).

## Solution

Show the union of configured categories and anything already granted, so a stranded grant stays visible and editable:

```ts
const shown = new Set<ToolPrivacyCategory>([...(configuredCategories ?? ALL_GATEABLE), ...allowed])
const options = CATEGORY_OPTIONS.filter((option) => shown.has(option.value))
```

The row renders checked; the owner can uncheck it, which writes the narrowed policy through the normal mutation path. Display-only — enforcement is unchanged (the grant was already inert), matching #923's decision 5 rather than reopening it.

Row ordering still derives from `CATEGORY_OPTIONS` (web → workspace → github → linear), and `messaging` can never leak in since it isn't a member of `CATEGORY_OPTIONS`.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/stream-settings/tool-policy-picker.tsx` | `shown` is now the union of `configuredCategories` and the already-granted `allowed` set, so a granted-but-unconfigured category stays in the picker. |
| `apps/frontend/src/components/stream-settings/tool-policy-picker.test.tsx` | Added a test: a `["web", "github"]` policy with only `["web", "workspace"]` configured still renders GitHub checked, and unchecking it narrows the policy to `["web"]`. |

## Test plan

- [x] `bun run test src/components/stream-settings/tool-policy-picker.test.tsx` — 7 pass (1 new)
- [x] `bun run test` on `draft-agent-settings` + `live-agent-settings` (other `ToolPolicyControl` callers) — 6 pass
- [x] `bun run typecheck` (14 workspaces) — clean
- [x] Pre-commit hooks (prettier, full typecheck, lint, `generate-api-docs --check`, astro) — clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011GokBgiVQbpuchjxgw1nc3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784013123&installation_id=129946197&pr_number=927&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F927&signature=ed682215edca5c09d094c817daf2b05cc84ec271075e05da74dd52bf78df9932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->