### PR TITLE
chore(sync): drop the v2 qualifier from sync engine comments, logs, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ CodeRabbit reviews PRs automatically using the project rules in `.coderabbit.yam
 
 If tests fail, fix them or explicitly isolate the failure in a separate follow-up change.
 
+### Opening Pull Requests
+
+When a unit of work is complete — committed, pushed, and verified — default to opening a pull request with the `/create-pr` skill rather than stopping at the pushed branch. The skill writes the structured description (summary, design decisions, file changes) the reviewers and CodeRabbit expect. Skip it only when the user has said not to open a PR, when the work is mid-stream and not yet coherent, or when a PR for the branch already exists (push the follow-up commits to it instead).
+
 ## Project Structure
 
 Monorepo with Bun workspaces:

--- a/apps/backend/src/features/activity/outbox-handler.ts
+++ b/apps/backend/src/features/activity/outbox-handler.ts
@@ -309,7 +309,7 @@ export class ActivityFeedHandler implements OutboxHandler {
    * one transaction per call to keep outbox writes batched.
    *
    * Each payload carries the target user's absolute unread counts for the
-   * stream (sync-v2 phase 2c): clients set counters from these instead of
+   * stream (sync phase 2c): clients set counters from these instead of
    * incrementing, so replayed/duplicated events converge. The activity rows
    * are committed before this runs, so the counts include them; rows sharing
    * a (user, stream) pair carry identical final counts, which is correct

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -669,7 +669,7 @@ export class EventService {
 
     // 9. Publish stream activity for sidebar updates
     // Stream-scoped: only members of this stream receive the preview content.
-    // sequence/messageOrdinal are absolute stream facts (sync-v2 phase 2c):
+    // sequence/messageOrdinal are absolute stream facts (sync phase 2c):
     // clients derive unread as latestOrdinal - lastReadOrdinal instead of
     // incrementing, so replayed/duplicated events converge. Exact under
     // concurrency: the sequence allocator's row lock serializes message

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1112,7 +1112,7 @@ describe("StreamService.createScratchpad (E2E)", () => {
 })
 
 // The stream:read / stream:read_all payloads carry absolute read positions
-// (sync-v2 phase 2c): clients derive unread as latestOrdinal - lastReadOrdinal,
+// (sync phase 2c): clients derive unread as latestOrdinal - lastReadOrdinal,
 // so these events must say where the read lands in message-ordinal space.
 describe("StreamService.markAsRead", () => {
   let service: StreamService

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1657,7 +1657,7 @@ export class StreamService {
     return withTransaction(this.pool, async (client) => {
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
       if (membership) {
-        // Absolute read position (sync-v2 phase 2c): clients derive unread as
+        // Absolute read position (sync phase 2c): clients derive unread as
         // latestOrdinal - lastReadOrdinal, so the event carries where this
         // read lands in message-ordinal space. A missing event mirrors the
         // unread query's COALESCE(sequence, 0) convention.
@@ -1712,7 +1712,7 @@ export class StreamService {
       if (updatedStreamIds.length > 0) {
         // Read-all sets each membership to its stream's latest event, so the
         // absolute read position per stream is the stream's total message
-        // count (sync-v2 phase 2c).
+        // count (sync phase 2c).
         const messageCounts = await StreamEventRepository.countMessagesByStreamBatch(client, updatedStreamIds)
         await OutboxRepository.insert(client, "stream:read_all", {
           workspaceId,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -354,7 +354,7 @@ export interface StreamActivityOutboxPayload extends StreamScopedPayload {
   sequence: string
   /**
    * Count of message_created events with sequence ≤ this one — an absolute,
-   * recipient-independent stream fact (sync-v2 phase 2c). Clients derive
+   * recipient-independent stream fact (sync phase 2c). Clients derive
    * unread as latestOrdinal - lastReadOrdinal instead of incrementing.
    */
   messageOrdinal: number
@@ -450,7 +450,7 @@ export interface StreamReadOutboxPayload extends WorkspaceScopedPayload {
   /** The read event's per-stream sequence (bigint as string; "0" when the event is missing). */
   lastReadSequence: string
   /**
-   * Message ordinal of the read position (sync-v2 phase 2c): count of
+   * Message ordinal of the read position (sync phase 2c): count of
    * message_created events with sequence ≤ the read event's. Clients derive
    * unread as latestOrdinal - lastReadOrdinal.
    */
@@ -461,7 +461,7 @@ export interface StreamsReadAllOutboxPayload extends WorkspaceScopedPayload {
   authorId: string
   streamIds: string[]
   /**
-   * Absolute read position per updated stream (sync-v2 phase 2c). Read-all
+   * Absolute read position per updated stream (sync phase 2c). Read-all
    * pins each membership to its stream's latest event, so the ordinal is the
    * stream's total message count at read time.
    */
@@ -531,7 +531,7 @@ export interface ActivityCreatedOutboxPayload extends WorkspaceScopedPayload {
   targetUserId: string
   /**
    * The target user's absolute unread counts for the activity's stream,
-   * computed after the row was inserted (sync-v2 phase 2c). Clients set
+   * computed after the row was inserted (sync phase 2c). Clients set
    * counters from these — never increment — so replays converge.
    */
   counts: {

--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -456,7 +456,7 @@ describe("Unread Counts", () => {
     })
   })
 
-  // Sync-v2 phase 2c: the unread counter events carry absolute values so
+  // Sync phase 2c: the unread counter events carry absolute values so
   // replayed/duplicated sync-log entries converge instead of compounding.
   // Clients derive unread = latestOrdinal - lastReadOrdinal; these tests pin
   // the ordinal payloads end-to-end through the real write paths.

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -389,7 +389,7 @@ export interface CachedUnreadState {
   activityCounts: Record<string, number>
   unreadActivityCount: number
   /**
-   * Latest message ordinal per stream (sync-v2 phase 2c) — seeded from
+   * Latest message ordinal per stream (sync phase 2c) — seeded from
    * bootstrap `messageCounts`, max-merged from `stream:activity`. The read
    * position is implicit: latestOrdinals[s] − unreadCounts[s]. Absent for
    * rows cached before the field shipped; see sync/unread-counters.ts.

--- a/apps/frontend/src/hooks/use-activity.ts
+++ b/apps/frontend/src/hooks/use-activity.ts
@@ -56,7 +56,7 @@ export function useMarkActivityRead(workspaceId: string) {
 
       // Decrement the per-stream counts together with the workspace total:
       // absolute counter events rederive the total as Σ activityCounts
-      // (sync-v2 phase 2c), so a total-only decrement would resurrect on the
+      // (sync phase 2c), so a total-only decrement would resurrect on the
       // next apply. Rows already read (or self rows) never counted. When the
       // row isn't in any cached list we can't resolve its stream — decrement
       // the total alone and let the next absolute apply settle it.

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -149,7 +149,7 @@ export function useConversations(workspaceId: string, streamId: string, options?
       queryClient.invalidateQueries({ queryKey: conversationKeys.messages(payload.toConversationId) })
     }
 
-    // In active sync-v2 mode, register through the engine's event gate so
+    // In active sync mode, register through the engine's event gate so
     // these handlers receive catch-up replays and respect buffer-and-splice
     // ordering exactly like engine-owned handlers — conversation events are
     // stream-scoped sync-log entries, and a raw-socket registration would

--- a/apps/frontend/src/hooks/use-saved.test.ts
+++ b/apps/frontend/src/hooks/use-saved.test.ts
@@ -199,7 +199,7 @@ describe("replaceSavedPage", () => {
   })
 })
 
-describe("useSavedList refetchOnReconnect (sync-v2 mode gate)", () => {
+describe("useSavedList refetchOnReconnect (sync mode gate)", () => {
   let listFn: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {

--- a/apps/frontend/src/hooks/use-scheduled.test.ts
+++ b/apps/frontend/src/hooks/use-scheduled.test.ts
@@ -9,7 +9,7 @@ import { scheduledKeys, useScheduledList } from "./use-scheduled"
 
 const WORKSPACE_ID = "ws_test"
 
-describe("useScheduledList refetchOnReconnect (sync-v2 mode gate)", () => {
+describe("useScheduledList refetchOnReconnect (sync mode gate)", () => {
   let listFn: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {

--- a/apps/frontend/src/hooks/use-stream-socket.ts
+++ b/apps/frontend/src/hooks/use-stream-socket.ts
@@ -33,7 +33,7 @@ export function useStreamSocket(workspaceId: string, streamId: string, options?:
     // queryClient is passed for transitional workspace bootstrap preview updates
     // (will be removed in Phase 3).
     //
-    // In active sync-v2 mode, register through the engine's event gate so
+    // In active sync mode, register through the engine's event gate so
     // these handlers receive catch-up entries and respect buffer-and-splice
     // exactly like engine-owned handlers; a raw-socket registration here
     // would apply live events out of order while catch-up replays the log.

--- a/apps/frontend/src/sync/socket-event-gate.ts
+++ b/apps/frontend/src/sync/socket-event-gate.ts
@@ -3,7 +3,7 @@ import type { Socket } from "socket.io-client"
 /**
  * Minimal registration surface shared by the raw socket and the gate. Handler
  * registration code (workspace-sync, stream-sync, useStreamSocket) is written
- * against this so the SyncEngine can interpose the gate in active sync-v2
+ * against this so the SyncEngine can interpose the gate in active sync
  * mode without the handlers knowing.
  */
 export interface SyncEventSource {
@@ -31,7 +31,7 @@ interface BufferedEvent {
 const DEFAULT_BUFFER_LIMIT = 2_000
 
 /**
- * The single delivery chokepoint for sync-v2 active mode. Live socket events
+ * The single delivery chokepoint for sync active mode. Live socket events
  * and catch-up log entries must apply through the SAME registered handlers
  * (the protocol guarantees `entry.payload` is the exact payload the socket
  * emits), so handlers register here instead of on the raw socket and the
@@ -184,7 +184,7 @@ export class SocketEventGate implements SyncEventSource {
     const results = await Promise.allSettled(snapshot.map(async (handler) => handler(payload)))
     for (const result of results) {
       if (result.status === "rejected") {
-        console.error("Sync-v2 catch-up handler failed", { eventType, error: result.reason })
+        console.error("Sync catch-up handler failed", { eventType, error: result.reason })
       }
     }
   }
@@ -213,7 +213,7 @@ export class SocketEventGate implements SyncEventSource {
         }
         if (!this.overflowWarned) {
           this.overflowWarned = true
-          console.warn("Sync-v2 gate buffer overflow — applying live events immediately", {
+          console.warn("Sync gate buffer overflow — applying live events immediately", {
             workspaceId: this.workspaceId,
           })
         }

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -892,7 +892,7 @@ describe("SyncEngine.backfillStreamGap", () => {
   })
 })
 
-describe("SyncEngine sync-v2 cursor (active mode)", () => {
+describe("SyncEngine sync cursor (active mode)", () => {
   beforeEach(async () => {
     resetRevealGate()
     await Promise.all([

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -1041,10 +1041,10 @@ export class SyncEngine {
       if (this.isDestroyed) return
       cursorStore.advance(head)
       this.noteSeenHead(head)
-      console.info("Sync-v2 cursor seeded from head", { workspaceId: this.workspaceId, head })
+      console.info("Sync cursor seeded from head", { workspaceId: this.workspaceId, head })
     } catch (error) {
       if (this.isDestroyed) return
-      console.error("Sync-v2 cursor initialization failed", { workspaceId: this.workspaceId, error })
+      console.error("Sync cursor initialization failed", { workspaceId: this.workspaceId, error })
     }
   }
 
@@ -1084,7 +1084,7 @@ export class SyncEngine {
       .catch((error) => {
         // A destroy-triggered abort is expected teardown, not a failure.
         if (this.isDestroyed) return
-        console.error("Sync-v2 catch-up failed", {
+        console.error("Sync catch-up failed", {
           workspaceId: this.workspaceId,
           trigger,
           error,
@@ -1171,7 +1171,7 @@ export class SyncEngine {
           // the upcoming snapshot (the race falls on the duplicate side). The
           // splice (appliedThrough = head) then drops buffered events <= head,
           // which the snapshot already covers, and applies only those above it.
-          console.info("Sync-v2 catch-up below retention floor; re-bootstrapping", {
+          console.info("Sync catch-up below retention floor; re-bootstrapping", {
             workspaceId: this.workspaceId,
             trigger,
             cursorBefore,
@@ -1217,7 +1217,7 @@ export class SyncEngine {
       }
 
       if (fetched > 0 || trigger !== "connect") {
-        console.info("Sync-v2 active catch-up", {
+        console.info("Sync active catch-up", {
           workspaceId: this.workspaceId,
           trigger,
           cursorBefore,
@@ -1271,7 +1271,7 @@ function parseHeartbeatHead(value: string): bigint | null {
   try {
     return BigInt(value)
   } catch {
-    console.warn("Sync-v2: ignoring malformed heartbeat head", { value })
+    console.warn("Sync: ignoring malformed heartbeat head", { value })
     return null
   }
 }

--- a/apps/frontend/src/sync/sync-log-cursor.ts
+++ b/apps/frontend/src/sync/sync-log-cursor.ts
@@ -15,7 +15,7 @@ function parseSyncId(value: string, context: string): bigint | null {
   try {
     return BigInt(value)
   } catch {
-    console.warn(`Sync-v2: ignoring malformed sync id (${context})`, { value })
+    console.warn(`Sync: ignoring malformed sync id (${context})`, { value })
     return null
   }
 }

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceBootstrap } from "@threa/types"
 
 /**
- * Pure state math for the unread counter family (sync-v2 phase 2c).
+ * Pure state math for the unread counter family (sync phase 2c).
  *
  * The four counter events (`stream:activity`, `stream:read`,
  * `stream:read_all`, `activity:created`) carry ABSOLUTE values so clients set

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1198,7 +1198,7 @@ describe("registerWorkspaceSocketHandlers", () => {
   })
 })
 
-describe("unread counter events (absolute payloads, sync-v2 phase 2c)", () => {
+describe("unread counter events (absolute payloads, sync phase 2c)", () => {
   const preview = {
     authorId: "member_2",
     authorType: "user" as const,
@@ -1474,7 +1474,7 @@ describe("unread counter events (absolute payloads, sync-v2 phase 2c)", () => {
   })
 })
 
-describe("latest ordinal seeding and reconnect merge (sync-v2 phase 2c)", () => {
+describe("latest ordinal seeding and reconnect merge (sync phase 2c)", () => {
   beforeEach(async () => {
     await db.unreadState.clear()
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -108,7 +108,7 @@ interface WorkspaceUserUpdatedPayload {
   user: WorkspaceUserPayload
 }
 
-// The unread counter payloads carry absolute fields (sync-v2 phase 2c): the
+// The unread counter payloads carry absolute fields (sync phase 2c): the
 // backend always emits them, so clients set counters from
 // latestOrdinal − lastReadOrdinal instead of incrementing and replayed or
 // duplicated events converge.
@@ -313,7 +313,7 @@ export function mergeReconnectWorkspaceBootstrap({
   const unreadCounts = { ...workspaceBootstrap.unreadCounts }
   const mentionCounts = { ...workspaceBootstrap.mentionCounts }
   const activityCounts = { ...workspaceBootstrap.activityCounts }
-  // The latest message ordinals (sync-v2 phase 2c). A stream's ordinal must
+  // The latest message ordinals (sync phase 2c). A stream's ordinal must
   // stay paired with whichever unreadCounts source wins for it — the implied
   // read position is latestOrdinal − unreadCount, so mixing a local unread
   // with the server ordinal (or vice versa) would shift it. Streams whose
@@ -1257,7 +1257,7 @@ export function registerWorkspaceSocketHandlers(
     if (payload.workspaceId !== workspaceId) return
 
     const { streamId, activityType, isSelf } = payload.activity
-    // Absolute per-stream counts for the target user (sync-v2 phase 2c);
+    // Absolute per-stream counts for the target user (sync phase 2c);
     // undefined on legacy payloads.
     const counts = payload.counts
 
@@ -1320,7 +1320,7 @@ export function registerWorkspaceSocketHandlers(
 
   // GAM memo extraction: surface new memos in the memory explorer without a
   // manual refresh. memo:created is workspace-group routed (sync log + emit),
-  // so registering here puts memos on the sync-v2 catch-up path like every
+  // so registering here puts memos on the sync catch-up path like every
   // other workspace-level event — a reconnect replay invalidates the same
   // queries a live emit does. The in-situ timeline row rides the separate
   // stream:memos_captured event (stream-sync).
@@ -1334,7 +1334,7 @@ export function registerWorkspaceSocketHandlers(
   // not just the one who performed the mutation. The five events are
   // permission-scoped to members:write holders (delivery-groups.ts) — logged and
   // emitted to that group only — so registering here both updates an open list
-  // live and replays through the sync-v2 catch-up cursor on reconnect, the same
+  // live and replays through the sync catch-up cursor on reconnect, the same
   // query a viewer's own send/revoke/resend mutation already invalidates. Every
   // payload carries workspaceId; the differing per-event fields are unused since
   // we only invalidate.

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -121,9 +121,9 @@ rather than per-phase edits.
   it and is marked drifting above.
 - **e2e scratchpads + enclave**: still `building` and actively changing (e.g. #794
   enclave auto-titles). Both docs exist with `status: building`; refresh when it ships.
-- **sync**: client cursor is now the active, sole sync path (#832, #833, #846;
+- **sync**: client cursor is the active, sole sync path (#832, #833, #846;
   made default in #884, flag deleted and hardwired in #926). `architecture/sync-engine.md`
-  still frames it as a shadow-mode rollout and needs a refresh pass.
+  is refreshed to the shipped engine.
 - **conversation overlay**: conversation grouping overlay with user corrections (#842)
   is new; fold into threads-and-conversations once it stabilizes.
 

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -121,8 +121,9 @@ rather than per-phase edits.
   it and is marked drifting above.
 - **e2e scratchpads + enclave**: still `building` and actively changing (e.g. #794
   enclave auto-titles). Both docs exist with `status: building`; refresh when it ships.
-- **sync**: client cursor in shadow mode (#832, #833, #846). Parts of
-  `architecture/sync-engine.md` will need updating when it leaves shadow mode.
+- **sync**: client cursor is now the active, sole sync path (#832, #833, #846;
+  made default in #884, flag deleted and hardwired in #926). `architecture/sync-engine.md`
+  still frames it as a shadow-mode rollout and needs a refresh pass.
 - **conversation overlay**: conversation grouping overlay with user corrections (#842)
   is new; fold into threads-and-conversations once it stabilizes.
 

--- a/docs/features/INVENTORY.md
+++ b/docs/features/INVENTORY.md
@@ -121,7 +121,7 @@ rather than per-phase edits.
   it and is marked drifting above.
 - **e2e scratchpads + enclave**: still `building` and actively changing (e.g. #794
   enclave auto-titles). Both docs exist with `status: building`; refresh when it ships.
-- **sync-v2**: client cursor in shadow mode (#832, #833, #846). Parts of
+- **sync**: client cursor in shadow mode (#832, #833, #846). Parts of
   `architecture/sync-engine.md` will need updating when it leaves shadow mode.
 - **conversation overlay**: conversation grouping overlay with user corrections (#842)
   is new; fold into threads-and-conversations once it stabilizes.

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -134,7 +134,7 @@ Every catch-up trigger above is connectivity-shaped (connect, reconnect, online
 flip, resume) — a client whose transport stays healthy for hours would never
 notice a dropped emit. The backend's `SyncHeartbeatWorker` therefore broadcasts
 each workspace's sync-log head to its room (`sync:heartbeat`, every 15s,
-node-local emits under the Postgres adapter). In active sync-v2 mode the engine
+node-local emits under the Postgres adapter). In active sync mode the engine
 compares the head against `max(cursor, lastSeenHead)` — the cursor is per-user
 filtered and can sit permanently below the workspace-global head, so a catch-up
 that drains to an empty page records that page's `head` as the known-clean

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -134,8 +134,8 @@ Every catch-up trigger above is connectivity-shaped (connect, reconnect, online
 flip, resume) — a client whose transport stays healthy for hours would never
 notice a dropped emit. The backend's `SyncHeartbeatWorker` therefore broadcasts
 each workspace's sync-log head to its room (`sync:heartbeat`, every 15s,
-node-local emits under the Postgres adapter). In active sync mode the engine
-compares the head against `max(cursor, lastSeenHead)` — the cursor is per-user
+node-local emits under the Postgres adapter). The engine compares the head
+against `max(cursor, lastSeenHead)` — the cursor is per-user
 filtered and can sit permanently below the workspace-global head, so a catch-up
 that drains to an empty page records that page's `head` as the known-clean
 high-water mark (`lastSeenHead`; non-empty pages don't move it, so a failed or

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1136,7 +1136,7 @@ export interface WorkspaceBootstrap {
   /**
    * Per-stream total message count (message ordinal) at snapshot time —
    * the baseline for deriving unread from absolute counter payloads
-   * (sync-v2 phase 2c): lastReadOrdinal = messageCounts - unreadCounts.
+   * (sync phase 2c): lastReadOrdinal = messageCounts - unreadCounts.
    * Optional during rollout: snapshots cached before the field shipped lack it.
    */
   messageCounts?: Record<string, number>
@@ -1293,7 +1293,7 @@ export interface ActivityCreatedPayload {
   targetUserId: string
   /**
    * The target user's absolute unread counts for the activity's stream
-   * (sync-v2 phase 2c). Clients set counters from these — never increment —
+   * (sync phase 2c). Clients set counters from these — never increment —
    * so replayed/duplicated events converge. Optional: sync-log entries
    * persisted before the field shipped lack it; consumers must fall back to
    * legacy increment-or-skip handling for those.


### PR DESCRIPTION
## Problem

The `sync-v2-cursor` feature flag was deleted in #926 and the cursor is now hardwired active. The `v2` qualifier that scattered through comments, log strings, test labels, and docs no longer distinguishes anything from a "v1" — there is no v1. It's now just the sync engine, and the leftover `v2` reads as a stale rollout artifact.

## Solution

Drop the `v2` qualifier wherever it appears as prose: code comments, `console.*` message prefixes (`"Sync-v2 …"` → `"Sync …"`), test `describe` labels, and the two living docs (`docs/features/INVENTORY.md`, `docs/features/architecture/sync-engine.md`). No code identifiers, types, imports, or filenames carried `v2`, so this is text-only with zero type/import churn — the earlier sweep confirmed every hit was a comment, a log string, or doc text.

Two categories are deliberately left untouched:

- **Append-only migrations (INV-17)** — the 4 `apps/backend/src/db/migrations/*.sql` files that mention `sync-v2` keep their text.
- **Dated `docs/plans/sync-v2-*.md` records** — these are the historical project record; filenames and content stay. Crucially, the **path references** to those files (`docs/plans/sync-v2-log-retention.md`, `docs/plans/sync-v2-heartbeat.md`) that appear in `packages/types/src/api.ts`, `apps/backend/src/features/sync/*`, and `sync-engine.md` are preserved — a blanket replace would have turned those into broken links. The rename used a negative-lookahead on `-` so `sync-v2-…` paths were protected while conceptual `sync-v2 ` / `Sync-v2:` mentions were renamed.

This PR also bakes in a CLAUDE.md workflow change (per Kris's request): default to opening a PR with `/create-pr` once work is complete, committed, pushed, and verified — rather than stopping at a pushed branch.

## Files changed

- **CLAUDE.md** — new "Opening Pull Requests" note under Workflow and Verification: default to `/create-pr` on completed work; skip only when told not to, when mid-stream, or when a PR already exists.
- **21 source/doc files** — `sync-v2` → `sync` in comments, log strings, and test labels (`apps/frontend/src/sync/*`, `apps/frontend/src/hooks/*`, `apps/backend/src/{features,lib}/*`, `packages/types/src/api.ts`, `docs/features/{INVENTORY,architecture/sync-engine}.md`). The recurring phrase `sync-v2 phase 2c` → `sync phase 2c`; log prefixes `"Sync-v2 …"` → `"Sync …"`.

## Out of scope (deliberate)

- The 4 append-only migration files (INV-17) and the `docs/plans/sync-v2-*.md` filenames + content — left as the dated record. Path references to those files are preserved verbatim.

## Test plan

- [x] `tsc --noEmit` — clean across `apps/frontend`, `apps/backend`, `packages/types`
- [x] Frontend `bunx vitest run src/sync src/hooks/use-saved.test.ts src/hooks/use-scheduled.test.ts` — 194 pass (10 files)
- [x] Verified post-rename grep: remaining `sync-v2` hits are only the protected migrations, the dated plan docs, and valid path references to them
- [x] Pre-commit hook (full monorepo lint + per-package tsc chain) passed on both commits
- [ ] No backend suite run for the touched backend files — changes there are comment-only (no executable lines), so the typecheck is the relevant gate

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012sJur789BDsvdA6HwBV5wm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784014957&installation_id=129946197&pr_number=929&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F929&signature=dc19ec4aa4f65a64d58595328b142b079fb126cbfa4c018dacd5c39a4f0cbf9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->