### PR TITLE
docs(agent-runtimes): resolve §2.8 Q7 (per-episode context window policy)

### DIFF
--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -923,6 +923,61 @@ timestamps)`, carries the non-null `e2e_streams` rows over, and **drops**
    want deep continuity; a channel mention probably still wants the shallow
    window. The `ContextWindowPolicy` should be per-trigger-kind (deep for
    companion-mode scratchpad turns, shallow for mention turns), not global.
+   _Resolved as per-**episode**, not per-trigger-kind as a free axis and not
+   global: one policy **type** — the C-2 budgeted-window + rolling-summary
+   mechanism — instantiated per dispatch from facts the turn already carries,
+   selected at the `Hydrate` step and handed to the driver, never chosen inside
+   it. `ContextWindowPolicy` does not exist in code yet (it lands with C-2);
+   this fixes its shape rather than describing shipped behavior._
+   - _**The axis is the episode, and §2.5 already computes it.** Keying
+     directly on the two trigger kinds (`mention`, `companion`; `AGENT_TRIGGERS`,
+     `packages/types/src/constants.ts:430`) is almost right but
+     under-determined: a `mention` lands in either a channel-thread or a DM, and
+     those want different continuity rules, while `companion` only ever fires on
+     a companion-mode scratchpad (`companion-outbox-handler.ts:87-94` gates on
+     `StreamTypes.SCRATCHPAD` + `CompanionModes.ON`). The disambiguating fact is
+     the **episode** §2.5 already defines from surface shape + recency —
+     scratchpad/thread = the stream, channel = the spawned thread, DM = recency.
+     So the policy's input is the resolved episode; `(trigger kind, stream
+type)` are how the episode is computed, not a parallel dimension._
+   - _**The mapping.** `companion` (scratchpad, companion mode) → **deep**: a
+     token-budgeted window filled newest-first, overflow folded into the rolling
+     summary (C-2). `mention` in a channel → **shallow**: the mention already
+     spawns a bounded thread (§2.5 "channels reduce to threads"; the routing is
+     documented at `mention-invoke-outbox-handler.ts:17-23` and the thread is
+     created by the `PersonaAgent`, per that handler's own note), so the episode
+     is that thread and
+     the existing surrounding depth is the right cap. `mention` in a DM → the
+     DM-episode window by recency (`lastSeenSequence`,
+     `session-repository.ts:92`, the same cursor `companion-outbox-handler.ts`
+     already compares against); the count/time boundary itself is Q8._
+   - _**One path, not two (INV-29/INV-43).** Deep and shallow are the same
+     mechanism with different budgets, not two code paths: on a bounded thread
+     nothing overflows, so the rolling summary degrades to a no-op and the deep
+     path's machinery is inert. Two literal branches keyed on trigger kind would
+     be the footgun the shared-behavior rule exists to prevent._
+   - _**Where it lives — the question's "where".** Not a global constant
+     (today's flat `MAX_CONTEXT_MESSAGES = 20`, `context-builder.ts:135`, applied
+     identically by all four stream-type builders with no trigger branching —
+     the cliff C-2 removes), not a per-driver hardcode (the enclave's
+     `MAX_HISTORY_MESSAGES`, 30 at `claim-service.ts:36` / 200 at
+     `assignment.ts:16`), and not a new config surface (INV-36 — no per-persona
+     "window depth" knob; the signal is already in the trigger). It is a derived
+     value on the dispatch binding, read at the `Hydrate` step, the same
+     forward-compat slot the inline `contextHandle` already occupies (Q2)._
+   - _**Reconciles C-2 and forces Q2's `ref`.** C-2's "one `ContextWindowPolicy`
+     consumed by all drivers" means one shared **type/mechanism**; a policy is
+     parameterized by definition, so per-episode **values** are no contradiction
+     — they are the inputs the noun already implied (the same shape Q3 settled
+     for tool policy: one `negotiateCapabilities` predicate, per-stream
+     parameters). And the deep window is the concrete payload-size forcing
+     function Q2 deferred to: when a deep budget overflows the inline claim
+     response or the 48 MB assignment (E2EE-23), that is when the deferred
+     `{ kind: "ref" }` context handle gets built; until then inline carries it.
+     Note `truncateMessages(messages, maxChars)` (`runtime/truncation.ts:124`)
+     is char-based per-message clamping, not the budgeted newest-first fill — it
+     bounds a single oversized message; the window-fill + rolling-summary is the
+     new C-2 work this policy parameterizes._
 8. **DM episode boundary tuning:** "invocation within the last ~20 messages"
    is a message-count heuristic; a long pause in a quiet DM still reads as the
    same conversation to a human. Decide whether the boundary is count-based,


### PR DESCRIPTION
**Design doc:** `docs/plans/agent-runtimes-unification-redesign.md` §2.8 Q7

## Problem

§2.8 Q7 of the agent-runtimes redesign was open: _"Where does the budgeted window live for mentions/channels? The `ContextWindowPolicy` should be per-trigger-kind (deep for companion-mode scratchpad turns, shallow for mention turns), not global."_

The framing in the open question (key on the two trigger kinds) is almost right but under-determined, and the question of _where_ the selection lives was unanswered. Today the context window is the opposite of what the redesign wants: a flat `MAX_CONTEXT_MESSAGES = 20` applied identically by all four stream-type builders with no trigger branching (`context-builder.ts:135`), plus the enclave's separate hard-coded caps (`MAX_HISTORY_MESSAGES`, 30 at `claim-service.ts:36` / 200 at `assignment.ts:16`). A deep scratchpad and a shallow channel mention get the same window.

## Solution

A doc-only `_Resolved..._` note appended to §2.8 Q7, in the same style as the other resolved items. **The ruling: per-_episode_, not per-trigger-kind as a free axis and not global** — one policy _type_ (the C-2 budgeted-window + rolling-summary mechanism), instantiated per dispatch from facts the turn already carries, selected at the `Hydrate` step and handed to the driver, never chosen inside it.

This is a **forward design ruling**, not a description of shipped behavior — `ContextWindowPolicy` does not exist in code yet; it lands with C-2. The note states that explicitly, unlike the Q5 ruling (which documented already-shipped Phase 0.7 code).

Five facets, each grounded in cited code:

1. **The axis is the episode, and §2.5 already computes it.** Keying directly on `mention`/`companion` (`AGENT_TRIGGERS`, `constants.ts:430`) is under-determined: a `mention` lands in a channel-thread _or_ a DM (different rules), and `companion` only ever fires on a companion-mode scratchpad (`companion-outbox-handler.ts:87-94` gates on `StreamTypes.SCRATCHPAD` + `CompanionModes.ON`). The disambiguating fact is the episode §2.5 already defines from surface shape + recency.
2. **Mapping:** companion → deep (token-budgeted window + rolling summary); channel mention → shallow (the mention spawns a bounded thread, so the episode is that thread); DM mention → recency window (`lastSeenSequence`, `session-repository.ts:92`), with the boundary itself deferred to Q8.
3. **One path, not two (INV-29/INV-43):** same mechanism, different budgets — on a bounded thread nothing overflows, so the rolling summary degrades to a no-op. Two literal branches would be the footgun.
4. **Where it lives:** not a global constant (today's flat `MAX_CONTEXT_MESSAGES = 20`), not a per-driver hardcode (enclave's 30/200), not a new config surface (INV-36). A derived value on the dispatch binding, read at `Hydrate` — the same forward-compat slot the inline `contextHandle` already occupies (Q2).
5. **Reconciles C-2 and forces Q2's `ref`:** "one policy consumed by all drivers" means one shared _type_; per-episode _values_ are no contradiction (the same shape Q3 settled for tool policy). The deep window is the concrete payload-size forcing function Q2 deferred to — when a deep budget overflows the inline claim response or the 48 MB assignment (E2EE-23), that's when `{ kind: "ref" }` gets built.

After this, only Q8 (DM episode boundary tuning) remains open in §2.8.

## Files changed

| File | Change |
| ---- | ------ |
| `docs/plans/agent-runtimes-unification-redesign.md` | Append the `_Resolved..._` note to §2.8 Q7 (+53 lines) |

## Self-review

Every file:line citation in the note was checked against the code: `constants.ts:430` (`AGENT_TRIGGERS`), `context-builder.ts:135` (`MAX_CONTEXT_MESSAGES = 20`, flat across all four builders), `claim-service.ts:36` / `assignment.ts:16` (`MAX_HISTORY_MESSAGES` 30/200), `companion-outbox-handler.ts:87-94` (scratchpad+companion gate), `session-repository.ts:92` (`lastSeenSequence`), `truncation.ts:124` (`truncateMessages(messages, maxChars)` — char-clamping, not the budgeted fill, called out as such in the note).

One imprecision caught and fixed in self-review: the draft reused §2.5's `mention-invoke-outbox-handler.ts:34-43` citation for "the mention spawns a thread," but those lines are the event-type guard; that handler's own note (`:17-23`) says thread creation for channels is done by the `PersonaAgent`, not the handler. Corrected the citation to the documented routing block.

## Test plan

- [x] `bunx prettier --check` on the doc — clean
- [x] Pre-commit hook (full 14-workspace typecheck, lint, dockerfile, `generate-api-docs --check`, astro) — passed on commit (exit 0)
- [ ] No unit/integration tests — docs-only change, no code touched, no INV enforced in code (forward design ruling for unbuilt C-2 work, like the §2.8 Q6 note)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSBXDiXiiRxSg9p8FGjALB)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784017008&installation_id=129946197&pr_number=930&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F930&signature=ce1165047550b2d92d7d73d802257d6ad1c0f995b5ce648ded2b341cfd40bd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->