### PR TITLE
feat(drafts): stage 4a — resolve-on-send (frontend CAS clear)

### DIFF
--- a/apps/frontend/src/api/drafts.ts
+++ b/apps/frontend/src/api/drafts.ts
@@ -1,16 +1,22 @@
 import { api } from "./client"
-import type { DraftListResponse, UpsertDraftInput, UpsertDraftResponse } from "@threa/types"
+import type {
+  DraftListResponse,
+  ResolveDraftInput,
+  ResolveDraftResponse,
+  UpsertDraftInput,
+  UpsertDraftResponse,
+} from "@threa/types"
 
 /**
- * Centralized-draft REST client (Stage 3). Drafts are user-scoped on the
- * backend (auth resolves the owner), so no user id is sent — only the
- * workspace and the draft id.
+ * Centralized-draft REST client. Drafts are user-scoped on the backend (auth
+ * resolves the owner), so no user id is sent — only the workspace and the draft
+ * id.
  *
- * `upsert` is the debounced background mirror of a local draft; `delete` clears
- * a discarded draft. Both are driven from the offline operation queue with
- * silent retry — callers never surface their errors (a failed remote draft save
- * is invisible by design, the local copy stands). Resolve-on-send lands in
- * Stage 4.
+ * `upsert` is the debounced background mirror of a local draft; `resolve` clears
+ * a draft CAS-safely after its message sends (a drifted copy survives); `delete`
+ * is an unconditional discard. All are driven from the offline operation queue
+ * with silent retry — callers never surface their errors (a failed remote draft
+ * save is invisible by design, the local copy stands).
  */
 export const draftsApi = {
   /** Bootstrap seed: every live draft owned by the viewer in this workspace. */
@@ -26,6 +32,16 @@ export const draftsApi = {
    */
   async upsert(workspaceId: string, id: string, input: UpsertDraftInput): Promise<UpsertDraftResponse> {
     return api.put<UpsertDraftResponse>(`/api/workspaces/${workspaceId}/drafts/${id}`, input)
+  },
+
+  /**
+   * Resolve-on-send: CAS soft-delete guarded by `expectedVersion`. The server
+   * removes the draft only if its version still matches, so a copy that drifted
+   * since the send started survives as a stash entry instead of being
+   * collaterally destroyed (`response.resolved` is false in that case).
+   */
+  async resolve(workspaceId: string, id: string, input: ResolveDraftInput): Promise<ResolveDraftResponse> {
+    return api.post<ResolveDraftResponse>(`/api/workspaces/${workspaceId}/drafts/${id}/resolve`, input)
   },
 
   /** Unconditional soft-delete (idempotent on an already-gone draft). */

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -355,7 +355,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     try {
       // Clear input optimistically inside try so we can restore on failure
       composer.setContent(EMPTY_DOC)
-      composer.clearDraft()
+      composer.resolveDraft()
       composer.clearAttachments()
 
       // Seal the reply under the encrypted root when the parent is E2E — the

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -56,6 +56,7 @@ let mockMessageSendMode: "enter" | "cmdEnter" = "enter"
 // Mock hooks
 const mockSendMessage = vi.fn()
 const mockClearDraft = vi.fn()
+const mockResolveDraft = vi.fn()
 const mockClearAttachments = vi.fn()
 const mockSetContent = vi.fn()
 const mockSetIsSending = vi.fn()
@@ -200,6 +201,7 @@ beforeEach(() => {
         isSending: mockComposerState.isSending,
         setIsSending: mockSetIsSending,
         clearDraft: mockClearDraft,
+        resolveDraft: mockResolveDraft,
         clearAttachments: mockClearAttachments,
         isLoaded: mockComposerState.isLoaded,
       }) as unknown as ReturnType<typeof hooksModule.useDraftComposer>
@@ -384,7 +386,7 @@ describe("MessageInput", () => {
       })
     })
 
-    it("should clear draft and attachments after sending", async () => {
+    it("should resolve the draft and clear attachments after sending", async () => {
       mockComposerState.canSend = true
       mockComposerState.content = makeDoc("Hello world")
 
@@ -393,7 +395,10 @@ describe("MessageInput", () => {
       const sendButton = screen.getByRole("button", { name: /send/i })
       await userEvent.click(sendButton)
 
-      expect(mockClearDraft).toHaveBeenCalled()
+      // Send uses the CAS resolve path (not the unconditional discard) so a copy
+      // edited on another device survives as a stash entry.
+      expect(mockResolveDraft).toHaveBeenCalled()
+      expect(mockClearDraft).not.toHaveBeenCalled()
       expect(mockClearAttachments).toHaveBeenCalled()
     })
 
@@ -437,7 +442,7 @@ describe("MessageInput", () => {
       await userEvent.click(sendButton)
 
       expect(mockSetContent).toHaveBeenCalledWith(EMPTY_DOC)
-      expect(mockClearDraft).not.toHaveBeenCalled()
+      expect(mockResolveDraft).not.toHaveBeenCalled()
 
       resolveSend?.({})
     })

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -485,7 +485,7 @@ function MessageInputComponent({
         // path does. Either branch below consumes the command, so the user
         // shouldn't see their chip linger after pressing send.
         composer.setContent(EMPTY_DOC)
-        composer.clearDraft()
+        composer.resolveDraft()
         setExpanded(false)
 
         // Client-action commands are routed locally — `/discuss-with-ariadne`
@@ -538,7 +538,7 @@ function MessageInputComponent({
         })
 
         composer.setContent(EMPTY_DOC)
-        composer.clearDraft()
+        composer.resolveDraft()
         composer.clearAttachments()
         if (result.navigateTo) {
           navigate(result.navigateTo, { replace: result.replace ?? false })
@@ -584,7 +584,7 @@ function MessageInputComponent({
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
           scheduledFor: when.toISOString(),
         })
-        composer.clearDraft()
+        composer.resolveDraft()
         composer.clearAttachments()
         toast.success("Scheduled")
       } catch (err) {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -305,14 +305,17 @@ export interface PendingOperation {
     | "cancel_scheduled_message"
     | "send_scheduled_now"
     | "dispatch_command"
-    // Centralized-draft sync (Stage 3): mirror a local draft to the backend
-    // `drafts` table. Both retry silently with no error surface — a failed
-    // remote draft save is invisible by design because the local copy stands.
-    // `upsert_draft` reads the draft's current content fresh at drain time and
-    // pushes it with `expectedVersion = baseVersion`; the server splits on a
-    // version mismatch. `delete_draft` is an unconditional, idempotent soft
-    // delete (the local row is already gone before the op is enqueued).
+    // Centralized-draft sync: mirror a local draft to the backend `drafts`
+    // table. All retry silently with no error surface — a failed remote draft
+    // save is invisible by design because the local copy stands. `upsert_draft`
+    // reads the draft's current content fresh at drain time and pushes it with
+    // `expectedVersion = baseVersion`; the server splits on a version mismatch.
+    // `resolve_draft` (Stage 4) is the CAS clear-on-send: it removes the server
+    // row only if `expectedVersion` still matches, so a drifted copy survives.
+    // `delete_draft` is an unconditional, idempotent soft delete (the local row
+    // is already gone before the op is enqueued).
     | "upsert_draft"
+    | "resolve_draft"
     | "delete_draft"
   payload: Record<string, unknown>
   createdAt: number

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -16,6 +16,7 @@ const mockSaveDraftDebounced = vi.fn()
 const mockAddDraftAttachment = vi.fn()
 const mockRemoveDraftAttachment = vi.fn()
 const mockClearDraft = vi.fn()
+const mockResolveDraft = vi.fn()
 
 interface MockDraftState {
   isLoaded: boolean
@@ -64,6 +65,7 @@ describe("useDraftComposer", () => {
     mockAddDraftAttachment.mockReset()
     mockRemoveDraftAttachment.mockReset()
     mockClearDraft.mockReset()
+    mockResolveDraft.mockReset()
     mockHandleFileSelect.mockReset()
     mockRemoveAttachment.mockReset()
     mockClearAttachments.mockReset()
@@ -92,6 +94,7 @@ describe("useDraftComposer", () => {
           addAttachment: mockAddDraftAttachment,
           removeAttachment: mockRemoveDraftAttachment,
           clearDraft: mockClearDraft,
+          resolveDraft: mockResolveDraft,
         } as unknown as ReturnType<typeof useDraftMessageModule.useDraftMessage>
       }
     )
@@ -567,6 +570,16 @@ describe("useDraftComposer", () => {
       })
 
       expect(mockClearDraft).toHaveBeenCalled()
+    })
+
+    it("should expose resolveDraft from useDraftMessage", () => {
+      const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.resolveDraft()
+      })
+
+      expect(mockResolveDraft).toHaveBeenCalled()
     })
 
     it("should expose clearAttachments from useAttachments", () => {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -57,6 +57,13 @@ export interface DraftComposerState {
 
   // Clear helpers
   clearDraft: () => Promise<void>
+  /**
+   * Clear the loaded draft because its message was sent (resolve-on-send): same
+   * local teardown as `clearDraft`, but the backend removal is CAS-guarded so a
+   * copy that drifted on another device survives as a stash entry. Send paths
+   * use this; plain discards (stash, empty composer) use `clearDraft`.
+   */
+  resolveDraft: () => Promise<void>
   clearAttachments: () => void
 
   /**
@@ -89,6 +96,7 @@ export function useDraftComposer({
     addAttachment: addDraftAttachment,
     removeAttachment: removeDraftAttachment,
     clearDraft,
+    resolveDraft,
   } = useDraftMessage(workspaceId, draftKey, e2eEnabled)
 
   // Attachment handling
@@ -273,6 +281,7 @@ export function useDraftComposer({
 
     // Clear helpers
     clearDraft,
+    resolveDraft,
     clearAttachments,
     restoreAttachments,
 

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -350,4 +350,45 @@ describe("useDraftMessage", () => {
       expect(await loadedDraft(draftKey)).toBeUndefined()
     })
   })
+
+  describe("resolveDraft", () => {
+    it("removes the loaded draft locally and enqueues a CAS resolve for a confirmed draft", async () => {
+      await db.pendingOperations.clear()
+      // A draft the server has already confirmed at version 2.
+      await db.drafts.put({
+        id: "draft_confirmed",
+        workspaceId,
+        scope: draftKey,
+        contentJson: makeDoc("sent"),
+        attachments: [],
+        baseVersion: 2,
+        clientUpdatedAt: Date.now(),
+      })
+      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_confirmed" })
+
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+      await act(async () => {
+        await result.current.resolveDraft()
+      })
+
+      expect(await db.drafts.get("draft_confirmed")).toBeUndefined()
+      expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
+      const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+      expect(resolves).toHaveLength(1)
+      expect(resolves[0]?.payload).toMatchObject({ draftId: "draft_confirmed", expectedVersion: 2 })
+    })
+
+    it("does not enqueue a server resolve for a never-synced draft (nothing to resolve)", async () => {
+      await db.pendingOperations.clear()
+      await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("x"), attachments: [] })
+
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+      await act(async () => {
+        await result.current.resolveDraft()
+      })
+
+      expect(await loadedDraft(draftKey)).toBeUndefined()
+      expect(await db.pendingOperations.where("type").equals("resolve_draft").count()).toBe(0)
+    })
+  })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -10,7 +10,7 @@ import {
   useComposerLoadedFromStore,
   useDraftsFromStore,
 } from "@/stores/draft-store"
-import { enqueueDraftUpsert, syncDraftRemoval } from "@/sync/draft-sync"
+import { enqueueDraftUpsert, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import type { JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
@@ -91,29 +91,59 @@ export async function upsertLoadedDraft(workspaceId: string, scope: string, fiel
   return row
 }
 
-/** Delete the loaded draft for `scope` and clear its pointer (stashes survive). */
-export async function clearLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+/**
+ * Remove the loaded draft for `scope` locally (IDB row + pointer + cache) and
+ * report what was removed. Shared by `clearLoadedDraft` (discard) and
+ * `resolveLoadedDraft` (send) — they differ only in how the removal is mirrored
+ * to the backend, so the local teardown lives on one path (INV-43).
+ *
+ * The row delete AND the pointer clear happen in ONE transaction. Reading
+ * `baseVersion` here also keeps a mid-clear server confirmation from slipping
+ * between read and delete (the "ghost draft" race). Crucially the pointer clear
+ * is inside the txn too: otherwise a `draft:upserted` echo landing between the
+ * row delete and the pointer clear would find no local row and re-insert the
+ * just-cleared draft as an orphan stash entry (resurrection race).
+ */
+async function removeLoadedDraftLocally(
+  workspaceId: string,
+  scope: string
+): Promise<{ loadedId: string | null; baseVersion: number | undefined }> {
   const loadedId = await getLoadedDraftId(scope)
-  // Delete the draft row AND clear its loaded pointer in ONE transaction. Reading
-  // `baseVersion` here also keeps a mid-clear server confirmation from slipping
-  // between read and delete (the "ghost draft" race). Crucially the pointer clear
-  // is inside the txn too: otherwise a `draft:upserted` echo landing between the
-  // row delete and the pointer clear would find no local row and re-insert the
-  // just-cleared draft as an orphan stash entry (resurrection race).
-  const removedBaseVersion = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
-    let baseVersion: number | undefined
+  const baseVersion = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+    let version: number | undefined
     if (loadedId) {
       const row = await db.drafts.get(loadedId)
-      baseVersion = row?.baseVersion
+      version = row?.baseVersion
       await db.drafts.delete(loadedId)
     }
     await db.composerLoaded.delete(scope)
-    return baseVersion
+    return version
   })
   if (loadedId) deleteDraftFromCache(workspaceId, loadedId)
   setComposerLoadedInCache(workspaceId, scope, null)
+  return { loadedId, baseVersion }
+}
+
+/**
+ * Discard the loaded draft for `scope` and clear its pointer (stashes survive).
+ * The backend mirror is an UNCONDITIONAL delete — the user threw it away, so
+ * drift doesn't matter.
+ */
+export async function clearLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+  const { loadedId, baseVersion } = await removeLoadedDraftLocally(workspaceId, scope)
   // Sync side-effect after the local state is fully cleared.
-  if (loadedId) await syncDraftRemoval(workspaceId, loadedId, removedBaseVersion)
+  if (loadedId) await syncDraftRemoval(workspaceId, loadedId, baseVersion)
+}
+
+/**
+ * Resolve the loaded draft for `scope` after its message sent: remove it locally
+ * (same teardown as a discard), but mirror the removal to the backend as a
+ * CAS clear-on-send so a copy that drifted on another device survives as a stash
+ * entry instead of being collaterally deleted (plan §resolve-on-send).
+ */
+export async function resolveLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+  const { loadedId, baseVersion } = await removeLoadedDraftLocally(workspaceId, scope)
+  if (loadedId) await syncDraftResolution(workspaceId, loadedId, baseVersion)
 }
 
 /**
@@ -302,6 +332,23 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
     syncEngine?.kickOperationQueue()
   }, [draftKey, workspaceId, syncEngine])
 
+  /**
+   * Clear the loaded draft because its message was sent (resolve-on-send). Same
+   * local teardown as `clearDraft`, but the backend removal is CAS-guarded so a
+   * draft edited on another device after this send started survives as a stash
+   * entry. Used by the send/schedule/command paths; plain discards use
+   * `clearDraft`.
+   */
+  const resolveDraft = useCallback(async () => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+
+    await resolveLoadedDraft(workspaceId, draftKey)
+    syncEngine?.kickOperationQueue()
+  }, [draftKey, workspaceId, syncEngine])
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -323,5 +370,6 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
     addAttachment,
     removeAttachment,
     clearDraft,
+    resolveDraft,
   }
 }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -232,6 +232,7 @@ function WorkspaceSyncHandler({
       draftsService: {
         list: (wid: string) => draftsApi.list(wid),
         upsert: draftsApi.upsert,
+        resolve: draftsApi.resolve,
         delete: draftsApi.delete,
       },
       syncService: syncApi,

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -8,10 +8,13 @@ import {
   applyDraftUpserted,
   cachedDraftFromWire,
   enqueueDraftDelete,
+  enqueueDraftResolve,
   enqueueDraftUpsert,
   executeDraftDelete,
+  executeDraftResolve,
   executeDraftUpsert,
   hasPendingDraftUpsert,
+  syncDraftResolution,
   type DraftsServiceLike,
 } from "./draft-sync"
 
@@ -264,11 +267,39 @@ describe("enqueueDraftUpsert / enqueueDraftDelete", () => {
     const dels = await db.pendingOperations.where("type").equals("delete_draft").toArray()
     expect(dels.filter((o) => o.payload.draftId === "draft_x")).toHaveLength(1)
   })
+
+  it("enqueueDraftResolve drops a queued push and adds a CAS resolve carrying expectedVersion", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    await enqueueDraftResolve(workspaceId, "draft_x", 3)
+
+    expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
+    const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+    const forDraft = resolves.filter((o) => o.payload.draftId === "draft_x")
+    expect(forDraft).toHaveLength(1)
+    expect(forDraft[0]?.payload.expectedVersion).toBe(3)
+  })
+})
+
+describe("syncDraftResolution", () => {
+  it("enqueues a CAS resolve for a confirmed draft (baseVersion > 0)", async () => {
+    await syncDraftResolution(workspaceId, "draft_x", 4)
+
+    const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+    expect(resolves.filter((o) => o.payload.draftId === "draft_x" && o.payload.expectedVersion === 4)).toHaveLength(1)
+  })
+
+  it("only drops the pending push for a never-synced draft (nothing to resolve server-side)", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    await syncDraftResolution(workspaceId, "draft_x", 0)
+
+    expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
+    expect(await db.pendingOperations.where("type").equals("resolve_draft").count()).toBe(0)
+  })
 })
 
 describe("executeDraftUpsert", () => {
   function service(upsert: DraftsServiceLike["upsert"]): DraftsServiceLike {
-    return { upsert, delete: vi.fn(async () => {}) }
+    return { upsert, resolve: vi.fn(async () => ({ resolved: true })), delete: vi.fn(async () => {}) }
   }
 
   it("pushes expectedVersion = baseVersion and confirms the returned version without clobbering content", async () => {
@@ -368,5 +399,27 @@ describe("executeDraftDelete", () => {
     const del = vi.fn(async () => {})
     await executeDraftDelete(workspaceId, "draft_x", { upsert: vi.fn(), delete: del } as unknown as DraftsServiceLike)
     expect(del).toHaveBeenCalledWith(workspaceId, "draft_x")
+  })
+})
+
+describe("executeDraftResolve", () => {
+  it("delegates a CAS resolve carrying expectedVersion to the service", async () => {
+    const resolve = vi.fn(async () => ({ resolved: true }))
+    await executeDraftResolve(workspaceId, "draft_x", 5, {
+      upsert: vi.fn(),
+      resolve,
+      delete: vi.fn(),
+    } as unknown as DraftsServiceLike)
+    expect(resolve).toHaveBeenCalledWith(workspaceId, "draft_x", { expectedVersion: 5 })
+  })
+
+  it("propagates a declined resolve (drift) without throwing — the drifted copy survives", async () => {
+    const resolve = vi.fn(async () => ({ resolved: false }))
+    await executeDraftResolve(workspaceId, "draft_x", 2, {
+      upsert: vi.fn(),
+      resolve,
+      delete: vi.fn(),
+    } as unknown as DraftsServiceLike)
+    expect(resolve).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -12,6 +12,8 @@ import type {
   DraftDeletedPayload,
   DraftUpsertedPayload,
   JSONContent,
+  ResolveDraftInput,
+  ResolveDraftResponse,
   UpsertDraftInput,
   UpsertDraftResponse,
 } from "@threa/types"
@@ -45,6 +47,7 @@ const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 /** Minimal surface of the drafts REST client the queue replays against. */
 export interface DraftsServiceLike {
   upsert: (workspaceId: string, id: string, input: UpsertDraftInput) => Promise<UpsertDraftResponse>
+  resolve: (workspaceId: string, id: string, input: ResolveDraftInput) => Promise<ResolveDraftResponse>
   delete: (workspaceId: string, id: string) => Promise<void>
 }
 
@@ -147,7 +150,10 @@ function writeId(): string {
   return `write_${Date.now()}_${Math.random().toString(36).slice(2)}`
 }
 
-async function pendingDraftOps(type: "upsert_draft" | "delete_draft", draftId: string): Promise<PendingOperation[]> {
+async function pendingDraftOps(
+  type: "upsert_draft" | "resolve_draft" | "delete_draft",
+  draftId: string
+): Promise<PendingOperation[]> {
   const ops = await db.pendingOperations.where("type").equals(type).toArray()
   return ops.filter((op) => op.payload.draftId === draftId)
 }
@@ -203,6 +209,37 @@ export async function enqueueDraftDelete(workspaceId: string, draftId: string): 
   })
 }
 
+/**
+ * Enqueue a CAS clear-on-send for a draft (resolve-on-send) and drop any queued
+ * push or delete for it. `expectedVersion` is the last server-confirmed version
+ * (`baseVersion`); the server removes the row only if it still matches, so a
+ * copy that drifted on another device survives as a stash entry. Use only when
+ * the draft reached the server (`baseVersion > 0`); for a never-synced draft
+ * call `cancelPendingDraftUpsert` — there is nothing on the server to resolve.
+ */
+export async function enqueueDraftResolve(
+  workspaceId: string,
+  draftId: string,
+  expectedVersion: number
+): Promise<void> {
+  await db.transaction("rw", db.pendingOperations, async () => {
+    const stale = [
+      ...(await pendingDraftOps("upsert_draft", draftId)),
+      ...(await pendingDraftOps("resolve_draft", draftId)),
+      ...(await pendingDraftOps("delete_draft", draftId)),
+    ]
+    if (stale.length > 0) await db.pendingOperations.bulkDelete(stale.map((op) => op.id))
+    await db.pendingOperations.add({
+      id: operationId(),
+      workspaceId,
+      type: "resolve_draft",
+      payload: { draftId, expectedVersion },
+      createdAt: Date.now(),
+      retryCount: 0,
+    })
+  })
+}
+
 /** Drop any queued push for a draft (e.g. an unsynced draft was discarded). */
 export async function cancelPendingDraftUpsert(draftId: string): Promise<void> {
   const dupes = await pendingDraftOps("upsert_draft", draftId)
@@ -222,6 +259,26 @@ export async function syncDraftRemoval(
 ): Promise<void> {
   if ((baseVersion ?? 0) > 0) {
     await enqueueDraftDelete(workspaceId, id)
+  } else {
+    await cancelPendingDraftUpsert(id)
+  }
+}
+
+/**
+ * Mirror a sent draft's removal to the backend CAS-safely (resolve-on-send): a
+ * confirmed draft (`baseVersion > 0`) is resolved on the version it was last
+ * confirmed at, so a copy that drifted on another device survives as a stash
+ * entry; a never-synced one only needs its queued push dropped (nothing exists
+ * server-side). The counterpart to `syncDraftRemoval` for the send path — the
+ * local row is already gone by the time this runs.
+ */
+export async function syncDraftResolution(
+  workspaceId: string,
+  id: string,
+  baseVersion: number | undefined
+): Promise<void> {
+  if ((baseVersion ?? 0) > 0) {
+    await enqueueDraftResolve(workspaceId, id, baseVersion as number)
   } else {
     await cancelPendingDraftUpsert(id)
   }
@@ -425,6 +482,25 @@ export async function executeDraftUpsert(
     return
   }
   if (hasSeededDraftCache(workspaceId)) upsertDraftInCache(workspaceId, confirmed)
+}
+
+/**
+ * Resolve a draft on the backend after its message sent (operation-queue replay
+ * of `resolve_draft`). CAS-guarded by `expectedVersion`: the server keeps a
+ * drifted copy (`resolved: false`) rather than deleting it, and that copy
+ * re-syncs as a stash entry on the next bootstrap. Either outcome is terminal
+ * for this op — the local row is already gone — so the response is informational
+ * and nothing more runs locally. Throws (network) so the queue retries; resolve
+ * is idempotent (a re-run hits an already-tombstoned row and returns
+ * `resolved: false`), so no idempotency key is needed.
+ */
+export async function executeDraftResolve(
+  workspaceId: string,
+  draftId: string,
+  expectedVersion: number,
+  service: DraftsServiceLike
+): Promise<void> {
+  await service.resolve(workspaceId, draftId, { expectedVersion })
 }
 
 /** Push a draft deletion to the backend (operation-queue replay of `delete_draft`). */

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -3,7 +3,7 @@ import type { CachedEvent, PendingOperation } from "@/db/database"
 import type { CommandFailedPayload, ScheduleMessageInput, ScheduledMessageView } from "@threa/types"
 import { ApiError, commandsApi } from "@/api"
 import { persistScheduledRows, replaceLocalScheduledRow } from "@/hooks/use-scheduled"
-import { executeDraftDelete, executeDraftUpsert, type DraftsServiceLike } from "./draft-sync"
+import { executeDraftDelete, executeDraftResolve, executeDraftUpsert, type DraftsServiceLike } from "./draft-sync"
 
 function getRetryDelay(retryCount: number): number {
   if (retryCount <= 3) return 0
@@ -226,6 +226,21 @@ async function executeOperation(
       // than throw (a throw would retry forever, never reaching a service).
       if (!draftsService) break
       await executeDraftUpsert(workspaceId, payload.draftId as string, payload.writeId as string, draftsService)
+      break
+    }
+
+    case "resolve_draft": {
+      // CAS clear-on-send (silent retry, no error surface). Drops the server row
+      // only if `expectedVersion` still matches; a drifted copy survives. Without
+      // a drafts service this context is local-only — drop the op (a throw would
+      // retry forever, never reaching a service).
+      if (!draftsService) break
+      await executeDraftResolve(
+        workspaceId,
+        payload.draftId as string,
+        payload.expectedVersion as number,
+        draftsService
+      )
       break
     }
 

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -193,12 +193,40 @@ Each stage is an independently mergeable PR with its own tests, sized for a clea
 
 ### Stage 4 — Resolve-on-send, thread re-pointing, E2E
 
-**Scope:** Close the loop on the message lifecycle and encrypted streams.
+**Scope:** Close the loop on the message lifecycle and encrypted streams. Shipped
+as three independently mergeable PRs (the three workstreams are independent and
+E2E is the largest/riskiest), not one combined PR.
 
-**Changes:**
+#### Stage 4a — Resolve-on-send (frontend wiring) — DONE
 
-- Send path (`use-stream-or-draft.ts` / `message-input.tsx`): carry `draftId + version`; on send success enqueue `resolve_draft` (CAS delete), clear loaded pointer.
+The backend resolve endpoint, service, CAS repo method, and tests already landed
+in Stage 1 (`POST /drafts/:id/resolve`, `softDeleteCas`, `DraftsService.resolve`).
+4a is the frontend wiring that calls it:
+
+- `api/drafts.ts`: `resolve(workspaceId, id, { expectedVersion })`.
+- `db/database.ts`: `PendingOperation.type` += `resolve_draft`.
+- `sync/draft-sync.ts`: `enqueueDraftResolve` (coalesced CAS resolve op),
+  `syncDraftResolution` (confirmed → resolve, never-synced → cancel push),
+  `executeDraftResolve` (queue replay), `DraftsServiceLike.resolve`.
+- `sync/operation-queue.ts`: `resolve_draft` case (silent retry, break when no service).
+- `hooks/use-draft-message.ts`: shared `removeLoadedDraftLocally`; `resolveLoadedDraft`
+  (CAS) alongside `clearLoadedDraft` (unconditional discard); `resolveDraft` callback.
+- `hooks/use-draft-composer.ts`: expose `resolveDraft`.
+- Send/schedule/command sites (`message-input.tsx`, `thread/stream-panel.tsx`):
+  call `resolveDraft` (CAS, drifted copy survives) instead of `clearDraft`. Stash
+  move + empty-composer discard keep `clearDraft` (unconditional).
+- `pages/workspace-layout.tsx`: wire `draftsApi.resolve` into `draftsService`.
+
+**Verification:** `bun run test` (frontend unit/integration — resolve enqueue/execute,
+CAS-vs-cancel by baseVersion, send uses resolve not clear). Backend resolve tests
+from Stage 1 still green.
+
+#### Stage 4b — Thread re-pointing
+
 - `moveMessagesToThread` (`event-service.ts`): re-scope user's `thread:{targetMessageId}` drafts → `stream:{threadStreamId}` (+ `root_stream_id`) in the move transaction, emit `draft:upserted`. Frontend handler moves the local draft + loaded pointer. Fold the unpromoted-draft-stream case into the existing `promoteDraft` flow (re-scope + push on promotion).
+
+#### Stage 4c — E2E
+
 - E2E: seal draft to stream SSK before persist/push; store ciphertext locally; decrypt on load.
 
 **Reuse:** `sealOutgoingMessage` E2E path; existing `promoteDraft` / `setParentThreadId`; resolve CAS from Stage 1.


### PR DESCRIPTION
## Problem

Sending a message clears its draft, but until now the clear was an **unconditional** delete: the send path called `composer.clearDraft()` → `clearLoadedDraft` → `syncDraftRemoval`, which enqueues a `delete_draft` op that soft-deletes the server row regardless of version. That violates the centralized-draft system's cardinal rule (`docs/plans/centralized-draft-system.md` §9, "local wins, on drift split, never overwrite, never lose"): if the same draft was edited on another device after this send started, the server row has drifted past the version this device knows, and an unconditional delete destroys that other device's work.

The backend already had the safe primitive — `DraftsService.resolve` + `DraftsRepository.softDeleteCas` (CAS soft-delete guarded by `expectedVersion`) and the `POST /api/workspaces/:wid/drafts/:id/resolve` route landed in Stage 1 with tests — but nothing on the frontend called it. This is Stage 4a: the frontend wiring for resolve-on-send.

## Solution

Split the draft-clear path in two by intent: **discard** (unconditional, unchanged) vs **resolve-on-send** (CAS-guarded). The send/schedule/command sites now resolve; stash-move and empty-composer discards keep the unconditional clear.

### How it works

1. `draftsApi.resolve(workspaceId, id, { expectedVersion })` → `POST /drafts/:id/resolve`. Added to `DraftsServiceLike` and wired into `draftsService` in `workspace-layout.tsx`.
2. `PendingOperation.type` gains `resolve_draft` (non-indexed union extension, no Dexie migration — same shape as the Stage 3 `upsert_draft`/`delete_draft` additions). `operation-queue.ts` gets a `resolve_draft` case that `break`s when no `draftsService` is present (local-only contexts), matching the existing draft ops.
3. `sync/draft-sync.ts`:
   - `enqueueDraftResolve(workspaceId, draftId, expectedVersion)` — coalesces by dropping any pending `upsert_draft`/`resolve_draft`/`delete_draft` for the id, then adds one `resolve_draft` op carrying `expectedVersion`.
   - `syncDraftResolution(workspaceId, id, baseVersion)` — the send-path counterpart to `syncDraftRemoval`: a confirmed draft (`baseVersion > 0`) enqueues a CAS resolve; a never-synced one (`baseVersion 0/undefined`) only cancels its pending push, because there is no server row to resolve.
   - `executeDraftResolve(...)` — queue replay; calls `service.resolve`. Resolve is idempotent server-side (a lost-ack retry hits an already-tombstoned row and returns `resolved: false`), so no idempotency key is needed.
4. `hooks/use-draft-message.ts`: the local teardown (delete row + clear pointer in one transaction, capture `baseVersion`, update cache) is extracted into a shared `removeLoadedDraftLocally`. `clearLoadedDraft` (discard) and the new `resolveLoadedDraft` (send) both call it and differ only in the sync tail — `syncDraftRemoval` vs `syncDraftResolution` (INV-43, one shared path for the shared behavior). A `resolveDraft` callback is exposed alongside `clearDraft`.
5. `hooks/use-draft-composer.ts` re-exports `resolveDraft`. The send (`message-input.tsx` regular send + command dispatch + schedule; `thread/stream-panel.tsx` thread send) call `composer.resolveDraft()`. `use-stash-composer.ts` (stash move) and the empty-content/remove-last-attachment discards inside `useDraftMessage` deliberately keep `clearDraft`.

### Key design decisions

**1. Resolve only on send, discard stays unconditional.** The CAS-vs-unconditional distinction only matters under drift, and drift-preservation is only correct for sends — when the user *explicitly* throws a draft away (stash move, deleting all text), an unconditional delete is the intended behavior. So `clearLoadedDraft` is untouched; resolve is a parallel path, not a replacement.

**2. `baseVersion 0` resolves to a cancel, not a CAS call.** The backend `resolveSchema` requires `expectedVersion >= 1` and there is no server row for a never-synced draft, so `syncDraftResolution` falls back to `cancelPendingDraftUpsert` — identical to how `syncDraftRemoval` already handles the unsynced case. A draft sent before its first push confirmed loses only its in-flight mirror; if that PUT already raced to the server, the orphan reappears as a stash entry on the next bootstrap (a duplicate, never a loss), which is the same pre-existing race as the discard path.

**3. Schedule and command dispatch resolve too.** Both consume the draft as an outgoing action, semantically identical to a send, so they take the same CAS path rather than the discard path.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/api/drafts.ts` | Add `resolve(workspaceId, id, { expectedVersion })`; refresh the doc comment (drop the "Stage 4 later" note). |
| `apps/frontend/src/db/database.ts` | `PendingOperation.type` += `resolve_draft`; expand the draft-ops comment. |
| `apps/frontend/src/sync/draft-sync.ts` | `DraftsServiceLike.resolve`; `enqueueDraftResolve`, `syncDraftResolution`, `executeDraftResolve`; widen `pendingDraftOps` to include `resolve_draft`. |
| `apps/frontend/src/sync/operation-queue.ts` | `resolve_draft` case (silent retry, break when no service); import `executeDraftResolve`. |
| `apps/frontend/src/hooks/use-draft-message.ts` | Extract `removeLoadedDraftLocally`; add `resolveLoadedDraft` + `resolveDraft` callback; expose it. |
| `apps/frontend/src/hooks/use-draft-composer.ts` | Re-export `resolveDraft` on `DraftComposerState`. |
| `apps/frontend/src/components/timeline/message-input.tsx` | Send, command dispatch, and schedule use `resolveDraft` instead of `clearDraft`. |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Thread send uses `resolveDraft`. |
| `apps/frontend/src/pages/workspace-layout.tsx` | Wire `draftsApi.resolve` into `draftsService`. |
| `docs/plans/centralized-draft-system.md` | Split Stage 4 into 4a/4b/4c (incremental PRs); document 4a as done. |
| `*.test.{ts,tsx}` (4 files) | Resolve coverage + mock updates (see Test plan). |

## Out of scope (deliberate)

- **Stage 4b — thread re-pointing** (`moveMessagesToThread` re-scope + `draft:upserted` + frontend pointer move + `promoteDraft` fold). Next PR.
- **Stage 4c — E2E** (seal-before-push, ciphertext at rest, decrypt-on-load). Encrypted-stream drafts stay deliberately local-only until then.
- **No backend changes.** `DraftsService.resolve`, `softDeleteCas`, the route, and their tests already shipped in Stage 1 and are untouched here.

## Test plan

- [x] `apps/frontend` full suite — **2682 pass / 241 files** (`bunx vitest run`)
- [x] Targeted draft suites — `draft-sync.test.ts`, `use-draft-message.test.ts`, `use-draft-composer.test.ts`, `message-input.test.tsx` (103 pass), covering: `enqueueDraftResolve`/`syncDraftResolution` CAS-vs-cancel by `baseVersion`, `executeDraftResolve` delegate + declined-resolve (drift) no-throw, `resolveLoadedDraft` removes-local + enqueues-`resolve_draft`-with-version, and send calls `resolveDraft` not `clearDraft`.
- [x] Pre-commit gate — prettier + eslint + `tsc --noEmit` across all workspaces + OpenAPI doc check + Dockerfile-workspace check, all clean.
- [ ] `bun run test:e2e` — not run for 4a; the end-to-end send/resolve and drifted-copy-survives scenarios are part of the Stage 4 verification and will be exercised once 4b/4c land the rest of the loop. 4a's behavior is covered by the unit/integration tests above.
- [ ] Backend resolve tests — unchanged from Stage 1 (no backend edits), not re-run.

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Stage 4a of the centralized draft system — wire the frontend to resolve a draft CAS-safely when its message sends, so a copy edited on another device after the send started survives instead of being collaterally deleted.

**What was built:** frontend resolve-on-send path (API client `resolve`, `resolve_draft` queue op, `enqueueDraftResolve`/`syncDraftResolution`/`executeDraftResolve`, shared `removeLoadedDraftLocally` + `resolveLoadedDraft`/`resolveDraft`, send-site wiring). Backend resolve endpoint/service/CAS/tests already existed from Stage 1.

**Design decisions:** resolve only on send (discard stays unconditional); `baseVersion 0` → cancel pending push rather than CAS; schedule/command treated as sends.

**Schema changes:** none (Dexie union extension only; backend `drafts` table unchanged).

**What's NOT included:** Stage 4b (thread re-pointing), Stage 4c (E2E). Tracked in `docs/plans/centralized-draft-system.md`.

**Status:** done, full frontend suite green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve3BGtxZF2QoxdhQiogSYK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784027058&installation_id=129946197&pr_number=932&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F932&signature=aca7dc4d2c4298d2e47ff49a03af16bb740830e1d22c244fdbd10e51ba0093c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->