### PR TITLE
feat(agents): C-2a — episode-aware context hydration policy for DMs

### DIFF
--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -12,6 +12,7 @@ import { AttachmentRepository } from "../../attachments"
 import { StreamRepository, type Stream } from "../../streams"
 import { awaitAttachmentProcessing } from "../../attachments"
 import { buildStreamContext, type StreamContext } from "../context-builder"
+import type { ContextWindowPolicy } from "../context-window-policy"
 import type { ConversationSummaryService } from "../conversation-summary-service"
 import { buildSystemPrompt } from "./prompt/system-prompt"
 import { loadTurnDigestPromptBlock } from "./turn-digests"
@@ -35,6 +36,12 @@ export interface ContextParams {
   messageId: string
   persona: Persona
   trigger?: typeof AgentTriggers.MENTION
+  /**
+   * Per-turn hydration policy, resolved at the dispatch (`Hydrate`) seam by
+   * `resolveContextWindowPolicy`. Fixes the window budget and whether prior
+   * turn digests carry into this turn (DM episode recency, §2.8 Q7/Q8).
+   */
+  policy: ContextWindowPolicy
   /** Invocation time override for deterministic evals/tests. Production uses Date.now(). */
   currentTime?: Date
 }
@@ -93,7 +100,7 @@ async function resolveScratchpadCustomPrompt(
  */
 export async function buildAgentContext(deps: ContextDeps, params: ContextParams): Promise<AgentContext> {
   const { db, userPreferencesService, conversationSummaryService } = deps
-  const { workspaceId, streamId, stream, messageId, persona, trigger, currentTime } = params
+  const { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime } = params
 
   const triggerMessage = await MessageRepository.findById(db, messageId)
   const invokingUserId = triggerMessage?.authorType === AuthorTypes.USER ? triggerMessage.authorId : undefined
@@ -137,6 +144,7 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
   const streamContext = await buildStreamContext(db, stream, {
     preferences,
     currentTime,
+    maxMessages: policy.maxMessages,
     triggerMessageId: messageId,
     includeAttachments: true,
   })
@@ -295,11 +303,18 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
   // rule. Appended after the base prompt so both first-party drivers fold the
   // identically-formatted block in at the same point (the enclave appends the
   // same formatter's output in run-turn).
-  const turnDigestBlock = await loadTurnDigestPromptBlock(db, {
-    streamId: stream.id,
-    personaId: persona.id,
-    accessibleStreamIds,
-  })
+  //
+  // Gated on the episode boundary (§2.5 / §2.8 Q8): a DM turn that opens a
+  // fresh episode — the prior session's cursor fell outside this window — must
+  // not carry that episode's digest chain. Bounded surfaces always carry
+  // (`policy.carryDigests` is true for them).
+  const turnDigestBlock = policy.carryDigests
+    ? await loadTurnDigestPromptBlock(db, {
+        streamId: stream.id,
+        personaId: persona.id,
+        accessibleStreamIds,
+      })
+    : null
 
   const composeSystemPrompt = (tools: AgentTool[]): string => {
     let systemPrompt = buildSystemPrompt(

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -24,6 +24,7 @@ import { UserRepository } from "../workspaces"
 import { AttachmentRepository } from "../attachments"
 import { AttachmentExtractionRepository, type PdfMetadata, type PdfSection } from "../attachments"
 import { getUtcOffset, type TemporalContext, type ParticipantTemporal } from "../../lib/temporal"
+import { DEFAULT_CONTEXT_WINDOW_MESSAGES } from "./context-window-policy"
 
 /**
  * A participant in a stream (user or persona).
@@ -132,14 +133,19 @@ export interface StreamContext {
   participantTimezones?: ParticipantTemporal[]
 }
 
-const MAX_CONTEXT_MESSAGES = 20
-
 /**
  * Options for building stream context with temporal information.
  */
 export interface BuildStreamContextOptions {
   /** User preferences (used for temporal context) */
   preferences?: UserPreferences
+  /**
+   * Newest-first message budget for the conversation window. Resolved once at
+   * the dispatch (`Hydrate`) seam by `resolveContextWindowPolicy` and handed in;
+   * defaults to `DEFAULT_CONTEXT_WINDOW_MESSAGES` for callers that build context
+   * outside a turn (evals, the enclave prompt assembly).
+   */
+  maxMessages?: number
   /** Current time at invocation (for deterministic testing) */
   currentTime?: Date
   /** Trigger message ID (for determining attachment detail levels) */
@@ -191,26 +197,28 @@ export async function buildStreamContext(
     )
   }
 
+  const maxMessages = options?.maxMessages ?? DEFAULT_CONTEXT_WINDOW_MESSAGES
+
   let context: StreamContext
   switch (stream.type) {
     case StreamTypes.SCRATCHPAD:
-      context = await buildScratchpadContext(db, stream, temporal)
+      context = await buildScratchpadContext(db, stream, temporal, maxMessages)
       break
 
     case StreamTypes.CHANNEL:
-      context = await buildChannelContext(db, stream, temporal, options?.currentTime)
+      context = await buildChannelContext(db, stream, temporal, maxMessages, options?.currentTime)
       break
 
     case StreamTypes.THREAD:
-      context = await buildThreadContext(db, stream, temporal)
+      context = await buildThreadContext(db, stream, temporal, maxMessages)
       break
 
     case StreamTypes.DM:
-      context = await buildDmContext(db, stream, temporal, options?.currentTime)
+      context = await buildDmContext(db, stream, temporal, maxMessages, options?.currentTime)
       break
 
     default:
-      context = await buildScratchpadContext(db, stream, temporal)
+      context = await buildScratchpadContext(db, stream, temporal, maxMessages)
   }
 
   // Enrich with attachment context if requested
@@ -245,8 +253,13 @@ function buildTemporalContext(preferences: TemporalPreferenceFields, currentTime
 /**
  * Scratchpad context: personal, solo-first. Conversation history is primary context.
  */
-async function buildScratchpadContext(db: Querier, stream: Stream, temporal?: TemporalContext): Promise<StreamContext> {
-  const messages = await MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES })
+async function buildScratchpadContext(
+  db: Querier,
+  stream: Stream,
+  temporal: TemporalContext | undefined,
+  maxMessages: number
+): Promise<StreamContext> {
+  const messages = await MessageRepository.list(db, stream.id, { limit: maxMessages })
 
   return {
     streamType: stream.type,
@@ -267,11 +280,12 @@ async function buildScratchpadContext(db: Querier, stream: Stream, temporal?: Te
 async function buildChannelContext(
   db: Querier,
   stream: Stream,
-  temporal?: TemporalContext,
+  temporal: TemporalContext | undefined,
+  maxMessages: number,
   currentTime?: Date
 ): Promise<StreamContext> {
   const [messages, members] = await Promise.all([
-    MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
+    MessageRepository.list(db, stream.id, { limit: maxMessages }),
     StreamMemberRepository.list(db, { streamId: stream.id }),
   ])
 
@@ -305,11 +319,12 @@ async function buildChannelContext(
 async function buildDmContext(
   db: Querier,
   stream: Stream,
-  temporal?: TemporalContext,
+  temporal: TemporalContext | undefined,
+  maxMessages: number,
   currentTime?: Date
 ): Promise<StreamContext> {
   const [messages, members] = await Promise.all([
-    MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES }),
+    MessageRepository.list(db, stream.id, { limit: maxMessages }),
     StreamMemberRepository.list(db, { streamId: stream.id }),
   ])
 
@@ -344,8 +359,13 @@ async function buildDmContext(
  * in conversation history. This ensures the agent sees the full context
  * (including attachments like images) that led to the thread being created.
  */
-async function buildThreadContext(db: Querier, stream: Stream, temporal?: TemporalContext): Promise<StreamContext> {
-  const messages = await MessageRepository.list(db, stream.id, { limit: MAX_CONTEXT_MESSAGES })
+async function buildThreadContext(
+  db: Querier,
+  stream: Stream,
+  temporal: TemporalContext | undefined,
+  maxMessages: number
+): Promise<StreamContext> {
+  const messages = await MessageRepository.list(db, stream.id, { limit: maxMessages })
 
   // Build thread path from current thread up to root
   const threadPath = await buildThreadPath(db, stream)

--- a/apps/backend/src/features/agents/context-window-policy.ts
+++ b/apps/backend/src/features/agents/context-window-policy.ts
@@ -59,7 +59,11 @@ export async function resolveContextWindowPolicy(
   db: Querier,
   params: ResolveContextWindowPolicyParams
 ): Promise<ContextWindowPolicy> {
-  const maxMessages = params.maxMessages ?? DEFAULT_CONTEXT_WINDOW_MESSAGES
+  // A window always holds at least the triggering message; clamp so a
+  // degenerate budget can't make `findWindowFloorSequence` return null
+  // (→ "whole stream fits in window" → continue) for what is really an empty
+  // window.
+  const maxMessages = Math.max(1, params.maxMessages ?? DEFAULT_CONTEXT_WINDOW_MESSAGES)
 
   if (params.stream.type !== StreamTypes.DM) {
     return { episode: { kind: "stream" }, maxMessages, carryDigests: true }

--- a/apps/backend/src/features/agents/context-window-policy.ts
+++ b/apps/backend/src/features/agents/context-window-policy.ts
@@ -1,0 +1,81 @@
+import type { Querier } from "../../db"
+import { StreamTypes } from "@threa/types"
+import type { Stream } from "../streams"
+import { MessageRepository } from "../messaging"
+import { AgentSessionRepository } from "./session-repository"
+
+/**
+ * Default budgeted-window size: the newest-N messages a context build hydrates.
+ * C-2a keeps the message-count budget; C-2b swaps the count for a token budget
+ * (the `truncateMessages` newest-first fill) without changing this seam.
+ */
+export const DEFAULT_CONTEXT_WINDOW_MESSAGES = 20
+
+/**
+ * Which conversation episode a turn belongs to. Bounded surfaces (scratchpads,
+ * threads, channel-spawned threads) are one continuous episode; a DM is an
+ * unbounded surface whose episode boundary is recency.
+ */
+export type ContextEpisode = { kind: "stream" } | { kind: "dm-recency"; continues: boolean }
+
+/**
+ * The hydration policy for a single turn, resolved once at the dispatch
+ * (`Hydrate`) seam and handed to the context build — never chosen inside it
+ * (agent-runtimes §2.5 / §2.8 Q7). It fixes the window budget and whether the
+ * prior turn digests (C-1) carry into this turn.
+ */
+export interface ContextWindowPolicy {
+  episode: ContextEpisode
+  /** Newest-first message budget for the window. */
+  maxMessages: number
+  /** Whether prior `turn_digest` steps inject as "Prior Tool Work" this turn. */
+  carryDigests: boolean
+}
+
+export interface ResolveContextWindowPolicyParams {
+  stream: Stream
+  /** Override the default window budget (tests pin a small budget). */
+  maxMessages?: number
+}
+
+/**
+ * Resolve the per-turn context window policy.
+ *
+ * Bounded surfaces are a single continuous episode: digests always carry (Q7).
+ *
+ * A DM is unbounded, so its episode boundary is recency anchored on the
+ * SEQUENTIAL window — not the async `conversations` segmenter (agent-runtimes
+ * §2.8 Q8). The window is always the reliable, non-blocking base; the prior
+ * completed session's `lastSeenSequence` decides continuity: continue the
+ * episode — carrying its digest chain — only while that cursor still falls
+ * inside the window about to be built. A gap larger than the window starts a
+ * fresh episode with no digest carry-over. Anchoring on the sequence (rather
+ * than on conversation identity) is deliberate: it can never revive a
+ * weeks-old session, and it errs toward continuing — the costlier mistake is a
+ * false fresh that drops context the user expected the agent to hold (Q8 error
+ * asymmetry).
+ */
+export async function resolveContextWindowPolicy(
+  db: Querier,
+  params: ResolveContextWindowPolicyParams
+): Promise<ContextWindowPolicy> {
+  const maxMessages = params.maxMessages ?? DEFAULT_CONTEXT_WINDOW_MESSAGES
+
+  if (params.stream.type !== StreamTypes.DM) {
+    return { episode: { kind: "stream" }, maxMessages, carryDigests: true }
+  }
+
+  const priorSession = await AgentSessionRepository.findLatestCompletedByStream(db, params.stream.id)
+
+  // No prior completed session → there are no digests to carry; start fresh.
+  if (!priorSession || priorSession.lastSeenSequence === null) {
+    return { episode: { kind: "dm-recency", continues: false }, maxMessages, carryDigests: false }
+  }
+
+  const windowFloor = await MessageRepository.findWindowFloorSequence(db, params.stream.id, maxMessages)
+  // `null` floor → the stream has fewer than `maxMessages` messages, so the
+  // window covers everything and any prior cursor is inside it (continue).
+  const continues = windowFloor === null || priorSession.lastSeenSequence >= windowFloor
+
+  return { episode: { kind: "dm-recency", continues }, maxMessages, carryDigests: continues }
+}

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -154,6 +154,10 @@ export { resolveActorNames } from "./actor-names"
 // Context builder
 export { buildStreamContext, enrichMessagesWithAttachments } from "./context-builder"
 
+// Per-turn hydration policy (window budget + digest carry; the `Hydrate` seam)
+export { resolveContextWindowPolicy, DEFAULT_CONTEXT_WINDOW_MESSAGES } from "./context-window-policy"
+export type { ContextWindowPolicy, ContextEpisode, ResolveContextWindowPolicyParams } from "./context-window-policy"
+
 // Enclave system-prompt assembly (shared builder + reduced toolset) so the
 // enclave runs Ariadne on the same prompt as the main app.
 export { buildEnclaveSystemPrompt } from "./enclave-system-prompt"

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -303,8 +303,11 @@ export class PersonaAgent {
         // seam — window budget + whether prior turn digests carry — and hand it
         // to the context build. For a DM this reads the PRIOR completed
         // session's cursor (the current RUNNING session, just inserted, is
-        // skipped) to decide the episode boundary (§2.8 Q7/Q8).
-        const policy = await resolveContextWindowPolicy(pool, { stream })
+        // skipped) to decide the episode boundary (§2.8 Q7/Q8). Two related
+        // reads with no AI work, so take a single connection — unlike
+        // buildAgentContext below, which holds none across its rolling-summary
+        // AI call (INV-41).
+        const policy = await withClient(pool, (client) => resolveContextWindowPolicy(client, { stream }))
 
         // Build all context the agent needs
         const agentContext = await buildAgentContext(

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -34,6 +34,7 @@ import { WorkspaceAgent, type WorkspaceAgentResult } from "./researcher"
 import { GeneralResearcher, GENERAL_RESEARCH_TOOL_POLICY, type GeneralResearchResult } from "./general-researcher"
 import { logger } from "../../lib/logger"
 import { buildAgentContext, buildToolSet, withCompanionSession, type WithSessionResult } from "./companion"
+import { resolveContextWindowPolicy } from "./context-window-policy"
 import { resolveBagForStream, persistSnapshot, appendBagToSystemPrompt, type ResolvedBag } from "./context-bag"
 import { createMemoizedGithubClient, createMemoizedLinearClient, type RunGeneralResearchOptions } from "./tools"
 import { createSessionTraceProjector, OtelObserver, type AgentRuntimeConfig, type NewMessageInfo } from "./runtime"
@@ -298,10 +299,17 @@ export class PersonaAgent {
         })
         trace.notifyActivityStarted()
 
+        // Resolve the per-turn hydration policy at the dispatch (`Hydrate`)
+        // seam — window budget + whether prior turn digests carry — and hand it
+        // to the context build. For a DM this reads the PRIOR completed
+        // session's cursor (the current RUNNING session, just inserted, is
+        // skipped) to decide the episode boundary (§2.8 Q7/Q8).
+        const policy = await resolveContextWindowPolicy(pool, { stream })
+
         // Build all context the agent needs
         const agentContext = await buildAgentContext(
           { db: pool, userPreferencesService, conversationSummaryService },
-          { workspaceId, streamId, stream, messageId, persona, trigger, currentTime }
+          { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime }
         )
 
         // Resolve an attached ContextBag (if any) so `stable + delta` flow into

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -553,7 +553,7 @@ export const AgentSessionRepository = {
         FROM agent_sessions
         WHERE stream_id = ${streamId}
           AND status = ${SessionStatuses.COMPLETED}
-        ORDER BY created_at DESC
+        ORDER BY created_at DESC, id DESC
         LIMIT 1
       `
     )

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -540,6 +540,27 @@ export const AgentSessionRepository = {
   },
 
   /**
+   * Find the most recent COMPLETED session for a stream. Unlike
+   * `findLatestByStream` this skips the in-flight RUNNING session a turn
+   * inserts before it builds its context, so the context window policy reads
+   * the PRIOR episode's `lastSeenSequence` (DM episode recency) rather than the
+   * current session's.
+   */
+  async findLatestCompletedByStream(db: Querier, streamId: string): Promise<AgentSession | null> {
+    const result = await db.query<SessionRow>(
+      sql`
+        SELECT ${sql.raw(SESSION_SELECT_FIELDS)}
+        FROM agent_sessions
+        WHERE stream_id = ${streamId}
+          AND status = ${SessionStatuses.COMPLETED}
+        ORDER BY created_at DESC
+        LIMIT 1
+      `
+    )
+    return result.rows[0] ? mapRowToSession(result.rows[0]) : null
+  },
+
+  /**
    * Find the most recent session for a stream (regardless of status).
    * Used to check lastSeenSequence when deciding whether to dispatch a new job.
    */

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -751,6 +751,28 @@ export const MessageRepository = {
   },
 
   /**
+   * Sequence of the `windowSize`-th most recent non-deleted message in a
+   * stream — i.e. the oldest message that still falls inside a budgeted
+   * newest-first window of that size. Returns null when the stream has fewer
+   * than `windowSize` messages (the window covers the whole stream). Mirrors
+   * the filter `list()` applies (non-deleted, by `sequence`), so the floor it
+   * reports matches the window `list()` would build. Used by the agent context
+   * window policy to decide whether a prior session's cursor is still inside
+   * the window about to be built (DM episode recency, INV-30 single query).
+   */
+  async findWindowFloorSequence(db: Querier, streamId: string, windowSize: number): Promise<bigint | null> {
+    if (windowSize < 1) return null
+    const result = await db.query<{ sequence: string }>(sql`
+      SELECT sequence::text AS sequence FROM messages
+      WHERE stream_id = ${streamId}
+        AND deleted_at IS NULL
+      ORDER BY sequence DESC
+      OFFSET ${windowSize - 1} LIMIT 1
+    `)
+    return result.rows[0] ? BigInt(result.rows[0].sequence) : null
+  },
+
+  /**
    * Update the embedding for a message.
    * Used by the embedding worker after generating embeddings.
    */

--- a/apps/backend/tests/integration/context-window-policy.test.ts
+++ b/apps/backend/tests/integration/context-window-policy.test.ts
@@ -180,4 +180,21 @@ describe("resolveContextWindowPolicy", () => {
       expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
     })
   })
+
+  test("clamps a degenerate window budget so it can't continue into an empty window", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 5)
+      await insertCompletedSession(client, dm.id, BigInt(4))
+
+      // 0 clamps to 1: the window is the single newest message (sequence 5), and
+      // the prior cursor (4) sits outside it → fresh. Without the clamp a 0
+      // budget made findWindowFloorSequence return null → a spurious "continue"
+      // into a zero-message window.
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 0 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 1, carryDigests: false })
+    })
+  })
 })

--- a/apps/backend/tests/integration/context-window-policy.test.ts
+++ b/apps/backend/tests/integration/context-window-policy.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Context Window Policy Integration Tests
+ *
+ * `resolveContextWindowPolicy` fixes the per-turn window budget and whether the
+ * prior turn digests carry (the DM episode boundary, agent-runtimes §2.8 Q7/Q8).
+ *
+ * Verifies:
+ * 1. Bounded surfaces (scratchpad/thread/channel) are one episode — always carry.
+ * 2. A DM with no prior completed session starts fresh (nothing to carry).
+ * 3. A DM continues — carrying digests — when the prior session's cursor is
+ *    still inside the budgeted window.
+ * 4. A DM starts fresh when that cursor fell outside the window (a gap larger
+ *    than the budget).
+ * 5. A DM whose whole history fits inside the window always continues.
+ * 6. The in-flight RUNNING session is ignored; the PRIOR completed one decides.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Pool } from "pg"
+import { withTestTransaction, setupTestDatabase, testMessageContent, addTestMember } from "./setup"
+import { WorkspaceRepository } from "../../src/features/workspaces"
+import { StreamRepository, type Stream } from "../../src/features/streams"
+import { MessageRepository } from "../../src/features/messaging"
+import { AgentSessionRepository, SessionStatuses, resolveContextWindowPolicy } from "../../src/features/agents"
+import type { PoolClient } from "pg"
+import { userId, workspaceId, streamId, messageId, sessionId, personaId } from "../../src/lib/id"
+import { StreamTypes, Visibilities } from "@threa/types"
+
+type StreamType = (typeof StreamTypes)[keyof typeof StreamTypes]
+
+const TEST_PERSONA_ID = personaId()
+
+async function setupWorkspaceMember(client: PoolClient): Promise<{ workspaceId: string; memberId: string }> {
+  const wsId = workspaceId()
+  const workosUserId = userId()
+  await WorkspaceRepository.insert(client, {
+    id: wsId,
+    name: "Window Policy Workspace",
+    slug: `cwp-ws-${wsId}`,
+    createdBy: workosUserId,
+  })
+  const member = await addTestMember(client, wsId, workosUserId)
+  return { workspaceId: wsId, memberId: member.id }
+}
+
+async function insertStream(client: PoolClient, wsId: string, memberId: string, type: StreamType): Promise<Stream> {
+  return StreamRepository.insert(client, {
+    id: streamId(),
+    workspaceId: wsId,
+    type,
+    displayName: type === StreamTypes.DM ? undefined : `${type} stream`,
+    visibility: Visibilities.PRIVATE,
+    createdBy: memberId,
+  })
+}
+
+async function insertMessages(client: PoolClient, streamIdArg: string, authorId: string, count: number): Promise<void> {
+  for (let i = 1; i <= count; i++) {
+    await MessageRepository.insert(client, {
+      id: messageId(),
+      streamId: streamIdArg,
+      sequence: BigInt(i),
+      authorId,
+      authorType: "user",
+      ...testMessageContent(`message ${i}`),
+    })
+  }
+}
+
+async function insertCompletedSession(
+  client: PoolClient,
+  streamIdArg: string,
+  lastSeenSequence: bigint
+): Promise<void> {
+  const id = sessionId()
+  await AgentSessionRepository.insert(client, {
+    id,
+    streamId: streamIdArg,
+    personaId: TEST_PERSONA_ID,
+    triggerMessageId: messageId(),
+    status: SessionStatuses.RUNNING,
+    serverId: "test-server",
+  })
+  await AgentSessionRepository.completeSession(client, id, { lastSeenSequence })
+}
+
+describe("resolveContextWindowPolicy", () => {
+  let pool: Pool
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  test("bounded surfaces are one episode — always carry digests", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const scratchpad = await insertStream(client, wsId, memberId, StreamTypes.SCRATCHPAD)
+
+      const policy = await resolveContextWindowPolicy(client, { stream: scratchpad, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "stream" }, maxMessages: 3, carryDigests: true })
+    })
+  })
+
+  test("DM with no prior completed session starts fresh", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 5)
+
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 3, carryDigests: false })
+    })
+  })
+
+  test("DM continues when the prior cursor is inside the window", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 5) // budget 3 → window floor is sequence 3
+      await insertCompletedSession(client, dm.id, BigInt(4)) // 4 >= 3, inside
+
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+    })
+  })
+
+  test("DM starts fresh when the prior cursor fell outside the window", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 5) // budget 3 → window floor is sequence 3
+      await insertCompletedSession(client, dm.id, BigInt(2)) // 2 < 3, outside → gap > window
+
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 3, carryDigests: false })
+    })
+  })
+
+  test("DM continues when its whole history fits inside the window", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 2) // fewer than budget 3 → no floor
+      await insertCompletedSession(client, dm.id, BigInt(1))
+
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+    })
+  })
+
+  test("DM ignores the in-flight running session and reads the prior completed one", async () => {
+    await withTestTransaction(pool, async (client) => {
+      const { workspaceId: wsId, memberId } = await setupWorkspaceMember(client)
+      const dm = await insertStream(client, wsId, memberId, StreamTypes.DM)
+      await insertMessages(client, dm.id, memberId, 5)
+      await insertCompletedSession(client, dm.id, BigInt(4)) // prior episode, cursor inside
+
+      // The current turn's RUNNING session (no lastSeenSequence yet) must not
+      // shadow the prior completed session's cursor.
+      await AgentSessionRepository.insert(client, {
+        id: sessionId(),
+        streamId: dm.id,
+        personaId: TEST_PERSONA_ID,
+        triggerMessageId: messageId(),
+        status: SessionStatuses.RUNNING,
+        serverId: "test-server",
+      })
+
+      const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
+
+      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+    })
+  })
+})

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -984,52 +984,62 @@ type)` are how the episode is computed, not a parallel dimension._
    time-based, or both (e.g., within the window **or** within 24h), and
    whether the user can explicitly start fresh ("new conversation" affordance,
    like clearing a Claude.ai thread).
-   _Resolved as **best-effort segmentation by the existing conversations system,
-   not a raw message count and not a wall-clock horizon**: the DM episode is the
-   LLM-extracted conversation the triggering message lands in — hydrate (fill up)
-   that conversation's messages — with the structural window edge as the fallback
-   when no conversation is confidently assigned yet, and **no dedicated DM "clear"
-   affordance now** (INV-36). Like Q7 this fixes the shape of unbuilt C-2 work,
-   not shipped behavior: the conversations system already extracts boundaries on
-   every message but is consumed by GAM, not yet by agent context hydration (the
-   context-builder still uses a flat `MAX_CONTEXT_MESSAGES = 20`,
-   `context-builder.ts:135`); and today `lastSeenSequence` is only the companion
-   **dedup** cursor (`companion-outbox-handler.ts:131-144`, "message already seen,
-   skipping"), with the DM-mention path not setting it at all
-   (`persona-agent-worker.ts:66` excludes `AgentTriggers.MENTION`). The DM
-   episode-by-recency rule (§2.5, line ~554) is the C-2 surface this
-   parameterizes._
-   - _**The boundary is the conversations system, which already does model-based
-     segmentation (INV-54).** `conversations` (`20251225231931_conversations.sql`,
+   _Resolved as **a recency episode anchored on the sequential window — not a raw
+   message count, not a wall-clock horizon, and not the async `conversations`
+   segmenter as a hard filter — with the conversations system layered on top as a
+   best-effort highlight**. The DM context window is always the contiguous,
+   newest-first range of messages (reliable and non-blocking); the episode
+   boundary is whether the prior completed session's `lastSeenSequence` still
+   falls inside that window. The LLM-extracted conversation the triggering message
+   lands in is read best-effort and can only ever expand the window to stay
+   coherent — never shrink it to a spotty subset, never block the turn on
+   extraction — so a misclassification or a still-pending segmentation degrades to
+   "use the sequential window," never to dropped context. **No dedicated DM
+   "clear" affordance now** (INV-36). C-2a ships this boundary:
+   `resolveContextWindowPolicy` (`context-window-policy.ts`) resolves the window
+   budget and whether the prior turn digests (C-1) carry at the dispatch
+   (`Hydrate`) seam — reading the prior completed session's `lastSeenSequence`
+   (`findLatestCompletedByStream`) against the window floor
+   (`MessageRepository.findWindowFloorSequence`) — and `buildAgentContext` gates
+   the digest block on it. The token-budget window fill (C-2b), the in-enclave
+   sealed summary (C-2c, §2.8 Q6), and the conversation highlight remain
+   follow-ups. The DM episode-by-recency rule (§2.5, line ~554) is the surface
+   this parameterizes._
+   - _**The conversations system is the highlight, not the boundary — read
+     best-effort, never awaited.** `conversations` (`20251225231931_conversations.sql`,
      feature `conversations/`) groups a stream's messages into "a coherent unit of
      discussion" by LLM boundary extraction on every `message:created`
      (`boundary-extraction-service.ts`, confidence-scored), carrying `message_ids`,
      a `topic_summary`, a `completeness_score` (1–7), and `status`
-     (active/stalled/resolved). This is exactly the semantic continuity axis INV-54
-     demands — and it already exists, so the episode rides it rather than
-     re-deriving a parallel boundary. The DM episode is the conversation the
-     triggering message belongs to (`ConversationRepository.findByMessageId`,
-     GIN-indexed on `message_ids`); "continue" hydrates that conversation's
-     messages — Kris's "if the last message ends up in a convo, fill that up too."_
+     (active/stalled/resolved). Extraction is async and debounced, and membership
+     is sparse — a topic can own messages 4 and 6 but not 5 — so consuming
+     `message_ids` directly as the window would both block the turn on a pending
+     segmentation and produce a discontiguous context. Instead the conversation
+     the triggering message belongs to (`ConversationRepository.findPrimaryByMessageId`,
+     GIN-indexed) is surfaced as a **highlight** over the sequential window: it
+     marks the live topic and may pull the window floor earlier to keep that topic
+     whole, but the window itself stays contiguous and is built whether or not
+     extraction has caught up._
    - _**Raw message count is rejected as the unit.** "Within the last ~20
      messages" assumes AI-chat cadence — a handful of composed, self-contained
      turns. Workspace chat is bursty: many short one-line messages, so twenty of
      them is a fraction of one exchange while twenty composed turns span several. A
-     count threshold is a unit mismatch with the surface. The conversations system
-     is unit-agnostic — it segments by topical coherence, not by counting rows —
-     which is why it, not a count, is the boundary._
-   - _**Best-effort, with the structural window as the fallback.** Boundary
-     extraction is async and debounced (outbox handler + worker, `staleness.ts`),
-     so a just-arrived trigger may not be assigned to a conversation yet, or be
-     extracted at low confidence. When there is no confident conversation to ride,
-     fall back to the structural window edge: continue iff the prior completed
-     session's `lastSeenSequence` falls inside the budgeted window about to be
-     built (the intervening messages then already fill the gap; otherwise start
-     fresh). The window is the floor, the conversation is the signal — never a hard
-     count knob exposed as config (INV-36). C-2's rolling summary
-     (`ConversationSummaryService`, "rolling summaries for conversation segments
-     dropped from active context windows") softens a wrong segmentation by keeping
-     older turns present compressed rather than dropping them at a hard edge._
+     count threshold is a unit mismatch as a *continuity* metric. The episode
+     boundary is recency on the window, not a count of messages; the window budget
+     is a separate sizing knob (a message count in C-2a, a token budget in C-2b),
+     never the boundary itself._
+   - _**The sequential window is the base; recency is the boundary.** Continuity
+     is decided by the prior completed session's `lastSeenSequence`: continue —
+     carrying the digest chain — iff it falls inside the budgeted window about to
+     be built (the intervening messages already fill the gap), otherwise start
+     fresh. This needs no extraction and never blocks, so it holds even when the
+     segmenter is behind or wrong. The window budget is a derived value on the
+     dispatch binding, never a hard count knob exposed as config (INV-36). C-2's
+     rolling summary (`ConversationSummaryService`, "rolling summaries for
+     conversation segments dropped from active context windows") keeps older turns
+     present compressed rather than dropping them at a hard edge, so even a fresh
+     episode loses no conversation content — only the prior tool-work digest
+     carry._
    - _**Wall-clock is rejected as a boundary; it survives only as the conversations
      system's own secondary staleness nudge.** Human conversational continuity does
      not decay on a clock — a colleague replying eight weeks on, after two stacked
@@ -1047,8 +1057,9 @@ type)` are how the episode is computed, not a parallel dimension._
      context the user expected the agent to still hold — the exact forgetting
      C-1/C-2 exist to kill, and only partly mitigated because the in-window
      messages survive even when the digest is dropped. The costlier mistake is the
-     false fresh, so where the segmentation is uncertain — low extraction
-     confidence, or no conversation assigned yet — it continues._
+     false fresh, so the recency check errs toward continuing: the window floor is
+     inclusive and the budget is generous, and only a gap that clears the whole
+     window starts fresh._
    - _**No dedicated DM "clear conversation" control now (INV-36), and "clear
      like Claude.ai" is the wrong model for a shared DM.** A DM is a two-party
      (`DM_PARTICIPANT_COUNT = 2`, `constants.ts:13`) shared, append-only timeline
@@ -1057,16 +1068,23 @@ type)` are how the episode is computed, not a parallel dimension._
      doesn't transfer. The explicit fresh-start that **does** exist in Threa is
      bounded-surface creation — a new scratchpad or thread is a fresh episode by
      construction (§2.5) — and that is the primary surface, so the unbounded DM is
-     the only place the affordance is even missing. The conversations boundary
-     handles the common case automatically; per INV-36 no control ships until a
-     need the auto-boundary doesn't cover is demonstrated._
+     the only place the affordance is even missing. The recency boundary handles
+     the common case automatically; per INV-36 no control ships until a need the
+     auto-boundary doesn't cover is demonstrated._
    - _**If a DM-specific fresh-start is later wanted, it forces a new conversation
      boundary — not a history mutation.** The realizing shape: a user-declared
      "start fresh" marks the open conversation `resolved` (the segmenter's own
-     terminal `status`), so the next message opens a new conversation and the
-     episode hydration finds nothing prior to carry. This rides the one segmenter
-     the boundary already trusts rather than adding a parallel predicate, mutates
-     no message history (no INV-61 violation, nothing deleted), and works
-     identically on plaintext and E2E because it gates digest **carry**, not
-     content. Until a concrete need appears, the automatic conversation boundary is
-     the entire contract (INV-36)._
+     terminal `status`), so the next message opens a new conversation and — once
+     the conversation highlight feeds the boundary — the episode hydration finds
+     nothing prior to carry. This rides the one segmenter rather than adding a
+     parallel predicate, mutates no message history (no INV-61 violation, nothing
+     deleted), and works identically on plaintext and E2E because it gates digest
+     **carry**, not content. Until a concrete need appears, the automatic recency
+     boundary is the entire contract (INV-36)._
+   - _**Follow-up: a conversation that spans surfaces.** A topic can begin in a
+     channel and continue in a thread — e.g. the persona is pulled into a channel
+     discussion but must answer in a spawned thread — so one conversation lives
+     across two streams with two episode keys. The per-stream window here does not
+     stitch that together; cross-surface episode continuity (and the conversation
+     **highlight** that would carry it) is left as a follow-up rather than widened
+     into this boundary now (INV-36)._


### PR DESCRIPTION
**Design doc:** `docs/plans/agent-runtimes-unification-redesign.md` — agent-runtimes §2.5 (C-2 / Hydrate) and §2.8 Q7+Q8. No Linear ticket.

## Problem

A companion agent's context window is a flat `MAX_CONTEXT_MESSAGES = 20` applied identically by every stream-type builder (`context-builder.ts`), and prior turn digests (C-1) are injected unconditionally for the stream/persona (`companion/context.ts` → `loadTurnDigestPromptBlock`). For a DM — the one unbounded, never-ending agent surface — that means the agent always carries forward the last sessions' tool-work digest chain, even across a multi-week gap that a human reads as a brand-new conversation. §2.8 Q8 ruled the DM episode boundary; nothing implemented it. There was also no seam to resolve "which window / does continuity carry" per turn — the §2.5 `Hydrate` step the redesign introduces.

## Solution

Introduce the per-turn `ContextWindowPolicy` and resolve it once at the dispatch (`Hydrate`) seam, then use it to gate digest carry on the DM episode boundary. The boundary is anchored on the **sequential window**, not the async `conversations` segmenter: a DM continues its prior episode only while the prior completed session's cursor is still inside the window about to be built.

### How it works

1. **`resolveContextWindowPolicy(db, { stream, maxMessages? })`** (`context-window-policy.ts`) returns `{ episode, maxMessages, carryDigests }`. Bounded surfaces (scratchpad / thread / channel) → `{ kind: "stream" }`, `carryDigests: true` — one continuous episode (Q7).
2. **DM episode (Q8):** read the prior **completed** session via `AgentSessionRepository.findLatestCompletedByStream` — which skips the in-flight RUNNING session the turn inserts before it builds context, so the policy reads the *prior* episode's `lastSeenSequence`, not the current one. Compare it to `MessageRepository.findWindowFloorSequence(stream, maxMessages)` (the oldest sequence inside a budgeted newest-first window, mirroring `list()`'s `deleted_at IS NULL` filter). `lastSeenSequence >= floor` → continue + carry digests; a gap that clears the whole window → fresh, no carry. A `null` floor (stream smaller than the budget) → the window covers everything → continue. No prior completed session → fresh (no digests exist to carry).
3. **`persona-agent.ts`** resolves the policy just before `buildAgentContext` and passes it through. `buildAgentContext` threads `policy.maxMessages` into `buildStreamContext` (replacing the hardcoded constant) and gates the digest block: `policy.carryDigests ? loadTurnDigestPromptBlock(...) : null`.

### Key design decisions

**1. Anchor on the sequence, not on conversation identity.** The DM episode could have keyed on the `conversations` segmenter (Q8's original framing). It doesn't: extraction is async/debounced and membership is sparse (a topic can own messages 4 and 6 but not 5), so consuming `message_ids` directly would block the turn and produce a discontiguous context. The sequential window is the reliable, non-blocking base; the conversation is demoted to a (deferred) highlight. Anchoring on the cursor also means a new message that merely references a weeks-old message can never revive that old session.

**2. Bias toward continue (Q8 error asymmetry).** A false *continue* injects a stale digest chain — cheap and self-correcting (the reader block re-verifies, the live turn outweighs system-context, the carry ages out). A false *fresh* drops context the user expected the agent to hold — the exact forgetting C-1/C-2 exist to kill. So the floor comparison is inclusive (`>=`) and only a gap clearing the whole window starts fresh.

**3. `findLatestCompletedByStream`, not `findLatestByStream`.** The existing helper returns the latest session regardless of status; at policy-resolution time that is the just-inserted RUNNING session of the current turn, which would shadow the prior episode. The new helper filters to `COMPLETED`. Covered by the "ignores the in-flight running session" test.

**4. Rolling summary untouched.** Conversation content still folds into `ConversationSummaryService` cumulatively. A fresh episode drops only the prior *tool-work digest* carry, never conversation content — true conversation compaction/reset is a separate mechanism, deferred.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/context-window-policy.ts` | `ContextWindowPolicy` type + `resolveContextWindowPolicy` (the `Hydrate` seam) and `DEFAULT_CONTEXT_WINDOW_MESSAGES` |
| `apps/backend/tests/integration/context-window-policy.test.ts` | Integration coverage for the policy (6 tests) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/session-repository.ts` | Add `findLatestCompletedByStream` (skips the in-flight RUNNING session) |
| `apps/backend/src/features/messaging/repository.ts` | Add `findWindowFloorSequence` (oldest sequence inside a budgeted window; mirrors `list()`'s filter) |
| `apps/backend/src/features/agents/context-builder.ts` | `BuildStreamContextOptions.maxMessages` threaded through all four builders, replacing `MAX_CONTEXT_MESSAGES` |
| `apps/backend/src/features/agents/companion/context.ts` | Accept the policy; pass `maxMessages`; gate the turn-digest block on `policy.carryDigests` |
| `apps/backend/src/features/agents/persona-agent.ts` | Resolve the policy at the `Hydrate` seam and hand it to `buildAgentContext` |
| `apps/backend/src/features/agents/index.ts` | Export the policy API |
| `docs/plans/agent-runtimes-unification-redesign.md` | Reconcile §2.8 Q8 to the sequence-anchored design (sequential window = base, conversations = non-blocking highlight); record the channel→thread cross-surface continuity follow-up |

## Out of scope (deliberate)

- **Conversation highlight** — surfacing the active topic to the model is the only role the conversations system plays in this design; it's an eval-sensitive prompt-format change, kept out of this PR. In c2a the conversation could only ever be a highlight (it can't move the boundary without contradicting bias-to-continue), so deferring it costs no boundary behavior.
- **C-2b** token-budget window fill (the `truncateMessages` newest-first budget replacing the message count) — the seam is in place; the budget stays a message count here.
- **C-2c** in-enclave sealed rolling summary — blocked on §2.8 Q6 (unbuilt). The enclave path (`enclave-system-prompt.ts`) is untouched and still passes `null` for the summary by construction.
- **Channel→thread** cross-surface episode continuity — a conversation that begins in a channel and continues in a spawned thread has two episode keys; recorded as a doc follow-up, not stitched here.

## Test plan

- [x] `bun test tests/integration/context-window-policy.test.ts` — 6 pass (continue/fresh inside vs outside window, no-prior-session, sub-window history, in-flight-session shadowing guard)
- [x] `bun test tests/integration/context-builder.test.ts tests/integration/agent-session.test.ts` — 31 pass (no regression from the `maxMessages` threading)
- [x] `bun test` agent prompt + access-scope suites (enclave-system-prompt, system-prompt, message-format, turn-digests, agent-access-scope, stream-persona-participants) — 30 pass
- [x] `tsc --noEmit` backend clean; full pre-commit suite green (14-workspace typecheck, `astro check`, `generate-api-docs --check`)
- [ ] No end-to-end DM turn run against a live model — the digest-gating is verified at the policy + wiring level (the gate is `policy.carryDigests ? load : null`); a full `PersonaAgent.run` harness was not exercised

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNwKMU7a4ts7gZAY3iWAjM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784029834&installation_id=129946197&pr_number=934&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F934&signature=27c7c75af4a8200ba3b0654be8e1cb6f1224cd0e4c8c9f6f5fb76ad6be499040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->