### PR TITLE
feat(agents): C-2b — token-budgeted context window fill for companion

### DIFF
--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -145,6 +145,7 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
     preferences,
     currentTime,
     maxMessages: policy.maxMessages,
+    maxChars: policy.maxChars,
     triggerMessageId: messageId,
     includeAttachments: true,
   })

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -122,6 +122,15 @@ export interface StreamContext {
   participants?: Participant[]
   /** Conversation history - messages in chronological order, may include attachment context */
   conversationHistory: MessageWithAttachments[]
+  /**
+   * Number of leading `conversationHistory` entries that are pinned context and
+   * must survive windowing (the C-2b char-budget trim). The thread builder
+   * prepends the root/parent message as the thread anchor and sets this to 1;
+   * other surfaces leave it unset (treated as 0). Declared by the builder so
+   * the shared trim in `buildStreamContext` preserves the anchor without
+   * re-deriving it from message shape.
+   */
+  pinnedHistoryPrefix?: number
   /** For threads: path from current thread up to root channel */
   threadContext?: {
     depth: number
@@ -261,16 +270,14 @@ export async function buildStreamContext(
   // runs on kept messages. Older messages that fall out fold into the rolling
   // conversation summary downstream (it keys off the oldest kept message).
   //
-  // The thread builder prepends the root/parent message as the thread anchor —
-  // the only history entry from a different stream (`streamId !== stream.id`).
-  // Pin it so a long thread can never trim away its own anchor; the trim runs
-  // over the remaining in-stream messages. A no-op for non-thread surfaces,
-  // whose history is all from `stream.id`.
+  // `pinnedHistoryPrefix` leading entries are anchors the builder declared must
+  // survive (the thread root); trim only the rest so a long thread can never
+  // trim away its own anchor.
   if (options?.maxChars !== undefined) {
-    const history = context.conversationHistory
-    const anchor = history.length > 0 && history[0].streamId !== stream.id ? history[0] : undefined
-    const trimmed = trimToCharBudget(anchor ? history.slice(1) : history, options.maxChars)
-    context.conversationHistory = anchor ? [anchor, ...trimmed] : trimmed
+    const pinned = context.pinnedHistoryPrefix ?? 0
+    const head = context.conversationHistory.slice(0, pinned)
+    const trimmed = trimToCharBudget(context.conversationHistory.slice(pinned), options.maxChars)
+    context.conversationHistory = pinned > 0 ? [...head, ...trimmed] : trimmed
   }
 
   // Enrich with attachment context if requested
@@ -440,6 +447,8 @@ async function buildThreadContext(
       slug: stream.slug,
     },
     conversationHistory,
+    // The prepended parent is a pinned anchor: keep it through the C-2b trim.
+    pinnedHistoryPrefix: parentMessage ? 1 : 0,
     threadContext: {
       depth: threadPath.length,
       path: threadPath,

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -146,6 +146,17 @@ export interface BuildStreamContextOptions {
    * outside a turn (evals, the enclave prompt assembly).
    */
   maxMessages?: number
+  /**
+   * Char budget for the verbatim conversation window (C-2b). When set, the
+   * fetched history (capped at `maxMessages`) is trimmed newest-first to this
+   * many chars of raw message markdown, replacing the message-count cliff with
+   * a budgeted window. Omitted by out-of-turn callers (evals, enclave-prompt
+   * assembly), which keep the pure message-count behavior. Applied before
+   * attachment/quote/shared-message enrichment, so enrichment only runs on kept
+   * messages; the 400k `MAX_MESSAGE_CHARS` clamp in `AgentRuntime` is the
+   * backstop for enrichment growth.
+   */
+  maxChars?: number
   /** Current time at invocation (for deterministic testing) */
   currentTime?: Date
   /** Trigger message ID (for determining attachment detail levels) */
@@ -165,6 +176,30 @@ export interface BuildStreamContextOptions {
    * and included as base64 data URLs so the model can see them.
    */
   loadImages?: boolean
+}
+
+/**
+ * Trim a chronological (oldest-first) message list to the newest suffix that
+ * fits within `maxChars` of raw `contentMarkdown`, always keeping at least the
+ * newest message (the trigger). This is the C-2b budgeted-window fill: a deeper,
+ * size-bounded window in place of a fixed message count. Generic over any row
+ * carrying `contentMarkdown` so it can run before the history is enriched into
+ * `MessageWithAttachments`.
+ */
+export function trimToCharBudget<T extends { contentMarkdown: string }>(messages: T[], maxChars: number): T[] {
+  if (messages.length <= 1) return messages
+
+  let total = 0
+  let kept = 0
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const len = messages[i].contentMarkdown.length
+    // Always keep the newest message; stop once another would overflow.
+    if (kept > 0 && total + len > maxChars) break
+    total += len
+    kept++
+  }
+
+  return kept >= messages.length ? messages : messages.slice(messages.length - kept)
 }
 
 /**
@@ -219,6 +254,14 @@ export async function buildStreamContext(
 
     default:
       context = await buildScratchpadContext(db, stream, temporal, maxMessages)
+  }
+
+  // C-2b budgeted window: trim the fetched history newest-first to the char
+  // budget BEFORE enrichment, so quote/shared-message/attachment expansion only
+  // runs on kept messages. Older messages that fall out fold into the rolling
+  // conversation summary downstream (it keys off the oldest kept message).
+  if (options?.maxChars !== undefined) {
+    context.conversationHistory = trimToCharBudget(context.conversationHistory, options.maxChars)
   }
 
   // Enrich with attachment context if requested

--- a/apps/backend/src/features/agents/context-builder.ts
+++ b/apps/backend/src/features/agents/context-builder.ts
@@ -260,8 +260,17 @@ export async function buildStreamContext(
   // budget BEFORE enrichment, so quote/shared-message/attachment expansion only
   // runs on kept messages. Older messages that fall out fold into the rolling
   // conversation summary downstream (it keys off the oldest kept message).
+  //
+  // The thread builder prepends the root/parent message as the thread anchor —
+  // the only history entry from a different stream (`streamId !== stream.id`).
+  // Pin it so a long thread can never trim away its own anchor; the trim runs
+  // over the remaining in-stream messages. A no-op for non-thread surfaces,
+  // whose history is all from `stream.id`.
   if (options?.maxChars !== undefined) {
-    context.conversationHistory = trimToCharBudget(context.conversationHistory, options.maxChars)
+    const history = context.conversationHistory
+    const anchor = history.length > 0 && history[0].streamId !== stream.id ? history[0] : undefined
+    const trimmed = trimToCharBudget(anchor ? history.slice(1) : history, options.maxChars)
+    context.conversationHistory = anchor ? [anchor, ...trimmed] : trimmed
   }
 
   // Enrich with attachment context if requested

--- a/apps/backend/src/features/agents/context-builder.unit.test.ts
+++ b/apps/backend/src/features/agents/context-builder.unit.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for `trimToCharBudget` — the C-2b budgeted-window fill.
+ *
+ * Contract: given a chronological (oldest-first) list, keep the newest suffix
+ * that fits within the char budget, always keeping at least the newest message
+ * (the trigger). Pure function, no DB.
+ */
+
+import { describe, test, expect } from "bun:test"
+import { trimToCharBudget } from "./context-builder"
+
+const msg = (contentMarkdown: string) => ({ contentMarkdown })
+
+describe("trimToCharBudget", () => {
+  test("returns the same array when empty or single", () => {
+    const empty: { contentMarkdown: string }[] = []
+    expect(trimToCharBudget(empty, 10)).toBe(empty)
+
+    const one = [msg("hello")]
+    expect(trimToCharBudget(one, 1)).toBe(one)
+  })
+
+  test("returns the same array when everything fits", () => {
+    const all = [msg("aa"), msg("bb"), msg("cc")]
+    expect(trimToCharBudget(all, 100)).toBe(all)
+  })
+
+  test("keeps the newest suffix within budget, dropping older messages", () => {
+    const messages = [msg("11111"), msg("22222"), msg("33333")] // 5 chars each
+    // Budget 10 holds the newest two (10 chars); a third would overflow.
+    expect(trimToCharBudget(messages, 10)).toEqual([msg("22222"), msg("33333")])
+  })
+
+  test("always keeps at least the newest message even when it alone overflows", () => {
+    const messages = [msg("old"), msg("x".repeat(50))]
+    expect(trimToCharBudget(messages, 10)).toEqual([msg("x".repeat(50))])
+  })
+})

--- a/apps/backend/src/features/agents/context-window-policy.ts
+++ b/apps/backend/src/features/agents/context-window-policy.ts
@@ -5,11 +5,41 @@ import { MessageRepository } from "../messaging"
 import { AgentSessionRepository } from "./session-repository"
 
 /**
- * Default budgeted-window size: the newest-N messages a context build hydrates.
- * C-2a keeps the message-count budget; C-2b swaps the count for a token budget
- * (the `truncateMessages` newest-first fill) without changing this seam.
+ * Builder fallback window size: the newest-N messages a context build hydrates
+ * for callers that build context OUTSIDE a turn and pass no policy — evals and
+ * the regional enclave-prompt assembly (`enclave-system-prompt.ts`). Turn-driven
+ * companion builds resolve a `ContextWindowPolicy` instead, whose deeper
+ * candidate ceiling + char budget (below) govern the window. This stays at the
+ * pre-C-2b value so widening the companion window can't silently deepen those
+ * out-of-turn callers' fetches.
  */
 export const DEFAULT_CONTEXT_WINDOW_MESSAGES = 20
+
+/**
+ * Candidate fetch ceiling for a turn's budgeted window (C-2b). The char budget
+ * below is the intended limiter; this caps how many messages are ever fetched
+ * before the newest-first char trim, bounding fetch volume on a long stream. It
+ * is also the DM episode boundary's recency horizon: a turn continues the prior
+ * episode iff that session's cursor still falls inside this window (agent-runtimes
+ * §2.8 Q8 — "only a gap that clears the whole window starts fresh"; the boundary
+ * tracks the window's deepest extent, biasing toward continue).
+ */
+export const CONTEXT_WINDOW_CANDIDATE_CEILING = 200
+
+/**
+ * Char budget for a turn's verbatim conversation window (C-2b). Replaces the
+ * message-count cliff with a newest-first fill under this budget; older turns
+ * that fall out fold into the rolling conversation summary (which keys off the
+ * oldest kept message, so the fold composes automatically). Expressed in chars
+ * to reuse the project's ~4-chars-per-token heuristic with no model-specific
+ * tokenizer — the same unit `MAX_MESSAGE_CHARS` (the 400k AgentRuntime safety
+ * clamp) uses. This is the intended window limiter and sits well under that
+ * clamp, leaving room for the system prompt, tools, digests, and the summary.
+ * The budget is measured on raw message markdown at the fetch layer, before
+ * quote / shared-message / attachment enrichment inflates it; the 400k clamp is
+ * the backstop for that enrichment.
+ */
+export const DEFAULT_CONTEXT_WINDOW_CHARS = 80_000
 
 /**
  * Which conversation episode a turn belongs to. Bounded surfaces (scratchpads,
@@ -26,16 +56,24 @@ export type ContextEpisode = { kind: "stream" } | { kind: "dm-recency"; continue
  */
 export interface ContextWindowPolicy {
   episode: ContextEpisode
-  /** Newest-first message budget for the window. */
+  /**
+   * Candidate fetch ceiling for the window: the most messages a build fetches
+   * before the newest-first char trim. Also the DM episode boundary's recency
+   * horizon (see `CONTEXT_WINDOW_CANDIDATE_CEILING`).
+   */
   maxMessages: number
+  /** Char budget the verbatim window is filled up to, newest-first (C-2b). */
+  maxChars: number
   /** Whether prior `turn_digest` steps inject as "Prior Tool Work" this turn. */
   carryDigests: boolean
 }
 
 export interface ResolveContextWindowPolicyParams {
   stream: Stream
-  /** Override the default window budget (tests pin a small budget). */
+  /** Override the candidate fetch ceiling (tests pin a small budget). */
   maxMessages?: number
+  /** Override the char budget (tests pin a small budget). */
+  maxChars?: number
 }
 
 /**
@@ -48,9 +86,12 @@ export interface ResolveContextWindowPolicyParams {
  * §2.8 Q8). The window is always the reliable, non-blocking base; the prior
  * completed session's `lastSeenSequence` decides continuity: continue the
  * episode — carrying its digest chain — only while that cursor still falls
- * inside the window about to be built. A gap larger than the window starts a
- * fresh episode with no digest carry-over. Anchoring on the sequence (rather
- * than on conversation identity) is deliberate: it can never revive a
+ * inside the window about to be built. The boundary uses the candidate ceiling
+ * (`maxMessages`), the window's deepest extent, not the narrower char-budgeted
+ * fill — "only a gap that clears the whole window starts fresh" (Q8), so the
+ * boundary tracks the widest the window could reach. A gap larger than that
+ * starts a fresh episode with no digest carry-over. Anchoring on the sequence
+ * (rather than on conversation identity) is deliberate: it can never revive a
  * weeks-old session, and it errs toward continuing — the costlier mistake is a
  * false fresh that drops context the user expected the agent to hold (Q8 error
  * asymmetry).
@@ -63,17 +104,18 @@ export async function resolveContextWindowPolicy(
   // degenerate budget can't make `findWindowFloorSequence` return null
   // (→ "whole stream fits in window" → continue) for what is really an empty
   // window.
-  const maxMessages = Math.max(1, params.maxMessages ?? DEFAULT_CONTEXT_WINDOW_MESSAGES)
+  const maxMessages = Math.max(1, params.maxMessages ?? CONTEXT_WINDOW_CANDIDATE_CEILING)
+  const maxChars = Math.max(1, params.maxChars ?? DEFAULT_CONTEXT_WINDOW_CHARS)
 
   if (params.stream.type !== StreamTypes.DM) {
-    return { episode: { kind: "stream" }, maxMessages, carryDigests: true }
+    return { episode: { kind: "stream" }, maxMessages, maxChars, carryDigests: true }
   }
 
   const priorSession = await AgentSessionRepository.findLatestCompletedByStream(db, params.stream.id)
 
   // No prior completed session → there are no digests to carry; start fresh.
   if (!priorSession || priorSession.lastSeenSequence === null) {
-    return { episode: { kind: "dm-recency", continues: false }, maxMessages, carryDigests: false }
+    return { episode: { kind: "dm-recency", continues: false }, maxMessages, maxChars, carryDigests: false }
   }
 
   const windowFloor = await MessageRepository.findWindowFloorSequence(db, params.stream.id, maxMessages)
@@ -81,5 +123,5 @@ export async function resolveContextWindowPolicy(
   // window covers everything and any prior cursor is inside it (continue).
   const continues = windowFloor === null || priorSession.lastSeenSequence >= windowFloor
 
-  return { episode: { kind: "dm-recency", continues }, maxMessages, carryDigests: continues }
+  return { episode: { kind: "dm-recency", continues }, maxMessages, maxChars, carryDigests: continues }
 }

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -152,7 +152,7 @@ export type { ResolveQuoteRepliesInput, ResolveQuoteRepliesResult } from "./quot
 export { resolveActorNames } from "./actor-names"
 
 // Context builder
-export { buildStreamContext, enrichMessagesWithAttachments, trimToCharBudget } from "./context-builder"
+export { buildStreamContext, enrichMessagesWithAttachments } from "./context-builder"
 
 // Per-turn hydration policy (window budget + digest carry; the `Hydrate` seam)
 export {

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -152,10 +152,15 @@ export type { ResolveQuoteRepliesInput, ResolveQuoteRepliesResult } from "./quot
 export { resolveActorNames } from "./actor-names"
 
 // Context builder
-export { buildStreamContext, enrichMessagesWithAttachments } from "./context-builder"
+export { buildStreamContext, enrichMessagesWithAttachments, trimToCharBudget } from "./context-builder"
 
 // Per-turn hydration policy (window budget + digest carry; the `Hydrate` seam)
-export { resolveContextWindowPolicy, DEFAULT_CONTEXT_WINDOW_MESSAGES } from "./context-window-policy"
+export {
+  resolveContextWindowPolicy,
+  DEFAULT_CONTEXT_WINDOW_MESSAGES,
+  CONTEXT_WINDOW_CANDIDATE_CEILING,
+  DEFAULT_CONTEXT_WINDOW_CHARS,
+} from "./context-window-policy"
 export type { ContextWindowPolicy, ContextEpisode, ResolveContextWindowPolicyParams } from "./context-window-policy"
 
 // Enclave system-prompt assembly (shared builder + reduced toolset) so the

--- a/apps/backend/tests/integration/context-builder.test.ts
+++ b/apps/backend/tests/integration/context-builder.test.ts
@@ -508,5 +508,73 @@ describe("Context Builder", () => {
         expect(trimmed.conversationHistory).toHaveLength(1)
       })
     })
+
+    test("keeps the prepended thread root anchor even when the budget trims thread messages", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const workosUserId = userId()
+        const wsId = workspaceId()
+        const channelId = streamId()
+        const threadId = streamId()
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Thread Budget Workspace",
+          slug: `ctx-ws-${wsId}`,
+          createdBy: workosUserId,
+        })
+        const ownerUserId = (await addTestMember(client, wsId, workosUserId)).id
+
+        await StreamRepository.insert(client, {
+          id: channelId,
+          workspaceId: wsId,
+          type: StreamTypes.CHANNEL,
+          displayName: "Discussions",
+          slug: "discussions",
+          visibility: Visibilities.PUBLIC,
+          createdBy: ownerUserId,
+        })
+
+        const parentMsgId = messageId()
+        await MessageRepository.insert(client, {
+          id: parentMsgId,
+          streamId: channelId,
+          sequence: BigInt(1),
+          authorId: ownerUserId,
+          authorType: "user",
+          ...testMessageContent("ANCHOR: the parent message that spawned the thread"),
+        })
+
+        const thread = await StreamRepository.insert(client, {
+          id: threadId,
+          workspaceId: wsId,
+          type: StreamTypes.THREAD,
+          displayName: "Thread Discussion",
+          visibility: Visibilities.PRIVATE,
+          parentStreamId: channelId,
+          parentMessageId: parentMsgId,
+          rootStreamId: channelId,
+          createdBy: ownerUserId,
+        })
+
+        // Three ~100-char thread replies; a 150 char budget keeps only the newest
+        // thread reply, but the anchor (from the channel) must remain pinned.
+        for (let i = 1; i <= 3; i++) {
+          await MessageRepository.insert(client, {
+            id: messageId(),
+            streamId: threadId,
+            sequence: BigInt(i),
+            authorId: ownerUserId,
+            authorType: "user",
+            ...testMessageContent(`${"r".repeat(100)}-${i}`),
+          })
+        }
+
+        const trimmed = await buildStreamContext(client, thread, { maxMessages: 10, maxChars: 150 })
+
+        expect(trimmed.conversationHistory.at(0)?.contentMarkdown).toContain("ANCHOR")
+        expect(trimmed.conversationHistory.at(-1)?.contentMarkdown).toContain("-3")
+        // Anchor + the single newest thread reply that fits the budget.
+        expect(trimmed.conversationHistory).toHaveLength(2)
+      })
+    })
   })
 })

--- a/apps/backend/tests/integration/context-builder.test.ts
+++ b/apps/backend/tests/integration/context-builder.test.ts
@@ -420,4 +420,93 @@ describe("Context Builder", () => {
       })
     })
   })
+
+  describe("Budgeted window (C-2b)", () => {
+    test("maxChars trims the window newest-first; maxMessages alone keeps all", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const workosUserId = userId()
+        const wsId = workspaceId()
+        const scratchpadId = streamId()
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Budget Window Workspace",
+          slug: `ctx-ws-${wsId}`,
+          createdBy: workosUserId,
+        })
+        const ownerUserId = (await addTestMember(client, wsId, workosUserId)).id
+
+        const scratchpad = await StreamRepository.insert(client, {
+          id: scratchpadId,
+          workspaceId: wsId,
+          type: StreamTypes.SCRATCHPAD,
+          displayName: "Budgeted scratchpad",
+          description: null,
+          visibility: Visibilities.PRIVATE,
+          createdBy: ownerUserId,
+        })
+
+        // 6 messages of 100 chars each (chronological).
+        const body = "x".repeat(100)
+        for (let i = 1; i <= 6; i++) {
+          await MessageRepository.insert(client, {
+            id: messageId(),
+            streamId: scratchpadId,
+            sequence: BigInt(i),
+            authorId: ownerUserId,
+            authorType: "user",
+            ...testMessageContent(`${body}-${i}`),
+          })
+        }
+
+        // No char budget → all 6 fetched (within the message ceiling).
+        const full = await buildStreamContext(client, scratchpad, { maxMessages: 10 })
+        expect(full.conversationHistory).toHaveLength(6)
+        expect(full.conversationHistory.at(-1)?.contentMarkdown).toContain("-6")
+
+        // ~250 char budget keeps only the newest messages that fit, always the
+        // last one. Each message is ~102 chars, so the window holds the newest 2.
+        const trimmed = await buildStreamContext(client, scratchpad, { maxMessages: 10, maxChars: 250 })
+        expect(trimmed.conversationHistory).toHaveLength(2)
+        expect(trimmed.conversationHistory.at(-1)?.contentMarkdown).toContain("-6")
+        expect(trimmed.conversationHistory.at(0)?.contentMarkdown).toContain("-5")
+      })
+    })
+
+    test("a single oversized message is still kept (window holds at least the trigger)", async () => {
+      await withTestTransaction(pool, async (client) => {
+        const workosUserId = userId()
+        const wsId = workspaceId()
+        const scratchpadId = streamId()
+        await WorkspaceRepository.insert(client, {
+          id: wsId,
+          name: "Oversized Window Workspace",
+          slug: `ctx-ws-${wsId}`,
+          createdBy: workosUserId,
+        })
+        const ownerUserId = (await addTestMember(client, wsId, workosUserId)).id
+
+        const scratchpad = await StreamRepository.insert(client, {
+          id: scratchpadId,
+          workspaceId: wsId,
+          type: StreamTypes.SCRATCHPAD,
+          displayName: "Oversized scratchpad",
+          description: null,
+          visibility: Visibilities.PRIVATE,
+          createdBy: ownerUserId,
+        })
+
+        await MessageRepository.insert(client, {
+          id: messageId(),
+          streamId: scratchpadId,
+          sequence: BigInt(1),
+          authorId: ownerUserId,
+          authorType: "user",
+          ...testMessageContent("y".repeat(1000)),
+        })
+
+        const trimmed = await buildStreamContext(client, scratchpad, { maxMessages: 10, maxChars: 50 })
+        expect(trimmed.conversationHistory).toHaveLength(1)
+      })
+    })
+  })
 })

--- a/apps/backend/tests/integration/context-builder.test.ts
+++ b/apps/backend/tests/integration/context-builder.test.ts
@@ -256,6 +256,8 @@ describe("Context Builder", () => {
             { contentMarkdown: "This is the parent message that spawned the thread" },
             { contentMarkdown: "Reply in thread" },
           ],
+          // The prepended parent is the pinned anchor the C-2b trim must keep.
+          pinnedHistoryPrefix: 1,
           threadContext: {
             depth: 2,
             path: [

--- a/apps/backend/tests/integration/context-window-policy.test.ts
+++ b/apps/backend/tests/integration/context-window-policy.test.ts
@@ -21,7 +21,12 @@ import { withTestTransaction, setupTestDatabase, testMessageContent, addTestMemb
 import { WorkspaceRepository } from "../../src/features/workspaces"
 import { StreamRepository, type Stream } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
-import { AgentSessionRepository, SessionStatuses, resolveContextWindowPolicy } from "../../src/features/agents"
+import {
+  AgentSessionRepository,
+  SessionStatuses,
+  resolveContextWindowPolicy,
+  DEFAULT_CONTEXT_WINDOW_CHARS,
+} from "../../src/features/agents"
 import type { PoolClient } from "pg"
 import { userId, workspaceId, streamId, messageId, sessionId, personaId } from "../../src/lib/id"
 import { StreamTypes, Visibilities } from "@threa/types"
@@ -102,7 +107,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: scratchpad, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "stream" }, maxMessages: 3, carryDigests: true })
+      expect(policy).toEqual({
+        episode: { kind: "stream" },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: true,
+      })
     })
   })
 
@@ -114,7 +124,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 3, carryDigests: false })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: false },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: false,
+      })
     })
   })
 
@@ -127,7 +142,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: true },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: true,
+      })
     })
   })
 
@@ -140,7 +160,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 3, carryDigests: false })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: false },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: false,
+      })
     })
   })
 
@@ -153,7 +178,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: true },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: true,
+      })
     })
   })
 
@@ -177,7 +207,12 @@ describe("resolveContextWindowPolicy", () => {
 
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 3 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: true }, maxMessages: 3, carryDigests: true })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: true },
+        maxMessages: 3,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: true,
+      })
     })
   })
 
@@ -194,7 +229,12 @@ describe("resolveContextWindowPolicy", () => {
       // into a zero-message window.
       const policy = await resolveContextWindowPolicy(client, { stream: dm, maxMessages: 0 })
 
-      expect(policy).toEqual({ episode: { kind: "dm-recency", continues: false }, maxMessages: 1, carryDigests: false })
+      expect(policy).toEqual({
+        episode: { kind: "dm-recency", continues: false },
+        maxMessages: 1,
+        maxChars: DEFAULT_CONTEXT_WINDOW_CHARS,
+        carryDigests: false,
+      })
     })
   })
 })

--- a/docs/plans/agent-runtimes-unification-redesign.md
+++ b/docs/plans/agent-runtimes-unification-redesign.md
@@ -927,8 +927,10 @@ timestamps)`, carries the non-null `e2e_streams` rows over, and **drops**
    global: one policy **type** — the C-2 budgeted-window + rolling-summary
    mechanism — instantiated per dispatch from facts the turn already carries,
    selected at the `Hydrate` step and handed to the driver, never chosen inside
-   it. `ContextWindowPolicy` does not exist in code yet (it lands with C-2);
-   this fixes its shape rather than describing shipped behavior._
+   it. `ContextWindowPolicy` now exists in code (C-2a created the type + the
+   `Hydrate`-seam resolver; C-2b added the char budget it carries); the deep
+   budgeted-window fill is the companion default, with the bounded-surface case
+   degrading to a no-op as described below._
    - _**The axis is the episode, and §2.5 already computes it.** Keying
      directly on the two trigger kinds (`mention`, `companion`; `AGENT_TRIGGERS`,
      `packages/types/src/constants.ts:430`) is almost right but
@@ -1001,10 +1003,24 @@ type)` are how the episode is computed, not a parallel dimension._
    (`Hydrate`) seam — reading the prior completed session's `lastSeenSequence`
    (`findLatestCompletedByStream`) against the window floor
    (`MessageRepository.findWindowFloorSequence`) — and `buildAgentContext` gates
-   the digest block on it. The token-budget window fill (C-2b), the in-enclave
-   sealed summary (C-2c, §2.8 Q6), and the conversation highlight remain
-   follow-ups. The DM episode-by-recency rule (§2.5, line ~554) is the surface
-   this parameterizes._
+   the digest block on it. **C-2b has now shipped (companion/plaintext):** the
+   policy carries a char budget (`maxChars`, `DEFAULT_CONTEXT_WINDOW_CHARS`)
+   alongside a deepened candidate ceiling (`CONTEXT_WINDOW_CANDIDATE_CEILING`),
+   and `buildStreamContext` fills the window newest-first under that budget
+   (`trimToCharBudget`) before enrichment — the count cliff is gone on the
+   companion path, and overflow folds into the existing `ConversationSummaryService`
+   rolling summary automatically (it keys off the oldest kept message). The
+   budget is char-based (the project's ~4-chars-per-token heuristic, no
+   model-specific tokenizer) and is applied at the fetch layer on raw markdown,
+   with the 400k `MAX_MESSAGE_CHARS` clamp as the enrichment backstop. The DM
+   boundary now uses the deepened ceiling as its recency horizon (the window's
+   widest extent, per "only a gap that clears the whole window starts fresh"),
+   biasing further toward continue. The enclave window stays count-based until
+   the in-enclave sealed summary (C-2c, §2.8 Q6) lands — deepening it without a
+   sealed rolling summary would only move the cliff (and competes with the 48MB
+   assignment cap, E2EE-23). The conversation highlight remains a follow-up. The
+   DM episode-by-recency rule (§2.5, line ~554) is the surface this
+   parameterizes._
    - _**The conversations system is the highlight, not the boundary — read
      best-effort, never awaited.** `conversations` (`20251225231931_conversations.sql`,
      feature `conversations/`) groups a stream's messages into "a coherent unit of


### PR DESCRIPTION
**Design doc:** `docs/plans/agent-runtimes-unification-redesign.md` — §2.5 C-2, §2.8 Q7/Q8. Follow-on to C-2a (#934).

## Problem

After C-2a, a companion turn's conversation window is a hard message count: `policy.maxMessages` (default 20) becomes a SQL `LIMIT` in each `context-builder.ts` builder. That's the "shallow, cliff-edged window" the design calls C-2 (§1.7 / §2.5): 20 messages, then silent forgetting, with no relation to how much the model can actually hold. A scratchpad of many short one-line messages loses its beginning after a few exchanges.

The rolling-summary half of C-2 already exists and is wired on the companion path (`ConversationSummaryService.updateForContext`, called from `companion/context.ts`) — it summarizes everything older than the oldest kept message. What was missing is the budgeted window that decides where "oldest kept" falls.

## Solution

Replace the count cliff with a char-budgeted, newest-first window on the companion/plaintext path, and let the existing rolling-summary fold compose on top of it. The `ContextWindowPolicy` seam C-2a introduced is the insertion point: it gains a `maxChars` budget alongside a deepened candidate fetch ceiling. The window is filled newest-first under the char budget; whatever falls out is already picked up by the rolling summary because that service keys off the oldest kept message.

Scope matches C-2a: companion only. The enclave window stays count-based until the in-enclave sealed rolling summary (C-2c, §2.8 Q6) lands.

### How it works

1. **`ContextWindowPolicy.maxChars`** (`context-window-policy.ts`) — new required field, default `DEFAULT_CONTEXT_WINDOW_CHARS = 80_000`. `resolveContextWindowPolicy` carries it through all three return shapes; both budget params are clamped `Math.max(1, …)`.
2. **Deepened ceiling** — `CONTEXT_WINDOW_CANDIDATE_CEILING = 200` is the new default for the policy's `maxMessages`. With the count no longer the limiter, this caps how many messages are ever fetched before the char trim (fetch-volume guard) and doubles as the DM episode boundary's recency horizon.
3. **`trimToCharBudget(messages, maxChars)`** (`context-builder.ts`) — generic over `{ contentMarkdown: string }`, keeps the newest suffix that fits, always keeping at least the newest message (the trigger). Applied in `buildStreamContext` after the per-type builder returns but **before** attachment/quote/shared-message enrichment, so enrichment only runs on kept rows. Gated on an opt-in `maxChars`: callers that omit it (evals, `enclave-system-prompt.ts`) keep pure count behavior.
4. **Companion wiring** (`companion/context.ts`) — passes `maxChars: policy.maxChars` to `buildStreamContext`. `oldestKeptSequence` is the first of the trimmed set, so `ConversationSummaryService` folds everything older with no change to that service.

### Key design decisions

**1. Char budget, not a real tokenizer** — express the budget in chars using the project's ~4-chars-per-token heuristic (the same unit `MAX_MESSAGE_CHARS`, the 400k `AgentRuntime` clamp, already uses). A real tokenizer is model-specific and would add a dependency that the enclave-over-OpenRouter path can't carry uniformly; INV-36 says don't introduce it without a demonstrated need. Kris's call among the options.

**2. Trim at the fetch layer on raw `Message[]`, pre-enrichment** — the alternative (trim formatted `ModelMessage[]` after enrichment, reusing `truncateMessages`) accounts for enrichment growth exactly but loses `sequence`/`streamId`, so the rolling-summary boundary and cross-stream filtering would have to be re-derived. Trimming on raw markdown keeps `oldestKeptSequence` a clean single sequence and lets the summary fold compose untouched; the 400k clamp in `AgentRuntime` is the backstop for enrichment that inflates a kept message. Kris's call.

**3. Enclave stays count-based** — deepening the enclave's window without the sealed in-enclave rolling summary (C-2c) would just move the cliff, and competes with the 48MB sealed-assignment budget (E2EE-23). Decoupling here mirrors C-2a's companion-only discipline. The shared `DEFAULT_CONTEXT_WINDOW_MESSAGES = 20` (the builder's no-arg fallback, used by `enclave-system-prompt.ts` and evals) is deliberately **left unchanged**, so widening the companion window can't silently deepen those out-of-turn fetches.

**4. DM boundary horizon tracks the ceiling, biasing toward continue** — the boundary uses `findWindowFloorSequence(maxMessages)` where `maxMessages` is now the ceiling, i.e. the window's widest extent: "only a gap that clears the whole window starts fresh" (§2.8 Q8). A false-continue carries a stale digest chain that self-heals (the reader block re-verifies, the live turn outweighs system-context); a false-fresh drops context the user expected. The costlier mistake is the false-fresh, so the deeper horizon is the safe direction.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/context-window-policy.ts` | Add `maxChars` to `ContextWindowPolicy` + params; new `CONTEXT_WINDOW_CANDIDATE_CEILING` (200) and `DEFAULT_CONTEXT_WINDOW_CHARS` (80k); `resolveContextWindowPolicy` carries+clamps the budget; DM-boundary docstring updated for the ceiling horizon. `DEFAULT_CONTEXT_WINDOW_MESSAGES` (20) kept as the builder fallback. |
| `apps/backend/src/features/agents/context-builder.ts` | New exported `trimToCharBudget`; opt-in `maxChars` on `BuildStreamContextOptions`; applied in `buildStreamContext` before enrichment. |
| `apps/backend/src/features/agents/companion/context.ts` | Pass `policy.maxChars` to `buildStreamContext`. |
| `apps/backend/src/features/agents/index.ts` | Export `trimToCharBudget`, `CONTEXT_WINDOW_CANDIDATE_CEILING`, `DEFAULT_CONTEXT_WINDOW_CHARS`. |
| `docs/plans/agent-runtimes-unification-redesign.md` | Mark C-2b shipped in §2.8 Q8; fix the stale §2.8 Q7 "`ContextWindowPolicy` does not exist yet" note. |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/context-builder.unit.test.ts` | Pure unit contract for `trimToCharBudget` (empty/single/all-fit/newest-suffix/oversized-kept). |

## Out of scope (deliberate)

- **Enclave token-budget window** — waits for C-2c (sealed rolling summary, §2.8 Q6).
- **Conversation highlight** — `findPrimaryByMessageId` topic surfacing + window-floor expand; eval-sensitive (system-prompt/message-format), its own slice.
- **Prompt caching (C-3)** — independent optimization.

## Test plan

- [x] `bun test src/features/agents/context-builder.unit.test.ts` — 4 pass
- [x] `bun test tests/integration/context-window-policy.test.ts tests/integration/context-builder.test.ts` — 15 pass (incl. 2 new budgeted-window cases; C-2a policy tests updated for the new field), against local PG16 + pgvector
- [x] `bun test src/features/agents/conversation-summary-service.test.ts src/features/agents/enclave-system-prompt.test.ts` — 6 pass (adjacent paths)
- [x] Pre-commit suite green: prettier, 14-workspace `tsc --noEmit`, eslint, astro check, `generate-api-docs --check`
- [x] Self-review (author): verified no other code constructs a `ContextWindowPolicy` literal or calls `buildAgentContext` outside the resolver path, so `maxChars` flows automatically; confirmed `enclave-system-prompt.ts` omits `maxChars` and is unaffected; confirmed `MessageRepository.list` returns ascending so `trimToCharBudget`'s newest-suffix semantics and `oldestKeptSequence` hold.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01JtsfSnwyiwimWRu6vrTKd3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784037828&installation_id=129946197&pr_number=935&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F935&signature=c084b3329aa5941ea701541af9c635503c87928b60ec6a476e48704d73c635a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->