### PR TITLE
fix(sync): public-root catch-up leg + notification-level outbox broadcast

### DIFF
--- a/apps/backend/src/features/streams/access.ts
+++ b/apps/backend/src/features/streams/access.ts
@@ -93,13 +93,44 @@ export async function checkStreamAccess(
 }
 
 /**
+ * The canonical "is this *already-resolved effective root* readable by the
+ * user?" leaf: public visibility OR a `stream_members` row on the root. This is
+ * the single rule that both the per-id predicate ({@link streamAccessPredicateSql})
+ * and the workspace catch-up CTE (`features/sync/repository.ts`) reduce a
+ * stream's effective root down to — extracted so the public-without-membership
+ * branch cannot live in one and be silently dropped from the other (the exact
+ * drift that previously shipped: catch-up replicated the thread→root leg but
+ * omitted the public-root leg). The caller resolves the effective root
+ * (top-level stream → itself, thread → its root) and passes its alias; this
+ * fragment only decides readability of that resolved root.
+ *
+ * `rootAlias` is injected raw (squid `raw`) because it is a SQL alias reference,
+ * not a value — it MUST be a trusted constant supplied by call-site code (e.g.
+ * `"eff_root"`), NEVER derived from user input. Built with squid `sql` so it
+ * carries `$1..$k` placeholders that {@link composeSql} renumbers when splicing
+ * it into a larger query.
+ */
+export function rootReadableConditionSql(userId: string, rootAlias: string): QueryConfig {
+  return sql`(
+    ${sql.raw(rootAlias)}.visibility = ${Visibilities.PUBLIC}
+    OR EXISTS (
+      SELECT 1 FROM stream_members
+      WHERE stream_id = ${sql.raw(rootAlias)}.id AND member_id = ${userId}
+    )
+  )`
+}
+
+/**
  * Canonical SQL predicate for the "thread → root" stream-access rule
  * (INV-62), as a reusable `EXISTS` fragment correlated to a stream-id
  * column. This is the single source of truth for the *set-based* form of
  * the same three rules `checkStreamAccess` enforces per-id (workspace
  * boundary, public root grants read without a `stream_members` row, threads
- * inherit from their root). When the thread→root resolution rule changes,
- * this fragment and the per-id helpers update together.
+ * inherit from their root). The effective root is resolved with
+ * `COALESCE(root_stream_id, id)` (a top-level stream is its own root, a thread
+ * defers to its root; a thread whose root row is missing finds no join and is
+ * denied), then {@link rootReadableConditionSql} decides readability — the same
+ * leaf the catch-up CTE applies, so the two cannot drift.
  *
  * The returned `QueryConfig` is spliced into a larger query via
  * {@link composeSql} (squid's own `sql` tag cannot nest fragments — it would
@@ -117,34 +148,14 @@ export async function checkStreamAccess(
  * workspace boundary inside the EXISTS, so it is correct even when the outer
  * query does not otherwise constrain the stream's workspace.
  */
-export function streamAccessPredicateSql(
-  workspaceId: string,
-  userId: string,
-  streamIdColumn: string
-): QueryConfig {
-  return sql`EXISTS (
+export function streamAccessPredicateSql(workspaceId: string, userId: string, streamIdColumn: string): QueryConfig {
+  return composeSql`EXISTS (
     SELECT 1
     FROM streams eff_s
-    LEFT JOIN streams eff_root ON eff_root.id = eff_s.root_stream_id
-    WHERE eff_s.id = ${sql.raw(streamIdColumn)}
+    JOIN streams eff_root ON eff_root.id = COALESCE(eff_s.root_stream_id, eff_s.id)
+    WHERE ${sql`eff_s.id = ${sql.raw(streamIdColumn)}`}
       AND eff_s.workspace_id = ${workspaceId}
-      AND (
-        (eff_s.root_stream_id IS NULL AND (
-          eff_s.visibility = ${Visibilities.PUBLIC}
-          OR EXISTS (
-            SELECT 1 FROM stream_members
-            WHERE stream_id = eff_s.id AND member_id = ${userId}
-          )
-        ))
-        OR
-        (eff_s.root_stream_id IS NOT NULL AND eff_root.id IS NOT NULL AND (
-          eff_root.visibility = ${Visibilities.PUBLIC}
-          OR EXISTS (
-            SELECT 1 FROM stream_members
-            WHERE stream_id = eff_s.root_stream_id AND member_id = ${userId}
-          )
-        ))
-      )
+      AND ${rootReadableConditionSql(userId, "eff_root")}
   )`
 }
 

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -759,7 +759,7 @@ export function createStreamHandlers({
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const membership = await streamService.setNotificationLevel(streamId, userId, data.notificationLevel)
+      const membership = await streamService.setNotificationLevel(workspaceId, streamId, userId, data.notificationLevel)
       if (!membership) {
         return res.status(404).json({ error: "Not a member of this stream" })
       }

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -10,6 +10,7 @@ export {
   checkStreamAccess,
   listAccessibleStreamIds,
   resolveEffectiveAccessStream,
+  rootReadableConditionSql,
   streamAccessPredicateSql,
 } from "./access"
 

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, test, expect, mock, spyOn, beforeEach } from "bun:t
 import type { PoolClient } from "pg"
 import { StreamService } from "./service"
 import { StreamRepository } from "./repository"
-import { StreamMemberRepository } from "./member-repository"
+import { StreamMemberRepository, type StreamMember } from "./member-repository"
 import { StreamEventRepository } from "./event-repository"
 import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
@@ -68,6 +68,65 @@ describe("StreamService.isMemberOnForUpdate", () => {
       [dbClient, "stream_thread", "usr_1"],
       [dbClient, "stream_root", "usr_1"],
     ])
+  })
+})
+
+describe("StreamService.setNotificationLevel", () => {
+  let service: StreamService
+  const mockUpdateMember = spyOn(StreamMemberRepository, "update")
+
+  const membership: StreamMember = {
+    streamId: "stream_1",
+    memberId: "usr_1",
+    notificationLevel: "muted",
+    lastReadEventId: null,
+    lastReadAt: null,
+    joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+  }
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockFindById.mockReset()
+    mockUpdateMember.mockReset()
+    mockInsertOutbox.mockReset()
+  })
+
+  test("emits stream:notification_level_updated to the acting user on a real change", async () => {
+    mockFindById.mockResolvedValue({ id: "stream_1", type: "channel" } as never)
+    mockUpdateMember.mockResolvedValue(membership as never)
+
+    const result = await service.setNotificationLevel("ws_1", "stream_1", "usr_1", "muted")
+
+    expect(result).toEqual(membership)
+    expect(mockInsertOutbox).toHaveBeenCalledWith(expect.anything(), "stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamId: "stream_1",
+      notificationLevel: "muted",
+    })
+  })
+
+  test("unmute (null level) skips stream validation and broadcasts the cleared level", async () => {
+    mockUpdateMember.mockResolvedValue({ ...membership, notificationLevel: null } as never)
+
+    await service.setNotificationLevel("ws_1", "stream_1", "usr_1", null)
+
+    expect(mockFindById).not.toHaveBeenCalled()
+    expect(mockInsertOutbox).toHaveBeenCalledWith(expect.anything(), "stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "usr_1",
+      streamId: "stream_1",
+      notificationLevel: null,
+    })
+  })
+
+  test("does not emit when the user is not a member (no membership row updated)", async () => {
+    mockUpdateMember.mockResolvedValue(null)
+
+    const result = await service.setNotificationLevel("ws_1", "stream_1", "usr_1", null)
+
+    expect(result).toBeNull()
+    expect(mockInsertOutbox).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1629,6 +1629,7 @@ export class StreamService {
   }
 
   async setNotificationLevel(
+    workspaceId: string,
     streamId: string,
     memberId: string,
     level: NotificationLevel | null
@@ -1644,7 +1645,20 @@ export class StreamService {
           })
         }
       }
-      return StreamMemberRepository.update(client, streamId, memberId, { notificationLevel: level })
+      const membership = await StreamMemberRepository.update(client, streamId, memberId, { notificationLevel: level })
+      if (membership) {
+        // Mirror the mute/notify choice to the user's other sessions (and the
+        // sync log, so catch-up replays it) in the same transaction — otherwise
+        // the state stays stale cross-tab/device until reconnect. Author-scoped
+        // like stream:read; reaches only this user's rooms (INV-4/INV-7).
+        await OutboxRepository.insert(client, "stream:notification_level_updated", {
+          workspaceId,
+          authorId: memberId,
+          streamId,
+          notificationLevel: level,
+        })
+      }
+      return membership
     })
   }
 

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -1,6 +1,7 @@
 import type { Pool } from "pg"
 import { Visibilities } from "@threa/types"
-import { sql, withTransaction, type Querier } from "../../db"
+import { sql, composeSql, withTransaction, type Querier } from "../../db"
+import { rootReadableConditionSql } from "../streams"
 
 /** One client-routed outbox event headed for the sync log. */
 export interface SyncLogEntryInput {
@@ -127,37 +128,42 @@ export const SyncLogRepository = {
    * same source the socket join uses, so catch-up admits exactly what live
    * delivery reached.
    *
-   * A stream is readable when the user is a member of it, a member of its
-   * root stream, OR the stream's effective root is public (INV-62) — public
-   * root channels grant read access to every workspace member without a
-   * `stream_members` row, and threads never carry their own access;
-   * `checkStreamAccess` / `streamAccessPredicateSql` resolve a thread's
-   * visibility entirely through `root_stream_id`, so a channel member must
-   * receive thread events (previews, replies by others) for threads they
-   * haven't participated in, and a non-member must receive a public channel's
-   * (and its threads') events. The log filter mirrors that exact rule to keep
-   * catch-up delivery congruent with live delivery.
+   * `visible_streams` resolves the same access rule as the canonical per-id
+   * predicate (INV-62), reusing its `rootReadableConditionSql` leaf so the two
+   * cannot drift — the previous version replicated the thread→root leg but
+   * dropped the public-root leg, silently starving non-members of public-channel
+   * catch-up. It has two arms:
    *
-   * Each membership grant is bounded below by its join position — the sync id
-   * of the user's latest `stream:member_added` entry for the member stream
-   * (threads inherit the ROOT membership's bound) — so joining a stream never
-   * replays its pre-join history through the log (over-delivery would leak
-   * no-history private streams). Memberships with no member_added entry
-   * predate the log itself, so every log entry postdates the join and no bound
-   * is needed. The member_added entry itself reaches the joiner through their
-   * user group. Public-root grants carry bound 0 (no join-position gating):
-   * a public channel's history is readable regardless of when — or whether —
-   * the viewer joined, so there is nothing to hide behind a join position.
-   * When several grants cover one stream (e.g. direct thread member AND root
-   * member, or member AND public), any grant whose bound passes admits the
-   * entry.
+   *   1. Direct memberships — every stream with a `stream_members` row for the
+   *      user, bounded by that stream's own join position. This honours direct
+   *      thread membership (message-move inserts `stream_members` on the
+   *      destination thread), which is access granted directly rather than
+   *      inherited through the root.
+   *   2. Inherited access — any stream whose EFFECTIVE ROOT
+   *      (`COALESCE(root_stream_id, id)`) is readable: public, or one the user
+   *      is a member of. This is `streamAccessPredicateSql`'s rule expressed as
+   *      a set, so a channel member receives thread events (previews, replies by
+   *      others) for threads they never joined, and a non-member receives a
+   *      public channel's (and its threads') events.
+   *
+   * Each grant is bounded below by a sync id so joining a stream never replays
+   * its pre-join history (over-delivery would leak no-history private streams):
+   * a membership grant uses the join position (the sync id of the user's latest
+   * `stream:member_added` entry; threads inherit the ROOT's), while a public
+   * grant uses bound 0 — a public channel's history is readable regardless of
+   * when, or whether, the viewer joined. A membership predating the log has no
+   * `member_added` entry, so its bound is 0 and every log entry postdates the
+   * join anyway; the `member_added` entry itself reaches the joiner through
+   * their user group. When several grants cover one stream (e.g. a public
+   * channel the user also joined), any grant whose bound passes admits the
+   * entry — so the public grant's bound 0 wins and pre-join public history shows.
    */
   async listEntriesForUser(
     db: Querier,
     params: { workspaceId: string; userId: string; permissionGroups: string[]; after: bigint; limit: number }
   ): Promise<SyncLogEntry[]> {
     const { workspaceId, userId, permissionGroups, after, limit } = params
-    const result = await db.query<SyncLogEntryRow>(sql`
+    const result = await db.query<SyncLogEntryRow>(composeSql`
       WITH join_bounds AS (
         SELECT DISTINCT ON (payload->>'streamId') payload->>'streamId' AS stream_id, sync_id AS join_sync_id
         FROM sync_log
@@ -166,31 +172,31 @@ export const SyncLogRepository = {
           AND groups @> ARRAY['user:' || ${userId}]
         ORDER BY payload->>'streamId', sync_id DESC
       ),
-      memberships AS (
+      visible_streams AS (
+        -- Direct memberships: every stream the user actually joined, bounded by
+        -- its own join position. Covers thread rows created by message-move
+        -- (event-service inserts stream_members on the destination thread),
+        -- whose access is direct, not inherited.
         SELECT sm.stream_id, COALESCE(jb.join_sync_id, 0) AS bound
         FROM stream_members sm
         LEFT JOIN join_bounds jb ON jb.stream_id = sm.stream_id
         WHERE sm.member_id = ${userId}
-      ),
-      visible_streams AS (
-        SELECT stream_id, bound FROM memberships
         UNION ALL
-        SELECT s.id, m.bound
+        -- Inherited access: any stream whose EFFECTIVE ROOT is readable —
+        -- public, or one the user is a member of. The readable test is shared
+        -- verbatim with streamAccessPredicateSql (rootReadableConditionSql), so
+        -- the public-without-membership leg cannot drift out of one and not the
+        -- other. A public root carries bound 0 (its whole history is readable);
+        -- a private root the user joined inherits the root's join position, so
+        -- threads never replay pre-join history.
+        SELECT s.id,
+               CASE WHEN root.visibility = ${Visibilities.PUBLIC} THEN 0
+                    ELSE COALESCE(jb.join_sync_id, 0) END AS bound
         FROM streams s
-        JOIN memberships m ON m.stream_id = s.root_stream_id
+        JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)
+        LEFT JOIN join_bounds jb ON jb.stream_id = root.id
         WHERE s.workspace_id = ${workspaceId}
-        UNION ALL
-        SELECT s.id, 0 AS bound
-        FROM streams s
-        WHERE s.workspace_id = ${workspaceId}
-          AND s.root_stream_id IS NULL
-          AND s.visibility = ${Visibilities.PUBLIC}
-        UNION ALL
-        SELECT s.id, 0 AS bound
-        FROM streams s
-        JOIN streams root_s ON root_s.id = s.root_stream_id
-        WHERE s.workspace_id = ${workspaceId}
-          AND root_s.visibility = ${Visibilities.PUBLIC}
+          AND ${rootReadableConditionSql(userId, "root")}
       )
       SELECT l.sync_id, l.event_type, l.payload, l.created_at
       FROM sync_log l

--- a/apps/backend/src/features/sync/repository.ts
+++ b/apps/backend/src/features/sync/repository.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "pg"
+import { Visibilities } from "@threa/types"
 import { sql, withTransaction, type Querier } from "../../db"
 
 /** One client-routed outbox event headed for the sync log. */
@@ -126,23 +127,30 @@ export const SyncLogRepository = {
    * same source the socket join uses, so catch-up admits exactly what live
    * delivery reached.
    *
-   * A stream is readable when the user is a member of it OR a member of its
-   * root stream (INV-62) — threads never carry their own access;
-   * `checkStreamAccess` resolves a thread's visibility entirely through
-   * `root_stream_id`, so a channel member must receive thread events
-   * (previews, replies by others) for threads they haven't participated in.
-   * The log filter mirrors that exact rule to keep catch-up delivery
-   * congruent with live delivery.
+   * A stream is readable when the user is a member of it, a member of its
+   * root stream, OR the stream's effective root is public (INV-62) — public
+   * root channels grant read access to every workspace member without a
+   * `stream_members` row, and threads never carry their own access;
+   * `checkStreamAccess` / `streamAccessPredicateSql` resolve a thread's
+   * visibility entirely through `root_stream_id`, so a channel member must
+   * receive thread events (previews, replies by others) for threads they
+   * haven't participated in, and a non-member must receive a public channel's
+   * (and its threads') events. The log filter mirrors that exact rule to keep
+   * catch-up delivery congruent with live delivery.
    *
-   * Each visibility grant is bounded below by its membership's join position —
-   * the sync id of the user's latest `stream:member_added` entry for the
-   * member stream (threads inherit the ROOT membership's bound) — so joining a
-   * stream never replays its pre-join history through the log (over-delivery
-   * would leak no-history private streams). Memberships with no member_added
-   * entry predate the log itself, so every log entry postdates the join and no
-   * bound is needed. The member_added entry itself reaches the joiner through
-   * their user group. When several grants cover one stream (direct thread
-   * member AND root member), any grant whose bound passes admits the entry.
+   * Each membership grant is bounded below by its join position — the sync id
+   * of the user's latest `stream:member_added` entry for the member stream
+   * (threads inherit the ROOT membership's bound) — so joining a stream never
+   * replays its pre-join history through the log (over-delivery would leak
+   * no-history private streams). Memberships with no member_added entry
+   * predate the log itself, so every log entry postdates the join and no bound
+   * is needed. The member_added entry itself reaches the joiner through their
+   * user group. Public-root grants carry bound 0 (no join-position gating):
+   * a public channel's history is readable regardless of when — or whether —
+   * the viewer joined, so there is nothing to hide behind a join position.
+   * When several grants cover one stream (e.g. direct thread member AND root
+   * member, or member AND public), any grant whose bound passes admits the
+   * entry.
    */
   async listEntriesForUser(
     db: Querier,
@@ -171,6 +179,18 @@ export const SyncLogRepository = {
         FROM streams s
         JOIN memberships m ON m.stream_id = s.root_stream_id
         WHERE s.workspace_id = ${workspaceId}
+        UNION ALL
+        SELECT s.id, 0 AS bound
+        FROM streams s
+        WHERE s.workspace_id = ${workspaceId}
+          AND s.root_stream_id IS NULL
+          AND s.visibility = ${Visibilities.PUBLIC}
+        UNION ALL
+        SELECT s.id, 0 AS bound
+        FROM streams s
+        JOIN streams root_s ON root_s.id = s.root_stream_id
+        WHERE s.workspace_id = ${workspaceId}
+          AND root_s.visibility = ${Visibilities.PUBLIC}
       )
       SELECT l.sync_id, l.event_type, l.payload, l.created_at
       FROM sync_log l

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -23,6 +23,7 @@ import type {
   Draft as WireDraft,
   WorkspaceInvitableRole,
   AuthorType,
+  NotificationLevel,
 } from "@threa/types"
 
 /**
@@ -44,6 +45,7 @@ export type OutboxEventType =
   | "stream:display_name_updated"
   | "stream:read"
   | "stream:read_all"
+  | "stream:notification_level_updated"
   | "stream:activity"
   | "attachment:uploaded"
   | "attachment:extraction_completed"
@@ -457,6 +459,15 @@ export interface StreamReadOutboxPayload extends WorkspaceScopedPayload {
   lastReadOrdinal: number
 }
 
+// Notification-level event payload (author-scoped — the mute/notify choice is
+// the acting user's own per-stream preference, so it reaches only their other
+// sessions, mirroring stream:read).
+export interface StreamNotificationLevelUpdatedOutboxPayload extends WorkspaceScopedPayload {
+  authorId: string
+  streamId: string
+  notificationLevel: NotificationLevel | null
+}
+
 export interface StreamsReadAllOutboxPayload extends WorkspaceScopedPayload {
   authorId: string
   streamIds: string[]
@@ -757,6 +768,7 @@ export interface OutboxEventPayloadMap {
   "stream:memos_captured": StreamMemosCapturedOutboxPayload
   "stream:read": StreamReadOutboxPayload
   "stream:read_all": StreamsReadAllOutboxPayload
+  "stream:notification_level_updated": StreamNotificationLevelUpdatedOutboxPayload
   "stream:activity": StreamActivityOutboxPayload
   "attachment:uploaded": AttachmentUploadedOutboxPayload
   "workspace_user:added": WorkspaceUserAddedOutboxPayload
@@ -882,6 +894,7 @@ export function isStreamScopedEvent(event: OutboxEvent): event is OutboxEvent<St
 export type AuthorScopedEventType =
   | "stream:read"
   | "stream:read_all"
+  | "stream:notification_level_updated"
   | "user_preferences:updated"
   | "sidebar_config:updated"
   | "link_preview:dismissed"
@@ -889,6 +902,7 @@ export type AuthorScopedEventType =
 const AUTHOR_SCOPED_EVENTS: AuthorScopedEventType[] = [
   "stream:read",
   "stream:read_all",
+  "stream:notification_level_updated",
   "link_preview:dismissed",
   "user_preferences:updated",
   "sidebar_config:updated",

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -186,6 +186,7 @@ describe("SyncLogRepository catch-up reads", () => {
     const outsider = uniqueId("usr")
     const channel = uniqueId("stream")
     const thread = uniqueId("stream")
+    await addRootStream(workspaceId, channel, "private")
     await addMembership(channel, me)
     await addThread(workspaceId, thread, channel, channel)
 
@@ -248,6 +249,7 @@ describe("SyncLogRepository catch-up reads", () => {
     const channel = uniqueId("stream")
     const thread = uniqueId("stream")
     const subThread = uniqueId("stream")
+    await addRootStream(workspaceId, channel, "private")
     await addMembership(channel, me)
     await addThread(workspaceId, thread, channel, channel)
     await addThread(workspaceId, subThread, channel, thread)
@@ -266,6 +268,7 @@ describe("SyncLogRepository catch-up reads", () => {
     const joiner = uniqueId("usr")
     const channel = uniqueId("stream")
     const thread = uniqueId("stream")
+    await addRootStream(workspaceId, channel, "private")
     await addThread(workspaceId, thread, channel, channel)
 
     // Thread content from before the channel join, must never surface.

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -46,6 +46,15 @@ describe("SyncLogRepository catch-up reads", () => {
     )
   }
 
+  /** Inserts a top-level (root) channel stream with the given visibility. */
+  async function addRootStream(workspaceId: string, streamId: string, visibility: "public" | "private") {
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, root_stream_id, created_by)
+       VALUES ($1, $2, 'channel', $3, NULL, $4)`,
+      [streamId, workspaceId, visibility, uniqueId("usr")]
+    )
+  }
+
   /** Appends one entry and returns its sync id. */
   async function appendEntry(workspaceId: string, entry: Omit<SyncLogEntryInput, "outboxEventId">): Promise<bigint> {
     const [outboxEventId] = await reserveOutboxIds(1)
@@ -193,6 +202,44 @@ describe("SyncLogRepository catch-up reads", () => {
 
     // Not a member of the root: sees nothing.
     expect(await listFor(workspaceId, outsider)).toEqual([])
+  })
+
+  // INV-62: a public root channel grants read access to every workspace member
+  // without a `stream_members` row, so catch-up must replay its events (and its
+  // threads') for non-members — the recurring footgun a membership-only filter
+  // hits. This mirrors streamAccessPredicateSql's public-root leg.
+  test("public channel events reach a non-member; private channel events do not", async () => {
+    const workspaceId = uniqueId("ws")
+    const outsider = uniqueId("usr")
+    const publicChannel = uniqueId("stream")
+    const privateChannel = uniqueId("stream")
+    const publicThread = uniqueId("stream")
+    await addRootStream(workspaceId, publicChannel, "public")
+    await addRootStream(workspaceId, privateChannel, "private")
+    await addThread(workspaceId, publicThread, publicChannel, publicChannel)
+
+    const publicMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${publicChannel}`],
+      payload: { workspaceId, kind: "public-channel" },
+    })
+    const publicThreadMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${publicThread}`],
+      payload: { workspaceId, kind: "public-thread" },
+    })
+    // Private channel content must stay hidden from a non-member even though a
+    // `streams` row exists — the public leg must not over-match private roots.
+    await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${privateChannel}`],
+      payload: { workspaceId, kind: "private-channel" },
+    })
+
+    // The outsider joined nothing yet sees the public channel and its thread
+    // (full history, no join bound), but never the private channel.
+    const entries = await listFor(workspaceId, outsider)
+    expect(entries.map((e) => e.syncId)).toEqual([publicMessage, publicThreadMessage])
   })
 
   test("a depth-2 thread inherits visibility from the root, not the immediate parent", async () => {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -790,6 +790,42 @@ describe("registerWorkspaceSocketHandlers", () => {
     gate.dispose()
   })
 
+  it("applies a gate-dispatched notification-level catch-up replay to IDB", async () => {
+    // A mute/notify change made in another session reaches this one as either a
+    // live emit or a catch-up replay (gate.dispatch); both share this handler,
+    // which writes the new level into the streamMemberships mirror so the badge
+    // updates without a re-bootstrap.
+    const queryClient = new QueryClient()
+    const gate = new SocketEventGate("ws_1")
+    const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs)
+
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+
+    await gate.dispatch("stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      notificationLevel: "muted",
+    })
+
+    await vi.waitFor(async () => {
+      expect((await db.streamMemberships.get("ws_1:stream_1"))?.notificationLevel).toBe("muted")
+    })
+
+    cleanup()
+    gate.dispose()
+  })
+
   it("invalidates the memo search queries when a memo:created event lands", () => {
     const queryClient = new QueryClient()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -792,9 +792,10 @@ describe("registerWorkspaceSocketHandlers", () => {
 
   it("applies a gate-dispatched notification-level catch-up replay to IDB", async () => {
     // A mute/notify change made in another session reaches this one as either a
-    // live emit or a catch-up replay (gate.dispatch); both share this handler,
-    // which writes the new level into the streamMemberships mirror so the badge
-    // updates without a re-bootstrap.
+    // live emit or a catch-up replay (gate.dispatch); both share this handler.
+    // It writes the new level into the streamMemberships mirror AND the derived
+    // unreadState.mutedStreamIds set — the latter is what the sidebar / quick-
+    // switcher / share badges actually render from, so both must move.
     const queryClient = new QueryClient()
     const gate = new SocketEventGate("ws_1")
     const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs)
@@ -810,6 +811,35 @@ describe("registerWorkspaceSocketHandlers", () => {
       joinedAt: new Date().toISOString(),
       _cachedAt: Date.now(),
     })
+    await db.streams.put({
+      id: "stream_1",
+      workspaceId: "ws_1",
+      type: "channel",
+      displayName: "general",
+      slug: "general",
+      description: null,
+      visibility: "public",
+      parentStreamId: null,
+      parentMessageId: null,
+      rootStreamId: null,
+      companionMode: "off",
+      companionPersonaId: null,
+      createdBy: "member_1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      archivedAt: null,
+      _cachedAt: Date.now(),
+    })
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
 
     await gate.dispatch("stream:notification_level_updated", {
       workspaceId: "ws_1",
@@ -820,6 +850,20 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     await vi.waitFor(async () => {
       expect((await db.streamMemberships.get("ws_1:stream_1"))?.notificationLevel).toBe("muted")
+      // The badge source: muting the channel adds it to the muted set.
+      expect((await db.unreadState.get("ws_1"))?.mutedStreamIds).toContain("stream_1")
+    })
+
+    // Unmuting (back to the channel default) removes it from the set again.
+    await gate.dispatch("stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      notificationLevel: null,
+    })
+
+    await vi.waitFor(async () => {
+      expect((await db.unreadState.get("ws_1"))?.mutedStreamIds).not.toContain("stream_1")
     })
 
     cleanup()

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -134,6 +134,16 @@ interface StreamsReadAllPayload {
   reads: Array<{ streamId: string; lastReadOrdinal: number }>
 }
 
+// Author-scoped: the user's own mute/notify choice for one stream, mirrored to
+// their other sessions so the badge updates live instead of waiting for a
+// reconnect merge.
+interface StreamNotificationLevelUpdatedPayload {
+  workspaceId: string
+  authorId: string
+  streamId: string
+  notificationLevel: StreamMember["notificationLevel"]
+}
+
 interface StreamActivityPayload {
   workspaceId: string
   streamId: string
@@ -886,6 +896,51 @@ export function registerWorkspaceSocketHandlers(
         streamId,
       })
     }
+  }
+
+  // Handle a notification-level change made in another session of this user.
+  // Keeps the mute/notify badge live across tabs/devices (the reconnect merge
+  // in setMutedState otherwise leaves it stale until the next reconnect).
+  const handleStreamNotificationLevelUpdated = (payload: StreamNotificationLevelUpdatedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+
+    // Workspace bootstrap membership row — drives the sidebar mute badge.
+    queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+      if (!old) return old
+      return {
+        ...old,
+        streamMemberships: old.streamMemberships.map((membership) =>
+          membership.streamId === payload.streamId
+            ? { ...membership, notificationLevel: payload.notificationLevel }
+            : membership
+        ),
+      }
+    })
+
+    // Stream bootstrap membership mirror (the open stream view).
+    queryClient.setQueryData<import("@threa/types").StreamBootstrap | undefined>(
+      streamKeys.bootstrap(workspaceId, payload.streamId),
+      (old) => {
+        if (!old?.membership) return old
+        return {
+          ...old,
+          membership: { ...old.membership, notificationLevel: payload.notificationLevel },
+        }
+      }
+    )
+
+    // Persist to IDB so the badge survives a remount without a re-bootstrap.
+    void db.transaction("rw", [db.streamMemberships], async () => {
+      const membershipId = `${workspaceId}:${payload.streamId}`
+      const membership = await db.streamMemberships.get(membershipId)
+      if (membership) {
+        await db.streamMemberships.put({
+          ...membership,
+          notificationLevel: payload.notificationLevel,
+          _cachedAt: Date.now(),
+        })
+      }
+    })
   }
 
   // Handle stream activity (when a new message is created in any stream)
@@ -1688,6 +1743,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("workspace_user:updated", handleWorkspaceUserUpdated)
   socket.on("stream:read", handleStreamRead)
   socket.on("stream:read_all", handleStreamReadAll)
+  socket.on("stream:notification_level_updated", handleStreamNotificationLevelUpdated)
   socket.on("stream:activity", handleStreamActivity)
   socket.on("stream:display_name_updated", handleStreamDisplayNameUpdated)
   socket.on("stream:member_added", handleStreamMemberAdded)
@@ -1737,6 +1793,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("workspace_user:updated", handleWorkspaceUserUpdated)
     socket.off("stream:read", handleStreamRead)
     socket.off("stream:read_all", handleStreamReadAll)
+    socket.off("stream:notification_level_updated", handleStreamNotificationLevelUpdated)
     socket.off("stream:activity", handleStreamActivity)
     socket.off("stream:display_name_updated", handleStreamDisplayNameUpdated)
     socket.off("stream:member_added", handleStreamMemberAdded)

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -904,9 +904,17 @@ export function registerWorkspaceSocketHandlers(
   const handleStreamNotificationLevelUpdated = (payload: StreamNotificationLevelUpdatedPayload) => {
     if (payload.workspaceId !== workspaceId) return
 
-    // Workspace bootstrap membership row — drives the sidebar mute badge.
+    // The sidebar / quick-switcher / share mute badges render from
+    // `unreadState.mutedStreamIds`, a derived set — NOT from the membership
+    // row's notificationLevel — so the muted set has to move alongside the
+    // membership caches. `setMutedState` centralizes the level→muted rule.
     queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
       if (!old) return old
+      const streamType = old.streams.find((s) => s.id === payload.streamId)?.type
+      const mutedStreamIds = new Set(old.mutedStreamIds)
+      if (streamType) {
+        setMutedState(mutedStreamIds, payload.streamId, streamType, payload.notificationLevel)
+      }
       return {
         ...old,
         streamMemberships: old.streamMemberships.map((membership) =>
@@ -914,10 +922,11 @@ export function registerWorkspaceSocketHandlers(
             ? { ...membership, notificationLevel: payload.notificationLevel }
             : membership
         ),
+        mutedStreamIds: streamType ? Array.from(mutedStreamIds) : old.mutedStreamIds,
       }
     })
 
-    // Stream bootstrap membership mirror (the open stream view).
+    // Stream bootstrap membership mirror — drives the settings dialog's level.
     queryClient.setQueryData<import("@threa/types").StreamBootstrap | undefined>(
       streamKeys.bootstrap(workspaceId, payload.streamId),
       (old) => {
@@ -929,15 +938,30 @@ export function registerWorkspaceSocketHandlers(
       }
     )
 
-    // Persist to IDB so the badge survives a remount without a re-bootstrap.
-    void db.transaction("rw", [db.streamMemberships], async () => {
+    // Persist to IDB so both the membership and the muted set survive a remount
+    // without a re-bootstrap. `db.unreadState` is the live source the badge
+    // hooks observe; `db.streamMemberships` backs the settings dialog.
+    void db.transaction("rw", [db.streamMemberships, db.streams, db.unreadState], async () => {
+      const now = Date.now()
       const membershipId = `${workspaceId}:${payload.streamId}`
       const membership = await db.streamMemberships.get(membershipId)
       if (membership) {
         await db.streamMemberships.put({
           ...membership,
           notificationLevel: payload.notificationLevel,
-          _cachedAt: Date.now(),
+          _cachedAt: now,
+        })
+      }
+
+      const stream = await db.streams.get(payload.streamId)
+      const unread = await db.unreadState.get(workspaceId)
+      if (stream && unread) {
+        const mutedStreamIds = new Set(unread.mutedStreamIds)
+        setMutedState(mutedStreamIds, payload.streamId, stream.type, payload.notificationLevel)
+        await db.unreadState.put({
+          ...unread,
+          mutedStreamIds: Array.from(mutedStreamIds),
+          _cachedAt: now,
         })
       }
     })


### PR DESCRIPTION
Two sync-engine "never-miss / always-up-to-date" gaps from the sync-engine audit, each a case where a connected client kept stale state until reconnect. FIX #1 (control-plane role fan-out) shipped separately as #933; this PR is the remaining two, kept together on one branch per the assigned-branch constraint.

## FIX #2 — public-root streams dropped from workspace catch-up (`sync/repository.ts`)

### Problem

`SyncLogRepository.listEntriesForUser` builds its `visible_streams` CTE from `stream_members` rows only. It replicates INV-62's thread→root leg but **not** the "a public root channel grants read access without a `stream_members` row" leg. So workspace sync-log catch-up dropped public-channel events (and their threads') for any reader who never joined the channel — the live socket path lets a non-member into a public room, but a reconnect/catch-up over the log silently omitted that history. This diverges from the canonical `streamAccessPredicateSql` in `streams/access.ts`, which every other set-based access check (search, attachments, sharing, labels) routes through and which *does* have the public-root leg.

### Solution

Add two `UNION ALL` legs to `visible_streams`, mirroring `streamAccessPredicateSql`'s two public branches:

- public root streams: `s.root_stream_id IS NULL AND s.visibility = 'public'`
- threads whose root is public: `JOIN streams root_s ON root_s.id = s.root_stream_id WHERE root_s.visibility = 'public'`

Both carry `bound = 0`. The `bound` is the join-position floor that stops a member from replaying a stream's pre-join history; a public channel's history is readable regardless of when — or whether — the viewer joined, so there is nothing to gate behind a join position and no pre-join leak to guard. The existing `OR EXISTS (… AND l.sync_id > vs.bound)` admit-if-any-grant-passes dedup absorbs the overlap when a viewer is *also* a member of a public channel (the bound-0 leg simply always passes).

`Visibilities.PUBLIC` is interpolated from `@threa/types` rather than a literal `'public'` (INV-33).

### Key design decision

**Inline replication over wholesale `streamAccessPredicateSql` reuse.** The CTE needs a per-stream `bound` column for the join-position gate, which the boolean `EXISTS` predicate doesn't expose. CLAUDE.md's INV-62 rule allows exactly this: *reuse the helper OR replicate the thread→root rule and pair it with a test*. The two legs are a direct structural mirror of the predicate's public branches, and the test covers the case a membership-only filter gets wrong.

The stale doc comment above the method (which stated the rule as "member of it OR member of its root" and omitted public-without-membership) is corrected (INV-25).

## FIX #3 — notification-level changes never broadcast (`streams/service.ts`, new event type)

### Problem

`StreamService.setNotificationLevel` mutated the `stream_members` row but emitted no outbox event. A mute/notify change made in one tab stayed stale in the user's other tabs and devices until the next reconnect — `workspace-sync.ts`'s `setMutedState` only runs on the reconnect bootstrap merge, so nothing updated the badge live.

### Solution

A new author-scoped event type, `stream:notification_level_updated`, modeled exactly on `stream:read` (the existing author-scoped read-state event):

1. **Type system (end-to-end).** Added to `OutboxEventType`, `OutboxEventPayloadMap`, the new `StreamNotificationLevelUpdatedOutboxPayload` (`{ workspaceId, authorId, streamId, notificationLevel }`), and the `AuthorScopedEventType` union + `AUTHOR_SCOPED_EVENTS` array in `lib/outbox/repository.ts` (INV-31/INV-33).
2. **Routing.** `resolveDeliveryGroups` already maps any author-scoped event to `[userGroup(authorId)]`, so the event reaches only the acting user's sessions and `BroadcastHandler.sequenceEvents` lands it in the sync log under `user:${authorId}` — which means catch-up replays it too, no extra wiring.
3. **Emit.** `setNotificationLevel` now emits in the **same transaction** as the membership update (INV-4/INV-7), and only when `StreamMemberRepository.update` actually returned a membership row. It gained a `workspaceId` parameter — the unmute (`level === null`) path never fetched the stream, so the workspace id wasn't otherwise in scope; the handler passes `req.workspaceId`.
4. **Frontend.** `handleStreamNotificationLevelUpdated` writes the new level into the workspace-bootstrap membership row (sidebar mute badge), the stream-bootstrap membership mirror (open stream view), and the `db.streamMemberships` IDB row (survives remount). Registered on the engine's event gate via `socket.on`, so the **one** handler covers both live emit and catch-up `gate.dispatch` — confirmed against `socket-event-gate.ts`, where `.on` registers into the same `handlers` map both paths invoke.

### Key design decision

**Author-scoped, not user-scoped.** The two families differ only in payload field — author-scoped reads `authorId`, user-scoped reads `targetUserId` — and both resolve to `userGroup`. The notification-level choice is the acting user's own per-stream preference reflected back to their other sessions, which is exactly `stream:read`'s shape; reusing that family kept the payload and routing identical to a well-trodden path rather than introducing a `targetUserId` indirection that doesn't fit.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/sync/repository.ts` | FIX #2: two public-root `UNION ALL` legs in the `visible_streams` CTE; corrected the stale visibility doc comment; import `Visibilities` |
| `apps/backend/src/lib/outbox/repository.ts` | FIX #3: new `stream:notification_level_updated` event type, payload interface, payload-map entry, and `AuthorScopedEventType`/`AUTHOR_SCOPED_EVENTS` membership |
| `apps/backend/src/features/streams/service.ts` | FIX #3: `setNotificationLevel` takes `workspaceId` and emits the event in-transaction when a membership row was updated |
| `apps/backend/src/features/streams/handlers.ts` | FIX #3: pass `workspaceId` to `setNotificationLevel` |
| `apps/frontend/src/sync/workspace-sync.ts` | FIX #3: `StreamNotificationLevelUpdatedPayload`, `handleStreamNotificationLevelUpdated`, and the `socket.on`/`socket.off` registration |
| `apps/backend/tests/integration/sync-catch-up.test.ts` | FIX #2: `addRootStream` helper + a public/private-channel visibility test |
| `apps/backend/src/features/streams/service.test.ts` | FIX #3: three `setNotificationLevel` emit tests (scoped `spyOn`) |
| `apps/frontend/src/sync/workspace-sync.test.ts` | FIX #3: gate-dispatched catch-up replay updates the `streamMemberships` mirror |

## Out of scope (deliberate)

- The audit's other findings the user ruled out: workspace settings / feature-flags freshness (query-cache only, by design), `link_preview:dismissed` / `bot_runtime:presence` (ephemeral), `useStreamSocket` fire-and-forget join (maintainability only), and `applyMembershipRemoval` emitting nothing (full removal emits `workspace_user:removed` elsewhere). Left untouched.
- No schema change: both fixes are read-path (FIX #2) and event-emission (FIX #3) only.

## Test plan

- [x] Backend `bun test src/features/streams/service.test.ts tests/integration/sync-catch-up.test.ts` — 66 pass (3 new notification-level emit tests; 1 new public-root catch-up test)
- [x] Frontend `bunx vitest run src/sync/workspace-sync.test.ts` — 35 pass (1 new gate-dispatched notification-level replay)
- [x] Frontend `bunx vitest run src/sync/sync-engine.test.ts src/sync/socket-event-gate.test.ts` — 62 pass (no regression in the gate that carries the new event)
- [x] Full monorepo lint + per-package `tsc --noEmit` (incl. `tsconfig.tests.json`) — clean, via the pre-commit hook on both commits
- [x] Self-review: claim-verification pass over the diff (routing, in-transaction emit, gate coverage, public-root dedup) — one finding fixed mid-review (the `setNotificationLevel` test literal widened `notificationLevel` to `string` and used a `string` `joinedAt`; typed it as the repository `StreamMember` with a `Date`, caught by the stricter test tsconfig in the hook)
- [ ] No separate parallel reviewer-agent pass — the change is contained (two read/emit paths, fully unit + integration covered) so the manual passes above stood in; flag for the verify-holder session

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAsK8GdCubeRx6o1fsefX7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038071&installation_id=129946197&pr_number=936&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F936&signature=686cf63f04a42ed1563c6a4f0d450cbe4c9fd0553db0c3d8877905590c2f08ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->