### PR TITLE
feat(drafts): stage 4b — thread re-pointing for drafts

### DIFF
--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -200,6 +200,39 @@ describe("DraftsRepository.softDelete", () => {
   })
 })
 
+describe("DraftsRepository.rescopeByScope", () => {
+  afterEach(() => mock.restore())
+
+  it("re-scopes every owner's draft for a scope (no user filter) and bumps the version", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [
+      { ...DRAFT_ROW, id: "draft_01", user_id: "usr_1", scope: "stream:thread_1", root_stream_id: "stream_root" },
+      { ...DRAFT_ROW, id: "draft_02", user_id: "usr_2", scope: "stream:thread_1", root_stream_id: "stream_root" },
+    ])
+
+    const rows = await DraftsRepository.rescopeByScope(db, {
+      workspaceId: "ws_1",
+      fromScope: "thread:msg_1",
+      toScope: "stream:thread_1",
+      rootStreamId: "stream_root",
+    })
+
+    expect(captured.text).toContain("UPDATE drafts SET")
+    expect(captured.text).toContain("scope =")
+    expect(captured.text).toContain("root_stream_id =")
+    expect(captured.text).toContain("version = version + 1")
+    expect(captured.text).toContain("deleted_at IS NULL")
+    // Multi-user: matches by workspace + scope only, never user_id — a shared
+    // thread scope's drafts all follow the message regardless of author.
+    expect(captured.text).not.toContain("user_id =")
+    expect(captured.values).toContain("thread:msg_1")
+    expect(captured.values).toContain("stream:thread_1")
+    expect(captured.values).toContain("stream_root")
+    // Returns each re-scoped row so the caller can emit one event per owner.
+    expect(rows.map((row) => row.userId)).toEqual(["usr_1", "usr_2"])
+  })
+})
+
 describe("DraftsRepository.listByUser", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -248,6 +248,41 @@ export const DraftsRepository = {
   },
 
   /**
+   * Re-scope every live draft from `fromScope` to `toScope` (thread re-pointing).
+   * When a not-yet-threaded message is converted to a thread, its reply drafts
+   * must follow the message into the new thread stream so they keep roaming.
+   *
+   * Multi-user by design (no `user_id` filter): a shared `thread:{messageId}`
+   * scope can hold reply drafts from several authors, and every owner's draft
+   * follows the message — drafts stay private (each is delivered only to its own
+   * `user:{userId}` room by the caller). Set-based single UPDATE (INV-56), no
+   * select-then-write (INV-20).
+   *
+   * Bumps `version` so the client's drift-aware apply accepts the new scope: a
+   * clean local row sees `version > baseVersion` and adopts it, while a row with
+   * unpushed edits ignores the echo and its queued push splits CAS-safely
+   * (expectedVersion now trails the server). Returns the re-scoped rows so the
+   * caller can emit one `draft:upserted` per owner.
+   */
+  async rescopeByScope(
+    db: Querier,
+    params: { workspaceId: string; fromScope: string; toScope: string; rootStreamId: string | null }
+  ): Promise<Draft[]> {
+    const result = await db.query<DraftRow>(sql`
+      UPDATE drafts SET
+        scope = ${params.toScope},
+        root_stream_id = ${params.rootStreamId},
+        updated_at = NOW(),
+        version = version + 1
+      WHERE workspace_id = ${params.workspaceId}
+        AND scope = ${params.fromScope}
+        AND deleted_at IS NULL
+      RETURNING ${sql.raw(COLUMNS)}
+    `)
+    return result.rows.map(mapRow)
+  },
+
+  /**
    * Unconditional soft-delete for explicit discard (no CAS) — the user threw
    * the draft away, so drift doesn't matter. Idempotent on an already-deleted
    * row. Returns the row when it tombstoned, `null` when it was missing.

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -15,6 +15,7 @@ import {
 } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
 import { AgentSessionRepository, StreamPersonaParticipantRepository } from "../agents"
+import { DraftsRepository, toDraftView } from "../drafts"
 import { E2eStreamsRepository } from "../e2e-streams"
 import { attachmentReferenceId, eventId, messageId, messageVersionId, streamId as generateStreamId } from "../../lib/id"
 import { MessageVersionRepository, type MessageVersion } from "./version-repository"
@@ -27,6 +28,8 @@ import {
   CompanionModes,
   StreamTypes,
   Visibilities,
+  draftStreamScope,
+  draftThreadScope,
   type AttachmentSummary,
   type AuthorType,
   type EventType,
@@ -1159,6 +1162,28 @@ export class EventService {
         updates: agentSessionEventUpdates,
       })
       await MessageRepository.moveToStream(client, destinationThread.id, updates)
+
+      // Thread re-pointing: the target message just became a thread, so any reply
+      // draft composed against it (scope `thread:{targetMessageId}`) follows the
+      // message into the new thread stream (`stream:{destinationThread.id}`).
+      // Drafts are private per author but a shared target can hold several
+      // authors' reply drafts, so this re-scopes every owner's draft and emits
+      // one user-scoped `draft:upserted` each — in this same transaction so the
+      // re-point and the move commit together (INV-4/7).
+      const rescopedDrafts = await DraftsRepository.rescopeByScope(client, {
+        workspaceId: params.workspaceId,
+        fromScope: draftThreadScope(params.targetMessageId),
+        toScope: draftStreamScope(destinationThread.id),
+        rootStreamId,
+      })
+      for (const draft of rescopedDrafts) {
+        await OutboxRepository.insert(client, "draft:upserted", {
+          workspaceId: params.workspaceId,
+          targetUserId: draft.userId,
+          draft: toDraftView(draft),
+        })
+      }
+
       await MessageRepository.updateStreamScopedReferences(client, {
         workspaceId: params.workspaceId,
         sourceStreamId: params.sourceStreamId,

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1176,12 +1176,18 @@ export class EventService {
         toScope: draftStreamScope(destinationThread.id),
         rootStreamId,
       })
-      for (const draft of rescopedDrafts) {
-        await OutboxRepository.insert(client, "draft:upserted", {
-          workspaceId: params.workspaceId,
-          targetUserId: draft.userId,
-          draft: toDraftView(draft),
-        })
+      if (rescopedDrafts.length > 0) {
+        await OutboxRepository.insertMany(
+          client,
+          rescopedDrafts.map((draft) => ({
+            eventType: "draft:upserted" as const,
+            payload: {
+              workspaceId: params.workspaceId,
+              targetUserId: draft.userId,
+              draft: toDraftView(draft),
+            },
+          }))
+        )
       }
 
       await MessageRepository.updateStreamScopedReferences(client, {

--- a/apps/backend/tests/integration/message-move.test.ts
+++ b/apps/backend/tests/integration/message-move.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import type { Pool } from "pg"
 import { EventService } from "../../src/features/messaging"
+import { DraftsRepository } from "../../src/features/drafts"
 import { AgentSessionRepository, SessionStatuses } from "../../src/features/agents"
 import { StreamEventRepository, StreamMemberRepository, StreamRepository } from "../../src/features/streams"
 import { eventId, messageId, personaId, sessionId, streamId, userId, workspaceId } from "../../src/lib/id"
@@ -25,6 +26,7 @@ describe("message move integration", () => {
     await pool.query("DELETE FROM stream_persona_participants")
     await pool.query("DELETE FROM stream_members")
     await pool.query("DELETE FROM reactions")
+    await pool.query("DELETE FROM drafts")
     await pool.query("DELETE FROM messages")
     await pool.query("DELETE FROM stream_events")
     await pool.query("DELETE FROM stream_sequences")
@@ -291,6 +293,124 @@ describe("message move integration", () => {
       // per-message context-menu drill-in can fetch it from IDB.
       expect(payload.movedFrom?.moveTombstoneId).toBe(destinationTombstone?.id)
     }
+  })
+
+  test("re-points reply drafts onto the new thread for every author when the target becomes a thread", async () => {
+    const testWorkspaceId = workspaceId()
+    const sourceStreamId = streamId()
+    const actor = await addTestMember(pool, testWorkspaceId, userId())
+    const other = await addTestMember(pool, testWorkspaceId, userId())
+
+    await StreamRepository.insert(pool, {
+      id: sourceStreamId,
+      workspaceId: testWorkspaceId,
+      type: "channel",
+      visibility: "workspace",
+      companionMode: "off",
+      createdBy: actor.id,
+    })
+    await StreamMemberRepository.insert(pool, sourceStreamId, actor.id)
+    await StreamMemberRepository.insert(pool, sourceStreamId, other.id)
+
+    const target = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: sourceStreamId,
+      authorId: actor.id,
+      authorType: "user",
+      ...testMessageContent("target"),
+    })
+    const moved = await eventService.createMessage({
+      workspaceId: testWorkspaceId,
+      streamId: sourceStreamId,
+      authorId: actor.id,
+      authorType: "user",
+      ...testMessageContent("moved"),
+    })
+
+    // Two authors are each composing a reply to `target` (no thread yet), so
+    // both hold a draft scoped to `thread:{target.id}`. A draft on an unrelated
+    // message must NOT move.
+    const insertDraftParams = {
+      workspaceId: testWorkspaceId,
+      rootStreamId: null,
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "reply",
+      attachmentIds: [],
+      command: null,
+      contextRefs: null,
+      ciphertext: null,
+      envelope: null,
+      e2eVersion: null,
+      clientUpdatedAt: new Date(),
+    }
+    await DraftsRepository.insertIfAbsent(pool, {
+      id: "draft_actor",
+      userId: actor.id,
+      scope: `thread:${target.id}`,
+      lastClientWriteId: "w_actor",
+      ...insertDraftParams,
+    })
+    await DraftsRepository.insertIfAbsent(pool, {
+      id: "draft_other",
+      userId: other.id,
+      scope: `thread:${target.id}`,
+      lastClientWriteId: "w_other",
+      ...insertDraftParams,
+    })
+    await DraftsRepository.insertIfAbsent(pool, {
+      id: "draft_unrelated",
+      userId: actor.id,
+      scope: `thread:${moved.id}`,
+      lastClientWriteId: "w_unrelated",
+      ...insertDraftParams,
+    })
+
+    const validation = await eventService.validateMoveMessagesToThread({
+      workspaceId: testWorkspaceId,
+      sourceStreamId,
+      targetMessageId: target.id,
+      messageIds: [moved.id],
+      actorId: actor.id,
+    })
+    const result = await eventService.moveMessagesToThread({
+      workspaceId: testWorkspaceId,
+      sourceStreamId,
+      targetMessageId: target.id,
+      messageIds: [moved.id],
+      actorId: actor.id,
+      leaseKey: validation.leaseKey,
+    })
+
+    const newScope = `stream:${result.thread.id}`
+
+    const actorDrafts = await DraftsRepository.listByUser(pool, testWorkspaceId, actor.id)
+    const otherDrafts = await DraftsRepository.listByUser(pool, testWorkspaceId, other.id)
+
+    const actorReply = actorDrafts.find((draft) => draft.id === "draft_actor")
+    const otherReply = otherDrafts.find((draft) => draft.id === "draft_other")
+    const unrelated = actorDrafts.find((draft) => draft.id === "draft_unrelated")
+
+    // Both authors' reply drafts followed the message into the new thread, with
+    // root_stream_id set and version bumped so the client adopts the new scope.
+    expect(actorReply?.scope).toBe(newScope)
+    expect(actorReply?.rootStreamId).toBe(result.thread.rootStreamId)
+    expect(actorReply?.version).toBe(2)
+    expect(otherReply?.scope).toBe(newScope)
+    expect(otherReply?.rootStreamId).toBe(result.thread.rootStreamId)
+
+    // A draft on a different message is untouched.
+    expect(unrelated?.scope).toBe(`thread:${moved.id}`)
+    expect(unrelated?.version).toBe(1)
+
+    // One user-scoped draft:upserted per re-scoped draft, delivered to its owner.
+    const draftEvents = await pool.query<{ payload: { targetUserId: string; draft: { id: string; scope: string } } }>(
+      `SELECT payload FROM outbox WHERE event_type = 'draft:upserted'`
+    )
+    const byDraftId = new Map(draftEvents.rows.map((row) => [row.payload.draft.id, row.payload]))
+    expect(byDraftId.get("draft_actor")?.targetUserId).toBe(actor.id)
+    expect(byDraftId.get("draft_actor")?.draft.scope).toBe(newScope)
+    expect(byDraftId.get("draft_other")?.targetUserId).toBe(other.id)
+    expect(byDraftId.has("draft_unrelated")).toBe(false)
   })
 
   test("rejects moving a message onto a following message", async () => {

--- a/apps/frontend/src/hooks/use-draft-message-sync.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message-sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { clearLoadedDraft, purgeScopeDrafts, upsertLoadedDraft } from "./use-draft-message"
+import { clearLoadedDraft, purgeScopeDrafts, rescopeScopeDrafts, upsertLoadedDraft } from "./use-draft-message"
 import { hasPendingDraftUpsert } from "@/sync/draft-sync"
 import { db, type CachedDraft } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
@@ -14,6 +14,11 @@ const makeDoc = (text: string): JSONContent => ({
 
 async function pendingDeletes(draftId: string): Promise<number> {
   const ops = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+  return ops.filter((o) => o.payload.draftId === draftId).length
+}
+
+async function pendingUpserts(draftId: string): Promise<number> {
+  const ops = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
   return ops.filter((o) => o.payload.draftId === draftId).length
 }
 
@@ -89,5 +94,36 @@ describe("draft write helpers — Stage 3 sync wiring", () => {
     expect(await pendingDeletes(confirmed.id)).toBe(1)
     expect(await pendingDeletes(unsyncedRow.id)).toBe(0)
     expect(await db.drafts.count()).toBe(0)
+  })
+
+  it("rescopeScopeDrafts moves every draft (and the loaded pointer) to the new scope and pushes each", async () => {
+    const fromScope = "stream:draft_local_stream"
+    const toScope = "stream:stream_real"
+    // The loaded draft for the scratchpad, plus a stash sibling.
+    const loadedRow = await upsertLoadedDraft(workspaceId, fromScope, {
+      contentJson: makeDoc("loaded"),
+      attachments: [],
+    })
+    const stashRow: CachedDraft = {
+      id: "draft_stash",
+      workspaceId,
+      scope: fromScope,
+      contentJson: makeDoc("stash"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    }
+    await db.drafts.add(stashRow)
+
+    await rescopeScopeDrafts(workspaceId, fromScope, toScope)
+
+    // Both rows kept their ids but moved to the real stream scope.
+    expect((await db.drafts.get(loadedRow.id))?.scope).toBe(toScope)
+    expect((await db.drafts.get("draft_stash"))?.scope).toBe(toScope)
+    // The loaded pointer followed its draft to the new scope; the old scope is empty.
+    expect((await db.composerLoaded.get(fromScope))?.draftId).toBeUndefined()
+    expect((await db.composerLoaded.get(toScope))?.draftId).toBe(loadedRow.id)
+    // Each draft is queued for a push so the server row follows.
+    expect(await pendingUpserts(loadedRow.id)).toBe(1)
+    expect(await pendingUpserts("draft_stash")).toBe(1)
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -10,9 +10,9 @@ import {
   useComposerLoadedFromStore,
   useDraftsFromStore,
 } from "@/stores/draft-store"
-import { enqueueDraftUpsert, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
+import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import type { JSONContent } from "@threa/types"
+import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 
 // Key formats (a draft's `scope`):
@@ -22,9 +22,9 @@ export function getDraftMessageKey(
   location: { type: "stream"; streamId: string } | { type: "thread"; parentMessageId: string }
 ): string {
   if (location.type === "stream") {
-    return `stream:${location.streamId}`
+    return draftStreamScope(location.streamId)
   }
-  return `thread:${location.parentMessageId}`
+  return draftThreadScope(location.parentMessageId)
 }
 
 const DEBOUNCE_MS = import.meta.env.VITE_DRAFT_DEBOUNCE_MS ? Number(import.meta.env.VITE_DRAFT_DEBOUNCE_MS) : 500
@@ -166,6 +166,25 @@ export async function purgeScopeDrafts(workspaceId: string, scope: string): Prom
   setComposerLoadedInCache(workspaceId, scope, null)
   // Sync side-effects after the local state is fully cleared.
   for (const row of rows) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
+}
+
+/**
+ * Re-scope every draft for `fromScope` to `toScope` and push each so the server
+ * row follows. The client-initiated counterpart to inbound thread re-pointing:
+ * used by `promoteDraft` when a not-yet-created scratchpad becomes a real stream,
+ * so the drafts composed in it (loaded plus any stash siblings) move onto the
+ * real stream and keep roaming instead of being discarded. The loaded pointer
+ * follows its draft (via `migrateLocalDraftScope`). No-op when the scope is empty.
+ *
+ * The just-sent loaded draft is already resolved by the send path before promotion
+ * runs, so in practice this carries the surviving stash entries.
+ */
+export async function rescopeScopeDrafts(workspaceId: string, fromScope: string, toScope: string): Promise<void> {
+  const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, fromScope]).toArray()
+  for (const row of rows) {
+    await migrateLocalDraftScope(workspaceId, fromScope, { ...row, scope: toScope })
+    await enqueueDraftUpsert(workspaceId, row.id)
+  }
 }
 
 /**

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -23,6 +23,7 @@ let mockIsConnected = true
 const mockStreamCreate = vi.fn()
 
 const mockSubscribeStream = vi.fn()
+const mockKickOperationQueue = vi.fn()
 
 // Mock IndexedDB
 interface MockPendingMessage {
@@ -69,6 +70,7 @@ describe("useMessageQueue", () => {
     mockRegisterQueueNotify.mockReset()
     mockStreamCreate.mockReset()
     mockSubscribeStream.mockReset()
+    mockKickOperationQueue.mockReset()
     mockDelete.mockClear()
     mockUpdate.mockClear()
     mockUpdate.mockResolvedValue(1)
@@ -100,6 +102,7 @@ describe("useMessageQueue", () => {
     // Sync engine
     vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
       subscribeStream: mockSubscribeStream,
+      kickOperationQueue: mockKickOperationQueue,
     } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
 
     // DB tables
@@ -152,8 +155,8 @@ describe("useMessageQueue", () => {
 
     // Draft store
     vi.spyOn(draftStoreModule, "deleteDraftScratchpadFromCache").mockImplementation(() => {})
-    // Post-promotion draft cleanup is exercised via its own tests; stub it here.
-    vi.spyOn(useDraftMessageModule, "purgeScopeDrafts").mockResolvedValue(undefined)
+    // Post-promotion draft re-pointing is exercised via its own tests; stub it here.
+    vi.spyOn(useDraftMessageModule, "rescopeScopeDrafts").mockResolvedValue(undefined)
   })
 
   it("should register its notify callback on mount", () => {

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -7,9 +7,9 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { emitDraftPromoted } from "@/lib/draft-promotions"
 import { setParentThreadId } from "@/sync/stream-sync"
 import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
-import { purgeScopeDrafts } from "./use-draft-message"
+import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
-import { StreamTypes, ShareErrorCodes } from "@threa/types"
+import { StreamTypes, ShareErrorCodes, draftStreamScope } from "@threa/types"
 import type { PendingMessage } from "@/db"
 import type { CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
 import { ApiError } from "@/api/client"
@@ -39,7 +39,7 @@ function getRetryDelay(retryCount: number): number {
 async function promoteDraft(
   next: PendingMessage,
   streamService: { create: (workspaceId: string, data: CreateStreamInput) => Promise<Stream> },
-  syncEngine: { subscribeStream: (id: string) => Promise<void> },
+  syncEngine: { subscribeStream: (id: string) => Promise<void>; kickOperationQueue: () => void },
   queryClient: QueryClient
 ): Promise<string> {
   const creation = next.streamCreation!
@@ -132,9 +132,12 @@ async function promoteDraft(
       }
     })
     deleteDraftScratchpadFromCache(next.workspaceId, next.draftId)
-    // Drop the scratchpad scope's drafts (the just-sent loaded draft plus any
-    // stash siblings) and its loaded pointer.
-    await purgeScopeDrafts(next.workspaceId, `stream:${next.draftId}`)
+    // Re-point the scratchpad scope's surviving drafts onto the real stream so
+    // stash entries composed before promotion keep roaming (the just-sent loaded
+    // draft was already resolved by the send path). Push each so the server row
+    // follows; kick the op queue so it drains promptly.
+    await rescopeScopeDrafts(next.workspaceId, draftStreamScope(next.draftId), draftStreamScope(realStreamId))
+    syncEngine.kickOperationQueue()
   }
 
   // Notify UI to navigate from draft to real stream

--- a/apps/frontend/src/stores/draft-store.ts
+++ b/apps/frontend/src/stores/draft-store.ts
@@ -238,6 +238,35 @@ export function migrateLoadedDraftInCache(
 }
 
 /**
+ * Re-scope a draft in the cache (same id, `oldScope` → `newRow.scope`) in ONE
+ * cache signal — the read-side of thread re-pointing (a `draft:upserted` whose
+ * scope changed) and draft-stream promotion. When `movedToScope` is set the
+ * draft was the loaded one under `oldScope`, so its composer-loaded pointer
+ * moves with it: the old-scope pointer is dropped and a new-scope pointer added.
+ * Doing the row replace and the pointer move as a single `seedDraftCache` keeps
+ * a reader from ever observing the draft under two scopes (old pointer still
+ * present + new row) or under none.
+ */
+export function migrateDraftScopeInCache(
+  workspaceId: string,
+  oldScope: string,
+  newRow: CachedDraft,
+  movedToScope: string | null
+): void {
+  const drafts = withDraftUpserted(cache.drafts.get(workspaceId) ?? [], newRow)
+  let loaded = cache.loaded.get(workspaceId) ?? []
+  if (movedToScope) {
+    loaded = loaded.filter((row) => row.scope !== oldScope && row.scope !== movedToScope)
+    loaded.push({ scope: movedToScope, workspaceId, draftId: newRow.id })
+  }
+  seedDraftCache(workspaceId, {
+    scratchpads: cache.scratchpads.get(workspaceId) ?? [],
+    drafts,
+    loaded,
+  })
+}
+
+/**
  * Set (or clear, with `draftId: null`) the composer-loaded pointer for a scope
  * in the in-memory cache. Mirrors the `composerLoaded` IDB row so the composer
  * resolves its checked-out draft synchronously on first paint.

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -173,6 +173,49 @@ describe("applyDraftUpserted", () => {
     expect(await hasPendingDraftUpsert("draft_x")).toBe(true)
   })
 
+  it("re-points the loaded draft to the new scope when the server re-scopes it (thread conversion)", async () => {
+    const oldScope = "thread:msg_1"
+    const newScope = "stream:thread_1"
+    await db.drafts.put(localDraft({ id: "draft_x", scope: oldScope, baseVersion: 1, contentJson: makeDoc("reply") }))
+    await db.composerLoaded.put({ scope: oldScope, workspaceId, draftId: "draft_x" })
+
+    await applyDraftUpserted(
+      {
+        workspaceId,
+        targetUserId: userId,
+        draft: wireDraft({ id: "draft_x", scope: newScope, version: 2, contentJson: makeDoc("reply") }),
+      },
+      workspaceId
+    )
+
+    // The draft (same id) now lives under the thread stream scope...
+    const row = await db.drafts.get("draft_x")
+    expect(row).toMatchObject({ scope: newScope, baseVersion: 2 })
+    // ...and the device-local loaded pointer followed it: the old scope is empty,
+    // the new scope points at the draft, so the reply isn't stranded.
+    expect((await db.composerLoaded.get(oldScope))?.draftId).toBeUndefined()
+    expect((await db.composerLoaded.get(newScope))?.draftId).toBe("draft_x")
+  })
+
+  it("re-scopes a non-loaded (stash) draft without creating a pointer", async () => {
+    const oldScope = "thread:msg_1"
+    const newScope = "stream:thread_1"
+    await db.drafts.put(localDraft({ id: "draft_stash", scope: oldScope, baseVersion: 1 }))
+    // no composerLoaded row for either scope — this draft was a stash entry
+
+    await applyDraftUpserted(
+      {
+        workspaceId,
+        targetUserId: userId,
+        draft: wireDraft({ id: "draft_stash", scope: newScope, version: 2 }),
+      },
+      workspaceId
+    )
+
+    expect((await db.drafts.get("draft_stash"))?.scope).toBe(newScope)
+    expect((await db.composerLoaded.get(newScope))?.draftId).toBeUndefined()
+  })
+
   it("does not duplicate on an echo of our own in-flight write (echo-before-ack)", async () => {
     // Brand-new draft mid-first-push: baseVersion still 0, push still queued.
     await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 0, contentJson: makeDoc("hello") }))

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -3,6 +3,7 @@ import type { DraftContextRef } from "@/lib/context-bag/types"
 import {
   deleteDraftFromCache,
   hasSeededDraftCache,
+  migrateDraftScopeInCache,
   migrateLoadedDraftInCache,
   setComposerLoadedInCache,
   upsertDraftInCache,
@@ -109,6 +110,36 @@ export async function deleteLocalDraft(workspaceId: string, id: string): Promise
   if (hasSeededDraftCache(workspaceId)) {
     deleteDraftFromCache(workspaceId, id)
     if (clearedScope) setComposerLoadedInCache(workspaceId, clearedScope, null)
+  }
+}
+
+/**
+ * Re-scope a draft in place (same id, `fromScope` → `toRow.scope`) when the
+ * server moves it — thread re-pointing (`moveMessagesToThread`) and draft-stream
+ * promotion. If the draft was the one checked out into the composer under
+ * `fromScope`, its device-local `composerLoaded` pointer moves with it so the
+ * reply being composed follows the message into its new thread instead of being
+ * stranded under a scope nothing renders. The row write and the pointer move
+ * share one transaction (and one cache signal) so a live reader never sees the
+ * draft loaded under both scopes or under neither.
+ */
+export async function migrateLocalDraftScope(
+  workspaceId: string,
+  fromScope: string,
+  toRow: CachedDraft
+): Promise<void> {
+  let movedToScope: string | null = null
+  await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+    await db.drafts.put(toRow)
+    const loaded = await db.composerLoaded.get(fromScope)
+    if (loaded?.draftId === toRow.id) {
+      await db.composerLoaded.delete(fromScope)
+      await db.composerLoaded.put({ scope: toRow.scope, workspaceId, draftId: toRow.id })
+      movedToScope = toRow.scope
+    }
+  })
+  if (hasSeededDraftCache(workspaceId)) {
+    migrateDraftScopeInCache(workspaceId, fromScope, toRow, movedToScope)
   }
 }
 
@@ -302,7 +333,9 @@ export async function syncDraftResolution(
  *    before the push's HTTP ack records `baseVersion`, and a local split would
  *    then mint a duplicate of the draft we are editing.
  *  - Newer server version, no unpushed edits → accept (preserving local
- *    attachment metadata the wire row lacks).
+ *    attachment metadata the wire row lacks). When the scope also changed
+ *    (thread re-pointing — the target message became a thread), the draft moves
+ *    to the new scope and its loaded pointer follows so the reply isn't stranded.
  */
 export async function applyDraftUpserted(
   payload: DraftUpsertedPayload,
@@ -328,8 +361,15 @@ export async function applyDraftUpserted(
   if (dirty) return
 
   // Clean locally — accept the server row, keeping any local attachment metadata
-  // (an echo of our own confirmed push matches it).
-  await putLocalDraft({ ...cachedDraftFromWire(draft), attachments: local.attachments })
+  // (an echo of our own confirmed push matches it). A changed scope (thread
+  // re-pointing) takes the scope-move path so the loaded pointer follows the
+  // draft to its new scope; same-scope edits are a plain put.
+  const accepted = { ...cachedDraftFromWire(draft), attachments: local.attachments }
+  if (local.scope !== draft.scope) {
+    await migrateLocalDraftScope(expectedWorkspaceId, local.scope, accepted)
+  } else {
+    await putLocalDraft(accepted)
+  }
 }
 
 /**
@@ -426,8 +466,9 @@ export async function executeDraftUpsert(
   const attachmentIds = row.attachments.length > 0 ? row.attachments.map((a) => a.id) : (row.attachmentIds ?? [])
   const input: UpsertDraftInput = {
     scope: row.scope,
-    // root_stream_id is populated with thread re-pointing (Stage 4); drafts are
-    // private + listed by owner regardless, so null is correct until then.
+    // The server owns root_stream_id on thread re-pointing (it sets it when a
+    // re-scoped draft follows its message into a thread); the client never needs
+    // to send it — drafts are private + listed by owner regardless of scope.
     rootStreamId: null,
     expectedVersion: row.baseVersion ?? 0,
     writeId: writeIdValue,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1748,6 +1748,22 @@ export interface ScheduledMessageCancelledPayload {
  */
 export type DraftScope = string
 
+/**
+ * Build the `stream:{streamId}` draft scope. Single source of truth (INV-33) for
+ * the scope string, shared by the composer (which keys drafts by scope) and the
+ * backend thread re-pointing / promotion paths that re-scope drafts onto a real
+ * stream. Keeping the format in one place is what lets a re-scope on either side
+ * line up with the other's stored rows.
+ */
+export function draftStreamScope(streamId: string): DraftScope {
+  return `stream:${streamId}`
+}
+
+/** Build the `thread:{parentMessageId}` draft scope (reply to a not-yet-threaded message). */
+export function draftThreadScope(parentMessageId: string): DraftScope {
+  return `thread:${parentMessageId}`
+}
+
 /** Slash-command draft payload (mirrors the composer's `ExtractedCommand`). */
 export interface DraftCommand {
   name: string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -516,6 +516,9 @@ export { DEVICE_KEY_LENGTH } from "./api"
 // Command kind constants
 export { CommandKinds, CommandScopes } from "./api"
 
+// Draft scope builders (single source of truth for the scope string format)
+export { draftStreamScope, draftThreadScope } from "./api"
+
 // Discuss-with-Ariadne client-action id (single source of truth)
 export const DISCUSS_WITH_ARIADNE_COMMAND = "discuss-with-ariadne" as const
 


### PR DESCRIPTION
**Plan:** `docs/plans/centralized-draft-system.md` §"Stage 4b". Stages 1–3 + 4a are merged; this is 4b. (No Linear ticket; tracked by the design doc.)

## Problem

A draft scoped to a not-yet-threaded message (`thread:{parentMessageId}`) or to a not-yet-created scratchpad (`stream:{localDraftId}`) was stranded the moment that scope stopped existing:

- **Thread conversion.** When messages are moved onto a target message (`EventService.moveMessagesToThread`), that message becomes a thread. Any reply draft composed against it — possibly by several authors — still pointed at `thread:{targetMessageId}`, a scope no surface renders once the thread stream exists. The reply you were typing vanished from view.
- **Scratchpad promotion.** `promoteDraft` (in `useMessageQueue`) called `purgeScopeDrafts(stream:{draftId})`, which **deleted** every draft in the scratchpad scope — including stash siblings the user hadn't sent. That contradicts the system's cardinal rule: duplicated drafts are acceptable, lost drafts are not.

## Solution

Drafts follow their message. The **server is the re-scope authority on a move** (one set-based UPDATE inside the move transaction, fanned out to each owner's `user:{userId}` room); the **client mirrors the same scope move on promotion** (it owns scratchpad promotion, which never reaches the server until the stream exists). Both reuse one local primitive that moves the draft row and the device-local "loaded" pointer together.

### How it works

1. **`DraftsRepository.rescopeByScope(db, { workspaceId, fromScope, toScope, rootStreamId })`** — a single `UPDATE drafts SET scope, root_stream_id, version = version + 1 WHERE workspace_id = $ AND scope = $ AND deleted_at IS NULL RETURNING …`. No `user_id` filter: a shared `thread:{messageId}` scope holds reply drafts from several authors and every owner's draft follows the message (each still delivered only to its own owner). Set-based (INV-56), no select-then-write (INV-20). Bumping `version` is what makes the client adopt the new scope (a clean local row sees `version > baseVersion`; a row with unpushed edits ignores the echo and its queued push splits CAS-safely).

2. **`moveMessagesToThread`** — after `MessageRepository.moveToStream`, re-scopes `thread:{targetMessageId}` → `stream:{destinationThread.id}` (+ `root_stream_id`) and emits one `draft:upserted` per re-scoped row, `targetUserId = draft.userId`, in the **same transaction** as the move (INV-4/7). `draft:upserted` was already a registered user-scoped outbox event, so no delivery-routing change.

3. **`migrateLocalDraftScope` + `migrateDraftScopeInCache`** (frontend) — re-scope a draft in place (same id). If it was the one checked out into the composer under the old scope, its `composerLoaded` pointer moves to the new scope so the reply isn't stranded under a scope nothing renders. Row write + pointer move share one IDB transaction and emit one cache signal, so a live reader never sees the draft loaded under two scopes or under none.

4. **`applyDraftUpserted`** — the clean-accept branch now branches on scope: `local.scope !== draft.scope` takes the scope-move path, same-scope edits stay a plain `putLocalDraft`. The dirty-row and stale-echo branches are unchanged (the server still arbitrates drift).

5. **`rescopeScopeDrafts` + `promoteDraft`** — promotion re-points the scratchpad scope's surviving drafts onto the real stream and pushes each (instead of purging), then kicks the op queue. The just-sent loaded draft was already resolved by the send path, so this carries the stash siblings.

6. **`draftStreamScope` / `draftThreadScope`** (`packages/types`) — shared builders for the scope string (INV-33), so the backend re-scope and the composer's `getDraftMessageKey` construct identical scopes. A re-scope on one side lines up with the other's stored rows precisely because the format lives in one place.

### Key design decisions

**1. Server owns re-scope on move; client owns it on promotion.** A move is a server operation touching other users' drafts, so it must re-scope server-side and broadcast. Promotion is a purely local transition (the stream doesn't exist server-side until promotion creates it), so the client re-scopes locally and pushes — there is nothing server-side to re-point.

**2. Re-scope is multi-user.** Drafts are private per author (INV-8), but a thread target can hold reply drafts from many authors. The UPDATE matches by workspace+scope only and emits one event per owner so each draft reaches exactly its author.

**3. Promotion re-scopes instead of purging.** The old `purgeScopeDrafts` deleted stash siblings — a loss. Re-scope + push preserves them. Strictly safer: if the loaded draft were somehow not yet resolved, re-scoping keeps it rather than deleting it. Stream promotion creates plaintext streams only (`PendingStreamCreation` carries no E2E fields), so this never pushes plaintext to an encrypted stream.

**4. Client still sends `rootStreamId: null` on push.** The server owns `root_stream_id` on re-scope; the client never needs to send it (drafts are private and listed by owner regardless of scope). Comment in `executeDraftUpsert` updated to say so.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/drafts/repository.ts` | `rescopeByScope` — set-based multi-user re-scope, version bump, `RETURNING` rows |
| `apps/backend/src/features/messaging/event-service.ts` | `moveMessagesToThread` re-scopes reply drafts + emits one `draft:upserted` per owner in the move txn |
| `apps/frontend/src/sync/draft-sync.ts` | `migrateLocalDraftScope`; `applyDraftUpserted` scope-move branch; `rootStreamId` comment |
| `apps/frontend/src/stores/draft-store.ts` | `migrateDraftScopeInCache` — re-scope + pointer move in one cache signal |
| `apps/frontend/src/hooks/use-draft-message.ts` | `rescopeScopeDrafts`; `getDraftMessageKey` uses shared builders |
| `apps/frontend/src/hooks/use-message-queue.ts` | `promoteDraft` re-scopes (was purge) + kicks op queue; widened `syncEngine` type |
| `packages/types/src/api.ts` / `index.ts` | `draftStreamScope` / `draftThreadScope` builders (INV-33) |
| `apps/backend/.../repository.test.ts`, `tests/integration/message-move.test.ts`, frontend `draft-sync.test.ts`, `use-draft-message-sync.test.ts`, `use-message-queue.test.ts` | Tests (below) |

## Out of scope (deliberate)

- **E2E drafts (Stage 4c).** `rescopeByScope` re-scopes E2E rows too, but the frontend `applyDraftUpserted` still ignores `contentJson === null` rows, and E2E drafts aren't synced before 4c — so an encrypted reply draft doesn't re-point on the client yet. No regression: E2E drafts are local-only today.
- **`thread:{messageId}` re-pointing on first *reply send*.** Only the move flow vacates `thread:{messageId}` without sending the draft. Sending a reply resolves its own draft (4a); other stash drafts on that message are not re-pointed by a send. The plan scopes 4b to move + promotion.

## Test plan

- [x] Backend `bun test src/features/drafts/repository.test.ts` — 9 pass (incl. `rescopeByScope`: multi-user, version bump, no `user_id` filter)
- [x] Backend `bun test tests/integration/message-move.test.ts` — 3 pass, deterministic across reruns (added `DELETE FROM drafts` to the suite `beforeEach`); new test asserts both authors' reply drafts follow, unrelated draft untouched, one `draft:upserted` per owner
- [x] Backend `bun test src/features/drafts src/features/messaging` — 110 pass
- [x] Frontend `draft-sync.test.ts` / `use-draft-message-sync.test.ts` — pointer-move on re-scope, stash re-scope (no pointer), `rescopeScopeDrafts` moves+pushes both rows
- [x] Frontend full suite `bunx vitest run` — 2685 pass / 241 files
- [x] `tsc --noEmit` across all 14 workspaces clean (pre-commit gate); lint + OpenAPI check clean
- [ ] Local Playwright e2e not run here (no browser harness in this session) — the "reply draft follows a message into its new thread" e2e runs in CI browser-tests

<details>
<summary>📋 Full implementation plan</summary>

**Goal (plan §Stage 4b):** A draft that targets a not-yet-threaded message re-points to the thread stream when that message becomes a thread; a draft in a not-yet-created scratchpad re-scopes onto the real stream on promotion.

**What was built:**
- Backend `DraftsRepository.rescopeByScope` + `moveMessagesToThread` wiring (re-scope in the move txn, one user-scoped `draft:upserted` per owner).
- Frontend `migrateLocalDraftScope` / `migrateDraftScopeInCache` (re-scope + loaded-pointer move, atomic); `applyDraftUpserted` scope-move branch; `rescopeScopeDrafts` folded into `promoteDraft` (re-scope + push, replacing purge).
- Shared `draftStreamScope` / `draftThreadScope` (INV-33).

**Design evolution (self-review):** the integration test first used fixed draft ids against a persistent test DB whose `beforeEach` didn't clear `drafts`, so reruns collided on `ON CONFLICT (id) DO NOTHING` and the re-scope matched nothing. Fixed by adding `DELETE FROM drafts` to the suite teardown; verified deterministic across reruns.

**Schema changes:** none (uses the Stage 1 `drafts` table; re-scope is a column UPDATE).

**What's NOT included:** E2E draft re-pointing on the client and the reply-send re-point case (see Out of scope); E2E sealing is Stage 4c.

**Status:** complete; CI pending.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019tNYzX8aDnRbgaTyHavan7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784038404&installation_id=129946197&pr_number=937&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F937&signature=e55076fb0e2730dc0a03190ab8fc231053b84f6d180732bbc9e221f080589da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->