### PR TITLE
feat(frontend): right-click context menu on sidebar stream rows

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -13,6 +13,7 @@ import { streamFallbackLabel } from "@/lib/streams"
 import { CompanionModes, LabelableResourceTypes } from "@threa/types"
 import { useUrgencyTracking } from "./use-urgency-tracking"
 import {
+  SidebarActionContextMenu,
   SidebarActionDrawer,
   SidebarActionMenu,
   type SidebarActionItem,
@@ -144,63 +145,65 @@ export function ScratchpadItem({
 
   return (
     <>
-      <div className="group relative">
-        <Link
-          ref={itemRef}
-          to={`/w/${workspaceId}/s/${streamWithPreview.id}`}
-          onClick={handleClick}
-          onTouchStart={isMobile ? longPress.handlers.onTouchStart : undefined}
-          onTouchEnd={isMobile ? longPress.handlers.onTouchEnd : undefined}
-          onTouchMove={isMobile ? longPress.handlers.onTouchMove : undefined}
-          onContextMenu={isMobile ? longPress.handlers.onContextMenu : undefined}
-          className={cn(
-            "flex items-stretch rounded-lg text-sm transition-colors",
-            isActive ? "bg-primary/10" : "hover:bg-muted/50",
-            hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
-            isMobile && actions.length > 0 && "select-none",
-            longPress.isPressed && "opacity-70 transition-opacity duration-100"
-          )}
-        >
-          {showUrgencyStrip && <UrgencyStrip urgency={streamWithPreview.urgency} />}
+      <SidebarActionContextMenu actions={actions} disabled={isMobile}>
+        <div className="group relative">
+          <Link
+            ref={itemRef}
+            to={`/w/${workspaceId}/s/${streamWithPreview.id}`}
+            onClick={handleClick}
+            onTouchStart={isMobile ? longPress.handlers.onTouchStart : undefined}
+            onTouchEnd={isMobile ? longPress.handlers.onTouchEnd : undefined}
+            onTouchMove={isMobile ? longPress.handlers.onTouchMove : undefined}
+            onContextMenu={isMobile ? longPress.handlers.onContextMenu : undefined}
+            className={cn(
+              "flex items-stretch rounded-lg text-sm transition-colors",
+              isActive ? "bg-primary/10" : "hover:bg-muted/50",
+              hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
+              isMobile && actions.length > 0 && "select-none",
+              longPress.isPressed && "opacity-70 transition-opacity duration-100"
+            )}
+          >
+            {showUrgencyStrip && <UrgencyStrip urgency={streamWithPreview.urgency} />}
 
-          <div className="flex items-center gap-2.5 flex-1 min-w-0 px-2 py-2">
-            <StreamItemAvatar
-              icon={<FileEdit className="h-3.5 w-3.5" />}
-              className="bg-primary/10 text-primary"
-              decoration={decoration}
-            />
-
-            <div
-              className={cn(
-                "relative flex flex-col flex-1 min-w-0 gap-0.5 transition-transform duration-150",
-                showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
-              )}
-            >
-              <div className="flex items-center gap-2 pr-8">
-                <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
-                  {name}
-                  {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
-                </span>
-                <div className="ml-auto flex items-center gap-1.5">
-                  <StreamLabelDots streamId={streamWithPreview.id} />
-                  <MentionIndicator count={mentionCount} />
-                </div>
-              </div>
-              <StreamItemPreview
-                preview={preview}
-                getActorName={getActorName}
-                toEmoji={toEmoji}
-                compact={compact}
-                showPreviewOnHover={showPreviewOnHover}
-                isMobile={isMobile}
-                e2eEnabled={streamWithPreview.e2eEnabled}
+            <div className="flex items-center gap-2.5 flex-1 min-w-0 px-2 py-2">
+              <StreamItemAvatar
+                icon={<FileEdit className="h-3.5 w-3.5" />}
+                className="bg-primary/10 text-primary"
+                decoration={decoration}
               />
-            </div>
-          </div>
-        </Link>
 
-        <SidebarActionMenu actions={actions} ariaLabel="Stream actions" />
-      </div>
+              <div
+                className={cn(
+                  "relative flex flex-col flex-1 min-w-0 gap-0.5 transition-transform duration-150",
+                  showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
+                )}
+              >
+                <div className="flex items-center gap-2 pr-8">
+                  <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
+                    {name}
+                    {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
+                  </span>
+                  <div className="ml-auto flex items-center gap-1.5">
+                    <StreamLabelDots streamId={streamWithPreview.id} />
+                    <MentionIndicator count={mentionCount} />
+                  </div>
+                </div>
+                <StreamItemPreview
+                  preview={preview}
+                  getActorName={getActorName}
+                  toEmoji={toEmoji}
+                  compact={compact}
+                  showPreviewOnHover={showPreviewOnHover}
+                  isMobile={isMobile}
+                  e2eEnabled={streamWithPreview.e2eEnabled}
+                />
+              </div>
+            </div>
+          </Link>
+
+          <SidebarActionMenu actions={actions} ariaLabel="Stream actions" />
+        </div>
+      </SidebarActionContextMenu>
       {labelPickerOpen && (
         <LabelPicker
           workspaceId={workspaceId}

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -145,7 +145,7 @@ export function ScratchpadItem({
 
   return (
     <>
-      <SidebarActionContextMenu actions={actions} disabled={isMobile}>
+      <SidebarActionContextMenu actions={actions} disabled={isMobile} focusRef={itemRef}>
         <div className="group relative">
           <Link
             ref={itemRef}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
@@ -3,8 +3,13 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 import { toast } from "sonner"
-import { render, screen, userEvent, waitFor, spyOnExport } from "@/test"
-import { SidebarActionDrawer, SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
+import { fireEvent, render, screen, userEvent, waitFor, spyOnExport } from "@/test"
+import {
+  SidebarActionContextMenu,
+  SidebarActionDrawer,
+  SidebarActionMenu,
+  type SidebarActionItem,
+} from "./sidebar-actions"
 import * as contextsModule from "@/contexts"
 import * as relativeTimeModule from "@/components/relative-time"
 import * as drawerModule from "@/components/ui/drawer"
@@ -87,6 +92,54 @@ describe("sidebar-actions", () => {
       await user.click(screen.getByText("Settings"))
 
       expect(onSelect).toHaveBeenCalled()
+    })
+  })
+
+  describe("SidebarActionContextMenu", () => {
+    it("opens on right-click and runs the selected action", async () => {
+      const user = userEvent.setup()
+      const onSelect = vi.fn()
+      const actions: SidebarActionItem[] = [{ id: "settings", label: "Settings", icon: Settings, onSelect }]
+
+      renderWithRouter(
+        <SidebarActionContextMenu actions={actions}>
+          <div>Stream row</div>
+        </SidebarActionContextMenu>
+      )
+
+      fireEvent.contextMenu(screen.getByText("Stream row"))
+
+      await user.click(await screen.findByText("Settings"))
+
+      expect(onSelect).toHaveBeenCalled()
+      expect(setMenuOpen).toHaveBeenCalledWith(true)
+    })
+
+    it("renders children untouched when disabled", () => {
+      const actions: SidebarActionItem[] = [{ id: "settings", label: "Settings", icon: Settings, onSelect: vi.fn() }]
+
+      renderWithRouter(
+        <SidebarActionContextMenu actions={actions} disabled>
+          <div>Stream row</div>
+        </SidebarActionContextMenu>
+      )
+
+      fireEvent.contextMenu(screen.getByText("Stream row"))
+
+      expect(screen.queryByText("Settings")).not.toBeInTheDocument()
+    })
+
+    it("renders children untouched when there are no actions", () => {
+      renderWithRouter(
+        <SidebarActionContextMenu actions={[]}>
+          <div>Stream row</div>
+        </SidebarActionContextMenu>
+      )
+
+      fireEvent.contextMenu(screen.getByText("Stream row"))
+
+      expect(screen.getByText("Stream row")).toBeInTheDocument()
+      expect(setMenuOpen).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
@@ -1,5 +1,5 @@
 import { Archive, Settings } from "lucide-react"
-import type { ReactNode } from "react"
+import { useRef, type ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MemoryRouter } from "react-router-dom"
 import { toast } from "sonner"
@@ -18,6 +18,17 @@ const setMenuOpen = vi.fn()
 
 function renderWithRouter(ui: React.ReactElement) {
   return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+function ContextMenuHarness({ actions }: { actions: SidebarActionItem[] }) {
+  const ref = useRef<HTMLAnchorElement>(null)
+  return (
+    <SidebarActionContextMenu actions={actions} focusRef={ref}>
+      <a ref={ref} href="/row" data-testid="row">
+        Row
+      </a>
+    </SidebarActionContextMenu>
+  )
 }
 
 describe("sidebar-actions", () => {
@@ -127,6 +138,20 @@ describe("sidebar-actions", () => {
       fireEvent.contextMenu(screen.getByText("Stream row"))
 
       expect(screen.queryByText("Settings")).not.toBeInTheDocument()
+    })
+
+    it("restores focus to the row element when the menu closes", async () => {
+      const user = userEvent.setup()
+      const actions: SidebarActionItem[] = [{ id: "settings", label: "Settings", icon: Settings, onSelect: vi.fn() }]
+
+      renderWithRouter(<ContextMenuHarness actions={actions} />)
+
+      fireEvent.contextMenu(screen.getByTestId("row"))
+      await screen.findByText("Settings")
+
+      await user.keyboard("{Escape}")
+
+      await waitFor(() => expect(screen.getByTestId("row")).toHaveFocus())
     })
 
     it("renders children untouched when there are no actions", () => {

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, MouseEvent, ReactNode } from "react"
+import type { ComponentProps, MouseEvent, ReactNode, RefObject } from "react"
 import { type LucideIcon, MoreHorizontal } from "lucide-react"
 import { Link } from "react-router-dom"
 import { toast } from "sonner"
@@ -266,6 +266,13 @@ interface SidebarActionContextMenuProps {
    * hijack the same long-press gesture.
    */
   disabled?: boolean
+  /**
+   * The row's focusable element (its `<Link>`). On close Radix would otherwise
+   * restore focus to the trigger — here a non-focusable wrapper `<div>` — which
+   * drops focus to `<body>`. Returning it to the row keeps keyboard navigation
+   * where the user left it.
+   */
+  focusRef?: RefObject<HTMLElement | null>
 }
 
 /**
@@ -274,7 +281,7 @@ interface SidebarActionContextMenuProps {
  * `SidebarActionItem[]`, so they never drift. Renders `children` untouched when
  * there are no actions or the menu is disabled.
  */
-export function SidebarActionContextMenu({ actions, children, disabled }: SidebarActionContextMenuProps) {
+export function SidebarActionContextMenu({ actions, children, disabled, focusRef }: SidebarActionContextMenuProps) {
   const { setMenuOpen } = useSidebar()
 
   if (disabled || actions.length === 0) return <>{children}</>
@@ -282,7 +289,15 @@ export function SidebarActionContextMenu({ actions, children, disabled }: Sideba
   return (
     <ContextMenu onOpenChange={setMenuOpen}>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-      <ContextMenuContent className="w-40">
+      <ContextMenuContent
+        className="w-40"
+        onCloseAutoFocus={(event) => {
+          const target = focusRef?.current
+          if (!target) return
+          event.preventDefault()
+          target.focus()
+        }}
+      >
         {actions.map((action) => (
           <SidebarActionContextMenuEntry key={action.id} action={action} />
         ))}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
@@ -11,6 +11,13 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 import { RelativeTime } from "@/components/relative-time"
 import { Separator } from "@/components/ui/separator"
 import { useSidebar } from "@/contexts"
@@ -192,6 +199,95 @@ export function SidebarActionMenu({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+function SidebarActionContextMenuEntry({ action }: { action: SidebarActionItem }) {
+  const isDestructive = action.variant === "destructive"
+  const content = <SidebarActionContent action={action} iconClassName="mr-2 h-4 w-4" />
+  const itemClassName = cn(isDestructive && "text-destructive focus:text-destructive")
+
+  let item: ReactNode
+  if (action.href && action.external) {
+    item = (
+      <ContextMenuItem asChild className={itemClassName}>
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
+            void runSidebarAction(action)
+          }}
+        >
+          {content}
+        </a>
+      </ContextMenuItem>
+    )
+  } else if (action.href) {
+    item = (
+      <ContextMenuItem asChild className={itemClassName}>
+        <Link
+          to={action.href}
+          onClick={() => {
+            void runSidebarAction(action)
+          }}
+        >
+          {content}
+        </Link>
+      </ContextMenuItem>
+    )
+  } else {
+    item = (
+      <ContextMenuItem
+        className={itemClassName}
+        onSelect={() => {
+          void runSidebarAction(action)
+        }}
+      >
+        {content}
+      </ContextMenuItem>
+    )
+  }
+
+  return (
+    <div>
+      {action.separatorBefore && <ContextMenuSeparator />}
+      {item}
+    </div>
+  )
+}
+
+interface SidebarActionContextMenuProps {
+  actions: SidebarActionItem[]
+  children: ReactNode
+  /**
+   * Suppress the right-click menu. Used on mobile, where a long-press already
+   * opens the {@link SidebarActionDrawer} — Radix's context menu would otherwise
+   * hijack the same long-press gesture.
+   */
+  disabled?: boolean
+}
+
+/**
+ * Wraps a sidebar row so a desktop right-click opens the same actions exposed by
+ * the hover "…" {@link SidebarActionMenu}. Both menus render the same
+ * `SidebarActionItem[]`, so they never drift. Renders `children` untouched when
+ * there are no actions or the menu is disabled.
+ */
+export function SidebarActionContextMenu({ actions, children, disabled }: SidebarActionContextMenuProps) {
+  const { setMenuOpen } = useSidebar()
+
+  if (disabled || actions.length === 0) return <>{children}</>
+
+  return (
+    <ContextMenu onOpenChange={setMenuOpen}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-40">
+        {actions.map((action) => (
+          <SidebarActionContextMenuEntry key={action.id} action={action} />
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -342,7 +342,7 @@ export function StreamItem({
 
   return (
     <>
-      <SidebarActionContextMenu actions={actions} disabled={isMobile}>
+      <SidebarActionContextMenu actions={actions} disabled={isMobile} focusRef={itemRef}>
         <div className="group relative">
           <Link
             ref={itemRef}

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -16,6 +16,7 @@ import { streamLabel } from "@/lib/streams"
 import { copyStreamLink } from "@/lib/stream-links"
 import { BADGE_CONFIG, URGENCY_COLORS } from "./config"
 import {
+  SidebarActionContextMenu,
   SidebarActionDrawer,
   SidebarActionMenu,
   type SidebarActionItem,
@@ -341,77 +342,79 @@ export function StreamItem({
 
   return (
     <>
-      <div className="group relative">
-        <Link
-          ref={itemRef}
-          to={`/w/${workspaceId}/s/${stream.id}`}
-          onClick={handleClick}
-          onTouchStart={isMobile ? longPress.handlers.onTouchStart : undefined}
-          onTouchEnd={isMobile ? longPress.handlers.onTouchEnd : undefined}
-          onTouchMove={isMobile ? longPress.handlers.onTouchMove : undefined}
-          onContextMenu={isMobile ? longPress.handlers.onContextMenu : undefined}
-          className={cn(
-            "flex items-stretch rounded-lg text-sm transition-colors",
-            isActive ? "bg-primary/10" : "hover:bg-muted/50",
-            hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
-            isMobile && canOpenDrawer && "select-none",
-            longPress.isPressed && "opacity-70 transition-opacity duration-100"
-          )}
-        >
-          {showUrgencyStrip && <UrgencyStrip urgency={stream.urgency} />}
+      <SidebarActionContextMenu actions={actions} disabled={isMobile}>
+        <div className="group relative">
+          <Link
+            ref={itemRef}
+            to={`/w/${workspaceId}/s/${stream.id}`}
+            onClick={handleClick}
+            onTouchStart={isMobile ? longPress.handlers.onTouchStart : undefined}
+            onTouchEnd={isMobile ? longPress.handlers.onTouchEnd : undefined}
+            onTouchMove={isMobile ? longPress.handlers.onTouchMove : undefined}
+            onContextMenu={isMobile ? longPress.handlers.onContextMenu : undefined}
+            className={cn(
+              "flex items-stretch rounded-lg text-sm transition-colors",
+              isActive ? "bg-primary/10" : "hover:bg-muted/50",
+              hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
+              isMobile && canOpenDrawer && "select-none",
+              longPress.isPressed && "opacity-70 transition-opacity duration-100"
+            )}
+          >
+            {showUrgencyStrip && <UrgencyStrip urgency={stream.urgency} />}
 
-          <div className="flex items-center gap-2.5 flex-1 min-w-0 px-2 py-2">
-            <StreamItemAvatar
-              icon={avatar.icon}
-              className={avatar.className}
-              avatarUrl={dmPeerAvatar?.avatarUrl}
-              avatarAlt={name}
-              badge={threadBadge}
-            />
-
-            <div
-              className={cn(
-                "relative flex flex-col flex-1 min-w-0 gap-0.5 transition-transform duration-150",
-                showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
-              )}
-            >
-              <div className="flex items-center gap-2 pr-8">
-                <span
-                  className={cn(
-                    "truncate text-sm",
-                    hasUnread ? "font-semibold" : "font-medium",
-                    // The truncation ellipsis inherits the color of this element. When a grey parent-stream
-                    // context trails the title it's the usual cut point, so tint the container grey (and keep
-                    // the title itself at foreground) so the ellipsis matches the text it's shortening.
-                    threadRootContext && "text-muted-foreground/60"
-                  )}
-                >
-                  {threadRootContext ? <span className="text-foreground">{name}</span> : name}
-                  {threadRootContext && <span className="font-normal text-xs"> · {threadRootContext}</span>}
-                </span>
-                {stream.type === StreamTypes.CHANNEL && stream.visibility === Visibilities.PRIVATE && (
-                  <Lock className="h-3 w-3 shrink-0 text-muted-foreground/60" />
-                )}
-                <div className="ml-auto flex items-center gap-1.5">
-                  <StreamLabelDots streamId={stream.id} />
-                  <MentionIndicator count={mentionCount} />
-                </div>
-              </div>
-              <StreamItemPreview
-                preview={preview}
-                getActorName={getActorName}
-                toEmoji={toEmoji}
-                compact={compact}
-                showPreviewOnHover={showPreviewOnHover}
-                isMobile={isMobile}
-                e2eEnabled={stream.e2eEnabled}
+            <div className="flex items-center gap-2.5 flex-1 min-w-0 px-2 py-2">
+              <StreamItemAvatar
+                icon={avatar.icon}
+                className={avatar.className}
+                avatarUrl={dmPeerAvatar?.avatarUrl}
+                avatarAlt={name}
+                badge={threadBadge}
               />
-            </div>
-          </div>
-        </Link>
 
-        <SidebarActionMenu actions={actions} ariaLabel="Stream actions" />
-      </div>
+              <div
+                className={cn(
+                  "relative flex flex-col flex-1 min-w-0 gap-0.5 transition-transform duration-150",
+                  showHoverPreview && "group-hover:-translate-y-[0.3125rem]"
+                )}
+              >
+                <div className="flex items-center gap-2 pr-8">
+                  <span
+                    className={cn(
+                      "truncate text-sm",
+                      hasUnread ? "font-semibold" : "font-medium",
+                      // The truncation ellipsis inherits the color of this element. When a grey parent-stream
+                      // context trails the title it's the usual cut point, so tint the container grey (and keep
+                      // the title itself at foreground) so the ellipsis matches the text it's shortening.
+                      threadRootContext && "text-muted-foreground/60"
+                    )}
+                  >
+                    {threadRootContext ? <span className="text-foreground">{name}</span> : name}
+                    {threadRootContext && <span className="font-normal text-xs"> · {threadRootContext}</span>}
+                  </span>
+                  {stream.type === StreamTypes.CHANNEL && stream.visibility === Visibilities.PRIVATE && (
+                    <Lock className="h-3 w-3 shrink-0 text-muted-foreground/60" />
+                  )}
+                  <div className="ml-auto flex items-center gap-1.5">
+                    <StreamLabelDots streamId={stream.id} />
+                    <MentionIndicator count={mentionCount} />
+                  </div>
+                </div>
+                <StreamItemPreview
+                  preview={preview}
+                  getActorName={getActorName}
+                  toEmoji={toEmoji}
+                  compact={compact}
+                  showPreviewOnHover={showPreviewOnHover}
+                  isMobile={isMobile}
+                  e2eEnabled={stream.e2eEnabled}
+                />
+              </div>
+            </div>
+          </Link>
+
+          <SidebarActionMenu actions={actions} ariaLabel="Stream actions" />
+        </div>
+      </SidebarActionContextMenu>
       {labelPickerOpen && (
         <LabelPicker
           workspaceId={workspaceId}


### PR DESCRIPTION
## Problem

The sidebar's per-row actions (Settings, Labels…, Copy link, Add to section…, Archive) were reachable on desktop only through the hover-revealed "…" button (`SidebarActionMenu`) in the top-right corner of each stream/scratchpad row. Right-clicking a row fell through to the browser's native context menu. Right-click is the reflex for "act on this thing", so the actions were a step less discoverable than they could be.

## Solution

Wrap each sidebar row in the vendored Radix context-menu primitive (`apps/frontend/src/components/ui/context-menu.tsx`) so a desktop right-click opens the same actions the row's hover "…" menu already exposes. The new `SidebarActionContextMenu` and the existing `SidebarActionMenu` are both fed the row's single `actions: SidebarActionItem[]` array, so the two menus can't drift.

### How it works

- `SidebarActionContextMenu` (new, in `sidebar-actions.tsx`) wraps its `children` in `ContextMenu` / `ContextMenuTrigger asChild` / `ContextMenuContent` and renders each `SidebarActionItem` via `SidebarActionContextMenuEntry`. The entry reuses the existing `SidebarActionContent` (icon/label) and `runSidebarAction` (await + error toast) helpers, and handles `href` / `external` / `separatorBefore` / destructive `variant` exactly like `SidebarActionMenuEntry` does — only the Radix primitive differs (`ContextMenuItem` vs `DropdownMenuItem`).
- `StreamItem` and `ScratchpadItem` now wrap their `div.group.relative` row in `<SidebarActionContextMenu actions={actions} disabled={isMobile}>`. The hover "…" `SidebarActionMenu` stays exactly where it was, inside the wrapped row.
- Open state is wired to `useSidebar().setMenuOpen` (`onOpenChange={setMenuOpen}`), the same balanced open/close counter the hover dropdown uses. The context-menu content renders in a portal outside the sidebar DOM, so without this the floating/auto-collapse sidebar could collapse out from under an open menu.

### Key design decisions

**1. Desktop only — `disabled={isMobile}` short-circuits to `children`.** Radix's context menu also opens on touch long-press, which would collide with the existing mobile long-press → `SidebarActionDrawer` gesture. When disabled (or when `actions` is empty, e.g. a virtual draft row), the wrapper returns `<>{children}</>` and adds no Radix root, so mobile behavior and empty-action rows are untouched.

**2. One shared `actions` array, two renderers.** Rather than a second action definition, both menus consume the row's existing memoized `actions`. This mirrors how `SidebarActionMenuEntry` and `SidebarActionDrawerEntry` already coexist as separate renderers over the same `SidebarActionItem` model — the genuinely shared bits (`SidebarActionContent`, `runSidebarAction`) are reused rather than duplicated.

**3. Trigger is the whole row.** Wrapping `div.group.relative` (not just the `<Link>`) means right-clicking anywhere on the row — including the "…" button's corner — opens the menu. `asChild` merges onto the existing div via Radix's Slot, so there's no extra DOM node and no layout change.

This is purely additive: the hover "…" button (keyboard/pointer) and the mobile long-press drawer remain the accessible paths; right-click is a new affordance on top.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx` | Add `SidebarActionContextMenu` + `SidebarActionContextMenuEntry`; import the Radix context-menu primitives |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Wrap the row in `SidebarActionContextMenu` (disabled on mobile) |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx` | Wrap the row in `SidebarActionContextMenu` (disabled on mobile) |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx` | Tests: right-click opens + runs an action and toggles `setMenuOpen`; no menu when disabled or actionless |

## Out of scope (deliberate)

- **Sidebar section headers (`sections.tsx`)** — their `SidebarActionMenu` is an add/create menu fired by a "+" button, not per-row actions; right-clicking a header for a "create" menu is a different interaction, left alone.
- **Account/user menu in `sidebar-footer.tsx`** and the **stream-header menus** in `pages/stream.tsx` / `thread/stream-panel.tsx` — not sidebar rows.

## Test plan

- [x] `vitest run` on `sidebar-actions.test.tsx`, `stream-item.test.tsx`, `scratchpad-item.test.tsx` — 20 pass (3 new)
- [x] `tsc --noEmit -p apps/frontend/tsconfig.json` — clean (exit 0)
- [x] `eslint` on the four changed files — clean (exit 0)
- [x] Self-review: confirmed both menus receive the same `actions`, mobile path returns `children` untouched, `setMenuOpen` open/close stays balanced, and section-header/footer menus were not touched

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeTafuMbM9pon6c9ESJirg)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784050100&installation_id=129946197&pr_number=939&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F939&signature=7fcc20b6d84156c95946ef6490a3d9ceae326dac009ed082884e34fecfe9cb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->