### PR TITLE
test(sync): cover missing-root catch-up denial and in-memory mute-badge caches

### DIFF
--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -263,6 +263,40 @@ describe("SyncLogRepository catch-up reads", () => {
     expect((await listFor(workspaceId, me)).map((e) => e.syncId)).toEqual([deepMessage])
   })
 
+  // INV-62 / checkStreamAccess parity: a thread inherits access through its
+  // root's `streams` row. The FK-less schema (INV-1) permits a dangling
+  // root_stream_id, and when that root row is absent the thread resolves to no
+  // readable root, so catch-up denies it — exactly as checkStreamAccess does
+  // (resolveEffectiveAccessStream collapses a missing root back to the thread,
+  // which then fails its own membership/visibility check). A stream_members row
+  // on the dangling root id does not resurrect inheritance: the inherited leg
+  // JOINs the root `streams` row, which isn't there. Re-inserting the root is
+  // the only change that follows, and delivery resolves — proving the absent
+  // root caused the denial, not an unrelated gap.
+  test("a thread whose root stream row is missing is denied; adding the root restores inheritance", async () => {
+    const workspaceId = uniqueId("ws")
+    const me = uniqueId("usr")
+    const root = uniqueId("stream") // deliberately left out of `streams` at first
+    const thread = uniqueId("stream")
+    await addThread(workspaceId, thread, root, root)
+    await addMembership(root, me) // member of the still-missing root
+
+    const threadMessage = await appendEntry(workspaceId, {
+      eventType: "message:created",
+      groups: [`stream:${thread}`],
+      payload: { workspaceId, kind: "dangling-root-thread" },
+    })
+
+    // Root row absent → no inherited access, and the direct-membership leg only
+    // covers the root id (which carries no entries of its own), never the thread.
+    expect(await listFor(workspaceId, me)).toEqual([])
+
+    // The sole change: the root `streams` row now exists. Inheritance resolves
+    // through it (private root + membership) and the thread message is delivered.
+    await addRootStream(workspaceId, root, "private")
+    expect((await listFor(workspaceId, me)).map((e) => e.syncId)).toEqual([threadMessage])
+  })
+
   test("inherited thread visibility is bounded by the root membership's join position", async () => {
     const workspaceId = uniqueId("ws")
     const joiner = uniqueId("usr")

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest"
 import { db } from "@/db"
 import { QueryClient } from "@tanstack/react-query"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import { streamKeys } from "@/hooks/use-streams"
 import {
   applyWorkspaceBootstrap,
   mergeReconnectWorkspaceBootstrap,
@@ -21,6 +22,8 @@ import {
   type SavedMessageView,
   type ScheduledMessageView,
   type StreamBootstrap,
+  type StreamMember,
+  type StreamWithPreview,
   type WorkspaceBootstrap,
 } from "@threa/types"
 import { assignmentId } from "@/hooks/use-labels"
@@ -865,6 +868,66 @@ describe("registerWorkspaceSocketHandlers", () => {
     await vi.waitFor(async () => {
       expect((await db.unreadState.get("ws_1"))?.mutedStreamIds).not.toContain("stream_1")
     })
+
+    cleanup()
+    gate.dispose()
+  })
+
+  it("applies a gate-dispatched notification-level replay to the in-memory bootstrap caches", async () => {
+    // Companion to the IDB test above. The same handler also moves the two
+    // TanStack caches the UI reads in-memory, with no IDB round-trip or remount:
+    // the workspace bootstrap's derived `mutedStreamIds` (what the sidebar /
+    // quick-switcher / share badges render from) and the stream bootstrap's
+    // `membership.notificationLevel` (the settings dialog's selected level).
+    // setQueryData is synchronous inside the handler, so the caches are current
+    // the moment dispatch resolves — no waitFor needed for these reads.
+    const queryClient = new QueryClient()
+    const gate = new SocketEventGate("ws_1")
+    const cleanup = registerWorkspaceSocketHandlers(gate, "ws_1", queryClient, handlerRefs)
+
+    const channel: StreamWithPreview = { ...makeStreamBootstrap("stream_1").stream, lastMessagePreview: null }
+    const membership: StreamMember = {
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: null,
+      lastReadEventId: null,
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+    }
+    queryClient.setQueryData(
+      workspaceKeys.bootstrap("ws_1"),
+      makeBootstrap({ streams: [channel], streamMemberships: [membership], mutedStreamIds: [] })
+    )
+    queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_1"), makeStreamBootstrap("stream_1", { membership }))
+
+    await gate.dispatch("stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      notificationLevel: "muted",
+    })
+
+    const mutedWorkspace = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(mutedWorkspace?.mutedStreamIds).toContain("stream_1")
+    expect(mutedWorkspace?.streamMemberships.find((m) => m.streamId === "stream_1")?.notificationLevel).toBe("muted")
+    expect(
+      queryClient.getQueryData<StreamBootstrap>(streamKeys.bootstrap("ws_1", "stream_1"))?.membership?.notificationLevel
+    ).toBe("muted")
+
+    // Unmuting (back to the channel default) reverses both caches in place.
+    await gate.dispatch("stream:notification_level_updated", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      notificationLevel: null,
+    })
+
+    const unmutedWorkspace = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(unmutedWorkspace?.mutedStreamIds).not.toContain("stream_1")
+    expect(unmutedWorkspace?.streamMemberships.find((m) => m.streamId === "stream_1")?.notificationLevel).toBeNull()
+    expect(
+      queryClient.getQueryData<StreamBootstrap>(streamKeys.bootstrap("ws_1", "stream_1"))?.membership?.notificationLevel
+    ).toBeNull()
 
     cleanup()
     gate.dispose()


### PR DESCRIPTION
Standalone **test-coverage backfill** — no production code change, and no coding requirements from any linked issue. Adds two tests for behaviors the sync-engine audit's verifiers flagged as unpinned in the already-merged **fix PRs #933** (`8e3fda9`) and **#936** (`d7214f4`). Cites INV-62 (inherited stream access) for the backend case.

## Problem

The shipped code is correct; two behaviors weren't held by a test:

1. **#936's one intentional behavior delta was unpinned.** `SyncLogRepository.listEntriesForUser` (`apps/backend/src/features/sync/repository.ts`) now resolves a thread's access through its root's `streams` row (`JOIN streams root ON root.id = COALESCE(s.root_stream_id, s.id)` + `rootReadableConditionSql`), exactly like the canonical `checkStreamAccess` / `streamAccessPredicateSql`. A side effect: a thread whose root row is **missing** (the FK-less schema, INV-1, permits a dangling `root_stream_id`) is no longer delivered — stricter than the old membership-only leg. Three thread-inheritance tests were updated to seed the root row, but nothing positively asserted the new denial.

2. **The notification-level handler's in-memory cache path was unpinned.** `handleStreamNotificationLevelUpdated` (`apps/frontend/src/sync/workspace-sync.ts:904`) writes three sinks: the `workspaceKeys.bootstrap` query cache (`mutedStreamIds` + `streamMemberships[].notificationLevel`), the `streamKeys.bootstrap` query cache (`membership.notificationLevel`), and IDB (`db.streamMemberships` + `db.unreadState`). The existing test ("applies a gate-dispatched notification-level catch-up replay to IDB") asserted only the IDB writes, so the no-reload mute-badge / settings-dialog path through the TanStack caches wasn't covered.

## Solution

### Backend — `sync-catch-up.test.ts`

A positive test for the missing-root denial that proves causation by toggling only the root row's existence:

- A thread points at a `root` id with no `streams` row; the user even holds a `stream_members` row on that dangling root id. The thread's message is **not** delivered (`toEqual([])`) — the inherited leg finds no root to JOIN, and the direct-membership leg only covers the root id (which carries no entries), not the thread.
- Then `addRootStream(root, "private")` — the sole change — and the same query delivers the thread message. This isolates the absent root as the cause and mirrors `checkStreamAccess`, whose `resolveEffectiveAccessStream` collapses a missing root back to the thread and denies it.

### Frontend — `workspace-sync.test.ts`

A companion to the IDB test that seeds both query caches, dispatches mute then unmute through the event gate (the path a catch-up replay takes; a live emit reaches the same handler), and asserts the in-memory mutations directly after `dispatch` resolves — `setQueryData` runs synchronously in the handler, so no `waitFor` is needed for these reads:

- `workspaceKeys.bootstrap` → `mutedStreamIds` gains/loses the stream (the badge source) and `streamMemberships[].notificationLevel` moves.
- `streamKeys.bootstrap` → `membership.notificationLevel` moves (the settings-dialog source).

## Out of scope (deliberate)

- **The inherited-leg `UNION ALL` scan width (audit gap #2).** Correctness holds — when several grants cover one stream the bound-0 grant wins — and the `listEntriesForUser` doc comment (`repository.ts:135-159`) already explains the two-arm scan and dedup. An acknowledged characteristic, not a coverage gap, so no test or code change (INV-36).
- **The originating-tab optimistic mute badge.** Making the clicking tab's sidebar badge instant (rather than ~1 socket round-trip behind) would need a mutation hook writing `db.unreadState` directly — a layering deviation no other mutation makes. Left as-is per the prior session's recommendation.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/tests/integration/sync-catch-up.test.ts` | +1 test: missing-root thread is denied; adding the root restores inherited delivery (INV-62 / `checkStreamAccess` parity). |
| `apps/frontend/src/sync/workspace-sync.test.ts` | +1 test: notification-level handler's in-memory `workspaceKeys.bootstrap` + `streamKeys.bootstrap` cache mutations (mute/unmute). New imports: `streamKeys`, `StreamMember`, `StreamWithPreview`. |

## Test plan

- [x] Backend `bun test tests/integration/sync-catch-up.test.ts` — 16 pass (was 15)
- [x] Frontend `bunx vitest run src/sync/workspace-sync.test.ts` — 36 pass (was 35)
- [x] `tsc --noEmit` clean: frontend, backend `tsconfig.json`, backend `tsconfig.tests.json`
- [x] Pre-commit hook (full monorepo lint + all tsc + astro check + OpenAPI check) passed
- [x] Self-review / claim-verification pass against the catch-up CTE arms and the handler's three write-sinks; no multi-agent `/code-review` — test-only change, behavior verified by running both suites

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
