### PR TITLE
refactor(sync): drop redundant viewer-label reconnect reconcile

### DIFF
--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test"
-import { WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
-import { resolveDeliveryGroups, permissionGroupsForRole, permissionGroup } from "./delivery-groups"
+import { WORKSPACE_PERMISSION_SCOPES, LabelableResourceTypes } from "@threa/types"
+import {
+  resolveDeliveryGroups,
+  permissionGroupsForRole,
+  permissionGroup,
+  streamGroup,
+  userGroup,
+} from "./delivery-groups"
 import type { OutboxEvent, OutboxEventType } from "./repository"
 
 function event<T extends OutboxEventType>(eventType: T, payload: Record<string, unknown>): OutboxEvent<T> {
@@ -32,6 +38,51 @@ describe("resolveDeliveryGroups — invitation events", () => {
       expect(groups).not.toContain("workspace")
     })
   }
+})
+
+describe("resolveDeliveryGroups — label assignments", () => {
+  // A public-label assignment (no targetUserId) on a stream routes to that
+  // stream's group, so it lands in the sync log under `stream:<id>` and the
+  // public-root catch-up leg replays it to non-members — the same reach a
+  // message has. This is the routing half of that guarantee; the catch-up half
+  // (a non-member of a public channel receives the assignment) is covered in
+  // tests/integration/sync-catch-up.test.ts. Together they let the client drop
+  // the out-of-band label reconcile the reconnect path used to need.
+  it("scopes a public stream-label assignment to the stream group", () => {
+    const groups = resolveDeliveryGroups(
+      event("label:assigned", {
+        workspaceId: "ws_1",
+        targetUserId: null,
+        assignment: { labelId: "label_1", resourceType: LabelableResourceTypes.STREAM, resourceId: "stream_1" },
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_1")])
+  })
+
+  it("scopes a public stream-label unassignment to the stream group", () => {
+    const groups = resolveDeliveryGroups(
+      event("label:unassigned", {
+        workspaceId: "ws_1",
+        targetUserId: null,
+        labelId: "label_1",
+        resourceType: LabelableResourceTypes.STREAM,
+        resourceId: "stream_1",
+        userId: "usr_1",
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_1")])
+  })
+
+  it("routes a private-label assignment to its owner's user group, not a stream", () => {
+    const groups = resolveDeliveryGroups(
+      event("label:assigned", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_1",
+        assignment: { labelId: "label_1", resourceType: LabelableResourceTypes.STREAM, resourceId: "stream_1" },
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_1")])
+  })
 })
 
 describe("permissionGroupsForRole", () => {

--- a/apps/backend/tests/integration/sync-catch-up.test.ts
+++ b/apps/backend/tests/integration/sync-catch-up.test.ts
@@ -243,6 +243,37 @@ describe("SyncLogRepository catch-up reads", () => {
     expect(entries.map((e) => e.syncId)).toEqual([publicMessage, publicThreadMessage])
   })
 
+  // The reconnect path once reconciled label assignments out of band because a
+  // membership-only catch-up filter dropped a public channel's `label:assigned`
+  // for non-members. With the public-root leg, a public-stream label assignment
+  // rides `stream:<id>` into the log and replays to a non-member exactly like a
+  // message, so that out-of-band reconcile is redundant. This pins the slice it
+  // covered: the public-channel assignment reaches the outsider; the same event
+  // type on a private channel never does (the visibility rule does the gating,
+  // not a label-specific bypass).
+  test("public-stream label assignments reach a non-member through catch-up; private ones do not", async () => {
+    const workspaceId = uniqueId("ws")
+    const outsider = uniqueId("usr")
+    const publicChannel = uniqueId("stream")
+    const privateChannel = uniqueId("stream")
+    await addRootStream(workspaceId, publicChannel, "public")
+    await addRootStream(workspaceId, privateChannel, "private")
+
+    const publicAssignment = await appendEntry(workspaceId, {
+      eventType: "label:assigned",
+      groups: [`stream:${publicChannel}`],
+      payload: { workspaceId, kind: "public-channel-label" },
+    })
+    await appendEntry(workspaceId, {
+      eventType: "label:unassigned",
+      groups: [`stream:${privateChannel}`],
+      payload: { workspaceId, kind: "private-channel-label" },
+    })
+
+    const entries = await listFor(workspaceId, outsider)
+    expect(entries.map((e) => e.syncId)).toEqual([publicAssignment])
+  })
+
   test("a depth-2 thread inherits visibility from the root, not the immediate parent", async () => {
     const workspaceId = uniqueId("ws")
     const me = uniqueId("usr")

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -211,7 +211,6 @@ export {
   selectLabelStreams,
   useAssignLabel,
   useUnassignLabel,
-  reconcileLabels,
   labelKeys,
   type LabelViewerContext,
   type ResourceLabelState,

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -194,11 +194,10 @@ export function useLabelsSync(workspaceId: string) {
     // Explicit false (the v5 default is true): with staleTime Infinity a
     // reconnect refetch only ever fires for a query invalidated while
     // offline, and the only invalidators of this key are the label mutations
-    // below — which can't run offline. Reconnect healing lives elsewhere: the
-    // engine's reconnect workspace bootstrap reconciles labels/memberships/
-    // assignments into IDB (the render source), and active-mode catch-up
-    // replays `label:*` events through the gate-registered workspace-sync
-    // handlers.
+    // below — which can't run offline. Reconnect healing lives elsewhere:
+    // active-mode catch-up replays `label:*` events through the gate-registered
+    // workspace-sync handlers, the same path that heals every other
+    // workspace-scoped projection into IDB (the render source).
     refetchOnReconnect: false,
     enabled: !!workspaceId,
   })

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -27,7 +27,6 @@ import {
   useStreamService,
   useMessageService,
   useScheduledService,
-  useLabelService,
   PanelProvider,
   QuickSwitcherProvider,
   PreferencesProvider,
@@ -199,7 +198,6 @@ function WorkspaceSyncHandler({
   const streamService = useStreamService()
   const messageService = useMessageService()
   const scheduledService = useScheduledService()
-  const labelService = useLabelService()
   const syncStatusStore = useContext(SyncStatusContext)
   const { user } = useAuth()
   const isOnline = useOnlineStatus()
@@ -228,7 +226,6 @@ function WorkspaceSyncHandler({
         delete: scheduledService.delete,
         sendNow: scheduledService.sendNow,
       },
-      labelService: { list: labelService.list },
       draftsService: {
         list: (wid: string) => draftsApi.list(wid),
         upsert: draftsApi.upsert,

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -5,20 +5,15 @@ import { SyncEngine, isSyncEngineCurrent } from "./sync-engine"
 import { SyncStatusStore } from "./sync-status"
 import { markInitialRevealComplete, resetRevealGate } from "./reveal-gate"
 import { workspaceKeys } from "@/hooks/use-workspaces"
-import { assignmentId } from "@/hooks/use-labels"
 import { db } from "@/db"
 import {
   DEFAULT_USER_PREFERENCES,
   DEFAULT_WORKSPACE_SETTINGS,
   defaultFeatureFlags,
   DEFAULT_SIDEBAR_CONFIG,
-  LabelableResourceTypes,
   type WorkspaceBootstrap,
   type StreamBootstrap,
   type SyncCatchUpResponse,
-  type Label,
-  type LabelMember,
-  type LabelAssignment,
 } from "@threa/types"
 
 type EventHandler = (...args: unknown[]) => void
@@ -1522,59 +1517,28 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
     return { entries: [], head }
   }
 
-  /** A public-stream assignment on a stream the viewer can see but isn't a
-   *  member of — the slice `listEntriesForUser` (stream_members scoped) can't
-   *  replay, so only the label reconcile heals it. */
-  function publicStreamAssignment(overrides?: Partial<LabelAssignment>): LabelAssignment {
-    return {
-      labelId: "label_1",
-      resourceType: LabelableResourceTypes.STREAM,
-      resourceId: "stream_public",
-      userId: "user_1",
-      workspaceId: "ws_1",
-      assignedAt: new Date().toISOString(),
-      ...overrides,
-    }
-  }
-
-  function makeReconnectDeps(assignments: LabelAssignment[] = []) {
+  function makeReconnectDeps() {
     const catchUp = vi.fn(async () => emptyPage("0"))
-    const list = vi.fn(async () => ({
-      labels: [] as Label[],
-      memberships: [] as LabelMember[],
-      assignments,
-    }))
     return {
       ...makeDeps(),
       syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
-      labelService: { list },
     }
   }
 
-  it("skips the full workspace snapshot on an active reconnect and reconciles viewer labels instead", async () => {
-    const deps = makeReconnectDeps([publicStreamAssignment()])
+  it("skips the full workspace snapshot on an active reconnect", async () => {
+    const deps = makeReconnectDeps()
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
 
-    // First connect runs the full bootstrap and does not touch labelService.
     await engine.onConnect(asSocket(socket))
     expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
-    expect(deps.labelService.list).not.toHaveBeenCalled()
     deps.workspaceService.bootstrap.mockClear()
 
-    // Reconnect: no full snapshot fetch; the viewer label reconcile runs and
-    // lands the non-member public-stream assignment in IDB (the render source).
+    // Reconnect: catch-up replay re-seeds every workspace-scoped projection, so
+    // the slim path skips the full snapshot refetch.
     await engine.onConnect(asSocket(socket))
 
     expect(deps.workspaceService.bootstrap).not.toHaveBeenCalled()
-    expect(deps.labelService.list).toHaveBeenCalledWith("ws_1")
-    await vi.waitFor(async () =>
-      expect(
-        await db.labelAssignments.get(
-          assignmentId("ws_1", LabelableResourceTypes.STREAM, "stream_public", "label_1", "user_1")
-        )
-      ).toBeDefined()
-    )
     engine.destroy()
   })
 
@@ -1663,46 +1627,20 @@ describe("SyncEngine active-mode reconnect bootstrap slimming", () => {
     engine.destroy()
   })
 
-  it("keeps the full reconnect bootstrap when a sync service is wired but no labelService is", async () => {
-    const catchUp = vi.fn(async () => emptyPage("0"))
-    const deps = {
-      ...makeDeps(),
-      syncService: { catchUp: catchUp as (...args: unknown[]) => Promise<SyncCatchUpResponse> },
-    }
+  it("slims an active-mode resume too — no full snapshot", async () => {
+    const deps = makeReconnectDeps()
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
 
     await engine.onConnect(asSocket(socket))
     deps.workspaceService.bootstrap.mockClear()
-    await engine.onConnect(asSocket(socket))
-
-    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
-    engine.destroy()
-  })
-
-  it("slims an active-mode resume too — no full snapshot, label reconcile instead", async () => {
-    const deps = makeReconnectDeps([publicStreamAssignment()])
-    const engine = new SyncEngine(deps)
-    const socket = new MockSocket()
-
-    await engine.onConnect(asSocket(socket))
-    deps.workspaceService.bootstrap.mockClear()
-    deps.labelService.list.mockClear()
 
     // Resume is reconnect-shaped: catch-up replay + the slim bootstrap re-seed
     // everything the full snapshot would, so resume takes the slim path in
-    // active mode and lands the non-member public-stream assignment in IDB.
+    // active mode.
     await engine.refreshAfterConnectivityResume()
 
     expect(deps.workspaceService.bootstrap).not.toHaveBeenCalled()
-    expect(deps.labelService.list).toHaveBeenCalledWith("ws_1")
-    await vi.waitFor(async () =>
-      expect(
-        await db.labelAssignments.get(
-          assignmentId("ws_1", LabelableResourceTypes.STREAM, "stream_public", "label_1", "user_1")
-        )
-      ).toBeDefined()
-    )
     engine.destroy()
   })
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -25,7 +25,6 @@ import { SocketEventGate, type SyncEventSource } from "./socket-event-gate"
 import { SyncStatusStore } from "./sync-status"
 import { streamKeys } from "@/hooks/use-streams"
 import { workspaceKeys } from "@/hooks/use-workspaces"
-import { reconcileLabels } from "@/hooks/use-labels"
 import type { WorkspaceBootstrap } from "@threa/types"
 
 interface SyncEngineDeps {
@@ -39,19 +38,6 @@ interface SyncEngineDeps {
       streamId: string,
       params?: { after?: string }
     ) => Promise<import("@threa/types").StreamBootstrap>
-  }
-  /** Viewer-scoped label catalog + assignments (`listForViewer`). Used by the
-   *  active-mode slim reconnect bootstrap to reconcile the one label slice
-   *  workspace catch-up can't replay: assignments on public streams the viewer
-   *  can see (INV-62) but has no `stream_members` row for, so the
-   *  stream-group-scoped `label:*` event never reaches their sync-log cursor.
-   *  Absent (no-syncService/test deps) → the reconnect bootstrap stays full. */
-  labelService?: {
-    list: (workspaceId: string) => Promise<{
-      labels: import("@threa/types").Label[]
-      memberships: import("@threa/types").LabelMember[]
-      assignments: import("@threa/types").LabelAssignment[]
-    }>
   }
   messageService?: {
     update: (workspaceId: string, messageId: string, data: any) => Promise<any>
@@ -491,12 +477,11 @@ export class SyncEngine {
     // re-seeds every workspace-scoped projection through the gate-registered
     // handlers, so re-fetching the full workspace snapshot on every reconnect
     // is redundant. Skip it and instead do only what catch-up can't: the
-    // per-stream message deltas (the per-stream cursor mechanism, unchanged)
-    // and a reconcile of the viewer's label assignments (the one non-member
-    // public-stream slice the sync-log can't carry). `forceFull` (below-floor
-    // fallback) and the first connect / no-syncService / no-labelService cases
-    // keep the full snapshot.
-    if (_isReconnect && !forceFull && this.eventGate && this.deps.labelService) {
+    // per-stream message deltas (the per-stream cursor mechanism, unchanged).
+    // `forceFull` (below-floor fallback) and the first connect / no-syncService
+    // cases keep the full snapshot. `eventGate` is present iff a sync service is
+    // wired, so it stands in for "catch-up will run".
+    if (_isReconnect && !forceFull && this.eventGate) {
       await this.slimReconnectBootstrap()
       return
     }
@@ -701,14 +686,6 @@ export class SyncEngine {
    *   per-stream sequence (INV-61), not the workspace sync-log, so they heal
    *   through `bootstrap?after=` (cursor-before-join), never catch-up. Same
    *   mechanism the full path and post-navigation refresh use.
-   * - The viewer's label assignments. `listEntriesForUser` scopes the sync-log
-   *   to `stream_members` rows, so a `label:assigned/unassigned` on a public
-   *   stream the viewer can see (INV-62) but isn't a member of never replays.
-   *   `labelService.list` returns `listForViewer` (gated through
-   *   `listAccessibleStreamIds`, which includes those streams) and
-   *   `reconcileLabels` bulkPuts + stale-deletes it into IDB — the render
-   *   source. Member-stream label events still replay through catch-up; this
-   *   only backstops the non-member public slice.
    * - Re-subscribing member rooms from the cached membership list, so
    *   `stream:activity` keeps flowing onto the sidebar. Membership added/removed
    *   while offline is replayed by catch-up (`stream:member_*` → subscribe).
@@ -734,12 +711,9 @@ export class SyncEngine {
       }
       if (this.isDestroyed) return
 
-      // Per-stream deltas (each refresh owns its own status + error handling)
-      // and the label reconcile run together; neither depends on the other.
-      await Promise.all([
-        ...this.getVisibleServerStreamIds().map((streamId) => this.refreshStreamAfterNavigation(streamId)),
-        this.reconcileViewerLabels(),
-      ])
+      // Per-stream message deltas: each refresh owns its own status + error
+      // handling, and they run in parallel.
+      await Promise.all(this.getVisibleServerStreamIds().map((streamId) => this.refreshStreamAfterNavigation(streamId)))
       if (this.isDestroyed) return
 
       await this.subscribeMemberStreams(await this.cachedMemberStreamIds())
@@ -750,24 +724,6 @@ export class SyncEngine {
     } catch (error) {
       this.lastWorkspaceError = error
       syncStatus.set(`workspace:${workspaceId}`, "stale")
-    }
-  }
-
-  /**
-   * Reconcile the viewer's label catalog + assignments into IDB. Non-fatal:
-   * member-stream label events still heal through catch-up, so a failed fetch
-   * only leaves the non-member public-stream slice stale until the next
-   * reconnect — never a hard error on the connect path.
-   */
-  private async reconcileViewerLabels(): Promise<void> {
-    const { workspaceId, labelService } = this.deps
-    if (!labelService) return
-    try {
-      const { labels, memberships, assignments } = await labelService.list(workspaceId)
-      if (this.isDestroyed) return
-      await reconcileLabels(workspaceId, labels, memberships, assignments)
-    } catch {
-      // Swallow — catch-up covers member streams; the next reconnect retries.
     }
   }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -256,10 +256,10 @@ export class SyncEngine {
     // must not move between this trigger and the catch-up fetch.
     this.beginCatchUpCycle()
     // Resume is a reconnect-shaped trigger: when the cursor is active the slim
-    // path (per-stream deltas for visible streams + a viewer-label reconcile)
-    // plus the catch-up replay below re-seeds every workspace-scoped
-    // projection, so a full snapshot refetch would only duplicate what catch-up
-    // already heals. No-syncService deps and the first connect fall through to
+    // path (per-stream deltas for visible streams) plus the catch-up replay
+    // below re-seeds every workspace-scoped projection, so a full snapshot
+    // refetch would only duplicate what catch-up already heals. No-syncService
+    // deps and the first connect fall through to
     // the full snapshot inside runBootstrap; the below-floor catch-up fallback
     // re-forces full when the cursor has dropped beneath the retained
     // sync-log floor.
@@ -730,7 +730,7 @@ export class SyncEngine {
   /**
    * @param forceFull Run the full workspace-snapshot bootstrap even on an
    *   active-mode reconnect (where it would otherwise be slimmed to per-stream
-   *   deltas + a label reconcile). The below-floor catch-up fallback sets this:
+   *   deltas). The below-floor catch-up fallback sets this:
    *   a cursor below the retained sync-log floor has no log to replay, so only
    *   the full snapshot is authoritative for everything `<= head`.
    */
@@ -1172,7 +1172,7 @@ export class SyncEngine {
           // forceFull: the cursor is below the retained floor, so catch-up has
           // no entries to replay — only the full workspace snapshot is
           // authoritative for everything <= head. The slim reconnect path
-          // (per-stream deltas + label reconcile) would leave the rest stale.
+          // (per-stream deltas only) would leave the rest stale.
           void this.runBootstrap(true, { forceFull: true })
           return
         }

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1701,9 +1701,10 @@ export function registerWorkspaceSocketHandlers(
     void db.labelMemberships.delete(id)
   }
 
-  // Assignments — viewer-scoped, so these arrive only in the assigning user's
-  // room. Generic over resourceType: the handler never special-cases what kind
-  // of resource was labeled.
+  // Assignments — a private label's assignment reaches only the owner's user
+  // room; a public label's reaches the resource's audience (the stream room)
+  // and replays to non-members via catch-up. Generic over resourceType: the
+  // handler never special-cases what kind of resource was labeled.
   const sameAssignment = (
     a: { labelId: string; resourceType: string; resourceId: string; userId: string },
     b: { labelId: string; resourceType: string; resourceId: string; userId: string }


### PR DESCRIPTION
## Problem

The active-mode slim reconnect bootstrap carried a label-specific backstop,
`reconcileViewerLabels` (`apps/frontend/src/sync/sync-engine.ts`). On every
reconnect it re-fetched the viewer's entire label catalog + assignments
(`labelService.list`) and reconciled them into IDB, purely to heal one slice
catch-up could not replay: a `label:assigned` / `label:unassigned` on a **public
stream the viewer can see (INV-62) but is not a member of**. Pre-#936 the
catch-up read (`listEntriesForUser`) admitted stream-group entries only through
`stream_members` rows, so that non-member public slice never reached the
viewer's cursor — hence the out-of-band reconcile.

#936 (`d7214f4`) closed that gap. The `visible_streams` CTE in
`apps/backend/src/features/sync/repository.ts` now has a second arm that admits
any stream whose effective root is readable, with a public root carrying
`bound 0`. A public-stream label assignment routes to `stream:<id>`
(`resolveDeliveryGroups`), lands in `sync_log`, and replays to a non-member
through catch-up exactly like a message. The backstop became dead weight that
still ran a full label refetch on every reconnect.

## Solution

Prove the slice is covered by catch-up, then delete the backstop and the
dependency wiring that only existed to feed it. Tests land first and gate the
removal: if the non-member-public-stream slice were *not* covered, they fail and
the removal is wrong.

### How it works

The "slice is covered" guarantee has two links, each pinned by a test:

1. **Routing** — `resolveDeliveryGroups` (`apps/backend/src/lib/outbox/delivery-groups.ts`)
   maps a public-label (no `targetUserId`) stream assignment to
   `streamGroup(resourceId)`, and a private-label one to `userGroup(targetUserId)`.
   New unit cases in `delivery-groups.test.ts` pin both.
2. **Catch-up** — `listEntriesForUser`'s public-root arm admits the
   `stream:<id>` entry to a non-member at `bound 0`. A new integration case in
   `sync-catch-up.test.ts` appends a `label:assigned` on a public channel and a
   `label:unassigned` on a private one, then asserts an outsider receives only
   the public one (the visibility rule gates it, not a label-specific path).

With both links pinned, `reconcileViewerLabels`, its `labelService` dep on
`SyncEngineDeps`, the `reconcileLabels` import, and the construction-site wiring
in `workspace-layout.tsx` are removed. Labels now heal on reconnect the same way
every other workspace-scoped projection does: active-mode catch-up replays
`label:*` events through the gate-registered `workspace-sync` handlers
(`socket.on("label:assigned", …)` et al.). The stale comment on
`useLabelsSync`'s `refetchOnReconnect: false` that cited the removed backstop is
updated to match.

### Key design decisions

**1. The slim-path gate loses its `labelService` clause.** The reconnect gate was
`_isReconnect && !forceFull && this.eventGate && this.deps.labelService`. The
`labelService` clause meant "only slim if we can cover the label slice"; with the
slice now covered by catch-up it is meaningless, and leaving it would make
`labelService` a required-but-unused gate flag (INV-10/INV-38). It becomes
`_isReconnect && !forceFull && this.eventGate`. This is **behaviour-neutral in
production**: `workspace-layout.tsx` always wires `syncService` and
`labelService` together, and `eventGate` is constructed iff `syncService` is
present, so the two clauses were always true or false together. Only the
degenerate test-deps combination (syncService wired, labelService absent) changes
— it now takes the slim path, which is correct.

**2. Tests first, gating the removal.** The redundancy was traced statically; the
reconnect path is sensitive, so the regression tests were written and the
catch-up coverage confirmed *before* deleting reconnect-path code, not after.

**3. The forceFull / below-floor path is untouched.** `reconcileViewerLabels`
only ever ran on the slim path (gated `!forceFull`), so a below-floor or
no-syncService reconnect is byte-for-byte unchanged. No new gap there.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | Remove `reconcileViewerLabels`, its call site, the `labelService` dep + `reconcileLabels` import; drop the `labelService` clause from the slim-reconnect gate; update comments |
| `apps/frontend/src/pages/workspace-layout.tsx` | Stop wiring `labelService` into `SyncEngine`; drop the now-dead `useLabelService` import + const |
| `apps/frontend/src/hooks/use-labels.ts` | Update the `refetchOnReconnect: false` comment that referenced the removed backstop |
| `apps/frontend/src/sync/sync-engine.test.ts` | Simplify `makeReconnectDeps` (no labelService); rewrite the two label-reconcile tests to assert the surviving behaviour (slim path skips the full snapshot); delete the now-inverted "syncService but no labelService → full" test; drop dead imports |
| `apps/backend/src/lib/outbox/delivery-groups.test.ts` | New `label:assigned` / `label:unassigned` routing cases (public → stream group, private → user group) |
| `apps/backend/tests/integration/sync-catch-up.test.ts` | New case: a non-member of a public channel receives a `label:assigned` via catch-up; the same on a private channel does not |

## Out of scope (deliberate)

- **The `sync-log.md` doc Boundaries bullet.** The architecture doc in open PR
  #943 still describes this backstop as a live boundary. It is corrected on that
  docs branch, not here, to keep this PR code-only.
- **Below-floor label healing.** Unchanged by this PR (the backstop was
  slim-only); not investigated.

## Test plan

- [x] `bun test ./apps/backend/src/lib/outbox/delivery-groups.test.ts` — 11 pass (routing cases included)
- [x] `bunx vitest run src/sync/sync-engine.test.ts` (frontend) — 49 pass
- [x] `tsc --noEmit` (backend `src` + `tests`) and frontend `tsc --noEmit` — clean
- [x] Pre-commit gate (prettier, eslint across packages, astro check, dockerfile check, monorepo typecheck) passed on commit `ae654e6`
- [ ] `sync-catch-up.test.ts` integration case **not run locally** — needs Postgres at `127.0.0.1:5454`, absent in this environment; it parses and fails only at `setupTestDatabase()` with `ECONNREFUSED`. Runs in CI's Tests job.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Remove the redundant `reconcileViewerLabels` reconnect backstop now
that #936's public-root catch-up leg covers the non-member public-stream label
slice it existed for.

**Lineage.** Flagged in the sync-hardening handover (follow-up 1b) after #936
landed; the user chose "Full cleanup" (test-first removal) over a doc-only fix.

**What was built.**
- Routing regression (`delivery-groups.test.ts`): public stream-label
  (un)assignment → `stream:<id>`; private → `user:<id>`.
- Catch-up regression (`sync-catch-up.test.ts`): non-member of a public channel
  receives `label:assigned` via catch-up; private channel does not.
- Removal of `reconcileViewerLabels` + `labelService` dep + construction wiring;
  slim-reconnect gate simplified to `eventGate`.
- Reworked `sync-engine.test.ts` reconnect suite; refreshed `use-labels.ts`
  reconnect comment.

**Design decisions.** Gate change is prod-neutral (syncService + labelService
co-wired; eventGate iff syncService). Tests gate the removal. forceFull path
untouched.

**What's NOT included.** The `sync-log.md` Boundaries-bullet fix (PR #943,
docs-only). Below-floor label healing (unchanged).

**Status.** Code complete and locally verified except the integration case,
which runs in CI.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wnz3vhqhJoQfCfdK2bjCQn)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784060567&installation_id=129946197&pr_number=945&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F945&signature=a9faa3940e650e5b3e46e89eb61c52bc989db66a6d3e1a892c7abbf7c3395d53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->