### PR TITLE
feat(drafts): stage 4c — E2E draft body roaming

### DIFF
--- a/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { StashedDraftsPicker } from "./stashed-drafts-picker"
 import * as useMobileModule from "@/hooks/use-mobile"
-import type { CachedDraft } from "@/hooks"
+import type { CachedDraft, DraftPreview } from "@/hooks"
 
 let isMobileMockValue = false
 
@@ -83,6 +83,43 @@ describe("StashedDraftsPicker", () => {
 
     await userEvent.click(screen.getByText("Saved one"))
     expect(onRestore).toHaveBeenCalledWith("draft_1")
+  })
+
+  describe("preview rendering", () => {
+    const sealed = makeDraft("draft_e", "placeholder")
+    const open = () => userEvent.click(screen.getByRole("button", { name: /drafts/i }))
+    const preview = (status: DraftPreview["status"], text = ""): Map<string, DraftPreview> =>
+      new Map([["draft_e", { text, status }]])
+
+    it("renders the host-supplied decrypted body when ready", async () => {
+      renderPicker({ drafts: [sealed], previewById: preview("ready", "decrypted body") })
+      await open()
+      expect(screen.getByText("decrypted body")).toBeInTheDocument()
+    })
+
+    it("shows 'Decrypting…' while the body is in flight", async () => {
+      renderPicker({ drafts: [sealed], previewById: preview("decrypting") })
+      await open()
+      expect(screen.getByText("Decrypting…")).toBeInTheDocument()
+    })
+
+    it("shows 'Encrypted draft' while the session is locked", async () => {
+      renderPicker({ drafts: [sealed], previewById: preview("locked") })
+      await open()
+      expect(screen.getByText("Encrypted draft")).toBeInTheDocument()
+    })
+
+    it("shows 'Couldn't decrypt' on a failed decrypt", async () => {
+      renderPicker({ drafts: [sealed], previewById: preview("failed") })
+      await open()
+      expect(screen.getByText("Couldn't decrypt")).toBeInTheDocument()
+    })
+
+    it("falls back to the plaintext body when no preview map is supplied", async () => {
+      renderPicker({ drafts: [makeDraft("draft_p", "plain body")] })
+      await open()
+      expect(screen.getByText("plain body")).toBeInTheDocument()
+    })
   })
 
   describe("delete confirmation", () => {

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -10,13 +10,20 @@ import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
-import type { CachedDraft } from "@/hooks"
+import type { CachedDraft, DraftPreview } from "@/hooks"
 
 /** Keystroke hint for the "Save current" action. Rendered only on non-mobile (no hardware keyboard). */
 const MOD_SYMBOL = typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.platform) ? "⌘" : "Ctrl+"
 
 interface StashedDraftsPickerProps {
   drafts: CachedDraft[]
+  /**
+   * Decrypted (or plaintext) inline previews per draft id, computed by the host
+   * via `useDecryptedDraftPreviews`. The picker stays presentational — it never
+   * touches the decrypt cache or session itself. Absent → previews fall back to
+   * the row's `contentJson` (plaintext-only callers / tests).
+   */
+  previewById?: Map<string, DraftPreview>
   /** True when the composer has something worth stashing (controls "Save current" enablement). */
   canStashCurrent: boolean
   /** Called when the user clicks "Save current draft" or presses Enter on the save affordance. */
@@ -34,14 +41,7 @@ interface StashedDraftsPickerProps {
   size?: "compact" | "fab"
 }
 
-function getPreview(draft: CachedDraft): string {
-  try {
-    const md = serializeToMarkdown(draft.contentJson)
-    const stripped = stripMarkdownToInline(md).trim()
-    if (stripped.length > 0) return stripped
-  } catch {
-    // Fall through to attachment-only label below.
-  }
+function attachmentOrEmptyLabel(draft: CachedDraft): string {
   const attachmentCount = draft.attachments?.length ?? 0
   if (attachmentCount > 0) {
     return `${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}`
@@ -49,8 +49,35 @@ function getPreview(draft: CachedDraft): string {
   return "Empty draft"
 }
 
+function plaintextPreview(draft: CachedDraft): string {
+  try {
+    const md = serializeToMarkdown(draft.contentJson)
+    const stripped = stripMarkdownToInline(md).trim()
+    if (stripped.length > 0) return stripped
+  } catch {
+    // Fall through to attachment-only label below.
+  }
+  return attachmentOrEmptyLabel(draft)
+}
+
+/**
+ * The row label: the host-supplied decrypted preview when present (E2E + plaintext
+ * alike), otherwise derived from `contentJson` for plaintext-only callers/tests.
+ * A sealed draft mid-decrypt / locked / failed gets a status label instead of a
+ * blank row.
+ */
+function rowPreview(draft: CachedDraft, previewById?: Map<string, DraftPreview>): string {
+  const preview = previewById?.get(draft.id)
+  if (!preview) return plaintextPreview(draft)
+  if (preview.status === "decrypting") return "Decrypting…"
+  if (preview.status === "locked") return "Encrypted draft"
+  if (preview.status === "failed") return "Couldn't decrypt"
+  return preview.text || attachmentOrEmptyLabel(draft)
+}
+
 export function StashedDraftsPicker({
   drafts,
+  previewById,
   canStashCurrent,
   onStashCurrent,
   onRestore,
@@ -163,7 +190,7 @@ export function StashedDraftsPicker({
           ) : (
             <ul className="max-h-64 overflow-y-auto py-1" role="list">
               {drafts.map((draft) => {
-                const preview = getPreview(draft)
+                const preview = rowPreview(draft, previewById)
                 const attachmentCount = draft.attachments?.length ?? 0
                 return (
                   <li key={draft.id} className="group/row">

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -35,10 +35,6 @@ interface StashedDraftsPickerProps {
 }
 
 function getPreview(draft: CachedDraft): string {
-  // A sealed (E2E) draft body can't be previewed without decrypting it; v1 shows
-  // a neutral placeholder rather than decrypting every list row (keeps plaintext
-  // out of the list — E2EE-4). Decryptable previews are a follow-up.
-  if (draft.ciphertext) return "Encrypted draft"
   try {
     const md = serializeToMarkdown(draft.contentJson)
     const stripped = stripMarkdownToInline(md).trim()

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useMemo, useState } from "react"
 import { FileEdit, FilePlus, Trash2 } from "lucide-react"
-import { serializeToMarkdown } from "@threa/prosemirror"
 import { Button } from "@/components/ui/button"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { DeleteDraftConfirmDialog } from "@/components/drafts/delete-draft-confirm-dialog"
-import { stripMarkdownToInline } from "@/lib/markdown"
+import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { formatRelativeTime } from "@/lib/dates"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -49,17 +48,6 @@ function attachmentOrEmptyLabel(draft: CachedDraft): string {
   return "Empty draft"
 }
 
-function plaintextPreview(draft: CachedDraft): string {
-  try {
-    const md = serializeToMarkdown(draft.contentJson)
-    const stripped = stripMarkdownToInline(md).trim()
-    if (stripped.length > 0) return stripped
-  } catch {
-    // Fall through to attachment-only label below.
-  }
-  return attachmentOrEmptyLabel(draft)
-}
-
 /**
  * The row label: the host-supplied decrypted preview when present (E2E + plaintext
  * alike), otherwise derived from `contentJson` for plaintext-only callers/tests.
@@ -68,10 +56,8 @@ function plaintextPreview(draft: CachedDraft): string {
  */
 function rowPreview(draft: CachedDraft, previewById?: Map<string, DraftPreview>): string {
   const preview = previewById?.get(draft.id)
-  if (!preview) return plaintextPreview(draft)
-  if (preview.status === "decrypting") return "Decrypting…"
-  if (preview.status === "locked") return "Encrypted draft"
-  if (preview.status === "failed") return "Couldn't decrypt"
+  if (!preview) return draftInlineText(draft.contentJson) || attachmentOrEmptyLabel(draft)
+  if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
   return preview.text || attachmentOrEmptyLabel(draft)
 }
 

--- a/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
+++ b/apps/frontend/src/components/composer/stashed-drafts-picker.tsx
@@ -35,6 +35,10 @@ interface StashedDraftsPickerProps {
 }
 
 function getPreview(draft: CachedDraft): string {
+  // A sealed (E2E) draft body can't be previewed without decrypting it; v1 shows
+  // a neutral placeholder rather than decrypting every list row (keeps plaintext
+  // out of the list — E2EE-4). Decryptable previews are a follow-up.
+  if (draft.ciphertext) return "Encrypted draft"
   try {
     const md = serializeToMarkdown(draft.contentJson)
     const stripped = stripMarkdownToInline(md).trim()

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -52,6 +52,7 @@ import {
 import { StreamErrorBoundary } from "@/components/stream-error-boundary"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { FloatingComposerShell, MessageComposer, StashedDraftsPicker } from "@/components/composer"
+import { ComposerEncryptionNotice } from "@/components/encryption/stream-encryption-affordance"
 import { SidebarToggle } from "@/components/layout"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { ThreadParentMessage } from "./thread-parent-message"
@@ -170,11 +171,12 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   // so the composer encrypts attachments before upload and seals the draft body
   // to the root's key — exactly as it would in the sealed thread.
   const e2eBase = stream ?? parentStream
+  const e2eRoot = e2eBase?.e2eEnabled ? (e2eBase.rootStreamId ?? e2eBase.id) : undefined
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
     scopeId: draftInfo?.parentMessageId ?? "",
-    e2eStreamId: e2eBase?.e2eEnabled ? (e2eBase.rootStreamId ?? e2eBase.id) : undefined,
+    e2eStreamId: e2eRoot,
   })
 
   // Stashed drafts for this thread. `draftKey` is "" until the panel resolves
@@ -581,6 +583,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
               )}
             </div>
             <FloatingComposerShell ref={draftComposerRef} hidden={draftExpanded}>
+              <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={!!e2eRoot} streamId={e2eRoot} />
               {!draftExpanded && (
                 <MessageComposer
                   content={composer.content}
@@ -597,7 +600,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                   hasFailed={composer.hasFailed}
                   submitLabel="Reply"
                   submittingLabel="Creating..."
-                  placeholder="Write your reply..."
+                  placeholder={composer.isDecrypting ? "Decrypting your draft…" : "Write your reply..."}
                   autoFocus={!isMobile}
                   workspaceId={workspaceId}
                   scopeId={panelId}

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -32,6 +32,7 @@ import {
   useQueueDraftMessage,
   useComposerHeightPublish,
   useStashComposer,
+  useDecryptedDraftPreviews,
   useWorkspaceUserId,
 } from "@/hooks"
 import { useCoordinatedLoading, usePanel, isDraftPanel, parseDraftPanel, useSidebar } from "@/contexts"
@@ -183,12 +184,21 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   // a draft, so we pass `undefined` as the scope in that case — the hook
   // returns an empty list and silently no-ops.
   const stashScope = draftKey || undefined
-  const stash = useStashComposer(composer, workspaceId, stashScope, e2eBase?.e2eEnabled === true)
+  // Stash + restore are pointer moves, so they work for plaintext and E2E alike.
+  const stash = useStashComposer(composer, workspaceId, stashScope)
+  // Decrypt-on-read previews for the pile (sealed rows via the shared cache,
+  // plaintext from contentJson); every entry shares this thread's encrypted root.
+  const stashPreviewInputs = useMemo(
+    () => stash.drafts.map((draft) => ({ draft, rootStreamId: e2eRoot })),
+    [stash.drafts, e2eRoot]
+  )
+  const stashPreviews = useDecryptedDraftPreviews(workspaceId, stashPreviewInputs)
 
   const stashedDraftsTrigger = stashScope ? (
     <StashedDraftsPicker
       drafts={stash.drafts}
-      canStashCurrent={composer.canSend && !e2eBase?.e2eEnabled}
+      previewById={stashPreviews}
+      canStashCurrent={composer.canSend}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}
@@ -199,7 +209,8 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const stashedDraftsTriggerFab = stashScope ? (
     <StashedDraftsPicker
       drafts={stash.drafts}
-      canStashCurrent={composer.canSend && !e2eBase?.e2eEnabled}
+      previewById={stashPreviews}
+      canStashCurrent={composer.canSend}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -208,6 +208,13 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
     />
   ) : undefined
 
+  // Reply composer placeholder: surface an E2E draft's decrypt state so the
+  // briefly-empty editor doesn't read as "no draft", and a failed decrypt says
+  // so plainly instead of leaving a permanent spinner.
+  let replyPlaceholder = "Write your reply..."
+  if (composer.decryptFailed) replyPlaceholder = "Couldn't decrypt your saved draft"
+  else if (composer.isDecrypting) replyPlaceholder = "Decrypting your draft…"
+
   // Draft thread expand state
   const [draftExpanded, setDraftExpanded] = useState(false)
   const [isMenuDrawerOpen, setIsMenuDrawerOpen] = useState(false)
@@ -530,7 +537,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                     hasFailed={composer.hasFailed}
                     submitLabel="Reply"
                     submittingLabel="Creating..."
-                    placeholder="Write your reply..."
+                    placeholder={replyPlaceholder}
                     workspaceId={workspaceId}
                     scopeId={panelId}
                     memoAnchorStreamId={draftInfo.parentStreamId}
@@ -600,7 +607,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                   hasFailed={composer.hasFailed}
                   submitLabel="Reply"
                   submittingLabel="Creating..."
-                  placeholder={composer.isDecrypting ? "Decrypting your draft…" : "Write your reply..."}
+                  placeholder={replyPlaceholder}
                   autoFocus={!isMobile}
                   workspaceId={workspaceId}
                   scopeId={panelId}

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -166,25 +166,27 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const draftKey = draftInfo ? getDraftMessageKey({ type: "thread", parentMessageId: draftInfo.parentMessageId }) : ""
   // A draft thread has no stream row of its own yet — its E2E state is the
   // parent's (threads inherit the root's SSK server-side, INV-E1). Read the flag
-  // off the parent so the composer encrypts attachments before upload and skips
-  // plaintext draft persistence, exactly as it would in the sealed thread.
+  // and the encrypted root off the thread stream when it exists, else the parent,
+  // so the composer encrypts attachments before upload and seals the draft body
+  // to the root's key — exactly as it would in the sealed thread.
+  const e2eBase = stream ?? parentStream
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
     scopeId: draftInfo?.parentMessageId ?? "",
-    e2eEnabled: (stream ?? parentStream)?.e2eEnabled === true,
+    e2eStreamId: e2eBase?.e2eEnabled ? (e2eBase.rootStreamId ?? e2eBase.id) : undefined,
   })
 
   // Stashed drafts for this thread. `draftKey` is "" until the panel resolves
   // a draft, so we pass `undefined` as the scope in that case — the hook
   // returns an empty list and silently no-ops.
   const stashScope = draftKey || undefined
-  const stash = useStashComposer(composer, workspaceId, stashScope)
+  const stash = useStashComposer(composer, workspaceId, stashScope, e2eBase?.e2eEnabled === true)
 
   const stashedDraftsTrigger = stashScope ? (
     <StashedDraftsPicker
       drafts={stash.drafts}
-      canStashCurrent={composer.canSend}
+      canStashCurrent={composer.canSend && !e2eBase?.e2eEnabled}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}
@@ -195,7 +197,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const stashedDraftsTriggerFab = stashScope ? (
     <StashedDraftsPicker
       drafts={stash.drafts}
-      canStashCurrent={composer.canSend}
+      canStashCurrent={composer.canSend && !e2eBase?.e2eEnabled}
       onStashCurrent={stash.handleStashDraft}
       onRestore={stash.handleRestoreStashed}
       onDelete={stash.handleDeleteStashed}

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -217,6 +217,9 @@ beforeEach(() => {
     mutate: vi.fn(),
     isPending: false,
   } as unknown as ReturnType<typeof hooksModule.useScheduleMessage>)
+  // Stash previews decrypt via the shared cache, which reads auth/session; these
+  // tests render without an AuthProvider, so stub the batch hook to an empty map.
+  vi.spyOn(hooksModule, "useDecryptedDraftPreviews").mockReturnValue(new Map())
 
   vi.spyOn(composerModule, "FloatingComposerShell").mockImplementation((({
     children,

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -614,6 +614,11 @@ function MessageInputComponent({
     )
   }
 
+  // While an unlocked E2E draft's sealed body decrypts into the composer, signal
+  // it in the placeholder so the briefly-empty editor doesn't read as "no draft".
+  const offlinePlaceholder = isOffline ? "Type a message (sent when back online)" : undefined
+  const composerPlaceholder = composer.isDecrypting ? "Decrypting your draft…" : offlinePlaceholder
+
   // Shared composer props used by both inline and expanded layouts
   const composerProps = {
     content: composer.content,
@@ -631,7 +636,7 @@ function MessageInputComponent({
     canSubmit: composer.canSend,
     isSubmitting: composer.isSending,
     hasFailed: composer.hasFailed,
-    placeholder: isOffline ? "Type a message (sent when back online)" : undefined,
+    placeholder: composerPlaceholder,
     messageSendMode,
     scopeId: streamId,
     onEditLastMessage: triggerEditLast

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -227,12 +227,14 @@ function MessageInputComponent({
   const streamContext = useMentionStreamContext(workspaceId, stream)
 
   const e2eEnabled = stream?.e2eEnabled === true
+  // The encrypted root holds the SSK + wraps (a thread shares its root's key), so
+  // both sealing and the repair notice key off the root, not the (maybe-thread) id.
+  const e2eRootStreamId = e2eEnabled ? (stream?.rootStreamId ?? streamId) : undefined
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
     scopeId: streamId,
-    // Seal drafts to the encrypted root's SSK (a thread shares its root's key).
-    e2eStreamId: e2eEnabled ? (stream?.rootStreamId ?? streamId) : undefined,
+    e2eStreamId: e2eRootStreamId,
   })
   const quoteReplyCtx = useQuoteReply()
 
@@ -728,7 +730,7 @@ function MessageInputComponent({
           This replaces a previous ref-counted React state mechanism that was prone to
           leaks across hydration races and virtualization cycles. */}
       <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
-        <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={!!stream?.e2eEnabled} streamId={stream?.id} />
+        <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={e2eEnabled} streamId={e2eRootStreamId} />
         {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       </FloatingComposerShell>

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -617,9 +617,12 @@ function MessageInputComponent({
   }
 
   // While an unlocked E2E draft's sealed body decrypts into the composer, signal
-  // it in the placeholder so the briefly-empty editor doesn't read as "no draft".
+  // it in the placeholder so the briefly-empty editor doesn't read as "no draft";
+  // a failed decrypt says so plainly instead of leaving a permanent spinner.
   const offlinePlaceholder = isOffline ? "Type a message (sent when back online)" : undefined
-  const composerPlaceholder = composer.isDecrypting ? "Decrypting your draft…" : offlinePlaceholder
+  let composerPlaceholder = offlinePlaceholder
+  if (composer.decryptFailed) composerPlaceholder = "Couldn't decrypt your saved draft"
+  else if (composer.isDecrypting) composerPlaceholder = "Decrypting your draft…"
 
   // Shared composer props used by both inline and expanded layouts
   const composerProps = {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -226,18 +226,20 @@ function MessageInputComponent({
   // through their root channel for access grants — handled inside the hook.
   const streamContext = useMentionStreamContext(workspaceId, stream)
 
+  const e2eEnabled = stream?.e2eEnabled === true
   const composer = useDraftComposer({
     workspaceId,
     draftKey,
     scopeId: streamId,
-    e2eEnabled: stream?.e2eEnabled === true,
+    // Seal drafts to the encrypted root's SSK (a thread shares its root's key).
+    e2eStreamId: e2eEnabled ? (stream?.rootStreamId ?? streamId) : undefined,
   })
   const quoteReplyCtx = useQuoteReply()
 
   // Stashed drafts — explicit "Save for later" pile scoped to this stream.
   // Active DraftMessage stays one-per-scope; this hook manages the sibling
   // many-per-scope stash and the `?stash=<id>` URL auto-restore.
-  const stash = useStashComposer(composer, workspaceId, draftKey)
+  const stash = useStashComposer(composer, workspaceId, draftKey, e2eEnabled)
 
   // Use a ref so the handler always reads fresh composer state without
   // re-registering on every render (composer object is not memoized).
@@ -663,7 +665,7 @@ function MessageInputComponent({
     stashedDraftsTrigger: (
       <StashedDraftsPicker
         drafts={stash.drafts}
-        canStashCurrent={composer.canSend}
+        canStashCurrent={composer.canSend && !e2eEnabled}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}
@@ -673,7 +675,7 @@ function MessageInputComponent({
     stashedDraftsTriggerFab: (
       <StashedDraftsPicker
         drafts={stash.drafts}
-        canStashCurrent={composer.canSend}
+        canStashCurrent={composer.canSend && !e2eEnabled}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback, useEffect, useRef } from "react"
+import { memo, useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { createPortal } from "react-dom"
 import { useNavigate } from "react-router-dom"
 import {
@@ -7,6 +7,7 @@ import {
   useStreamOrDraft,
   useComposerHeightPublish,
   useStashComposer,
+  useDecryptedDraftPreviews,
   useMentionStreamContext,
 } from "@/hooks"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -240,8 +241,17 @@ function MessageInputComponent({
 
   // Stashed drafts — explicit "Save for later" pile scoped to this stream.
   // Active DraftMessage stays one-per-scope; this hook manages the sibling
-  // many-per-scope stash and the `?stash=<id>` URL auto-restore.
-  const stash = useStashComposer(composer, workspaceId, draftKey, e2eEnabled)
+  // many-per-scope stash and the `?stash=<id>` URL auto-restore. Stash + restore
+  // are pointer moves, so they work for plaintext and E2E alike (no gating).
+  const stash = useStashComposer(composer, workspaceId, draftKey)
+  // Decrypt-on-read previews for the stash pile (sealed rows decrypt via the
+  // shared cache; plaintext rows resolve from contentJson). All entries share
+  // this stream's encrypted root.
+  const stashPreviewInputs = useMemo(
+    () => stash.drafts.map((draft) => ({ draft, rootStreamId: e2eRootStreamId })),
+    [stash.drafts, e2eRootStreamId]
+  )
+  const stashPreviews = useDecryptedDraftPreviews(workspaceId, stashPreviewInputs)
 
   // Use a ref so the handler always reads fresh composer state without
   // re-registering on every render (composer object is not memoized).
@@ -675,7 +685,8 @@ function MessageInputComponent({
     stashedDraftsTrigger: (
       <StashedDraftsPicker
         drafts={stash.drafts}
-        canStashCurrent={composer.canSend && !e2eEnabled}
+        previewById={stashPreviews}
+        canStashCurrent={composer.canSend}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}
@@ -685,7 +696,8 @@ function MessageInputComponent({
     stashedDraftsTriggerFab: (
       <StashedDraftsPicker
         drafts={stash.drafts}
-        canStashCurrent={composer.canSend && !e2eEnabled}
+        previewById={stashPreviews}
+        canStashCurrent={composer.canSend}
         onStashCurrent={stash.handleStashDraft}
         onRestore={stash.handleRestoreStashed}
         onDelete={stash.handleDeleteStashed}

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -397,6 +397,17 @@ export interface CachedDraft {
    * version is `<= baseVersion` is ignored.
    */
   baseVersion?: number
+  /**
+   * E2E variant (Stage 4c). When present, this draft belongs to an encrypted
+   * stream and `ciphertext` is the draft body sealed to the stream's SSK; the
+   * plaintext `contentJson` at rest is the empty placeholder (no plaintext on
+   * disk, E2EE-4) and the composer decrypts `ciphertext` into memory on load.
+   * Absent on plaintext drafts. `envelope` carries the framing the open path
+   * needs (key generation, IV, AAD); `e2eVersion` is the seal scheme version.
+   */
+  ciphertext?: string
+  envelope?: unknown
+  e2eVersion?: number
 }
 
 /**

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -53,14 +53,16 @@ export {
 
 export { useDraftMessage, getDraftMessageKey } from "./use-draft-message"
 
-export {
-  useStashedDrafts,
-  type UseStashedDraftsResult,
-  type StashDraftInput,
-  type CachedDraft,
-} from "./use-stashed-drafts"
+export { useStashedDrafts, type UseStashedDraftsResult, type CachedDraft } from "./use-stashed-drafts"
 
 export { useStashComposer, type UseStashComposerResult } from "./use-stash-composer"
+
+export {
+  useDecryptedDraftPreviews,
+  type DraftPreview,
+  type DraftPreviewStatus,
+  type DraftPreviewInput,
+} from "./use-decrypted-draft-previews"
 
 export { useStreamSocket } from "./use-stream-socket"
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -1,12 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
+import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
 import type { JSONContent } from "@threa/types"
 import { db, type CachedDraft } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
+import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
+import * as currentUserHook from "./use-current-workspace-user-id"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
 import { useAllDrafts } from "./use-all-drafts"
+
+const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
+const UNLOCKED_SESSION = {
+  status: "unlocked",
+  keyId: "ek_1",
+  publicKey: null,
+  privateKey: {} as CryptoKey,
+  deviceTrusted: true,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
 
 const workspaceId = "ws_1"
 
@@ -48,6 +61,18 @@ beforeEach(async () => {
   await db.composerLoaded.clear()
   await db.pendingOperations.clear()
   await db.draftScratchpads.clear()
+  // The drafts explorer now decrypts E2E previews via the shared cache, which
+  // reads the viewer id + session; default them to "no viewer / locked" so these
+  // plaintext-draft tests run without an AuthProvider (INV-48 namespace spyOn).
+  vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+  vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue({
+    status: "locked",
+    keyId: null,
+    publicKey: null,
+    privateKey: null,
+    deviceTrusted: false,
+    error: null,
+  } as ReturnType<typeof e2eSessionStore.useE2eSession>)
 })
 
 describe("useAllDrafts deleteDraft", () => {
@@ -98,5 +123,64 @@ describe("useAllDrafts deleteDraft", () => {
     expect(await db.composerLoaded.get(scope)).toBeUndefined()
     expect(await pendingDeleteIds()).toContain("draft_loaded")
     expect(kickOperationQueue).toHaveBeenCalled()
+  })
+})
+
+describe("useAllDrafts E2E drafts", () => {
+  it("lists a sealed draft with its decrypted preview instead of dropping it", async () => {
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(UNLOCKED_SESSION)
+    clearDecryptCache()
+
+    // A sealed draft at rest: ciphertext only, the empty placeholder as contentJson.
+    await db.drafts.add({
+      id: "draft_e2e",
+      workspaceId,
+      scope: "stream:stream_enc",
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_sealed",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      baseVersion: 1,
+      clientUpdatedAt: 2000,
+    })
+    // The viewer already holds the plaintext in the shared cache (seeded by the
+    // authoring device's save, or a prior decrypt-on-read).
+    seedDecryption("draft_e2e", { contentMarkdown: "secret body", contentJson: makeDoc("secret body") })
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts.some((d) => d.id === "draft_e2e")).toBe(true))
+    const row = result.current.drafts.find((d) => d.id === "draft_e2e")!
+    // The encrypted draft shows up (not filtered out for an empty contentJson),
+    // and its preview is the decrypted body — never the ciphertext or a blank.
+    expect(row.preview).toBe("secret body")
+    expect(row.isStashed).toBe(true)
+  })
+
+  it("shows an 'Encrypted draft' placeholder (not a blank row) while the session is locked", async () => {
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+    // Default locked session from beforeEach stands.
+    clearDecryptCache()
+    await db.drafts.add({
+      id: "draft_locked",
+      workspaceId,
+      scope: "stream:stream_enc",
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_sealed",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      baseVersion: 1,
+      clientUpdatedAt: 2000,
+    })
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useAllDrafts(workspaceId), { wrapper })
+
+    await waitFor(() => expect(result.current.drafts.some((d) => d.id === "draft_locked")).toBe(true))
+    expect(result.current.drafts.find((d) => d.id === "draft_locked")!.preview).toBe("Encrypted draft")
   })
 })

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -12,11 +12,10 @@ import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { isDraftId } from "./use-draft-scratchpads"
 import { purgeScopeDrafts } from "./use-draft-message"
-import { serializeToMarkdown } from "@threa/prosemirror"
-import type { CompanionMode, JSONContent } from "@threa/types"
+import type { CompanionMode } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
-import { stripMarkdownToInline } from "@/lib/markdown"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { draftInlineText, draftPreviewStatusLabel } from "@/lib/drafts/decryption"
 import { useDecryptedDraftPreviews, type DraftPreview, type DraftPreviewInput } from "./use-decrypted-draft-previews"
 
 export type DraftType = "scratchpad" | "channel" | "dm" | "thread"
@@ -93,28 +92,16 @@ function truncatePreview(content: string, maxLength: number = 80): string {
 }
 
 /**
- * Get a display-safe inline preview from JSONContent. Markdown is stripped
- * here (not at the render site) because every current consumer renders the
- * value as plain inline text — keeping that guarantee at the source
- * satisfies INV-60 without requiring every caller to remember the strip.
- */
-function getContentPreview(contentJson: JSONContent | undefined): string {
-  if (!contentJson || isEmptyContent(contentJson)) return ""
-  return stripMarkdownToInline(serializeToMarkdown(contentJson))
-}
-
-/**
  * The explorer preview for a draft row. Plaintext rows read `contentJson`
  * directly; E2E rows (ciphertext at rest) read the decrypted body from the shared
  * cache via `previewMap`, falling back to a status label so a sealed draft still
  * shows up identifiably instead of as a blank/empty row (the bug this fixes).
  */
 function draftPreviewLabel(draft: CachedDraft, previewMap: Map<string, DraftPreview>): string {
-  if (draft.ciphertext == null) return truncatePreview(getContentPreview(draft.contentJson))
+  if (draft.ciphertext == null) return truncatePreview(draftInlineText(draft.contentJson))
   const preview = previewMap.get(draft.id)
-  if (!preview || preview.status === "locked") return "Encrypted draft"
-  if (preview.status === "decrypting") return "Decrypting…"
-  if (preview.status === "failed") return "Couldn't decrypt"
+  if (!preview) return "Encrypted draft"
+  if (preview.status !== "ready") return draftPreviewStatusLabel(preview.status)
   return truncatePreview(preview.text) || "Encrypted draft"
 }
 

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -311,7 +311,12 @@ export function useAllDrafts(workspaceId: string) {
       if (!parsed) continue
       // Scratchpad-scoped rows are handled above (the loaded one); skip siblings.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
-      inputs.push({ draft, rootStreamId: resolveRootStreamId(parsed, streamMap, messageToStreamMap) })
+      // No resolvable encrypted root (e.g. a thread whose parent isn't cached yet)
+      // → don't queue a decrypt that can never fire; the row shows "Encrypted
+      // draft" until the root resolves, rather than a stuck "Decrypting…".
+      const rootStreamId = resolveRootStreamId(parsed, streamMap, messageToStreamMap)
+      if (!rootStreamId) continue
+      inputs.push({ draft, rootStreamId })
     }
     return inputs
   }, [allDrafts, draftScratchpads, loadedByScope, draftsById, streamMap, messageToStreamMap])

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -17,6 +17,7 @@ import type { CompanionMode, JSONContent } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { useDecryptedDraftPreviews, type DraftPreview, type DraftPreviewInput } from "./use-decrypted-draft-previews"
 
 export type DraftType = "scratchpad" | "channel" | "dm" | "thread"
 
@@ -100,6 +101,35 @@ function truncatePreview(content: string, maxLength: number = 80): string {
 function getContentPreview(contentJson: JSONContent | undefined): string {
   if (!contentJson || isEmptyContent(contentJson)) return ""
   return stripMarkdownToInline(serializeToMarkdown(contentJson))
+}
+
+/**
+ * The explorer preview for a draft row. Plaintext rows read `contentJson`
+ * directly; E2E rows (ciphertext at rest) read the decrypted body from the shared
+ * cache via `previewMap`, falling back to a status label so a sealed draft still
+ * shows up identifiably instead of as a blank/empty row (the bug this fixes).
+ */
+function draftPreviewLabel(draft: CachedDraft, previewMap: Map<string, DraftPreview>): string {
+  if (draft.ciphertext == null) return truncatePreview(getContentPreview(draft.contentJson))
+  const preview = previewMap.get(draft.id)
+  if (!preview || preview.status === "locked") return "Encrypted draft"
+  if (preview.status === "decrypting") return "Decrypting…"
+  if (preview.status === "failed") return "Couldn't decrypt"
+  return truncatePreview(preview.text) || "Encrypted draft"
+}
+
+/** The encrypted root whose SSK seals a draft's body, for decrypt-on-read previews. */
+function resolveRootStreamId(
+  parsed: { type: "stream" | "thread"; id: string },
+  streamMap: Map<string, CachedStream>,
+  messageToStreamMap: Map<string, { streamId: string; parentMessageId: string }>
+): string | null {
+  if (parsed.type === "thread") {
+    const info = messageToStreamMap.get(parsed.id)
+    if (!info) return null
+    return streamMap.get(info.streamId)?.rootStreamId ?? info.streamId
+  }
+  return streamMap.get(parsed.id)?.rootStreamId ?? parsed.id
 }
 
 interface ResolvedDraftLocation {
@@ -257,11 +287,40 @@ export function useAllDrafts(workspaceId: string) {
     return map
   }, [cachedEvents])
 
+  const draftsById = useMemo(() => {
+    const map = new Map<string, CachedDraft>()
+    for (const draft of allDrafts) map.set(draft.id, draft)
+    return map
+  }, [allDrafts])
+
+  // E2E draft rows that need a decrypt-on-read preview — every sealed row (loaded
+  // or stashed) plus the loaded draft of an E2E scratchpad (its own encrypted
+  // root). Resolved here once and decrypted through the shared cache so the
+  // explorer lists encrypted drafts with readable previews instead of dropping
+  // them (their `contentJson` is the empty placeholder at rest).
+  const previewInputs = useMemo((): DraftPreviewInput[] => {
+    const inputs: DraftPreviewInput[] = []
+    for (const scratchpad of draftScratchpads ?? []) {
+      const loadedId = loadedByScope.get(`stream:${scratchpad.id}`) ?? null
+      const loadedDraft = loadedId ? draftsById.get(loadedId) : undefined
+      if (loadedDraft?.ciphertext != null) inputs.push({ draft: loadedDraft, rootStreamId: scratchpad.id })
+    }
+    for (const draft of allDrafts) {
+      if (draft.ciphertext == null) continue
+      const parsed = parseDraftMessageKey(draft.scope)
+      if (!parsed) continue
+      // Scratchpad-scoped rows are handled above (the loaded one); skip siblings.
+      if (parsed.type === "stream" && isDraftId(parsed.id)) continue
+      inputs.push({ draft, rootStreamId: resolveRootStreamId(parsed, streamMap, messageToStreamMap) })
+    }
+    return inputs
+  }, [allDrafts, draftScratchpads, loadedByScope, draftsById, streamMap, messageToStreamMap])
+
+  const previewMap = useDecryptedDraftPreviews(workspaceId, previewInputs)
+
   // Combine and transform drafts
   const drafts = useMemo((): UnifiedDraft[] => {
     const result: UnifiedDraft[] = []
-    const draftsById = new Map<string, CachedDraft>()
-    for (const draft of allDrafts) draftsById.set(draft.id, draft)
 
     // Scratchpads (streams not yet created on the server). Their content is the
     // loaded draft for the `stream:{scratchpadId}` scope.
@@ -270,17 +329,18 @@ export function useAllDrafts(workspaceId: string) {
       const loadedId = loadedByScope.get(scope) ?? null
       const loadedDraft = loadedId ? draftsById.get(loadedId) : undefined
 
+      const isE2e = loadedDraft?.ciphertext != null
       const hasContent = !isEmptyContent(loadedDraft?.contentJson)
       const hasAttachments = (loadedDraft?.attachments?.length ?? 0) > 0
 
-      if (hasContent || hasAttachments) {
+      if (loadedDraft && (hasContent || hasAttachments || isE2e)) {
         const displayName = scratchpad.displayName ?? streamFallbackLabel("scratchpad", "sidebar")
         result.push({
           id: scratchpad.id,
           type: "scratchpad",
           streamId: scratchpad.id,
           displayName,
-          preview: truncatePreview(getContentPreview(loadedDraft?.contentJson)),
+          preview: draftPreviewLabel(loadedDraft, previewMap),
           attachmentCount: loadedDraft?.attachments?.length ?? 0,
           updatedAt: loadedDraft?.clientUpdatedAt ?? scratchpad.createdAt,
           href: `/w/${workspaceId}/s/${scratchpad.id}`,
@@ -301,9 +361,13 @@ export function useAllDrafts(workspaceId: string) {
       // supports them.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
 
+      // An E2E draft's `contentJson` is the empty placeholder (the body is sealed),
+      // so it counts as content on the strength of its ciphertext — otherwise it
+      // would be dropped from the explorer entirely.
+      const isE2e = draft.ciphertext != null
       const hasContent = !isEmptyContent(draft.contentJson)
       const hasAttachments = (draft.attachments?.length ?? 0) > 0
-      if (!hasContent && !hasAttachments) continue
+      if (!isE2e && !hasContent && !hasAttachments) continue
 
       const resolved = resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
       const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
@@ -321,7 +385,7 @@ export function useAllDrafts(workspaceId: string) {
         type: resolved.draftType,
         streamId: resolved.streamId,
         displayName: resolved.displayName,
-        preview: truncatePreview(getContentPreview(draft.contentJson)),
+        preview: draftPreviewLabel(draft, previewMap),
         attachmentCount: draft.attachments?.length ?? 0,
         updatedAt: draft.clientUpdatedAt,
         href,
@@ -336,7 +400,7 @@ export function useAllDrafts(workspaceId: string) {
     result.sort((a, b) => b.updatedAt - a.updatedAt)
 
     return result
-  }, [draftScratchpads, allDrafts, loadedByScope, streamMap, messageToStreamMap, workspaceId])
+  }, [draftScratchpads, allDrafts, draftsById, loadedByScope, streamMap, messageToStreamMap, previewMap, workspaceId])
 
   // Delete a draft by its `UnifiedDraft.id`. Scratchpad rows carry a scratchpad
   // id; every other row carries a unified draft id — both `draft_`-prefixed, so

--- a/apps/frontend/src/hooks/use-current-workspace-user-id.ts
+++ b/apps/frontend/src/hooks/use-current-workspace-user-id.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react"
+import { useAuth } from "@/auth"
+import { useWorkspaceUsers } from "@/stores/workspace-store"
+
+/**
+ * Resolve the current viewer's workspace-scoped user id (`UserId`, INV-50), or
+ * null while it can't be resolved yet. The auth `user.id` is the global WorkOS
+ * id; the workspace-scoped id is the matching `users` row for this workspace.
+ *
+ * Several surfaces need this mapping (labels, drafts, …); it lives here so they
+ * don't each re-derive the `workosUserId` lookup by hand and drift — the same
+ * footgun the stream-name resolver warns about in `apps/frontend/CLAUDE.md`.
+ */
+export function useCurrentWorkspaceUserId(workspaceId: string): string | null {
+  const { user } = useAuth()
+  const workspaceUsers = useWorkspaceUsers(workspaceId)
+  return useMemo(() => {
+    if (!user) return null
+    return workspaceUsers.find((u) => u.workosUserId === user.id)?.id ?? null
+  }, [user, workspaceUsers])
+}

--- a/apps/frontend/src/hooks/use-decrypted-draft-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import type { JSONContent } from "@threa/types"
 import type { CachedDraft } from "@/db"
-import { useDecryptedDraftPreviews } from "./use-decrypted-draft-previews"
+import { useDecryptedDraftContent } from "./use-decrypted-draft-content"
 import { requestDecryption, seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as messageEnvelope from "@/lib/crypto/message-envelope"
 import * as currentUserHook from "./use-current-workspace-user-id"
@@ -35,9 +35,9 @@ const locked = {
   error: null,
 } as ReturnType<typeof e2eSessionStore.useE2eSession>
 
-function plaintextDraft(id: string, text: string): CachedDraft {
+function plaintextDraft(text: string): CachedDraft {
   return {
-    id,
+    id: "draft_p",
     workspaceId,
     scope: `stream:${rootStreamId}`,
     contentJson: makeDoc(text),
@@ -46,7 +46,7 @@ function plaintextDraft(id: string, text: string): CachedDraft {
   }
 }
 
-function sealedDraft(id: string): CachedDraft {
+function sealedDraft(id = "draft_e"): CachedDraft {
   return {
     id,
     workspaceId,
@@ -67,44 +67,42 @@ beforeEach(() => {
   vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(unlocked)
 })
 
-describe("useDecryptedDraftPreviews", () => {
-  it("returns plaintext previews straight from contentJson", () => {
-    const draft = plaintextDraft("draft_p", "hello plain")
-    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId: undefined }]))
-    expect(result.current.get("draft_p")).toEqual({ text: "hello plain", status: "ready" })
+describe("useDecryptedDraftContent", () => {
+  it("reports none when there is no draft", () => {
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, undefined, rootStreamId))
+    expect(result.current.status).toBe("none")
   })
 
-  it("returns the decrypted body for a sealed draft already in the shared cache", () => {
-    const draft = sealedDraft("draft_e")
-    seedDecryption("draft_e", { contentMarkdown: "secret body", contentJson: makeDoc("secret body") })
-    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "secret body", status: "ready" })
+  it("reports plaintext (with the body) for a non-E2E draft", () => {
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, plaintextDraft("hi"), undefined))
+    expect(result.current).toEqual({ status: "plaintext", contentJson: makeDoc("hi") })
   })
 
-  it("reports a sealed draft as locked while the session is locked (no decrypt attempted)", () => {
+  it("reports locked for a sealed draft while the session is locked", () => {
     vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(locked)
-    const draft = sealedDraft("draft_e")
-    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", status: "locked" })
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), rootStreamId))
+    expect(result.current.status).toBe("locked")
   })
 
-  it("reports decrypting for an unlocked sealed draft whose body hasn't landed yet", () => {
-    // Decrypt is in flight (never resolves here) → the preview is `decrypting`.
-    vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockReturnValue(new Promise(() => {}))
-    const draft = sealedDraft("draft_e")
-    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    expect(result.current.get("draft_e")).toEqual({ text: "", status: "decrypting" })
+  it("reports decrypted (with the body) when the shared cache already holds the plaintext", () => {
+    seedDecryption("draft_e", { contentMarkdown: "secret", contentJson: makeDoc("secret") })
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), rootStreamId))
+    expect(result.current).toEqual({ status: "decrypted", contentJson: makeDoc("secret") })
   })
 
-  it("reports failed when the decrypt returns null", async () => {
+  it("reports pending while unlocked but the encrypted root isn't known yet (no decrypt fired)", () => {
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), undefined))
+    expect(result.current.status).toBe("pending")
+  })
+
+  it("reports failed when the decrypt returns null (wrong recipient / garbled)", async () => {
     vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockResolvedValue(null)
     await requestDecryption(
       "draft_e",
       { contentMarkdown: "", ciphertext: "ct_sealed", envelope: { v: 2 } },
       { privateKey: {} as CryptoKey, recipientKeyId: "ek_1", workspaceId, streamId: rootStreamId, rootStreamId }
     )
-    const draft = sealedDraft("draft_e")
-    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
-    await waitFor(() => expect(result.current.get("draft_e")).toEqual({ text: "", status: "failed" }))
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), rootStreamId))
+    await waitFor(() => expect(result.current.status).toBe("failed"))
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-draft-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.ts
@@ -22,13 +22,11 @@ import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
  * root whose SSK wraps the body (a thread passes its root); decrypt holds at
  * `pending` until it is known so we never poison the cache against an unknown root.
  */
-export type DecryptedDraftContent = DraftDecryption
-
 export function useDecryptedDraftContent(
   workspaceId: string,
   draft: CachedDraft | undefined,
   rootStreamId: string | null | undefined
-): DecryptedDraftContent {
+): DraftDecryption {
   const userId = useCurrentWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
   const draftId = draft?.id

--- a/apps/frontend/src/hooks/use-decrypted-draft-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.ts
@@ -1,48 +1,28 @@
 import { useEffect, useSyncExternalStore } from "react"
-import type { JSONContent } from "@threa/types"
-import {
-  getCachedDecryption,
-  requestDecryption,
-  subscribeToDecryption,
-  type DecryptCacheEntry,
-} from "@/lib/crypto/decrypt-cache"
+import { getCachedDecryption, subscribeToDecryption, type DecryptCacheEntry } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import type { CachedDraft } from "@/db"
+import {
+  isE2eUnlocked,
+  requestDraftDecryption,
+  resolveDraftDecryption,
+  type DraftDecryption,
+} from "@/lib/drafts/decryption"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 
 /**
- * Decrypt-on-read for a draft, following the same path messages use
- * (`useDecryptedMessageContent`): one entity carries either plaintext
- * (`contentJson`) or the `ciphertext`/`envelope` sibling shape, and this hook
- * branches on `ciphertext` and decrypts through the shared `decrypt-cache`.
+ * Decrypt-on-read for the ONE draft loaded into the composer, following the same
+ * shared `decrypt-cache` messages use. Branches on `ciphertext`: a plaintext draft
+ * renders `contentJson` directly; a sealed draft decrypts in memory (IDB holds only
+ * ciphertext — E2EE-4), dropped on lock and re-decrypted on unlock (cache miss →
+ * re-request). A failed decrypt is `failed`, not a permanent spinner.
  *
- * Reusing that cache is what makes E2E drafts behave: the plaintext lives in
- * memory only (IDB holds ciphertext, treated like the backend — E2EE-4), it is
- * dropped on lock (the cache is cleared by `lock()`), and it is re-decrypted on
- * the next unlock (cache miss → re-request). A failed decrypt is a `failed`
- * status, not a permanent spinner.
- *
- * Statuses mirror the message hook:
- *  - `none`      — no draft loaded.
- *  - `plaintext` — a non-E2E draft; render `contentJson` directly.
- *  - `locked`    — E2E draft but the session isn't unlocked.
- *  - `pending`   — unlocked, decrypt in flight (or the root isn't known yet).
- *  - `decrypted` — unlocked, decrypt succeeded; render the returned content.
- *  - `failed`    — decrypt threw (wrong recipient, tampered/garbled payload).
- *
- * `rootStreamId` is the encrypted stream whose SSK wraps the body (a thread
- * passes its root). Like the message hook gating on stream hydration, decrypt
- * holds at `pending` until it is known, so we never decrypt against an unknown
- * root and poison the cache with a permanent failure.
+ * Subscribes per-id (not the global cache version) so the composer — a hot path —
+ * only re-renders when THIS draft's body changes. `rootStreamId` is the encrypted
+ * root whose SSK wraps the body (a thread passes its root); decrypt holds at
+ * `pending` until it is known so we never poison the cache against an unknown root.
  */
-export type DecryptedDraftContent =
-  | { status: "none" }
-  | { status: "plaintext"; contentJson: JSONContent }
-  | { status: "locked" }
-  | { status: "pending" }
-  | { status: "decrypted"; contentJson: JSONContent }
-  | { status: "failed" }
+export type DecryptedDraftContent = DraftDecryption
 
 export function useDecryptedDraftContent(
   workspaceId: string,
@@ -51,10 +31,7 @@ export function useDecryptedDraftContent(
 ): DecryptedDraftContent {
   const userId = useCurrentWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
-
   const draftId = draft?.id
-  const ciphertext = draft?.ciphertext
-  const envelope = draft?.envelope
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => (draftId ? subscribeToDecryption(draftId, listener) : () => {}),
@@ -62,31 +39,16 @@ export function useDecryptedDraftContent(
     () => undefined
   )
 
-  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
-  const canDecrypt = !!draftId && !!ciphertext && !!rootStreamId && sessionUnlocked
-  const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
-
   useEffect(() => {
-    if (!needsDecrypt || !draftId || !ciphertext || !rootStreamId || !session.privateKey || !session.keyId) return
-    void requestDecryption(
-      draftId,
-      { contentMarkdown: "", ciphertext, envelope },
-      {
-        privateKey: session.privateKey,
-        recipientKeyId: session.keyId,
+    if (draft) {
+      requestDraftDecryption(
+        draft,
+        { privateKey: session.privateKey, recipientKeyId: session.keyId },
         workspaceId,
-        streamId: rootStreamId,
-        rootStreamId,
-      }
-    )
-  }, [needsDecrypt, draftId, ciphertext, envelope, rootStreamId, session.privateKey, session.keyId, workspaceId])
+        rootStreamId
+      )
+    }
+  }, [draft, session.privateKey, session.keyId, workspaceId, rootStreamId])
 
-  if (!draft) return { status: "none" }
-  if (!ciphertext) return { status: "plaintext", contentJson: draft.contentJson ?? EMPTY_DOC }
-  if (!sessionUnlocked) return { status: "locked" }
-  if (cached?.status === "decrypted" && cached.content) {
-    return { status: "decrypted", contentJson: cached.content.contentJson }
-  }
-  if (cached?.status === "failed") return { status: "failed" }
-  return { status: "pending" }
+  return resolveDraftDecryption(draft, isE2eUnlocked(session), cached)
 }

--- a/apps/frontend/src/hooks/use-decrypted-draft-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.ts
@@ -1,0 +1,93 @@
+import { useEffect, useSyncExternalStore } from "react"
+import type { JSONContent } from "@threa/types"
+import {
+  getCachedDecryption,
+  requestDecryption,
+  subscribeToDecryption,
+  type DecryptCacheEntry,
+} from "@/lib/crypto/decrypt-cache"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import type { CachedDraft } from "@/db"
+import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
+
+const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
+
+/**
+ * Decrypt-on-read for a draft, following the same path messages use
+ * (`useDecryptedMessageContent`): one entity carries either plaintext
+ * (`contentJson`) or the `ciphertext`/`envelope` sibling shape, and this hook
+ * branches on `ciphertext` and decrypts through the shared `decrypt-cache`.
+ *
+ * Reusing that cache is what makes E2E drafts behave: the plaintext lives in
+ * memory only (IDB holds ciphertext, treated like the backend — E2EE-4), it is
+ * dropped on lock (the cache is cleared by `lock()`), and it is re-decrypted on
+ * the next unlock (cache miss → re-request). A failed decrypt is a `failed`
+ * status, not a permanent spinner.
+ *
+ * Statuses mirror the message hook:
+ *  - `none`      — no draft loaded.
+ *  - `plaintext` — a non-E2E draft; render `contentJson` directly.
+ *  - `locked`    — E2E draft but the session isn't unlocked.
+ *  - `pending`   — unlocked, decrypt in flight (or the root isn't known yet).
+ *  - `decrypted` — unlocked, decrypt succeeded; render the returned content.
+ *  - `failed`    — decrypt threw (wrong recipient, tampered/garbled payload).
+ *
+ * `rootStreamId` is the encrypted stream whose SSK wraps the body (a thread
+ * passes its root). Like the message hook gating on stream hydration, decrypt
+ * holds at `pending` until it is known, so we never decrypt against an unknown
+ * root and poison the cache with a permanent failure.
+ */
+export type DecryptedDraftContent =
+  | { status: "none" }
+  | { status: "plaintext"; contentJson: JSONContent }
+  | { status: "locked" }
+  | { status: "pending" }
+  | { status: "decrypted"; contentJson: JSONContent }
+  | { status: "failed" }
+
+export function useDecryptedDraftContent(
+  workspaceId: string,
+  draft: CachedDraft | undefined,
+  rootStreamId: string | null | undefined
+): DecryptedDraftContent {
+  const userId = useCurrentWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+
+  const draftId = draft?.id
+  const ciphertext = draft?.ciphertext
+  const envelope = draft?.envelope
+
+  const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
+    (listener) => (draftId ? subscribeToDecryption(draftId, listener) : () => {}),
+    () => (draftId ? getCachedDecryption(draftId) : undefined),
+    () => undefined
+  )
+
+  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const canDecrypt = !!draftId && !!ciphertext && !!rootStreamId && sessionUnlocked
+  const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
+
+  useEffect(() => {
+    if (!needsDecrypt || !draftId || !ciphertext || !rootStreamId || !session.privateKey || !session.keyId) return
+    void requestDecryption(
+      draftId,
+      { contentMarkdown: "", ciphertext, envelope },
+      {
+        privateKey: session.privateKey,
+        recipientKeyId: session.keyId,
+        workspaceId,
+        streamId: rootStreamId,
+        rootStreamId,
+      }
+    )
+  }, [needsDecrypt, draftId, ciphertext, envelope, rootStreamId, session.privateKey, session.keyId, workspaceId])
+
+  if (!draft) return { status: "none" }
+  if (!ciphertext) return { status: "plaintext", contentJson: draft.contentJson ?? EMPTY_DOC }
+  if (!sessionUnlocked) return { status: "locked" }
+  if (cached?.status === "decrypted" && cached.content) {
+    return { status: "decrypted", contentJson: cached.content.contentJson }
+  }
+  if (cached?.status === "failed") return { status: "failed" }
+  return { status: "pending" }
+}

--- a/apps/frontend/src/hooks/use-decrypted-draft-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.ts
@@ -7,10 +7,9 @@ import {
   type DecryptCacheEntry,
 } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
+import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import type { CachedDraft } from "@/db"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
-
-const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 
 /**
  * Decrypt-on-read for a draft, following the same path messages use

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
@@ -46,14 +46,14 @@ function plaintextDraft(id: string, text: string): CachedDraft {
   }
 }
 
-function sealedDraft(id: string): CachedDraft {
+function sealedDraft(id: string, ciphertext = "ct_sealed"): CachedDraft {
   return {
     id,
     workspaceId,
     scope: `stream:${rootStreamId}`,
     contentJson: EMPTY_DOC,
     attachments: [],
-    ciphertext: "ct_sealed",
+    ciphertext,
     envelope: { v: 2 },
     e2eVersion: 2,
     clientUpdatedAt: 1,
@@ -106,5 +106,31 @@ describe("useDecryptedDraftPreviews", () => {
     const draft = sealedDraft("draft_e")
     const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
     await waitFor(() => expect(result.current.get("draft_e")).toEqual({ text: "", status: "failed" }))
+  })
+
+  it("resolves each id independently across a mixed batch in one render", async () => {
+    // The whole reason this hook exists (vs. the per-id one in a loop) is to build
+    // a correct per-id map across MANY drafts at once. One unlocked session, four
+    // drafts, four different outcomes — distinct ciphertexts let one decrypt fail
+    // while another hangs in the SAME render, so a bug that smeared inputs[0]'s
+    // state across the map (or only handled the first row) would surface here.
+    vi.spyOn(messageEnvelope, "tryDecryptMessagePayload").mockImplementation((payload) =>
+      payload.ciphertext === "ct_fail" ? Promise.resolve(null) : new Promise<null>(() => {})
+    )
+    seedDecryption("draft_seeded", { contentMarkdown: "seeded body", contentJson: makeDoc("seeded body") })
+
+    const inputs = [
+      { draft: plaintextDraft("draft_plain", "plain body"), rootStreamId: undefined },
+      { draft: sealedDraft("draft_seeded"), rootStreamId },
+      { draft: sealedDraft("draft_fail", "ct_fail"), rootStreamId },
+      { draft: sealedDraft("draft_hang", "ct_hang"), rootStreamId },
+    ]
+    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, inputs))
+
+    await waitFor(() => expect(result.current.get("draft_fail")).toEqual({ text: "", status: "failed" }))
+    expect(result.current.get("draft_plain")).toEqual({ text: "plain body", status: "ready" })
+    expect(result.current.get("draft_seeded")).toEqual({ text: "seeded body", status: "ready" })
+    expect(result.current.get("draft_hang")).toEqual({ text: "", status: "decrypting" })
+    expect(result.current.size).toBe(4)
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { JSONContent } from "@threa/types"
+import type { CachedDraft } from "@/db"
+import { useDecryptedDraftPreviews } from "./use-decrypted-draft-previews"
+import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
+import * as currentUserHook from "./use-current-workspace-user-id"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
+
+const workspaceId = "ws_1"
+const rootStreamId = "stream_e2e"
+
+const unlocked = {
+  status: "unlocked",
+  keyId: "ek_1",
+  publicKey: null,
+  privateKey: {} as CryptoKey,
+  deviceTrusted: true,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+const locked = {
+  status: "locked",
+  keyId: null,
+  publicKey: null,
+  privateKey: null,
+  deviceTrusted: false,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+function plaintextDraft(id: string, text: string): CachedDraft {
+  return {
+    id,
+    workspaceId,
+    scope: `stream:${rootStreamId}`,
+    contentJson: makeDoc(text),
+    attachments: [],
+    clientUpdatedAt: 1,
+  }
+}
+
+function sealedDraft(id: string): CachedDraft {
+  return {
+    id,
+    workspaceId,
+    scope: `stream:${rootStreamId}`,
+    contentJson: EMPTY_DOC,
+    attachments: [],
+    ciphertext: "ct_sealed",
+    envelope: { v: 2 },
+    e2eVersion: 2,
+    clientUpdatedAt: 1,
+  }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  clearDecryptCache()
+  vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+  vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(unlocked)
+})
+
+describe("useDecryptedDraftPreviews", () => {
+  it("returns plaintext previews straight from contentJson", () => {
+    const draft = plaintextDraft("draft_p", "hello plain")
+    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId: undefined }]))
+    expect(result.current.get("draft_p")).toEqual({ text: "hello plain", status: "ready" })
+  })
+
+  it("returns the decrypted body for a sealed draft already in the shared cache", () => {
+    const draft = sealedDraft("draft_e")
+    seedDecryption("draft_e", { contentMarkdown: "secret body", contentJson: makeDoc("secret body") })
+    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
+    expect(result.current.get("draft_e")).toEqual({ text: "secret body", status: "ready" })
+  })
+
+  it("reports a sealed draft as locked while the session is locked (no decrypt attempted)", () => {
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(locked)
+    const draft = sealedDraft("draft_e")
+    const { result } = renderHook(() => useDecryptedDraftPreviews(workspaceId, [{ draft, rootStreamId }]))
+    expect(result.current.get("draft_e")).toEqual({ text: "", status: "locked" })
+  })
+})

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.ts
@@ -1,38 +1,17 @@
 import { useEffect, useMemo, useSyncExternalStore } from "react"
-import { serializeToMarkdown } from "@threa/prosemirror"
-import type { JSONContent } from "@threa/types"
-import {
-  getCachedDecryption,
-  getDecryptCacheVersion,
-  requestDecryption,
-  subscribeDecryptCacheVersion,
-} from "@/lib/crypto/decrypt-cache"
+import { getCachedDecryption, getDecryptCacheVersion, subscribeDecryptCacheVersion } from "@/lib/crypto/decrypt-cache"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { isEmptyContent } from "@/lib/prosemirror-utils"
-import { stripMarkdownToInline } from "@/lib/markdown"
 import type { CachedDraft } from "@/db"
+import {
+  draftDecryptionToPreview,
+  isE2eUnlocked,
+  requestDraftDecryption,
+  resolveDraftDecryption,
+  type DraftPreview,
+} from "@/lib/drafts/decryption"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 
-/**
- * Decrypt-on-read previews for a LIST of drafts, following the same shared
- * `decrypt-cache` the composer and message timeline use. Components that render
- * many draft rows at once (the stash picker, the /drafts explorer) can't call the
- * per-row `useDecryptedDraftContent` hook in a loop, so this hook batches: it
- * watches the cache's global version, reads each id's plaintext when present, and
- * fires a decrypt for any E2E row that's missing one (unlocked + root known).
- *
- * The plaintext never leaves memory — IDB holds only ciphertext (E2EE-4) — and a
- * locked session yields a `locked` status (no decrypt attempted), a failed
- * decrypt a `failed` status (not a permanent spinner). Plaintext drafts resolve
- * to `ready` immediately from their `contentJson`.
- */
-export type DraftPreviewStatus = "ready" | "decrypting" | "locked" | "failed"
-
-export interface DraftPreview {
-  /** Inline, markdown-stripped body text; "" when the body is empty or unavailable. */
-  text: string
-  status: DraftPreviewStatus
-}
+export type { DraftPreview, DraftPreviewStatus } from "@/lib/drafts/decryption"
 
 export interface DraftPreviewInput {
   draft: CachedDraft
@@ -40,15 +19,17 @@ export interface DraftPreviewInput {
   rootStreamId: string | null | undefined
 }
 
-function inlineText(contentJson: JSONContent | null | undefined): string {
-  if (!contentJson || isEmptyContent(contentJson)) return ""
-  return stripMarkdownToInline(serializeToMarkdown(contentJson)).trim()
-}
-
+/**
+ * Decrypt-on-read previews for a LIST of drafts (the stash picker, the /drafts
+ * explorer). Components rendering many rows can't call the per-row
+ * `useDecryptedDraftContent` in a loop, so this batches: it watches the cache's
+ * global version, reads each id via the shared decrypt core, and fires a decrypt
+ * for any sealed row that's missing one. Plaintext lives in memory only (E2EE-4).
+ */
 export function useDecryptedDraftPreviews(workspaceId: string, inputs: DraftPreviewInput[]): Map<string, DraftPreview> {
   const userId = useCurrentWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
-  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  const unlocked = isE2eUnlocked(session)
 
   // Re-render on any decrypt-cache change so previews fill in as bodies decrypt.
   const cacheVersion = useSyncExternalStore(
@@ -57,49 +38,20 @@ export function useDecryptedDraftPreviews(workspaceId: string, inputs: DraftPrev
     getDecryptCacheVersion
   )
 
-  // Fire a decrypt for every E2E row we can but haven't yet — cache miss, unlocked,
-  // root known. Already-cached/in-flight ids short-circuit inside requestDecryption.
   useEffect(() => {
-    if (!sessionUnlocked || !session.privateKey || !session.keyId) return
-    for (const { draft, rootStreamId } of inputs) {
-      if (!draft.ciphertext || !rootStreamId) continue
-      const cached = getCachedDecryption(draft.id)
-      if (cached && cached.status !== "pending") continue
-      void requestDecryption(
-        draft.id,
-        { contentMarkdown: "", ciphertext: draft.ciphertext, envelope: draft.envelope },
-        {
-          privateKey: session.privateKey,
-          recipientKeyId: session.keyId,
-          workspaceId,
-          streamId: rootStreamId,
-          rootStreamId,
-        }
-      )
-    }
-  }, [inputs, sessionUnlocked, session.privateKey, session.keyId, workspaceId])
+    const keys = { privateKey: session.privateKey, recipientKeyId: session.keyId }
+    for (const { draft, rootStreamId } of inputs) requestDraftDecryption(draft, keys, workspaceId, rootStreamId)
+  }, [inputs, session.privateKey, session.keyId, workspaceId])
 
   return useMemo(() => {
     const map = new Map<string, DraftPreview>()
     for (const { draft } of inputs) {
-      if (!draft.ciphertext) {
-        map.set(draft.id, { text: inlineText(draft.contentJson), status: "ready" })
-        continue
-      }
-      if (!sessionUnlocked) {
-        map.set(draft.id, { text: "", status: "locked" })
-        continue
-      }
-      const cached = getCachedDecryption(draft.id)
-      if (cached?.status === "decrypted" && cached.content) {
-        map.set(draft.id, { text: inlineText(cached.content.contentJson), status: "ready" })
-      } else if (cached?.status === "failed") {
-        map.set(draft.id, { text: "", status: "failed" })
-      } else {
-        map.set(draft.id, { text: "", status: "decrypting" })
-      }
+      map.set(
+        draft.id,
+        draftDecryptionToPreview(resolveDraftDecryption(draft, unlocked, getCachedDecryption(draft.id)))
+      )
     }
     return map
     // `cacheVersion` is the read-trigger: getCachedDecryption is read fresh when it bumps.
-  }, [inputs, sessionUnlocked, cacheVersion])
+  }, [inputs, unlocked, cacheVersion])
 }

--- a/apps/frontend/src/hooks/use-decrypted-draft-previews.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-previews.ts
@@ -1,0 +1,105 @@
+import { useEffect, useMemo, useSyncExternalStore } from "react"
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+import {
+  getCachedDecryption,
+  getDecryptCacheVersion,
+  requestDecryption,
+  subscribeDecryptCacheVersion,
+} from "@/lib/crypto/decrypt-cache"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { stripMarkdownToInline } from "@/lib/markdown"
+import type { CachedDraft } from "@/db"
+import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
+
+/**
+ * Decrypt-on-read previews for a LIST of drafts, following the same shared
+ * `decrypt-cache` the composer and message timeline use. Components that render
+ * many draft rows at once (the stash picker, the /drafts explorer) can't call the
+ * per-row `useDecryptedDraftContent` hook in a loop, so this hook batches: it
+ * watches the cache's global version, reads each id's plaintext when present, and
+ * fires a decrypt for any E2E row that's missing one (unlocked + root known).
+ *
+ * The plaintext never leaves memory — IDB holds only ciphertext (E2EE-4) — and a
+ * locked session yields a `locked` status (no decrypt attempted), a failed
+ * decrypt a `failed` status (not a permanent spinner). Plaintext drafts resolve
+ * to `ready` immediately from their `contentJson`.
+ */
+export type DraftPreviewStatus = "ready" | "decrypting" | "locked" | "failed"
+
+export interface DraftPreview {
+  /** Inline, markdown-stripped body text; "" when the body is empty or unavailable. */
+  text: string
+  status: DraftPreviewStatus
+}
+
+export interface DraftPreviewInput {
+  draft: CachedDraft
+  /** Encrypted root whose SSK seals the body; null/undefined for a plaintext draft. */
+  rootStreamId: string | null | undefined
+}
+
+function inlineText(contentJson: JSONContent | null | undefined): string {
+  if (!contentJson || isEmptyContent(contentJson)) return ""
+  return stripMarkdownToInline(serializeToMarkdown(contentJson)).trim()
+}
+
+export function useDecryptedDraftPreviews(workspaceId: string, inputs: DraftPreviewInput[]): Map<string, DraftPreview> {
+  const userId = useCurrentWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
+
+  // Re-render on any decrypt-cache change so previews fill in as bodies decrypt.
+  const cacheVersion = useSyncExternalStore(
+    subscribeDecryptCacheVersion,
+    getDecryptCacheVersion,
+    getDecryptCacheVersion
+  )
+
+  // Fire a decrypt for every E2E row we can but haven't yet — cache miss, unlocked,
+  // root known. Already-cached/in-flight ids short-circuit inside requestDecryption.
+  useEffect(() => {
+    if (!sessionUnlocked || !session.privateKey || !session.keyId) return
+    for (const { draft, rootStreamId } of inputs) {
+      if (!draft.ciphertext || !rootStreamId) continue
+      const cached = getCachedDecryption(draft.id)
+      if (cached && cached.status !== "pending") continue
+      void requestDecryption(
+        draft.id,
+        { contentMarkdown: "", ciphertext: draft.ciphertext, envelope: draft.envelope },
+        {
+          privateKey: session.privateKey,
+          recipientKeyId: session.keyId,
+          workspaceId,
+          streamId: rootStreamId,
+          rootStreamId,
+        }
+      )
+    }
+  }, [inputs, sessionUnlocked, session.privateKey, session.keyId, workspaceId])
+
+  return useMemo(() => {
+    const map = new Map<string, DraftPreview>()
+    for (const { draft } of inputs) {
+      if (!draft.ciphertext) {
+        map.set(draft.id, { text: inlineText(draft.contentJson), status: "ready" })
+        continue
+      }
+      if (!sessionUnlocked) {
+        map.set(draft.id, { text: "", status: "locked" })
+        continue
+      }
+      const cached = getCachedDecryption(draft.id)
+      if (cached?.status === "decrypted" && cached.content) {
+        map.set(draft.id, { text: inlineText(cached.content.contentJson), status: "ready" })
+      } else if (cached?.status === "failed") {
+        map.set(draft.id, { text: "", status: "failed" })
+      } else {
+        map.set(draft.id, { text: "", status: "decrypting" })
+      }
+    }
+    return map
+    // `cacheVersion` is the read-trigger: getCachedDecryption is read fresh when it bumps.
+  }, [inputs, sessionUnlocked, cacheVersion])
+}

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -12,6 +12,7 @@ const makeDoc = (text: string): JSONContent => ({
 })
 
 // Mock useDraftMessage
+const mockSaveDraft = vi.fn()
 const mockSaveDraftDebounced = vi.fn()
 const mockAddDraftAttachment = vi.fn()
 const mockRemoveDraftAttachment = vi.fn()
@@ -61,6 +62,7 @@ describe("useDraftComposer", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks()
+    mockSaveDraft.mockReset()
     mockSaveDraftDebounced.mockReset()
     mockAddDraftAttachment.mockReset()
     mockRemoveDraftAttachment.mockReset()
@@ -90,6 +92,7 @@ describe("useDraftComposer", () => {
           contentJson: state.contentJson,
           attachments: state.attachments,
           contextRefs: state.contextRefs ?? [],
+          saveDraft: mockSaveDraft,
           saveDraftDebounced: mockSaveDraftDebounced,
           addAttachment: mockAddDraftAttachment,
           removeAttachment: mockRemoveDraftAttachment,
@@ -645,6 +648,68 @@ describe("useDraftComposer", () => {
       const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
 
       expect(result.current.handleFileSelect).toBe(mockHandleFileSelect)
+    })
+  })
+
+  describe("flushDraft (safe flush — never deletes)", () => {
+    it("persists the live editor content when it is non-empty", async () => {
+      const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      act(() => {
+        result.current.setContent(makeDoc("unsaved keystrokes"))
+      })
+      await act(async () => {
+        await result.current.flushDraft()
+      })
+
+      expect(mockSaveDraft).toHaveBeenCalledWith(makeDoc("unsaved keystrokes"))
+    })
+
+    it("no-ops on an empty editor so a restore mid-hydration can't delete the loaded draft", async () => {
+      // Regression: stash/restore used to flush `composer.content` unconditionally;
+      // when the editor was still mid-hydration (transiently empty), the save took
+      // the empty→delete path and destroyed the loaded draft.
+      const { result } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+
+      await act(async () => {
+        await result.current.flushDraft()
+      })
+
+      expect(mockSaveDraft).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("markNeedsRehydrate (stash-restore re-hydration)", () => {
+    it("applies the newly-loaded draft body in place after a rehydrate", () => {
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("first")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("first"))
+
+      // A restore swaps the loaded pointer to a different draft, then re-hydrates.
+      mockDraftContentJson = makeDoc("restored")
+      act(() => {
+        result.current.markNeedsRehydrate()
+      })
+      rerender()
+
+      expect(result.current.content).toEqual(makeDoc("restored"))
+    })
+
+    it("does not re-fill the editor after the user clears it (no clobber)", () => {
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("saved body")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("saved body"))
+
+      // User clears the editor — `savedDraft` still lags at "saved body" for a tick.
+      act(() => {
+        result.current.handleContentChange(EMPTY_DOC)
+      })
+      rerender()
+
+      // Stays cleared: the late-hydrate yields to user engagement.
+      expect(result.current.content).toEqual(EMPTY_DOC)
     })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -37,6 +37,7 @@ interface MockDraftState {
 let mockDraftIsLoaded = true
 let mockDraftContentJson: JSONContent = EMPTY_DOC
 let mockDraftAttachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }> = []
+let mockDraftLoadedId: string | null = "draft_mock"
 let mockDraftStateByKey: Record<string, MockDraftState> = {}
 
 // Mock useAttachments
@@ -76,6 +77,7 @@ describe("useDraftComposer", () => {
     mockDraftIsLoaded = true
     mockDraftContentJson = EMPTY_DOC
     mockDraftAttachments = []
+    mockDraftLoadedId = "draft_mock"
     mockDraftStateByKey = {}
     mockPendingAttachments = []
 
@@ -92,6 +94,7 @@ describe("useDraftComposer", () => {
           contentJson: state.contentJson,
           attachments: state.attachments,
           contextRefs: state.contextRefs ?? [],
+          loadedDraftId: mockDraftLoadedId,
           saveDraft: mockSaveDraft,
           saveDraftDebounced: mockSaveDraftDebounced,
           addAttachment: mockAddDraftAttachment,
@@ -709,6 +712,42 @@ describe("useDraftComposer", () => {
       rerender()
 
       // Stays cleared: the late-hydrate yields to user engagement.
+      expect(result.current.content).toEqual(EMPTY_DOC)
+    })
+
+    it("does not re-fill after a send-style clear while the loaded row lags (restored-then-sent)", () => {
+      // Regression: a restored draft sent without further typing left `userEngaged`
+      // false; the editor cleared on send but the late-hydrate re-filled it from the
+      // still-present `savedDraft` before the resolve removed the row.
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("restored body")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("restored body")) // hydrated; user did NOT type
+
+      // Send clears the editor; the loaded row still lags (savedDraft unchanged for a tick).
+      act(() => {
+        result.current.setContent(EMPTY_DOC)
+      })
+      rerender()
+
+      // Stays cleared — no rising edge of body-availability, so no re-fill.
+      expect(result.current.content).toEqual(EMPTY_DOC)
+    })
+
+    it("blanks the editor when the loaded draft is removed underneath it (resolved on another device)", () => {
+      // Start typing on one device, finish + send on another: the partial draft
+      // must not linger here once its pointer is cleared (loaded id → null).
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("roamed body")
+      mockDraftLoadedId = "draft_roamed"
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("roamed body"))
+
+      // The draft is sent/resolved elsewhere: its `draft:deleted` clears the pointer.
+      mockDraftLoadedId = null
+      mockDraftContentJson = EMPTY_DOC
+      rerender()
+
       expect(result.current.content).toEqual(EMPTY_DOC)
     })
   })

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -784,5 +784,38 @@ describe("useDraftComposer", () => {
 
       expect(result.current.content).toEqual(makeDoc("typed during decrypt"))
     })
+
+    it("preserves in-progress edits when the loaded pointer briefly flickers to null", () => {
+      // Repro of the mobile revert seen on staging: while the user edits (live
+      // content ahead of the debounced save), `loadedDraftId` momentarily reads
+      // null — a transient re-read of the loaded pointer. The clear-on-removal
+      // effect used to blank the editor and reset the engagement guard; on the
+      // pointer's return, the late-hydrate rising edge then re-filled the stale
+      // last-saved body, dropping the un-saved keystrokes. A real removal migrates
+      // unpushed edits to a NEW id rather than nulling, so a null-while-engaged is
+      // a flicker and must never wipe the editor.
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("saved body")
+      mockDraftLoadedId = "draft_x"
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("saved body"))
+
+      // User types ahead of the debounce (savedDraft still lags at "saved body").
+      act(() => {
+        result.current.handleContentChange(makeDoc("saved body and more"))
+      })
+      expect(result.current.content).toEqual(makeDoc("saved body and more"))
+
+      // Pointer flickers to null (no loaded row → savedDraft reads empty) …
+      mockDraftLoadedId = null
+      mockDraftContentJson = EMPTY_DOC
+      rerender()
+      // … then returns, with savedDraft still the stale last-saved body.
+      mockDraftLoadedId = "draft_x"
+      mockDraftContentJson = makeDoc("saved body")
+      rerender()
+
+      expect(result.current.content).toEqual(makeDoc("saved body and more"))
+    })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -750,5 +750,39 @@ describe("useDraftComposer", () => {
 
       expect(result.current.content).toEqual(EMPTY_DOC)
     })
+
+    it("does not clobber typed content when a deferred (decrypting) draft body lands after the user types", () => {
+      // Repro of the staging data-loss bug: restore an E2E draft whose sealed body
+      // is still decrypting. `isDraftLoaded` stays false, so the one-shot init is
+      // DEFERRED. The user types into the blanked editor; when the decrypt lands,
+      // `isDraftLoaded` flips true and the deferred init runs for the FIRST time.
+      // It must yield to the keystrokes the user already made — a focused composer
+      // is never overwritten by anything but the user's own typing.
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("original body")
+      const { result, rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(result.current.content).toEqual(makeDoc("original body"))
+
+      // Restore a different draft, then simulate its sealed body still decrypting.
+      act(() => {
+        result.current.markNeedsRehydrate()
+      })
+      mockDraftIsLoaded = false
+      mockDraftContentJson = EMPTY_DOC
+      rerender()
+
+      // User types into the blank editor before the restored body is readable.
+      act(() => {
+        result.current.handleContentChange(makeDoc("typed during decrypt"))
+      })
+      expect(result.current.content).toEqual(makeDoc("typed during decrypt"))
+
+      // Decrypt lands: the loaded body becomes available and isLoaded flips true.
+      mockDraftIsLoaded = true
+      mockDraftContentJson = makeDoc("decrypted loaded body")
+      rerender()
+
+      expect(result.current.content).toEqual(makeDoc("typed during decrypt"))
+    })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -81,6 +81,8 @@ export interface DraftComposerState {
 
   // Loading
   isLoaded: boolean
+  /** An E2E draft whose sealed body is still being decrypted into the composer. */
+  isDecrypting: boolean
 }
 
 export function useDraftComposer({
@@ -93,6 +95,7 @@ export function useDraftComposer({
   // Draft message persistence
   const {
     isLoaded: isDraftLoaded,
+    isDecrypting,
     contentJson: savedDraft,
     attachments: savedAttachments,
     contextRefs: savedContextRefs = [] as DraftContextRef[],
@@ -291,5 +294,6 @@ export function useDraftComposer({
 
     // Loading
     isLoaded: isDraftLoaded,
+    isDecrypting,
   }
 }

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -280,13 +280,20 @@ export function useDraftComposer({
   // Blank the editor the moment the loaded draft is removed underneath the
   // composer: sent/resolved here, or discarded/resolved on another device (its
   // `draft:deleted` clears this scope's pointer). Without this the just-sent or
-  // remotely-cleared body lingers on screen. A transition to null is always safe
-  // to clear — the delete path preserves any unpushed local edits under a NEW id
-  // (so the loaded id MIGRATES rather than going null).
+  // remotely-cleared body lingers on screen.
+  //
+  // But NOT while the user is actively editing non-empty content. A genuine
+  // removal of a draft with unpushed edits MIGRATES those edits to a new id (the
+  // loaded id changes value rather than going null — see `applyDraftDeleted`), so
+  // a null arriving WHILE the editor holds engaged keystrokes is a transient
+  // re-read flicker of the loaded pointer, not a real removal. Blanking on it
+  // wiped the in-progress edits and, on the pointer's return, the late-hydrate
+  // rising edge re-filled the stale last-saved body — the keystrokes were lost.
+  // A clean (unedited) loaded draft still clears: that is the cross-device case.
   useEffect(() => {
     const prev = prevLoadedIdRef.current
     prevLoadedIdRef.current = loadedDraftId ?? null
-    if (prev && !loadedDraftId) {
+    if (prev && !loadedDraftId && !(userEngagedRef.current && hasDocContent(contentRef.current))) {
       userEngagedRef.current = false
       setContent(initialContent)
       clearAttachments()

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -59,6 +59,20 @@ export interface DraftComposerState {
   isSending: boolean
   setIsSending: (sending: boolean) => void
 
+  /**
+   * Persist the composer's current content into its loaded draft row immediately
+   * (bypassing the debounce), sealing it for E2E. Used by stash/restore to flush
+   * unsaved keystrokes into the row before it is detached or swapped, so nothing
+   * typed since the last debounce tick is lost.
+   */
+  saveDraft: (content: JSONContent) => Promise<void>
+  /**
+   * Re-run the composer's init from whatever draft is now loaded for the scope.
+   * Called after a stash/restore pointer move so the editor re-reads (and, for
+   * E2E, re-decrypts) the newly-loaded draft instead of keeping the old one.
+   */
+  markNeedsRehydrate: () => void
+
   // Clear helpers
   clearDraft: () => Promise<void>
   /**
@@ -102,6 +116,7 @@ export function useDraftComposer({
     contentJson: savedDraft,
     attachments: savedAttachments,
     contextRefs: savedContextRefs = [] as DraftContextRef[],
+    saveDraft,
     saveDraftDebounced,
     addAttachment: addDraftAttachment,
     removeAttachment: removeDraftAttachment,
@@ -141,6 +156,28 @@ export function useDraftComposer({
   const suspendAttachmentPersistence = useRef(false)
   const staleAttachmentIdsRef = useRef<Set<string>>(new Set())
   const restoredAttachmentIdsRef = useRef<Set<string>>(new Set())
+  // Latest pending attachments, read by the reset below without making it a
+  // dependency (which would churn its identity every render).
+  const pendingAttachmentsRef = useRef(pendingAttachments)
+  pendingAttachmentsRef.current = pendingAttachments
+
+  // Blank the composer to an un-initialized state so the init effect below
+  // re-hydrates it from whatever draft is now loaded for the scope. Used on both
+  // a scope change and an explicit stash/restore — the latter is a pointer move
+  // that swaps the loaded draft WITHIN the same scope, so the editor must re-read
+  // from the newly-pointed draft (decrypting it on the way in for E2E) exactly as
+  // it would after a scope change.
+  const resetForReinit = useCallback(() => {
+    hasInitialized.current = false
+    userEngagedRef.current = false
+    suspendAttachmentPersistence.current = true
+    staleAttachmentIdsRef.current = new Set(
+      pendingAttachmentsRef.current.filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_")).map((a) => a.id)
+    )
+    restoredAttachmentIdsRef.current = new Set()
+    setContent(initialContent)
+    clearAttachments()
+  }, [clearAttachments, initialContent])
 
   // Initialize content and attachments from saved draft, reset on scope change
   useEffect(() => {
@@ -148,15 +185,7 @@ export function useDraftComposer({
 
     // On scope change, reset state
     if (isScopeChange) {
-      hasInitialized.current = false
-      userEngagedRef.current = false
-      suspendAttachmentPersistence.current = true
-      staleAttachmentIdsRef.current = new Set(
-        pendingAttachments.filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_")).map((a) => a.id)
-      )
-      restoredAttachmentIdsRef.current = new Set()
-      setContent(initialContent)
-      clearAttachments()
+      resetForReinit()
     }
 
     // Track scope changes
@@ -180,16 +209,7 @@ export function useDraftComposer({
       restoredAttachmentIdsRef.current = new Set(savedAttachments.map((attachment: { id: string }) => attachment.id))
       hasInitialized.current = true
     }
-  }, [
-    scopeId,
-    isDraftLoaded,
-    savedDraft,
-    savedAttachments,
-    restoreAttachments,
-    clearAttachments,
-    initialContent,
-    pendingAttachments,
-  ])
+  }, [scopeId, isDraftLoaded, savedDraft, savedAttachments, restoreAttachments, resetForReinit])
 
   // Late hydrate: an E2E draft can finish decrypting AFTER the one-shot init
   // above already ran — it was locked or still decrypting when the composer
@@ -313,6 +333,10 @@ export function useDraftComposer({
     canSend,
     isSending,
     setIsSending,
+
+    // Flush / re-hydrate (used by stash + restore)
+    saveDraft,
+    markNeedsRehydrate: resetForReinit,
 
     // Clear helpers
     clearDraft,

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -114,6 +114,7 @@ export function useDraftComposer({
     isLoaded: isDraftLoaded,
     isDecrypting,
     decryptFailed,
+    loadedDraftId,
     contentJson: savedDraft,
     attachments: savedAttachments,
     contextRefs: savedContextRefs = [] as DraftContextRef[],
@@ -156,6 +157,14 @@ export function useDraftComposer({
   // re-filled from the previous draft during the swap (the in-place restore race).
   // Cleared once that body lands; still yields to `userEngagedRef`.
   const awaitingRehydrateRef = useRef(false)
+  // Tracks whether the loaded draft's body was available last render, so the
+  // late-hydrate fires only on the RISING edge (a body arriving into an empty
+  // editor — unlock/decrypt), never on a falling edge (a send/clear emptying it).
+  const prevSavedAvailableRef = useRef(false)
+  // Tracks the loaded draft id so the composer can blank the editor the moment the
+  // draft is removed underneath it (sent/resolved here, or discarded/resolved on
+  // another device — id → null), instead of leaving a gone draft on screen.
+  const prevLoadedIdRef = useRef<string | null>(null)
   const prevScopeIdRef = useRef<string | null>(null)
   // Keeps attachment persistence suspended until the previous scope's uploaded
   // attachments are gone from React state.
@@ -233,30 +242,49 @@ export function useDraftComposer({
 
   // Late hydrate: the loaded draft's body can become available AFTER the one-shot
   // init above already ran — an E2E draft that was locked or still decrypting at
-  // mount (unlock/decrypt lands later), or a stash/restore pointer move that
-  // swaps in a different draft whose body decrypts on a later tick. When that
-  // body lands and the user hasn't engaged with the editor, drop it in.
+  // mount (unlock/decrypt lands later), or a stash/restore pointer move that swaps
+  // in a different draft whose body decrypts on a later tick. When that body lands
+  // and the user hasn't engaged with the editor, drop it in.
   //
-  // Crucially this is NOT gated on `hasInitialized`: `markNeedsRehydrate` clears
-  // it on a restore, and the restored body may only resolve across a pending
-  // decrypt — so the apply has to survive that window. `userEngagedRef` is the
-  // real guard: it flips true on the first keystroke, so this never overwrites
-  // typed content nor re-fills a draft the user just cleared (whose `savedDraft`
-  // lags by a debounce tick).
-  //
-  // Apply when EITHER the editor is empty (unlock/late decrypt into an untouched
-  // editor) OR an explicit rehydrate is pending (scope change / stash-restore) —
-  // the latter overrides transient content the init effect may have re-filled
-  // from the OUTGOING draft before the pointer swap propagated (the in-place
-  // restore race). The override fires once, then clears.
+  // `userEngagedRef` is the real guard: it flips true on the first keystroke, so
+  // this never overwrites typed content. The two apply paths are deliberately
+  // narrow so a SEND/clear (which empties the editor) can't trigger a re-fill:
+  //  - explicit rehydrate (scope change / stash-restore): override transient
+  //    content once, even across a pending decrypt (`awaitingRehydrateRef`).
+  //  - unlock/late-decrypt: apply only on the RISING edge of body-availability
+  //    (the body just became available) into a still-empty editor. A send clears
+  //    the editor while `savedDraft` briefly lags non-empty — that's a falling
+  //    edge / no edge, so it never re-fills the just-sent content.
   useEffect(() => {
-    if (!isDraftLoaded) return
-    if (userEngagedRef.current) return
-    if (!hasDocContent(savedDraft)) return
-    if (!awaitingRehydrateRef.current && hasDocContent(content)) return
-    setContent(savedDraft)
-    awaitingRehydrateRef.current = false
+    const savedAvailable = hasDocContent(savedDraft)
+    const becameAvailable = savedAvailable && !prevSavedAvailableRef.current
+    prevSavedAvailableRef.current = savedAvailable
+    if (!isDraftLoaded || userEngagedRef.current || !savedAvailable) return
+    if (awaitingRehydrateRef.current) {
+      setContent(savedDraft)
+      awaitingRehydrateRef.current = false
+      return
+    }
+    if (becameAvailable && !hasDocContent(content)) {
+      setContent(savedDraft)
+    }
   }, [isDraftLoaded, savedDraft, content])
+
+  // Blank the editor the moment the loaded draft is removed underneath the
+  // composer: sent/resolved here, or discarded/resolved on another device (its
+  // `draft:deleted` clears this scope's pointer). Without this the just-sent or
+  // remotely-cleared body lingers on screen. A transition to null is always safe
+  // to clear — the delete path preserves any unpushed local edits under a NEW id
+  // (so the loaded id MIGRATES rather than going null).
+  useEffect(() => {
+    const prev = prevLoadedIdRef.current
+    prevLoadedIdRef.current = loadedDraftId ?? null
+    if (prev && !loadedDraftId) {
+      userEngagedRef.current = false
+      setContent(initialContent)
+      clearAttachments()
+    }
+  }, [loadedDraftId, initialContent, clearAttachments])
 
   // When attachments change, persist to draft storage
   useEffect(() => {

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -83,6 +83,8 @@ export interface DraftComposerState {
   isLoaded: boolean
   /** An E2E draft whose sealed body is still being decrypted into the composer. */
   isDecrypting: boolean
+  /** An E2E draft whose sealed body couldn't be decrypted (wrong recipient / garbled). */
+  decryptFailed: boolean
 }
 
 export function useDraftComposer({
@@ -96,6 +98,7 @@ export function useDraftComposer({
   const {
     isLoaded: isDraftLoaded,
     isDecrypting,
+    decryptFailed,
     contentJson: savedDraft,
     attachments: savedAttachments,
     contextRefs: savedContextRefs = [] as DraftContextRef[],
@@ -126,6 +129,12 @@ export function useDraftComposer({
   const [content, setContent] = useState<JSONContent>(initialContent)
   const [isSending, setIsSending] = useState(false)
   const hasInitialized = useRef(false)
+  // True once the user has touched the editor for the current draft. Gates the
+  // late-hydrate effect below so it only ever fills an editor the user hasn't
+  // engaged with — never overwriting typed content nor re-filling a draft the
+  // user just cleared (whose `savedDraft` lags by a debounce tick). Reset on
+  // scope change and on an explicit restore.
+  const userEngagedRef = useRef(false)
   const prevScopeIdRef = useRef<string | null>(null)
   // Keeps attachment persistence suspended until the previous scope's uploaded
   // attachments are gone from React state.
@@ -140,6 +149,7 @@ export function useDraftComposer({
     // On scope change, reset state
     if (isScopeChange) {
       hasInitialized.current = false
+      userEngagedRef.current = false
       suspendAttachmentPersistence.current = true
       staleAttachmentIdsRef.current = new Set(
         pendingAttachments.filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_")).map((a) => a.id)
@@ -181,6 +191,22 @@ export function useDraftComposer({
     pendingAttachments,
   ])
 
+  // Late hydrate: an E2E draft can finish decrypting AFTER the one-shot init
+  // above already ran — it was locked or still decrypting when the composer
+  // mounted, so `savedDraft` was empty then and becomes the real body only once
+  // the session unlocks. When that plaintext lands and the user hasn't engaged
+  // with the editor, drop it in. Every clause is a guard against clobbering:
+  // `isDraftLoaded`/`hasInitialized` wait for the first apply to be done;
+  // `userEngagedRef` yields the editor the moment the user types; `hasDocContent`
+  // skips when the editor already shows something (so a manual clear, whose
+  // `savedDraft` lags by a debounce tick, is never re-filled).
+  useEffect(() => {
+    if (!isDraftLoaded || !hasInitialized.current) return
+    if (userEngagedRef.current) return
+    if (hasDocContent(content)) return
+    if (hasDocContent(savedDraft)) setContent(savedDraft)
+  }, [isDraftLoaded, savedDraft, content])
+
   // When attachments change, persist to draft storage
   useEffect(() => {
     const uploaded = pendingAttachments.filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_"))
@@ -216,6 +242,8 @@ export function useDraftComposer({
   // Handle content change with draft persistence
   const handleContentChange = useCallback(
     (newContent: JSONContent) => {
+      // The user owns the editor from here on — suppress the late-hydrate effect.
+      userEngagedRef.current = true
       setContent(newContent)
       saveDraftDebounced(newContent)
     },
@@ -295,5 +323,6 @@ export function useDraftComposer({
     // Loading
     isLoaded: isDraftLoaded,
     isDecrypting,
+    decryptFailed,
   }
 }

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -60,12 +60,13 @@ export interface DraftComposerState {
   setIsSending: (sending: boolean) => void
 
   /**
-   * Persist the composer's current content into its loaded draft row immediately
-   * (bypassing the debounce), sealing it for E2E. Used by stash/restore to flush
-   * unsaved keystrokes into the row before it is detached or swapped, so nothing
-   * typed since the last debounce tick is lost.
+   * Persist the live editor content into the loaded draft row immediately
+   * (bypassing the debounce, sealing it for E2E) — but only when it is non-empty,
+   * so it never takes the empty→delete path. Used by stash/restore to preserve
+   * unsaved keystrokes before the loaded draft is detached or swapped, without
+   * risking deletion of a draft whose editor is still mid-hydration.
    */
-  saveDraft: (content: JSONContent) => Promise<void>
+  flushDraft: () => Promise<void>
   /**
    * Re-run the composer's init from whatever draft is now loaded for the scope.
    * Called after a stash/restore pointer move so the editor re-reads (and, for
@@ -150,6 +151,11 @@ export function useDraftComposer({
   // user just cleared (whose `savedDraft` lags by a debounce tick). Reset on
   // scope change and on an explicit restore.
   const userEngagedRef = useRef(false)
+  // Set by an explicit scope-change / stash-restore: the NEXT available loaded-draft
+  // body must be applied even over transient content the init effect may have
+  // re-filled from the previous draft during the swap (the in-place restore race).
+  // Cleared once that body lands; still yields to `userEngagedRef`.
+  const awaitingRehydrateRef = useRef(false)
   const prevScopeIdRef = useRef<string | null>(null)
   // Keeps attachment persistence suspended until the previous scope's uploaded
   // attachments are gone from React state.
@@ -160,6 +166,19 @@ export function useDraftComposer({
   // dependency (which would churn its identity every render).
   const pendingAttachmentsRef = useRef(pendingAttachments)
   pendingAttachmentsRef.current = pendingAttachments
+  // Latest editor content, so `flushDraft` always persists what's on screen now
+  // rather than a value captured in a stale closure.
+  const contentRef = useRef(content)
+  contentRef.current = content
+
+  // Persist the live editor content into the loaded draft row immediately
+  // (sealed for E2E), but ONLY when it is non-empty. A stash/restore can fire
+  // while the editor is still mid-hydration (transiently empty) — taking the
+  // empty→delete path then would silently destroy the loaded draft. An
+  // intentional clear is handled by the debounced save, never here.
+  const flushDraft = useCallback(async () => {
+    if (hasDocContent(contentRef.current)) await saveDraft(contentRef.current)
+  }, [saveDraft])
 
   // Blank the composer to an un-initialized state so the init effect below
   // re-hydrates it from whatever draft is now loaded for the scope. Used on both
@@ -170,6 +189,7 @@ export function useDraftComposer({
   const resetForReinit = useCallback(() => {
     hasInitialized.current = false
     userEngagedRef.current = false
+    awaitingRehydrateRef.current = true
     suspendAttachmentPersistence.current = true
     staleAttachmentIdsRef.current = new Set(
       pendingAttachmentsRef.current.filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_")).map((a) => a.id)
@@ -211,20 +231,31 @@ export function useDraftComposer({
     }
   }, [scopeId, isDraftLoaded, savedDraft, savedAttachments, restoreAttachments, resetForReinit])
 
-  // Late hydrate: an E2E draft can finish decrypting AFTER the one-shot init
-  // above already ran — it was locked or still decrypting when the composer
-  // mounted, so `savedDraft` was empty then and becomes the real body only once
-  // the session unlocks. When that plaintext lands and the user hasn't engaged
-  // with the editor, drop it in. Every clause is a guard against clobbering:
-  // `isDraftLoaded`/`hasInitialized` wait for the first apply to be done;
-  // `userEngagedRef` yields the editor the moment the user types; `hasDocContent`
-  // skips when the editor already shows something (so a manual clear, whose
-  // `savedDraft` lags by a debounce tick, is never re-filled).
+  // Late hydrate: the loaded draft's body can become available AFTER the one-shot
+  // init above already ran — an E2E draft that was locked or still decrypting at
+  // mount (unlock/decrypt lands later), or a stash/restore pointer move that
+  // swaps in a different draft whose body decrypts on a later tick. When that
+  // body lands and the user hasn't engaged with the editor, drop it in.
+  //
+  // Crucially this is NOT gated on `hasInitialized`: `markNeedsRehydrate` clears
+  // it on a restore, and the restored body may only resolve across a pending
+  // decrypt — so the apply has to survive that window. `userEngagedRef` is the
+  // real guard: it flips true on the first keystroke, so this never overwrites
+  // typed content nor re-fills a draft the user just cleared (whose `savedDraft`
+  // lags by a debounce tick).
+  //
+  // Apply when EITHER the editor is empty (unlock/late decrypt into an untouched
+  // editor) OR an explicit rehydrate is pending (scope change / stash-restore) —
+  // the latter overrides transient content the init effect may have re-filled
+  // from the OUTGOING draft before the pointer swap propagated (the in-place
+  // restore race). The override fires once, then clears.
   useEffect(() => {
-    if (!isDraftLoaded || !hasInitialized.current) return
+    if (!isDraftLoaded) return
     if (userEngagedRef.current) return
-    if (hasDocContent(content)) return
-    if (hasDocContent(savedDraft)) setContent(savedDraft)
+    if (!hasDocContent(savedDraft)) return
+    if (!awaitingRehydrateRef.current && hasDocContent(content)) return
+    setContent(savedDraft)
+    awaitingRehydrateRef.current = false
   }, [isDraftLoaded, savedDraft, content])
 
   // When attachments change, persist to draft storage
@@ -335,7 +366,7 @@ export function useDraftComposer({
     setIsSending,
 
     // Flush / re-hydrate (used by stash + restore)
-    saveDraft,
+    flushDraft,
     markNeedsRehydrate: resetForReinit,
 
     // Clear helpers

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -85,15 +85,6 @@ export interface DraftComposerState {
   resolveDraft: () => Promise<void>
   clearAttachments: () => void
 
-  /**
-   * Hydrate attachments from a snapshot (e.g. when restoring a stashed draft).
-   * Pushes them into the pending-attachments list; the persistence effect
-   * then writes them into the scope's loaded draft on next flush.
-   */
-  restoreAttachments: (
-    attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>
-  ) => void
-
   // Loading
   isLoaded: boolean
   /** An E2E draft whose sealed body is still being decrypted into the composer. */
@@ -356,13 +347,7 @@ export function useDraftComposer({
   )
 
   // Check if document has actual content (not just empty paragraphs)
-  const hasContent =
-    content.content?.some((node) => {
-      if (node.type === "paragraph") {
-        return node.content && node.content.length > 0
-      }
-      return true // Non-paragraph nodes count as content
-    }) ?? false
+  const hasContent = hasDocContent(content)
 
   // Sending while uploads are still in flight is not safe: the message would
   // be created before attachment IDs exist, leaving uploaded files unattached.
@@ -418,7 +403,6 @@ export function useDraftComposer({
     clearDraft,
     resolveDraft,
     clearAttachments,
-    restoreAttachments,
 
     // Loading
     isLoaded: isDraftLoaded,

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -146,11 +146,11 @@ export function useDraftComposer({
   const [content, setContent] = useState<JSONContent>(initialContent)
   const [isSending, setIsSending] = useState(false)
   const hasInitialized = useRef(false)
-  // True once the user has touched the editor for the current draft. Gates the
-  // late-hydrate effect below so it only ever fills an editor the user hasn't
-  // engaged with — never overwriting typed content nor re-filling a draft the
-  // user just cleared (whose `savedDraft` lags by a debounce tick). Reset on
-  // scope change and on an explicit restore.
+  // True once the user has touched the editor for the current draft. Gates BOTH
+  // the one-shot init fill and the late-hydrate effect below so they only ever
+  // fill an editor the user hasn't engaged with — never overwriting typed content
+  // nor re-filling a draft the user just cleared (whose `savedDraft` lags by a
+  // debounce tick). Reset on scope change and on an explicit restore.
   const userEngagedRef = useRef(false)
   // Set by an explicit scope-change / stash-restore: the NEXT available loaded-draft
   // body must be applied even over transient content the init effect may have
@@ -229,7 +229,14 @@ export function useDraftComposer({
 
     // Restore saved draft content and attachments
     if (!hasInitialized.current) {
-      if (hasDocContent(savedDraft)) {
+      // This one-shot init can be DEFERRED past the user's first keystroke: an E2E
+      // body only becomes readable once its decrypt lands (`isDraftLoaded` gates
+      // this effect off until then), so a fast typist may already own the editor by
+      // the time it finally runs. Filling content the user has engaged with would
+      // overwrite their keystrokes with the stale loaded body — a focused composer
+      // is never overwritten by anything but the user's own typing. Same guard the
+      // late-hydrate effect below uses.
+      if (hasDocContent(savedDraft) && !userEngagedRef.current) {
         setContent(savedDraft)
       }
       if (savedAttachments.length > 0) {
@@ -321,8 +328,11 @@ export function useDraftComposer({
   // Handle content change with draft persistence
   const handleContentChange = useCallback(
     (newContent: JSONContent) => {
-      // The user owns the editor from here on — suppress the late-hydrate effect.
+      // The user owns the editor from here on — suppress the init/late-hydrate
+      // fills, and cancel any pending rehydrate: a restore/scope-change body that
+      // hasn't landed yet is now moot, since the user's keystrokes supersede it.
       userEngagedRef.current = true
+      awaitingRehydrateRef.current = false
       setContent(newContent)
       saveDraftDebounced(newContent)
     },

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -12,8 +12,12 @@ export interface UseDraftComposerOptions {
   scopeId: string
   /** Initial content (optional, for pre-filled content as JSON) */
   initialContent?: JSONContent
-  /** When the destination stream is E2E, encrypt uploads client-side. */
-  e2eEnabled?: boolean
+  /**
+   * The encrypted stream the draft seals to — the root stream whose SSK wraps
+   * the body (a thread passes its root). Set only for E2E streams. Drives both
+   * client-side upload encryption and draft body sealing/decryption (Stage 4c).
+   */
+  e2eStreamId?: string | null
 }
 
 /** Check if a document is empty (no actual text content) */
@@ -84,7 +88,7 @@ export function useDraftComposer({
   draftKey,
   scopeId,
   initialContent = EMPTY_DOC,
-  e2eEnabled,
+  e2eStreamId,
 }: UseDraftComposerOptions): DraftComposerState {
   // Draft message persistence
   const {
@@ -97,7 +101,7 @@ export function useDraftComposer({
     removeAttachment: removeDraftAttachment,
     clearDraft,
     resolveDraft,
-  } = useDraftMessage(workspaceId, draftKey, e2eEnabled)
+  } = useDraftMessage(workspaceId, draftKey, e2eStreamId)
 
   // Attachment handling
   const {
@@ -113,7 +117,7 @@ export function useDraftComposer({
     clear: clearAttachments,
     restore: restoreAttachments,
     imageCount,
-  } = useAttachments(workspaceId, { e2eEnabled })
+  } = useAttachments(workspaceId, { e2eEnabled: !!e2eStreamId })
 
   // Local state
   const [content, setContent] = useState<JSONContent>(initialContent)

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -8,7 +8,7 @@ import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-stor
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
 import * as sealDraft from "@/lib/crypto/seal-draft"
-import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
+import { seedDecryption, clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const makeDoc = (text: string): JSONContent => ({
@@ -499,6 +499,38 @@ describe("useDraftMessage", () => {
       expect(result.current.contentJson).toEqual(EMPTY_DOC)
       // The sealed row is kept (only plaintext rows are purged) so it decrypts on unlock.
       expect(await db.drafts.get("draft_sealed")).toBeDefined()
+    })
+
+    it("re-seeds the decrypt cache on every edit of the same draft id (no stale first edit)", async () => {
+      // A draft id is stable across edits, so the seal path must REPLACE the
+      // cached plaintext each time. Without `invalidateDecryption`, `seedDecryption`
+      // would short-circuit on the already-decrypted id and the read path would
+      // serve the FIRST edit forever — the latest keystrokes look lost on remount
+      // (safe in the sealed row at rest, but never displayed).
+      vi.spyOn(sealDraft, "sealDraftContent").mockResolvedValue({
+        ciphertext: "ct",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+        contentMarkdown: "x",
+      })
+      await seedDraftCacheFromIdb(workspaceId)
+
+      await upsertLoadedDraft(
+        workspaceId,
+        draftKey,
+        { contentJson: makeDoc("first edit"), attachments: [] },
+        { senderId: "user_1", streamId: e2eStreamId }
+      )
+      const id = (await db.composerLoaded.get(draftKey))!.draftId!
+      expect(getCachedDecryption(id)?.content?.contentJson).toEqual(makeDoc("first edit"))
+
+      await upsertLoadedDraft(
+        workspaceId,
+        draftKey,
+        { contentJson: makeDoc("second edit"), attachments: [] },
+        { senderId: "user_1", streamId: e2eStreamId }
+      )
+      expect(getCachedDecryption(id)?.content?.contentJson).toEqual(makeDoc("second edit"))
     })
 
     it("keeps content in the composer (no plaintext written) when the session is locked", async () => {

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -8,6 +8,7 @@ import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-stor
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
 import * as sealDraft from "@/lib/crypto/seal-draft"
+import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const makeDoc = (text: string): JSONContent => ({
@@ -424,14 +425,36 @@ describe("useDraftMessage", () => {
     } as ReturnType<typeof e2eSessionStore.useE2eSession>
 
     beforeEach(() => {
+      clearDecryptCache()
       vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
       vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(unlockedSession)
     })
 
+    /** Persist a sealed (E2E) draft loaded into the composer for the scope. */
+    async function putSealedLoaded(id: string) {
+      await db.drafts.put({
+        id,
+        workspaceId,
+        scope: draftKey,
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        ciphertext: "ct_sealed",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+        baseVersion: 1,
+        clientUpdatedAt: Date.now(),
+      })
+      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: id })
+      await seedDraftCacheFromIdb(workspaceId)
+    }
+
     it("seals the body and persists ciphertext only — never plaintext at rest (E2EE-4)", async () => {
-      const sealSpy = vi
-        .spyOn(sealDraft, "sealDraftContent")
-        .mockResolvedValue({ ciphertext: "ct_sealed", envelope: { v: 2 }, e2eVersion: 2 })
+      const sealSpy = vi.spyOn(sealDraft, "sealDraftContent").mockResolvedValue({
+        ciphertext: "ct_sealed",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+        contentMarkdown: "top secret",
+      })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
 
@@ -451,62 +474,31 @@ describe("useDraftMessage", () => {
       expect(await db.pendingOperations.where("type").equals("upsert_draft").count()).toBe(1)
     })
 
-    it("decrypts a sealed loaded draft into the composer on load", async () => {
-      vi.spyOn(sealDraft, "decryptDraftContent").mockResolvedValue(makeDoc("decrypted body"))
-      await db.drafts.put({
-        id: "draft_sealed",
-        workspaceId,
-        scope: draftKey,
-        contentJson: EMPTY_DOC,
-        attachments: [],
-        ciphertext: "ct_sealed",
-        envelope: { v: 2 },
-        e2eVersion: 2,
-        baseVersion: 1,
-        clientUpdatedAt: Date.now(),
-      })
-      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_sealed" })
-      await seedDraftCacheFromIdb(workspaceId)
+    it("surfaces the decrypted body on load via the shared decrypt cache", async () => {
+      await putSealedLoaded("draft_sealed")
+      // The plaintext is in the shared cache — seeded by the authoring device's
+      // save, or (on a fresh device) populated by the read path's decrypt. Either
+      // way the composer reads it back the same way a message does.
+      seedDecryption("draft_sealed", { contentMarkdown: "decrypted body", contentJson: makeDoc("decrypted body") })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
 
       await waitFor(() => expect(result.current.isLoaded).toBe(true))
       expect(result.current.contentJson).toEqual(makeDoc("decrypted body"))
+      expect(result.current.isDecrypting).toBe(false)
     })
 
-    it("drops the decrypted body from memory on lock and re-decrypts on the next unlock (E2EE-4)", async () => {
-      let session = unlockedSession
-      vi.spyOn(e2eSessionStore, "useE2eSession").mockImplementation(() => session)
-      const decryptSpy = vi.spyOn(sealDraft, "decryptDraftContent").mockResolvedValue(makeDoc("secret body"))
-      await db.drafts.put({
-        id: "draft_sealed",
-        workspaceId,
-        scope: draftKey,
-        contentJson: EMPTY_DOC,
-        attachments: [],
-        ciphertext: "ct",
-        envelope: { v: 2 },
-        e2eVersion: 2,
-        baseVersion: 1,
-        clientUpdatedAt: Date.now(),
-      })
-      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_sealed" })
-      await seedDraftCacheFromIdb(workspaceId)
+    it("reports a locked sealed draft as empty (not stuck), without losing the row", async () => {
+      vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+      await putSealedLoaded("draft_sealed")
 
-      const { result, rerender } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
-      await waitFor(() => expect(result.current.contentJson).toEqual(makeDoc("secret body")))
-      expect(decryptSpy).toHaveBeenCalledTimes(1)
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
 
-      // Lock: the in-memory plaintext must go, and the composer must stop surfacing it.
-      session = LOCKED_SESSION
-      rerender()
-      await waitFor(() => expect(result.current.contentJson).toEqual(EMPTY_DOC))
-
-      // Unlock again: the body is re-decrypted from the still-sealed row, not reused.
-      session = unlockedSession
-      rerender()
-      await waitFor(() => expect(result.current.contentJson).toEqual(makeDoc("secret body")))
-      expect(decryptSpy).toHaveBeenCalledTimes(2)
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+      expect(result.current.isDecrypting).toBe(false)
+      expect(result.current.contentJson).toEqual(EMPTY_DOC)
+      // The sealed row is kept (only plaintext rows are purged) so it decrypts on unlock.
+      expect(await db.drafts.get("draft_sealed")).toBeDefined()
     })
 
     it("keeps content in the composer (no plaintext written) when the session is locked", async () => {

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -474,6 +474,41 @@ describe("useDraftMessage", () => {
       expect(result.current.contentJson).toEqual(makeDoc("decrypted body"))
     })
 
+    it("drops the decrypted body from memory on lock and re-decrypts on the next unlock (E2EE-4)", async () => {
+      let session = unlockedSession
+      vi.spyOn(e2eSessionStore, "useE2eSession").mockImplementation(() => session)
+      const decryptSpy = vi.spyOn(sealDraft, "decryptDraftContent").mockResolvedValue(makeDoc("secret body"))
+      await db.drafts.put({
+        id: "draft_sealed",
+        workspaceId,
+        scope: draftKey,
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        ciphertext: "ct",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+        baseVersion: 1,
+        clientUpdatedAt: Date.now(),
+      })
+      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_sealed" })
+      await seedDraftCacheFromIdb(workspaceId)
+
+      const { result, rerender } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+      await waitFor(() => expect(result.current.contentJson).toEqual(makeDoc("secret body")))
+      expect(decryptSpy).toHaveBeenCalledTimes(1)
+
+      // Lock: the in-memory plaintext must go, and the composer must stop surfacing it.
+      session = LOCKED_SESSION
+      rerender()
+      await waitFor(() => expect(result.current.contentJson).toEqual(EMPTY_DOC))
+
+      // Unlock again: the body is re-decrypted from the still-sealed row, not reused.
+      session = unlockedSession
+      rerender()
+      await waitFor(() => expect(result.current.contentJson).toEqual(makeDoc("secret body")))
+      expect(decryptSpy).toHaveBeenCalledTimes(2)
+    })
+
     it("keeps content in the composer (no plaintext written) when the session is locked", async () => {
       vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
       const sealSpy = vi.spyOn(sealDraft, "sealDraftContent")

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -5,6 +5,9 @@ import { ContextRefKinds, type JSONContent } from "@threa/types"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import { db } from "@/db"
 import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import * as currentUserHook from "./use-current-workspace-user-id"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
+import * as sealDraft from "@/lib/crypto/seal-draft"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const makeDoc = (text: string): JSONContent => ({
@@ -14,6 +17,16 @@ const makeDoc = (text: string): JSONContent => ({
 
 const workspaceId = "ws_123"
 const draftKey = "stream:stream_456"
+
+/** A locked E2E session — the default; the composer must not seal/decrypt. */
+const LOCKED_SESSION = {
+  status: "locked",
+  keyId: null,
+  publicKey: null,
+  privateKey: null,
+  deviceTrusted: false,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
 
 /** Read back the single loaded draft for a scope (or undefined). */
 async function loadedDraft(scope: string) {
@@ -37,6 +50,12 @@ describe("useDraftMessage", () => {
     resetDraftStoreCache()
     await db.drafts.clear()
     await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    // The composer reads the viewer id + E2E session unconditionally now; default
+    // them to "no viewer / locked" so the plaintext tests run without an
+    // AuthProvider, and override per-test for the unlocked-E2E cases.
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
   })
 
   afterEach(() => {
@@ -114,11 +133,11 @@ describe("useDraftMessage", () => {
       expect(persisted!.id.startsWith("draft_")).toBe(true)
     })
 
-    it("never persists a draft for an E2E stream and purges any on disk (E2EE-4)", async () => {
-      // A plaintext draft written before the gate existed...
+    it("while locked, never persists an E2E draft and purges plaintext on disk (E2EE-4)", async () => {
+      // A plaintext draft written before the stream was encrypted...
       await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("secret"), attachments: [] })
 
-      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, true))
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, "stream_e2e_root"))
 
       await act(async () => {
         await result.current.saveDraft(makeDoc("secret plaintext"))
@@ -126,25 +145,26 @@ describe("useDraftMessage", () => {
         await result.current.addAttachment({ id: "att_1", filename: "f", mimeType: "text/plain", sizeBytes: 1 })
       })
 
-      // ...is purged on mount, and nothing new is written to disk.
+      // ...is purged on mount, and nothing new persists while the session is locked.
       await waitFor(async () => expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0))
       expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
     })
 
     it("cancels a debounced plaintext save when the stream becomes encrypted mid-flight (E2EE-4 race)", async () => {
       const { result, rerender } = renderHook(
-        ({ e2e }: { e2e: boolean }) => useDraftMessage(workspaceId, draftKey, e2e),
+        ({ e2e }: { e2e: string | undefined }) => useDraftMessage(workspaceId, draftKey, e2e),
         {
-          initialProps: { e2e: false },
+          initialProps: { e2e: undefined as string | undefined },
         }
       )
 
       act(() => {
         result.current.saveDraftDebounced(makeDoc("typed before the stream was encrypted"))
       })
-      rerender({ e2e: true })
+      rerender({ e2e: "stream_e2e_root" })
 
-      // Past the debounce window: the in-flight save must NOT persist plaintext.
+      // Past the debounce window: the in-flight save reads the live (now encrypted,
+      // locked) gate and must NOT persist plaintext.
       await new Promise((r) => setTimeout(r, 700))
       expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
     })
@@ -389,6 +409,83 @@ describe("useDraftMessage", () => {
 
       expect(await loadedDraft(draftKey)).toBeUndefined()
       expect(await db.pendingOperations.where("type").equals("resolve_draft").count()).toBe(0)
+    })
+  })
+
+  describe("E2E drafts (unlocked session)", () => {
+    const e2eStreamId = "stream_e2e_root"
+    const unlockedSession = {
+      status: "unlocked",
+      keyId: "ek_test",
+      publicKey: null,
+      privateKey: {} as CryptoKey,
+      deviceTrusted: true,
+      error: null,
+    } as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+    beforeEach(() => {
+      vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+      vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(unlockedSession)
+    })
+
+    it("seals the body and persists ciphertext only — never plaintext at rest (E2EE-4)", async () => {
+      const sealSpy = vi
+        .spyOn(sealDraft, "sealDraftContent")
+        .mockResolvedValue({ ciphertext: "ct_sealed", envelope: { v: 2 }, e2eVersion: 2 })
+
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+
+      await act(async () => {
+        await result.current.saveDraft(makeDoc("top secret"))
+      })
+
+      const persisted = await loadedDraft(draftKey)
+      expect(persisted?.ciphertext).toBe("ct_sealed")
+      expect(persisted?.e2eVersion).toBe(2)
+      // The plaintext body never lands on disk — only the empty placeholder does.
+      expect(persisted?.contentJson).toEqual(EMPTY_DOC)
+      expect(sealSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ senderId: "user_1", streamId: e2eStreamId, contentJson: makeDoc("top secret") })
+      )
+      // And it is queued to roam to the author's other devices.
+      expect(await db.pendingOperations.where("type").equals("upsert_draft").count()).toBe(1)
+    })
+
+    it("decrypts a sealed loaded draft into the composer on load", async () => {
+      vi.spyOn(sealDraft, "decryptDraftContent").mockResolvedValue(makeDoc("decrypted body"))
+      await db.drafts.put({
+        id: "draft_sealed",
+        workspaceId,
+        scope: draftKey,
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        ciphertext: "ct_sealed",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+        baseVersion: 1,
+        clientUpdatedAt: Date.now(),
+      })
+      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_sealed" })
+      await seedDraftCacheFromIdb(workspaceId)
+
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+
+      await waitFor(() => expect(result.current.isLoaded).toBe(true))
+      expect(result.current.contentJson).toEqual(makeDoc("decrypted body"))
+    })
+
+    it("keeps content in the composer (no plaintext written) when the session is locked", async () => {
+      vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+      const sealSpy = vi.spyOn(sealDraft, "sealDraftContent")
+
+      const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+
+      await act(async () => {
+        await result.current.saveDraft(makeDoc("secret while locked"))
+      })
+
+      expect(sealSpy).not.toHaveBeenCalled()
+      expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
     })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -14,10 +14,10 @@ import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraft
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { sealDraftContent } from "@/lib/crypto/seal-draft"
-import { seedDecryption } from "@/lib/crypto/decrypt-cache"
+import { invalidateDecryption, seedDecryption } from "@/lib/crypto/decrypt-cache"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { useDecryptedDraftContent } from "./use-decrypted-draft-content"
 
@@ -34,8 +34,6 @@ export function getDraftMessageKey(
 }
 
 const DEBOUNCE_MS = import.meta.env.VITE_DRAFT_DEBOUNCE_MS ? Number(import.meta.env.VITE_DRAFT_DEBOUNCE_MS) : 500
-
-const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 
 /** Resolve the draft id currently checked out into the composer for a scope. */
 async function getLoadedDraftId(scope: string): Promise<string | null> {
@@ -65,10 +63,12 @@ export interface DraftSealContext {
  * only the `ciphertext`/`envelope`/`e2eVersion` sibling is persisted — IDB never
  * holds the plaintext (E2EE-4, treat IDB like the backend).
  *
- * On the E2E path the shared decrypt cache is seeded with the just-authored
- * plaintext, so the read path (`useDecryptedDraftContent`) serves the live body
- * with no self-decrypt round-trip and an edit is never served stale from a prior
- * cached decrypt of this id. The seed is dropped with every other entry on lock.
+ * On the E2E path the shared decrypt cache is invalidated and then re-seeded with
+ * the just-authored plaintext, so the read path (`useDecryptedDraftContent`) serves
+ * the live body with no self-decrypt round-trip. The invalidate matters because a
+ * draft id is stable across edits: `seedDecryption` alone no-ops once an id is
+ * decrypted, so without it the SECOND edit would be ignored and a remount would
+ * render the first edit's body. The seed is dropped with every other entry on lock.
  *
  * v1 seals the body only — attachments / context refs on E2E drafts stay
  * session-local — so the seal path doesn't carry them.
@@ -145,7 +145,10 @@ export async function upsertLoadedDraft(
   }
 
   if (seal) {
-    // Keep the read path serving the live plaintext (see the doc comment above).
+    // Keep the read path serving the live plaintext (see the doc comment above):
+    // invalidate the reused id's stale entry, then seed the fresh body so the
+    // next decrypt-on-read (and any remount) serves THIS edit, not a prior one.
+    invalidateDecryption(id)
     seedDecryption(id, {
       contentMarkdown: serializeToMarkdown(fields.contentJson),
       contentJson: fields.contentJson,

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { db, generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import {
@@ -13,10 +13,13 @@ import {
 import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
+import { serializeToMarkdown } from "@threa/prosemirror"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { decryptDraftContent, sealDraftContent } from "@/lib/crypto/seal-draft"
+import { sealDraftContent } from "@/lib/crypto/seal-draft"
+import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
+import { useDecryptedDraftContent } from "./use-decrypted-draft-content"
 
 // Key formats (a draft's `scope`):
 // - "stream:{streamId}" for messages in existing streams
@@ -47,33 +50,85 @@ export interface DraftFields {
 }
 
 /**
- * Create or update the draft currently loaded into the composer for `scope`,
- * setting the loaded pointer when a fresh draft is minted. Writes IDB and the
- * in-memory cache together so the composer reflects the change on next paint.
- * Shared by `useDraftMessage` and the context-bag / share-target seeders so a
- * scope never ends up with a draft that no pointer references.
+ * E2E seal context for a draft write — present only for encrypted streams.
+ * `streamId` is the encrypted root whose current SSK seals the body.
  */
-export async function upsertLoadedDraft(workspaceId: string, scope: string, fields: DraftFields): Promise<CachedDraft> {
+export interface DraftSealContext {
+  senderId: string
+  streamId: string
+}
+
+/**
+ * Create or update the draft loaded into the composer for `scope`. The single
+ * write path for both shapes (INV-35): with no `seal` context the body is stored
+ * as plaintext `contentJson`; with one, the body is sealed to the stream SSK and
+ * only the `ciphertext`/`envelope`/`e2eVersion` sibling is persisted — IDB never
+ * holds the plaintext (E2EE-4, treat IDB like the backend).
+ *
+ * On the E2E path the shared decrypt cache is seeded with the just-authored
+ * plaintext, so the read path (`useDecryptedDraftContent`) serves the live body
+ * with no self-decrypt round-trip and an edit is never served stale from a prior
+ * cached decrypt of this id. The seed is dropped with every other entry on lock.
+ *
+ * v1 seals the body only — attachments / context refs on E2E drafts stay
+ * session-local — so the seal path doesn't carry them.
+ */
+export async function upsertLoadedDraft(
+  workspaceId: string,
+  scope: string,
+  fields: DraftFields,
+  seal?: DraftSealContext
+): Promise<CachedDraft> {
   const loadedId = await getLoadedDraftId(scope)
   const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+  // The draft id binds the seal AAD (in the message-id slot), so resolve it
+  // before sealing — a re-seal of the same draft reuses the id.
   const id = existing?.id ?? generateLocalDraftId()
-  const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
-  const row: CachedDraft = {
-    id,
-    workspaceId,
-    scope,
-    contentJson: fields.contentJson,
-    attachments: fields.attachments,
-    contextRefs,
-    clientUpdatedAt: Date.now(),
-    // Carry the sync bookkeeping forward. Without this, editing a
-    // confirmed draft would reset baseVersion to undefined, and the next push
-    // (expectedVersion 0) would collide with the server's existing row and the
-    // server would SPLIT it into a duplicate — once per keystroke after the
-    // first sync. Preserve it so the push CAS-updates in place instead.
-    baseVersion: existing?.baseVersion,
-    attachmentIds: existing?.attachmentIds,
+
+  let row: CachedDraft
+  if (seal) {
+    const sealed = await sealDraftContent({
+      workspaceId,
+      senderId: seal.senderId,
+      streamId: seal.streamId,
+      draftId: id,
+      contentJson: fields.contentJson,
+    })
+    row = {
+      id,
+      workspaceId,
+      scope,
+      // E2EE-4: the plaintext never lands on disk — the sealed body is the
+      // at-rest copy and `contentJson` is only the empty placeholder.
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+      baseVersion: existing?.baseVersion,
+      attachmentIds: existing?.attachmentIds,
+      ciphertext: sealed.ciphertext,
+      envelope: sealed.envelope,
+      e2eVersion: sealed.e2eVersion,
+    }
+  } else {
+    const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
+    row = {
+      id,
+      workspaceId,
+      scope,
+      contentJson: fields.contentJson,
+      attachments: fields.attachments,
+      contextRefs,
+      clientUpdatedAt: Date.now(),
+      // Carry the sync bookkeeping forward. Without this, editing a confirmed
+      // draft would reset baseVersion to undefined, and the next push
+      // (expectedVersion 0) would collide with the server's existing row and the
+      // server would SPLIT it into a duplicate — once per keystroke after the
+      // first sync. Preserve it so the push CAS-updates in place instead.
+      baseVersion: existing?.baseVersion,
+      attachmentIds: existing?.attachmentIds,
+    }
   }
+
   if (existing) {
     await db.drafts.put(row)
     upsertDraftInCache(workspaceId, row)
@@ -88,66 +143,21 @@ export async function upsertLoadedDraft(workspaceId: string, scope: string, fiel
     })
     upsertLoadedDraftInCache(workspaceId, row, scope)
   }
-  // Mirror to the backend: a coalesced, debounced push that retries
-  // silently. The caller kicks the queue so it drains promptly.
+
+  if (seal) {
+    // Keep the read path serving the live plaintext (see the doc comment above).
+    seedDecryption(id, {
+      contentMarkdown: serializeToMarkdown(fields.contentJson),
+      contentJson: fields.contentJson,
+      attachmentRefs: [],
+      sources: [],
+    })
+  }
+
+  // Mirror to the backend: a coalesced, debounced push that retries silently.
+  // The caller kicks the queue so it drains promptly.
   await enqueueDraftUpsert(workspaceId, id)
   return row
-}
-
-/**
- * Seal-and-persist the loaded draft for an E2E `scope` (Stage 4c). The body is
- * sealed to the stream's SSK before it touches IndexedDB, so only ciphertext is
- * at rest (E2EE-4) — `contentJson` on the row is the empty placeholder and the
- * composer decrypts the body into memory on load. Otherwise mirrors
- * `upsertLoadedDraft`: reuse/mint the loaded id, set the pointer when the draft
- * is new, and enqueue the debounced push (which sends the ciphertext triple).
- *
- * Throws if the session is locked or the SSK can't be resolved — the caller
- * keeps the content in the composer and never surfaces the failure.
- */
-export async function upsertLoadedSealedDraft(
-  workspaceId: string,
-  scope: string,
-  fields: { senderId: string; streamId: string; contentJson: JSONContent }
-): Promise<void> {
-  const loadedId = await getLoadedDraftId(scope)
-  const existing = loadedId ? await db.drafts.get(loadedId) : undefined
-  const id = existing?.id ?? generateLocalDraftId()
-  // The draft id binds the seal AAD (in the message-id slot), so resolve it
-  // before sealing — a re-seal of the same draft reuses the id.
-  const sealed = await sealDraftContent({
-    workspaceId,
-    senderId: fields.senderId,
-    streamId: fields.streamId,
-    draftId: id,
-    contentJson: fields.contentJson,
-  })
-  const row: CachedDraft = {
-    id,
-    workspaceId,
-    scope,
-    // E2EE-4: the plaintext never lands on disk — the sealed body is the
-    // at-rest copy and `contentJson` is only the empty placeholder.
-    contentJson: EMPTY_DOC,
-    attachments: [],
-    clientUpdatedAt: Date.now(),
-    baseVersion: existing?.baseVersion,
-    attachmentIds: existing?.attachmentIds,
-    ciphertext: sealed.ciphertext,
-    envelope: sealed.envelope,
-    e2eVersion: sealed.e2eVersion,
-  }
-  if (existing) {
-    await db.drafts.put(row)
-    upsertDraftInCache(workspaceId, row)
-  } else {
-    await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
-      await db.drafts.put(row)
-      await db.composerLoaded.put({ scope, workspaceId, draftId: id })
-    })
-    upsertLoadedDraftInCache(workspaceId, row, scope)
-  }
-  await enqueueDraftUpsert(workspaceId, id)
 }
 
 /**
@@ -206,9 +216,8 @@ export async function resolveLoadedDraft(workspaceId: string, scope: string): Pr
 }
 
 /**
- * Delete every draft for `scope` and clear its pointer. Used by the E2E gate to
- * ensure no plaintext draft (loaded or stashed) for a sealed stream stays at
- * rest (E2EE-4).
+ * Delete every draft for `scope` and clear its pointer. Used by the draft-stream
+ * promotion / discard flows to clear a scope entirely.
  */
 export async function purgeScopeDrafts(workspaceId: string, scope: string): Promise<void> {
   // Read + delete the rows AND clear the loaded pointer atomically: `baseVersion`
@@ -230,9 +239,10 @@ export async function purgeScopeDrafts(workspaceId: string, scope: string): Prom
 /**
  * Delete only the PLAINTEXT drafts for an E2E `scope`, keeping sealed rows. Run
  * on mount of an encrypted-stream composer: a plaintext draft written before the
- * stream was encrypted (or before the seal path existed) must not stay at rest
- * (E2EE-4), but a sealed draft is the legitimate roaming copy and is preserved.
- * The loaded pointer is cleared only when it referenced a purged plaintext row.
+ * stream was encrypted (or in the brief window before the stream row loaded and
+ * the composer knew it was E2E) must not stay at rest (E2EE-4), but a sealed
+ * draft is the legitimate roaming copy and is preserved. The loaded pointer is
+ * cleared only when it referenced a purged plaintext row.
  */
 export async function purgePlaintextScopeDrafts(workspaceId: string, scope: string): Promise<void> {
   let clearedPointer = false
@@ -276,20 +286,19 @@ export async function rescopeScopeDrafts(workspaceId: string, fromScope: string,
  * @param e2eStreamId The encrypted stream the draft seals to — the root stream
  *   whose SSK wraps the body (a thread passes its root). Pass it only for E2E
  *   streams; `undefined`/`null` means plaintext. When set and the session is
- *   unlocked, the body is sealed before it touches disk and decrypted into the
- *   composer on load (Stage 4c, E2EE-4); while the session is locked the composer
- *   behaves as it did before this stage — nothing loads or persists, and the
- *   sealed row waits on disk for unlock. Attachments / context refs / slash
- *   commands on E2E drafts are not sealed yet and stay session-local.
+ *   unlocked, the body is sealed before it touches disk (E2EE-4) and decrypted
+ *   on read through the shared decrypt cache (the same path messages use), which
+ *   retries on unlock and clears on lock. While the session is locked the read
+ *   reports `locked` and the composer shows the encryption notice; the sealed row
+ *   waits on disk. Attachments / context refs on E2E drafts stay session-local.
  */
 export function useDraftMessage(workspaceId: string, draftKey: string, e2eStreamId?: string | null) {
   const e2eEnabled = !!e2eStreamId
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Seal/decrypt need the viewer's workspace user id and unlocked UIK. Both are
-  // read here (not threaded from the call site) so the composer reacts when the
-  // session unlocks — a locked scope becomes a sealing/decrypting one without a
-  // remount.
+  // Seal needs the viewer's workspace user id and unlocked UIK. Read here (not
+  // threaded from the call site) so the composer reacts when the session unlocks
+  // without a remount.
   const senderId = useCurrentWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, senderId ?? "")
   const e2eUnlocked =
@@ -297,10 +306,16 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
 
   const drafts = useDraftsFromStore(workspaceId)
   const loaded = useComposerLoadedFromStore(workspaceId)
-  // A locked E2E scope behaves as it did before Stage 4c: nothing is checked out
-  // and nothing persists. Only the unlocked path resolves a loaded draft.
-  const loadedId = e2eEnabled && !e2eUnlocked ? null : (loaded.find((row) => row.scope === draftKey)?.draftId ?? null)
+  // The loaded row resolves the same whether the stream is plaintext, E2E-locked,
+  // or E2E-unlocked — the read path below reports the right status. (A locked E2E
+  // draft resolves its row but renders as `locked`, not as content.)
+  const loadedId = loaded.find((row) => row.scope === draftKey)?.draftId ?? null
   const resolvedDraft = loadedId ? drafts.find((draft) => draft.id === loadedId) : undefined
+
+  // Decrypt-on-read through the shared cache — same path messages use. Branches
+  // on `ciphertext`, holds at `pending` until the root is known + session
+  // unlocked, retries on unlock, clears on lock. No bespoke per-hook decrypt.
+  const decryptedContent = useDecryptedDraftContent(workspaceId, resolvedDraft, e2eStreamId)
 
   // Drains the offline queue so a debounced draft push (enqueued by the write
   // helpers) mirrors to the backend promptly instead of waiting for the next
@@ -317,50 +332,8 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     e2eGateRef.current = { enabled: e2eEnabled, unlocked: e2eUnlocked, senderId, streamId: e2eStreamId ?? null }
   }, [e2eEnabled, e2eUnlocked, senderId, e2eStreamId])
 
-  // Decrypt-on-load: an unlocked E2E draft is decrypted into memory once per
-  // loaded id. A self-edit re-seals the row under the same id without
-  // re-decrypting — the composer holds the live plaintext after it initializes,
-  // so this only needs to seed that first paint.
-  const [decrypted, setDecrypted] = useState<{ id: string; content: JSONContent } | null>(null)
-  const sealedLoaded = e2eUnlocked && resolvedDraft?.ciphertext ? resolvedDraft : undefined
-  const decryptReady = !sealedLoaded || decrypted?.id === sealedLoaded.id
-
-  useEffect(() => {
-    if (!sealedLoaded?.ciphertext || !e2eStreamId || !session.privateKey || !session.keyId) return
-    if (decrypted?.id === sealedLoaded.id) return
-    let cancelled = false
-    void decryptDraftContent({
-      ciphertext: sealedLoaded.ciphertext,
-      envelope: sealedLoaded.envelope,
-      e2eVersion: sealedLoaded.e2eVersion,
-      workspaceId,
-      streamId: e2eStreamId,
-      privateKey: session.privateKey,
-      recipientKeyId: session.keyId,
-    }).then((content) => {
-      // A null result is a transient/blocked decrypt (session locked mid-flight,
-      // key not yet resolvable). Leave `decrypted` unset so the effect retries
-      // when a dep changes (e.g. the session unlocks) instead of baking an empty
-      // body in — which the same-id guard would then make permanent, inviting the
-      // user to type over a still-recoverable sealed draft.
-      if (!cancelled && content) setDecrypted({ id: sealedLoaded.id, content })
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [sealedLoaded, e2eStreamId, session.privateKey, session.keyId, workspaceId, decrypted?.id])
-
-  // Drop the decrypted plaintext from memory when the scope changes OR the
-  // session locks. IDB only ever holds ciphertext for an E2E draft (E2EE-4 —
-  // treat it like the backend), so this in-memory copy is the only plaintext,
-  // and it must not outlive the unlocked session or a navigated-away scope —
-  // mirroring the message decrypt-cache's clear-on-lock.
-  useEffect(() => {
-    setDecrypted(null)
-  }, [draftKey, e2eUnlocked])
-
   // Purge only the PLAINTEXT drafts left on disk for an E2E scope (one written
-  // before the stream was encrypted, or before the seal path existed). Sealed
+  // before the stream was encrypted, or before the stream row loaded). Sealed
   // rows are the legitimate roaming copy and are kept — only plaintext at rest
   // violates E2EE-4.
   useEffect(() => {
@@ -388,11 +361,12 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
           return
         }
         try {
-          await upsertLoadedSealedDraft(workspaceId, draftKey, {
-            senderId: gate.senderId,
-            streamId: gate.streamId,
-            contentJson,
-          })
+          await upsertLoadedDraft(
+            workspaceId,
+            draftKey,
+            { contentJson, attachments: [] },
+            { senderId: gate.senderId, streamId: gate.streamId }
+          )
           syncEngine?.kickOperationQueue()
         } catch (err) {
           // A failed seal (e.g. the session locked between the gate check and the
@@ -450,7 +424,8 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
    */
   const addAttachment = useCallback(
     async (attachment: DraftAttachment) => {
-      // E2EE-4: encrypted-stream drafts (incl. attachment metadata) stay in memory.
+      // E2EE-4: attachments on encrypted-stream drafts are not sealed yet (v1) —
+      // they stay in the composer session and are not persisted to the draft.
       if (e2eEnabled) return
       const currentLoadedId = await getLoadedDraftId(draftKey)
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
@@ -539,17 +514,20 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     }
   }, [])
 
-  // For an unlocked E2E draft the renderable content is the in-memory decrypt,
-  // not the on-disk placeholder; everything else reads straight off the row.
-  const decryptedForLoaded =
-    sealedLoaded && decrypted && decrypted.id === sealedLoaded.id ? decrypted.content : EMPTY_DOC
-  const contentJson = e2eUnlocked ? decryptedForLoaded : (resolvedDraft?.contentJson ?? EMPTY_DOC)
+  // The renderable body comes from the shared read path: decrypted/plaintext
+  // content, or the empty placeholder while locked/decrypting/failed/absent.
+  const contentJson =
+    decryptedContent.status === "decrypted" || decryptedContent.status === "plaintext"
+      ? decryptedContent.contentJson
+      : EMPTY_DOC
 
   return {
-    /** True once Dexie has loaded and (for an unlocked E2E draft) decryption has resolved. */
-    isLoaded: hasSeededDraftCache(workspaceId) && decryptReady,
-    /** An unlocked E2E draft whose sealed body is still being decrypted into the composer. */
-    isDecrypting: !decryptReady,
+    /** True once Dexie has loaded and (for an E2E draft) the read has settled (not mid-decrypt). */
+    isLoaded: hasSeededDraftCache(workspaceId) && decryptedContent.status !== "pending",
+    /** An E2E draft whose sealed body is still being decrypted into the composer. */
+    isDecrypting: decryptedContent.status === "pending",
+    /** An E2E draft whose body couldn't be decrypted (wrong recipient / garbled). */
+    decryptFailed: decryptedContent.status === "failed",
     contentJson,
     attachments: resolvedDraft?.attachments ?? [],
     /** Sidecar context refs attached to the draft (see DraftContextRef). */

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -99,12 +99,14 @@ export async function upsertLoadedDraft(
       workspaceId,
       scope,
       // E2EE-4: the plaintext never lands on disk — the sealed body is the
-      // at-rest copy and `contentJson` is only the empty placeholder.
+      // at-rest copy and `contentJson` is only the empty placeholder. v1 seals
+      // the body only and does not carry attachments, so `attachmentIds` is left
+      // off too — an E2E row must not ship plaintext attachment linkage to the
+      // server/disk alongside its sealed body.
       contentJson: EMPTY_DOC,
       attachments: [],
       clientUpdatedAt: Date.now(),
       baseVersion: existing?.baseVersion,
-      attachmentIds: existing?.attachmentIds,
       ciphertext: sealed.ciphertext,
       envelope: sealed.envelope,
       e2eVersion: sealed.e2eVersion,

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { db, generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import {
@@ -14,6 +14,9 @@ import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraft
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { decryptDraftContent, sealDraftContent } from "@/lib/crypto/seal-draft"
+import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 
 // Key formats (a draft's `scope`):
 // - "stream:{streamId}" for messages in existing streams
@@ -89,6 +92,61 @@ export async function upsertLoadedDraft(workspaceId: string, scope: string, fiel
   // silently. The caller kicks the queue so it drains promptly.
   await enqueueDraftUpsert(workspaceId, id)
   return row
+}
+
+/**
+ * Seal-and-persist the loaded draft for an E2E `scope` (Stage 4c). The body is
+ * sealed to the stream's SSK before it touches IndexedDB, so only ciphertext is
+ * at rest (E2EE-4) — `contentJson` on the row is the empty placeholder and the
+ * composer decrypts the body into memory on load. Otherwise mirrors
+ * `upsertLoadedDraft`: reuse/mint the loaded id, set the pointer when the draft
+ * is new, and enqueue the debounced push (which sends the ciphertext triple).
+ *
+ * Throws if the session is locked or the SSK can't be resolved — the caller
+ * keeps the content in the composer and never surfaces the failure.
+ */
+export async function upsertLoadedSealedDraft(
+  workspaceId: string,
+  scope: string,
+  fields: { senderId: string; streamId: string; contentJson: JSONContent }
+): Promise<void> {
+  const loadedId = await getLoadedDraftId(scope)
+  const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+  const id = existing?.id ?? generateLocalDraftId()
+  // The draft id binds the seal AAD (in the message-id slot), so resolve it
+  // before sealing — a re-seal of the same draft reuses the id.
+  const sealed = await sealDraftContent({
+    workspaceId,
+    senderId: fields.senderId,
+    streamId: fields.streamId,
+    draftId: id,
+    contentJson: fields.contentJson,
+  })
+  const row: CachedDraft = {
+    id,
+    workspaceId,
+    scope,
+    // E2EE-4: the plaintext never lands on disk — the sealed body is the
+    // at-rest copy and `contentJson` is only the empty placeholder.
+    contentJson: EMPTY_DOC,
+    attachments: [],
+    clientUpdatedAt: Date.now(),
+    baseVersion: existing?.baseVersion,
+    ciphertext: sealed.ciphertext,
+    envelope: sealed.envelope,
+    e2eVersion: sealed.e2eVersion,
+  }
+  if (existing) {
+    await db.drafts.put(row)
+    upsertDraftInCache(workspaceId, row)
+  } else {
+    await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+      await db.drafts.put(row)
+      await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+    })
+    upsertLoadedDraftInCache(workspaceId, row, scope)
+  }
+  await enqueueDraftUpsert(workspaceId, id)
 }
 
 /**
@@ -169,6 +227,32 @@ export async function purgeScopeDrafts(workspaceId: string, scope: string): Prom
 }
 
 /**
+ * Delete only the PLAINTEXT drafts for an E2E `scope`, keeping sealed rows. Run
+ * on mount of an encrypted-stream composer: a plaintext draft written before the
+ * stream was encrypted (or before the seal path existed) must not stay at rest
+ * (E2EE-4), but a sealed draft is the legitimate roaming copy and is preserved.
+ * The loaded pointer is cleared only when it referenced a purged plaintext row.
+ */
+export async function purgePlaintextScopeDrafts(workspaceId: string, scope: string): Promise<void> {
+  let clearedPointer = false
+  const removed = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+    const found = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
+    const plaintext = found.filter((row) => !row.ciphertext)
+    const loaded = await db.composerLoaded.get(scope)
+    for (const row of plaintext) await db.drafts.delete(row.id)
+    if (loaded && plaintext.some((row) => row.id === loaded.draftId)) {
+      await db.composerLoaded.delete(scope)
+      clearedPointer = true
+    }
+    return plaintext
+  })
+  for (const row of removed) deleteDraftFromCache(workspaceId, row.id)
+  if (clearedPointer) setComposerLoadedInCache(workspaceId, scope, null)
+  // Mirror the removal of any plaintext copy that reached the server too.
+  for (const row of removed) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
+}
+
+/**
  * Re-scope every draft for `fromScope` to `toScope` and push each so the server
  * row follows. The client-initiated counterpart to inbound thread re-pointing:
  * used by `promoteDraft` when a not-yet-created scratchpad becomes a real stream,
@@ -188,53 +272,119 @@ export async function rescopeScopeDrafts(workspaceId: string, fromScope: string,
 }
 
 /**
- * @param e2eEnabled When the draft belongs to an end-to-end-encrypted stream,
- *   persistence and restore are disabled (E2EE-4): the composer keeps content in
- *   memory for the session only, so no plaintext draft for a sealed scratchpad
- *   ever touches IndexedDB or survives lock/reload. Any draft persisted before
- *   this gate existed is purged on mount.
+ * @param e2eStreamId The encrypted stream the draft seals to — the root stream
+ *   whose SSK wraps the body (a thread passes its root). Pass it only for E2E
+ *   streams; `undefined`/`null` means plaintext. When set and the session is
+ *   unlocked, the body is sealed before it touches disk and decrypted into the
+ *   composer on load (Stage 4c, E2EE-4); while the session is locked the composer
+ *   behaves as it did before this stage — nothing loads or persists, and the
+ *   sealed row waits on disk for unlock. Attachments / context refs / slash
+ *   commands on E2E drafts are not sealed yet and stay session-local.
  */
-export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnabled = false) {
+export function useDraftMessage(workspaceId: string, draftKey: string, e2eStreamId?: string | null) {
+  const e2eEnabled = !!e2eStreamId
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Read inside the debounced timer so a save scheduled while the stream was
-  // plaintext can't write after the stream becomes encrypted (E2EE-4).
-  const e2eEnabledRef = useRef(e2eEnabled)
+
+  // Seal/decrypt need the viewer's workspace user id and unlocked UIK. Both are
+  // read here (not threaded from the call site) so the composer reacts when the
+  // session unlocks — a locked scope becomes a sealing/decrypting one without a
+  // remount.
+  const senderId = useCurrentWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, senderId ?? "")
+  const e2eUnlocked =
+    e2eEnabled && !!senderId && session.status === "unlocked" && !!session.privateKey && !!session.keyId
+
   const drafts = useDraftsFromStore(workspaceId)
   const loaded = useComposerLoadedFromStore(workspaceId)
-  const loadedId = e2eEnabled ? null : (loaded.find((row) => row.scope === draftKey)?.draftId ?? null)
+  // A locked E2E scope behaves as it did before Stage 4c: nothing is checked out
+  // and nothing persists. Only the unlocked path resolves a loaded draft.
+  const loadedId = e2eEnabled && !e2eUnlocked ? null : (loaded.find((row) => row.scope === draftKey)?.draftId ?? null)
   const resolvedDraft = loadedId ? drafts.find((draft) => draft.id === loadedId) : undefined
+
   // Drains the offline queue so a debounced draft push (enqueued by the write
   // helpers) mirrors to the backend promptly instead of waiting for the next
   // reconnect. Optional — outside a workspace (login/loading) there is no engine
   // and the local write still stands.
   const syncEngine = useOptionalSyncEngine()
 
-  // When a stream becomes encrypted, cancel any debounced plaintext save still
-  // in flight — otherwise it fires after the purge below and re-persists the
-  // very plaintext we just deleted (write-after-purge race, E2EE-4).
+  // Latest E2E gate for the debounced save: the timer may fire after the stream's
+  // encryption/unlock state changed, so the save reads the gate at fire time
+  // rather than from a stale closure — this is what keeps a plaintext save
+  // scheduled before encryption from ever writing plaintext after it (E2EE-4).
+  const e2eGateRef = useRef({ enabled: e2eEnabled, unlocked: e2eUnlocked, senderId, streamId: e2eStreamId ?? null })
   useEffect(() => {
-    e2eEnabledRef.current = e2eEnabled
-    if (e2eEnabled && debounceRef.current) {
-      clearTimeout(debounceRef.current)
-      debounceRef.current = null
-    }
-  }, [e2eEnabled])
+    e2eGateRef.current = { enabled: e2eEnabled, unlocked: e2eUnlocked, senderId, streamId: e2eStreamId ?? null }
+  })
 
-  // Purge any pre-existing on-disk draft for an E2E stream (e.g. one written
-  // before this gate landed, or carried over when a stream is encrypted).
+  // Decrypt-on-load: an unlocked E2E draft is decrypted into memory once per
+  // loaded id. A self-edit re-seals the row under the same id without
+  // re-decrypting — the composer holds the live plaintext after it initializes,
+  // so this only needs to seed that first paint.
+  const [decrypted, setDecrypted] = useState<{ id: string; content: JSONContent } | null>(null)
+  const sealedLoaded = e2eUnlocked && resolvedDraft?.ciphertext ? resolvedDraft : undefined
+  const decryptReady = !sealedLoaded || decrypted?.id === sealedLoaded.id
+
+  useEffect(() => {
+    if (!sealedLoaded?.ciphertext || !e2eStreamId || !session.privateKey || !session.keyId) return
+    if (decrypted?.id === sealedLoaded.id) return
+    let cancelled = false
+    void decryptDraftContent({
+      ciphertext: sealedLoaded.ciphertext,
+      envelope: sealedLoaded.envelope,
+      e2eVersion: sealedLoaded.e2eVersion,
+      workspaceId,
+      streamId: e2eStreamId,
+      privateKey: session.privateKey,
+      recipientKeyId: session.keyId,
+    }).then((content) => {
+      if (!cancelled) setDecrypted({ id: sealedLoaded.id, content: content ?? EMPTY_DOC })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [sealedLoaded, e2eStreamId, session.privateKey, session.keyId, workspaceId, decrypted?.id])
+
+  // Purge only the PLAINTEXT drafts left on disk for an E2E scope (one written
+  // before the stream was encrypted, or before the seal path existed). Sealed
+  // rows are the legitimate roaming copy and are kept — only plaintext at rest
+  // violates E2EE-4.
   useEffect(() => {
     if (!e2eEnabled) return
-    void purgeScopeDrafts(workspaceId, draftKey)
+    void purgePlaintextScopeDrafts(workspaceId, draftKey)
   }, [e2eEnabled, draftKey, workspaceId])
 
   const saveDraft = useCallback(
     async (contentJson: JSONContent, attachments?: DraftAttachment[]) => {
-      // E2EE-4: encrypted-stream drafts are never written to disk.
-      if (e2eEnabled) return
       // Clear any pending debounced save
       if (debounceRef.current) {
         clearTimeout(debounceRef.current)
         debounceRef.current = null
+      }
+
+      const gate = e2eGateRef.current
+      if (gate.enabled) {
+        // E2EE-4: seal before disk, and only while unlocked. Locked → keep the
+        // content in the composer for the session; nothing persists. v1 seals the
+        // body only, so an `attachments` arg is intentionally ignored here.
+        if (!gate.unlocked || !gate.senderId || !gate.streamId) return
+        if (isEmptyContent(contentJson)) {
+          await clearLoadedDraft(workspaceId, draftKey)
+          syncEngine?.kickOperationQueue()
+          return
+        }
+        try {
+          await upsertLoadedSealedDraft(workspaceId, draftKey, {
+            senderId: gate.senderId,
+            streamId: gate.streamId,
+            contentJson,
+          })
+          syncEngine?.kickOperationQueue()
+        } catch (err) {
+          // A failed seal (e.g. the session locked between the gate check and the
+          // seal) must never interrupt the user — the content stands in the composer.
+          console.error("Failed to seal draft; kept in composer", err)
+        }
+        return
       }
 
       // Get current attachments + contextRefs if not provided. The contextRefs
@@ -260,27 +410,24 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
       })
       syncEngine?.kickOperationQueue()
     },
-    [draftKey, workspaceId, e2eEnabled, syncEngine]
+    [draftKey, workspaceId, syncEngine]
   )
 
   const saveDraftDebounced = useCallback(
     (contentJson: JSONContent) => {
-      // E2EE-4: encrypted-stream drafts are never written to disk.
-      if (e2eEnabled) return
       // Clear any pending debounced save
       if (debounceRef.current) {
         clearTimeout(debounceRef.current)
       }
-
+      // `saveDraft` reads the live E2E gate when the timer fires, so a value typed
+      // while the stream was plaintext is sealed (or dropped) — never written as
+      // plaintext — if the stream became encrypted in the meantime (E2EE-4).
       debounceRef.current = setTimeout(() => {
         debounceRef.current = null
-        // The stream may have been encrypted between scheduling and firing;
-        // never write plaintext to disk in that case (E2EE-4).
-        if (e2eEnabledRef.current) return
-        saveDraft(contentJson)
+        void saveDraft(contentJson)
       }, DEBOUNCE_MS)
     },
-    [saveDraft, e2eEnabled]
+    [saveDraft]
   )
 
   /**
@@ -377,10 +524,16 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eEnable
     }
   }, [])
 
+  // For an unlocked E2E draft the renderable content is the in-memory decrypt,
+  // not the on-disk placeholder; everything else reads straight off the row.
+  const decryptedForLoaded =
+    sealedLoaded && decrypted && decrypted.id === sealedLoaded.id ? decrypted.content : EMPTY_DOC
+  const contentJson = e2eUnlocked ? decryptedForLoaded : (resolvedDraft?.contentJson ?? EMPTY_DOC)
+
   return {
-    /** Whether Dexie has finished loading the draft (true even if no draft exists) */
-    isLoaded: hasSeededDraftCache(workspaceId),
-    contentJson: resolvedDraft?.contentJson ?? EMPTY_DOC,
+    /** True once Dexie has loaded and (for an unlocked E2E draft) decryption has resolved. */
+    isLoaded: hasSeededDraftCache(workspaceId) && decryptReady,
+    contentJson,
     attachments: resolvedDraft?.attachments ?? [],
     /** Sidecar context refs attached to the draft (see DraftContextRef). */
     contextRefs: (resolvedDraft?.contextRefs ?? []) as DraftContextRef[],

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -132,6 +132,7 @@ export async function upsertLoadedSealedDraft(
     attachments: [],
     clientUpdatedAt: Date.now(),
     baseVersion: existing?.baseVersion,
+    attachmentIds: existing?.attachmentIds,
     ciphertext: sealed.ciphertext,
     envelope: sealed.envelope,
     e2eVersion: sealed.e2eVersion,
@@ -314,7 +315,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
   const e2eGateRef = useRef({ enabled: e2eEnabled, unlocked: e2eUnlocked, senderId, streamId: e2eStreamId ?? null })
   useEffect(() => {
     e2eGateRef.current = { enabled: e2eEnabled, unlocked: e2eUnlocked, senderId, streamId: e2eStreamId ?? null }
-  })
+  }, [e2eEnabled, e2eUnlocked, senderId, e2eStreamId])
 
   // Decrypt-on-load: an unlocked E2E draft is decrypted into memory once per
   // loaded id. A self-edit re-seals the row under the same id without
@@ -337,12 +338,23 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       privateKey: session.privateKey,
       recipientKeyId: session.keyId,
     }).then((content) => {
-      if (!cancelled) setDecrypted({ id: sealedLoaded.id, content: content ?? EMPTY_DOC })
+      // A null result is a transient/blocked decrypt (session locked mid-flight,
+      // key not yet resolvable). Leave `decrypted` unset so the effect retries
+      // when a dep changes (e.g. the session unlocks) instead of baking an empty
+      // body in — which the same-id guard would then make permanent, inviting the
+      // user to type over a still-recoverable sealed draft.
+      if (!cancelled && content) setDecrypted({ id: sealedLoaded.id, content })
     })
     return () => {
       cancelled = true
     }
   }, [sealedLoaded, e2eStreamId, session.privateKey, session.keyId, workspaceId, decrypted?.id])
+
+  // Drop the decrypted plaintext when the scope changes so a navigated-away
+  // draft's body never lingers in memory and the new scope re-decrypts cleanly.
+  useEffect(() => {
+    setDecrypted(null)
+  }, [draftKey])
 
   // Purge only the PLAINTEXT drafts left on disk for an E2E scope (one written
   // before the stream was encrypted, or before the seal path existed). Sealed

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -568,6 +568,13 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     isDecrypting: decryptedContent.status === "pending",
     /** An E2E draft whose body couldn't be decrypted (wrong recipient / garbled). */
     decryptFailed: decryptedContent.status === "failed",
+    /**
+     * The draft id currently checked out into the composer for this scope, or null.
+     * Goes null when the draft is removed underneath the composer — sent/resolved
+     * here, or discarded/resolved on another device — which the composer uses to
+     * clear the editor so a gone draft doesn't linger.
+     */
+    loadedDraftId: loadedId,
     contentJson,
     attachments: resolvedDraft?.attachments ?? [],
     /** Sidecar context refs attached to the draft (see DraftContextRef). */

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -554,12 +554,10 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     }
   }, [])
 
-  // The renderable body comes from the shared read path: decrypted/plaintext
-  // content, or the empty placeholder while locked/decrypting/failed/absent.
-  const contentJson =
-    decryptedContent.status === "decrypted" || decryptedContent.status === "plaintext"
-      ? decryptedContent.contentJson
-      : EMPTY_DOC
+  // The renderable body comes from the shared read path: the decrypted/plaintext
+  // content, or the empty placeholder while locked/decrypting/failed/absent (the
+  // shared core returns null contentJson for those states).
+  const contentJson = decryptedContent.contentJson ?? EMPTY_DOC
 
   return {
     /** True once Dexie has loaded and (for an E2E draft) the read has settled (not mid-decrypt). */

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -350,11 +350,14 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
     }
   }, [sealedLoaded, e2eStreamId, session.privateKey, session.keyId, workspaceId, decrypted?.id])
 
-  // Drop the decrypted plaintext when the scope changes so a navigated-away
-  // draft's body never lingers in memory and the new scope re-decrypts cleanly.
+  // Drop the decrypted plaintext from memory when the scope changes OR the
+  // session locks. IDB only ever holds ciphertext for an E2E draft (E2EE-4 —
+  // treat it like the backend), so this in-memory copy is the only plaintext,
+  // and it must not outlive the unlocked session or a navigated-away scope —
+  // mirroring the message decrypt-cache's clear-on-lock.
   useEffect(() => {
     setDecrypted(null)
-  }, [draftKey])
+  }, [draftKey, e2eUnlocked])
 
   // Purge only the PLAINTEXT drafts left on disk for an E2E scope (one written
   // before the stream was encrypted, or before the seal path existed). Sealed
@@ -545,6 +548,8 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
   return {
     /** True once Dexie has loaded and (for an unlocked E2E draft) decryption has resolved. */
     isLoaded: hasSeededDraftCache(workspaceId) && decryptReady,
+    /** An unlocked E2E draft whose sealed body is still being decrypted into the composer. */
+    isDecrypting: !decryptReady,
     contentJson,
     attachments: resolvedDraft?.attachments ?? [],
     /** Sidecar context refs attached to the draft (see DraftContextRef). */

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -267,6 +267,41 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
 }
 
 /**
+ * Stash the draft currently loaded into the composer for `scope`: detach it (clear
+ * the device-local loaded pointer) so it becomes a stash entry, WITHOUT copying or
+ * re-writing its body. The row stays at rest exactly as it is — plaintext or sealed
+ * (E2EE-4) — and keeps roaming; only the "checked out" pointer is cleared. This is
+ * the shape-agnostic stash: there is no plaintext snapshot to leak for an E2E draft
+ * because the sealed row already holds the body. Returns the detached draft id, or
+ * `null` when nothing was loaded. Callers flush the live editor content into the row
+ * first (so unsaved keystrokes survive) and reset the editor afterward.
+ */
+export async function stashLoadedDraft(workspaceId: string, scope: string): Promise<string | null> {
+  const draftId = (await db.composerLoaded.get(scope))?.draftId ?? null
+  if (!draftId) return null
+  await db.composerLoaded.delete(scope)
+  setComposerLoadedInCache(workspaceId, scope, null)
+  return draftId
+}
+
+/**
+ * Restore stash entry `draftId` into the composer for `scope` by pointing the
+ * scope at it. Whatever was loaded becomes a stash entry automatically (the scope
+ * points at exactly one draft), so this is a swap that never loses work. The row's
+ * body — plaintext or sealed — is untouched; the composer decrypts on read. Like
+ * stash, it is a pure pointer move: no snapshot, no server round-trip (the row was
+ * already pushed when it was last edited).
+ */
+export async function restoreStashedDraftToComposer(
+  workspaceId: string,
+  scope: string,
+  draftId: string
+): Promise<void> {
+  await db.composerLoaded.put({ scope, workspaceId, draftId })
+  setComposerLoadedInCache(workspaceId, scope, draftId)
+}
+
+/**
  * Re-scope every draft for `fromScope` to `toScope` and push each so the server
  * row follows. The client-initiated counterpart to inbound thread re-pointing:
  * used by `promoteDraft` when a not-yet-created scratchpad becomes a real stream,

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -11,6 +11,7 @@ import {
   useWorkspaceStreams,
   useWorkspaceUsers,
 } from "@/stores/workspace-store"
+import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { LabelableResourceTypes, Visibilities } from "@threa/types"
 import type {
   CreateLabelInput,
@@ -356,16 +357,6 @@ export function usePromoteLabel(workspaceId: string) {
       queryClient.invalidateQueries({ queryKey: labelKeys.list(workspaceId) })
     },
   })
-}
-
-/** Resolve the current viewer's workspace-scoped user id (UserId), or null. */
-function useCurrentWorkspaceUserId(workspaceId: string): string | null {
-  const { user } = useAuth()
-  const workspaceUsers = useWorkspaceUsers(workspaceId)
-  return useMemo(() => {
-    if (!user) return null
-    return workspaceUsers.find((u) => u.workosUserId === user.id)?.id ?? null
-  }, [user, workspaceUsers])
 }
 
 export interface ResourceLabelState {

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { useAuth } from "@/auth"
 import { useLabelService } from "@/contexts"
 import { db, type CachedLabel, type CachedLabelMembership, type CachedLabelAssignment, type CachedStream } from "@/db"
 import {
@@ -9,7 +8,6 @@ import {
   useWorkspaceLabelMemberships,
   useWorkspaceLabelAssignments,
   useWorkspaceStreams,
-  useWorkspaceUsers,
 } from "@/stores/workspace-store"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { LabelableResourceTypes, Visibilities } from "@threa/types"
@@ -239,15 +237,9 @@ export interface LabelViewerContext {
  * consulted for them.
  */
 export function useLabelsView(workspaceId: string): LabelViewerContext {
-  const { user } = useAuth()
-  const workspaceUsers = useWorkspaceUsers(workspaceId)
   const labels = useWorkspaceLabels(workspaceId)
   const memberships = useWorkspaceLabelMemberships(workspaceId)
-
-  const currentUserId = useMemo(() => {
-    if (!user) return null
-    return workspaceUsers.find((u) => u.workosUserId === user.id)?.id ?? null
-  }, [user, workspaceUsers])
+  const currentUserId = useCurrentWorkspaceUserId(workspaceId)
 
   return useMemo(() => {
     const joinedLabelIds = new Set<string>()

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -1,23 +1,15 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
-import { EMPTY_DOC } from "@/lib/prosemirror-utils"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { restoreStashedDraftToComposer, stashLoadedDraft } from "./use-draft-message"
 import { useStashedDrafts, type CachedDraft } from "./use-stashed-drafts"
 import type { DraftComposerState } from "./use-draft-composer"
-import type { DraftAttachment } from "@/db"
-import type { PendingAttachment } from "./use-attachments"
-
-/** Distil the uploaded-attachment snapshot the stash pile persists. */
-function snapshotUploadedAttachments(pending: PendingAttachment[]): DraftAttachment[] {
-  return pending
-    .filter((a) => a.status === "uploaded" && !a.id.startsWith("temp_"))
-    .map((a) => ({ id: a.id, filename: a.filename, mimeType: a.mimeType, sizeBytes: a.sizeBytes }))
-}
 
 export interface UseStashComposerResult {
   /** Stashed drafts for the current scope, newest first. Empty when `scope` is undefined. */
   drafts: CachedDraft[]
-  /** Snapshot the current composer content + attachments into the stash, clear the editor, toast. Empty composer → silent no-op. */
+  /** Snapshot the current composer content into the stash, clear the editor, toast. Empty composer → silent no-op. */
   handleStashDraft: () => Promise<void>
   /** Swap: stash current content first (if any), then load the chosen stashed row into the composer. */
   handleRestoreStashed: (id: string) => Promise<void>
@@ -27,72 +19,64 @@ export interface UseStashComposerResult {
 
 /**
  * Binds the stashed-drafts pile (`useStashedDrafts`) to a `DraftComposerState`
- * so the two composer hosts (`MessageInput` and `StreamPanel`) don't each
- * carry their own copy of the stash / restore / delete callbacks. The hook
- * also owns the `?stash=<id>` URL auto-restore: the param is consumed
- * _after_ the restore resolves so a mid-flight failure doesn't silently
- * strip the deep link — a refresh will retry (dedup via a ref prevents
- * loops within a single mount).
+ * so the two composer hosts (`MessageInput` and `StreamPanel`) don't each carry
+ * their own copy of the stash / restore / delete callbacks. It also owns the
+ * `?stash=<id>` URL auto-restore.
+ *
+ * Stash and restore are **pointer moves**, not content snapshots — exactly "a
+ * stashed draft is a draft without the active state". Stashing flushes the live
+ * editor into its row (sealed for E2E) and detaches the loaded pointer so the row
+ * becomes a stash entry; restoring points the scope at the chosen row and lets
+ * the composer re-read (decrypting on the way in for E2E) the newly-loaded body.
+ * Because nothing is copied, an encrypted draft rides the identical path with no
+ * plaintext ever leaving memory (E2EE-4) — so the pile works the same for
+ * plaintext and E2E streams with no special-casing here.
  */
 export function useStashComposer(
   composer: DraftComposerState,
   workspaceId: string,
-  scope: string | undefined,
-  // Stashing snapshots the composer's plaintext content, so it is disabled for
-  // encrypted streams in v1 (E2EE-4): the ambient draft still roams sealed, but
-  // the manual save-for-later pile is a follow-up. Both stash + restore no-op
-  // when set, so every trigger (button, keyboard, `?stash=` URL) is covered.
-  e2eEnabled = false
+  scope: string | undefined
 ): UseStashComposerResult {
   const stashedDrafts = useStashedDrafts(workspaceId, scope)
 
   const handleStashDraft = useCallback(async () => {
-    if (e2eEnabled) return // E2EE-4: never snapshot encrypted-stream plaintext into a stash row.
-    const row = await stashedDrafts.stashDraft({
-      contentJson: composer.content,
-      attachments: snapshotUploadedAttachments(composer.pendingAttachments),
-    })
-    if (!row) return // Empty composer: silent no-op per product brief.
+    if (!scope) return
+    // Nothing worth stashing → silent no-op (parity with the picker's disabled
+    // button and the product brief). Attachments alone count as content.
+    const hasContent = !isEmptyContent(composer.content)
+    const hasAttachments = composer.uploadedIds.length > 0
+    if (!hasContent && !hasAttachments) return
 
-    composer.setContent(EMPTY_DOC)
-    await composer.clearDraft()
-    composer.clearAttachments()
+    // Flush the live editor into its row first (sealed for E2E, E2EE-4) so the
+    // stash entry carries exactly what the user was typing, then detach it.
+    await composer.saveDraft(composer.content)
+    const stashedId = await stashLoadedDraft(workspaceId, scope)
+    if (!stashedId) return
+    // Re-init the (now draft-less) composer so the editor blanks out.
+    composer.markNeedsRehydrate()
     toast.success("Saved as draft")
-  }, [composer, stashedDrafts, e2eEnabled])
+  }, [composer, workspaceId, scope])
 
   const handleRestoreStashed = useCallback(
     async (id: string) => {
-      // Encrypted streams don't expose the stash in v1: a restore would both
-      // snapshot the composer's plaintext (E2EE-4) and load a sealed row's empty
-      // placeholder. No-op so the `?stash=` deep link can't trip either.
-      if (e2eEnabled) return
-      // Swap semantics: stash whatever the composer holds first so switching
-      // drafts never silently destroys work. A thrown error here (e.g. IDB
-      // quota) is swallowed — losing a recent auto-save is a smaller harm
-      // than aborting the deliberate restore of an explicit stash row.
+      if (!scope) return
+      // Swap semantics: flush whatever the composer holds into its row first so
+      // switching drafts never silently destroys work — it stays as a stash entry
+      // once the pointer moves off it. A thrown flush (e.g. IDB quota, or a seal
+      // that raced a lock) is swallowed: losing a recent auto-save is a smaller
+      // harm than aborting the deliberate restore of an explicit stash row.
       try {
-        await stashedDrafts.stashDraft({
-          contentJson: composer.content,
-          attachments: snapshotUploadedAttachments(composer.pendingAttachments),
-        })
+        await composer.saveDraft(composer.content)
       } catch (err) {
-        console.error("Failed to stash current content before restoring", err)
+        console.error("Failed to flush current content before restoring", err)
       }
 
-      const row = await stashedDrafts.restoreStashedDraft(id)
-      if (!row) return
-
-      composer.clearAttachments()
-      composer.setContent(row.contentJson)
-      // handleContentChange drives the debounced write into DraftMessage
-      // once the editor picks up the new content.
-      composer.handleContentChange(row.contentJson)
-      if (row.attachments && row.attachments.length > 0) {
-        composer.restoreAttachments(row.attachments)
-      }
+      await restoreStashedDraftToComposer(workspaceId, scope, id)
+      // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
+      composer.markNeedsRehydrate()
       toast.success("Draft restored")
     },
-    [composer, stashedDrafts, e2eEnabled]
+    [composer, workspaceId, scope]
   )
 
   const handleDeleteStashed = useCallback(
@@ -102,11 +86,11 @@ export function useStashComposer(
     [stashedDrafts]
   )
 
-  // Auto-restore when the URL carries `?stash=<id>` — how the /drafts
-  // explorer deep-links to a specific snapshot. The dedup ref prevents the
-  // same id firing twice within one mount if React re-runs the effect, and
-  // the param is stripped only after the restore resolves so a thrown
-  // error doesn't silently eat the deep link.
+  // Auto-restore when the URL carries `?stash=<id>` — how the /drafts explorer
+  // deep-links to a specific snapshot. The dedup ref prevents the same id firing
+  // twice within one mount if React re-runs the effect, and the param is stripped
+  // only after the restore resolves so a thrown error doesn't silently eat the
+  // deep link (a refresh can retry).
   const [searchParams, setSearchParams] = useSearchParams()
   const pendingStashRestoreRef = useRef<string | null>(null)
   useEffect(() => {
@@ -131,10 +115,7 @@ export function useStashComposer(
   }, [searchParams, setSearchParams, scope, composer.isLoaded, handleRestoreStashed])
 
   return {
-    // The stash is disabled for encrypted streams in v1, so surface no entries
-    // there — a sealed row that arrives via sync would otherwise render as a
-    // restore control whose handler no-ops (a dead button).
-    drafts: e2eEnabled ? [] : stashedDrafts.drafts,
+    drafts: stashedDrafts.drafts,
     handleStashDraft,
     handleRestoreStashed,
     handleDeleteStashed,

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -37,11 +37,17 @@ export interface UseStashComposerResult {
 export function useStashComposer(
   composer: DraftComposerState,
   workspaceId: string,
-  scope: string | undefined
+  scope: string | undefined,
+  // Stashing snapshots the composer's plaintext content, so it is disabled for
+  // encrypted streams in v1 (E2EE-4): the ambient draft still roams sealed, but
+  // the manual save-for-later pile is a follow-up. Both stash + restore no-op
+  // when set, so every trigger (button, keyboard, `?stash=` URL) is covered.
+  e2eEnabled = false
 ): UseStashComposerResult {
   const stashedDrafts = useStashedDrafts(workspaceId, scope)
 
   const handleStashDraft = useCallback(async () => {
+    if (e2eEnabled) return // E2EE-4: never snapshot encrypted-stream plaintext into a stash row.
     const row = await stashedDrafts.stashDraft({
       contentJson: composer.content,
       attachments: snapshotUploadedAttachments(composer.pendingAttachments),
@@ -52,10 +58,14 @@ export function useStashComposer(
     await composer.clearDraft()
     composer.clearAttachments()
     toast.success("Saved as draft")
-  }, [composer, stashedDrafts])
+  }, [composer, stashedDrafts, e2eEnabled])
 
   const handleRestoreStashed = useCallback(
     async (id: string) => {
+      // Encrypted streams don't expose the stash in v1: a restore would both
+      // snapshot the composer's plaintext (E2EE-4) and load a sealed row's empty
+      // placeholder. No-op so the `?stash=` deep link can't trip either.
+      if (e2eEnabled) return
       // Swap semantics: stash whatever the composer holds first so switching
       // drafts never silently destroys work. A thrown error here (e.g. IDB
       // quota) is swallowed — losing a recent auto-save is a smaller harm
@@ -82,7 +92,7 @@ export function useStashComposer(
       }
       toast.success("Draft restored")
     },
-    [composer, stashedDrafts]
+    [composer, stashedDrafts, e2eEnabled]
   )
 
   const handleDeleteStashed = useCallback(

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -48,8 +48,9 @@ export function useStashComposer(
     if (!hasContent && !hasAttachments) return
 
     // Flush the live editor into its row first (sealed for E2E, E2EE-4) so the
-    // stash entry carries exactly what the user was typing, then detach it.
-    await composer.saveDraft(composer.content)
+    // stash entry carries exactly what the user was typing, then detach it. The
+    // flush never deletes (it no-ops on empty), so it can't destroy the draft.
+    await composer.flushDraft()
     const stashedId = await stashLoadedDraft(workspaceId, scope)
     if (!stashedId) return
     // Re-init the (now draft-less) composer so the editor blanks out.
@@ -62,11 +63,13 @@ export function useStashComposer(
       if (!scope) return
       // Swap semantics: flush whatever the composer holds into its row first so
       // switching drafts never silently destroys work — it stays as a stash entry
-      // once the pointer moves off it. A thrown flush (e.g. IDB quota, or a seal
-      // that raced a lock) is swallowed: losing a recent auto-save is a smaller
-      // harm than aborting the deliberate restore of an explicit stash row.
+      // once the pointer moves off it. `flushDraft` only persists a non-empty
+      // editor, so a restore fired while the composer is still mid-hydration
+      // (transiently empty) can NEVER delete the currently-loaded draft. A thrown
+      // flush (e.g. IDB quota, or a seal that raced a lock) is swallowed: losing a
+      // recent auto-save is a smaller harm than aborting the deliberate restore.
       try {
-        await composer.saveDraft(composer.content)
+        await composer.flushDraft()
       } catch (err) {
         console.error("Failed to flush current content before restoring", err)
       }

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -131,7 +131,10 @@ export function useStashComposer(
   }, [searchParams, setSearchParams, scope, composer.isLoaded, handleRestoreStashed])
 
   return {
-    drafts: stashedDrafts.drafts,
+    // The stash is disabled for encrypted streams in v1, so surface no entries
+    // there — a sealed row that arrives via sync would otherwise render as a
+    // restore control whose handler no-ops (a dead button).
+    drafts: e2eEnabled ? [] : stashedDrafts.drafts,
     handleStashDraft,
     handleRestoreStashed,
     handleDeleteStashed,

--- a/apps/frontend/src/hooks/use-stashed-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { createStashedDraft, popStashedDraft } from "./use-stashed-drafts"
-import { upsertLoadedDraft } from "./use-draft-message"
+import { stashLoadedDraft, restoreStashedDraftToComposer, upsertLoadedDraft } from "./use-draft-message"
 import type { JSONContent } from "@threa/types"
 import { db } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
@@ -18,80 +17,64 @@ beforeEach(async () => {
   resetDraftStoreCache()
   await db.drafts.clear()
   await db.composerLoaded.clear()
+  await db.pendingOperations.clear()
 })
 
-describe("createStashedDraft", () => {
-  it("persists a draft_-prefixed row with workspaceId, scope, and contentJson", async () => {
-    const content = makeDoc("Hello saved world")
-
-    const row = await createStashedDraft(workspaceId, scope, { contentJson: content })
-
-    expect(row).not.toBeNull()
-    expect(row!.workspaceId).toBe(workspaceId)
-    expect(row!.scope).toBe(scope)
-    expect(row!.contentJson).toEqual(content)
-    expect(row!.id.startsWith("draft_")).toBe(true)
-
-    const persisted = await db.drafts.get(row!.id)
-    expect(persisted).toMatchObject({ workspaceId, scope, contentJson: content })
-  })
-
-  it("no-ops on empty content with no attachments", async () => {
-    const row = await createStashedDraft(workspaceId, scope, { contentJson: EMPTY_DOC })
-
-    expect(row).toBeNull()
-    expect(await db.drafts.count()).toBe(0)
-  })
-
-  it("stashes attachment-only drafts (empty body + attachments)", async () => {
-    const attachments = [{ id: "attach_1", filename: "a.png", mimeType: "image/png", sizeBytes: 10 }]
-
-    const row = await createStashedDraft(workspaceId, scope, { contentJson: EMPTY_DOC, attachments })
-
-    expect(row).not.toBeNull()
-    expect(row!.attachments).toEqual(attachments)
-    expect(await db.drafts.count()).toBe(1)
-  })
-
-  it("no-ops when scope is undefined (host still resolving)", async () => {
-    const row = await createStashedDraft(workspaceId, undefined, { contentJson: makeDoc("x") })
-
-    expect(row).toBeNull()
-    expect(await db.drafts.count()).toBe(0)
-  })
-
-  it("no-ops when workspaceId is empty", async () => {
-    const row = await createStashedDraft("", scope, { contentJson: makeDoc("x") })
-
-    expect(row).toBeNull()
-    expect(await db.drafts.count()).toBe(0)
-  })
-
-  it("never resurrects the loaded draft — a stash is a separate row", async () => {
-    const loaded = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("loaded"), attachments: [] })
-    const stash = await createStashedDraft(workspaceId, scope, { contentJson: makeDoc("stashed") })
-
-    expect(stash!.id).not.toBe(loaded.id)
-    expect(await db.drafts.count()).toBe(2)
-    // The loaded pointer is untouched by stashing.
+describe("stashLoadedDraft (pointer-move stash)", () => {
+  it("detaches the loaded pointer but keeps the row at rest, so it roams as a stash entry", async () => {
+    const loaded = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("draft body"), attachments: [] })
     expect((await db.composerLoaded.get(scope))?.draftId).toBe(loaded.id)
+
+    const stashedId = await stashLoadedDraft(workspaceId, scope)
+
+    expect(stashedId).toBe(loaded.id)
+    // Pointer cleared; the row is preserved (not deleted) so it stays a stash entry
+    // and keeps roaming — no plaintext snapshot into a new row.
+    expect(await db.composerLoaded.get(scope)).toBeUndefined()
+    expect(await db.drafts.get(loaded.id)).toBeDefined()
+  })
+
+  it("no-ops when nothing is loaded", async () => {
+    expect(await stashLoadedDraft(workspaceId, scope)).toBeNull()
+  })
+
+  it("keeps a sealed E2E row at rest — never writes plaintext (E2EE-4)", async () => {
+    await db.drafts.put({
+      id: "draft_sealed",
+      workspaceId,
+      scope,
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_sealed",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_sealed" })
+
+    const stashedId = await stashLoadedDraft(workspaceId, scope)
+
+    expect(stashedId).toBe("draft_sealed")
+    const row = await db.drafts.get("draft_sealed")
+    expect(row?.ciphertext).toBe("ct_sealed")
+    // Still ciphertext-only at rest after stashing.
+    expect(row?.contentJson).toEqual(EMPTY_DOC)
+    expect(await db.composerLoaded.get(scope)).toBeUndefined()
   })
 })
 
-describe("popStashedDraft", () => {
-  it("returns the row and deletes it from the table", async () => {
-    const created = await createStashedDraft(workspaceId, scope, { contentJson: makeDoc("Saved earlier") })
+describe("restoreStashedDraftToComposer (pointer-move restore)", () => {
+  it("points the scope at the chosen row; the previously-loaded one becomes the stash entry", async () => {
+    const first = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("first"), attachments: [] })
+    await stashLoadedDraft(workspaceId, scope)
+    const second = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("second"), attachments: [] })
+    expect((await db.composerLoaded.get(scope))?.draftId).toBe(second.id)
 
-    const restored = await popStashedDraft(created!.id)
+    await restoreStashedDraftToComposer(workspaceId, scope, first.id)
 
-    expect(restored?.id).toBe(created!.id)
-    expect(restored?.contentJson).toEqual(makeDoc("Saved earlier"))
-    expect(await db.drafts.get(created!.id)).toBeUndefined()
-  })
-
-  it("returns null when the row is missing (no-op delete)", async () => {
-    const restored = await popStashedDraft("draft_missing")
-
-    expect(restored).toBeNull()
+    expect((await db.composerLoaded.get(scope))?.draftId).toBe(first.id)
+    // Both rows survive (nothing deleted) — `second` is now the stash entry.
+    expect(await db.drafts.get(first.id)).toBeDefined()
+    expect(await db.drafts.get(second.id)).toBeDefined()
   })
 })

--- a/apps/frontend/src/hooks/use-stashed-drafts.ts
+++ b/apps/frontend/src/hooks/use-stashed-drafts.ts
@@ -1,114 +1,35 @@
 import { useCallback, useMemo } from "react"
-import { db, generateLocalDraftId, type CachedDraft, type DraftAttachment } from "@/db"
-import {
-  deleteDraftFromCache,
-  hasSeededDraftCache,
-  upsertDraftInCache,
-  useComposerLoadedFromStore,
-  useDraftsFromStore,
-} from "@/stores/draft-store"
-import { deleteDraftById, enqueueDraftUpsert, syncDraftRemoval } from "@/sync/draft-sync"
+import { type CachedDraft } from "@/db"
+import { hasSeededDraftCache, useComposerLoadedFromStore, useDraftsFromStore } from "@/stores/draft-store"
+import { deleteDraftById } from "@/sync/draft-sync"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import type { JSONContent } from "@threa/types"
-import { isEmptyContent } from "@/lib/prosemirror-utils"
 
 // Re-exported so components (which cannot import from `@/db` per INV-15) can
 // still get the row type they render without reaching into the data layer.
 // A "stashed" draft is just a `CachedDraft` that isn't the loaded one for its
-// scope.
+// scope — there is no separate stash entity, plaintext or sealed.
 export type { CachedDraft }
-
-export interface StashDraftInput {
-  contentJson: JSONContent
-  attachments?: DraftAttachment[]
-}
 
 export interface UseStashedDraftsResult {
   /** Stashed drafts for the current scope (every draft except the loaded one), newest first. */
   drafts: CachedDraft[]
   /** True once the draft cache has been seeded (used to suppress empty-flash in the picker). */
   isLoaded: boolean
-  /**
-   * Persist a new stashed draft. Refuses to save when the content is empty
-   * and no attachments are present — callers should still honour a no-op
-   * locally (e.g. skip the toast) so the UX doesn't confirm a save that
-   * didn't happen.
-   */
-  stashDraft: (input: StashDraftInput) => Promise<CachedDraft | null>
-  /** Fetch-and-delete: returns the row so the caller can load it into the composer. */
-  restoreStashedDraft: (id: string) => Promise<CachedDraft | null>
-  /** Delete without restoring. */
+  /** Delete a stashed row (and mirror the removal to the backend). */
   deleteStashedDraft: (id: string) => Promise<void>
 }
 
 /**
- * Persist a new stashed draft (a `CachedDraft` left unloaded). Returns `null`
- * (no DB write) when both the content is empty and there are no attachments —
- * callers should treat the null return as a silent no-op (e.g. skip the
- * confirmation toast).
- */
-export async function createStashedDraft(
-  workspaceId: string,
-  scope: string | undefined,
-  input: StashDraftInput
-): Promise<CachedDraft | null> {
-  if (!workspaceId || !scope) return null
-  const hasContent = !isEmptyContent(input.contentJson)
-  const hasAttachments = (input.attachments?.length ?? 0) > 0
-  if (!hasContent && !hasAttachments) return null
-
-  const row: CachedDraft = {
-    id: generateLocalDraftId(),
-    workspaceId,
-    scope,
-    contentJson: input.contentJson,
-    attachments: input.attachments ?? [],
-    clientUpdatedAt: Date.now(),
-  }
-  await db.drafts.add(row)
-  upsertDraftInCache(workspaceId, row)
-  // Mirror the new stash to the backend so it roams across devices.
-  await enqueueDraftUpsert(workspaceId, row.id)
-  return row
-}
-
-/**
- * Fetch-and-delete a draft by id. Returns the row so the caller can hydrate the
- * composer; returns `null` if the id is missing (idempotent).
+ * The stashed drafts for a specific scope (a stream or a thread's parent
+ * message) — every draft for the scope except the one loaded into the composer.
+ * Pass `undefined` for `scope` while the host is still resolving what to target;
+ * the hook returns an empty list and silently no-ops.
  *
- * Wrapped in a Dexie rw transaction so the get + delete are atomic against
- * concurrent tabs — without it, two tabs opening the same `?stash=` link
- * could both read the row before either deletes, and both would restore
- * the same content into their composers.
- */
-export async function popStashedDraft(id: string): Promise<CachedDraft | null> {
-  const row = await db.transaction("rw", db.drafts, async () => {
-    const found = await db.drafts.get(id)
-    if (!found) return null
-    await db.drafts.delete(id)
-    return found
-  })
-  if (row) {
-    deleteDraftFromCache(row.workspaceId, id)
-    // Restore is copy-then-pop (the content is reloaded into the composer as a
-    // fresh draft), so the popped stash row is removed server-side too.
-    await syncDraftRemoval(row.workspaceId, row.id, row.baseVersion)
-  }
-  return row
-}
-
-/**
- * Query + mutate the stashed drafts for a specific scope (a stream or a thread's
- * parent message) — every draft for the scope except the one loaded into the
- * composer. Pass `undefined` for `scope` when the host is still resolving what
- * scope to target — the hook returns an empty list and silently no-ops
- * mutations rather than throw.
- *
- * The mutation methods are thin wrappers over the module-level helpers
- * (`createStashedDraft`, `popStashedDraft`, and the shared `deleteDraftById`) so
- * the mutation behavior is testable without `renderHook`. Deletion routes
- * through the same `deleteDraftById` the Drafts explorer uses — a draft is a
- * draft, so the two delete surfaces share one path.
+ * Stash and restore are pointer moves (see `useStashComposer`): the loaded draft
+ * is simply detached/attached via the `composerLoaded` pointer, so a sealed E2E
+ * draft rides the same path with no plaintext snapshot (E2EE-4). This hook owns
+ * only the read (`drafts`) and delete; deletion routes through the same
+ * `deleteDraftById` the Drafts explorer uses so the two surfaces can't drift.
  */
 export function useStashedDrafts(workspaceId: string, scope: string | undefined): UseStashedDraftsResult {
   const allDrafts = useDraftsFromStore(workspaceId)
@@ -125,22 +46,6 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
   const isLoaded = hasSeededDraftCache(workspaceId)
   const syncEngine = useOptionalSyncEngine()
 
-  const stashDraft = useCallback(
-    async (input: StashDraftInput) => {
-      const row = await createStashedDraft(workspaceId, scope, input)
-      if (row) syncEngine?.kickOperationQueue()
-      return row
-    },
-    [workspaceId, scope, syncEngine]
-  )
-  const restoreStashedDraft = useCallback(
-    async (id: string) => {
-      const row = await popStashedDraft(id)
-      if (row) syncEngine?.kickOperationQueue()
-      return row
-    },
-    [syncEngine]
-  )
   const deleteStashedDraft = useCallback(
     async (id: string) => {
       await deleteDraftById(workspaceId, id)
@@ -149,5 +54,5 @@ export function useStashedDrafts(workspaceId: string, scope: string | undefined)
     [workspaceId, syncEngine]
   )
 
-  return { drafts, isLoaded, stashDraft, restoreStashedDraft, deleteStashedDraft }
+  return { drafts, isLoaded, deleteStashedDraft }
 }

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -88,7 +88,10 @@ export function requestDecryption(
   touch(eventId, { status: "pending", content: null })
 
   const startGeneration = generation
-  const promise = (async (): Promise<DecryptCacheEntry> => {
+  // A holder so the async body can compare against its own promise identity
+  // (`holder.promise` is assigned synchronously below, before any await resolves).
+  const holder: { promise?: Promise<DecryptCacheEntry> } = {}
+  holder.promise = (async (): Promise<DecryptCacheEntry> => {
     const decrypted = await tryDecryptMessagePayload(payload, opts)
     const entry: DecryptCacheEntry = decrypted
       ? { status: "decrypted", content: decrypted }
@@ -97,14 +100,18 @@ export function requestDecryption(
     // in flight, drop the result — writing it back would leak plaintext past
     // the lock boundary.
     if (startGeneration !== generation) return entry
+    // A concurrent `invalidateDecryption` (or a fresh `seedDecryption`) may have
+    // replaced this id's slot while we were decrypting; only the current inflight
+    // writes back, so a stale decrypt can never clobber freshly-authored content.
+    if (inflight.get(eventId) !== holder.promise) return entry
     touch(eventId, entry)
     inflight.delete(eventId)
     emit(eventId)
     return entry
   })()
 
-  inflight.set(eventId, promise)
-  return promise
+  inflight.set(eventId, holder.promise)
+  return holder.promise
 }
 
 /**
@@ -121,6 +128,24 @@ export function seedDecryption(eventId: string, content: DecryptedMessageContent
   touch(eventId, { status: "decrypted", content })
   inflight.delete(eventId)
   emit(eventId)
+}
+
+/**
+ * Drop the cached (and in-flight) decryption for a single id and notify
+ * subscribers. Unlike `clearDecryptCache` (which wipes everything on lock), this
+ * targets one id so a caller can REPLACE stale plaintext for a reused id.
+ *
+ * `seedDecryption` deliberately no-ops when an id already has a decrypted entry
+ * (a message's id is immutable, so its first good decrypt is final). A draft id,
+ * by contrast, is stable across edits — every keystroke re-seals the SAME id with
+ * new plaintext. Without invalidation the second edit's seed would be ignored and
+ * the read path would serve the FIRST edit's body on the next remount. The draft
+ * write path therefore invalidates this id, then seeds the fresh plaintext.
+ */
+export function invalidateDecryption(eventId: string): void {
+  const had = entries.delete(eventId)
+  const wasInflight = inflight.delete(eventId)
+  if (had || wasInflight) emit(eventId)
 }
 
 export function clearDecryptCache(): void {

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -32,10 +32,30 @@ const listeners = new Map<string, Set<() => void>>()
 // can detect they're stale and refuse to write plaintext back into the cache.
 let generation = 0
 
+// A monotonic version bumped on EVERY cache change, with its own listener set.
+// Per-id subscriptions (`subscribeToDecryption`) suit a single rendered message;
+// a batch reader (e.g. decrypted draft previews across a list) instead watches
+// this one signal and re-reads the ids it cares about.
+let cacheVersion = 0
+const versionListeners = new Set<() => void>()
+
 function emit(eventId: string): void {
+  cacheVersion++
+  for (const listener of versionListeners) listener()
   const set = listeners.get(eventId)
   if (!set) return
   for (const listener of set) listener()
+}
+
+/** Snapshot of the global cache version — changes on any insert/seed/invalidate/clear. */
+export function getDecryptCacheVersion(): number {
+  return cacheVersion
+}
+
+/** Subscribe to ANY cache change (for batch readers like draft-preview lists). */
+export function subscribeDecryptCacheVersion(listener: () => void): () => void {
+  versionListeners.add(listener)
+  return () => versionListeners.delete(listener)
 }
 
 function touch(eventId: string, entry: DecryptCacheEntry): void {

--- a/apps/frontend/src/lib/crypto/seal-draft.test.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { parseMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
-import { sealDraftContent, decryptDraftContent } from "./seal-draft"
+import { sealDraftContent } from "./seal-draft"
+import { tryDecryptMessagePayload } from "./message-envelope"
 import * as sessionStore from "@/stores/e2e-session-store"
 import * as streamKeyCache from "./stream-key-cache"
 
@@ -33,7 +34,7 @@ beforeEach(() => {
 })
 
 describe("seal-draft", () => {
-  it("round-trips a draft body through the stream SSK (seal → decrypt)", async () => {
+  it("round-trips a draft body through the stream SSK (seal → shared decrypt path)", async () => {
     vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(unlockedSession)
     vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })
     vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(ssk)
@@ -48,19 +49,20 @@ describe("seal-draft", () => {
     expect(typeof sealed.ciphertext).toBe("string")
     expect(sealed.ciphertext.length).toBeGreaterThan(0)
     expect(sealed.e2eVersion).toBe(2)
+    expect(sealed.contentMarkdown).toBe("hello e2e world")
 
-    const decrypted = await decryptDraftContent({
-      ciphertext: sealed.ciphertext,
-      envelope: sealed.envelope,
-      e2eVersion: sealed.e2eVersion,
-      workspaceId,
-      streamId,
-      privateKey: unlockedSession.privateKey!,
-      recipientKeyId: unlockedSession.keyId!,
-    })
-    // The body survives the seal → wire → open round-trip (modulo markdown
-    // serialization, which is the same transform a sent message goes through).
-    expect(decrypted).toEqual(parseMarkdown("hello e2e world"))
+    // Decrypt via the same primitive the shared decrypt-cache uses on read.
+    const opened = await tryDecryptMessagePayload(
+      { contentMarkdown: "", ciphertext: sealed.ciphertext, envelope: sealed.envelope, e2eVersion: sealed.e2eVersion },
+      {
+        privateKey: unlockedSession.privateKey!,
+        recipientKeyId: unlockedSession.keyId!,
+        workspaceId,
+        streamId,
+        rootStreamId: streamId,
+      }
+    )
+    expect(opened?.contentJson).toEqual(parseMarkdown("hello e2e world"))
   })
 
   it("throws when the session is locked (the caller keeps content in the composer)", async () => {
@@ -76,18 +78,24 @@ describe("seal-draft", () => {
     ).rejects.toThrow()
   })
 
-  it("returns null when the viewer can't resolve the stream key", async () => {
+  it("the decrypt path returns null when the viewer can't resolve the stream key", async () => {
     vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(null)
 
-    const decrypted = await decryptDraftContent({
-      ciphertext: "AAAA",
-      envelope: { v: 2, keyGeneration: 1, iv: "AAAA", aad: "AAAA" },
-      e2eVersion: 2,
-      workspaceId,
-      streamId,
-      privateKey: {} as CryptoKey,
-      recipientKeyId: "ek_1",
-    })
-    expect(decrypted).toBeNull()
+    const opened = await tryDecryptMessagePayload(
+      {
+        contentMarkdown: "",
+        ciphertext: "AAAA",
+        envelope: { v: 2, keyGeneration: 1, iv: "AAAA", aad: "AAAA" },
+        e2eVersion: 2,
+      },
+      {
+        privateKey: {} as CryptoKey,
+        recipientKeyId: "ek_1",
+        workspaceId,
+        streamId,
+        rootStreamId: streamId,
+      }
+    )
+    expect(opened).toBeNull()
   })
 })

--- a/apps/frontend/src/lib/crypto/seal-draft.test.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { parseMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+import { sealDraftContent, decryptDraftContent } from "./seal-draft"
+import * as sessionStore from "@/stores/e2e-session-store"
+import * as streamKeyCache from "./stream-key-cache"
+
+const workspaceId = "ws_1"
+const senderId = "user_1"
+const streamId = "stream_e2e"
+const draftId = "draft_1"
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+// A real 32-byte SSK so the seal/open below run actual AES-256-GCM (only the
+// key resolution + session lookup are stubbed — the crypto itself is genuine).
+const ssk = crypto.getRandomValues(new Uint8Array(32))
+
+const unlockedSession = {
+  status: "unlocked",
+  keyId: "ek_1",
+  publicKey: null,
+  privateKey: {} as CryptoKey,
+  deviceTrusted: true,
+  error: null,
+} as ReturnType<typeof sessionStore.getE2eSessionState>
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("seal-draft", () => {
+  it("round-trips a draft body through the stream SSK (seal → decrypt)", async () => {
+    vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(unlockedSession)
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })
+    vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(ssk)
+
+    const sealed = await sealDraftContent({
+      workspaceId,
+      senderId,
+      streamId,
+      draftId,
+      contentJson: makeDoc("hello e2e world"),
+    })
+    expect(typeof sealed.ciphertext).toBe("string")
+    expect(sealed.ciphertext.length).toBeGreaterThan(0)
+    expect(sealed.e2eVersion).toBe(2)
+
+    const decrypted = await decryptDraftContent({
+      ciphertext: sealed.ciphertext,
+      envelope: sealed.envelope,
+      e2eVersion: sealed.e2eVersion,
+      workspaceId,
+      streamId,
+      privateKey: unlockedSession.privateKey!,
+      recipientKeyId: unlockedSession.keyId!,
+    })
+    // The body survives the seal → wire → open round-trip (modulo markdown
+    // serialization, which is the same transform a sent message goes through).
+    expect(decrypted).toEqual(parseMarkdown("hello e2e world"))
+  })
+
+  it("throws when the session is locked (the caller keeps content in the composer)", async () => {
+    vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue({
+      ...unlockedSession,
+      status: "locked",
+      privateKey: null,
+      keyId: null,
+    } as ReturnType<typeof sessionStore.getE2eSessionState>)
+
+    await expect(
+      sealDraftContent({ workspaceId, senderId, streamId, draftId, contentJson: makeDoc("secret") })
+    ).rejects.toThrow()
+  })
+
+  it("returns null when the viewer can't resolve the stream key", async () => {
+    vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(null)
+
+    const decrypted = await decryptDraftContent({
+      ciphertext: "AAAA",
+      envelope: { v: 2, keyGeneration: 1, iv: "AAAA", aad: "AAAA" },
+      e2eVersion: 2,
+      workspaceId,
+      streamId,
+      privateKey: {} as CryptoKey,
+      recipientKeyId: "ek_1",
+    })
+    expect(decrypted).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/crypto/seal-draft.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.ts
@@ -1,13 +1,15 @@
 import { serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import { sealOutgoingMessage } from "./seal-send"
-import { tryDecryptMessagePayload } from "./message-envelope"
 
-/** The E2E triple persisted at rest in place of a draft's plaintext (E2EE-4). */
+/** The E2E triple persisted at rest in place of a draft's plaintext (E2EE-4),
+ * plus the markdown that was sealed (so callers can seed the decrypt cache with
+ * the just-authored plaintext without re-serializing). */
 export interface SealedDraftFields {
   ciphertext: string
   envelope: unknown
   e2eVersion: number
+  contentMarkdown: string
 }
 
 /**
@@ -15,11 +17,12 @@ export interface SealedDraftFields {
  * across the author's devices without plaintext ever touching disk or wire
  * (E2EE-4). Reuses the message seal path (INV-35): the draft id binds the AAD in
  * the `messageId` slot exactly as a message id would, so a sealed draft is
- * indistinguishable on the wire from a sealed message and opens the same way.
+ * indistinguishable on the wire from a sealed message and opens the same way —
+ * decrypt-on-read goes through the shared `decrypt-cache` (`tryDecryptMessagePayload`).
  *
  * v1 seals the body only — attachments / context refs / slash commands on E2E
- * drafts are not yet sealed (they stay session-local, as they were before this
- * stage), so no `attachmentIds` are passed and the payload is bare markdown.
+ * drafts are not yet sealed (they stay session-local), so no `attachmentIds` are
+ * passed and the payload is bare markdown.
  *
  * Throws (locked session, missing SSK) the same way `sealOutgoingMessage` does;
  * the caller treats a throw as "can't persist right now" and keeps the content
@@ -33,47 +36,18 @@ export async function sealDraftContent(input: {
   draftId: string
   contentJson: JSONContent
 }): Promise<SealedDraftFields> {
+  const contentMarkdown = serializeToMarkdown(input.contentJson)
   const { e2eFields } = await sealOutgoingMessage({
     workspaceId: input.workspaceId,
     senderId: input.senderId,
     streamId: input.streamId,
     messageId: input.draftId,
-    contentMarkdown: serializeToMarkdown(input.contentJson),
+    contentMarkdown,
   })
-  return { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
-}
-
-/**
- * Open a sealed draft body back into ProseMirror content for the composer.
- * Mirrors the inbound message decrypt: the AAD travels in the envelope, so no
- * draft id is needed here. Returns null when the session is locked, the viewer
- * isn't a recipient of the stream key, or the payload is malformed — the caller
- * then renders an empty composer until the session unlocks.
- */
-export async function decryptDraftContent(input: {
-  ciphertext: string
-  envelope: unknown
-  e2eVersion: number | null | undefined
-  workspaceId: string
-  /** The E2E stream whose SSK wraps open the draft — the root for a thread. */
-  streamId: string
-  privateKey: CryptoKey
-  recipientKeyId: string
-}): Promise<JSONContent | null> {
-  const result = await tryDecryptMessagePayload(
-    {
-      contentMarkdown: "",
-      ciphertext: input.ciphertext,
-      envelope: input.envelope,
-      e2eVersion: input.e2eVersion ?? undefined,
-    },
-    {
-      privateKey: input.privateKey,
-      recipientKeyId: input.recipientKeyId,
-      workspaceId: input.workspaceId,
-      streamId: input.streamId,
-      rootStreamId: input.streamId,
-    }
-  )
-  return result?.contentJson ?? null
+  return {
+    ciphertext: e2eFields.ciphertext,
+    envelope: e2eFields.envelope,
+    e2eVersion: e2eFields.e2eVersion,
+    contentMarkdown,
+  }
 }

--- a/apps/frontend/src/lib/crypto/seal-draft.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.ts
@@ -1,0 +1,79 @@
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+import { sealOutgoingMessage } from "./seal-send"
+import { tryDecryptMessagePayload } from "./message-envelope"
+
+/** The E2E triple persisted at rest in place of a draft's plaintext (E2EE-4). */
+export interface SealedDraftFields {
+  ciphertext: string
+  envelope: unknown
+  e2eVersion: number
+}
+
+/**
+ * Seal a draft body to the stream's SSK so an encrypted-stream draft roams
+ * across the author's devices without plaintext ever touching disk or wire
+ * (E2EE-4). Reuses the message seal path (INV-35): the draft id binds the AAD in
+ * the `messageId` slot exactly as a message id would, so a sealed draft is
+ * indistinguishable on the wire from a sealed message and opens the same way.
+ *
+ * v1 seals the body only — attachments / context refs / slash commands on E2E
+ * drafts are not yet sealed (they stay session-local, as they were before this
+ * stage), so no `attachmentIds` are passed and the payload is bare markdown.
+ *
+ * Throws (locked session, missing SSK) the same way `sealOutgoingMessage` does;
+ * the caller treats a throw as "can't persist right now" and keeps the content
+ * in the composer for the session — drafts never surface a save error.
+ */
+export async function sealDraftContent(input: {
+  workspaceId: string
+  senderId: string
+  /** The E2E stream whose current SSK seals the draft — the root for a thread. */
+  streamId: string
+  draftId: string
+  contentJson: JSONContent
+}): Promise<SealedDraftFields> {
+  const { e2eFields } = await sealOutgoingMessage({
+    workspaceId: input.workspaceId,
+    senderId: input.senderId,
+    streamId: input.streamId,
+    messageId: input.draftId,
+    contentMarkdown: serializeToMarkdown(input.contentJson),
+  })
+  return { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
+}
+
+/**
+ * Open a sealed draft body back into ProseMirror content for the composer.
+ * Mirrors the inbound message decrypt: the AAD travels in the envelope, so no
+ * draft id is needed here. Returns null when the session is locked, the viewer
+ * isn't a recipient of the stream key, or the payload is malformed — the caller
+ * then renders an empty composer until the session unlocks.
+ */
+export async function decryptDraftContent(input: {
+  ciphertext: string
+  envelope: unknown
+  e2eVersion: number | null | undefined
+  workspaceId: string
+  /** The E2E stream whose SSK wraps open the draft — the root for a thread. */
+  streamId: string
+  privateKey: CryptoKey
+  recipientKeyId: string
+}): Promise<JSONContent | null> {
+  const result = await tryDecryptMessagePayload(
+    {
+      contentMarkdown: "",
+      ciphertext: input.ciphertext,
+      envelope: input.envelope,
+      e2eVersion: input.e2eVersion ?? undefined,
+    },
+    {
+      privateKey: input.privateKey,
+      recipientKeyId: input.recipientKeyId,
+      workspaceId: input.workspaceId,
+      streamId: input.streamId,
+      rootStreamId: input.streamId,
+    }
+  )
+  return result?.contentJson ?? null
+}

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -1,0 +1,108 @@
+import { serializeToMarkdown } from "@threa/prosemirror"
+import type { JSONContent } from "@threa/types"
+import type { CachedDraft } from "@/db"
+import { getCachedDecryption, requestDecryption, type DecryptCacheEntry } from "@/lib/crypto/decrypt-cache"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
+import { stripMarkdownToInline } from "@/lib/markdown"
+import type { useE2eSession } from "@/stores/e2e-session-store"
+
+/**
+ * The decrypt-on-read core shared by the composer (`useDecryptedDraftContent`)
+ * and list previews (`useDecryptedDraftPreviews`). Both read draft bodies from
+ * the same in-memory decrypt cache — plaintext never lands on disk (E2EE-4) — so
+ * the status machine and the "fire a decrypt" rule live here once; the hooks only
+ * differ in HOW they subscribe (per-id vs. a global cache version).
+ */
+type E2eSession = ReturnType<typeof useE2eSession>
+
+export type DraftDecryptionStatus = "none" | "plaintext" | "locked" | "pending" | "decrypted" | "failed"
+
+export interface DraftDecryption {
+  status: DraftDecryptionStatus
+  /** The plaintext body for plaintext/decrypted; null while none/locked/pending/failed. */
+  contentJson: JSONContent | null
+}
+
+/** A session that can actually open sealed content (unlocked, keys present). */
+export function isE2eUnlocked(session: E2eSession): boolean {
+  return session.status === "unlocked" && !!session.privateKey && !!session.keyId
+}
+
+/**
+ * Pure read of a draft's decrypt state from the session + its shared-cache entry.
+ * Plaintext drafts resolve immediately; sealed drafts report locked (session
+ * locked), decrypted/failed (cache result), or pending (in flight / root unknown).
+ */
+export function resolveDraftDecryption(
+  draft: CachedDraft | undefined,
+  unlocked: boolean,
+  cached: DecryptCacheEntry | undefined
+): DraftDecryption {
+  if (!draft) return { status: "none", contentJson: null }
+  if (draft.ciphertext == null) return { status: "plaintext", contentJson: draft.contentJson ?? null }
+  if (!unlocked) return { status: "locked", contentJson: null }
+  if (cached?.status === "decrypted" && cached.content)
+    return { status: "decrypted", contentJson: cached.content.contentJson }
+  if (cached?.status === "failed") return { status: "failed", contentJson: null }
+  return { status: "pending", contentJson: null }
+}
+
+/**
+ * Fire a decrypt for a sealed draft when possible and not already cached/in-flight
+ * — a no-op otherwise (so callers can invoke it unconditionally). The plaintext
+ * only ever lands in the in-memory cache (E2EE-4).
+ */
+export function requestDraftDecryption(
+  draft: CachedDraft,
+  keys: { privateKey: CryptoKey | null; recipientKeyId: string | null },
+  workspaceId: string,
+  rootStreamId: string | null | undefined
+): void {
+  if (draft.ciphertext == null || !rootStreamId || !keys.privateKey || !keys.recipientKeyId) return
+  const cached = getCachedDecryption(draft.id)
+  if (cached && cached.status !== "pending") return
+  void requestDecryption(
+    draft.id,
+    { contentMarkdown: "", ciphertext: draft.ciphertext, envelope: draft.envelope },
+    {
+      privateKey: keys.privateKey,
+      recipientKeyId: keys.recipientKeyId,
+      workspaceId,
+      streamId: rootStreamId,
+      rootStreamId,
+    }
+  )
+}
+
+// --- List-preview presentation (stash picker, /drafts explorer) ---
+
+export type DraftPreviewStatus = "ready" | "decrypting" | "locked" | "failed"
+
+export interface DraftPreview {
+  /** Inline, markdown-stripped body text; "" when empty or unavailable. */
+  text: string
+  status: DraftPreviewStatus
+}
+
+/** Inline, markdown-stripped text from a draft body; "" when empty. */
+export function draftInlineText(contentJson: JSONContent | null | undefined): string {
+  if (!contentJson || isEmptyContent(contentJson)) return ""
+  return stripMarkdownToInline(serializeToMarkdown(contentJson)).trim()
+}
+
+/** Project a decrypt state onto the list-preview shape. */
+export function draftDecryptionToPreview(decryption: DraftDecryption): DraftPreview {
+  if (decryption.status === "plaintext" || decryption.status === "decrypted") {
+    return { text: draftInlineText(decryption.contentJson), status: "ready" }
+  }
+  if (decryption.status === "failed") return { text: "", status: "failed" }
+  if (decryption.status === "locked") return { text: "", status: "locked" }
+  return { text: "", status: "decrypting" } // pending / none
+}
+
+/** User-facing label for a non-ready preview status. */
+export function draftPreviewStatusLabel(status: Exclude<DraftPreviewStatus, "ready">): string {
+  if (status === "decrypting") return "Decrypting…"
+  if (status === "failed") return "Couldn't decrypt"
+  return "Encrypted draft" // locked
+}

--- a/apps/frontend/src/sync/draft-e2e-roam.test.ts
+++ b/apps/frontend/src/sync/draft-e2e-roam.test.ts
@@ -87,7 +87,7 @@ describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
     // At rest on B: ciphertext only, never the plaintext body (E2EE-4).
     const stored = await db.drafts.get("draft_x")
     expect(stored?.ciphertext).toBe(sealed.ciphertext)
-    expect(stored?.e2eVersion).toBe(2)
+    expect(stored?.e2eVersion).toBe(sealed.e2eVersion)
     expect(stored?.contentJson).toEqual(EMPTY_DOC)
 
     // B decrypts on read — the same primitive the shared decrypt cache runs.

--- a/apps/frontend/src/sync/draft-e2e-roam.test.ts
+++ b/apps/frontend/src/sync/draft-e2e-roam.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { parseMarkdown } from "@threa/prosemirror"
+import type { Draft, JSONContent } from "@threa/types"
+import { db } from "@/db"
+import { resetDraftStoreCache } from "@/stores/draft-store"
+import { sealDraftContent } from "@/lib/crypto/seal-draft"
+import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
+import { applyDraftUpserted } from "./draft-sync"
+import * as sessionStore from "@/stores/e2e-session-store"
+import * as streamKeyCache from "@/lib/crypto/stream-key-cache"
+
+/**
+ * End-to-end roam proof for E2E drafts: seal on device A → the wire shape →
+ * `applyDraftUpserted` on a fresh device B → decrypt on read. Real AES-256-GCM
+ * runs (only the SSK resolution + session lookup are stubbed). This is the loop
+ * that was never exercised — the unit tests passed while the real roam was
+ * broken.
+ */
+
+const workspaceId = "ws_1"
+const userId = "user_1"
+const streamId = "stream_e2e" // the encrypted root whose SSK seals the body
+const scope = `stream:${streamId}`
+const EMPTY_DOC = { type: "doc", content: [{ type: "paragraph" }] }
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+})
+
+const ssk = crypto.getRandomValues(new Uint8Array(32))
+const session = {
+  status: "unlocked",
+  keyId: "ek_1",
+  publicKey: null,
+  privateKey: {} as CryptoKey,
+  deviceTrusted: true,
+  error: null,
+} as ReturnType<typeof sessionStore.getE2eSessionState>
+
+beforeEach(async () => {
+  vi.restoreAllMocks()
+  resetDraftStoreCache()
+  await db.drafts.clear()
+  await db.composerLoaded.clear()
+  await db.pendingOperations.clear()
+  vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(session)
+  vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })
+  vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(ssk)
+})
+
+describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
+  it("a sealed draft survives the wire shape and decrypts on the receiving device", async () => {
+    // Device A seals the body.
+    const sealed = await sealDraftContent({
+      workspaceId,
+      senderId: userId,
+      streamId,
+      draftId: "draft_x",
+      contentJson: makeDoc("roaming secret"),
+    })
+
+    // The row the backend stores and fans out: ciphertext sibling, no plaintext.
+    const wire: Draft = {
+      id: "draft_x",
+      workspaceId,
+      userId,
+      scope,
+      rootStreamId: streamId,
+      contentJson: null,
+      contentMarkdown: null,
+      attachmentIds: [],
+      command: null,
+      contextRefs: null,
+      ciphertext: sealed.ciphertext,
+      envelope: sealed.envelope,
+      e2eVersion: sealed.e2eVersion,
+      version: 1,
+      clientUpdatedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    // Device B applies the inbound draft (socket / bootstrap).
+    await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wire }, workspaceId)
+
+    // At rest on B: ciphertext only, never the plaintext body (E2EE-4).
+    const stored = await db.drafts.get("draft_x")
+    expect(stored?.ciphertext).toBe(sealed.ciphertext)
+    expect(stored?.e2eVersion).toBe(2)
+    expect(stored?.contentJson).toEqual(EMPTY_DOC)
+
+    // B decrypts on read — the same primitive the shared decrypt cache runs.
+    const opened = await tryDecryptMessagePayload(
+      {
+        contentMarkdown: "",
+        ciphertext: stored!.ciphertext!,
+        envelope: stored!.envelope,
+        e2eVersion: stored!.e2eVersion,
+      },
+      {
+        privateKey: session.privateKey!,
+        recipientKeyId: session.keyId!,
+        workspaceId,
+        streamId,
+        rootStreamId: streamId,
+      }
+    )
+    expect(opened?.contentJson).toEqual(parseMarkdown("roaming secret"))
+  })
+})

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -89,6 +89,21 @@ describe("cachedDraftFromWire", () => {
     expect(cachedDraftFromWire(wireDraft({ contextRefs: [] })).contextRefs).toBeUndefined()
     expect(cachedDraftFromWire(wireDraft({ contextRefs: [{ kind: "x" }] })).contextRefs).toEqual([{ kind: "x" }])
   })
+
+  it("maps the E2E triple and uses the placeholder body for a sealed row", () => {
+    const row = cachedDraftFromWire(
+      wireDraft({ contentJson: null, ciphertext: "ct", envelope: { v: 2 }, e2eVersion: 2 })
+    )
+    expect(row).toMatchObject({ ciphertext: "ct", e2eVersion: 2 })
+    expect(row.contentJson).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+  })
+
+  it("leaves the E2E fields unset for a plaintext row", () => {
+    const row = cachedDraftFromWire(wireDraft())
+    expect(row.ciphertext).toBeUndefined()
+    expect(row.envelope).toBeUndefined()
+    expect(row.e2eVersion).toBeUndefined()
+  })
 })
 
 describe("applyDraftUpserted", () => {
@@ -105,12 +120,20 @@ describe("applyDraftUpserted", () => {
     expect(await db.drafts.count()).toBe(0)
   })
 
-  it("ignores an E2E (contentless) row", async () => {
+  it("accepts an E2E (sealed) row, storing the ciphertext and a placeholder body", async () => {
     await applyDraftUpserted(
-      { workspaceId, targetUserId: userId, draft: wireDraft({ contentJson: null, ciphertext: "x" }) },
+      {
+        workspaceId,
+        targetUserId: userId,
+        draft: wireDraft({ contentJson: null, ciphertext: "ct_x", envelope: { v: 2 }, e2eVersion: 2 }),
+      },
       workspaceId
     )
-    expect(await db.drafts.count()).toBe(0)
+
+    const row = await db.drafts.get("draft_server1")
+    expect(row).toMatchObject({ scope, baseVersion: 1, ciphertext: "ct_x", e2eVersion: 2 })
+    // No plaintext at rest — the body lives in `ciphertext`; `contentJson` is the placeholder.
+    expect(row?.contentJson).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
   })
 
   it("ignores a stale echo at or below the confirmed version", async () => {
@@ -361,6 +384,33 @@ describe("executeDraftUpsert", () => {
     expect(row?.baseVersion).toBe(3)
     // local content is NOT overwritten with the server's derived copy
     expect(row?.contentJson).toEqual(makeDoc("typed"))
+  })
+
+  it("pushes the ciphertext triple (never plaintext) for an E2E draft", async () => {
+    await db.drafts.put(
+      localDraft({
+        id: "draft_e2e",
+        baseVersion: 1,
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+        ciphertext: "ct_sealed",
+        envelope: { v: 2 },
+        e2eVersion: 2,
+      })
+    )
+    const calls: UpsertDraftInput[] = []
+    const upsert = vi.fn(async (_w: string, id: string, input: UpsertDraftInput): Promise<UpsertDraftResponse> => {
+      calls.push(input)
+      return {
+        draft: wireDraft({ id, version: 2, contentJson: null, ciphertext: "ct_sealed", e2eVersion: 2 }),
+        split: false,
+      }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_e2e", "write_a", service(upsert))
+
+    // The sealed body goes on the wire; plaintext does not (the upsert schema rejects both).
+    expect(calls[0]).toMatchObject({ ciphertext: "ct_sealed", e2eVersion: 2, contentJson: null })
+    expect((await db.drafts.get("draft_e2e"))?.baseVersion).toBe(2)
   })
 
   it("migrates the local id to the server-minted id on a split", async () => {

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -386,7 +386,7 @@ describe("executeDraftUpsert", () => {
     expect(row?.contentJson).toEqual(makeDoc("typed"))
   })
 
-  it("pushes the ciphertext triple (never plaintext) for an E2E draft", async () => {
+  it("pushes the ciphertext triple (never plaintext or attachment linkage) for an E2E draft", async () => {
     await db.drafts.put(
       localDraft({
         id: "draft_e2e",
@@ -395,6 +395,10 @@ describe("executeDraftUpsert", () => {
         ciphertext: "ct_sealed",
         envelope: { v: 2 },
         e2eVersion: 2,
+        // A stray attachment id (e.g. carried by a pre-seal wire row): it must NOT
+        // ship alongside the ciphertext — v1 is body-only and an E2E row leaks no
+        // plaintext attachment linkage (E2EE-4).
+        attachmentIds: ["a_leak"],
       })
     )
     const calls: UpsertDraftInput[] = []
@@ -408,8 +412,9 @@ describe("executeDraftUpsert", () => {
 
     await executeDraftUpsert(workspaceId, "draft_e2e", "write_a", service(upsert))
 
-    // The sealed body goes on the wire; plaintext does not (the upsert schema rejects both).
-    expect(calls[0]).toMatchObject({ ciphertext: "ct_sealed", e2eVersion: 2, contentJson: null })
+    // The sealed body goes on the wire; plaintext does not (the upsert schema rejects both),
+    // and the sealed push carries no attachment ids.
+    expect(calls[0]).toMatchObject({ ciphertext: "ct_sealed", e2eVersion: 2, contentJson: null, attachmentIds: [] })
     expect((await db.drafts.get("draft_e2e"))?.baseVersion).toBe(2)
   })
 

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -511,8 +511,15 @@ export async function executeDraftUpsert(
   const row = await db.drafts.get(draftId)
   if (!row) return // discarded locally after the op was enqueued — nothing to push
 
-  const attachmentIds = row.attachments.length > 0 ? row.attachments.map((a) => a.id) : (row.attachmentIds ?? [])
   const isE2e = row.ciphertext != null
+  // A sealed row never ships attachment linkage: v1 is body-only, and an E2E row
+  // must not push plaintext attachment ids alongside its ciphertext (E2EE-4) — no
+  // matter how the row acquired them (e.g. a pre-seal wire row). Enforced here at
+  // the push boundary, not just on the write paths.
+  let attachmentIds: string[] = []
+  if (!isE2e) {
+    attachmentIds = row.attachments.length > 0 ? row.attachments.map((a) => a.id) : (row.attachmentIds ?? [])
+  }
   const input: UpsertDraftInput = {
     scope: row.scope,
     // The server owns root_stream_id on thread re-pointing (it sets it when a

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -38,9 +38,11 @@ import type {
  * `upsert_draft` op for an id IS the local dirty bit — rather than a flag on the
  * row, so the two can never drift apart.
  *
- * E2E drafts (null `contentJson`, ciphertext-only) are out of scope here: Stage
- * 3 never pushes them (the composer hook gates encrypted streams), and inbound
- * E2E rows are ignored until decrypt-on-load lands in Stage 4.
+ * E2E drafts roam as ciphertext (Stage 4c): the composer seals the body before
+ * it is persisted and pushed, so this layer carries the `ciphertext` / `envelope`
+ * / `e2eVersion` triple (with null `contentJson`) over the wire and stores it
+ * sealed at rest — the plaintext is decrypted into memory only when the composer
+ * loads the draft. The drift/split bookkeeping below is content-shape-agnostic.
  */
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
@@ -71,12 +73,18 @@ export function cachedDraftFromWire(draft: Draft): CachedDraft {
     id: draft.id,
     workspaceId: draft.workspaceId,
     scope: draft.scope,
+    // E2E rows carry null `contentJson` on the wire (the body lives sealed in
+    // `ciphertext`); the placeholder keeps the local shape uniform and the
+    // composer decrypts the body into memory on load.
     contentJson: draft.contentJson ?? EMPTY_DOC,
     attachments: [],
     contextRefs,
     attachmentIds: draft.attachmentIds,
     baseVersion: draft.version,
     clientUpdatedAt: Number.isNaN(clientUpdatedAt) ? Date.now() : clientUpdatedAt,
+    ...(draft.ciphertext != null
+      ? { ciphertext: draft.ciphertext, envelope: draft.envelope, e2eVersion: draft.e2eVersion ?? undefined }
+      : {}),
   }
 }
 
@@ -376,8 +384,6 @@ export async function applyDraftUpserted(
 ): Promise<void> {
   const { draft } = payload
   if (draft.workspaceId !== expectedWorkspaceId) return
-  // E2E rows carry no plaintext to render/store yet (Stage 4).
-  if (draft.contentJson === null) return
 
   // A queued local delete wins: the user discarded this draft here and its
   // `delete_draft` op (not yet drained) will remove the server row. Until then,
@@ -508,6 +514,7 @@ export async function executeDraftUpsert(
   if (!row) return // discarded locally after the op was enqueued — nothing to push
 
   const attachmentIds = row.attachments.length > 0 ? row.attachments.map((a) => a.id) : (row.attachmentIds ?? [])
+  const isE2e = row.ciphertext != null
   const input: UpsertDraftInput = {
     scope: row.scope,
     // The server owns root_stream_id on thread re-pointing (it sets it when a
@@ -517,9 +524,14 @@ export async function executeDraftUpsert(
     expectedVersion: row.baseVersion ?? 0,
     writeId: writeIdValue,
     clientUpdatedAt: new Date(row.clientUpdatedAt).toISOString(),
-    contentJson: row.contentJson,
+    // An E2E draft pushes its sealed body, never plaintext — the server stores
+    // the ciphertext opaquely and the upsert schema rejects carrying both.
+    contentJson: isE2e ? null : row.contentJson,
     attachmentIds,
     contextRefs: (row.contextRefs as unknown as Record<string, unknown>[] | undefined) ?? null,
+    ciphertext: isE2e ? row.ciphertext : null,
+    envelope: isE2e ? row.envelope : null,
+    e2eVersion: isE2e ? (row.e2eVersion ?? null) : null,
   }
 
   const res = await service.upsert(workspaceId, draftId, input)

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -12,12 +12,12 @@ import type {
   Draft,
   DraftDeletedPayload,
   DraftUpsertedPayload,
-  JSONContent,
   ResolveDraftInput,
   ResolveDraftResponse,
   UpsertDraftInput,
   UpsertDraftResponse,
 } from "@threa/types"
+import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 
 /**
  * Stage 3 draft sync — wires the local-first draft store (Stage 2) to the
@@ -44,8 +44,6 @@ import type {
  * sealed at rest — the plaintext is decrypted into memory only when the composer
  * loads the draft. The drift/split bookkeeping below is content-shape-agnostic.
  */
-
-const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 
 /** Minimal surface of the drafts REST client the queue replays against. */
 export interface DraftsServiceLike {

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -226,9 +226,48 @@ from Stage 1 still green.
 
 - `moveMessagesToThread` (`event-service.ts`): re-scope user's `thread:{targetMessageId}` drafts → `stream:{threadStreamId}` (+ `root_stream_id`) in the move transaction, emit `draft:upserted`. Frontend handler moves the local draft + loaded pointer. Fold the unpromoted-draft-stream case into the existing `promoteDraft` flow (re-scope + push on promotion).
 
-#### Stage 4c — E2E
+#### Stage 4c — E2E — DONE (body only)
 
 - E2E: seal draft to stream SSK before persist/push; store ciphertext locally; decrypt on load.
+
+The backend (table + `upsertSchema` + repo/service/view) already carried the
+`ciphertext` / `envelope` / `e2eVersion` triple from Stage 1, so 4c was
+frontend-only:
+
+- `lib/crypto/seal-draft.ts` (new): `sealDraftContent` (reuses `sealOutgoingMessage`,
+  the draft id binds the AAD in the message-id slot) and `decryptDraftContent`
+  (reuses `tryDecryptMessagePayload`; the AAD travels in the envelope, so no draft
+  id needed on open).
+- `hooks/use-draft-message.ts`: the old "encrypted streams disable persistence"
+  gate is replaced. The hook now reads the viewer id (`useCurrentWorkspaceUserId`,
+  extracted to its own hook) + `useE2eSession`, and the third arg is `e2eStreamId`
+  (the encrypted root to seal against) instead of a boolean. **Unlocked** → seal on
+  save (`upsertLoadedSealedDraft` writes ciphertext + an EMPTY_DOC placeholder, never
+  plaintext) and decrypt-on-load into the composer (gated by `isLoaded` until the
+  decrypt resolves). **Locked** → behaves exactly as before (nothing loads/persists;
+  the sealed row waits on disk). Mount sweep is `purgePlaintextScopeDrafts` (keeps
+  sealed rows, removes only plaintext-at-rest).
+- `sync/draft-sync.ts`: `cachedDraftFromWire` maps the triple; `applyDraftUpserted`
+  no longer drops E2E rows; `executeDraftUpsert` pushes the ciphertext triple (null
+  `contentJson`) for sealed rows.
+- Call sites (`message-input.tsx`, `thread/stream-panel.tsx`) pass the encrypted
+  root (`rootStreamId ?? id`); `use-draft-composer.ts` threads `e2eStreamId`.
+
+**Scope boundary (v1) — deferred follow-ups, all non-regressing vs. pre-4c:**
+
+- **E2E-draft attachments / context refs / slash commands are not sealed yet** —
+  only the body roams. They stay session-local exactly as before (per-file
+  attachment-key roaming across devices is its own design).
+- **The manual stash (Cmd+S) is disabled for encrypted streams** (`useStashComposer`
+  no-ops + the trigger is disabled): stashing snapshots composer plaintext, which
+  would violate E2EE-4. The ambient (auto-saved) draft still roams.
+- **The `/drafts` explorer doesn't list E2E drafts** (sealed rows have an empty
+  placeholder body, so the existing empty-content filter skips them). The stash
+  picker shows a neutral "Encrypted draft" placeholder for any sealed row that
+  arrives via sync rather than decrypting in the list.
+- **Unlock-after-open**: a draft that decrypts only after the session unlocks
+  needs the stream reopened to load into an already-mounted composer (the common
+  flow — unlock at workspace entry, then open — works).
 
 **Reuse:** `sealOutgoingMessage` E2E path; existing `promoteDraft` / `setParentThreadId`; resolve CAS from Stage 1.
 

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -262,9 +262,10 @@ frontend-only:
   no-ops + the trigger is disabled): stashing snapshots composer plaintext, which
   would violate E2EE-4. The ambient (auto-saved) draft still roams.
 - **The `/drafts` explorer doesn't list E2E drafts** (sealed rows have an empty
-  placeholder body, so the existing empty-content filter skips them). The stash
-  picker shows a neutral "Encrypted draft" placeholder for any sealed row that
-  arrives via sync rather than decrypting in the list.
+  placeholder body, so the existing empty-content filter skips them). The
+  in-composer stash list is empty for encrypted streams (`useStashComposer`
+  returns no entries when E2E), so a sealed row never renders as a dead restore
+  control.
 - **Unlock-after-open**: a draft that decrypts only after the session unlocks
   needs the stream reopened to load into an already-mounted composer (the common
   flow — unlock at workspace entry, then open — works).

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -253,22 +253,29 @@ frontend-only:
 - Call sites (`message-input.tsx`, `thread/stream-panel.tsx`) pass the encrypted
   root (`rootStreamId ?? id`); `use-draft-composer.ts` threads `e2eStreamId`.
 
-**Scope boundary (v1) — deferred follow-ups, all non-regressing vs. pre-4c:**
+**Scope boundary (v1) — deferred follow-up, non-regressing vs. pre-4c:**
 
 - **E2E-draft attachments / context refs / slash commands are not sealed yet** —
   only the body roams. They stay session-local exactly as before (per-file
   attachment-key roaming across devices is its own design).
-- **The manual stash (Cmd+S) is disabled for encrypted streams** (`useStashComposer`
-  no-ops + the trigger is disabled): stashing snapshots composer plaintext, which
-  would violate E2EE-4. The ambient (auto-saved) draft still roams.
-- **The `/drafts` explorer doesn't list E2E drafts** (sealed rows have an empty
-  placeholder body, so the existing empty-content filter skips them). The
-  in-composer stash list is empty for encrypted streams (`useStashComposer`
-  returns no entries when E2E), so a sealed row never renders as a dead restore
-  control.
-- **Unlock-after-open**: a draft that decrypts only after the session unlocks
-  needs the stream reopened to load into an already-mounted composer (the common
-  flow — unlock at workspace entry, then open — works).
+
+**Shipped beyond the initial cut, so the feature is usable end-to-end:**
+
+- **Manual stash (Cmd+S) works for encrypted streams.** Stash/restore are pointer
+  moves (`stashLoadedDraft` / `restoreStashedDraftToComposer`), not plaintext
+  snapshots: the sealed row is detached/attached via the `composerLoaded` pointer,
+  so nothing plaintext leaves memory (E2EE-4) and the pile behaves the same for
+  plaintext and E2E. `flushDraft` only persists a non-empty editor, so a restore
+  fired mid-hydration can't delete the loaded draft.
+- **The `/drafts` explorer lists E2E drafts** with decrypt-on-read previews
+  (`useDecryptedDraftPreviews` over the shared cache): a ciphertext row counts as
+  content, and its body decrypts in memory, falling back to an `Encrypted draft` /
+  `Decrypting…` label while locked or mid-decrypt. Rows whose encrypted root can't
+  be resolved yet are simply not queued for decrypt (no stuck spinner).
+- **Unlock-after-open loads in place.** A draft that decrypts only after the
+  session unlocks — or a stash-restore pointer swap — re-hydrates the already-open
+  composer via a late-hydrate effect (no stream reopen required), guarded by
+  `userEngagedRef` so it never clobbers typed content.
 
 **Reuse:** `sealOutgoingMessage` E2E path; existing `promoteDraft` / `setParentThreadId`; resolve CAS from Stage 1.
 


### PR DESCRIPTION
## Problem

Drafts in encrypted streams didn't roam. The centralized-draft system (Stages 1–4b) syncs plaintext message/thread drafts across a user's devices through the `user:{userId}` outbox room, but `useDraftMessage` had an explicit gate that **disabled persistence entirely** for E2E streams: every save/add/remove early-returned on `e2eEnabled`, `loadedId` was forced to `null`, and a mount-time `purgeScopeDrafts` wiped any draft on disk. That honored E2EE-4 ("no plaintext draft at rest") the blunt way — by keeping nothing — so a reply you start in an encrypted scratchpad on your phone was invisible on your laptop.

## Solution

Reuse the message E2E path for drafts: seal the draft body to the stream SSK before it is persisted/pushed, store only ciphertext at rest, and decrypt into the composer on load. A draft body is sealed exactly like a message body — `sealOutgoingMessage` under the stream's current SSK, with the **draft id** binding the AAD in the message-id slot — and opened with `tryDecryptMessagePayload`, which reads the AAD back out of the envelope (so the open side needs no draft id).

The backend was already E2E-ready from Stage 1 — the `drafts` table, `upsertSchema`, repository, service, and `toDraftView` all carry the `ciphertext` / `envelope` / `e2eVersion` triple — so this change is **frontend-only**.

### How it works

1. **Seal on save.** `lib/crypto/seal-draft.ts` adds `sealDraftContent` (serialize `contentJson` → markdown via `serializeToMarkdown`, then `sealOutgoingMessage`, return the triple). `upsertLoadedSealedDraft` (in `use-draft-message.ts`) writes a `CachedDraft` whose `contentJson` is the `EMPTY_DOC` placeholder and whose `ciphertext`/`envelope`/`e2eVersion` hold the sealed body — no plaintext touches IndexedDB (E2EE-4).
2. **Decrypt on load.** `decryptDraftContent` (reuses `tryDecryptMessagePayload`) opens the loaded draft's ciphertext into memory once per loaded id; `useDraftMessage` returns it as `contentJson` and gates `isLoaded` on the decrypt so the composer initializes with the real body instead of flashing empty. The decrypted plaintext lives only in the hook's state — never in IDB, never in the workspace-wide draft cache.
3. **Push/pull the triple.** `draft-sync.ts`: `executeDraftUpsert` sends `{ ciphertext, envelope, e2eVersion, contentJson: null }` for sealed rows (the `upsertSchema` `.refine` rejects carrying both); `cachedDraftFromWire` maps the triple inbound; `applyDraftUpserted` no longer drops E2E rows, so a sealed draft from another device lands in the local store and decrypts when the composer opens it. The drift/split bookkeeping is content-shape-agnostic and is reused unchanged.
4. **Locked = prior behavior.** Seal/decrypt run only when the E2E session is unlocked. Locked, `loadedId` is `null` and nothing persists — exactly the pre-4c gate — and the sealed row waits on disk for unlock. `saveDraft` reads the live unlock/encryption state from a ref at debounce-fire time, so a value typed while the stream was plaintext is never written as plaintext after it becomes encrypted.
5. **Mount sweep keeps sealed rows.** The old `purgeScopeDrafts` (delete-all) mount effect is replaced by `purgePlaintextScopeDrafts`, which removes only plaintext rows for the E2E scope and preserves sealed ones.

### Key design decisions

**1. Reuse the message seal/open pair, draft id as the AAD message-id (INV-35).** `sealOutgoingMessage` / `tryDecryptMessagePayload` are the canonical SSK path; a draft seals indistinguishably from a message and inherits the same AAD binding. The open side reads `envelope.aad` rather than recomputing it, so a server split (which copies the ciphertext to a fresh id) doesn't break decryption — the AAD still references the original draft id, and nothing recomputes it.

**2. Read the viewer id + session inside the hook, not threaded from the call site.** `useDraftMessage`'s third arg is now the **e2e root stream id** (a thread passes its root, where the SSK wraps live); `useCurrentWorkspaceUserId` + `useE2eSession` are read internally so the composer reacts to an unlock without a remount. The viewer-id lookup was extracted from a private helper in `use-labels.ts` into its own hook so the two surfaces don't each re-derive the `workosUserId` → workspace-user mapping (the footgun `apps/frontend/CLAUDE.md` warns about).

**3. Body-only, and stash disabled for E2E — both deliberately non-regressing.** v1 seals the body; attachments / context refs / slash commands on E2E drafts stay session-local exactly as before (per-file attachment-key roaming across devices is its own design). The manual stash (Cmd+S) is gated off for encrypted streams at its one chokepoint (`useStashComposer`'s `handleStashDraft` / `handleRestoreStashed`, which all triggers — button, keyboard, `?stash=` URL — route through), because stashing snapshots the composer's plaintext and would write it at rest. Both are strictly better than pre-4c (which persisted nothing for E2E), so neither regresses behavior.

### Design evolution (self-review)

- **Stash leak.** First sweep of the surfaces found that `useStashComposer` snapshots `composer.content` (plaintext) straight into `db.drafts` — a real E2EE-4 violation once E2E composers persist. Gated both handlers (one chokepoint covers every trigger) rather than sealing stash entries, which is deferred.
- **Provider-less hook tests.** Adding the unconditional `useCurrentWorkspaceUserId` → `useAuth()` read would have thrown in the existing `renderHook` tests (no `AuthProvider`). Fixed by default-spying the viewer-id + session hooks in `beforeEach` (INV-48 namespace `spyOn`), with per-test overrides for the unlocked-E2E cases.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crypto/seal-draft.ts` | `sealDraftContent` / `decryptDraftContent` — seal/open a draft body, reusing the message E2E path |
| `apps/frontend/src/lib/crypto/seal-draft.test.ts` | Real-WebCrypto seal→decrypt round-trip; locked-session throw; non-recipient → `null` |
| `apps/frontend/src/hooks/use-current-workspace-user-id.ts` | Shared viewer workspace-user-id hook (extracted from `use-labels.ts`) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | Seal-on-save (`upsertLoadedSealedDraft`), decrypt-on-load, locked = prior gate, `purgePlaintextScopeDrafts` mount sweep; 3rd arg is now the e2e root stream id |
| `apps/frontend/src/sync/draft-sync.ts` | Map (`cachedDraftFromWire`), accept (`applyDraftUpserted`), and push (`executeDraftUpsert`) the E2E triple instead of plaintext |
| `apps/frontend/src/hooks/use-draft-composer.ts` | Option `e2eStreamId` (replaces the `e2eEnabled` boolean); derives the upload-encryption flag |
| `apps/frontend/src/hooks/use-stash-composer.ts` | Gate stash + restore for E2E at the chokepoint (covers button / keyboard / `?stash=` URL) |
| `apps/frontend/src/components/timeline/message-input.tsx` | Pass the e2e root stream id; disable the stash trigger for E2E |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Same, resolving the root off the thread stream or its parent |
| `apps/frontend/src/components/composer/stashed-drafts-picker.tsx` | "Encrypted draft" placeholder for any sealed row in the list |
| `apps/frontend/src/db/database.ts` | `CachedDraft` gains optional `ciphertext` / `envelope` / `e2eVersion` (no Dexie version bump — non-indexed) |
| `apps/frontend/src/hooks/use-labels.ts` | Import the extracted viewer-id hook; remove the private copy |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | Unlocked-E2E coverage; adapt the gate tests to the locked path + new signature |
| `apps/frontend/src/sync/draft-sync.test.ts` | Accept-and-store E2E row; map/push triple coverage |
| `docs/plans/centralized-draft-system.md` | Mark Stage 4c DONE (body only) + record the deferred follow-ups |

## Out of scope (deliberate)

- **E2E-draft attachments / context refs / slash commands** — sealed body only; these stay session-local as before. Roaming the per-file attachment keys across devices is a separate design.
- **Manual stash / `/drafts` explorer for E2E** — stash is gated off; the explorer's existing empty-content filter skips sealed rows (their body is the placeholder). The stash picker shows a neutral placeholder for any sealed row that arrives via sync.
- **Unlock-after-open** — a draft that decrypts only after the session unlocks needs the stream reopened to load into an already-mounted composer. The common flow (unlock at workspace entry, then open) works.

## Test plan

- [x] `vitest run src/hooks/use-draft-message.test.ts` — 25 pass (seal-on-save ciphertext-only, decrypt-on-load, locked no-op, plus the existing plaintext suite)
- [x] `vitest run src/sync/draft-sync.test.ts` — 39 pass (accept+store E2E row, map triple, push triple)
- [x] `vitest run src/lib/crypto/seal-draft.test.ts` — 3 pass (real-WebCrypto round-trip, locked throws, non-recipient → null)
- [x] `vitest run src/hooks src/sync src/components/{composer,timeline,thread}` — 980 pass across the touched dirs
- [x] `tsc --noEmit` across all workspaces (pre-commit gate), eslint clean, prettier applied
- [x] `generate-api-docs.ts --check` — OpenAPI spec unchanged (frontend-only)
- [ ] `test:e2e` (Playwright) not run — needs a full app + an unlocked E2E session; the send-path E2E spec is unchanged and draft seal/decrypt is covered at unit level including real WebCrypto

<details>
<summary>📋 Full implementation plan</summary>

**Goal (plan §Stage 4c):** seal draft to stream SSK before persist/push; store ciphertext locally; decrypt on load — so encrypted-stream drafts roam without plaintext at rest or on the wire (E2EE-4).

**What was built:** frontend-only (backend carried the E2E columns + validation since Stage 1).
- `seal-draft.ts`: `sealDraftContent` (reuse `sealOutgoingMessage`, draft id → AAD message-id slot) / `decryptDraftContent` (reuse `tryDecryptMessagePayload`; AAD travels in the envelope).
- `use-draft-message.ts`: unlocked → seal-on-save + decrypt-on-load (gated `isLoaded`); locked → prior gate; plaintext-only mount purge; 3rd arg is the e2e root stream id (reads viewer id + session internally).
- `draft-sync.ts`: map/accept/push the `ciphertext`/`envelope`/`e2eVersion` triple.
- Call sites pass the encrypted root; `use-draft-composer.ts` threads `e2eStreamId`.
- Shared `useCurrentWorkspaceUserId` extracted from `use-labels.ts`.

**Design decisions:** reuse the message seal/open pair (INV-35); read viewer/session in-hook for unlock reactivity; body-only + stash-disabled for E2E, both non-regressing.

**Schema changes:** none (no migration; `CachedDraft` gains non-indexed optional fields, no Dexie bump).

**Not included (deferred):** E2E-draft attachments/context-refs/commands roaming; E2E stash; decryptable list previews; unlock-after-open re-init.

**Status:** Stages 1, 2, 3, 4a (#932), 4b (#937) merged; 4c is this PR. The centralized-draft sequence completes here for the message/thread-draft surface (encrypted *scratchpad* drafts remain a separate design per the plan's non-goals).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011RPQEKUDCQ3nm8HVR9i8Sa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784060811&installation_id=129946197&pr_number=946&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F946&signature=3ac60522cc5c33eaa70183744906521eb1d728028d403bd0da360a91eef64362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->