### PR TITLE
feat: render decrypted E2E sealed stream names across all label surfaces

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -52,6 +52,20 @@ Pick the entry point by what you're holding:
 selects context-appropriate placeholder wording for unnamed streams; pass the
 one that matches the surface. `streamLabel` defaults to `"generic"`.
 
+### E2E sealed names resolve through the same path
+
+An E2E scratchpad's name can be sealed (the enclave auto-title, or a manual
+rename re-sealed under the SSK). The server-mutable plaintext `displayName` is
+only the locked-state fallback; an unlocked owner should see the tamper-evident
+decrypted copy. You do **not** thread this through call sites: `useWorkspaceStreams`
+overlays the decrypted name onto `displayName` at the store-read boundary, so
+`streamLabel`/`resolveStreamName`/`useStreamName` already reflect it everywhere.
+The plaintext is held only in the memory-only `lib/crypto/stream-name-cache`
+(decrypt authority), never persisted — IDB keeps `sealedNameCiphertext`. A locked
+session shows the placeholder; the open-stream header reads the same cache via
+`useDecryptedStreamName`. Don't re-decrypt names per surface — extend the cache /
+overlay if a new surface bypasses the workspace store.
+
 ### Why this exists
 
 DM display names are computed per-viewer on the backend at bootstrap and are

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -60,6 +60,7 @@ import { ResponsiveBreadcrumbs } from "./responsive-breadcrumbs"
 import { LabelableResourceTypes, StreamTypes } from "@threa/types"
 import type { MentionStreamContext } from "@/hooks/use-mentionables"
 import { streamLabel } from "@/lib/streams"
+import { useDecryptedStreamName } from "@/hooks/use-decrypted-stream-name"
 import { copyStreamLink } from "@/lib/stream-links"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { StreamLabelStack } from "@/components/labels/stream-label-stack"
@@ -100,6 +101,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   const stream = idbPanelStream ?? bootstrap?.stream
   const isThread = stream?.type === StreamTypes.THREAD
   const currentWorkspaceUserId = useWorkspaceUserId(workspaceId)
+  // The bootstrap fallback above isn't overlaid by the workspace store, so an
+  // E2E scratchpad opened in a panel before its row lands in the cache would
+  // show the placeholder. Decrypt the resolved stream's sealed name directly
+  // (same cache as the overlay) to keep the panel header consistent.
+  const decryptedPanelName = useDecryptedStreamName(workspaceId, stream)
 
   // Show loading indicator only for real streams (not drafts) and only when actively loading after initial data
   const showLoadingIndicator = !isDraft && !!panelId && getStreamState(panelId) === "loading"
@@ -432,7 +438,11 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
   } else if (isThread && stream) {
     headerContent = <ThreadHeader workspaceId={workspaceId} stream={stream} inPanel />
   } else {
-    headerContent = <SidePanelTitle className="flex-1">{stream ? streamLabel(stream) : "Stream"}</SidePanelTitle>
+    headerContent = (
+      <SidePanelTitle className="flex-1">
+        {stream ? (decryptedPanelName ?? streamLabel(stream)) : "Stream"}
+      </SidePanelTitle>
+    )
   }
 
   return (
@@ -479,7 +489,9 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 description="Choose an action for this stream."
                 header={
                   <div className="px-4 pt-2 pb-3">
-                    <p className="truncate text-base font-semibold text-foreground">{streamLabel(stream)}</p>
+                    <p className="truncate text-base font-semibold text-foreground">
+                      {decryptedPanelName ?? streamLabel(stream)}
+                    </p>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                       {stream.type === StreamTypes.THREAD ? "Thread" : "Stream"} actions
                     </p>

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -107,6 +107,17 @@ export interface CachedStream {
    * older cached rows still parse; treated as an empty set when absent.
    */
   e2eActors?: E2eActor[]
+  /**
+   * The stream's display name sealed under the SSK (base64 ciphertext + its
+   * `StreamEnvelope` framing). Persisting *ciphertext* at rest is safe — it
+   * mirrors how message bodies keep ciphertext in `db.events.payload` and
+   * decrypt only in memory. An unlocked client decrypts this and prefers it
+   * over the plaintext `displayName`; the decrypted plaintext is held only in
+   * the memory-only `stream-name-cache` and is never written back to IDB.
+   * Both null until the stream is renamed (or auto-titled) while E2E.
+   */
+  sealedNameCiphertext?: string | null
+  sealedNameEnvelope?: unknown | null
   _cachedAt: number
 }
 

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, act, waitFor } from "@testing-library/react"
+import { StreamTypes, type StreamType } from "@threa/types"
+import { db, type CachedStream } from "@/db"
+import { resetWorkspaceStoreCache, seedWorkspaceCache } from "@/stores/workspace-store"
+import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
+import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
+import { useStreamName } from "@/hooks/use-stream-name"
+import * as e2eSession from "@/stores/e2e-session-store"
+import * as workspaces from "@/hooks/use-workspaces"
+import * as messageEnvelope from "@/lib/crypto/message-envelope"
+
+// End-to-end of the reactive render path the unit tests can't reach: mount the
+// real per-workspace decryptor next to the canonical resolver hook and prove a
+// landing decrypt propagates (cache emit -> useWorkspaceStreams overlay
+// re-render -> useStreamName) so every label surface flips placeholder ->
+// decrypted name, and stays on the placeholder while locked.
+
+const WS = "workspace_1"
+const STREAM = "stream_scratch"
+const CIPHERTEXT = "ct_sealed_name"
+
+function sealedScratchpad(): CachedStream {
+  return {
+    id: STREAM,
+    workspaceId: WS,
+    type: StreamTypes.SCRATCHPAD as StreamType,
+    // The enclave auto-title never writes plaintext, so the locked/undecrypted
+    // resolver must fall through to the placeholder.
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "private",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-01T00:00:00Z",
+    archivedAt: null,
+    e2eEnabled: true,
+    sealedNameCiphertext: CIPHERTEXT,
+    sealedNameEnvelope: { v: 2 },
+    _cachedAt: Date.now(),
+  }
+}
+
+function session(overrides: Partial<e2eSession.E2eSessionState>): e2eSession.E2eSessionState {
+  return {
+    status: "unlocked",
+    keyId: "ek_owner",
+    publicKey: new Uint8Array(),
+    privateKey: {} as CryptoKey,
+    deviceTrusted: true,
+    error: null,
+    ...overrides,
+  }
+}
+
+function Harness() {
+  useDecryptStreamNames(WS)
+  const name = useStreamName(WS, STREAM, "sidebar")
+  return <span data-testid="label">{name}</span>
+}
+
+async function seedSealedStream() {
+  await db.streams.put(sealedScratchpad())
+  seedWorkspaceCache(WS, {
+    workspace: {
+      id: WS,
+      name: "Workspace",
+      slug: "workspace",
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:00:00Z",
+      _cachedAt: Date.now(),
+    },
+    users: [],
+    streams: [sealedScratchpad()],
+    memberships: [],
+    dmPeers: [],
+    personas: [],
+    bots: [],
+  })
+}
+
+beforeEach(async () => {
+  resetWorkspaceStoreCache()
+  clearStreamNameCache()
+  await db.streams.clear()
+  vi.spyOn(workspaces, "useWorkspaceUserId").mockReturnValue("user_1")
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("decrypted stream name overlay (reactive integration)", () => {
+  it("flips placeholder -> decrypted name through the resolver when the decrypt lands", async () => {
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "unlocked" }))
+    // Hold the decrypt open so the placeholder is observable before it resolves.
+    let resolveDecrypt: (value: string | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveDecrypt = resolve
+        })
+    )
+
+    await seedSealedStream()
+    render(<Harness />)
+
+    // Decrypt in flight: the resolver shows the locked-state placeholder.
+    expect(screen.getByTestId("label")).toHaveTextContent("New scratchpad")
+
+    // The decrypt lands → cache emits → useWorkspaceStreams re-overlays →
+    // useStreamName re-renders with the tamper-evident name. No per-surface wiring.
+    await act(async () => {
+      resolveDecrypt("Quarterly Plan")
+    })
+    await waitFor(() => expect(screen.getByTestId("label")).toHaveTextContent("Quarterly Plan"))
+  })
+
+  it("keeps the placeholder and never decrypts while the session is locked", async () => {
+    const open = vi.spyOn(messageEnvelope, "tryOpenStreamName").mockResolvedValue("Should Not Appear")
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "locked", privateKey: null }))
+
+    await seedSealedStream()
+    render(<Harness />)
+
+    await waitFor(() => expect(screen.getByTestId("label")).toHaveTextContent("New scratchpad"))
+    expect(open).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.ts
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
 import { requestStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
 
 /**
@@ -19,7 +19,7 @@ import { requestStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-
 export function useDecryptStreamNames(workspaceId: string): void {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
-  const streams = useWorkspaceStreams(workspaceId)
+  const streams = useWorkspaceStreamsRaw(workspaceId)
 
   const unlocked = session.status === "unlocked"
   const keyId = session.keyId

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.ts
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo } from "react"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { requestStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
+
+/**
+ * Background decryptor for E2E stream names. Mounted once per workspace, it walks
+ * the cached streams and — once the session is unlocked — kicks off a decrypt for
+ * every sealed name into the memory-only `stream-name-cache`. The store-read
+ * overlay (`useWorkspaceStreams`) then reflects the decrypted name everywhere a
+ * label is resolved, with the plaintext held only in memory.
+ *
+ * The trigger is separate from the read so decrypts fire from one place (here +
+ * the open-stream header) rather than from each render of each list row.
+ * `requestStreamName` is idempotent per `(stream, ciphertext)`, so the effect
+ * re-running as names land is cheap (a `Map.has` per stream).
+ */
+export function useDecryptStreamNames(workspaceId: string): void {
+  const userId = useWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const streams = useWorkspaceStreams(workspaceId)
+
+  const unlocked = session.status === "unlocked"
+  const keyId = session.keyId
+  const privateKey = session.privateKey
+
+  // Only sealed E2E streams matter; deriving the targets keeps the decrypt loop
+  // off non-E2E streams and the churny sidebar-preview fields.
+  const targets = useMemo(
+    () =>
+      streams
+        .filter((stream) => stream.e2eEnabled && stream.sealedNameCiphertext && stream.sealedNameEnvelope)
+        .map((stream) => ({
+          id: stream.id,
+          rootStreamId: stream.rootStreamId ?? stream.id,
+          ciphertext: stream.sealedNameCiphertext as string,
+          envelope: stream.sealedNameEnvelope,
+        })),
+    [streams]
+  )
+
+  useEffect(() => {
+    if (!unlocked || !keyId || !privateKey) return
+    for (const target of targets) {
+      requestStreamName(
+        streamNameCacheKey(workspaceId, target.id, target.ciphertext),
+        { ciphertext: target.ciphertext, envelope: target.envelope },
+        {
+          workspaceId,
+          streamId: target.id,
+          rootStreamId: target.rootStreamId,
+          recipientKeyId: keyId,
+          privateKey,
+        }
+      )
+    }
+  }, [targets, unlocked, keyId, privateKey, workspaceId])
+}

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -1,13 +1,21 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useSyncExternalStore } from "react"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { tryOpenStreamName } from "@/lib/crypto/message-envelope"
+import {
+  getCachedStreamName,
+  getStreamNameCacheVersion,
+  requestStreamName,
+  streamNameCacheKey,
+  subscribeStreamNameCache,
+} from "@/lib/crypto/stream-name-cache"
 
 interface SealedNameStream {
   id: string
   e2eEnabled?: boolean
   sealedNameCiphertext?: string | null
   sealedNameEnvelope?: unknown
+  /** The root whose SSK seals this name; a scratchpad is its own root. */
+  rootStreamId?: string | null
 }
 
 /**
@@ -18,6 +26,12 @@ interface SealedNameStream {
  * user sees. Returns null for plaintext streams, a locked session, a missing
  * sealed name, or any decrypt failure — callers fall back to the plaintext label
  * (which is also what a locked session shows).
+ *
+ * Reads the shared `stream-name-cache` (the single decrypt authority), so the
+ * open-stream header and the list-surface overlay never drift. Keying the cache
+ * on the ciphertext makes the lookup self-guarding: a previous stream's name or
+ * a pre-rename name maps to a different key, so it can never flash before the
+ * current name's async decrypt resolves.
  */
 export function useDecryptedStreamName(
   workspaceId: string,
@@ -25,44 +39,31 @@ export function useDecryptedStreamName(
 ): string | null {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
+  const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
 
   const streamId = stream?.id
   const e2eEnabled = stream?.e2eEnabled ?? false
   const ciphertext = stream?.sealedNameCiphertext ?? null
-  const sealedEnvelope = stream?.sealedNameEnvelope ?? null
+  const envelope = stream?.sealedNameEnvelope ?? null
+  const rootStreamId = stream?.rootStreamId ?? undefined
   const unlocked = session.status === "unlocked"
   const keyId = session.keyId
   const privateKey = session.privateKey
 
-  // A stable key for the exact inputs a decrypted name depends on. The decrypted
-  // value is stored against it and only returned when it still matches, so a
-  // previous stream's name (or a pre-rename name) is never shown after the inputs
-  // change but before the async decrypt resolves.
-  const sourceKey =
-    e2eEnabled && streamId && ciphertext && sealedEnvelope && unlocked && keyId && privateKey
-      ? `${workspaceId}:${streamId}:${ciphertext}:${keyId}`
-      : null
-  const [result, setResult] = useState<{ sourceKey: string | null; name: string | null }>({
-    sourceKey: null,
-    name: null,
-  })
+  const key = e2eEnabled && streamId && ciphertext ? streamNameCacheKey(workspaceId, streamId, ciphertext) : null
 
   useEffect(() => {
-    if (!sourceKey || !streamId || !ciphertext || !sealedEnvelope || !keyId || !privateKey) {
-      setResult({ sourceKey: null, name: null })
-      return
-    }
-    let cancelled = false
-    void tryOpenStreamName(
-      { ciphertext, envelope: sealedEnvelope },
-      { workspaceId, streamId, recipientKeyId: keyId, privateKey }
-    ).then((decrypted) => {
-      if (!cancelled) setResult({ sourceKey, name: decrypted })
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [sourceKey, workspaceId, streamId, ciphertext, sealedEnvelope, keyId, privateKey])
+    if (!key || !streamId || !ciphertext || !envelope || !unlocked || !keyId || !privateKey) return
+    requestStreamName(
+      key,
+      { ciphertext, envelope },
+      { workspaceId, streamId, rootStreamId: rootStreamId ?? streamId, recipientKeyId: keyId, privateKey }
+    )
+  }, [key, streamId, ciphertext, envelope, rootStreamId, unlocked, keyId, privateKey, workspaceId])
 
-  return result.sourceKey === sourceKey ? result.name : null
+  return useMemo(
+    () => (key && unlocked ? getCachedStreamName(key) : null),
+    // `version` re-reads the cache when a decrypt lands; the rest key the lookup.
+    [key, unlocked, version]
+  )
 }

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -115,6 +115,16 @@ export interface VirtualStream {
    */
   e2eActors?: E2eActor[]
   /**
+   * Sealed display name for an E2E stream (base64 ciphertext + its
+   * `StreamEnvelope` framing). Carried from the underlying stream so the
+   * open-stream header can decrypt it via `useDecryptedStreamName` — the
+   * workspace-store overlay covers list surfaces, this covers the single-stream
+   * header including the first-open bootstrap path (before the row is in the
+   * workspace cache). Null/absent on plaintext streams and drafts.
+   */
+  sealedNameCiphertext?: string | null
+  sealedNameEnvelope?: unknown | null
+  /**
    * Tool-privacy policy chosen at creation. On drafts this is the local,
    * not-yet-persisted choice (threaded into the create request on the first
    * message); on server streams it is the current policy. `undefined` =
@@ -477,6 +487,8 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         archivedAt: baseStream.archivedAt,
         e2eEnabled: baseStream.e2eEnabled,
         e2eActors: baseStream.e2eActors,
+        sealedNameCiphertext: baseStream.sealedNameCiphertext ?? null,
+        sealedNameEnvelope: baseStream.sealedNameEnvelope ?? null,
       }
     : undefined
 

--- a/apps/frontend/src/lib/crypto/__tests__/stream-name-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-name-cache.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  applyDecryptedNameOverlay,
+  clearStreamNameCache,
+  getCachedStreamName,
+  requestStreamName,
+  streamNameCacheKey,
+  subscribeStreamNameCache,
+} from "../stream-name-cache"
+import * as messageEnvelope from "../message-envelope"
+import { resolveStreamName, streamLabel } from "@/lib/streams"
+import { StreamTypes } from "@threa/types"
+
+const STUB_OPTS = {
+  privateKey: {} as CryptoKey,
+  recipientKeyId: "e2ek_alice",
+  workspaceId: "ws_1",
+  streamId: "stream_1",
+}
+
+const PAYLOAD = { ciphertext: "ct_1", envelope: { v: 2 } }
+const KEY = streamNameCacheKey("ws_1", "stream_1", "ct_1")
+
+function stubOpen(returnValue: string | null) {
+  return vi.spyOn(messageEnvelope, "tryOpenStreamName").mockResolvedValue(returnValue)
+}
+
+beforeEach(() => {
+  clearStreamNameCache()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("stream-name-cache", () => {
+  it("returns the decrypted name from cache after the first request", async () => {
+    const open = stubOpen("Quarterly Planning")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(getCachedStreamName(KEY)).toBe("Quarterly Planning")
+    expect(open).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent requests for the same key into a single decrypt", async () => {
+    const open = stubOpen("Once")
+    await Promise.all([
+      requestStreamName(KEY, PAYLOAD, STUB_OPTS),
+      requestStreamName(KEY, PAYLOAD, STUB_OPTS),
+      requestStreamName(KEY, PAYLOAD, STUB_OPTS),
+    ])
+    expect(open).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not cache a failed/locked decrypt, so a later request retries", async () => {
+    const open = stubOpen(null)
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(getCachedStreamName(KEY)).toBeNull()
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(open).toHaveBeenCalledTimes(2)
+  })
+
+  it("notifies subscribers when a name lands", async () => {
+    stubOpen("Heard")
+    const listener = vi.fn()
+    const unsubscribe = subscribeStreamNameCache(listener)
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("drops listeners on unsubscribe", async () => {
+    stubOpen("Silent")
+    const listener = vi.fn()
+    const unsubscribe = subscribeStreamNameCache(listener)
+    unsubscribe()
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it("clears all cached names and notifies subscribers on clearStreamNameCache", async () => {
+    stubOpen("Gone")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    const listener = vi.fn()
+    subscribeStreamNameCache(listener)
+    clearStreamNameCache()
+    expect(getCachedStreamName(KEY)).toBeNull()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("drops in-flight decrypt results that resolve after clearStreamNameCache (no plaintext leak past lock)", async () => {
+    let resolveOpen: (value: string | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockImplementation(
+      () =>
+        new Promise<string | null>((r) => {
+          resolveOpen = r
+        })
+    )
+    const pending = requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+
+    // Session locks (or account switches) while the decrypt is still in flight.
+    clearStreamNameCache()
+
+    // The decrypt now resolves — its plaintext must NOT be written back.
+    resolveOpen("Top Secret")
+    await pending
+    expect(getCachedStreamName(KEY)).toBeNull()
+  })
+})
+
+describe("applyDecryptedNameOverlay", () => {
+  type Row = {
+    id: string
+    displayName: string | null
+    e2eEnabled?: boolean
+    sealedNameCiphertext?: string | null
+  }
+
+  const sealedRow: Row = {
+    id: "stream_1",
+    displayName: "New scratchpad",
+    e2eEnabled: true,
+    sealedNameCiphertext: "ct_1",
+  }
+
+  it("overlays the decrypted name onto displayName for a sealed E2E stream", async () => {
+    stubOpen("Budget 2026")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+
+    const [overlaid] = applyDecryptedNameOverlay("ws_1", [sealedRow])
+    expect(overlaid.displayName).toBe("Budget 2026")
+    // The input row is not mutated — only a fresh copy carries the plaintext.
+    expect(sealedRow.displayName).toBe("New scratchpad")
+  })
+
+  it("keeps the plaintext placeholder when the name is not decrypted (locked)", () => {
+    const [overlaid] = applyDecryptedNameOverlay("ws_1", [sealedRow])
+    expect(overlaid.displayName).toBe("New scratchpad")
+  })
+
+  it("returns the same array reference when nothing is overlaid (memo-stable)", () => {
+    const rows: Row[] = [
+      { id: "plain", displayName: "Plaintext stream" },
+      { id: "no-seal", displayName: "E2E no name", e2eEnabled: true, sealedNameCiphertext: null },
+    ]
+    expect(applyDecryptedNameOverlay("ws_1", rows)).toBe(rows)
+  })
+
+  it("does not overlay a name decrypted for a different workspace", async () => {
+    stubOpen("Other WS")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    const [overlaid] = applyDecryptedNameOverlay("ws_other", [sealedRow])
+    expect(overlaid.displayName).toBe("New scratchpad")
+  })
+
+  // The whole point of the overlay: the canonical resolver reflects the
+  // decrypted name with no per-surface plumbing, and falls back to the
+  // placeholder when locked.
+  it("makes streamLabel/resolveStreamName return the decrypted name once unlocked", async () => {
+    // The enclave auto-title never writes plaintext, so `displayName` is null and
+    // the locked-state resolver falls through to the real placeholder.
+    const scratchpad = {
+      id: "stream_1",
+      displayName: null,
+      type: StreamTypes.SCRATCHPAD,
+      slug: null,
+      e2eEnabled: true,
+      sealedNameCiphertext: "ct_1",
+    }
+
+    // Locked: the resolver shows the context placeholder, not the seal.
+    expect(streamLabel(applyDecryptedNameOverlay("ws_1", [scratchpad])[0], "sidebar")).toBe("New scratchpad")
+
+    stubOpen("Launch Plan")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+
+    const [overlaid] = applyDecryptedNameOverlay("ws_1", [scratchpad])
+    expect(streamLabel(overlaid, "sidebar")).toBe("Launch Plan")
+    expect(resolveStreamName("stream_1", { streams: [overlaid], users: [], dmPeers: [] }, "sidebar")).toBe(
+      "Launch Plan"
+    )
+  })
+})

--- a/apps/frontend/src/lib/crypto/stream-name-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-name-cache.ts
@@ -1,0 +1,135 @@
+import { tryOpenStreamName, type DecryptMessageOpts } from "./message-envelope"
+
+/**
+ * In-memory cache for decrypted E2E stream names.
+ *
+ * The enclave seals a scratchpad's auto-title (and a manual rename re-seals it)
+ * under the stream's SSK, AAD-bound to the stream. The ciphertext lives at rest
+ * in `db.streams` (`sealedNameCiphertext`/`sealedNameEnvelope`); the decrypted
+ * plaintext is held ONLY here and is never persisted, mirroring `decrypt-cache`
+ * for message bodies. This keeps a single decrypt authority for names so every
+ * surface that resolves a label (sidebar, search, breadcrumbs, …) reflects the
+ * tamper-evident name without each re-implementing the decrypt.
+ *
+ * A single global version counter drives re-renders: the store-read overlay
+ * (`useWorkspaceStreams`) and the open-stream header subscribe once and re-read
+ * when any name lands. Keyed by `${workspaceId}:${streamId}:${ciphertext}` so a
+ * rename (fresh ciphertext) supersedes the prior plaintext without a manual
+ * purge, and a never-decrypted key reads `null` rather than a stale value.
+ *
+ * Lifecycle: `clearStreamNameCache()` drops everything and bumps the lock epoch
+ * so an in-flight decrypt that resolves after a lock refuses to write plaintext
+ * back — call it on session lock / account switch, the same boundary
+ * `clearDecryptCache` / `clearStreamKeyCache` enforce.
+ */
+
+/** Decrypted plaintext names keyed by `${workspaceId}:${streamId}:${ciphertext}`. */
+const names = new Map<string, string>()
+const inflight = new Map<string, Promise<void>>()
+const listeners = new Set<() => void>()
+
+// Monotonic snapshot for useSyncExternalStore — bumped on every cache change so
+// subscribers (the overlay, the open-stream header) re-read.
+let version = 0
+// Bumped by clearStreamNameCache so an in-flight decrypt that resolves after a
+// lock detects it's stale and refuses to write plaintext back into the cache.
+let generation = 0
+
+export function streamNameCacheKey(workspaceId: string, streamId: string, ciphertext: string): string {
+  return `${workspaceId}:${streamId}:${ciphertext}`
+}
+
+function emit(): void {
+  version++
+  for (const listener of listeners) listener()
+}
+
+export function subscribeStreamNameCache(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getStreamNameCacheVersion(): number {
+  return version
+}
+
+/** The decrypted name for a key, or `null` if not yet decrypted / decrypt failed. */
+export function getCachedStreamName(key: string): string | null {
+  return names.get(key) ?? null
+}
+
+export interface RequestStreamNameInput {
+  /** Base64 ciphertext from `sealedNameCiphertext`. */
+  ciphertext: string
+  /** `StreamEnvelope` framing from `sealedNameEnvelope`. */
+  envelope: unknown
+}
+
+/**
+ * Decrypt a sealed stream name and cache the plaintext, deduped per key. A
+ * no-op when the key is already decrypted or in flight. A decrypt that returns
+ * null (locked, not a recipient, forged AAD) is not cached, so a later unlock
+ * (or a wrap that becomes resolvable) retries instead of pinning the
+ * placeholder — callers fall back to the plaintext label meanwhile.
+ */
+export function requestStreamName(
+  key: string,
+  payload: RequestStreamNameInput,
+  opts: DecryptMessageOpts
+): Promise<void> {
+  const existing = inflight.get(key)
+  if (existing) return existing
+  if (names.has(key)) return Promise.resolve()
+
+  const startGeneration = generation
+  const promise = (async () => {
+    const decrypted = await tryOpenStreamName({ ciphertext: payload.ciphertext, envelope: payload.envelope }, opts)
+    // Dropped if the cache was cleared (lock / account switch) mid-flight —
+    // writing plaintext back would leak it past the lock boundary.
+    if (startGeneration !== generation) return
+    inflight.delete(key)
+    if (decrypted == null) return
+    names.set(key, decrypted)
+    emit()
+  })()
+
+  inflight.set(key, promise)
+  return promise
+}
+
+/**
+ * Overlay decrypted names onto a list of streams: for each unlocked, sealed E2E
+ * stream whose name is cached, replace `displayName` with the tamper-evident
+ * decrypted copy. Identity-preserving — returns the input array unchanged when
+ * nothing is overlaid, and only allocates fresh objects for streams it rewrites,
+ * so the resolver (`streamLabel`/`resolveStreamName`) reflects the decrypted
+ * name with no per-surface plumbing. Locked / undecrypted streams keep their
+ * plaintext `displayName` (the placeholder for an auto-titled scratchpad).
+ */
+export function applyDecryptedNameOverlay<
+  T extends {
+    id: string
+    displayName: string | null
+    e2eEnabled?: boolean
+    sealedNameCiphertext?: string | null
+  },
+>(workspaceId: string, streams: T[]): T[] {
+  let changed = false
+  const next = streams.map((stream) => {
+    if (!stream.e2eEnabled || !stream.sealedNameCiphertext) return stream
+    const decrypted = getCachedStreamName(streamNameCacheKey(workspaceId, stream.id, stream.sealedNameCiphertext))
+    if (decrypted == null || decrypted === stream.displayName) return stream
+    changed = true
+    return { ...stream, displayName: decrypted }
+  })
+  return changed ? next : streams
+}
+
+export function clearStreamNameCache(): void {
+  generation++
+  names.clear()
+  inflight.clear()
+  emit()
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -53,6 +53,7 @@ import {
   useUnreadTabIndicator,
   useBackgroundBootstrapSync,
 } from "@/hooks"
+import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
 import { usePageResume } from "@/hooks/use-page-resume"
 import { setLastWorkspaceId } from "@/lib/last-workspace"
 import { useAuth } from "@/auth"
@@ -315,6 +316,11 @@ function MessageQueueHandler() {
   return null
 }
 
+function StreamNameDecryptor({ workspaceId }: { workspaceId: string }) {
+  useDecryptStreamNames(workspaceId)
+  return null
+}
+
 function UnreadTabIndicator({ workspaceId }: { workspaceId: string }) {
   useUnreadTabIndicator(workspaceId)
   return null
@@ -420,6 +426,7 @@ export function WorkspaceLayout() {
           <AppUpdateChecker />
           <FreshnessWatchers />
           <MessageQueueHandler />
+          <StreamNameDecryptor workspaceId={workspaceId} />
           <CoordinatedLoadingProvider workspaceId={workspaceId} streamIds={streamIds}>
             <ChannelLinkProvider workspaceId={workspaceId} streams={streams}>
               <UserProfileProvider>

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -2,6 +2,7 @@ import { useSyncExternalStore } from "react"
 import { e2eKeysApi } from "@/api/e2e-keys"
 import { clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import { clearStreamKeyCache } from "@/lib/crypto/stream-key-cache"
+import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import { clearAttachmentRefCache } from "@/lib/crypto/attachment-crypto"
 import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
 import { generateUIK, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
@@ -911,6 +912,7 @@ export async function lock(workspaceId: string, userId: string): Promise<void> {
   // only surface holding plaintext for this session.
   clearDecryptCache()
   clearStreamKeyCache()
+  clearStreamNameCache()
   clearAttachmentRefCache()
   // Bump the generation so a concurrent loadE2eKeyForUser can't restore the
   // device key we're about to delete back into an unlocked state.
@@ -1077,5 +1079,6 @@ export function resetE2eSessionStoreCache(): void {
   listeners.clear()
   clearDecryptCache()
   clearStreamKeyCache()
+  clearStreamNameCache()
   clearAttachmentRefCache()
 }

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -318,14 +318,24 @@ export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorksp
   )
 }
 
-export function useWorkspaceStreams(workspaceId: string | undefined): CachedStream[] {
+/**
+ * The raw cached streams — no decrypted-name overlay. The decryptor
+ * (`useDecryptStreamNames`) reads this so it isn't woken by its own output: it
+ * only needs the sealed ciphertext (unchanged by the overlay), and subscribing
+ * to the post-overlay hook would re-run it on every name that lands.
+ */
+export function useWorkspaceStreamsRaw(workspaceId: string | undefined): CachedStream[] {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.streams.get(workspaceId) ?? []) : []
-  const streams = useArrayStoreHook(
+  return useArrayStoreHook(
     () => (workspaceId ? db.streams.where("workspaceId").equals(workspaceId).toArray() : []),
     [workspaceId],
     cached
   )
+}
+
+export function useWorkspaceStreams(workspaceId: string | undefined): CachedStream[] {
+  const streams = useWorkspaceStreamsRaw(workspaceId)
   // Decrypt-at-the-read-boundary: overlay the tamper-evident decrypted name onto
   // `displayName` so every label resolver reflects it without per-surface changes.
   // The plaintext lives only in the memory-only `stream-name-cache`; IDB keeps

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -1,5 +1,10 @@
-import { useSyncExternalStore } from "react"
+import { useMemo, useSyncExternalStore } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
+import {
+  applyDecryptedNameOverlay,
+  getStreamNameCacheVersion,
+  subscribeStreamNameCache,
+} from "@/lib/crypto/stream-name-cache"
 import {
   db,
   type CachedWorkspace,
@@ -316,10 +321,19 @@ export function useWorkspaceUsers(workspaceId: string | undefined): CachedWorksp
 export function useWorkspaceStreams(workspaceId: string | undefined): CachedStream[] {
   useWorkspaceCacheSignal(workspaceId)
   const cached = workspaceId ? (cache.streams.get(workspaceId) ?? []) : []
-  return useArrayStoreHook(
+  const streams = useArrayStoreHook(
     () => (workspaceId ? db.streams.where("workspaceId").equals(workspaceId).toArray() : []),
     [workspaceId],
     cached
+  )
+  // Decrypt-at-the-read-boundary: overlay the tamper-evident decrypted name onto
+  // `displayName` so every label resolver reflects it without per-surface changes.
+  // The plaintext lives only in the memory-only `stream-name-cache`; IDB keeps
+  // ciphertext. `version` re-overlays when a decrypt lands (see `stream-name-cache`).
+  const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
+  return useMemo(
+    () => (workspaceId ? applyDecryptedNameOverlay(workspaceId, streams) : streams),
+    [streams, workspaceId, version]
   )
 }
 


### PR DESCRIPTION
## Problem

An E2E scratchpad's display name is sealed under the stream key (SSK), AAD-bound
to the stream: the enclave writes the auto-title into `e2e_streams.name_ciphertext`
only — never the plaintext `streams.display_name` — and a manual rename re-seals
the same way (`use-stream-or-draft.ts` rename path). Until now only the open
stream header decrypted it (`pages/stream.tsx` via `useDecryptedStreamName`).
Every other surface that resolves a label goes through the canonical resolver in
`lib/streams.ts` (`streamLabel` / `resolveStreamName` / `useStreamName` /
`getStreamName`), which had **no** sealed-name awareness. So the sidebar, search,
quick-switcher, breadcrumbs, share-picker, saved view, and memory page all showed
the plaintext fallback — which for an auto-titled E2E scratchpad is the empty
placeholder ("New scratchpad"). The real title only appeared when the scratchpad
was open.

The hard part is shape mismatch: the resolver is **synchronous and pure** (used
in list `.map()`s and sort/search keys), but the sealed-name decrypt
(`tryOpenStreamName`) is **async** and session-dependent.

## Solution

Decrypt at the store-read boundary into a memory-only cache, and overlay the
result onto `displayName` there — so the existing resolver returns the decrypted
name unchanged, with no per-call-site plumbing across the ~30 label surfaces. The
plaintext is held only in memory and never persisted; IDB keeps ciphertext, the
same contract message bodies already follow (`db.events.payload` ciphertext +
in-memory `decrypt-cache`).

### How it works

1. **`lib/crypto/stream-name-cache.ts`** — an in-memory decrypt cache for names,
   mirroring `decrypt-cache.ts` for message bodies. Keyed by
   `${workspaceId}:${streamId}:${ciphertext}`, so a rename (fresh ciphertext)
   supersedes the prior name and a never-decrypted key reads `null` (the lookup
   is self-guarding — a stale/pre-rename name can't flash before the current
   one's async decrypt lands, replacing the old hook's `useState` source-key
   guard). A decrypt that returns null (locked / not a recipient / forged AAD) is
   not cached, so a later unlock retries. `clearStreamNameCache()` drops
   everything and bumps a `generation` epoch so an in-flight decrypt that
   resolves *after* a lock refuses to write plaintext back.

2. **Overlay at the read boundary** — `useWorkspaceStreams` (workspace store) runs
   `applyDecryptedNameOverlay(workspaceId, streams)`: for each unlocked, sealed
   E2E stream whose name is cached, it replaces `displayName` with the decrypted
   copy. Identity-preserving (returns the input array when nothing changed; only
   allocates fresh objects for rewritten rows), and subscribes once to the cache
   version via `useSyncExternalStore` so it re-overlays when a decrypt lands.
   `streamLabel` / `resolveStreamName` / `useStreamName` read `displayName`, so
   they all reflect it for free.

3. **`hooks/use-decrypt-stream-names.ts`** — the trigger, mounted once per
   workspace as `StreamNameDecryptor` in `workspace-layout.tsx` (alongside
   `UnreadTabIndicator` / `FreshnessWatchers`). Once unlocked it walks the
   workspace's sealed E2E streams and fires `requestStreamName` (idempotent per
   `(stream, ciphertext)`). Trigger is separate from read so decrypts fire from
   one place, not from each render of each list row.

4. **`useDecryptedStreamName`** (open-stream header) now routes through the same
   cache instead of its own `tryOpenStreamName` + `useState`, so there is a
   single decrypt authority and the header can't drift from the lists.

5. **Persistence** — `CachedStream` gains `sealedNameCiphertext` /
   `sealedNameEnvelope`. The existing write paths already spread the wire
   `Stream`/`StreamWithPreview` (bootstrap `bulkPut`, `seedWorkspaceCache`,
   `stream:updated`, the rename `toCachedStream`), so the ciphertext flows into
   the cache + IDB once the type allows it — no new write plumbing. Not indexed,
   so no Dexie version bump.

### Key design decisions

**1. Decrypt-at-the-read-boundary, memory-only, never persisted** — Kris's call:
"reduce the likelihood of leakage … put this at the boundary where we read it and
put it into memory, i.e. memoize the shit out of it and then make sure it never is
persisted." Overlaying at the store read covers every surface (including pure
mappers and sort keys) without threading a lookup through ~30 call sites — the
drift `apps/frontend/CLAUDE.md` ("one place that knows how to turn a stream into
a label") exists to prevent. Persisting *ciphertext* at rest is safe and matches
how message bodies are handled; only the decrypted plaintext is memory-only.

**2. Decrypted name outranks plaintext only when unlocked** — the sealed name is
AAD-bound (`buildNameAad`), so a compromised server can't silently relabel what
an unlocked owner sees. A locked/missing/failed decrypt falls back to the
plaintext label, which is the placeholder for an auto-titled scratchpad — locked
⇒ placeholder is preserved, render never blocks on decrypt.

**3. Module-level cache singleton** — consistent with the codebase's accepted
memory crypto caches (`decrypt-cache`, `stream-key-cache`, `attachment-crypto`),
read via `useSyncExternalStore` and cleared at the same lock boundary
(`e2e-session-store` `lock` + `resetE2eSessionStoreCache`).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crypto/stream-name-cache.ts` | Memory-only decrypted-name cache + `applyDecryptedNameOverlay`; lock-cleared with a generation guard |
| `apps/frontend/src/hooks/use-decrypt-stream-names.ts` | Per-workspace background decryptor that populates the cache |
| `apps/frontend/src/lib/crypto/__tests__/stream-name-cache.test.ts` | Cache, overlay, no-leak-past-lock, and resolver-integration tests |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/stores/workspace-store.ts` | `useWorkspaceStreams` overlays decrypted names onto `displayName`, subscribed to the cache version |
| `apps/frontend/src/hooks/use-decrypted-stream-name.ts` | Routes the open-stream header through the shared cache (single decrypt authority) |
| `apps/frontend/src/db/database.ts` | `CachedStream` gains `sealedNameCiphertext` / `sealedNameEnvelope` (ciphertext at rest) |
| `apps/frontend/src/stores/e2e-session-store.ts` | `clearStreamNameCache()` at the lock + reset boundary |
| `apps/frontend/src/pages/workspace-layout.tsx` | Mounts `StreamNameDecryptor` once per workspace |
| `apps/frontend/AGENTS.md` | Documents that sealed names resolve through the same label path |

## Out of scope (deliberate)

- No backend / wire / crypto changes — the seal→store→owner-decrypt loop already
  shipped on `main` (migration `20260603100000_e2e_stream_sealed_name.sql`). This
  PR is purely the frontend render path.
- Only sealed names on root scratchpads exist today (the enclave gates the
  auto-title to untitled root scratchpads), so the decryptor only needs the
  workspace streams list; threads carry no sealed name of their own.

## Test plan

- [x] `bun run test src/lib/crypto/__tests__/stream-name-cache.test.ts` — 12 pass (cache semantics, no-leak-past-lock, overlay identity-stability, and `streamLabel`/`resolveStreamName` returning the decrypted name when unlocked / placeholder when locked)
- [x] `bun run test` on the affected surfaces — `streams`, `stream-sort`, `memory`, `saved-item`, `quick-switcher`, `search`, `share`, `stream-settings` (115 pass), plus `decrypt-cache` / `use-decrypted-message-content` (15), `encryption/*` (28), `e2e-session-store` (29)
- [x] Pre-commit hook: ESLint + `tsc --noEmit` across all workspaces, astro check, API-docs check — all clean
- [ ] No automated end-to-end render test mounting a live list surface with an unlocked session — covered at the unit level via `applyDecryptedNameOverlay` + the real resolver; the hook wiring (`useDecryptStreamNames`, overlay subscription) is exercised manually-equivalent through the cache/overlay tests rather than a full DOM mount

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq9uAVcuuALawBBaT1gUHm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784063718&installation_id=129946197&pr_number=949&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F949&signature=cb7bede1147c0be298c55123dc0539963f4dc7928454f817a3c0297a0457a948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->