### PR TITLE
fix(e2e): make user stream renames sealed-only (no plaintext name at rest)

### DIFF
--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -134,7 +134,9 @@ export interface InsertStreamParams {
 }
 
 export interface UpdateStreamParams {
-  displayName?: string
+  // `null` scrubs the plaintext name — used by a sealed-only E2E rename, where
+  // the authoritative name lives in `e2e_streams.name_ciphertext`.
+  displayName?: string | null
   slug?: string
   description?: string
   visibility?: Visibility

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -25,6 +25,8 @@ const mockInsertOutbox = spyOn(OutboxRepository, "insert")
 const mockFindMembersByIds = spyOn(UserRepository, "findByIds")
 const mockInsertStream = spyOn(StreamRepository, "insert")
 const mockMarkStreamE2e = spyOn(E2eStreamsRepository, "markStreamE2e")
+const mockUpdate = spyOn(StreamRepository, "update")
+const mockUpdateSealedName = spyOn(E2eStreamsRepository, "updateSealedName")
 
 spyOn(idModule, "eventId").mockReturnValue("evt_1")
 spyOn(idModule, "streamId").mockReturnValue("stream_new")
@@ -1279,5 +1281,56 @@ describe("StreamService.markAllAsRead", () => {
         { streamId: "stream_2", lastReadOrdinal: 3 },
       ],
     })
+  })
+})
+
+describe("StreamService.updateStream sealed-name handling", () => {
+  let service: StreamService
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockFindById.mockReset()
+    mockUpdate.mockReset()
+    mockUpdateSealedName.mockReset()
+    mockInsertOutbox.mockReset()
+  })
+
+  test("setting a sealed name scrubs the plaintext display_name to null (INV-E1)", async () => {
+    const stream = { id: "stream_1", workspaceId: "ws_1", displayName: null } as never
+    mockUpdate.mockResolvedValue(stream)
+    mockUpdateSealedName.mockResolvedValue(true)
+    mockFindById.mockResolvedValue(stream)
+
+    // Even if a client sends a plaintext displayName alongside the seal, the
+    // server must not persist it — the sealed ciphertext is the only name.
+    await service.updateStream("stream_1", {
+      displayName: "leak",
+      sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith({}, "stream_1", expect.objectContaining({ displayName: null }))
+    expect(mockUpdateSealedName).toHaveBeenCalledWith({}, "ws_1", "stream_1", {
+      ciphertext: "Y3Q=",
+      envelope: { v: 1 },
+    })
+  })
+
+  test("clearing a sealed name without a displayName is rejected", async () => {
+    await expect(service.updateStream("stream_1", { sealedName: null })).rejects.toMatchObject({
+      status: 400,
+      code: "SEALED_NAME_REQUIRES_DISPLAY_NAME",
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  test("a plain (non-sealed) rename writes the plaintext displayName unchanged", async () => {
+    const stream = { id: "stream_1", workspaceId: "ws_1", displayName: "New name" } as never
+    mockUpdate.mockResolvedValue(stream)
+    mockFindById.mockResolvedValue(stream)
+
+    await service.updateStream("stream_1", { displayName: "New name" })
+
+    expect(mockUpdate).toHaveBeenCalledWith({}, "stream_1", expect.objectContaining({ displayName: "New name" }))
+    expect(mockUpdateSealedName).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1315,6 +1315,22 @@ describe("StreamService.updateStream sealed-name handling", () => {
     })
   })
 
+  test("setting a sealed name on a non-E2E stream fails loudly and emits no outbox event", async () => {
+    const stream = { id: "stream_1", workspaceId: "ws_1", displayName: null } as never
+    mockUpdate.mockResolvedValue(stream)
+    // No e2e_streams row to update — the stream isn't E2E.
+    mockUpdateSealedName.mockResolvedValue(false)
+
+    await expect(
+      service.updateStream("stream_1", {
+        sealedName: { ciphertext: "Y3Q=", envelope: { v: 1 } },
+      })
+    ).rejects.toMatchObject({ status: 400, code: "STREAM_NOT_E2E" })
+
+    // Transaction rolls back; no stream:updated event for a half-applied rename.
+    expect(mockInsertOutbox).not.toHaveBeenCalled()
+  })
+
   test("clearing a sealed name without a displayName is rejected", async () => {
     await expect(service.updateStream("stream_1", { sealedName: null })).rejects.toMatchObject({
       status: 400,

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -836,7 +836,22 @@ export class StreamService {
         // otherwise an E2E `stream:updated` would ship a partial shape (missing
         // e2eEnabled / actors / sealed name). INV-7.
         if (sealedName !== undefined) {
-          await E2eStreamsRepository.updateSealedName(client, stream.workspaceId, streamId, sealedName)
+          const sealedUpdated = await E2eStreamsRepository.updateSealedName(
+            client,
+            stream.workspaceId,
+            streamId,
+            sealedName
+          )
+          // No e2e_streams row means this isn't an E2E stream. Setting a sealed
+          // name has already scrubbed `display_name` to null above, so a silent
+          // no-op here would strand the stream with no name at all — fail loudly
+          // instead (INV-11).
+          if (!sealedUpdated) {
+            throw new HttpError("Sealed name updates require an end-to-end encrypted stream", {
+              status: 400,
+              code: "STREAM_NOT_E2E",
+            })
+          }
         }
         const result = (await StreamRepository.findById(client, streamId)) ?? stream
 

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -776,27 +776,36 @@ export class StreamService {
   async updateStream(
     streamId: string,
     data: {
-      displayName?: string
+      displayName?: string | null
       slug?: string
       description?: string
       visibility?: Visibility
       /**
        * Sealed (encrypted) display name for an E2E stream — stored on
-       * `e2e_streams`, not `streams`. The plaintext `displayName` stays the
-       * locked-state fallback; this is the authoritative name an unlocked client
-       * prefers. `{ciphertext, envelope}` sets it, `null` clears it (rename
-       * without a fresh seal), `undefined` leaves it untouched. Required to come
-       * with a `displayName` so the two never desync.
+       * `e2e_streams`, not `streams`. The server holds opaque bytes it can't
+       * read. `{ciphertext, envelope}` SETS it (an E2E rename); `null` CLEARS it
+       * (revert to a plaintext name); `undefined` leaves it untouched. Setting a
+       * sealed name is sealed-only: the plaintext `display_name` is scrubbed to
+       * null so the server never holds the cleartext name at rest.
        */
       sealedName?: { ciphertext: string; envelope: unknown } | null
     }
   ): Promise<Stream | null> {
     const { sealedName, ...streamData } = data
-    // A sealed-name change (set or clear) must accompany a plaintext displayName,
-    // or `streams.display_name` and the sealed copy desync (locked/sidebar
-    // surfaces show the old label while unlocked clients decrypt the new one).
-    if (sealedName !== undefined && streamData.displayName === undefined) {
-      throw new HttpError("displayName is required when sealedName is provided", {
+    if (sealedName) {
+      // Setting a sealed name is a sealed-only E2E rename: the authoritative name
+      // lives in the ciphertext, so scrub the plaintext `display_name` to null —
+      // the server must never hold the cleartext name at rest (INV-E1). Enforced
+      // here, not trusted from the client, so a stale/leaky plaintext can't ride
+      // along. Trade-off: server-side name search (ILIKE/similarity on
+      // display_name) can't see E2E streams — name search for them is
+      // client-side over decrypted names.
+      streamData.displayName = null
+    } else if (sealedName === null && streamData.displayName == null) {
+      // Clearing a sealed name reverts to a plaintext label, so one must be
+      // provided — otherwise the stream loses its name entirely (no ciphertext,
+      // no cleartext).
+      throw new HttpError("displayName is required when clearing a sealed name", {
         status: 400,
         code: "SEALED_NAME_REQUIRES_DISPLAY_NAME",
       })

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -73,3 +73,25 @@ DM display names are computed per-viewer on the backend at bootstrap and are
 wire). Every surface that re-derived this by hand drifted: the Saved view showed
 "Unknown", scheduled rows skipped peer resolution, etc. Routing through the
 shared resolver is the fix — reach for it instead of writing the lookup again.
+
+## Renaming an E2E (sealed) stream
+
+An E2E stream's name is **sealed-only**: a rename persists only the
+tamper-evident ciphertext on `e2e_streams` and never the plaintext
+`streams.display_name` (the server scrubs it to null when a sealed name is set —
+INV-E1, no plaintext at rest). This matches the enclave auto-title, which has
+always written the sealed columns only.
+
+- **One sealing path.** Both rename surfaces — the open-stream header
+  (`useStreamOrDraft().rename`) and stream settings (`DisplayNameSection`) — go
+  through `sealStreamRename` in `lib/crypto/stream-rename.ts`. Don't re-derive
+  the seal; call it. It throws `StreamNameSealUnavailableError` rather than ever
+  falling back to plaintext.
+- **Renaming requires an unlocked session** (sealing needs the SSK). Gate the
+  rename affordance on `useE2eSession(...).status === "unlocked"`; it's hidden in
+  the header menu and read-only in settings while locked.
+- **Known residuals** (accepted, not bugs): server-side name search
+  (ILIKE/`similarity` on `display_name`) can't see E2E streams — their names are
+  searchable only client-side over the decrypted copy. Streams renamed _before_
+  this shipped still hold plaintext in `display_name`; the server can't re-seal
+  them, so they stay until the owner renames again while unlocked.

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -222,6 +222,42 @@ describe("ScratchpadItem", () => {
     expect(screen.queryByLabelText("AI companion attached")).not.toBeInTheDocument()
   })
 
+  it("shows a loader instead of the placeholder while an encrypted scratchpad's sealed name decrypts", () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({ e2eEnabled: true, companionMode: "off", displayName: null, nameDecrypting: true })}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    // Neither the decrypted name nor the "New scratchpad" placeholder flashes
+    // while the name is still resolving.
+    expect(screen.queryByText("New scratchpad")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Encrypted scratchpad")).toBeInTheDocument()
+  })
+
+  it("renders the decrypted name once resolved (no loader)", () => {
+    renderWithRouter(
+      <ScratchpadItem
+        workspaceId="workspace_1"
+        stream={createScratchpad({
+          e2eEnabled: true,
+          companionMode: "off",
+          displayName: "Therapy notes",
+          nameDecrypting: false,
+        })}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+      />
+    )
+
+    expect(screen.getByText("Therapy notes")).toBeInTheDocument()
+  })
+
   it("deletes draft scratchpads directly and navigates away when the active draft is removed", async () => {
     renderWithRouter(
       <ScratchpadItem

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -8,6 +8,7 @@ import { isDraftId, useActors, useArchiveStream, useDraftScratchpads } from "@/h
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { streamFallbackLabel } from "@/lib/streams"
 import { CompanionModes, LabelableResourceTypes } from "@threa/types"
@@ -63,6 +64,11 @@ export function ScratchpadItem({
 
   const currentDisplayName = streamWithPreview.displayName ?? null
   const name = currentDisplayName || streamFallbackLabel("scratchpad", "sidebar")
+  // Resolved once by the stream-list builder off the shared name cache, so the
+  // row shows a loader (not the "New scratchpad" placeholder) while an encrypted
+  // scratchpad's sealed name is still decrypting on cold load — same treatment as
+  // the open-stream header.
+  const nameDecrypting = streamWithPreview.nameDecrypting ?? false
   const preview = streamWithPreview.lastMessagePreview
 
   useUrgencyTracking(itemRef, streamWithPreview.id, streamWithPreview.urgency, scrollContainerRef)
@@ -179,10 +185,14 @@ export function ScratchpadItem({
                 )}
               >
                 <div className="flex items-center gap-2 pr-8">
-                  <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
-                    {name}
-                    {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
-                  </span>
+                  {nameDecrypting ? (
+                    <Skeleton className="h-4 w-28" />
+                  ) : (
+                    <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
+                      {name}
+                      {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
+                    </span>
+                  )}
                   <div className="ml-auto flex items-center gap-1.5">
                     <StreamLabelDots streamId={streamWithPreview.id} />
                     <MentionIndicator count={mentionCount} />

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import { toast } from "sonner"
 import { FileText, Lock, RefreshCw, StickyNote } from "lucide-react"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
 import { useE2eUnlockOptional } from "@/components/encryption/e2e-unlock-provider"
-import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { getE2eSessionState, useE2eSession } from "@/stores/e2e-session-store"
+import { resolveSealedNamePending } from "@/hooks/use-decrypted-stream-name"
+import { getStreamNameCacheVersion, subscribeStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import {
   useActivityCounts,
   useAllDrafts,
@@ -97,6 +99,16 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
   const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
   const e2eUnlock = useE2eUnlockOptional()
+  // Resolve the sealed-name loading state for the whole list in one place (the
+  // session + shared name cache), so each row reads it as plain data instead of
+  // re-wiring the session. `nameCacheVersion` re-evaluates when a decrypt settles
+  // — including a failure, which leaves the overlaid row unchanged.
+  const e2eSessionStatus = useE2eSession(workspaceId, currentUser?.id ?? "").status
+  const nameCacheVersion = useSyncExternalStore(
+    subscribeStreamNameCache,
+    getStreamNameCacheVersion,
+    getStreamNameCacheVersion
+  )
 
   const draftCount = allDrafts.length
   const savedCount = useLiveSavedCount(workspaceId)
@@ -155,6 +167,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           urgency,
           section,
           dmPeerUserId,
+          nameDecrypting: resolveSealedNamePending(workspaceId, streamWithPreview, e2eSessionStatus),
         }
       })
   }, [
@@ -168,6 +181,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     idbDmPeers,
     workspaceUsers,
     unreadState,
+    workspaceId,
+    e2eSessionStatus,
+    nameCacheVersion,
   ])
 
   // System streams are auto-created infrastructure — don't count toward "has content"

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -17,4 +17,11 @@ export interface StreamItemData extends StreamWithPreview {
   urgency: UrgencyLevel
   section: SectionKey
   dmPeerUserId?: string
+  /**
+   * True while this stream's sealed E2E name is still decrypting on cold load, so
+   * the row renders a loader instead of the placeholder. Resolved once by the
+   * sidebar builder off the shared name cache + session (see
+   * `resolveSealedNamePending`), not per row.
+   */
+  nameDecrypting?: boolean
 }

--- a/apps/frontend/src/components/stream-settings/general-tab.rename.test.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.rename.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ServicesProvider, type StreamService } from "@/contexts"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as e2eSession from "@/stores/e2e-session-store"
+import * as streamKeyCache from "@/lib/crypto/stream-key-cache"
+import * as messageEnvelope from "@/lib/crypto/message-envelope"
+import { clearStreamNameCache, getCachedStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
+import { StreamTypes, Visibilities, type Stream } from "@threa/types"
+import { GeneralTab } from "./general-tab"
+
+const WS = "ws_1"
+const USER = "usr_alice"
+
+function encryptedScratchpad(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_pad_1",
+    workspaceId: WS,
+    type: StreamTypes.SCRATCHPAD,
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: Visibilities.PRIVATE,
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "on",
+    companionPersonaId: null,
+    createdBy: USER,
+    createdAt: "2026-03-31T10:00:00Z",
+    updatedAt: "2026-03-31T10:00:00Z",
+    archivedAt: null,
+    e2eEnabled: true,
+    sealedNameCiphertext: "old_ct",
+    sealedNameEnvelope: { v: 0 },
+    ...overrides,
+  }
+}
+
+function unlocked(): ReturnType<typeof e2eSession.getE2eSessionState> {
+  return {
+    status: "unlocked",
+    keyId: "e2ek_alice",
+    publicKey: null,
+    privateKey: {} as CryptoKey,
+    deviceTrusted: true,
+    error: null,
+  } as ReturnType<typeof e2eSession.getE2eSessionState>
+}
+
+function locked(): ReturnType<typeof e2eSession.getE2eSessionState> {
+  return {
+    status: "locked",
+    keyId: null,
+    publicKey: null,
+    privateKey: null,
+    deviceTrusted: false,
+    error: null,
+  } as ReturnType<typeof e2eSession.getE2eSessionState>
+}
+
+function renderTab(stream: Stream, update: ReturnType<typeof vi.fn>) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ServicesProvider services={{ streams: { update } as unknown as StreamService }}>
+        <GeneralTab workspaceId={WS} stream={stream} currentUserId={USER} notificationLevel={null} />
+      </ServicesProvider>
+    </QueryClientProvider>
+  )
+}
+
+afterEach(() => {
+  clearStreamNameCache()
+  vi.restoreAllMocks()
+})
+
+describe("GeneralTab display-name rename (stream settings surface)", () => {
+  it("seals the new name and sends a sealed-only update when the session is unlocked", async () => {
+    vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER)
+    // The component's lock gate reads `useE2eSession`; `sealStreamRename` reads
+    // `getE2eSessionState`. They live in the same module, so the hook calls its
+    // local binding — spy both to drive the unlocked path end to end.
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(unlocked())
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(unlocked())
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({
+      key: new Uint8Array(32),
+      keyGeneration: 0,
+    } as never)
+    vi.spyOn(messageEnvelope, "sealStreamName").mockResolvedValue({ ciphertext: "Y3Q=", envelope: { v: 1 } as never })
+
+    const stream = encryptedScratchpad()
+    const update = vi.fn().mockResolvedValue({ ...stream, displayName: null, sealedNameCiphertext: "Y3Q=" })
+
+    renderTab(stream, update)
+
+    await userEvent.type(screen.getByPlaceholderText("Scratchpad name"), "Therapy notes")
+    await userEvent.click(screen.getByRole("button", { name: /save/i }))
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    expect(update).toHaveBeenCalledWith(WS, stream.id, {
+      sealedNameCiphertext: "Y3Q=",
+      sealedNameEnvelope: { v: 1 },
+    })
+    // No plaintext name on the wire (INV-E1).
+    expect(update.mock.calls[0]![2]).not.toHaveProperty("displayName")
+    // The new name is immediately resolvable on this device (no re-decrypt flicker).
+    expect(getCachedStreamName(streamNameCacheKey(WS, stream.id, "Y3Q="))).toBe("Therapy notes")
+  })
+
+  it("makes the field read-only and never updates while the session is locked", async () => {
+    vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue(USER)
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(locked())
+    const sealSpy = vi.spyOn(messageEnvelope, "sealStreamName")
+
+    const update = vi.fn()
+    renderTab(encryptedScratchpad(), update)
+
+    const input = screen.getByPlaceholderText("Scratchpad name")
+    expect(input).toBeDisabled()
+    expect(screen.getByText("Unlock this scratchpad to rename it.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /save/i })).not.toBeInTheDocument()
+    expect(update).not.toHaveBeenCalled()
+    expect(sealSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -19,6 +19,9 @@ import {
 import { ChannelSlugInput } from "./channel-slug-input"
 import { getStreamName } from "@/lib/streams"
 import { useUpdateStream, useArchiveStream, useUnarchiveStream, useSetNotificationLevel } from "@/hooks"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { sealStreamRename } from "@/lib/crypto/stream-rename"
 import {
   StreamTypes,
   Visibilities,
@@ -341,22 +344,42 @@ function DisplayNameSection({ workspaceId, stream }: { workspaceId: string; stre
   const updateMutation = useUpdateStream(workspaceId, stream.id)
   const hasChanged = name !== (stream.displayName ?? "")
 
-  const handleSave = () => {
-    if (!name.trim() || !hasChanged) return
-    updateMutation.mutate(
-      { displayName: name.trim() },
-      {
+  // An E2E scratchpad's name is sealed-only — renaming seals the new name under
+  // the stream key and never writes plaintext (INV-E1), so it needs an unlocked
+  // session. While locked the field is read-only and points the user at unlock.
+  const isEncrypted = !!stream.e2eEnabled
+  const currentUserId = useWorkspaceUserId(workspaceId)
+  const e2eUnlocked = useE2eSession(workspaceId, currentUserId ?? "").status === "unlocked"
+  const locked = isEncrypted && !e2eUnlocked
+
+  const handleSave = async () => {
+    const trimmed = name.trim()
+    if (!trimmed || !hasChanged || locked) return
+    try {
+      const data = isEncrypted
+        ? await sealStreamRename({ workspaceId, streamId: stream.id, userId: currentUserId ?? "", name: trimmed })
+        : { displayName: trimmed }
+      updateMutation.mutate(data, {
         onSuccess: () => toast.success("Name updated"),
         onError: () => toast.error("Failed to update name"),
-      }
-    )
+      })
+    } catch {
+      toast.error("Unlock this scratchpad to rename it")
+    }
   }
 
   return (
     <div className="space-y-3">
       <Label className="text-sm font-medium">Display name</Label>
-      <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Scratchpad name" maxLength={100} />
-      {hasChanged && (
+      <Input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Scratchpad name"
+        maxLength={100}
+        disabled={locked}
+      />
+      {locked && <p className="text-xs text-muted-foreground">Unlock this scratchpad to rename it.</p>}
+      {hasChanged && !locked && (
         <Button size="sm" onClick={handleSave} disabled={!name.trim() || updateMutation.isPending}>
           {updateMutation.isPending ? "Saving..." : "Save"}
         </Button>

--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -14,6 +14,9 @@ import * as usePreloadImagesModule from "@/hooks/use-preload-images"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as draftStoreModule from "@/stores/draft-store"
 import * as loadingComponentsModule from "@/components/loading"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as e2eSessionModule from "@/stores/e2e-session-store"
+import { clearStreamNameCache, primeStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
 
 type MockQueryResult = {
   status: "pending" | "success" | "error"
@@ -31,7 +34,14 @@ let mockSeedCacheFromIdbResult = false
 let mockHasSeededWorkspaceCache = false
 let mockWorkspace: { id: string } | undefined
 let mockUsers: Array<{ id: string; avatarUrl: string | null }> = []
-let mockStreams: Array<{ id: string; lastMessagePreview?: { createdAt: string } | null }> = []
+let mockStreams: Array<{
+  id: string
+  lastMessagePreview?: { createdAt: string } | null
+  e2eEnabled?: boolean
+  sealedNameCiphertext?: string | null
+  sealedNameEnvelope?: unknown
+}> = []
+let mockE2eSessionStatus: e2eSessionModule.E2eSessionStatus = "no-key"
 let mockMemberships: Array<{ streamId: string }> = []
 let mockDmPeers: Array<{ streamId: string; userId: string }> = []
 let mockPersonas: Array<{ id: string }> = []
@@ -99,6 +109,20 @@ function installSpies() {
   )
   vi.spyOn(draftStoreModule, "seedDraftCacheFromIdb").mockImplementation(async () => undefined)
   vi.spyOn(draftStoreModule, "hasSeededDraftCache").mockImplementation(() => mockHasSeededDraftCache)
+  // The sealed-name reveal gate reads the current user's session; default to a
+  // no-key (non-E2E) workspace so existing cases are unaffected.
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("user_1")
+  vi.spyOn(e2eSessionModule, "useE2eSession").mockImplementation(
+    () =>
+      ({
+        status: mockE2eSessionStatus,
+        keyId: null,
+        publicKey: null,
+        privateKey: null,
+        deviceTrusted: false,
+        error: null,
+      }) as e2eSessionModule.E2eSessionState
+  )
   vi.spyOn(loadingComponentsModule, "StreamContentSkeleton").mockImplementation(() => (
     <div data-testid="stream-content-skeleton">Stream Content Skeleton</div>
   ))
@@ -158,12 +182,15 @@ describe("CoordinatedLoadingProvider", () => {
     mockHasSeededDraftCache = false
     mockSyncStatuses = new Map()
     mockSyncErrors = new Map()
+    mockE2eSessionStatus = "no-key"
+    clearStreamNameCache()
     installSpies()
   })
 
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
+    clearStreamNameCache()
   })
 
   it("reports loading initially while initial data is unresolved", async () => {
@@ -599,6 +626,56 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("stream-state").textContent).toBe("idle")
     expect(screen.getByTestId("has-errors").textContent).toBe("false")
     warnSpy.mockRestore()
+  })
+
+  it("holds the reveal until an unlocked session's sealed name decrypts, then reveals", async () => {
+    makeReadyWorkspaceState()
+    mockSeedCacheFromIdbResult = true
+    mockE2eSessionStatus = "unlocked"
+    mockStreams = [{ id: "stream_1", e2eEnabled: true, sealedNameCiphertext: "ct_1", sealedNameEnvelope: { v: 1 } }]
+
+    const { rerender } = render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    // Everything else is ready, but the sealed name hasn't decrypted yet, so the
+    // gate holds rather than flashing the placeholder.
+    expect(screen.getByTestId("phase").textContent).not.toBe("ready")
+
+    // The decrypt lands (seeded into the shared cache) → the gate opens.
+    act(() => {
+      primeStreamName(streamNameCacheKey("workspace_1", "stream_1", "ct_1"), "Quarterly Plan")
+    })
+    rerender(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("does not wait on sealed names while the session is locked (reveals with the placeholder)", async () => {
+    makeReadyWorkspaceState()
+    mockSeedCacheFromIdbResult = true
+    mockE2eSessionStatus = "locked"
+    // A sealed name that can never decrypt while locked must not deadlock the reveal.
+    mockStreams = [{ id: "stream_1", e2eEnabled: true, sealedNameCiphertext: "ct_1", sealedNameEnvelope: { v: 1 } }]
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
   })
 })
 

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -1,6 +1,19 @@
-import { createContext, useContext, useState, useEffect, useMemo, useRef, type ReactNode } from "react"
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react"
 import { usePreloadImages } from "@/hooks/use-preload-images"
 import { useCoordinatedStreamQueries } from "@/hooks/use-coordinated-stream-queries"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
+import { resolveSealedNamePending } from "@/hooks/use-decrypted-stream-name"
+import { getStreamNameCacheVersion, subscribeStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import {
   hasSeededWorkspaceCache,
   seedCacheFromIdb,
@@ -179,6 +192,24 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   // user's real layout. A row always exists after the first bootstrap (the server
   // seeds the default), so this only ever waits on a genuinely-unloaded config.
   const idbSidebarConfig = useWorkspaceSidebarConfig(workspaceId)
+  // Hold the initial reveal until every sealed E2E stream name has decrypted, so
+  // the first painted render shows real names instead of flashing the placeholder
+  // and popping to the decrypted name a tick later. `resolveSealedNamePending`
+  // only waits while the session is settling or unlocked-and-decrypting; it
+  // returns false for a locked/no-key session (the placeholder is then the right
+  // answer) and once a decrypt settles, so this can't deadlock the reveal.
+  // `nameCacheVersion` re-evaluates it when a decrypt lands.
+  const currentUserId = useWorkspaceUserId(workspaceId)
+  const e2eSessionStatus = useE2eSession(workspaceId, currentUserId ?? "").status
+  const nameCacheVersion = useSyncExternalStore(
+    subscribeStreamNameCache,
+    getStreamNameCacheVersion,
+    getStreamNameCacheVersion
+  )
+  const sealedNamesPending = useMemo(
+    () => idbStreams.some((stream) => resolveSealedNamePending(workspaceId, stream, e2eSessionStatus)),
+    [idbStreams, workspaceId, e2eSessionStatus, nameCacheVersion]
+  )
   const streamById = useMemo(() => new Map(idbStreams.map((stream) => [stream.id, stream])), [idbStreams])
   const workspaceDataReady =
     hasSeededWorkspaceCache(workspaceId) &&
@@ -242,6 +273,7 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
     workspaceLoading ||
     (!isReady && streamsLoading) ||
     draftsLoading ||
+    (!isReady && sealedNamesPending) ||
     (isReady && hasSettledInitialSyncRef.current && isAnySyncing)
 
   if (isBootstrapDebugEnabled()) {
@@ -274,6 +306,8 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       workspaceLoading,
       streamsLoading,
       draftsLoading,
+      e2eSessionStatus,
+      sealedNamesPending,
       isAnySyncing,
       isLoading,
       isReady,

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
@@ -5,6 +5,7 @@ import { db, type CachedStream } from "@/db"
 import { resetWorkspaceStoreCache, seedWorkspaceCache } from "@/stores/workspace-store"
 import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
+import { useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
 import { useStreamName } from "@/hooks/use-stream-name"
 import * as e2eSession from "@/stores/e2e-session-store"
 import * as workspaces from "@/hooks/use-workspaces"
@@ -63,6 +64,20 @@ function Harness() {
   useDecryptStreamNames(WS)
   const name = useStreamName(WS, STREAM, "sidebar")
   return <span data-testid="label">{name}</span>
+}
+
+const SEALED_STREAM = {
+  id: STREAM,
+  e2eEnabled: true,
+  sealedNameCiphertext: CIPHERTEXT,
+  sealedNameEnvelope: { v: 2 },
+  rootStreamId: null,
+}
+
+function DecryptingHarness() {
+  useDecryptStreamNames(WS)
+  const decrypting = useStreamNameDecrypting(WS, SEALED_STREAM)
+  return <span data-testid="state">{decrypting ? "decrypting" : "settled"}</span>
 }
 
 async function seedSealedStream() {
@@ -131,5 +146,38 @@ describe("decrypted stream name overlay (reactive integration)", () => {
 
     await waitFor(() => expect(screen.getByTestId("label")).toHaveTextContent("New scratchpad"))
     expect(open).not.toHaveBeenCalled()
+  })
+})
+
+describe("useStreamNameDecrypting (cold-load loading state)", () => {
+  it("reports decrypting until the name lands, so the header shows a loader not the placeholder", async () => {
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "unlocked" }))
+    let resolveDecrypt: (value: string | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveDecrypt = resolve
+        })
+    )
+
+    await seedSealedStream()
+    render(<DecryptingHarness />)
+
+    expect(screen.getByTestId("state")).toHaveTextContent("decrypting")
+
+    await act(async () => {
+      resolveDecrypt("Quarterly Plan")
+    })
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("settled"))
+  })
+
+  it("is settled (placeholder, not a loader) while the session is locked", async () => {
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockResolvedValue("Should Not Appear")
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "locked", privateKey: null }))
+
+    await seedSealedStream()
+    render(<DecryptingHarness />)
+
+    await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("settled"))
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useSyncExternalStore } from "react"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useE2eSession } from "@/stores/e2e-session-store"
+import { useE2eSession, type E2eSessionStatus } from "@/stores/e2e-session-store"
 import {
   getCachedStreamName,
   getStreamNameCacheVersion,
@@ -70,32 +70,46 @@ export function useDecryptedStreamName(
 }
 
 /**
- * Whether a sealed E2E stream's name is still resolving — the session is settling
- * (`unknown`/`unlocking`) or it's unlocked and the decrypt hasn't landed yet — so
- * a surface can show a loader instead of flashing the placeholder during the
- * cold-load decrypt window. Returns false for plaintext streams, a locked/no-key
- * session (the placeholder is then the right, settled answer), and once the name
- * has decrypted (or definitively failed). Reads the same cache as
- * `useDecryptedStreamName`, so the two never disagree.
+ * Whether a sealed E2E stream's name is still resolving, given the session status:
+ * the session is settling (`unknown`/`unlocking`) or it's unlocked and the decrypt
+ * hasn't landed yet — so a surface can show a loader instead of flashing the
+ * placeholder during the cold-load decrypt window. False for plaintext streams, a
+ * locked/no-key session (the placeholder is then the settled answer), and once the
+ * name has decrypted (or definitively failed).
+ *
+ * Pure so the single decision can be computed at the read boundary that already
+ * resolves the name — the open-stream header (via `useStreamNameDecrypting`) and
+ * the sidebar's stream-list builder — rather than each leaf row re-wiring the
+ * session. Reads the same cache as the name overlay, so loader and label agree.
+ */
+export function resolveSealedNamePending(
+  workspaceId: string,
+  stream: SealedNameStream | null | undefined,
+  sessionStatus: E2eSessionStatus
+): boolean {
+  const e2eEnabled = stream?.e2eEnabled ?? false
+  const streamId = stream?.id
+  const ciphertext = stream?.sealedNameCiphertext ?? null
+  if (!e2eEnabled || !streamId || !ciphertext) return false
+  if (sessionStatus === "unknown" || sessionStatus === "unlocking") return true
+  if (sessionStatus === "unlocked") return isStreamNamePending(streamNameCacheKey(workspaceId, streamId, ciphertext))
+  return false
+}
+
+/**
+ * Hook form of {@link resolveSealedNamePending} for a single open stream (the
+ * header), which already has session context. List surfaces resolve this through
+ * their stream-list builder instead, off the same shared cache.
  */
 export function useStreamNameDecrypting(workspaceId: string, stream: SealedNameStream | null | undefined): boolean {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
+  // `version` re-evaluates pending when a decrypt settles (including a failure,
+  // which doesn't change the overlaid row).
   const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
 
-  const e2eEnabled = stream?.e2eEnabled ?? false
-  const streamId = stream?.id
-  const ciphertext = stream?.sealedNameCiphertext ?? null
-  const key = e2eEnabled && streamId && ciphertext ? streamNameCacheKey(workspaceId, streamId, ciphertext) : null
-
-  return useMemo(() => {
-    if (!key) return false
-    // The session hasn't resolved yet — the name is loading, not absent.
-    if (session.status === "unknown" || session.status === "unlocking") return true
-    // Unlocked: loading only until the decrypt lands (or definitively fails).
-    if (session.status === "unlocked") return isStreamNamePending(key)
-    // locked / no-key: the placeholder is the settled answer, not a loading state.
-    return false
-    // `version` re-evaluates pending when a decrypt settles; the rest key it.
-  }, [key, session.status, version])
+  return useMemo(
+    () => resolveSealedNamePending(workspaceId, stream, session.status),
+    [workspaceId, stream, session.status, version]
+  )
 }

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -4,6 +4,7 @@ import { useE2eSession } from "@/stores/e2e-session-store"
 import {
   getCachedStreamName,
   getStreamNameCacheVersion,
+  isStreamNamePending,
   requestStreamName,
   streamNameCacheKey,
   subscribeStreamNameCache,
@@ -66,4 +67,35 @@ export function useDecryptedStreamName(
     // `version` re-reads the cache when a decrypt lands; the rest key the lookup.
     [key, unlocked, version]
   )
+}
+
+/**
+ * Whether a sealed E2E stream's name is still resolving — the session is settling
+ * (`unknown`/`unlocking`) or it's unlocked and the decrypt hasn't landed yet — so
+ * a surface can show a loader instead of flashing the placeholder during the
+ * cold-load decrypt window. Returns false for plaintext streams, a locked/no-key
+ * session (the placeholder is then the right, settled answer), and once the name
+ * has decrypted (or definitively failed). Reads the same cache as
+ * `useDecryptedStreamName`, so the two never disagree.
+ */
+export function useStreamNameDecrypting(workspaceId: string, stream: SealedNameStream | null | undefined): boolean {
+  const userId = useWorkspaceUserId(workspaceId)
+  const session = useE2eSession(workspaceId, userId ?? "")
+  const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
+
+  const e2eEnabled = stream?.e2eEnabled ?? false
+  const streamId = stream?.id
+  const ciphertext = stream?.sealedNameCiphertext ?? null
+  const key = e2eEnabled && streamId && ciphertext ? streamNameCacheKey(workspaceId, streamId, ciphertext) : null
+
+  return useMemo(() => {
+    if (!key) return false
+    // The session hasn't resolved yet — the name is loading, not absent.
+    if (session.status === "unknown" || session.status === "unlocking") return true
+    // Unlocked: loading only until the decrypt lands (or definitively fails).
+    if (session.status === "unlocked") return isStreamNamePending(key)
+    // locked / no-key: the placeholder is the settled answer, not a loading state.
+    return false
+    // `version` re-evaluates pending when a decrypt settles; the rest key it.
+  }, [key, session.status, version])
 }

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
 import { MemoryRouter } from "react-router-dom"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type MessageService, type StreamService } from "@/contexts"
 import { PendingMessagesProvider } from "@/contexts/pending-messages-context"
 import { clearAllCachedData, db } from "@/db"
@@ -12,6 +12,10 @@ import { seedWorkspaceCache } from "@/stores/workspace-store"
 import { SyncEngineContext } from "@/sync/sync-engine"
 import { workspaceKeys } from "./use-workspaces"
 import { useStreamOrDraft } from "./use-stream-or-draft"
+import * as e2eSession from "@/stores/e2e-session-store"
+import * as streamKeyCache from "@/lib/crypto/stream-key-cache"
+import * as messageEnvelope from "@/lib/crypto/message-envelope"
+import { clearStreamNameCache, getCachedStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
 
 function createWrapper(
   queryClient: QueryClient,
@@ -420,5 +424,223 @@ describe("useStreamOrDraft draft DM send", () => {
     expect(bootstrap?.streams).toContainEqual(expect.objectContaining({ id: "stream_dm_1", displayName: "Invitee" }))
     expect(bootstrap?.streamMemberships).toContainEqual(expect.objectContaining({ streamId: "stream_dm_1" }))
     expect(bootstrap?.dmPeers).toContainEqual(expect.objectContaining({ streamId: "stream_dm_1", userId: "member_2" }))
+  })
+})
+
+// The top-bar header editor renames a scratchpad by calling
+// `useStreamOrDraft().rename` on blur/Enter; these cover that engine for an
+// encrypted scratchpad (the inline editor lives inside the stream page and
+// isn't separately mountable).
+describe("useStreamOrDraft scratchpad rename (top-bar editor path)", () => {
+  const CREATED_AT = "2026-03-31T10:00:00Z"
+
+  function seedScratchpad(streamOverrides: Record<string, unknown>): string {
+    const streamId = "stream_pad_1"
+    seedWorkspaceCache("ws_1", {
+      workspace: {
+        id: "ws_1",
+        name: "Workspace",
+        slug: "workspace",
+        createdAt: CREATED_AT,
+        updatedAt: CREATED_AT,
+        _cachedAt: Date.now(),
+      },
+      users: [
+        {
+          id: "member_1",
+          workspaceId: "ws_1",
+          workosUserId: "workos_1",
+          email: "kris@example.com",
+          role: "owner",
+          slug: "kris",
+          name: "Kris",
+          description: null,
+          avatarUrl: null,
+          timezone: "Europe/Stockholm",
+          locale: "en",
+          pronouns: null,
+          phone: null,
+          githubUsername: null,
+          statusEmoji: null,
+          statusText: null,
+          statusExpiresAt: null,
+          statusPausesNotifications: false,
+          notificationsPausedUntil: null,
+          notificationsPausedIndefinitely: false,
+          setupCompleted: true,
+          joinedAt: CREATED_AT,
+          _cachedAt: Date.now(),
+        },
+      ],
+      streams: [
+        {
+          id: streamId,
+          workspaceId: "ws_1",
+          type: "scratchpad" as const,
+          displayName: null,
+          slug: null,
+          description: null,
+          visibility: "private" as const,
+          parentStreamId: null,
+          parentMessageId: null,
+          rootStreamId: null,
+          companionMode: "on" as const,
+          companionPersonaId: null,
+          createdBy: "member_1",
+          createdAt: CREATED_AT,
+          updatedAt: CREATED_AT,
+          archivedAt: null,
+          lastMessagePreview: null,
+          _cachedAt: Date.now(),
+          ...streamOverrides,
+        },
+      ],
+      memberships: [
+        {
+          id: `ws_1:${streamId}`,
+          workspaceId: "ws_1",
+          streamId,
+          memberId: "member_1",
+          notificationLevel: null,
+          lastReadEventId: null,
+          lastReadAt: null,
+          joinedAt: CREATED_AT,
+          _cachedAt: Date.now(),
+        },
+      ],
+      dmPeers: [],
+      personas: [],
+      bots: [],
+      unreadState: {
+        id: "ws_1",
+        workspaceId: "ws_1",
+        unreadCounts: {},
+        mentionCounts: {},
+        activityCounts: {},
+        unreadActivityCount: 0,
+        mutedStreamIds: [],
+        _cachedAt: Date.now(),
+      },
+      userPreferences: {
+        id: "ws_1",
+        workspaceId: "ws_1",
+        userId: "member_1",
+        theme: "system",
+        sendMode: "enter",
+        _cachedAt: Date.now(),
+      },
+      metadata: { id: "ws_1", workspaceId: "ws_1", emojis: [], emojiWeights: {}, commands: [], _cachedAt: Date.now() },
+    })
+    return streamId
+  }
+
+  beforeEach(async () => {
+    await clearAllCachedData()
+  })
+
+  afterEach(() => {
+    clearStreamNameCache()
+    vi.restoreAllMocks()
+  })
+
+  it("seals the new name and persists a sealed-only update (no plaintext) for an encrypted scratchpad", async () => {
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue({
+      status: "unlocked",
+      keyId: "e2ek_alice",
+      publicKey: null,
+      privateKey: {} as CryptoKey,
+      deviceTrusted: true,
+      error: null,
+    } as never)
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({
+      key: new Uint8Array(32),
+      keyGeneration: 0,
+    } as never)
+    vi.spyOn(messageEnvelope, "sealStreamName").mockResolvedValue({ ciphertext: "Y3Q=", envelope: { v: 1 } as never })
+
+    const streamId = seedScratchpad({ e2eEnabled: true, sealedNameCiphertext: "old_ct", sealedNameEnvelope: { v: 0 } })
+    const update = vi.fn().mockImplementation(async (_ws: string, id: string, data: Record<string, unknown>) => ({
+      id,
+      workspaceId: "ws_1",
+      type: "scratchpad",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: null,
+      parentMessageId: null,
+      rootStreamId: null,
+      companionMode: "on",
+      companionPersonaId: null,
+      createdBy: "member_1",
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+      archivedAt: null,
+      e2eEnabled: true,
+      ...data,
+    }))
+
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useStreamOrDraft("ws_1", streamId), {
+      wrapper: createWrapper(queryClient, { streamService: { update } }),
+    })
+
+    await waitFor(() => expect(result.current.stream?.e2eEnabled).toBe(true))
+
+    await act(async () => {
+      await result.current.rename("Therapy notes")
+    })
+
+    // The PATCH carries only the sealed ciphertext — never the plaintext name.
+    expect(update).toHaveBeenCalledWith("ws_1", streamId, {
+      sealedNameCiphertext: "Y3Q=",
+      sealedNameEnvelope: { v: 1 },
+    })
+    expect(update.mock.calls[0]![2]).not.toHaveProperty("displayName")
+
+    // The just-typed name is seeded into the decrypt cache keyed by the fresh
+    // ciphertext, so the header/sidebar render it immediately (no flicker).
+    expect(getCachedStreamName(streamNameCacheKey("ws_1", streamId, "Y3Q="))).toBe("Therapy notes")
+
+    const persisted = await db.streams.get(streamId)
+    expect(persisted).toMatchObject({ sealedNameCiphertext: "Y3Q=", displayName: null })
+  })
+
+  it("renames a plaintext scratchpad by writing displayName directly (no sealing)", async () => {
+    const sealSpy = vi.spyOn(messageEnvelope, "sealStreamName")
+    const streamId = seedScratchpad({ e2eEnabled: false })
+    const update = vi.fn().mockImplementation(async (_ws: string, id: string, data: Record<string, unknown>) => ({
+      id,
+      workspaceId: "ws_1",
+      type: "scratchpad",
+      displayName: null,
+      slug: null,
+      description: null,
+      visibility: "private",
+      parentStreamId: null,
+      parentMessageId: null,
+      rootStreamId: null,
+      companionMode: "on",
+      companionPersonaId: null,
+      createdBy: "member_1",
+      createdAt: CREATED_AT,
+      updatedAt: CREATED_AT,
+      archivedAt: null,
+      ...data,
+    }))
+
+    const queryClient = new QueryClient()
+    const { result } = renderHook(() => useStreamOrDraft("ws_1", streamId), {
+      wrapper: createWrapper(queryClient, { streamService: { update } }),
+    })
+
+    await waitFor(() => expect(result.current.stream?.id).toBe(streamId))
+
+    await act(async () => {
+      await result.current.rename("Groceries")
+    })
+
+    expect(update).toHaveBeenCalledWith("ws_1", streamId, { displayName: "Groceries" })
+    expect(sealSpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -4,10 +4,10 @@ import { useNavigate } from "react-router-dom"
 import { db, sequenceToNum, type CachedStream } from "@/db"
 import { useStreamService, useMessageService, usePendingMessages } from "@/contexts"
 import { useUser } from "@/auth"
-import { getE2eSessionState } from "@/stores/e2e-session-store"
-import { sealStreamName, type SealStreamMessageResult } from "@/lib/crypto/message-envelope"
-import { resolveCurrentStreamKey, reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
+import { type SealStreamMessageResult } from "@/lib/crypto/message-envelope"
+import { reviveStaleActorWraps } from "@/lib/crypto/stream-key-cache"
 import { sealOutgoingMessage } from "@/lib/crypto/seal-send"
+import { sealStreamRename } from "@/lib/crypto/stream-rename"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
@@ -494,39 +494,17 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
 
   const rename = useCallback(
     async (newName: string) => {
-      // For an encrypted stream the name has two copies: the plaintext fallback
-      // and a sealed (tamper-evident) copy an unlocked client prefers. We must
-      // never leave a STALE sealed name — if we can't produce a fresh seal (the
-      // session is locked or the key can't be resolved), explicitly CLEAR it
-      // (null) so the new plaintext name is authoritative, instead of leaving the
-      // old ciphertext to outrank it after the next unlock.
-      let sealedNameFields: { sealedNameCiphertext: string | null; sealedNameEnvelope: unknown } | undefined
-      if (baseStream?.e2eEnabled && currentUserId) {
-        sealedNameFields = { sealedNameCiphertext: null, sealedNameEnvelope: null }
-        const session = getE2eSessionState(workspaceId, currentUserId)
-        if (session.status === "unlocked" && session.privateKey && session.keyId) {
-          const streamKey = await resolveCurrentStreamKey({
-            workspaceId,
-            streamId,
-            recipientKeyId: session.keyId,
-            privateKey: session.privateKey,
-          })
-          if (streamKey) {
-            const sealed = await sealStreamName({
-              name: newName,
-              streamId,
-              ssk: streamKey.key,
-              keyGeneration: streamKey.keyGeneration,
-            })
-            sealedNameFields = { sealedNameCiphertext: sealed.ciphertext, sealedNameEnvelope: sealed.envelope }
-          }
-        }
-      }
+      // An E2E stream's name is sealed-only: we persist the tamper-evident
+      // ciphertext and NEVER the plaintext, so the server can't read it (the
+      // server scrubs `display_name` to null when a sealed name is set). Sealing
+      // needs the SSK, so it throws when the session is locked — the rename
+      // affordance is disabled in that state, and this is the backstop that
+      // keeps a rename from ever falling back to writing plaintext.
+      const updateInput = baseStream?.e2eEnabled
+        ? await sealStreamRename({ workspaceId, streamId, userId: currentUserId ?? "", name: newName })
+        : { displayName: newName }
 
-      const updatedStream = await streamService.update(workspaceId, streamId, {
-        displayName: newName,
-        ...sealedNameFields,
-      })
+      const updatedStream = await streamService.update(workspaceId, streamId, updateInput)
       await db.streams.put(toCachedStream(updatedStream, idbStream))
 
       queryClient.setQueryData(streamKeys.bootstrap(workspaceId, streamId), (old: unknown) => {

--- a/apps/frontend/src/lib/crypto/__tests__/stream-name-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-name-cache.test.ts
@@ -3,6 +3,7 @@ import {
   applyDecryptedNameOverlay,
   clearStreamNameCache,
   getCachedStreamName,
+  isStreamNamePending,
   requestStreamName,
   streamNameCacheKey,
   subscribeStreamNameCache,
@@ -104,6 +105,43 @@ describe("stream-name-cache", () => {
     resolveOpen("Top Secret")
     await pending
     expect(getCachedStreamName(KEY)).toBeNull()
+  })
+})
+
+describe("isStreamNamePending", () => {
+  it("is pending before any decrypt has been attempted (so a loader covers the first frame)", () => {
+    expect(isStreamNamePending(KEY)).toBe(true)
+  })
+
+  it("is pending while a decrypt is in flight and settles once it lands", async () => {
+    let resolveOpen: (value: string | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockImplementation(
+      () =>
+        new Promise<string | null>((r) => {
+          resolveOpen = r
+        })
+    )
+    const pending = requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(isStreamNamePending(KEY)).toBe(true)
+
+    resolveOpen("Launch Plan")
+    await pending
+    expect(isStreamNamePending(KEY)).toBe(false)
+  })
+
+  it("is not pending after a decrypt settles without a name (non-recipient / forged AAD)", async () => {
+    stubOpen(null)
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    // Settled, no name — the placeholder is the answer, so no perpetual loader.
+    expect(isStreamNamePending(KEY)).toBe(false)
+  })
+
+  it("becomes pending again after the cache is cleared on lock", async () => {
+    stubOpen("Budget")
+    await requestStreamName(KEY, PAYLOAD, STUB_OPTS)
+    expect(isStreamNamePending(KEY)).toBe(false)
+    clearStreamNameCache()
+    expect(isStreamNamePending(KEY)).toBe(true)
   })
 })
 

--- a/apps/frontend/src/lib/crypto/__tests__/stream-rename.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-rename.test.ts
@@ -3,6 +3,7 @@ import { sealStreamRename, StreamNameSealUnavailableError } from "../stream-rena
 import * as e2eSession from "@/stores/e2e-session-store"
 import * as streamKeyCache from "../stream-key-cache"
 import * as messageEnvelope from "../message-envelope"
+import { clearStreamNameCache, getCachedStreamName, streamNameCacheKey } from "../stream-name-cache"
 
 const WS = "ws_1"
 const STREAM = "stream_01"
@@ -32,7 +33,10 @@ function unlockedSession(): SessionState {
   } as SessionState
 }
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  clearStreamNameCache()
+})
 
 describe("sealStreamRename", () => {
   it("throws instead of falling back to plaintext when the session is locked", async () => {
@@ -70,5 +74,24 @@ describe("sealStreamRename", () => {
 
     expect(fields).toEqual({ sealedNameCiphertext: "Y3Q=", sealedNameEnvelope: { v: 1 } })
     expect(fields).not.toHaveProperty("displayName")
+  })
+
+  it("seeds the decrypt cache with the new name keyed by the fresh ciphertext (no re-decrypt flicker)", async () => {
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(unlockedSession())
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({
+      key: new Uint8Array(32),
+      keyGeneration: 0,
+    } as never)
+    vi.spyOn(messageEnvelope, "sealStreamName").mockResolvedValue({
+      ciphertext: "Y3Q=",
+      envelope: { v: 1 } as never,
+    })
+
+    await sealStreamRename({ workspaceId: WS, streamId: STREAM, userId: USER, name: "Therapy notes" })
+
+    // The cleartext we just sealed is immediately resolvable on this device,
+    // keyed by the fresh ciphertext, so the overlay/header render the new name
+    // the instant the stream row flips to it instead of decrypting our own write.
+    expect(getCachedStreamName(streamNameCacheKey(WS, STREAM, "Y3Q="))).toBe("Therapy notes")
   })
 })

--- a/apps/frontend/src/lib/crypto/__tests__/stream-rename.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/stream-rename.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { sealStreamRename, StreamNameSealUnavailableError } from "../stream-rename"
+import * as e2eSession from "@/stores/e2e-session-store"
+import * as streamKeyCache from "../stream-key-cache"
+import * as messageEnvelope from "../message-envelope"
+
+const WS = "ws_1"
+const STREAM = "stream_01"
+const USER = "usr_alice"
+
+type SessionState = ReturnType<typeof e2eSession.getE2eSessionState>
+
+function lockedSession(): SessionState {
+  return {
+    status: "locked",
+    keyId: null,
+    publicKey: null,
+    privateKey: null,
+    deviceTrusted: false,
+    error: null,
+  } as SessionState
+}
+
+function unlockedSession(): SessionState {
+  return {
+    status: "unlocked",
+    keyId: "e2ek_alice",
+    publicKey: null,
+    privateKey: {} as CryptoKey,
+    deviceTrusted: false,
+    error: null,
+  } as SessionState
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("sealStreamRename", () => {
+  it("throws instead of falling back to plaintext when the session is locked", async () => {
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(lockedSession())
+    const sealSpy = vi.spyOn(messageEnvelope, "sealStreamName")
+
+    await expect(
+      sealStreamRename({ workspaceId: WS, streamId: STREAM, userId: USER, name: "Therapy notes" })
+    ).rejects.toBeInstanceOf(StreamNameSealUnavailableError)
+    // The whole point: a locked rename must never reach the seal/plaintext write.
+    expect(sealSpy).not.toHaveBeenCalled()
+  })
+
+  it("throws when the stream key can't be resolved (not a recipient)", async () => {
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(unlockedSession())
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue(null)
+
+    await expect(
+      sealStreamRename({ workspaceId: WS, streamId: STREAM, userId: USER, name: "Therapy notes" })
+    ).rejects.toMatchObject({ reason: "no-stream-key" })
+  })
+
+  it("returns only the sealed fields (no plaintext) when unlocked", async () => {
+    vi.spyOn(e2eSession, "getE2eSessionState").mockReturnValue(unlockedSession())
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({
+      key: new Uint8Array(32),
+      keyGeneration: 0,
+    } as never)
+    vi.spyOn(messageEnvelope, "sealStreamName").mockResolvedValue({
+      ciphertext: "Y3Q=",
+      envelope: { v: 1 } as never,
+    })
+
+    const fields = await sealStreamRename({ workspaceId: WS, streamId: STREAM, userId: USER, name: "Therapy notes" })
+
+    expect(fields).toEqual({ sealedNameCiphertext: "Y3Q=", sealedNameEnvelope: { v: 1 } })
+    expect(fields).not.toHaveProperty("displayName")
+  })
+})

--- a/apps/frontend/src/lib/crypto/message-envelope.ts
+++ b/apps/frontend/src/lib/crypto/message-envelope.ts
@@ -79,9 +79,10 @@ export async function sealStreamMessage(input: SealStreamMessageInput): Promise<
 /**
  * Seal a stream's display name under its SSK, bound to `(streamId, "name",
  * generation)` so a malicious server can't relocate it onto another stream or
- * swap it with a message body. Stored alongside the plaintext `displayName`
- * (which stays the locked-state fallback); an unlocked client prefers this
- * tamper-evident copy. Reuses the same SSK ciphertext path as messages.
+ * swap it with a message body. This is the ONLY persisted copy of an E2E
+ * stream's name — the server scrubs `display_name` to null when a sealed name
+ * is set (INV-E1, no plaintext at rest); a locked client shows the placeholder.
+ * Reuses the same SSK ciphertext path as messages.
  */
 export async function sealStreamName(input: {
   name: string

--- a/apps/frontend/src/lib/crypto/stream-name-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-name-cache.ts
@@ -26,6 +26,11 @@ import { tryOpenStreamName, type DecryptMessageOpts } from "./message-envelope"
 /** Decrypted plaintext names keyed by `${workspaceId}:${streamId}:${ciphertext}`. */
 const names = new Map<string, string>()
 const inflight = new Map<string, Promise<void>>()
+// Keys whose decrypt has settled at least once (success or failure). Lets the UI
+// tell "still decrypting on cold load" (show a loader, not the placeholder) from
+// "decrypt finished with no name" (a non-recipient / forged AAD — show the
+// placeholder). Cleared with the cache on lock.
+const attempted = new Set<string>()
 const listeners = new Set<() => void>()
 
 // Monotonic snapshot for useSyncExternalStore — bumped on every cache change so
@@ -60,6 +65,19 @@ export function getCachedStreamName(key: string): string | null {
   return names.get(key) ?? null
 }
 
+/**
+ * Whether a sealed name is still resolving: no plaintext cached yet, and either
+ * a decrypt is in flight or none has been attempted (so one is imminent). Once a
+ * decrypt settles without a name (non-recipient / forged AAD) this returns false,
+ * so the UI can stop showing a loader and fall back to the placeholder rather
+ * than spinning forever. A surface uses this to avoid flashing the placeholder
+ * during the cold-load decrypt window.
+ */
+export function isStreamNamePending(key: string): boolean {
+  if (names.has(key)) return false
+  return inflight.has(key) || !attempted.has(key)
+}
+
 export interface RequestStreamNameInput {
   /** Base64 ciphertext from `sealedNameCiphertext`. */
   ciphertext: string
@@ -90,7 +108,13 @@ export function requestStreamName(
     // writing plaintext back would leak it past the lock boundary.
     if (startGeneration !== generation) return
     inflight.delete(key)
-    if (decrypted == null) return
+    attempted.add(key)
+    // Emit on both outcomes: success lands the name; a null result still flips
+    // the pending state so a loader can fall back to the placeholder.
+    if (decrypted == null) {
+      emit()
+      return
+    }
     names.set(key, decrypted)
     emit()
   })()
@@ -131,6 +155,7 @@ export function clearStreamNameCache(): void {
   generation++
   names.clear()
   inflight.clear()
+  attempted.clear()
   emit()
 }
 

--- a/apps/frontend/src/lib/crypto/stream-name-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-name-cache.ts
@@ -133,3 +133,17 @@ export function clearStreamNameCache(): void {
   inflight.clear()
   emit()
 }
+
+/**
+ * Seed the cache with a plaintext name we already hold — the local rename path,
+ * which sealed the name itself, so it knows the cleartext without decrypting.
+ * Keyed by the fresh ciphertext, so the store-read overlay and the open-stream
+ * header resolve the new name the instant the stream row flips to that ciphertext
+ * instead of flashing the placeholder while an async re-decrypt of our own write
+ * round-trips. Memory-only and cleared on lock like every other entry.
+ */
+export function primeStreamName(key: string, name: string): void {
+  if (names.get(key) === name) return
+  names.set(key, name)
+  emit()
+}

--- a/apps/frontend/src/lib/crypto/stream-rename.ts
+++ b/apps/frontend/src/lib/crypto/stream-rename.ts
@@ -1,6 +1,7 @@
 import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { sealStreamName } from "@/lib/crypto/message-envelope"
 import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
+import { primeStreamName, streamNameCacheKey } from "@/lib/crypto/stream-name-cache"
 
 /** Sealed-name PATCH fields for an E2E rename — sent WITHOUT a plaintext `displayName`. */
 export interface SealedNameFields {
@@ -57,5 +58,10 @@ export async function sealStreamRename(params: {
     ssk: streamKey.key,
     keyGeneration: streamKey.keyGeneration,
   })
+  // Seed the decrypt cache with the cleartext we just sealed, keyed by the fresh
+  // ciphertext, so the header and list overlay show the new name the moment the
+  // stream row flips to it — without flashing the placeholder while a re-decrypt
+  // of our own write round-trips (the rename flicker).
+  primeStreamName(streamNameCacheKey(workspaceId, streamId, sealed.ciphertext), name)
   return { sealedNameCiphertext: sealed.ciphertext, sealedNameEnvelope: sealed.envelope }
 }

--- a/apps/frontend/src/lib/crypto/stream-rename.ts
+++ b/apps/frontend/src/lib/crypto/stream-rename.ts
@@ -1,0 +1,61 @@
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { sealStreamName } from "@/lib/crypto/message-envelope"
+import { resolveCurrentStreamKey } from "@/lib/crypto/stream-key-cache"
+
+/** Sealed-name PATCH fields for an E2E rename — sent WITHOUT a plaintext `displayName`. */
+export interface SealedNameFields {
+  sealedNameCiphertext: string
+  sealedNameEnvelope: unknown
+}
+
+/**
+ * Thrown when an E2E stream can't be renamed because no stream key is available
+ * to seal the new name (the session is locked, or the SSK can't be resolved).
+ * The rename affordance is gated on the unlocked state; this is the backstop
+ * that guarantees a rename never silently falls back to writing the name as
+ * plaintext — the leak this module exists to remove.
+ */
+export class StreamNameSealUnavailableError extends Error {
+  constructor(public readonly reason: "locked" | "no-stream-key") {
+    super(`Cannot seal stream name: ${reason}`)
+    this.name = "StreamNameSealUnavailableError"
+  }
+}
+
+/**
+ * Seal a new display name for an E2E stream so a rename persists ONLY the
+ * tamper-evident ciphertext (AAD-bound to the stream) — the server never
+ * receives the cleartext name (INV-E1). Mirrors the enclave auto-title's sealed-only
+ * write (`setSealedNameIfAbsent`). The single sealing path for every rename
+ * surface (open-stream header + stream settings); both call this rather than
+ * re-deriving the seal. Throws — never returns a plaintext fallback — when the
+ * session is locked or the SSK can't be resolved.
+ */
+export async function sealStreamRename(params: {
+  workspaceId: string
+  streamId: string
+  userId: string
+  name: string
+}): Promise<SealedNameFields> {
+  const { workspaceId, streamId, userId, name } = params
+  const session = getE2eSessionState(workspaceId, userId)
+  if (session.status !== "unlocked" || !session.privateKey || !session.keyId) {
+    throw new StreamNameSealUnavailableError("locked")
+  }
+  const streamKey = await resolveCurrentStreamKey({
+    workspaceId,
+    streamId,
+    recipientKeyId: session.keyId,
+    privateKey: session.privateKey,
+  })
+  if (!streamKey) {
+    throw new StreamNameSealUnavailableError("no-stream-key")
+  }
+  const sealed = await sealStreamName({
+    name,
+    streamId,
+    ssk: streamKey.key,
+    keyGeneration: streamKey.keyGeneration,
+  })
+  return { sealedNameCiphertext: sealed.ciphertext, sealedNameEnvelope: sealed.envelope }
+}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -43,7 +43,8 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
-import { useDecryptedStreamName } from "@/hooks/use-decrypted-stream-name"
+import { useDecryptedStreamName, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
@@ -142,6 +143,10 @@ export function StreamPage() {
   // For an unlocked encrypted stream, the tamper-evident decrypted name; null
   // otherwise (plaintext stream, locked, or not yet decrypted) → plaintext label.
   const decryptedStreamName = useDecryptedStreamName(workspaceId ?? "", stream)
+  // True while a sealed name is still resolving (session settling, or unlocked
+  // but the decrypt hasn't landed) so the header shows a loader instead of
+  // flashing the "unnamed" placeholder on cold load.
+  const nameDecrypting = useStreamNameDecrypting(workspaceId ?? "", stream)
   // Renaming an E2E stream seals the new name under its key, so it requires an
   // unlocked session — the affordance is omitted while locked (the stream is in
   // its locked/unlock state then anyway).
@@ -438,10 +443,14 @@ export function StreamPage() {
         )}
         onClick={canRenameScratchpad ? handleStartRename : undefined}
       >
-        <h1 className="font-semibold truncate">
-          {streamName}
-          {isDraft && <span className="ml-2 text-xs font-normal text-muted-foreground">(draft)</span>}
-        </h1>
+        {nameDecrypting && !pendingName ? (
+          <Skeleton className="h-5 w-40" />
+        ) : (
+          <h1 className="font-semibold truncate">
+            {streamName}
+            {isDraft && <span className="ml-2 text-xs font-normal text-muted-foreground">(draft)</span>}
+          </h1>
+        )}
         {canRenameScratchpad && (
           <Pencil className="h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
         )}

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -196,7 +196,14 @@ export function StreamPage() {
   // would surprise the user with a stale/placeholder value (UX-35).
   const currentDisplayedName = decryptedStreamName ?? stream?.displayName ?? ""
 
+  // Renaming a sealed scratchpad needs an unlocked session to seal the new name;
+  // a non-encrypted scratchpad can always be renamed. Gate every rename affordance
+  // (header title click and menu item) on this so a locked session can't open the
+  // editor only for `rename()` to reject on seal.
+  const canRenameScratchpad = !isEncryptedScratchpad || e2eUnlocked
+
   const handleStartRename = () => {
+    if (!canRenameScratchpad) return
     setEditValue(currentDisplayedName)
     setIsEditing(true)
   }
@@ -261,10 +268,9 @@ export function StreamPage() {
     onSelect: () => openExplorer({ streamIds: [streamId] }),
   })
   if (isScratchpad) {
-    // Renaming a sealed scratchpad needs an unlocked session to seal the new
-    // name; hide the affordance while locked rather than let it fall back to
+    // Hide the rename affordance while locked rather than let it fall back to
     // plaintext. Archive/unarchive stay available regardless of lock state.
-    if (!isEncryptedScratchpad || e2eUnlocked) {
+    if (canRenameScratchpad) {
       streamMenuActions.push({
         id: "rename",
         label: "Rename",
@@ -412,14 +418,21 @@ export function StreamPage() {
   } else if (isScratchpad) {
     headerTitle = (
       <div
-        className="group inline-flex items-center gap-1 rounded-md px-2 py-1 -ml-2 hover:bg-accent/50 hover:outline hover:outline-1 hover:outline-border cursor-pointer transition-colors min-w-0"
-        onClick={handleStartRename}
+        className={cn(
+          "group inline-flex items-center gap-1 rounded-md px-2 py-1 -ml-2 transition-colors min-w-0",
+          canRenameScratchpad
+            ? "cursor-pointer hover:bg-accent/50 hover:outline hover:outline-1 hover:outline-border"
+            : "cursor-default"
+        )}
+        onClick={canRenameScratchpad ? handleStartRename : undefined}
       >
         <h1 className="font-semibold truncate">
           {streamName}
           {isDraft && <span className="ml-2 text-xs font-normal text-muted-foreground">(draft)</span>}
         </h1>
-        <Pencil className="h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        {canRenameScratchpad && (
+          <Pencil className="h-3.5 w-3.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+        )}
       </div>
     )
   } else if (isDm && dmPeerUserId) {

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -44,6 +44,8 @@ import { StreamLabelStack } from "@/components/labels/stream-label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
 import { useDecryptedStreamName } from "@/hooks/use-decrypted-stream-name"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useE2eSession } from "@/stores/e2e-session-store"
 import { StreamPanel, ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle } from "@/components/layout"
 import { ConversationList } from "@/components/conversations"
@@ -140,6 +142,11 @@ export function StreamPage() {
   // For an unlocked encrypted stream, the tamper-evident decrypted name; null
   // otherwise (plaintext stream, locked, or not yet decrypted) → plaintext label.
   const decryptedStreamName = useDecryptedStreamName(workspaceId ?? "", stream)
+  // Renaming an E2E stream seals the new name under its key, so it requires an
+  // unlocked session — the affordance is omitted while locked (the stream is in
+  // its locked/unlock state then anyway).
+  const currentUserId = useWorkspaceUserId(workspaceId ?? "")
+  const e2eUnlocked = useE2eSession(workspaceId ?? "", currentUserId ?? "").status === "unlocked"
 
   const isThread = stream?.type === StreamTypes.THREAD
   const isChannel = stream?.type === StreamTypes.CHANNEL
@@ -254,13 +261,18 @@ export function StreamPage() {
     onSelect: () => openExplorer({ streamIds: [streamId] }),
   })
   if (isScratchpad) {
-    streamMenuActions.push({
-      id: "rename",
-      label: "Rename",
-      icon: Pencil,
-      onSelect: handleStartRename,
-      separatorBefore: streamMenuActions.length > 0,
-    })
+    // Renaming a sealed scratchpad needs an unlocked session to seal the new
+    // name; hide the affordance while locked rather than let it fall back to
+    // plaintext. Archive/unarchive stay available regardless of lock state.
+    if (!isEncryptedScratchpad || e2eUnlocked) {
+      streamMenuActions.push({
+        id: "rename",
+        label: "Rename",
+        icon: Pencil,
+        onSelect: handleStartRename,
+        separatorBefore: streamMenuActions.length > 0,
+      })
+    }
     streamMenuActions.push(
       isArchived
         ? {

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -155,6 +155,11 @@ export function StreamPage() {
 
   const [isEditing, setIsEditing] = useState(false)
   const [editValue, setEditValue] = useState("")
+  // The just-submitted name, held while the rename is in flight so the header
+  // shows it continuously instead of dipping to the persisted name during the
+  // network round-trip. Cleared once the write lands (the decrypt cache is seeded
+  // by then, so it resolves straight to the new name).
+  const [pendingName, setPendingName] = useState<string | null>(null)
   const [isMenuDrawerOpen, setIsMenuDrawerOpen] = useState(false)
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -185,7 +190,7 @@ export function StreamPage() {
   const isDmDraft = isDraft && isDmDraftId(streamId)
   let streamName = "Stream"
   if (stream) {
-    streamName = decryptedStreamName ?? streamLabel(stream)
+    streamName = pendingName ?? decryptedStreamName ?? streamLabel(stream)
   } else if (isDraft) {
     streamName = streamFallbackLabel(isDmDraft ? "dm" : "scratchpad", "sidebar")
   }
@@ -214,7 +219,14 @@ export function StreamPage() {
 
     if (!trimmed || trimmed === currentDisplayedName) return
 
-    await rename(trimmed)
+    setPendingName(trimmed)
+    try {
+      await rename(trimmed)
+    } catch (err) {
+      console.error("Failed to rename stream", err)
+    } finally {
+      setPendingName(null)
+    }
   }
 
   const handleArchive = async () => {


### PR DESCRIPTION
**Invariant:** INV-E1 (no plaintext at rest for E2E streams) · **Audit:** [§A "Plaintext leaks into sealed streams"](docs/audits/e2ee-enclave-audit-2026-06.md), related UX-20/UX-35; UX-6 push is the deferred follow-up.

## Problem

A user-typed rename of an E2E stream leaked the new name to the server as plaintext. `useStreamOrDraft().rename` and the stream-settings `DisplayNameSection` both sent `displayName: newName` alongside the sealed copy, so `streams.display_name` held the cleartext name at rest — the server could read it. This contradicts how the enclave auto-title already behaves (`sealStreamName` / `setSealedNameIfAbsent` write the sealed columns on `e2e_streams` only) and the same "no plaintext at rest" guarantee INV-E1 enforces for E2E message bodies. Settings was the worse of the two: a straight plaintext write with no sealing at all.

The prior model treated the sealed name as a *preference* layered over a plaintext fallback ("an unlocked client prefers the ciphertext"). For a stream whose whole point is that the server can't read its contents, the name is content too — a plaintext fallback is a leak, not a fallback.

## Solution

Make a user rename behave exactly like the auto-title: persist **only** the tamper-evident ciphertext, never the cleartext. One sealing path, server-enforced scrub, and the affordance gated on an unlocked session so a rename can never silently fall back to plaintext.

### How it works

1. **Server scrubs `display_name` (`StreamService.updateStream`).** Setting a sealed name (`sealedName` truthy) forces `streamData.displayName = null` — enforced server-side, not trusted from the client, so a stale or leaky plaintext can't ride along in the same PATCH. The desync guard now fires only when *clearing* a seal (`sealedName === null`) without a replacement plaintext (`SEALED_NAME_REQUIRES_DISPLAY_NAME`), since that's the only case where the stream would otherwise lose its name entirely.
2. **Repo distinguishes `null` from `undefined` (`StreamRepository.update`).** `UpdateStreamParams.displayName` is now `string | null`; the builder gates each `SET` on `!== undefined`, so `null` emits `display_name = NULL` (the scrub) while `undefined` skips the column. No schema or migration change — the column was already nullable.
3. **One frontend sealing path (`sealStreamRename`, new `lib/crypto/stream-rename.ts`).** Resolves the session + current stream key and returns `{ sealedNameCiphertext, sealedNameEnvelope }` with no `displayName`. It **throws** `StreamNameSealUnavailableError` (`"locked"` / `"no-stream-key"`) rather than ever returning a plaintext shape. Both rename surfaces call it; neither re-derives the seal:
   - `useStreamOrDraft().rename` — `baseStream.e2eEnabled ? await sealStreamRename(...) : { displayName }`.
   - `DisplayNameSection.handleSave` — same branch; the catch surfaces "Unlock this scratchpad to rename it."
4. **Affordance gated on unlock.** The seal needs the SSK, so renaming requires `useE2eSession(...).status === "unlocked"`. The header menu omits the Rename item while locked (`stream.tsx`, gated on `isEncryptedScratchpad`); settings renders the field `disabled` with an unlock hint. Archive/unarchive stay available regardless of lock state.

### Key design decisions

**1. Sealed-only, not sealed-preferred** — the rejected alternative is the old "clear the seal to `null`, keep plaintext authoritative" path: it kept the leak by definition (plaintext at rest) and added a desync failure mode (old ciphertext outranking the new plaintext after unlock). INV-E1's principle — "never treat E2E content as plaintext" — applies to the name column the same way it applies to message bodies. Kris's ruling on scope: push labeling is a separate follow-up, this PR is the rename leak only.

**2. Scrub server-side, don't trust the client PATCH** — the client could send `displayName: null` itself, but then a buggy or malicious client could also send a stale plaintext alongside a sealed name. Forcing the null in `updateStream` makes "sealed name set ⇒ no plaintext at rest" a server invariant, not a client convention.

**3. Throw, never fall back** — `sealStreamRename` has no plaintext return shape at all, so "rename without a key" is structurally impossible rather than guarded by a branch someone could later drop. The unlocked-gate on the affordance is the UX layer; the throw is the backstop.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crypto/stream-rename.ts` | `sealStreamRename` — the single sealing path for both rename surfaces; throws `StreamNameSealUnavailableError` rather than ever producing a plaintext fallback. |
| `apps/frontend/src/lib/crypto/__tests__/stream-rename.test.ts` | Covers seal-success, locked-throw, and no-stream-key-throw. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/service.ts` | `updateStream` scrubs `displayName` to null when a sealed name is set; desync guard narrowed to the clear-seal case. `displayName?: string \| null`. |
| `apps/backend/src/features/streams/repository.ts` | `UpdateStreamParams.displayName?: string \| null` so `null` scrubs the column (`!== undefined` gate already distinguishes it from `undefined`). |
| `apps/backend/src/features/streams/service.test.ts` | Three cases: sealed-set scrubs to null (INV-E1), clear-without-name rejected, plain rename unchanged. |
| `apps/frontend/src/hooks/use-stream-or-draft.ts` | `rename` routes E2E through `sealStreamRename`; drops the inline seal/clear logic and its imports. |
| `apps/frontend/src/components/stream-settings/general-tab.tsx` | `DisplayNameSection` seals via `sealStreamRename` (was a plaintext write); field disabled + unlock hint while locked. |
| `apps/frontend/src/pages/stream.tsx` | Header Rename menu item hidden while an encrypted scratchpad is locked. |
| `apps/frontend/src/lib/crypto/message-envelope.ts` | `sealStreamName` doc: the sealed copy is now the *only* persisted name; locked client shows the placeholder. |
| `apps/frontend/AGENTS.md` | "Renaming an E2E (sealed) stream" — one sealing path, unlock requirement, accepted residuals. |

## Out of scope (deliberate)

- **Push labeling for E2E streams (UX-6).** E2E streams fire no push at all today — both push entry points (`deliverPushForActivity`, `deliverPushForSavedReminder`) short-circuit E2E *before* any payload is built (`activity/outbox-handler.ts:142`, `:231`), so there is no live path to attach a sealed name to. Carrying the name ciphertext into a push payload is only meaningful once E2E push *delivery* exists, which is UX-6 — deferred per Kris's call, not added here as dead code (INV-36).
- **Re-sealing streams renamed before this shipped.** They still hold plaintext in `display_name`; the server can't re-seal (no SSK), so they stay until the owner renames again while unlocked. Documented in `AGENTS.md`.
- **Server-side name search for E2E streams.** ILIKE/`similarity` on `display_name` can no longer see E2E streams (it's null) — their names are searchable only client-side over the decrypted copy. Accepted residual, documented.

## Test plan

- [x] Backend `bun test apps/backend/src/features/streams/service.test.ts` — 54 pass
- [x] Frontend `bun run test src/lib/crypto/__tests__/stream-rename.test.ts` — 3 pass
- [x] `bun run typecheck` — clean across all 14 workspaces
- [x] Self-review (claim-verification pass): confirmed `isEncryptedScratchpad` (`stream.tsx:183`), the repo `!== undefined` gate, INV-E1 as a real documented invariant (`docs/plans/e2e-encrypted-scratchpads.md:231`, `docs/features/architecture/e2e-enclave.md`), and that the "no E2E push path today" claim holds against the outbox handler. No findings.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPLThcLupjGWVAX6SoZqUS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784119368&installation_id=129946197&pr_number=951&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F951&signature=90a41be2d83aa479e005cc708934b60cfddaa8c5814f14af627c8777555c2962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->