### PR TITLE
refactor(frontend): drop happy-path success toasts, confirm copy/download inline

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -104,6 +104,13 @@ reviews:
       instructions: |
         Do not define React components inside other React components. Extract to separate
         functions or files. (INV-18)
+    - path: "apps/frontend/src/**/*.{ts,tsx}"
+      instructions: |
+        Success is silent: do not confirm a happy-path action with a success toast — the
+        UI already reflects saves, renames, archives, sends, etc. Reserve toasts for
+        errors, warnings the user must resolve, and deferred/offline state; confirm
+        clipboard/download in place (icon to checkmark). A toast.success(...) is allowed
+        only with an "INV-63-allow:" justification on the same or preceding line. (INV-63)
     - path: "apps/backoffice/src/**/*.tsx"
       instructions: |
         Do not define React components inside other React components. Extract to separate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,8 @@ Preview surfaces must strip markdown before rendering. Any UI that shows a previ
 
 The rendered timeline window is verifiably contiguous over the viewer-visible ordering (INV-61). Events every member receives as timeline rows (`TIMELINE_BROADCAST_EVENT_TYPES` in `packages/types`) consume a dense per-stream `broadcastSequence` allocated by `StreamEventRepository` alongside the global `sequence`; author-scoped command events and patch-style rows (edits, reactions, deletes) do not, so for any viewer a missing broadcast number is ALWAYS a real gap — never another user's invisible event. The message-move flow, the one operation that vacates slots, declares them on its source tombstone (`vacatedBroadcastSequences`). On the frontend, `computeTimelineHoles` (`apps/frontend/src/sync/contiguity.ts`) is the single read-side authority: a detected hole renders as an in-place loading placeholder (never a silent gap) and triggers a scoped backfill, so a missed message resolves the placeholder where it belongs instead of popping in above rows already on screen. The catch-up cursor has exactly one owner — `SyncEngine.joinStreamForCatchUp` reads the cursor BEFORE joining the room; never re-derive it at call sites.
 
+Success is silent; toasts are for what needs attention (INV-63). Do not confirm a happy-path action with a `toast.success(...)` when the UI already reflects it — a saved setting, a renamed stream, an archived channel, a sent message all show their own result, so the toast is noise (and on mobile it covers the very control the user just touched). Reserve toasts for what the user must notice or act on: failures (`toast.error`), warnings the user must resolve (`toast.warning`), and deferred/offline state ("Edit queued — will be saved when back online", `toast.info`). When an action genuinely has no other on-screen signal — clipboard copy or file download — confirm it **in place** (swap the triggering button's icon to a checkmark, same footprint so nothing shifts per INV-21) rather than toasting; reference surfaces are the image-gallery toolbar and the mobile attachment drawer. The only surfaces that keep a `toast.success` are those with no persistent anchor at all (a closing dropdown item, a keyboard shortcut), and each such call carries an `INV-63-allow:` justification comment. The guard test `apps/frontend/src/lib/no-happy-path-success-toast.test.ts` fails on any unjustified `toast.success`, so the policy can't regress as new mutation handlers land.
+
 ### 6) Testing and Reliability Expectations
 
 Always resolve failing tests; do not dismiss failures as pre-existing (INV-22).
@@ -274,7 +276,7 @@ When handling variants, colocate variant config and keep shared behavior on one 
 - **Architecture and dependencies:** INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-12, INV-13, INV-27, INV-34, INV-35, INV-37, INV-51, INV-52
 - **API and backend contracts:** INV-31, INV-32, INV-33, INV-46, INV-55, INV-58
 - **AI and eval discipline:** INV-16, INV-19, INV-28, INV-44, INV-45, INV-54
-- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61, INV-62
+- **Frontend and UX behavior:** INV-14, INV-15, INV-18, INV-21, INV-40, INV-42, INV-53, INV-59, INV-60, INV-61, INV-62, INV-63
 - **Testing:** INV-22, INV-23, INV-24, INV-26, INV-39, INV-48
 - **Code hygiene and maneuverability:** INV-25, INV-29, INV-36, INV-38, INV-43, INV-47, INV-49
 

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -206,7 +206,7 @@ export interface MessageComposerProps {
    * Triggered when the user presses Cmd/Ctrl+S with focus inside the composer,
    * or when they click "Save current" in the stashed-drafts picker. The host
    * is responsible for snapshotting the current content/attachments, adding a
-   * row to the stash, clearing the active draft, and showing a toast. An
+   * row to the stash, and clearing the active draft. An
    * empty composer should no-op; the picker disables its own button when
    * `canStashCurrent` is false.
    */

--- a/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/biometric-unlock-modal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { toast } from "sonner"
 import { Fingerprint } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
@@ -45,7 +44,6 @@ export function BiometricUnlockModal({
     setSubmitting(true)
     try {
       await unlockWithBiometric(workspaceId, userId)
-      toast.success("Encrypted scratchpads unlocked")
       // The modal stays mounted under the provider, so clear the busy flag or a
       // reopen would render a stuck "Waiting for biometrics…" button.
       setSubmitting(false)

--- a/apps/frontend/src/components/encryption/encrypted-scratchpads-section.tsx
+++ b/apps/frontend/src/components/encryption/encrypted-scratchpads-section.tsx
@@ -98,7 +98,6 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
     setMethodPending(true)
     try {
       await enrollDevicePin(workspaceId, userId, pin)
-      toast.success("PIN set for this device")
       setPin("")
       setPinEditorOpen(false)
       await refreshUnlockMethod()
@@ -115,7 +114,6 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
     try {
       const registration = await registerDeviceBiometric(userId)
       await enrollDeviceBiometric(workspaceId, userId, registration)
-      toast.success("Biometric unlock enabled for this device")
       setPinEditorOpen(false)
       await refreshUnlockMethod()
     } catch (err) {
@@ -132,7 +130,6 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
     setMethodPending(true)
     try {
       await setDeviceTrust(workspaceId, userId, true)
-      toast.success("This device will unlock automatically")
       setPinEditorOpen(false)
       await refreshUnlockMethod()
     } catch (err) {
@@ -146,7 +143,6 @@ function EncryptedScratchpadsSectionInner({ workspaceId, userId }: EncryptedScra
     setRevoking(true)
     try {
       await revokeKeyForUser(workspaceId, userId)
-      toast.success("Encryption key revoked")
       setRevokeOpen(false)
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to revoke key"

--- a/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-setup-modal.tsx
@@ -140,7 +140,6 @@ export function PassphraseSetupModal({
     try {
       const registration = await registerDeviceBiometric(userId)
       setBiometric(registration)
-      toast.success("Biometric unlock ready")
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Couldn't set up biometric unlock")
     } finally {
@@ -166,8 +165,6 @@ export function PassphraseSetupModal({
         toast.warning(
           "Encryption enabled, but couldn't keep you unlocked on this device. You'll need your passphrase next time."
         )
-      } else {
-        toast.success("Encrypted scratchpads enabled")
       }
       reset()
       onSetupComplete?.()

--- a/apps/frontend/src/components/encryption/passphrase-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/passphrase-unlock-modal.tsx
@@ -88,8 +88,6 @@ export function PassphraseUnlockModal({
       const result = await unlock(workspaceId, userId, passphrase, { trustDevice })
       if (result?.trustRequested && !result.trustPersisted) {
         toast.warning("Unlocked, but couldn't keep you unlocked on this device. You'll need your passphrase next time.")
-      } else {
-        toast.success("Encrypted scratchpads unlocked")
       }
       reset()
       onUnlocked?.()

--- a/apps/frontend/src/components/encryption/pin-unlock-modal.tsx
+++ b/apps/frontend/src/components/encryption/pin-unlock-modal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import {
   ResponsiveDialog,
@@ -31,7 +30,14 @@ interface PinUnlockModalProps {
  * inline error comes straight off the session so attempt-count messaging stays
  * in one place. Submits automatically once all digits are entered.
  */
-export function PinUnlockModal({ open, workspaceId, userId, onOpenChange, onUnlocked, onUsePassphrase }: PinUnlockModalProps) {
+export function PinUnlockModal({
+  open,
+  workspaceId,
+  userId,
+  onOpenChange,
+  onUnlocked,
+  onUsePassphrase,
+}: PinUnlockModalProps) {
   const session = useE2eSession(workspaceId, userId)
   const [pin, setPin] = useState("")
   const [submitting, setSubmitting] = useState(false)
@@ -52,7 +58,6 @@ export function PinUnlockModal({ open, workspaceId, userId, onOpenChange, onUnlo
     setSubmitting(true)
     try {
       await unlockWithPin(workspaceId, userId, candidate)
-      toast.success("Encrypted scratchpads unlocked")
       reset()
       onUnlocked?.()
       onOpenChange(false)

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -490,6 +490,14 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     },
     []
   )
+  // Clear any in-flight confirmation when the viewed item changes or the gallery
+  // reopens, so a checkmark from item A never lingers onto item B's button.
+  useEffect(() => {
+    setCopyDone(false)
+    setDownloadDone(false)
+    if (copyResetRef.current) clearTimeout(copyResetRef.current)
+    if (downloadResetRef.current) clearTimeout(downloadResetRef.current)
+  }, [isOpen, current?.attachmentId])
 
   const handleDownload = useCallback(async () => {
     if (!current) return

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -8,6 +8,7 @@ import {
   X,
   Download,
   Copy,
+  Check,
   ChevronLeft,
   ChevronRight,
   PanelRightClose,
@@ -475,9 +476,28 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   const goPrev = useCallback(() => goTo(currentIndex - 1), [goTo, currentIndex])
   const goNext = useCallback(() => goTo(currentIndex + 1), [goTo, currentIndex])
 
-  const handleDownload = useCallback(() => {
+  // In-place confirmation for the copy/download buttons: the icon swaps to a
+  // checkmark for a beat instead of popping a toast. Same h-5 w-5 footprint, so
+  // nothing shifts (INV-21). Timers are cleared on unmount and on re-trigger.
+  const [copyDone, setCopyDone] = useState(false)
+  const [downloadDone, setDownloadDone] = useState(false)
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const downloadResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+      if (downloadResetRef.current) clearTimeout(downloadResetRef.current)
+    },
+    []
+  )
+
+  const handleDownload = useCallback(async () => {
     if (!current) return
-    downloadImage(workspaceId, current.attachmentId, current.filename)
+    const ok = await downloadImage(workspaceId, current.attachmentId, current.filename)
+    if (!ok) return
+    setDownloadDone(true)
+    if (downloadResetRef.current) clearTimeout(downloadResetRef.current)
+    downloadResetRef.current = setTimeout(() => setDownloadDone(false), 1200)
   }, [workspaceId, current])
 
   const handleDownloadRaw = useCallback(async () => {
@@ -508,21 +528,26 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
 
   const handleCopy = useCallback(async () => {
     if (!current?.url) return
+    let ok = false
     if (current.type === "image") {
-      copyImage(current.url)
-      return
-    }
-    if (current.type === "markdown" || current.type === "html") {
+      ok = await copyImage(current.url)
+    } else if (current.type === "markdown" || current.type === "html") {
       try {
         const text = await fetchTextContent(current.url)
         await navigator.clipboard.writeText(text)
+        ok = true
       } catch {
         // Clipboard or fetch failed; nothing actionable for the user here.
       }
     }
+    if (!ok) return
+    setCopyDone(true)
+    if (copyResetRef.current) clearTimeout(copyResetRef.current)
+    copyResetRef.current = setTimeout(() => setCopyDone(false), 1200)
   }, [current])
 
   const canCopy = current?.type === "image" || current?.type === "markdown" || current?.type === "html"
+  const copyLabel = current?.type === "image" ? "Copy image" : "Copy source"
   const canToggleRaw = current?.type === "markdown" || current?.type === "html"
 
   // Keyboard navigation
@@ -772,8 +797,8 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
             className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
             onClick={handleDownload}
           >
-            <Download className="h-5 w-5" />
-            <span className="sr-only">Download</span>
+            {downloadDone ? <Check className="h-5 w-5" /> : <Download className="h-5 w-5" />}
+            <span className="sr-only">{downloadDone ? "Download started" : "Download"}</span>
           </Button>
           {canCopy && (
             <Button
@@ -782,8 +807,8 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
               className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
               onClick={handleCopy}
             >
-              <Copy className="h-5 w-5" />
-              <span className="sr-only">{current?.type === "image" ? "Copy image" : "Copy source"}</span>
+              {copyDone ? <Check className="h-5 w-5" /> : <Copy className="h-5 w-5" />}
+              <span className="sr-only">{copyDone ? "Copied" : copyLabel}</span>
             </Button>
           )}
         </>

--- a/apps/frontend/src/components/labels/label-edit-form.tsx
+++ b/apps/frontend/src/components/labels/label-edit-form.tsx
@@ -167,7 +167,6 @@ export function LabelEditForm({
       },
       {
         onSuccess: () => {
-          toast.success("Label updated")
           onDone()
         },
         onError: () => toast.error("Could not update label"),

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -184,7 +184,6 @@ export const commands: Command[] = [
           try {
             await createSavedTodo(title)
             closeDialog()
-            toast.success("To-do added to Saved")
           } catch (error) {
             console.error("Failed to add to-do:", error)
             toast.error("Could not add to-do")

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -423,10 +423,8 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
         await deleteDraft(streamId)
         // Drafts are fully deleted — leave the (now-gone) stream if viewing it.
         if (currentStreamId === streamId) navigate(`/w/${workspaceId}`)
-        toast.success("Draft deleted")
       } else {
         await archiveStream.mutateAsync(streamId)
-        toast.success("Stream archived")
       }
     } catch {
       toast.error(isDraft ? "Failed to delete draft" : "Failed to archive stream")

--- a/apps/frontend/src/components/saved/saved-edit-dialog.tsx
+++ b/apps/frontend/src/components/saved/saved-edit-dialog.tsx
@@ -71,7 +71,6 @@ export function SavedEditDialog({ open, onOpenChange, workspaceId, saved }: Save
       },
       {
         onSuccess: () => {
-          toast.success("Saved item updated")
           onOpenChange(false)
         },
         onError: () => toast.error("Could not update saved item"),

--- a/apps/frontend/src/components/saved/suggested-tab.tsx
+++ b/apps/frontend/src/components/saved/suggested-tab.tsx
@@ -20,7 +20,6 @@ export function SuggestedTab({ workspaceId }: SuggestedTabProps) {
 
   const handleAccept = (id: string) => {
     acceptMutation.mutate(id, {
-      onSuccess: () => toast.success("Added to Saved"),
       onError: () => toast.error("Could not add to Saved"),
     })
   }

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -168,7 +168,6 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
     if (isPastNow && scheduled && !isLocalRow) {
       try {
         await sendNowMutation.mutateAsync(scheduled.id)
-        toast.success("Sent")
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "Could not send"
         toast.error(message)
@@ -226,7 +225,6 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
           expectedVersion,
         },
       })
-      toast.success(isPast ? "Sent" : "Updated")
       handleClose()
     } catch (err: unknown) {
       const isStaleVersion =
@@ -239,17 +237,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
       const message = err instanceof Error ? err.message : "Could not save"
       setError(message)
     }
-  }, [
-    scheduled,
-    contentJson,
-    sendAtDate,
-    expectedVersion,
-    isLocalRow,
-    isPast,
-    updateMutation,
-    handleClose,
-    attachmentsHook,
-  ])
+  }, [scheduled, contentJson, sendAtDate, expectedVersion, isLocalRow, updateMutation, handleClose, attachmentsHook])
 
   const isSaving = updateMutation.isPending
 

--- a/apps/frontend/src/components/settings/avatar-section.tsx
+++ b/apps/frontend/src/components/settings/avatar-section.tsx
@@ -36,7 +36,6 @@ export function AvatarSection({ workspaceId, userName, avatarUrl }: AvatarSectio
     setUploading(true)
     try {
       await uploadAvatar.mutateAsync(file)
-      toast.success("Avatar uploaded")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to upload avatar")
     } finally {
@@ -47,7 +46,6 @@ export function AvatarSection({ workspaceId, userName, avatarUrl }: AvatarSectio
   const handleRemove = async () => {
     try {
       await removeAvatar.mutateAsync()
-      toast.success("Avatar removed")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to remove avatar")
     }

--- a/apps/frontend/src/components/settings/profile-settings.tsx
+++ b/apps/frontend/src/components/settings/profile-settings.tsx
@@ -74,7 +74,6 @@ export function ProfileSettings() {
     try {
       await updateProfile.mutateAsync({ name: currentName.trim() })
       setName(null)
-      toast.success("Name updated")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update name")
     }
@@ -92,7 +91,6 @@ export function ProfileSettings() {
     try {
       await updateProfile.mutateAsync({ description: currentDescription.trim() || null })
       setDescription(null)
-      toast.success("Description updated")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update description")
     }
@@ -117,7 +115,6 @@ export function ProfileSettings() {
       await updateProfile.mutateAsync({ pronouns: currentPronouns.trim() || null })
       setPronouns(null)
       setIsCustomPronouns(false)
-      toast.success("Pronouns updated")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update pronouns")
     }
@@ -128,7 +125,6 @@ export function ProfileSettings() {
     try {
       await updateProfile.mutateAsync({ phone: currentPhone.trim() || null })
       setPhone(null)
-      toast.success("Phone updated")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update phone")
     }
@@ -139,7 +135,6 @@ export function ProfileSettings() {
     try {
       await updateProfile.mutateAsync({ githubUsername: currentGithub.trim() || null })
       setGithubUsername(null)
-      toast.success("GitHub username updated")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to update GitHub username")
     }

--- a/apps/frontend/src/components/stream-settings/general-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/general-tab.tsx
@@ -185,7 +185,6 @@ function NotificationSection({
   const handleChange = (value: string) => {
     const level = value === "default" ? null : (value as NotificationLevel)
     mutation.mutate(level, {
-      onSuccess: () => toast.success("Notification preference updated"),
       onError: () => toast.error("Failed to update notification preference"),
     })
   }
@@ -236,7 +235,6 @@ function VisibilitySection({ workspaceId, stream }: { workspaceId: string; strea
     updateMutation.mutate(
       { visibility: pendingVisibility },
       {
-        onSuccess: () => toast.success("Visibility updated"),
         onError: () => toast.error("Failed to update visibility"),
       }
     )
@@ -313,7 +311,6 @@ function SlugSection({ workspaceId, stream }: { workspaceId: string; stream: Str
     updateMutation.mutate(
       { slug },
       {
-        onSuccess: () => toast.success("Channel slug updated"),
         onError: () => toast.error("Failed to update slug"),
       }
     )
@@ -360,7 +357,6 @@ function DisplayNameSection({ workspaceId, stream }: { workspaceId: string; stre
         ? await sealStreamRename({ workspaceId, streamId: stream.id, userId: currentUserId ?? "", name: trimmed })
         : { displayName: trimmed }
       updateMutation.mutate(data, {
-        onSuccess: () => toast.success("Name updated"),
         onError: () => toast.error("Failed to update name"),
       })
     } catch {
@@ -419,7 +415,6 @@ function DescriptionSection({ workspaceId, stream }: { workspaceId: string; stre
     updateMutation.mutate(
       { description },
       {
-        onSuccess: () => toast.success("Description updated"),
         onError: () => toast.error("Failed to update description"),
       }
     )
@@ -485,12 +480,10 @@ function ArchiveSection({
   const handleAction = () => {
     if (isArchived) {
       unarchiveMutation.mutate(stream.id, {
-        onSuccess: () => toast.success(`${capitalize(streamTypeLabel)} unarchived`),
         onError: () => toast.error("Failed to unarchive"),
       })
     } else {
       archiveMutation.mutate(stream.id, {
-        onSuccess: () => toast.success(`${capitalize(streamTypeLabel)} archived`),
         onError: () => toast.error("Failed to archive"),
       })
     }
@@ -547,8 +540,4 @@ function ArchiveSection({
       </ResponsiveAlertDialog>
     </div>
   )
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -94,7 +94,6 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
     (user: (typeof workspaceUsers)[number]) => {
       if (!canManageMembers) return
       addMutation.mutate(user.id, {
-        onSuccess: () => toast.success("Member added"),
         onError: () => toast.error("Failed to add member"),
       })
     },
@@ -109,7 +108,6 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   const handleRemove = () => {
     if (!removeMemberId) return
     removeMutation.mutate(removeMemberId, {
-      onSuccess: () => toast.success("Member removed"),
       onError: () => toast.error("Failed to remove member"),
     })
     setRemoveMemberId(null)

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useCallback, useEffect, useMemo } from "react"
-import { Download, FileText, File, Loader2, Copy, Play, Globe } from "lucide-react"
+import React, { useState, useCallback, useEffect, useMemo, useRef } from "react"
+import { Download, FileText, File, Loader2, Copy, Play, Globe, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
@@ -74,19 +74,47 @@ function ImageActionDrawer({
   workspaceId: string
   attachmentId: string
 }) {
-  const handleDownload = useCallback(() => {
-    onOpenChange(false)
-    downloadImage(workspaceId, attachmentId, filename)
+  // Confirm in place: the row's icon swaps to a checkmark for a beat, then the
+  // drawer dismisses itself — no toast (the source field stays visible on
+  // mobile). Failures fall back to closing; copyImage/downloadImage surface
+  // their own error toast.
+  const [downloadDone, setDownloadDone] = useState(false)
+  const [copyDone, setCopyDone] = useState(false)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(() => {
+    if (open) {
+      setDownloadDone(false)
+      setCopyDone(false)
+    }
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    }
+  }, [open])
+
+  const handleDownload = useCallback(async () => {
+    const ok = await downloadImage(workspaceId, attachmentId, filename)
+    if (!ok) {
+      onOpenChange(false)
+      return
+    }
+    setDownloadDone(true)
+    closeTimerRef.current = setTimeout(() => onOpenChange(false), 700)
   }, [workspaceId, attachmentId, filename, onOpenChange])
 
   // Copy the full-resolution original, not the inline thumbnail.
   const handleCopy = useCallback(async () => {
-    onOpenChange(false)
     try {
       const url = await attachmentsApi.getDownloadUrl(workspaceId, attachmentId)
-      await copyImage(url)
+      const ok = await copyImage(url)
+      if (!ok) {
+        onOpenChange(false)
+        return
+      }
+      setCopyDone(true)
+      closeTimerRef.current = setTimeout(() => onOpenChange(false), 700)
     } catch {
-      // copyImage surfaces its own failure toast; this guards the URL fetch.
+      // Guards the URL fetch; copyImage surfaces its own failure toast.
+      onOpenChange(false)
     }
   }, [workspaceId, attachmentId, onOpenChange])
 
@@ -105,16 +133,24 @@ function ImageActionDrawer({
             className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm active:bg-muted/80 transition-colors"
             onClick={handleDownload}
           >
-            <Download className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
-            <span>Save image</span>
+            {downloadDone ? (
+              <Check className="h-[18px] w-[18px] text-primary shrink-0" />
+            ) : (
+              <Download className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
+            )}
+            <span>{downloadDone ? "Download started" : "Save image"}</span>
           </button>
           <button
             type="button"
             className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm active:bg-muted/80 transition-colors"
             onClick={handleCopy}
           >
-            <Copy className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
-            <span>Copy image</span>
+            {copyDone ? (
+              <Check className="h-[18px] w-[18px] text-primary shrink-0" />
+            ) : (
+              <Copy className="h-[18px] w-[18px] text-muted-foreground shrink-0" />
+            )}
+            <span>{copyDone ? "Copied" : "Copy image"}</span>
           </button>
         </div>
       </DrawerContent>

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -371,7 +371,7 @@ export const messageActions: MessageAction[] = [
     action: async (ctx) => {
       try {
         await copyToClipboard(ctx.contentMarkdown)
-        toast.success("Copied as Markdown")
+        toast.success("Copied as Markdown") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
       } catch {
         toast.error("Failed to copy")
       }
@@ -386,7 +386,7 @@ export const messageActions: MessageAction[] = [
     action: async (ctx) => {
       try {
         await copyToClipboard(stripMarkdown(ctx.contentMarkdown))
-        toast.success("Copied as plain text")
+        toast.success("Copied as plain text") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
       } catch {
         toast.error("Failed to copy")
       }
@@ -403,7 +403,7 @@ export const messageActions: MessageAction[] = [
         // builder so the route shape lives in one place (stream-links.ts).
         const url = `${buildStreamLink(ctx.workspaceId!, ctx.streamId!)}?m=${ctx.messageId}`
         await copyToClipboard(url)
-        toast.success("Link copied")
+        toast.success("Link copied") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
       } catch {
         toast.error("Failed to copy link")
       }

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1009,7 +1009,6 @@ function SentMessageEvent({
       saveMessageMutation.mutate(
         { messageId: payload.messageId },
         {
-          onSuccess: () => toast.success("Saved for later"),
           onError: () => toast.error("Could not save message"),
         }
       )
@@ -1019,14 +1018,12 @@ function SentMessageEvent({
       saveMessageMutation.mutate(
         { messageId: payload.messageId },
         {
-          onSuccess: () => toast.success("Moved back to Saved"),
           onError: () => toast.error("Could not restore saved item"),
         }
       )
       return
     }
     unsaveMessageMutation.mutate(savedForMessage.id, {
-      onSuccess: () => toast.success("Removed from saved"),
       onError: () => toast.error("Could not remove saved item"),
     })
   }, [savedForMessage, saveMessageMutation, unsaveMessageMutation, payload.messageId])

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/components/composer"
 import type { ComposerControlHandle } from "@/components/composer"
 import { useScheduleMessage } from "@/hooks"
-import { toast } from "sonner"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
 import { extractCommandNode } from "@/lib/commands"
 import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
@@ -600,7 +599,6 @@ function MessageInputComponent({
         })
         composer.resolveDraft()
         composer.clearAttachments()
-        toast.success("Scheduled")
       } catch (err) {
         composer.setContent(liveContent)
         const message = err instanceof Error ? err.message : "Could not schedule message"

--- a/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
+++ b/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
@@ -70,7 +70,6 @@ export function ReminderPickerSheet({ open, onOpenChange, workspaceId, messageId
         { messageId, remindAt: date?.toISOString() ?? null },
         {
           onSuccess: () => {
-            toast.success(date ? "Reminder set" : "Saved")
             resetAndClose()
           },
           onError: () => toast.error("Could not save"),
@@ -82,7 +81,6 @@ export function ReminderPickerSheet({ open, onOpenChange, workspaceId, messageId
       { savedId: saved.id, input: { remindAt: date?.toISOString() ?? null } },
       {
         onSuccess: () => {
-          toast.success(date ? "Reminder set" : "Reminder cleared")
           resetAndClose()
         },
         onError: () => toast.error("Could not update reminder"),

--- a/apps/frontend/src/components/timeline/reminder-popover-content.tsx
+++ b/apps/frontend/src/components/timeline/reminder-popover-content.tsx
@@ -50,7 +50,6 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
       saveMutation.mutate(
         { messageId, remindAt: date?.toISOString() ?? null },
         {
-          onSuccess: () => toast.success(date ? "Reminder set" : "Saved"),
           onError: () => toast.error("Could not save"),
         }
       )
@@ -59,18 +58,16 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
     updateMutation.mutate(
       { savedId: saved.id, input: { remindAt: date?.toISOString() ?? null } },
       {
-        onSuccess: () => toast.success(date ? "Reminder set" : "Reminder cleared"),
         onError: () => toast.error("Could not update reminder"),
       }
     )
   }
 
-  const setStatus = (status: SavedStatus, successLabel: string) => {
+  const setStatus = (status: SavedStatus) => {
     if (!saved) return
     updateMutation.mutate(
       { savedId: saved.id, input: { status } },
       {
-        onSuccess: () => toast.success(successLabel),
         onError: () => toast.error("Could not update"),
       }
     )
@@ -79,7 +76,6 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
   const remove = () => {
     if (!saved) return
     deleteMutation.mutate(saved.id, {
-      onSuccess: () => toast.success("Removed from saved"),
       onError: () => toast.error("Could not remove"),
     })
   }
@@ -159,18 +155,18 @@ export function ReminderPopoverContent({ workspaceId, messageId, saved }: Remind
         <div className="p-1">
           {status === "saved" && (
             <>
-              <PopoverMenuButton onClick={() => setStatus("done", "Marked done")}>
+              <PopoverMenuButton onClick={() => setStatus("done")}>
                 <Check className="h-3.5 w-3.5" />
                 Mark done
               </PopoverMenuButton>
-              <PopoverMenuButton onClick={() => setStatus("archived", "Archived")}>
+              <PopoverMenuButton onClick={() => setStatus("archived")}>
                 <Archive className="h-3.5 w-3.5" />
                 Archive
               </PopoverMenuButton>
             </>
           )}
           {status !== "saved" && (
-            <PopoverMenuButton onClick={() => setStatus("saved", "Restored")}>
+            <PopoverMenuButton onClick={() => setStatus("saved")}>
               <Undo2 className="h-3.5 w-3.5" />
               Move back to Saved
             </PopoverMenuButton>

--- a/apps/frontend/src/components/timeline/save-message-button.tsx
+++ b/apps/frontend/src/components/timeline/save-message-button.tsx
@@ -39,7 +39,6 @@ export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonP
       saveMutation.mutate(
         { messageId },
         {
-          onSuccess: () => toast.success("Saved for later"),
           onError: () => toast.error("Could not save message"),
         }
       )
@@ -50,14 +49,12 @@ export function SaveMessageButton({ workspaceId, messageId }: SaveMessageButtonP
       saveMutation.mutate(
         { messageId },
         {
-          onSuccess: () => toast.success("Moved back to Saved"),
           onError: () => toast.error("Could not restore saved item"),
         }
       )
       return
     }
     deleteMutation.mutate(saved.id, {
-      onSuccess: () => toast.success("Removed from saved"),
       onError: () => toast.error("Could not remove saved item"),
     })
   }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -701,7 +701,6 @@ export function StreamContent({
         messageIds,
         leaseKey,
       })
-      toast.success(`Moved ${messageIds.length} message${messageIds.length === 1 ? "" : "s"} to thread`)
       cancelBatchMode()
     } catch (error) {
       console.error("moveToThread failed", { error, streamId, moveAttempt })

--- a/apps/frontend/src/components/workspace-settings/schedule-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/schedule-tab.tsx
@@ -38,7 +38,6 @@ export function ScheduleTab({ workspaceId }: ScheduleTabProps) {
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
         old ? { ...old, workspaceSettings: settings } : old
       )
-      toast.success("Workspace schedule saved")
     },
     onError: () => toast.error("Failed to save workspace schedule"),
   })

--- a/apps/frontend/src/components/workspace-settings/statuses-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/statuses-tab.tsx
@@ -57,7 +57,6 @@ export function StatusesTab({ workspaceId }: StatusesTabProps) {
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) =>
         old ? { ...old, workspaceSettings: settings } : old
       )
-      toast.success("Workspace statuses saved")
     },
     onError: () => toast.error("Failed to save workspace statuses"),
   })

--- a/apps/frontend/src/components/workspace-settings/users-tab.tsx
+++ b/apps/frontend/src/components/workspace-settings/users-tab.tsx
@@ -200,7 +200,6 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
                       changeRoleMutation.mutate(
                         { userId: user.id, roleSlug: value as WorkspaceRoleSlug },
                         {
-                          onSuccess: () => toast.success("Role updated"),
                           onError: (err) => toast.error(memberErrorMessage(err, "Failed to update role")),
                         }
                       )
@@ -380,7 +379,6 @@ export function UsersTab({ workspaceId }: UsersTabProps) {
                 removeMutation.mutate(
                   { userId: memberToRemove.id },
                   {
-                    onSuccess: () => toast.success("Member removed"),
                     onError: (err) => toast.error(memberErrorMessage(err, "Failed to remove member")),
                     onSettled: () => setMemberToRemove(null),
                   }

--- a/apps/frontend/src/contexts/preferences-context.tsx
+++ b/apps/frontend/src/contexts/preferences-context.tsx
@@ -164,7 +164,6 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
         if (!old) return old
         return { ...old, userPreferences: newPreferences }
       })
-      toast.success("Settings saved")
     },
   })
 

--- a/apps/frontend/src/hooks/use-invite-actor.ts
+++ b/apps/frontend/src/hooks/use-invite-actor.ts
@@ -108,12 +108,7 @@ export function useInviteActor(workspaceId: string, streamId: string) {
           session.status === "unlocked" && session.keyId && session.publicKey
             ? { keyId: session.keyId, publicKey: session.publicKey }
             : null
-        const result = await inviteActorToStream({ workspaceId, streamId, kind, actorId, queryClient, owner })
-        if (result === "invited-unwrapped") {
-          toast.success(`${E2E_ACTOR_LABELS[kind]} invited — unlock this scratchpad's encryption to grant it access.`)
-        } else {
-          toast.success(`${E2E_ACTOR_LABELS[kind]} invited to this scratchpad`)
-        }
+        await inviteActorToStream({ workspaceId, streamId, kind, actorId, queryClient, owner })
       } catch (err) {
         const message = err instanceof Error ? err.message : `Failed to invite ${E2E_ACTOR_LABELS[kind]}`
         toast.error(message)

--- a/apps/frontend/src/hooks/use-invite-actor.ts
+++ b/apps/frontend/src/hooks/use-invite-actor.ts
@@ -108,7 +108,13 @@ export function useInviteActor(workspaceId: string, streamId: string) {
           session.status === "unlocked" && session.keyId && session.publicKey
             ? { keyId: session.keyId, publicKey: session.publicKey }
             : null
-        await inviteActorToStream({ workspaceId, streamId, kind, actorId, queryClient, owner })
+        const result = await inviteActorToStream({ workspaceId, streamId, kind, actorId, queryClient, owner })
+        // The plain "invited" path is silent — the member list updates in place.
+        // `invited-unwrapped` is a degraded outcome the user must act on: the actor
+        // has no access until this scratchpad is unlocked and its key is wrapped.
+        if (result === "invited-unwrapped") {
+          toast.warning(`${E2E_ACTOR_LABELS[kind]} invited — unlock this scratchpad's encryption to grant it access.`)
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : `Failed to invite ${E2E_ACTOR_LABELS[kind]}`
         toast.error(message)

--- a/apps/frontend/src/hooks/use-stash-composer.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useSearchParams } from "react-router-dom"
-import { toast } from "sonner"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { restoreStashedDraftToComposer, stashLoadedDraft } from "./use-draft-message"
 import { useStashedDrafts, type CachedDraft } from "./use-stashed-drafts"
@@ -9,7 +8,7 @@ import type { DraftComposerState } from "./use-draft-composer"
 export interface UseStashComposerResult {
   /** Stashed drafts for the current scope, newest first. Empty when `scope` is undefined. */
   drafts: CachedDraft[]
-  /** Snapshot the current composer content into the stash, clear the editor, toast. Empty composer → silent no-op. */
+  /** Snapshot the current composer content into the stash, clear the editor. Empty composer → silent no-op. */
   handleStashDraft: () => Promise<void>
   /** Swap: stash current content first (if any), then load the chosen stashed row into the composer. */
   handleRestoreStashed: (id: string) => Promise<void>
@@ -55,7 +54,6 @@ export function useStashComposer(
     if (!stashedId) return
     // Re-init the (now draft-less) composer so the editor blanks out.
     composer.markNeedsRehydrate()
-    toast.success("Saved as draft")
   }, [composer, workspaceId, scope])
 
   const handleRestoreStashed = useCallback(
@@ -77,7 +75,6 @@ export function useStashComposer(
       await restoreStashedDraftToComposer(workspaceId, scope, id)
       // Re-read the newly-pointed draft into the editor (decrypting it for E2E).
       composer.markNeedsRehydrate()
-      toast.success("Draft restored")
     },
     [composer, workspaceId, scope]
   )

--- a/apps/frontend/src/lib/image-utils.ts
+++ b/apps/frontend/src/lib/image-utils.ts
@@ -15,22 +15,30 @@ export function triggerDownload(url: string, filename: string): void {
  * Downloads an image by requesting a presigned URL with Content-Disposition: attachment.
  * This avoids cross-origin fetch — the browser navigates directly to the S3 URL which
  * triggers a download thanks to the Content-Disposition header.
+ *
+ * Returns `true` on success so callers can render in-place confirmation (an icon
+ * swap on the triggering button) rather than a toast. Failures still surface a
+ * toast — there's no inline affordance to explain why a download didn't start.
  */
-export async function downloadImage(workspaceId: string, attachmentId: string, filename: string): Promise<void> {
+export async function downloadImage(workspaceId: string, attachmentId: string, filename: string): Promise<boolean> {
   try {
     const url = await attachmentsApi.getDownloadUrl(workspaceId, attachmentId, { download: true })
     triggerDownload(url, filename)
-    toast.success("Download started")
+    return true
   } catch {
     toast.error("Failed to download image")
+    return false
   }
 }
 
 /**
  * Copies an image to clipboard by fetching its blob data.
  * Requires S3 CORS to be configured for cross-origin fetch access.
+ *
+ * Returns `true` on success so the triggering button can show an in-place
+ * checkmark instead of a toast; failures still toast (no inline affordance).
  */
-export async function copyImage(url: string): Promise<void> {
+export async function copyImage(url: string): Promise<boolean> {
   try {
     const response = await fetch(url)
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
@@ -38,8 +46,9 @@ export async function copyImage(url: string): Promise<void> {
 
     if (!blob.type) throw new Error("Image has unknown MIME type")
     await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
-    toast.success("Image copied")
+    return true
   } catch {
     toast.error("Failed to copy image")
+    return false
   }
 }

--- a/apps/frontend/src/lib/no-happy-path-success-toast.test.ts
+++ b/apps/frontend/src/lib/no-happy-path-success-toast.test.ts
@@ -1,0 +1,51 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+// INV-63: success is silent. A happy-path action that the UI already reflects
+// must not pop a `toast.success(...)`. Toasts are reserved for what needs the
+// user's attention (errors, warnings, deferred/offline state). The only
+// `toast.success` calls allowed are actions with no other on-screen signal
+// (clipboard copy / download from a closing menu or a keyboard shortcut), and
+// each carries an `INV-63-allow:` justification on the same or preceding line.
+// This guard fails the build on any unjustified success toast so the policy
+// can't silently regress as new mutation handlers are added.
+
+const srcRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+
+function collectSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      files.push(...collectSourceFiles(full))
+    } else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.(ts|tsx)$/.test(entry)) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe("INV-63: no happy-path success toasts", () => {
+  it("has no toast.success() call without an INV-63-allow justification", () => {
+    const violations: string[] = []
+    for (const file of collectSourceFiles(srcRoot)) {
+      const lines = readFileSync(file, "utf8").split("\n")
+      lines.forEach((line, i) => {
+        if (!/\btoast\.success\s*\(/.test(line)) return
+        const prev = lines[i - 1] ?? ""
+        if (line.includes("INV-63-allow") || prev.includes("INV-63-allow")) return
+        violations.push(`${relative(srcRoot, file)}:${i + 1}`)
+      })
+    }
+
+    expect(
+      violations,
+      `Found happy-path success toast(s) (INV-63). Remove them — the UI already ` +
+        `reflects the result — or, if the action has no other on-screen signal, ` +
+        `confirm in place (icon → checkmark) or add an "INV-63-allow: <reason>" ` +
+        `comment:\n${violations.join("\n")}`
+    ).toEqual([])
+  })
+})

--- a/apps/frontend/src/lib/sonner-module.ts
+++ b/apps/frontend/src/lib/sonner-module.ts
@@ -1,4 +1,9 @@
 // Thin re-export so tests can spy on sonner's exports via a local (mutable)
 // ESM namespace. Sonner's own package namespace is frozen and not spy-able.
+//
+// Toast policy (INV-63): success is silent. Don't pop `toast.success` for a
+// happy path the UI already reflects — reserve toasts for errors, warnings, and
+// deferred/offline state, and confirm clipboard/download in place. See the root
+// CLAUDE.md and `no-happy-path-success-toast.test.ts`.
 export { Toaster as SonnerRoot, toast, useSonner } from "sonner"
 export type { ToastT } from "sonner"

--- a/apps/frontend/src/lib/stream-links.ts
+++ b/apps/frontend/src/lib/stream-links.ts
@@ -18,7 +18,7 @@ export function buildStreamLink(workspaceId: string, streamId: string): string {
 export async function copyStreamLink(workspaceId: string, streamId: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(buildStreamLink(workspaceId, streamId))
-    toast.success("Link copied")
+    toast.success("Link copied") // INV-63-allow: clipboard copy from a menu/shortcut has no inline anchor
   } catch {
     toast.error("Failed to copy link")
   }

--- a/apps/frontend/src/pages/labels.tsx
+++ b/apps/frontend/src/pages/labels.tsx
@@ -184,7 +184,6 @@ function AddLabelDialog({
       },
       {
         onSuccess: () => {
-          toast.success("Label created")
           handleOpenChange(false)
         },
         onError: () => toast.error("Could not create label"),
@@ -195,7 +194,6 @@ function AddLabelDialog({
   const handleJoin = (label: CachedLabel) => {
     joinMutation.mutate(label.id, {
       onSuccess: () => {
-        toast.success(`Joined ${label.name}`)
         handleOpenChange(false)
       },
       onError: () => toast.error("Could not join label"),
@@ -346,7 +344,6 @@ function OwnedLabelCard({ workspaceId, label }: { workspaceId: string; label: Ca
   const handleDelete = () => {
     deleteMutation.mutate(label.id, {
       onSuccess: () => {
-        toast.success("Label deleted")
         setConfirmKind(null)
       },
       onError: () => toast.error("Could not delete label"),
@@ -356,7 +353,6 @@ function OwnedLabelCard({ workspaceId, label }: { workspaceId: string; label: Ca
   const handlePromote = () => {
     promoteMutation.mutate(label.id, {
       onSuccess: () => {
-        toast.success("Label is now public")
         setConfirmKind(null)
       },
       onError: () => toast.error("Could not promote label"),
@@ -451,7 +447,6 @@ function JoinedLabelCard({ workspaceId, label, userId }: { workspaceId: string; 
     leaveMutation.mutate(
       { labelId: label.id, userId },
       {
-        onSuccess: () => toast.success(`Left ${label.name}`),
         onError: () => toast.error("Could not leave label"),
       }
     )

--- a/apps/frontend/src/pages/saved.tsx
+++ b/apps/frontend/src/pages/saved.tsx
@@ -106,11 +106,10 @@ function SavedList({ workspaceId, tab }: { workspaceId: string; tab: SavedStatus
   const updateMutation = useUpdateSaved(workspaceId)
   const deleteMutation = useDeleteSaved(workspaceId)
 
-  const handleUpdate = (savedId: string, status: SavedStatus, successLabel: string) => {
+  const handleUpdate = (savedId: string, status: SavedStatus) => {
     updateMutation.mutate(
       { savedId, input: { status } },
       {
-        onSuccess: () => toast.success(successLabel),
         onError: () => toast.error("Could not update saved item"),
       }
     )
@@ -118,7 +117,6 @@ function SavedList({ workspaceId, tab }: { workspaceId: string; tab: SavedStatus
 
   const handleDelete = (savedId: string) => {
     deleteMutation.mutate(savedId, {
-      onSuccess: () => toast.success("Saved item removed"),
       onError: () => toast.error("Could not remove saved item"),
     })
   }
@@ -133,9 +131,9 @@ function SavedList({ workspaceId, tab }: { workspaceId: string; tab: SavedStatus
           key={saved.id}
           saved={saved}
           workspaceId={workspaceId}
-          onMarkDone={tab === "saved" ? () => handleUpdate(saved.id, "done", "Marked done") : undefined}
-          onArchive={tab === "saved" ? () => handleUpdate(saved.id, "archived", "Archived") : undefined}
-          onRestore={tab !== "saved" ? () => handleUpdate(saved.id, "saved", "Restored") : undefined}
+          onMarkDone={tab === "saved" ? () => handleUpdate(saved.id, "done") : undefined}
+          onArchive={tab === "saved" ? () => handleUpdate(saved.id, "archived") : undefined}
+          onRestore={tab !== "saved" ? () => handleUpdate(saved.id, "saved") : undefined}
           onDelete={() => handleDelete(saved.id)}
         />
       ))}

--- a/apps/frontend/src/pages/scheduled.tsx
+++ b/apps/frontend/src/pages/scheduled.tsx
@@ -57,7 +57,6 @@ function ScheduledPageInner({ workspaceId, tab }: InnerProps) {
 
   const handleCancel = (id: string) => {
     cancelMutation.mutate(id, {
-      onSuccess: () => toast.success("Scheduled message cancelled"),
       // Error.message is typed string, never null — `??` would let an empty
       // message slip through and render an invisible toast. `||` falls back
       // to the human label in both nullish and empty-string cases.
@@ -67,7 +66,6 @@ function ScheduledPageInner({ workspaceId, tab }: InnerProps) {
 
   const handleSendNow = (id: string) => {
     sendNowMutation.mutate(id, {
-      onSuccess: () => toast.success("Sent"),
       onError: (err: Error) => toast.error(err.message || "Could not send"),
     })
   }


### PR DESCRIPTION
## Problem

Success toasts fired on nearly every state change in the app, even when the UI already
reflected the result. Toggling the theme from device-default to dark mode popped
`toast.success("Settings saved")` (`contexts/preferences-context.tsx`) — on mobile that
toast covers the very field you just changed, confirming something you can already see.
The same pattern repeated across ~30 files: profile edits, avatar, stream settings,
members, workspace statuses/schedule, labels, saved items, reminders, scheduling, drafts,
invites, encryption setup, message moves, quick-switcher actions. ~65 call sites in all.

Per the product call: a toast should be the exception — reserved for when the app genuinely
needs the user's attention (a failure, or a warning they must act on), not a receipt for a
happy path. "If the app shows as if it went well, that's fine."

The one defensible exception was copy/download: clipboard and download actions give no other
visual signal that they worked. The ruling there was not "drop the feedback" but "be smarter
about it" — confirm in place (icon → checkmark) rather than popping a toast, and never shift
layout doing it.

## Solution

Delete the happy-path success toasts; keep the toasts that carry real signal (errors,
deferred/offline state, the version-update prompt, encryption warnings, the share-privacy
warning). For copy/download, replace the toast with an in-place icon swap on the triggering
button.

### How it works

- **Success-toast removal.** Removed `toast.success(...)` and success-only `onSuccess`
  handlers across settings, encryption, scheduled, saved, labels, reminders, timeline, and
  quick-switcher surfaces. Where an `onSuccess` did real work (cache writes, `onOpenChange(false)`,
  navigation) only the toast line was dropped; toast-only handlers were removed whole. Locals
  that existed solely to feed a toast string (the `successLabel` params in `pages/saved.tsx`
  and `reminder-popover-content.tsx`) and the now-dead `capitalize` helper in `general-tab.tsx`
  were deleted (INV-38). `toast` imports left unused (`message-input.tsx`, `use-stash-composer.ts`)
  were removed; files that still call `toast.error` keep the import.

- **Inline copy/download confirmation.** `downloadImage`/`copyImage` in `lib/image-utils.ts`
  now return `Promise<boolean>` (success) instead of toasting on the happy path; failures still
  `toast.error` (no inline affordance can explain a failure). The two callers render the result
  in place:
  - `components/image-gallery.tsx` — the toolbar download/copy buttons swap their icon to a
    `Check` for 1200ms then revert (`copyDone`/`downloadDone` state, timers cleared on unmount
    and re-trigger). Same `h-5 w-5` footprint, so nothing reflows (INV-21). This also unifies
    the markdown/html copy path, which previously gave no feedback at all.
  - `components/timeline/attachment-list.tsx` — the mobile image action drawer swaps the row
    icon to a `Check`, then dismisses itself ~700ms later instead of popping a toast over the
    composer.

- **Toasts deliberately kept.** All `toast.error`; the deferred/offline `toast.info`
  ("Edit queued…", "Delete queued…", "Scheduling…"); the "New version available / Reload"
  prompt (`use-app-update.ts`); the encryption edge-case `toast.warning`s; and the
  private→public share-privacy warning (`lib/share-privacy-toast.ts`). The dropdown-menu copy
  items (`message-actions.ts`) and the `mod+L` copy-link shortcut (`copyStreamLink` in
  `lib/stream-links.ts`) keep their toasts — they fire from a menu that closes or a keyboard
  shortcut, so there is no persistent button to animate.

### Key design decisions

**1. Errors and deferred-state info stay; only happy-path confirmations go.** A failed save or
a "queued while offline" message is exactly the attention-worthy case the toast primitive is
for. Removing those would trade annoyance for silent failure. The trim was scoped to "the UI
already shows this succeeded."

**2. Copy/download confirm inline rather than losing feedback.** Clipboard/download is the one
happy path with no other on-screen signal, so the feedback was kept but moved onto the button
itself. The icon swap is in-place and same-size to satisfy the no-layout-shift constraint
(INV-21); there is already precedent for this pattern in `attachment-explorer/explorer-preview.tsx`
and the API-key copy buttons.

**3. No-anchor copy surfaces keep their toast.** A dropdown item unmounts when the menu closes
and a keyboard shortcut has no UI anchor at all, so there is nothing to show a checkmark on.
Per the ruling ("I'm not asking to not show stuff like this"), these retain the toast.

**4. The share-privacy warning is left as a toast for now.** It is a genuine "user must act"
case (Share anyway / Cancel) and arguably belongs in a modal/drawer like the existing
"Share this encrypted message?" confirmation (`share-message-modal.tsx`) — but that is its own
change, tracked as a follow-up handover rather than folded in here.

## Modified files

| File | Change |
| ---- | ------ |
| `contexts/preferences-context.tsx` | Drop `"Settings saved"` (the theme-toggle toast); keep cache write + error toast |
| `components/settings/profile-settings.tsx` | Drop 5 field-update success toasts |
| `components/settings/avatar-section.tsx` | Drop upload/remove success toasts |
| `components/workspace-settings/{users,statuses,schedule}-tab.tsx` | Drop role/member/statuses/schedule success toasts |
| `components/stream-settings/general-tab.tsx` | Drop 7 success toasts; delete dead `capitalize` helper |
| `components/stream-settings/members-tab.tsx` | Drop member add/remove success toasts |
| `components/encryption/{encrypted-scratchpads-section,passphrase-setup-modal,passphrase-unlock-modal,biometric-unlock-modal,pin-unlock-modal}.tsx` | Drop unlock/setup success toasts; keep warnings + errors |
| `pages/saved.tsx`, `components/saved/{saved-edit-dialog,suggested-tab}.tsx`, `components/timeline/save-message-button.tsx` | Drop saved-item success toasts; drop `successLabel` param |
| `pages/labels.tsx`, `components/labels/label-edit-form.tsx` | Drop label create/join/delete/promote/leave/update success toasts |
| `pages/scheduled.tsx`, `components/scheduled/scheduled-edit-dialog.tsx` | Drop "Sent"/"Updated"/"Cancelled" success toasts; keep "Scheduling…" info + errors |
| `components/timeline/{reminder-picker-sheet,reminder-popover-content}.tsx` | Drop reminder success toasts; drop `successLabel` param |
| `components/timeline/message-event.tsx` | Drop 3 saved-action success toasts; keep "Delete queued…" info |
| `components/timeline/message-input.tsx` | Drop "Scheduled" toast; remove now-unused `toast` import |
| `components/timeline/stream-content.tsx` | Drop "Moved N messages" toast |
| `components/quick-switcher/{commands.ts,quick-switcher.tsx}` | Drop to-do/draft/archive success toasts |
| `hooks/use-stash-composer.ts` | Drop draft stash/restore toasts; remove unused `toast` import |
| `hooks/use-invite-actor.ts` | Drop invite success branch; keep error path |
| `lib/image-utils.ts` | `downloadImage`/`copyImage` return `boolean` on success instead of toasting; errors still toast |
| `components/image-gallery.tsx` | Toolbar copy/download buttons confirm with an in-place `Check` swap (1200ms) |
| `components/timeline/attachment-list.tsx` | Mobile image drawer confirms with a `Check` then auto-dismisses |
| `components/composer/message-composer.tsx`, `hooks/use-stashed-drafts.ts` | Fix doc comments that referenced the removed toasts (INV-25) |

## Out of scope (deliberate)

- **Share-privacy toast → modal/drawer.** Left as-is; tracked as a separate follow-up (handover
  to be written) since it is a "must act" warning with its own UX shape.
- **Dropdown-menu copy items and `mod+L` copy-link.** Kept as toasts — no persistent anchor.
- **Error / offline-info / version-update / encryption-warning toasts.** Intentionally retained.

## Test plan

- [x] `apps/frontend` `tsc --noEmit` — clean (also clean across the full monorepo via the pre-commit hook)
- [x] `apps/frontend` ESLint on all 35 changed files — clean (caught + fixed a `no-nested-ternary` in the gallery sr-only label and the `useRef<…>()` no-arg overload)
- [x] Full frontend vitest suite — 248 files, 2736 tests pass
- [x] Targeted: `image-gallery.reopen`, `attachment-list`, `attachment-list.data-router` — 24 pass
- [ ] No manual mobile pass on a device — the drawer auto-dismiss timing (700ms) and the gallery checkmark were verified by reading the render + tests, not by hand on a phone

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Stop showing toasts for happy-path actions the UI already reflects; reserve toasts for
attention-worthy cases (errors, warnings, deferred state).

**Audit categories (the plan).**
- **A — happy-path success toasts (~65):** removed.
- **B — copy/download (no other signal):** converted to in-place icon confirmation where a
  persistent button exists (image gallery, mobile attachment drawer); kept as toasts where there
  is no anchor (dropdown copy items, `mod+L` shortcut).
- **C — deferred/offline info toasts:** kept.
- **D — error toasts:** kept (trimmed only where they would duplicate inline feedback — none
  needed removing in practice).
- **E — warnings:** kept. Share-privacy warning left as a toast, deferred to a follow-up; the
  E2E→public share warning is already a modal (`share-message-modal.tsx`), no change needed.

**Execution.** Category A removal was fanned out across four parallel agents on disjoint file
groups; each removal was diff-reviewed (onSuccess handling, unused imports/locals, dead helpers).
Category B (the inline-icon UX) was done by hand.

**What's NOT included.** Share-privacy modal conversion; any change to the no-anchor copy
toasts; any backend change (this is frontend-only).

**Status.** Complete, typecheck + lint + full frontend suite green, pushed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDuYsEjpCrtiDo33UT834G)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784149656&installation_id=129946197&pr_number=953&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F953&signature=cbff546c737f1b27cd426f5c7a50dc1b34c03c1324e5d14767c41283e7adc763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->