### PR TITLE
refactor(e2e): collapse sealed-name loading-state into a single authority

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -66,6 +66,18 @@ session shows the placeholder; the open-stream header reads the same cache via
 `useDecryptedStreamName`. Don't re-decrypt names per surface — extend the cache /
 overlay if a new surface bypasses the workspace store.
 
+**Loading state goes through the single authority.** The decrypted _value_ is
+transparent through the overlay above, but "is this sealed name still resolving"
+(show a loader vs. the placeholder) needs the session, so it has exactly one
+owner: `useSealedNamePendingResolver(workspaceId)` in `use-decrypted-stream-name`.
+It wires `useE2eSession` + the name-cache subscription once and returns a resolver;
+list surfaces apply it across rows (the sidebar builder's `nameDecrypting`, the
+coordinated-loading reveal gate's `.some`) and the open-stream header reads one
+stream via `useStreamNameDecrypting`. Do **not** re-pair `useE2eSession` with the
+cache version yourself — that triple drifted across three surfaces before it was
+collapsed here. A new surface that needs the loading state calls the resolver; it
+never reaches for the session directly.
+
 ### Why this exists
 
 DM display names are computed per-viewer on the backend at bootstrap and are

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { FileText, Lock, RefreshCw, StickyNote } from "lucide-react"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { useAuth } from "@/auth"
 import { useCreateEncryptedScratchpad } from "@/hooks/use-create-encrypted-scratchpad"
 import { useE2eUnlockOptional } from "@/components/encryption/e2e-unlock-provider"
-import { getE2eSessionState, useE2eSession } from "@/stores/e2e-session-store"
-import { resolveSealedNamePending } from "@/hooks/use-decrypted-stream-name"
-import { getStreamNameCacheVersion, subscribeStreamNameCache } from "@/lib/crypto/stream-name-cache"
+import { getE2eSessionState } from "@/stores/e2e-session-store"
+import { useSealedNamePendingResolver } from "@/hooks/use-decrypted-stream-name"
 import {
   useActivityCounts,
   useAllDrafts,
@@ -99,16 +98,11 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const currentUser = workspaceUsers.find((u) => u.workosUserId === user?.id) ?? null
   const createEncryptedScratchpad = useCreateEncryptedScratchpad(workspaceId, currentUser?.id ?? null)
   const e2eUnlock = useE2eUnlockOptional()
-  // Resolve the sealed-name loading state for the whole list in one place (the
-  // session + shared name cache), so each row reads it as plain data instead of
-  // re-wiring the session. `nameCacheVersion` re-evaluates when a decrypt settles
-  // — including a failure, which leaves the overlaid row unchanged.
-  const e2eSessionStatus = useE2eSession(workspaceId, currentUser?.id ?? "").status
-  const nameCacheVersion = useSyncExternalStore(
-    subscribeStreamNameCache,
-    getStreamNameCacheVersion,
-    getStreamNameCacheVersion
-  )
+  // Resolve the sealed-name loading state for the whole list off the single
+  // authority (session + shared name cache, wired once), so each row reads it as
+  // plain data instead of re-wiring the session. The resolver re-binds when a
+  // decrypt settles — including a failure, which leaves the overlaid row unchanged.
+  const isSealedNamePending = useSealedNamePendingResolver(workspaceId)
 
   const draftCount = allDrafts.length
   const savedCount = useLiveSavedCount(workspaceId)
@@ -167,7 +161,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           urgency,
           section,
           dmPeerUserId,
-          nameDecrypting: resolveSealedNamePending(workspaceId, streamWithPreview, e2eSessionStatus),
+          nameDecrypting: isSealedNamePending(streamWithPreview),
         }
       })
   }, [
@@ -182,8 +176,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     workspaceUsers,
     unreadState,
     workspaceId,
-    e2eSessionStatus,
-    nameCacheVersion,
+    isSealedNamePending,
   ])
 
   // System streams are auto-created infrastructure — don't count toward "has content"

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -19,9 +19,9 @@ export interface StreamItemData extends StreamWithPreview {
   dmPeerUserId?: string
   /**
    * True while this stream's sealed E2E name is still decrypting on cold load, so
-   * the row renders a loader instead of the placeholder. Resolved once by the
-   * sidebar builder off the shared name cache + session (see
-   * `resolveSealedNamePending`), not per row.
+   * the row renders a loader instead of the placeholder. The sidebar builder wires
+   * the single authority once (`useSealedNamePendingResolver`) and applies it per
+   * row, so the leaf reads this as plain data without touching the session.
    */
   nameDecrypting?: boolean
 }

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -1,19 +1,7 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-  type ReactNode,
-} from "react"
+import { createContext, useContext, useState, useEffect, useMemo, useRef, type ReactNode } from "react"
 import { usePreloadImages } from "@/hooks/use-preload-images"
 import { useCoordinatedStreamQueries } from "@/hooks/use-coordinated-stream-queries"
-import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useE2eSession } from "@/stores/e2e-session-store"
-import { resolveSealedNamePending } from "@/hooks/use-decrypted-stream-name"
-import { getStreamNameCacheVersion, subscribeStreamNameCache } from "@/lib/crypto/stream-name-cache"
+import { useSealedNamePendingResolver } from "@/hooks/use-decrypted-stream-name"
 import {
   hasSeededWorkspaceCache,
   seedCacheFromIdb,
@@ -194,22 +182,13 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   const idbSidebarConfig = useWorkspaceSidebarConfig(workspaceId)
   // Hold the initial reveal until every sealed E2E stream name has decrypted, so
   // the first painted render shows real names instead of flashing the placeholder
-  // and popping to the decrypted name a tick later. `resolveSealedNamePending`
-  // only waits while the session is settling or unlocked-and-decrypting; it
-  // returns false for a locked/no-key session (the placeholder is then the right
-  // answer) and once a decrypt settles, so this can't deadlock the reveal.
-  // `nameCacheVersion` re-evaluates it when a decrypt lands.
-  const currentUserId = useWorkspaceUserId(workspaceId)
-  const e2eSessionStatus = useE2eSession(workspaceId, currentUserId ?? "").status
-  const nameCacheVersion = useSyncExternalStore(
-    subscribeStreamNameCache,
-    getStreamNameCacheVersion,
-    getStreamNameCacheVersion
-  )
-  const sealedNamesPending = useMemo(
-    () => idbStreams.some((stream) => resolveSealedNamePending(workspaceId, stream, e2eSessionStatus)),
-    [idbStreams, workspaceId, e2eSessionStatus, nameCacheVersion]
-  )
+  // and popping to the decrypted name a tick later. The resolver (the single
+  // session + name-cache authority) only reports pending while the session is
+  // settling or unlocked-and-decrypting; it returns false for a locked/no-key
+  // session (the placeholder is then the right answer) and once a decrypt settles,
+  // so this can't deadlock the reveal. It re-binds when a decrypt lands.
+  const isSealedNamePending = useSealedNamePendingResolver(workspaceId)
+  const sealedNamesPending = useMemo(() => idbStreams.some(isSealedNamePending), [idbStreams, isSealedNamePending])
   const streamById = useMemo(() => new Map(idbStreams.map((stream) => [stream.id, stream])), [idbStreams])
   const workspaceDataReady =
     hasSeededWorkspaceCache(workspaceId) &&
@@ -306,7 +285,6 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
       workspaceLoading,
       streamsLoading,
       draftsLoading,
-      e2eSessionStatus,
       sealedNamesPending,
       isAnySyncing,
       isLoading,

--- a/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
+++ b/apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx
@@ -5,7 +5,7 @@ import { db, type CachedStream } from "@/db"
 import { resetWorkspaceStoreCache, seedWorkspaceCache } from "@/stores/workspace-store"
 import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
-import { useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
+import { useSealedNamePendingResolver, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
 import { useStreamName } from "@/hooks/use-stream-name"
 import * as e2eSession from "@/stores/e2e-session-store"
 import * as workspaces from "@/hooks/use-workspaces"
@@ -78,6 +78,17 @@ function DecryptingHarness() {
   useDecryptStreamNames(WS)
   const decrypting = useStreamNameDecrypting(WS, SEALED_STREAM)
   return <span data-testid="state">{decrypting ? "decrypting" : "settled"}</span>
+}
+
+const PLAINTEXT_STREAM = { id: "stream_plain", e2eEnabled: false, sealedNameCiphertext: null, rootStreamId: null }
+
+// Mirrors how the list surfaces (sidebar builder, coordinated-loading reveal
+// gate) consume the single authority: wire it once, then apply across rows.
+function ListHarness() {
+  useDecryptStreamNames(WS)
+  const isPending = useSealedNamePendingResolver(WS)
+  const anyPending = [SEALED_STREAM, PLAINTEXT_STREAM].some(isPending)
+  return <span data-testid="any-pending">{anyPending ? "pending" : "settled"}</span>
 }
 
 async function seedSealedStream() {
@@ -179,5 +190,40 @@ describe("useStreamNameDecrypting (cold-load loading state)", () => {
     render(<DecryptingHarness />)
 
     await waitFor(() => expect(screen.getByTestId("state")).toHaveTextContent("settled"))
+  })
+})
+
+describe("useSealedNamePendingResolver (the single list authority)", () => {
+  it("reports pending across rows until the sealed name lands, ignoring plaintext rows", async () => {
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "unlocked" }))
+    let resolveDecrypt: (value: string | null) => void = () => {}
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveDecrypt = resolve
+        })
+    )
+
+    await seedSealedStream()
+    render(<ListHarness />)
+
+    // One sealed name is still decrypting → the list reports pending; the
+    // plaintext row never contributes pending.
+    expect(screen.getByTestId("any-pending")).toHaveTextContent("pending")
+
+    await act(async () => {
+      resolveDecrypt("Quarterly Plan")
+    })
+    await waitFor(() => expect(screen.getByTestId("any-pending")).toHaveTextContent("settled"))
+  })
+
+  it("never reports pending while the session is locked (so the reveal gate can't deadlock)", async () => {
+    vi.spyOn(messageEnvelope, "tryOpenStreamName").mockResolvedValue("Should Not Appear")
+    vi.spyOn(e2eSession, "useE2eSession").mockReturnValue(session({ status: "locked", privateKey: null }))
+
+    await seedSealedStream()
+    render(<ListHarness />)
+
+    await waitFor(() => expect(screen.getByTestId("any-pending")).toHaveTextContent("settled"))
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-stream-name.ts
+++ b/apps/frontend/src/hooks/use-decrypted-stream-name.ts
@@ -77,10 +77,10 @@ export function useDecryptedStreamName(
  * locked/no-key session (the placeholder is then the settled answer), and once the
  * name has decrypted (or definitively failed).
  *
- * Pure so the single decision can be computed at the read boundary that already
- * resolves the name — the open-stream header (via `useStreamNameDecrypting`) and
- * the sidebar's stream-list builder — rather than each leaf row re-wiring the
- * session. Reads the same cache as the name overlay, so loader and label agree.
+ * The pure decision. Surfaces never call this with a hand-wired session — they go
+ * through {@link useSealedNamePendingResolver}, the single authority that binds it
+ * to the live session + name cache. Reads the same cache as the name overlay, so
+ * loader and label agree.
  */
 export function resolveSealedNamePending(
   workspaceId: string,
@@ -97,19 +97,39 @@ export function resolveSealedNamePending(
 }
 
 /**
- * Hook form of {@link resolveSealedNamePending} for a single open stream (the
- * header), which already has session context. List surfaces resolve this through
- * their stream-list builder instead, off the same shared cache.
+ * The single session-aware authority for "is this sealed E2E name still
+ * resolving". Wires the session and the name-cache version subscription once and
+ * returns a resolver bound to them; recompute is driven by the session flipping
+ * and by a decrypt landing (or the cache clearing on lock). Every surface that
+ * needs the loading state — the open-stream header, the sidebar's stream-list
+ * builder, the coordinated-loading reveal gate — calls this instead of
+ * re-deriving the `useE2eSession` + cache-subscription pairing, which is the
+ * recurring "fix one surface, miss another" drift. List surfaces apply the
+ * resolver across their rows (`.map`/`.some`); a single-stream surface calls
+ * {@link useStreamNameDecrypting}.
  */
-export function useStreamNameDecrypting(workspaceId: string, stream: SealedNameStream | null | undefined): boolean {
+export function useSealedNamePendingResolver(
+  workspaceId: string
+): (stream: SealedNameStream | null | undefined) => boolean {
   const userId = useWorkspaceUserId(workspaceId)
   const session = useE2eSession(workspaceId, userId ?? "")
-  // `version` re-evaluates pending when a decrypt settles (including a failure,
-  // which doesn't change the overlaid row).
+  // `version` re-binds the resolver when a decrypt settles (including a failure,
+  // which leaves the overlaid row unchanged) or the cache clears on lock.
   const version = useSyncExternalStore(subscribeStreamNameCache, getStreamNameCacheVersion, getStreamNameCacheVersion)
 
   return useMemo(
-    () => resolveSealedNamePending(workspaceId, stream, session.status),
-    [workspaceId, stream, session.status, version]
+    () => (stream: SealedNameStream | null | undefined) =>
+      resolveSealedNamePending(workspaceId, stream, session.status),
+    [workspaceId, session.status, version]
   )
+}
+
+/**
+ * Loading state for a single open stream's sealed name (the header), routed
+ * through the same {@link useSealedNamePendingResolver} authority the list
+ * surfaces use, so loader and label never drift.
+ */
+export function useStreamNameDecrypting(workspaceId: string, stream: SealedNameStream | null | undefined): boolean {
+  const resolve = useSealedNamePendingResolver(workspaceId)
+  return resolve(stream)
 }


### PR DESCRIPTION
## Problem

For E2E sealed stream names, the decrypted **value** is already centralized: one mounted driver (`useDecryptStreamNames`) kicks decrypts, and one store-boundary overlay (`applyDecryptedNameOverlay` in `useWorkspaceStreams`) reflects the result wherever a label resolves. The **status** — "is this sealed name still resolving, so show a loader instead of flashing the placeholder" — was not. It needs the session, and three surfaces each re-derived the same wiring by hand:

- `components/layout/sidebar/sidebar.tsx` — `useE2eSession(...).status` + a `useSyncExternalStore(subscribeStreamNameCache, ...)` version subscription, fed per row into `resolveSealedNamePending(workspaceId, stream, status)`.
- `contexts/coordinated-loading-context.tsx` — the same `useWorkspaceUserId` + `useE2eSession` + version-subscription triple, `.some()`-ed across streams to gate the initial reveal.
- `hooks/use-decrypted-stream-name.ts` `useStreamNameDecrypting` — the same triple for the open-stream header.

This is the "fix one surface, miss another" drift the frontend notes warn about: the decrypt machine itself is centralized, but every consumer that wants the loading state re-pairs `useE2eSession` with the cache subscription, so a fourth surface would copy it a fourth time.

## Solution

Collapse the triple into one session-aware authority and route every surface through it. `resolveSealedNamePending` stays the pure decision (unchanged logic); the wiring lives in exactly one hook.

### How it works

1. **`useSealedNamePendingResolver(workspaceId)`** (`hooks/use-decrypted-stream-name.ts`) wires `useE2eSession` (via `useWorkspaceUserId`) and the `subscribeStreamNameCache` version subscription once, and returns a resolver `(stream) => boolean` memoized on `[workspaceId, session.status, version]`. Its identity changes when the session flips or a decrypt lands (or the cache clears on lock), so consumers re-run.
2. **List surfaces apply the resolver across rows.** The sidebar builder calls it once and uses `isSealedNamePending(streamWithPreview)` per row for `nameDecrypting`; the coordinated-loading reveal gate does `idbStreams.some(isSealedNamePending)`. Both drop their own `useE2eSession` + version-subscription wiring.
3. **The header reads one stream** through `useStreamNameDecrypting`, now a thin wrapper over the same resolver.

The pure `resolveSealedNamePending` keeps the deadlock-safety the reveal gate depends on: it returns `true` only while the session is settling (`unknown`/`unlocking`) or unlocked-and-decrypting, and `false` for a locked/no-key session and once a decrypt settles (success or definitive failure) — so a locked user reveals immediately with placeholders.

### Key design decisions

**1. One authority hook, not status-on-the-row.** The fuller shape — carry `{ value, status }` on the `useWorkspaceStreams` row so a consumer reads decrypted data with no awareness it's encrypted — would require coupling the value overlay (and thus `useWorkspaceStreams`) to the session. That coupling is explicitly off-limits (it breaks the store-only tests that mount `useWorkspaceStreams` without a session) and would force a phase-in-cache rework that touches the reveal gate's deadlock-safety. The resolver hook gets the divergence fix without that risk; the transparent-row projection is a separable follow-up (see Out of scope). This is posture **C** from the design discussion (ciphertext stays at rest; reads centralized, not plaintext-at-rest-in-IDB).

**2. Keep `resolveSealedNamePending` pure and exported.** The hook is the wiring; the decision stays a pure function so it's unit-testable and the hook is a thin shell. No behavior change to the decision itself.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-decrypted-stream-name.ts` | Add `useSealedNamePendingResolver` (the single authority); `useStreamNameDecrypting` becomes a wrapper over it; `resolveSealedNamePending` unchanged logic, doc updated. |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | Drop `useE2eSession` + `useSyncExternalStore`/cache-version wiring; resolve `nameDecrypting` via the authority. Keeps `getE2eSessionState` (still used for the encrypted-scratchpad affordance). |
| `apps/frontend/src/contexts/coordinated-loading-context.tsx` | Drop `useWorkspaceUserId` + `useE2eSession` + cache-version wiring; reveal gate `.some()`s the authority. Removed the now-dead `e2eSessionStatus` debug field. |
| `apps/frontend/src/components/layout/sidebar/types.ts` | Refresh the `nameDecrypting` doc comment to name the new authority. |
| `apps/frontend/src/hooks/use-decrypt-stream-names.test.tsx` | Add a `ListHarness` + two cases covering the list-application contract (pending across rows until a decrypt lands, ignoring plaintext rows; never pending while locked). |
| `apps/frontend/AGENTS.md` | Document the rule: loading state goes through `useSealedNamePendingResolver`; don't re-pair `useE2eSession` with the cache version. |

## Out of scope (deliberate)

- **Transparent `{ value, status }` on the row** (the fuller projection) — deferred; requires coupling the overlay to the session, which is the constraint this change respects. Clean follow-up if reads should be fully session-unaware.
- **The open-stream header still calls `useE2eSession` directly** at `pages/stream.tsx:154` — but for the rename affordance gate (`e2eUnlocked`), not for name loading state. The name status there now goes through the authority. Left as-is.
- **Message-body / attachment decrypt caches** — already have their own single read path (`useDecryptedMessageContent`); not touched.

## Test plan

- [x] `bunx vitest run` on the touched + neighbor suites (use-decrypt-stream-names, stream-name-cache, coordinated-loading-context, scratchpad-item, general-tab.rename) — 56 pass. Existing locked / unlocked / decrypting reveal-gate and header cases stay green (behavior unchanged); two new cases lock the list-application contract.
- [x] `bunx tsc --noEmit` (frontend) — clean.
- [x] `bunx eslint` + `bunx prettier --check` on touched files — clean.
- [ ] No full `bun run test:e2e` — this is a render-path refactor with no wire/route change; covered by the integration-style component tests above rather than Playwright.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJimp1unpy4gmbJmsxBF2Z)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784152264&installation_id=129946197&pr_number=955&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F955&signature=06df081fa0bb656a00c3480c8c7ebf49a2a4067f5983cf1a4c53c1775d9783c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->