### PR TITLE
feat(agents): let personas read images on the web and in Threa

### DIFF
--- a/apps/backend/src/features/agents/built-in-agents.test.ts
+++ b/apps/backend/src/features/agents/built-in-agents.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test"
-import { ARIADNE_AGENT_ID, EMPTY_AGENT_ID, isE2eCapablePersona } from "./built-in-agents"
+import { AgentToolNames } from "@threa/types"
+import { BUILT_IN_AGENTS, ARIADNE_AGENT_ID, EMPTY_AGENT_ID, isE2eCapablePersona } from "./built-in-agents"
+
+describe("Ariadne built-in config", () => {
+  it("can load attachments for visual analysis (vision-capable model)", () => {
+    // load_attachment is what lets Ariadne actually SEE an uploaded image, not
+    // just read its caption — keep it enabled so that capability can't regress.
+    expect(BUILT_IN_AGENTS[ARIADNE_AGENT_ID].enabledTools).toContain(AgentToolNames.LOAD_ATTACHMENT)
+  })
+})
 
 describe("isE2eCapablePersona", () => {
   it("is true for Ariadne (the enclave persona)", () => {

--- a/apps/backend/src/features/agents/built-in-agents.ts
+++ b/apps/backend/src/features/agents/built-in-agents.ts
@@ -70,6 +70,7 @@ Keep responses short and direct. Default to a few sentences unless the user asks
       AgentToolNames.GENERAL_RESEARCH,
       AgentToolNames.DESCRIBE_MEMO,
       AgentToolNames.REACT_TO_MESSAGE,
+      AgentToolNames.LOAD_ATTACHMENT,
       AgentToolNames.GITHUB_LIST_REPOS,
       AgentToolNames.GITHUB_LIST_BRANCHES,
       AgentToolNames.GITHUB_LIST_COMMITS,

--- a/apps/backend/src/features/agents/companion/tool-set.ts
+++ b/apps/backend/src/features/agents/companion/tool-set.ts
@@ -117,7 +117,7 @@ export function buildToolSet(config: ToolSetConfig): AgentTool[] {
     tavilyApiKey && isToolEnabled(enabledTools, AgentToolNames.WEB_SEARCH)
       ? createWebSearchTool({ tavilyApiKey, currentTime, timezone })
       : null,
-    isToolEnabled(enabledTools, AgentToolNames.READ_URL) ? createReadUrlTool() : null,
+    isToolEnabled(enabledTools, AgentToolNames.READ_URL) ? createReadUrlTool({ supportsVision }) : null,
 
     // Workspace search tools
     workspace && isToolEnabled(enabledTools, AgentToolNames.SEARCH_MESSAGES)

--- a/apps/enclave/src/agent/tools.ts
+++ b/apps/enclave/src/agent/tools.ts
@@ -68,7 +68,10 @@ export function buildEnclaveTools(deps: EnclaveToolDeps): AgentTool[] {
         createWebSearchTool({ tavilyApiKey: deps.tavilyApiKey, currentTime: deps.currentTime, timezone: deps.timezone })
       )
     }
-    tools.push(createReadUrlTool())
+    // The enclave only serves e2e-capable personas, which run vision-capable
+    // models — and it already feeds images to the model via the ungated
+    // load_attachment tool above — so read_url may return images here too.
+    tools.push(createReadUrlTool({ supportsVision: true }))
     return tools
   }
 

--- a/packages/agent-runtime/src/tools/read-url-tool.test.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.test.ts
@@ -95,6 +95,110 @@ describe("read-url-tool", () => {
     expect(parsed.error).toContain("application/pdf")
   })
 
+  describe("image handling", () => {
+    // A 1x1 PNG — content is irrelevant, we only assert it round-trips as base64.
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMCAQDeY7HoAAAAAElFTkSuQmCC",
+      "base64"
+    )
+
+    // Exact-length copy so the mocked arrayBuffer() carries only the PNG bytes
+    // (Buffer.from on small inputs can sit in a shared pool).
+    const pngArrayBuffer = pngBytes.buffer.slice(pngBytes.byteOffset, pngBytes.byteOffset + pngBytes.byteLength)
+
+    const imageResponse = (contentType = "image/png", extraHeaders: Record<string, string> = {}) =>
+      mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": contentType, ...extraHeaders }),
+          arrayBuffer: () => Promise.resolve(pngArrayBuffer.slice(0)),
+        } as unknown as Response)
+      ) as unknown as typeof fetch
+
+    it("returns an image URL as a multimodal image block when vision is supported", async () => {
+      globalThis.fetch = imageResponse()
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const result = await tool.config.execute({ url: "https://example.com/chart.png" }, toolOpts)
+
+      expect(result.multimodal).toEqual([
+        { type: "image", url: `data:image/png;base64,${pngBytes.toString("base64")}` },
+      ])
+      const parsed = JSON.parse(result.output)
+      expect(parsed.kind).toBe("image")
+      expect(parsed.mimeType).toBe("image/png")
+    })
+
+    it("reports an image as unreadable when vision is not supported", async () => {
+      globalThis.fetch = imageResponse()
+
+      const tool = createReadUrlTool()
+      const { output, multimodal } = await tool.config.execute({ url: "https://example.com/chart.png" }, toolOpts)
+
+      expect(multimodal).toBeUndefined()
+      expect(JSON.parse(output).error).toContain("cannot view images")
+    })
+
+    it("refuses an unsupported image type", async () => {
+      globalThis.fetch = imageResponse("image/svg+xml")
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output } = await tool.config.execute({ url: "https://example.com/logo.svg" }, toolOpts)
+
+      expect(JSON.parse(output).error).toContain("Unsupported image type")
+    })
+
+    it("refuses an image whose declared size exceeds the cap without downloading it", async () => {
+      globalThis.fetch = imageResponse("image/png", { "content-length": String(6 * 1024 * 1024) })
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output, multimodal } = await tool.config.execute({ url: "https://example.com/huge.png" }, toolOpts)
+
+      expect(multimodal).toBeUndefined()
+      expect(JSON.parse(output).error).toContain("too large")
+    })
+
+    it("lists embedded image URLs (absolute) for vision-capable callers", async () => {
+      const html = `<html><head><title>Gallery</title></head><body>
+        <img src="/img/a.png">
+        <img src='https://cdn.example.com/b.jpg'>
+        <img src="data:image/png;base64,AAAA">
+      </body></html>`
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve(html),
+        } as Response)
+      ) as unknown as typeof fetch
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output } = await tool.config.execute({ url: "https://example.com/gallery" }, toolOpts)
+      const parsed = JSON.parse(output)
+
+      expect(parsed.images).toEqual(["https://example.com/img/a.png", "https://cdn.example.com/b.jpg"])
+    })
+
+    it("omits the image list when the caller has no vision", async () => {
+      const html = `<html><head><title>Gallery</title></head><body><img src="/img/a.png"></body></html>`
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve(html),
+        } as Response)
+      ) as unknown as typeof fetch
+
+      const tool = createReadUrlTool()
+      const { output } = await tool.config.execute({ url: "https://example.com/gallery" }, toolOpts)
+
+      expect(JSON.parse(output).images).toBeUndefined()
+    })
+  })
+
   it("should return error on HTTP failure", async () => {
     globalThis.fetch = mock(() =>
       Promise.resolve({

--- a/packages/agent-runtime/src/tools/read-url-tool.test.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.test.ts
@@ -144,8 +144,9 @@ describe("read-url-tool", () => {
       globalThis.fetch = imageResponse("image/svg+xml")
 
       const tool = createReadUrlTool({ supportsVision: true })
-      const { output } = await tool.config.execute({ url: "https://example.com/logo.svg" }, toolOpts)
+      const { output, multimodal } = await tool.config.execute({ url: "https://example.com/logo.svg" }, toolOpts)
 
+      expect(multimodal).toBeUndefined()
       expect(JSON.parse(output).error).toContain("Unsupported image type")
     })
 
@@ -154,6 +155,26 @@ describe("read-url-tool", () => {
 
       const tool = createReadUrlTool({ supportsVision: true })
       const { output, multimodal } = await tool.config.execute({ url: "https://example.com/huge.png" }, toolOpts)
+
+      expect(multimodal).toBeUndefined()
+      expect(JSON.parse(output).error).toContain("too large")
+    })
+
+    it("refuses an image whose actual bytes exceed the cap when content-length is absent", async () => {
+      // 5 MB + 1 byte; MAX_IMAGE_BYTES is 5 MB. No content-length header, so the
+      // second (post-download) size guard is the one that must fire.
+      const oversized = new ArrayBuffer(5 * 1024 * 1024 + 1)
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "image/png" }),
+          arrayBuffer: () => Promise.resolve(oversized),
+        } as unknown as Response)
+      ) as unknown as typeof fetch
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output, multimodal } = await tool.config.execute({ url: "https://example.com/sneaky.png" }, toolOpts)
 
       expect(multimodal).toBeUndefined()
       expect(JSON.parse(output).error).toContain("too large")
@@ -179,6 +200,45 @@ describe("read-url-tool", () => {
       const parsed = JSON.parse(output)
 
       expect(parsed.images).toEqual(["https://example.com/img/a.png", "https://cdn.example.com/b.jpg"])
+    })
+
+    it("omits obviously-internal image URLs from the list", async () => {
+      // A page embedding a metadata-endpoint <img> must not surface that URL into
+      // model context, even though read_url would later block the fetch itself.
+      const html = `<html><head><title>Gallery</title></head><body>
+        <img src="http://169.254.169.254/latest/meta-data/">
+        <img src="https://cdn.example.com/ok.png">
+      </body></html>`
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve(html),
+        } as Response)
+      ) as unknown as typeof fetch
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output } = await tool.config.execute({ url: "https://example.com/gallery" }, toolOpts)
+
+      expect(JSON.parse(output).images).toEqual(["https://cdn.example.com/ok.png"])
+    })
+
+    it("keeps a src value containing the opposite quote intact", async () => {
+      const html = `<html><head><title>T</title></head><body><img src="https://cdn.example.com/O'Reilly.png"></body></html>`
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "text/html" }),
+          text: () => Promise.resolve(html),
+        } as Response)
+      ) as unknown as typeof fetch
+
+      const tool = createReadUrlTool({ supportsVision: true })
+      const { output } = await tool.config.execute({ url: "https://example.com/p" }, toolOpts)
+
+      expect(JSON.parse(output).images).toEqual(["https://cdn.example.com/O'Reilly.png"])
     })
 
     it("omits the image list when the caller has no vision", async () => {

--- a/packages/agent-runtime/src/tools/read-url-tool.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.ts
@@ -24,11 +24,31 @@ export interface ReadUrlResult {
   url: string
   title: string
   content: string
+  /** Absolute URLs of images embedded in the page, surfaced for vision-capable
+   * callers to view via a follow-up read_url. Omitted when none/not applicable. */
+  images?: string[]
 }
 
 const MAX_CONTENT_LENGTH = 50000
 const FETCH_TIMEOUT_MS = 30000
 const MAX_REDIRECTS = 5
+
+// Image types Anthropic/OpenAI vision models accept natively.
+const SUPPORTED_IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+// A single image is capped near 5MB by the providers; stay under it.
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+// Cap the image-URL list so a media-heavy page can't flood the result.
+const MAX_IMAGE_URLS = 20
+
+export interface CreateReadUrlToolParams {
+  /**
+   * Whether the calling model can see images. When true, a URL that resolves to
+   * an image is fetched and returned as a multimodal image block (instead of
+   * being rejected), and HTML pages surface their embedded image URLs so the
+   * model can choose to view one. When false, images are reported as unreadable.
+   */
+  supportsVision?: boolean
+}
 
 const nhm = new NodeHtmlMarkdown()
 
@@ -201,12 +221,24 @@ async function fetchWithRedirectValidation(
   return response
 }
 
-export function createReadUrlTool() {
+export function createReadUrlTool(params: CreateReadUrlToolParams = {}) {
+  const { supportsVision = false } = params
+
+  // Vision-only guidance: only advertise image viewing to models that can see.
+  const imageDescription = supportsVision
+    ? " If the URL points directly at an image (PNG, JPEG, GIF, or WebP), the image itself is returned for you to view. " +
+      "When reading an HTML page, any images it embeds are listed under `images` as URLs you can read_url to view."
+    : ""
+  const imagePromptLine = supportsVision
+    ? "\n- To look at an image: pass an image URL directly (the image comes back for you to view), or read an HTML page and then read_url one of the image URLs listed under `images`"
+    : ""
+
   return defineAgentTool({
     name: "read_url",
     description:
       "Fetch and read the content of a web page or JSON resource. Use this after web_search when you need more detail than the snippet provides, or when the user shares a specific URL to analyze. " +
-      "HTML pages are returned as markdown. JSON is returned in full when small; when large, you instead get the data's `shape` (a schema sketch), a sampled `preview`, and a `hint` — then call again with `select` (e.g. '.data.items[0:20]') to drill into a specific part.",
+      "HTML pages are returned as markdown. JSON is returned in full when small; when large, you instead get the data's `shape` (a schema sketch), a sampled `preview`, and a `hint` — then call again with `select` (e.g. '.data.items[0:20]') to drill into a specific part." +
+      imageDescription,
     categories: TOOL_CATEGORIES_BY_NAME[AgentToolNames.READ_URL],
     promptBlock: `## Reading URLs
 
@@ -216,7 +248,7 @@ When to use read_url:
 - After web_search when you need more detail than the snippet provides
 - When the user shares a specific URL they want you to analyze
 - To verify information or get complete context from a source
-- To read JSON APIs: small responses come back in full. For large ones you get the data's \`shape\` (a schema sketch), a sampled \`preview\`, and a \`hint\` — then call read_url again with a \`select\` path (e.g. \`.data.items[0:20]\`, \`.results[3].name\`, \`.users[*].email\`) to drill into the part you need.`,
+- To read JSON APIs: small responses come back in full. For large ones you get the data's \`shape\` (a schema sketch), a sampled \`preview\`, and a \`hint\` — then call read_url again with a \`select\` path (e.g. \`.data.items[0:20]\`, \`.results[3].name\`, \`.users[*].email\`) to drill into the part you need.${imagePromptLine}`,
     inputSchema: ReadUrlSchema,
 
     execute: async (input): Promise<AgentToolResult> => {
@@ -254,7 +286,14 @@ When to use read_url:
         const contentType = (response.headers.get("content-type") || "").toLowerCase()
         const isHtml = contentType.includes("text/html")
         const isPlain = contentType.includes("text/plain")
+        const isImage = contentType.startsWith("image/")
         const declaresJson = /\bjson\b/.test(contentType) || contentType.includes("+json")
+
+        // A URL that resolves to an image: read it as a picture for vision-capable
+        // callers, otherwise report it as unreadable rather than dumping bytes.
+        if (isImage) {
+          return await readImageContent(response, input.url, contentType, supportsVision)
+        }
 
         if (!isHtml && !isPlain && !declaresJson) {
           return {
@@ -292,6 +331,12 @@ When to use read_url:
         }
 
         const readResult: ReadUrlResult = { url: input.url, title, content }
+        // Surface embedded image URLs only to vision-capable callers — they are
+        // useless noise to a model that can't then view them.
+        if (supportsVision && isHtml) {
+          const images = extractImageUrls(body, input.url)
+          if (images.length > 0) readResult.images = images
+        }
         logger.debug({ url: input.url, contentLength: content.length }, "URL read completed")
 
         const output = JSON.stringify(readResult)
@@ -352,6 +397,96 @@ When to use read_url:
 function extractTitle(html: string): string {
   const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
   return titleMatch?.[1]?.trim() || "Untitled"
+}
+
+/**
+ * Fetch a URL whose content type is an image and return it as a multimodal
+ * image block for vision-capable callers. Non-vision callers get an explanatory
+ * error; oversized or unsupported images are refused before they reach the model.
+ */
+async function readImageContent(
+  response: Response,
+  url: string,
+  contentType: string,
+  supportsVision: boolean
+): Promise<AgentToolResult> {
+  const mimeType = contentType.split(";")[0].trim()
+
+  if (!supportsVision) {
+    return {
+      output: JSON.stringify({
+        error: `This URL is an image (${mimeType}); the current model cannot view images, so it cannot be read.`,
+        url,
+      }),
+    }
+  }
+
+  if (!SUPPORTED_IMAGE_MIME_TYPES.includes(mimeType)) {
+    return {
+      output: JSON.stringify({
+        error: `Unsupported image type: ${mimeType}. Supported image types are PNG, JPEG, GIF, and WebP.`,
+        url,
+      }),
+    }
+  }
+
+  // Refuse an oversized image the server declares up front, before downloading it.
+  const declaredLength = Number(response.headers.get("content-length"))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+    return {
+      output: JSON.stringify({
+        error: `Image is too large (${declaredLength} bytes; max ${MAX_IMAGE_BYTES}).`,
+        url,
+      }),
+    }
+  }
+
+  const bytes = Buffer.from(await response.arrayBuffer())
+  if (bytes.length > MAX_IMAGE_BYTES) {
+    return {
+      output: JSON.stringify({
+        error: `Image is too large (${bytes.length} bytes; max ${MAX_IMAGE_BYTES}).`,
+        url,
+      }),
+    }
+  }
+
+  const dataUrl = `data:${mimeType};base64,${bytes.toString("base64")}`
+  logger.debug({ url, mimeType, byteSize: bytes.length }, "Image read for vision analysis")
+
+  return {
+    output: JSON.stringify({ url, kind: "image", mimeType, byteSize: bytes.length }),
+    multimodal: [{ type: "image", url: dataUrl }],
+    sources: [{ type: "web", title: url, url }],
+  }
+}
+
+/**
+ * Extract embedded image URLs from an HTML body, resolved to absolute http(s)
+ * URLs, deduped, and capped. Data-URI and non-http sources are skipped — the
+ * caller views these via a follow-up read_url, which only fetches over http(s).
+ */
+function extractImageUrls(html: string, baseUrl: string): string[] {
+  const urls: string[] = []
+  const seen = new Set<string>()
+  const re = /<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi
+  let match: RegExpExecArray | null
+  while ((match = re.exec(html)) !== null) {
+    const raw = match[1]?.trim()
+    if (!raw || raw.startsWith("data:")) continue
+    let resolved: string
+    try {
+      resolved = new URL(raw, baseUrl).toString()
+    } catch {
+      continue
+    }
+    if (!resolved.startsWith("http://") && !resolved.startsWith("https://")) continue
+    if (seen.has(resolved)) continue
+    seen.add(resolved)
+    urls.push(resolved)
+    if (urls.length >= MAX_IMAGE_URLS) break
+  }
+  return urls
 }
 
 type ParseJsonResult = { matched: true; value: unknown } | { matched: false } | { error: string }

--- a/packages/agent-runtime/src/tools/read-url-tool.ts
+++ b/packages/agent-runtime/src/tools/read-url-tool.ts
@@ -103,6 +103,37 @@ function isPrivateOrReservedIP(ip: string): boolean {
 }
 
 /**
+ * Synchronous host checks shared by the SSRF validator and the image-URL lister:
+ * literal internal hostnames and bare private/reserved IPs. Returns a block
+ * reason, or null when nothing obviously internal is detected (a DNS-based check
+ * still runs in validateUrlWithDns). Takes the raw URL hostname.
+ */
+function staticInternalHostReason(rawHostname: string): string | null {
+  // Normalize trailing dot for FQDN.
+  const hostname = rawHostname.toLowerCase().replace(/\.$/, "")
+  if (hostname === "localhost") {
+    return "Access to private or reserved IP addresses is not allowed."
+  }
+  if (
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".corp") ||
+    hostname.endsWith(".lan")
+  ) {
+    return "Access to internal hostnames is not allowed."
+  }
+
+  // Remove IPv6 brackets if present, then block bare private/reserved IPs.
+  const cleanHostname = hostname.replace(/^\[|\]$/g, "")
+  if (ipaddr.isValid(cleanHostname) && isPrivateOrReservedIP(cleanHostname)) {
+    return "Access to private or reserved IP addresses is not allowed."
+  }
+
+  return null
+}
+
+/**
  * Validate a URL for SSRF protection.
  * Returns error message if blocked, null if allowed.
  */
@@ -119,29 +150,16 @@ async function validateUrlWithDns(urlString: string): Promise<string | null> {
     return `Unsupported protocol: ${url.protocol}. Only HTTP and HTTPS are allowed.`
   }
 
-  // Block internal hostname patterns (normalize trailing dot for FQDN)
-  const hostname = url.hostname.toLowerCase().replace(/\.$/, "")
-  if (hostname === "localhost") {
-    return "Access to private or reserved IP addresses is not allowed."
-  }
-  if (
-    hostname.endsWith(".local") ||
-    hostname.endsWith(".internal") ||
-    hostname.endsWith(".localhost") ||
-    hostname.endsWith(".corp") ||
-    hostname.endsWith(".lan")
-  ) {
-    return "Access to internal hostnames is not allowed."
-  }
+  // Literal internal hostnames and bare private/reserved IPs (synchronous).
+  const staticReason = staticInternalHostReason(url.hostname)
+  if (staticReason) return staticReason
 
-  // Remove IPv6 brackets if present
-  const cleanHostname = hostname.replace(/^\[|\]$/g, "")
-
-  // Check if hostname is already an IP address
+  // A bare public IP needs no DNS resolution (and resolve4 would fail on it).
+  const cleanHostname = url.hostname
+    .toLowerCase()
+    .replace(/\.$/, "")
+    .replace(/^\[|\]$/g, "")
   if (ipaddr.isValid(cleanHostname)) {
-    if (isPrivateOrReservedIP(cleanHostname)) {
-      return "Access to private or reserved IP addresses is not allowed."
-    }
     return null
   }
 
@@ -454,10 +472,13 @@ async function readImageContent(
   const dataUrl = `data:${mimeType};base64,${bytes.toString("base64")}`
   logger.debug({ url, mimeType, byteSize: bytes.length }, "Image read for vision analysis")
 
+  // Prefer the filename for the source title; fall back to the full URL.
+  const title = new URL(url).pathname.split("/").pop() || url
+
   return {
     output: JSON.stringify({ url, kind: "image", mimeType, byteSize: bytes.length }),
     multimodal: [{ type: "image", url: dataUrl }],
-    sources: [{ type: "web", title: url, url }],
+    sources: [{ type: "web", title, url }],
   }
 }
 
@@ -469,18 +490,25 @@ async function readImageContent(
 function extractImageUrls(html: string, baseUrl: string): string[] {
   const urls: string[] = []
   const seen = new Set<string>()
-  const re = /<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/gi
+  // Match double- or single-quoted src separately so the delimiters are
+  // enforced and a value may contain the opposite quote (e.g. O'Reilly.png).
+  const re = /<img\b[^>]*?\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')/gi
   let match: RegExpExecArray | null
   while ((match = re.exec(html)) !== null) {
-    const raw = match[1]?.trim()
+    const raw = (match[1] ?? match[2])?.trim()
     if (!raw || raw.startsWith("data:")) continue
-    let resolved: string
+    let parsed: URL
     try {
-      resolved = new URL(raw, baseUrl).toString()
+      parsed = new URL(raw, baseUrl)
     } catch {
       continue
     }
-    if (!resolved.startsWith("http://") && !resolved.startsWith("https://")) continue
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") continue
+    // Don't surface obviously-internal URLs into model context — a follow-up
+    // read_url would reject them anyway (defense in depth against SSRF probes
+    // embedded in a page's <img> tags).
+    if (staticInternalHostReason(parsed.hostname)) continue
+    const resolved = parsed.toString()
     if (seen.has(resolved)) continue
     seen.add(resolved)
     urls.push(resolved)


### PR DESCRIPTION
## Problem

Agent personas couldn't actually *see* images — on the web or in Threa.

Two failure modes hid behind one symptom. When a user uploads an image, the `image-caption` pipeline (`apps/backend/src/features/attachments/image-caption/`) runs a vision model at upload time and stores a 1–2 sentence `summary`. `formatAttachmentDescription` (`apps/backend/src/features/agents/companion/prompt/message-format.ts:150`) injects that summary as **text** into the persona's context — so Ariadne was reading a caption, never the pixels. The tool that hands over the real bytes, `load_attachment`, exists and works, but was **not** in Ariadne's `enabledTools` (`built-in-agents.ts`). So "what's the exact value in this cell?" or "what's wrong with this screenshot?" — anything the caption didn't happen to capture — was unanswerable.

Web images were dropped entirely: `read_url` (`packages/agent-runtime/src/tools/read-url-tool.ts`) hard-rejected any `image/*` content type ("Unsupported content type") and `node-html-markdown` strips `<img>` tags, so images embedded in pages never surfaced.

## Solution

Feed real image bytes into the runtime's existing multimodal channel. `AgentToolResult.multimodal` already carries `{ type: "image"; url }` and the runtime injects it as a user-turn image block (`agent-runtime.ts` ~L679); `load_attachment` was already the working reference. This change extends that path to three surfaces, gated on the model's vision capability.

### How it works

1. **Images shared in Threa** — add `AgentToolNames.LOAD_ATTACHMENT` to Ariadne's `enabledTools`. `tool-set.ts:141` already gates it on `workspace && supportsVision`, and Ariadne runs `openrouter:anthropic/claude-sonnet-4.6` (`inputModalities: [text, image]`), so the tool now builds. She gets the attachment id from the `[Image: file (att_x)]` tag already in her context, so `load_attachment` alone is enough to view a conversation image.

2. **Image URLs on the web / pasted links** — `createReadUrlTool` takes `{ supportsVision }`. When set and the fetched `content-type` is `image/*`, `readImageContent` returns the bytes as a multimodal image block instead of rejecting them: restricted to PNG/JPEG/GIF/WebP (`SUPPORTED_IMAGE_MIME_TYPES`), capped at `MAX_IMAGE_BYTES` (5 MB — checked against the declared `content-length` first to avoid downloading an oversized body, then against actual bytes). The existing SSRF/DNS guards and redirect validation run unchanged before any of this.

3. **Images embedded in HTML pages** — for vision callers, `extractImageUrls` pulls `<img src>` values from the HTML, resolves them to absolute http(s) URLs, dedupes, and caps at `MAX_IMAGE_URLS` (20), returned under `ReadUrlResult.images`. The model then chooses to view one via a follow-up `read_url` (which only fetches over http(s); `data:` and non-http srcs are skipped).

`supportsVision` is wired through the companion tool-set (`createReadUrlTool({ supportsVision })`, derived from `modelRegistry.supportsVision(persona.model)`) and the enclave web tools.

### Key design decisions

**1. Gate everything on `supportsVision`.** A text-only persona gets the prior behavior — images reported unreadable, no `images` list — rather than wasted tokens or an error mid-turn. The companion already computed `supportsVision` for `load_attachment`; `read_url` reuses the same signal. Tool description and prompt prose are conditional on it, so a non-vision model isn't told it can view images.

**2. Return images as base64 data URLs, not raw provider URLs.** Mirrors `load_attachment`. Fetching the bytes ourselves keeps the SSRF guards in the loop and lets us enforce the size cap before the model ever sees the image, rather than trusting the provider to fetch an arbitrary URL.

**3. Surface embedded image URLs as text, not auto-injected images.** Auto-fetching every `<img>` on a page would blow context and cost. Listing the URLs and letting the agent pick one keeps it agent-driven and composes with surface #2 on a single path.

**4. Enclave `read_url` gets `supportsVision: true` unconditionally.** The enclave only serves e2e-capable personas (today only Ariadne, vision-capable) and already feeds images to its model via the ungated `load_attachment` (`apps/enclave/src/agent/attachment-tool.ts`). Threading a registry into the enclave just to re-derive a constant it already assumes elsewhere would be inconsistent; the comment records the assumption so both tools move together if a non-vision e2e persona is ever added.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/agent-runtime/src/tools/read-url-tool.ts` | `createReadUrlTool({ supportsVision })`; `readImageContent` (image/* → multimodal block, mime allowlist, 5 MB cap); `extractImageUrls` + `ReadUrlResult.images`; conditional description/prompt prose |
| `apps/backend/src/features/agents/built-in-agents.ts` | Add `LOAD_ATTACHMENT` to Ariadne's `enabledTools` |
| `apps/backend/src/features/agents/companion/tool-set.ts` | Pass `supportsVision` to `createReadUrlTool` |
| `apps/enclave/src/agent/tools.ts` | Build enclave `read_url` with `supportsVision: true` (rationale in comment) |
| `packages/agent-runtime/src/tools/read-url-tool.test.ts` | 6 new cases: image→multimodal, no-vision rejection, unsupported type, oversize-by-declared-length, embedded-URL listing, list omitted without vision |
| `apps/backend/src/features/agents/built-in-agents.test.ts` | Assert Ariadne's config keeps `LOAD_ATTACHMENT` |

## Out of scope (deliberate)

- **The `general_research` sub-loop stays `supportsVision: false`** (`persona-agent.ts:560`), matching the existing `load_attachment` treatment there — deep-research passes won't pull images, only top-level companion turns will. Easy to flip later.
- **No new `get_attachment`/`search_attachments` for Ariadne.** Reading a conversation image needs only the id already in context, so `load_attachment` alone covers the request without broadening her surface.
- **SVG and other image types remain unsupported** — limited to the four formats the providers accept natively.

## Test plan

- [x] `packages/agent-runtime` `bun test src/tools/read-url-tool.test.ts` — 42 pass (6 new)
- [x] `packages/agent-runtime` full suite — 205 pass
- [x] `apps/backend` `bun test src/features/agents/` — 295 pass
- [x] `apps/enclave` `bun test src/agent/tools.test.ts` — 6 pass
- [x] `tsc --noEmit` clean for agent-runtime, backend, enclave (also the full monorepo typecheck via the pre-push hook)
- [x] Self-review: caught `SourceItem` has no `domain` field (the multimodal source literal) and dropped it; the pre-existing read_url sources only compiled via an intermediate `const`
- [ ] Not manually exercised against a live model — covered by unit tests at the tool boundary (the runtime's multimodal injection is unchanged and already in production for `load_attachment`)

> Note: `apps/enclave` has 29 pre-existing failures in `createBackendCallbacks.pollMessages`, identical on a clean `origin/main` checkout and unrelated to this change.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8B2tbu4w5VDnYezHMETWa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784153388&installation_id=129946197&pr_number=958&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F958&signature=291fcd95f6a87228a4900f8b58f9a71874c85ee75c4fa11eefc2270556368e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->