### PR TITLE
feat(drafts): stage 4d — seal E2E draft attachments so they roam

### DIFF
--- a/apps/frontend/src/hooks/use-decrypted-draft-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-draft-content.test.ts
@@ -75,7 +75,7 @@ describe("useDecryptedDraftContent", () => {
 
   it("reports plaintext (with the body) for a non-E2E draft", () => {
     const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, plaintextDraft("hi"), undefined))
-    expect(result.current).toEqual({ status: "plaintext", contentJson: makeDoc("hi") })
+    expect(result.current).toEqual({ status: "plaintext", contentJson: makeDoc("hi"), attachments: [] })
   })
 
   it("reports locked for a sealed draft while the session is locked", () => {
@@ -87,7 +87,22 @@ describe("useDecryptedDraftContent", () => {
   it("reports decrypted (with the body) when the shared cache already holds the plaintext", () => {
     seedDecryption("draft_e", { contentMarkdown: "secret", contentJson: makeDoc("secret") })
     const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), rootStreamId))
-    expect(result.current).toEqual({ status: "decrypted", contentJson: makeDoc("secret") })
+    expect(result.current).toEqual({ status: "decrypted", contentJson: makeDoc("secret"), attachments: [] })
+  })
+
+  it("surfaces attachments recovered from the decrypted refs (Stage 4d)", () => {
+    seedDecryption("draft_e", {
+      contentMarkdown: "secret",
+      contentJson: makeDoc("secret"),
+      attachmentRefs: [
+        { attachmentId: "att_1", key: "k", iv: "i", filename: "doc.pdf", mimeType: "application/pdf", sizeBytes: 42 },
+      ],
+      sources: [],
+    })
+    const { result } = renderHook(() => useDecryptedDraftContent(workspaceId, sealedDraft(), rootStreamId))
+    expect(result.current.attachments).toEqual([
+      { id: "att_1", filename: "doc.pdf", mimeType: "application/pdf", sizeBytes: 42 },
+    ])
   })
 
   it("reports pending while unlocked but the encrypted root isn't known yet (no decrypt fired)", () => {

--- a/apps/frontend/src/hooks/use-draft-composer.test.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.test.ts
@@ -751,6 +751,24 @@ describe("useDraftComposer", () => {
       expect(result.current.content).toEqual(EMPTY_DOC)
     })
 
+    it("hydrates an attachment-only sealed draft's chips when they decrypt after unlock (Stage 4d)", () => {
+      // Locked at mount: an E2E draft with files but an empty body resolves no body
+      // and no attachments. On unlock its attachments decrypt and must late-hydrate
+      // even though there is no body to fill into the editor.
+      mockDraftIsLoaded = true
+      mockDraftContentJson = EMPTY_DOC
+      mockDraftAttachments = []
+      const { rerender } = renderHook(() => useDraftComposer({ workspaceId, draftKey, scopeId }))
+      expect(mockRestoreAttachments).not.toHaveBeenCalled()
+
+      // Unlock + decrypt: the attachment metadata becomes available (still no body).
+      const attachment = { id: "att_1", filename: "secret.pdf", mimeType: "application/pdf", sizeBytes: 1234 }
+      mockDraftAttachments = [attachment]
+      rerender()
+
+      expect(mockRestoreAttachments).toHaveBeenCalledWith([attachment])
+    })
+
     it("does not clobber typed content when a deferred (decrypting) draft body lands after the user types", () => {
       // Repro of the staging data-loss bug: restore an E2E draft whose sealed body
       // is still decrypting. `isDraftLoaded` stays false, so the one-shot init is

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -170,6 +170,12 @@ export function useDraftComposer({
   // rather than a value captured in a stale closure.
   const contentRef = useRef(content)
   contentRef.current = content
+  // Latest decrypted attachments, read by the late-hydrate effect without making
+  // them a dependency: `savedAttachments` is a fresh array each render (it maps
+  // decrypted refs), so depending on it would re-run the body late-hydrate every
+  // render and misfire its rising-edge tracking.
+  const savedAttachmentsRef = useRef(savedAttachments)
+  savedAttachmentsRef.current = savedAttachments
 
   // Persist the live editor content into the loaded draft row immediately
   // (sealed for E2E), but ONLY when it is non-empty. A stash/restore can fire
@@ -238,6 +244,19 @@ export function useDraftComposer({
     }
   }, [scopeId, isDraftLoaded, savedDraft, savedAttachments, restoreAttachments, resetForReinit])
 
+  // Restore the loaded draft's (decrypted) attachments alongside its body when the
+  // body late-hydrates. A sealed E2E draft's attachments become readable only once
+  // it decrypts (Stage 4d), so the unlock-after-open path that re-fills the body
+  // must re-fill the attachment chips too — they decrypt together. A no-op when
+  // there are none, so a body-only draft never clears an in-flight upload. Marks
+  // them restored so the persistence effect doesn't re-seal what we just read back.
+  const hydrateAttachments = useCallback(() => {
+    const attachments = savedAttachmentsRef.current
+    if (attachments.length === 0) return
+    restoredAttachmentIdsRef.current = new Set(attachments.map((a) => a.id))
+    restoreAttachments(attachments)
+  }, [restoreAttachments])
+
   // Late hydrate: the loaded draft's body can become available AFTER the one-shot
   // init above already ran — an E2E draft that was locked or still decrypting at
   // mount (unlock/decrypt lands later), or a stash/restore pointer move that swaps
@@ -260,13 +279,15 @@ export function useDraftComposer({
     if (!isDraftLoaded || userEngagedRef.current || !savedAvailable) return
     if (awaitingRehydrateRef.current) {
       setContent(savedDraft)
+      hydrateAttachments()
       awaitingRehydrateRef.current = false
       return
     }
     if (becameAvailable && !hasDocContent(content)) {
       setContent(savedDraft)
+      hydrateAttachments()
     }
-  }, [isDraftLoaded, savedDraft, content])
+  }, [isDraftLoaded, savedDraft, content, hydrateAttachments])
 
   // Blank the editor the moment the loaded draft is removed underneath the
   // composer: sent/resolved here, or discarded/resolved on another device (its

--- a/apps/frontend/src/hooks/use-draft-composer.ts
+++ b/apps/frontend/src/hooks/use-draft-composer.ts
@@ -257,37 +257,48 @@ export function useDraftComposer({
     restoreAttachments(attachments)
   }, [restoreAttachments])
 
-  // Late hydrate: the loaded draft's body can become available AFTER the one-shot
-  // init above already ran — an E2E draft that was locked or still decrypting at
-  // mount (unlock/decrypt lands later), or a stash/restore pointer move that swaps
-  // in a different draft whose body decrypts on a later tick. When that body lands
-  // and the user hasn't engaged with the editor, drop it in.
+  // Late hydrate: the loaded draft's body/attachments can become available AFTER
+  // the one-shot init above already ran — an E2E draft that was locked or still
+  // decrypting at mount (unlock/decrypt lands later), or a stash/restore pointer
+  // move that swaps in a different draft whose body decrypts on a later tick. When
+  // it lands and the user hasn't engaged with the editor, drop it in.
   //
   // `userEngagedRef` is the real guard: it flips true on the first keystroke, so
   // this never overwrites typed content. The two apply paths are deliberately
   // narrow so a SEND/clear (which empties the editor) can't trigger a re-fill:
   //  - explicit rehydrate (scope change / stash-restore): override transient
   //    content once, even across a pending decrypt (`awaitingRehydrateRef`).
-  //  - unlock/late-decrypt: apply only on the RISING edge of body-availability
-  //    (the body just became available) into a still-empty editor. A send clears
-  //    the editor while `savedDraft` briefly lags non-empty — that's a falling
-  //    edge / no edge, so it never re-fills the just-sent content.
+  //  - unlock/late-decrypt: apply only on the RISING edge of availability (body or
+  //    attachments just became available) into a still-empty editor. A send clears
+  //    the editor AND empties the decrypted attachments, so that's a falling edge /
+  //    no edge and it never re-fills the just-sent content.
+  //
+  // Availability tracks body OR attachments so an attachment-only sealed draft
+  // (empty body, files attached) hydrates its chips on unlock too; `setContent` is
+  // still gated on the body being present so an empty body never blanks the editor.
+  // A stable key over the loaded draft's attachment ids: it only changes when the
+  // set does, so it can drive the effect below (the `savedAttachments` array itself
+  // is a fresh identity every render and would re-run it constantly). This is what
+  // lets an attachment-only sealed draft — whose body never changes from empty —
+  // re-run the effect when its attachments decrypt in.
+  const savedAttachmentIds = savedAttachments.map((a) => a.id).join(",")
   useEffect(() => {
-    const savedAvailable = hasDocContent(savedDraft)
+    const savedBodyAvailable = hasDocContent(savedDraft)
+    const savedAvailable = savedBodyAvailable || savedAttachmentsRef.current.length > 0
     const becameAvailable = savedAvailable && !prevSavedAvailableRef.current
     prevSavedAvailableRef.current = savedAvailable
     if (!isDraftLoaded || userEngagedRef.current || !savedAvailable) return
     if (awaitingRehydrateRef.current) {
-      setContent(savedDraft)
+      if (savedBodyAvailable) setContent(savedDraft)
       hydrateAttachments()
       awaitingRehydrateRef.current = false
       return
     }
     if (becameAvailable && !hasDocContent(content)) {
-      setContent(savedDraft)
+      if (savedBodyAvailable) setContent(savedDraft)
       hydrateAttachments()
     }
-  }, [isDraftLoaded, savedDraft, content, hydrateAttachments])
+  }, [isDraftLoaded, savedDraft, savedAttachmentIds, content, hydrateAttachments])
 
   // Blank the editor the moment the loaded draft is removed underneath the
   // composer: sent/resolved here, or discarded/resolved on another device (its

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -454,6 +454,7 @@ describe("useDraftMessage", () => {
         envelope: { v: 2 },
         e2eVersion: 2,
         contentMarkdown: "top secret",
+        attachmentRefs: [],
       })
 
       const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
@@ -512,6 +513,7 @@ describe("useDraftMessage", () => {
         envelope: { v: 2 },
         e2eVersion: 2,
         contentMarkdown: "x",
+        attachmentRefs: [],
       })
       await seedDraftCacheFromIdb(workspaceId)
 
@@ -545,6 +547,156 @@ describe("useDraftMessage", () => {
 
       expect(sealSpy).not.toHaveBeenCalled()
       expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+    })
+
+    // Stage 4d — attachments roam sealed inside the body's ciphertext.
+    describe("attachments (Stage 4d)", () => {
+      const ref = (id: string, filename: string, sizeBytes: number) => ({
+        attachmentId: id,
+        key: "AAAA",
+        iv: "BBBB",
+        filename,
+        mimeType: "text/plain",
+        sizeBytes,
+      })
+      const sealMock = (attachmentRefs: ReturnType<typeof ref>[] = []) =>
+        vi.spyOn(sealDraft, "sealDraftContent").mockResolvedValue({
+          ciphertext: "ct",
+          envelope: { v: 2 },
+          e2eVersion: 2,
+          contentMarkdown: "body",
+          attachmentRefs,
+        })
+
+      it("seals the attachment ids into the body (passes attachmentIds to the seal, never at rest)", async () => {
+        const sealSpy = sealMock()
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+        const attachment = { id: "att_1", filename: "f.txt", mimeType: "text/plain", sizeBytes: 10 }
+
+        await act(async () => {
+          await result.current.saveDraft(makeDoc("body"), [attachment])
+        })
+
+        expect(sealSpy).toHaveBeenCalledWith(expect.objectContaining({ attachmentIds: ["att_1"] }))
+        // E2EE-4: the plaintext attachment linkage never lands on disk.
+        const persisted = await loadedDraft(draftKey)
+        expect(persisted?.attachments).toEqual([])
+      })
+
+      it("surfaces decrypted attachments recovered from the refs, not the empty at-rest row", async () => {
+        await putSealedLoaded("draft_sealed")
+        seedDecryption("draft_sealed", {
+          contentMarkdown: "hi",
+          contentJson: makeDoc("hi"),
+          attachmentRefs: [ref("att_7", "p.pdf", 99)],
+          sources: [],
+        })
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+
+        await waitFor(() => expect(result.current.isLoaded).toBe(true))
+        expect(result.current.attachments).toEqual([
+          { id: "att_7", filename: "p.pdf", mimeType: "text/plain", sizeBytes: 99 },
+        ])
+      })
+
+      it("addAttachment re-seals with the new attachment, reading the body from the decrypt cache", async () => {
+        await putSealedLoaded("draft_sealed")
+        seedDecryption("draft_sealed", {
+          contentMarkdown: "hi",
+          contentJson: makeDoc("hi"),
+          attachmentRefs: [],
+          sources: [],
+        })
+        const sealSpy = sealMock([ref("att_9", "a.png", 5)])
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+        await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+        await act(async () => {
+          await result.current.addAttachment({ id: "att_9", filename: "a.png", mimeType: "image/png", sizeBytes: 5 })
+        })
+
+        expect(sealSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ contentJson: makeDoc("hi"), attachmentIds: ["att_9"] })
+        )
+      })
+
+      it("a content-only save preserves the draft's already-sealed attachments", async () => {
+        await putSealedLoaded("draft_sealed")
+        seedDecryption("draft_sealed", {
+          contentMarkdown: "old",
+          contentJson: makeDoc("old"),
+          attachmentRefs: [ref("att_3", "x.txt", 3)],
+          sources: [],
+        })
+        const sealSpy = sealMock([ref("att_3", "x.txt", 3)])
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+        await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+        // A keystroke save carries no attachments arg — the sealed set must survive.
+        await act(async () => {
+          await result.current.saveDraft(makeDoc("new"))
+        })
+
+        expect(sealSpy).toHaveBeenCalledWith(expect.objectContaining({ attachmentIds: ["att_3"] }))
+      })
+
+      it("removeAttachment re-seals without the removed id", async () => {
+        await putSealedLoaded("draft_sealed")
+        seedDecryption("draft_sealed", {
+          contentMarkdown: "body",
+          contentJson: makeDoc("body"),
+          attachmentRefs: [ref("att_a", "a", 1), ref("att_b", "b", 1)],
+          sources: [],
+        })
+        const sealSpy = sealMock([ref("att_b", "b", 1)])
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+        await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+        await act(async () => {
+          await result.current.removeAttachment("att_a")
+        })
+
+        expect(sealSpy).toHaveBeenCalledWith(expect.objectContaining({ attachmentIds: ["att_b"] }))
+      })
+
+      it("removeAttachment clears the draft when it leaves no body and no attachments", async () => {
+        await putSealedLoaded("draft_sealed")
+        seedDecryption("draft_sealed", {
+          contentMarkdown: "",
+          contentJson: EMPTY_DOC,
+          attachmentRefs: [ref("att_only", "only", 1)],
+          sources: [],
+        })
+        const sealSpy = sealMock()
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+        await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+        await act(async () => {
+          await result.current.removeAttachment("att_only")
+        })
+
+        expect(sealSpy).not.toHaveBeenCalled()
+        expect(await loadedDraft(draftKey)).toBeUndefined()
+      })
+
+      it("does not persist an attachment while the session is locked (E2EE-4)", async () => {
+        vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+        const sealSpy = vi.spyOn(sealDraft, "sealDraftContent")
+
+        const { result } = renderHook(() => useDraftMessage(workspaceId, draftKey, e2eStreamId))
+
+        await act(async () => {
+          await result.current.addAttachment({ id: "att_x", filename: "x", mimeType: "text/plain", sizeBytes: 1 })
+        })
+
+        expect(sealSpy).not.toHaveBeenCalled()
+        expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+      })
     })
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -16,8 +16,9 @@ import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/typ
 import { serializeToMarkdown } from "@threa/prosemirror"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { sealDraftContent } from "@/lib/crypto/seal-draft"
+import { sealDraftContent, type SealedDraftFields } from "@/lib/crypto/seal-draft"
 import { invalidateDecryption, seedDecryption } from "@/lib/crypto/decrypt-cache"
+import { cachedDraftAttachments, cachedDraftBody } from "@/lib/drafts/decryption"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { useDecryptedDraftContent } from "./use-decrypted-draft-content"
 
@@ -70,8 +71,12 @@ export interface DraftSealContext {
  * decrypted, so without it the SECOND edit would be ignored and a remount would
  * render the first edit's body. The seed is dropped with every other entry on lock.
  *
- * v1 seals the body only — attachments / context refs on E2E drafts stay
- * session-local — so the seal path doesn't carry them.
+ * Stage 4d: the seal carries the draft's attachments — their per-file
+ * key/iv/filename ride sealed inside `ciphertext` (as `attachmentRefs`), exactly
+ * as a message's do, so attachments roam with the body. The plaintext attachment
+ * linkage never lands on disk (`attachments` stays `[]` at rest, E2EE-4); the
+ * composer reads it back from the seeded/decrypted cache. (Context refs stay
+ * session-local — deferred.)
  */
 export async function upsertLoadedDraft(
   workspaceId: string,
@@ -86,6 +91,9 @@ export async function upsertLoadedDraft(
   const id = existing?.id ?? generateLocalDraftId()
 
   let row: CachedDraft
+  // The attachment refs the seal embedded — re-seeded into the decrypt cache
+  // below so the composer reads attachments back without a self-decrypt.
+  let sealedAttachmentRefs: SealedDraftFields["attachmentRefs"] = []
   if (seal) {
     const sealed = await sealDraftContent({
       workspaceId,
@@ -93,16 +101,17 @@ export async function upsertLoadedDraft(
       streamId: seal.streamId,
       draftId: id,
       contentJson: fields.contentJson,
+      attachmentIds: fields.attachments.map((a) => a.id),
     })
     row = {
       id,
       workspaceId,
       scope,
-      // E2EE-4: the plaintext never lands on disk — the sealed body is the
-      // at-rest copy and `contentJson` is only the empty placeholder. v1 seals
-      // the body only and does not carry attachments, so `attachmentIds` is left
-      // off too — an E2E row must not ship plaintext attachment linkage to the
-      // server/disk alongside its sealed body.
+      // E2EE-4: neither the plaintext body nor the plaintext attachment linkage
+      // lands on disk — the sealed `ciphertext` is the at-rest copy of both (the
+      // attachment key/iv/filename ride inside it as `attachmentRefs`), and
+      // `contentJson`/`attachments` are only empty placeholders. The composer
+      // reads body + attachments back from the seeded/decrypted in-memory cache.
       contentJson: EMPTY_DOC,
       attachments: [],
       clientUpdatedAt: Date.now(),
@@ -111,6 +120,7 @@ export async function upsertLoadedDraft(
       envelope: sealed.envelope,
       e2eVersion: sealed.e2eVersion,
     }
+    sealedAttachmentRefs = sealed.attachmentRefs
   } else {
     const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
     row = {
@@ -148,13 +158,15 @@ export async function upsertLoadedDraft(
 
   if (seal) {
     // Keep the read path serving the live plaintext (see the doc comment above):
-    // invalidate the reused id's stale entry, then seed the fresh body so the
-    // next decrypt-on-read (and any remount) serves THIS edit, not a prior one.
+    // invalidate the reused id's stale entry, then seed the fresh body AND the
+    // attachment refs just sealed, so the next decrypt-on-read (and any remount)
+    // serves THIS edit's body + attachments, not a prior one. The refs carry the
+    // filename/mime/size the composer renders and the key/iv a later send re-seals.
     invalidateDecryption(id)
     seedDecryption(id, {
       contentMarkdown: serializeToMarkdown(fields.contentJson),
       contentJson: fields.contentJson,
-      attachmentRefs: [],
+      attachmentRefs: sealedAttachmentRefs,
       sources: [],
     })
   }
@@ -330,7 +342,8 @@ export async function rescopeScopeDrafts(workspaceId: string, fromScope: string,
  *   on read through the shared decrypt cache (the same path messages use), which
  *   retries on unlock and clears on lock. While the session is locked the read
  *   reports `locked` and the composer shows the encryption notice; the sealed row
- *   waits on disk. Attachments / context refs on E2E drafts stay session-local.
+ *   waits on disk. Attachments roam sealed inside the body's ciphertext (Stage 4d);
+ *   context refs on E2E drafts stay session-local (deferred).
  */
 export function useDraftMessage(workspaceId: string, draftKey: string, e2eStreamId?: string | null) {
   const e2eEnabled = !!e2eStreamId
@@ -392,10 +405,16 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       const gate = e2eGateRef.current
       if (gate.enabled) {
         // E2EE-4: seal before disk, and only while unlocked. Locked → keep the
-        // content in the composer for the session; nothing persists. v1 seals the
-        // body only, so an `attachments` arg is intentionally ignored here.
+        // content in the composer for the session; nothing persists.
         if (!gate.unlocked || !gate.senderId || !gate.streamId) return
-        if (isEmptyContent(contentJson)) {
+        // Resolve the attachment set: an explicit arg, else the draft's current
+        // (decrypted) attachments — a content-only save (a keystroke) must
+        // preserve them, exactly as the plaintext path preserves them below. The
+        // sealed row holds no plaintext attachments at rest, so they're read back
+        // from the in-memory decrypt cache (the plaintext authority).
+        const currentLoadedId = await getLoadedDraftId(draftKey)
+        const finalAttachments = attachments ?? (currentLoadedId ? cachedDraftAttachments(currentLoadedId) : [])
+        if (isEmptyContent(contentJson) && finalAttachments.length === 0) {
           await clearLoadedDraft(workspaceId, draftKey)
           syncEngine?.kickOperationQueue()
           return
@@ -404,7 +423,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
           await upsertLoadedDraft(
             workspaceId,
             draftKey,
-            { contentJson, attachments: [] },
+            { contentJson, attachments: finalAttachments },
             { senderId: gate.senderId, streamId: gate.streamId }
           )
           syncEngine?.kickOperationQueue()
@@ -464,9 +483,31 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
    */
   const addAttachment = useCallback(
     async (attachment: DraftAttachment) => {
-      // E2EE-4: attachments on encrypted-stream drafts are not sealed yet (v1) —
-      // they stay in the composer session and are not persisted to the draft.
-      if (e2eEnabled) return
+      if (e2eEnabled) {
+        // E2EE-4: re-seal the draft with the added attachment. The body + current
+        // attachments are the decrypted copy in memory (the row holds only
+        // ciphertext at rest); seal both together so the attachment's key/iv ride
+        // inside the body's ciphertext (Stage 4d). Locked → can't seal; the
+        // attachment stays in the composer session, like a typed body would.
+        const gate = e2eGateRef.current
+        if (!gate.unlocked || !gate.senderId || !gate.streamId) return
+        const sealedLoadedId = await getLoadedDraftId(draftKey)
+        const currentSealed = sealedLoadedId ? cachedDraftAttachments(sealedLoadedId) : []
+        if (currentSealed.some((a) => a.id === attachment.id)) return
+        const body = (sealedLoadedId ? cachedDraftBody(sealedLoadedId) : null) ?? EMPTY_DOC
+        try {
+          await upsertLoadedDraft(
+            workspaceId,
+            draftKey,
+            { contentJson: body, attachments: [...currentSealed, attachment] },
+            { senderId: gate.senderId, streamId: gate.streamId }
+          )
+          syncEngine?.kickOperationQueue()
+        } catch (err) {
+          console.error("Failed to seal draft attachment; kept in composer", err)
+        }
+        return
+      }
       const currentLoadedId = await getLoadedDraftId(draftKey)
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       const currentAttachments = currentDraft?.attachments ?? []
@@ -493,7 +534,34 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
    */
   const removeAttachment = useCallback(
     async (attachmentId: string) => {
-      if (e2eEnabled) return
+      if (e2eEnabled) {
+        // E2EE-4: re-seal without the removed attachment (or clear when the draft
+        // is left empty). Reads body + attachments from the in-memory decrypt
+        // cache for the same reason `addAttachment` does. Locked → no-op.
+        const gate = e2eGateRef.current
+        if (!gate.unlocked || !gate.senderId || !gate.streamId) return
+        const sealedLoadedId = await getLoadedDraftId(draftKey)
+        if (!sealedLoadedId) return
+        const remaining = cachedDraftAttachments(sealedLoadedId).filter((a) => a.id !== attachmentId)
+        const body = cachedDraftBody(sealedLoadedId) ?? EMPTY_DOC
+        if (isEmptyContent(body) && remaining.length === 0) {
+          await clearLoadedDraft(workspaceId, draftKey)
+          syncEngine?.kickOperationQueue()
+          return
+        }
+        try {
+          await upsertLoadedDraft(
+            workspaceId,
+            draftKey,
+            { contentJson: body, attachments: remaining },
+            { senderId: gate.senderId, streamId: gate.streamId }
+          )
+          syncEngine?.kickOperationQueue()
+        } catch (err) {
+          console.error("Failed to re-seal draft after attachment removal; kept in composer", err)
+        }
+        return
+      }
       const currentLoadedId = await getLoadedDraftId(draftKey)
       const currentDraft = currentLoadedId ? await db.drafts.get(currentLoadedId) : undefined
       if (!currentDraft) return
@@ -574,7 +642,10 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
      */
     loadedDraftId: loadedId,
     contentJson,
-    attachments: resolvedDraft?.attachments ?? [],
+    // Attachments come from the shared read path: a plaintext draft's own
+    // `attachments`, or — for a sealed draft — the metadata recovered from the
+    // decrypted `attachmentRefs` (empty while locked/decrypting, like the body).
+    attachments: decryptedContent.attachments,
     /** Sidecar context refs attached to the draft (see DraftContextRef). */
     contextRefs: (resolvedDraft?.contextRefs ?? []) as DraftContextRef[],
     saveDraft,

--- a/apps/frontend/src/lib/crypto/seal-draft.test.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.test.ts
@@ -3,6 +3,7 @@ import { parseMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
 import { sealDraftContent } from "./seal-draft"
 import { tryDecryptMessagePayload } from "./message-envelope"
+import { clearAttachmentRefCache, rememberAttachmentRef } from "./attachment-crypto"
 import * as sessionStore from "@/stores/e2e-session-store"
 import * as streamKeyCache from "./stream-key-cache"
 
@@ -31,6 +32,7 @@ const unlockedSession = {
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  clearAttachmentRefCache()
 })
 
 describe("seal-draft", () => {
@@ -63,6 +65,52 @@ describe("seal-draft", () => {
       }
     )
     expect(opened?.contentJson).toEqual(parseMarkdown("hello e2e world"))
+  })
+
+  it("seals attachment refs into the body and recovers them on decrypt (Stage 4d)", async () => {
+    vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(unlockedSession)
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })
+    vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(ssk)
+
+    // The per-file key/iv were minted at upload and live in the in-memory ref
+    // cache; the seal pulls them in by id (the same path messages use).
+    rememberAttachmentRef({
+      attachmentId: "att_1",
+      key: "a2V5",
+      iv: "aXY=",
+      filename: "secret.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1234,
+    })
+
+    const sealed = await sealDraftContent({
+      workspaceId,
+      senderId,
+      streamId,
+      draftId,
+      contentJson: makeDoc("body with a file"),
+      attachmentIds: ["att_1"],
+    })
+    expect(sealed.attachmentRefs).toHaveLength(1)
+
+    // The refs ride inside the SSK ciphertext — never on the wire — and come back
+    // on decrypt so the receiving device can render + fetch + re-seal the file.
+    const opened = await tryDecryptMessagePayload(
+      { contentMarkdown: "", ciphertext: sealed.ciphertext, envelope: sealed.envelope, e2eVersion: sealed.e2eVersion },
+      {
+        privateKey: unlockedSession.privateKey!,
+        recipientKeyId: unlockedSession.keyId!,
+        workspaceId,
+        streamId,
+        rootStreamId: streamId,
+      }
+    )
+    expect(opened?.contentJson).toEqual(parseMarkdown("body with a file"))
+    expect(opened?.attachmentRefs?.[0]).toMatchObject({
+      attachmentId: "att_1",
+      filename: "secret.pdf",
+      sizeBytes: 1234,
+    })
   })
 
   it("throws when the session is locked (the caller keeps content in the composer)", async () => {

--- a/apps/frontend/src/lib/crypto/seal-draft.test.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.test.ts
@@ -106,11 +106,18 @@ describe("seal-draft", () => {
       }
     )
     expect(opened?.contentJson).toEqual(parseMarkdown("body with a file"))
-    expect(opened?.attachmentRefs?.[0]).toMatchObject({
-      attachmentId: "att_1",
-      filename: "secret.pdf",
-      sizeBytes: 1234,
-    })
+    // The full ref must round-trip — display metadata AND the per-file crypto
+    // material (key/iv), which is what makes a roamed attachment viewable/sendable.
+    expect(opened?.attachmentRefs).toEqual([
+      {
+        attachmentId: "att_1",
+        key: "a2V5",
+        iv: "aXY=",
+        filename: "secret.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1234,
+      },
+    ])
   })
 
   it("throws when the session is locked (the caller keeps content in the composer)", async () => {

--- a/apps/frontend/src/lib/crypto/seal-draft.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.ts
@@ -1,32 +1,41 @@
 import { serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
+import type { AttachmentRef } from "@threa/crypto"
 import { sealOutgoingMessage } from "./seal-send"
 
 /** The E2E triple persisted at rest in place of a draft's plaintext (E2EE-4),
- * plus the markdown that was sealed (so callers can seed the decrypt cache with
- * the just-authored plaintext without re-serializing). */
+ * plus the markdown + attachment refs that were sealed (so callers can seed the
+ * decrypt cache with the just-authored plaintext without re-decrypting). */
 export interface SealedDraftFields {
   ciphertext: string
   envelope: unknown
   e2eVersion: number
   contentMarkdown: string
+  /** Per-attachment key/iv/filename sealed into the body (Stage 4d). Empty when
+   * the draft has no attachments. Plaintext only — never persisted at rest. */
+  attachmentRefs: AttachmentRef[]
 }
 
 /**
- * Seal a draft body to the stream's SSK so an encrypted-stream draft roams
- * across the author's devices without plaintext ever touching disk or wire
- * (E2EE-4). Reuses the message seal path (INV-35): the draft id binds the AAD in
- * the `messageId` slot exactly as a message id would, so a sealed draft is
- * indistinguishable on the wire from a sealed message and opens the same way —
- * decrypt-on-read goes through the shared `decrypt-cache` (`tryDecryptMessagePayload`).
+ * Seal a draft body (and its attachments) to the stream's SSK so an
+ * encrypted-stream draft roams across the author's devices without plaintext
+ * ever touching disk or wire (E2EE-4). Reuses the message seal path (INV-35):
+ * the draft id binds the AAD in the `messageId` slot exactly as a message id
+ * would, so a sealed draft is indistinguishable on the wire from a sealed
+ * message and opens the same way — decrypt-on-read goes through the shared
+ * `decrypt-cache` (`tryDecryptMessagePayload`).
  *
- * v1 seals the body only — attachments / context refs / slash commands on E2E
- * drafts are not yet sealed (they stay session-local), so no `attachmentIds` are
- * passed and the payload is bare markdown.
+ * Stage 4d seals attachments alongside the body: their per-file key/iv/filename
+ * ride inside the SSK ciphertext (as `attachmentRefs`) exactly as a message's
+ * do, so a roamed draft's attachments decrypt + send on the receiving device.
+ * The plaintext attachment linkage never lands on disk or the wire — only the
+ * opaque ciphertext does. (Context refs / slash commands remain session-local —
+ * their own design, deferred.)
  *
- * Throws (locked session, missing SSK) the same way `sealOutgoingMessage` does;
- * the caller treats a throw as "can't persist right now" and keeps the content
- * in the composer for the session — drafts never surface a save error.
+ * Throws (locked session, missing SSK, an attachment key lost on reload) the
+ * same way `sealOutgoingMessage` does; the caller treats a throw as "can't
+ * persist right now" and keeps the content in the composer for the session —
+ * drafts never surface a save error.
  */
 export async function sealDraftContent(input: {
   workspaceId: string
@@ -35,19 +44,23 @@ export async function sealDraftContent(input: {
   streamId: string
   draftId: string
   contentJson: JSONContent
+  /** Server ids of the draft's E2E attachments — sealed into the body (Stage 4d). */
+  attachmentIds?: string[]
 }): Promise<SealedDraftFields> {
   const contentMarkdown = serializeToMarkdown(input.contentJson)
-  const { e2eFields } = await sealOutgoingMessage({
+  const { e2eFields, attachmentRefs } = await sealOutgoingMessage({
     workspaceId: input.workspaceId,
     senderId: input.senderId,
     streamId: input.streamId,
     messageId: input.draftId,
     contentMarkdown,
+    attachmentIds: input.attachmentIds,
   })
   return {
     ciphertext: e2eFields.ciphertext,
     envelope: e2eFields.envelope,
     e2eVersion: e2eFields.e2eVersion,
     contentMarkdown,
+    attachmentRefs: attachmentRefs ?? [],
   }
 }

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -1,7 +1,9 @@
 import { serializeToMarkdown } from "@threa/prosemirror"
 import type { JSONContent } from "@threa/types"
-import type { CachedDraft } from "@/db"
+import type { AttachmentRef } from "@threa/crypto"
+import type { CachedDraft, DraftAttachment } from "@/db"
 import { getCachedDecryption, requestDecryption, type DecryptCacheEntry } from "@/lib/crypto/decrypt-cache"
+import { rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import type { useE2eSession } from "@/stores/e2e-session-store"
@@ -21,6 +23,19 @@ export interface DraftDecryption {
   status: DraftDecryptionStatus
   /** The plaintext body for plaintext/decrypted; null while none/locked/pending/failed. */
   contentJson: JSONContent | null
+  /**
+   * The draft's attachments (Stage 4d): a plaintext draft's `attachments` as-is,
+   * or — for a sealed draft — the display metadata recovered from the decrypted
+   * `attachmentRefs`. Empty while none/locked/pending/failed, so the composer
+   * shows attachment chips only once the body is readable (E2EE-4: the real
+   * filename rides sealed, never at rest).
+   */
+  attachments: DraftAttachment[]
+}
+
+/** Project a decrypted attachment ref onto the composer's display shape. */
+function attachmentFromRef(ref: AttachmentRef): DraftAttachment {
+  return { id: ref.attachmentId, filename: ref.filename, mimeType: ref.mimeType, sizeBytes: ref.sizeBytes }
 }
 
 /** A session that can actually open sealed content (unlocked, keys present). */
@@ -38,19 +53,31 @@ export function resolveDraftDecryption(
   unlocked: boolean,
   cached: DecryptCacheEntry | undefined
 ): DraftDecryption {
-  if (!draft) return { status: "none", contentJson: null }
-  if (draft.ciphertext == null) return { status: "plaintext", contentJson: draft.contentJson ?? null }
-  if (!unlocked) return { status: "locked", contentJson: null }
+  if (!draft) return { status: "none", contentJson: null, attachments: [] }
+  if (draft.ciphertext == null)
+    return { status: "plaintext", contentJson: draft.contentJson ?? null, attachments: draft.attachments }
+  if (!unlocked) return { status: "locked", contentJson: null, attachments: [] }
   if (cached?.status === "decrypted" && cached.content)
-    return { status: "decrypted", contentJson: cached.content.contentJson }
-  if (cached?.status === "failed") return { status: "failed", contentJson: null }
-  return { status: "pending", contentJson: null }
+    return {
+      status: "decrypted",
+      contentJson: cached.content.contentJson,
+      attachments: (cached.content.attachmentRefs ?? []).map(attachmentFromRef),
+    }
+  if (cached?.status === "failed") return { status: "failed", contentJson: null, attachments: [] }
+  return { status: "pending", contentJson: null, attachments: [] }
 }
 
 /**
  * Fire a decrypt for a sealed draft when possible and not already cached/in-flight
  * — a no-op otherwise (so callers can invoke it unconditionally). The plaintext
  * only ever lands in the in-memory cache (E2EE-4).
+ *
+ * Stage 4d: when the decrypt lands, re-register the recovered `attachmentRefs`
+ * in the in-memory ref cache (`rememberAttachmentRef`). On a fresh device the
+ * per-file key/iv were minted on the authoring device, so without this a roamed
+ * draft could neither decrypt its attachments for view nor re-seal them on send
+ * (the seal path resolves refs by id). Idempotent — a re-seal of the same id
+ * overwrites with identical material.
  */
 export function requestDraftDecryption(
   draft: CachedDraft,
@@ -60,7 +87,10 @@ export function requestDraftDecryption(
 ): void {
   if (draft.ciphertext == null || !rootStreamId || !keys.privateKey || !keys.recipientKeyId) return
   const cached = getCachedDecryption(draft.id)
-  if (cached && cached.status !== "pending") return
+  if (cached && cached.status !== "pending") {
+    if (cached.status === "decrypted") rememberDecryptedRefs(cached)
+    return
+  }
   void requestDecryption(
     draft.id,
     { contentMarkdown: "", ciphertext: draft.ciphertext, envelope: draft.envelope },
@@ -71,7 +101,38 @@ export function requestDraftDecryption(
       streamId: rootStreamId,
       rootStreamId,
     }
-  )
+  ).then((entry) => {
+    if (entry.status === "decrypted") rememberDecryptedRefs(entry)
+  })
+}
+
+/** Re-register a decrypted entry's attachment refs so a roamed draft is sendable. */
+function rememberDecryptedRefs(entry: DecryptCacheEntry): void {
+  for (const ref of entry.content?.attachmentRefs ?? []) rememberAttachmentRef(ref)
+}
+
+/**
+ * The decrypted body currently cached for a sealed draft id, or null when it
+ * isn't decrypted. The in-memory cache is the plaintext authority for a sealed
+ * draft (E2EE-4: the row at rest holds only the empty placeholder), so the write
+ * path reads the body back from it to re-seal across an attachment change.
+ */
+export function cachedDraftBody(draftId: string): JSONContent | null {
+  const cached = getCachedDecryption(draftId)
+  if (cached?.status !== "decrypted") return null
+  return cached.content?.contentJson ?? null
+}
+
+/**
+ * The decrypted attachments currently cached for a sealed draft id (Stage 4d),
+ * or [] when it isn't decrypted. Same rationale as `cachedDraftBody`: a
+ * content-only re-seal must preserve the attachments that were sealed alongside
+ * the body, and those live only in the in-memory decrypt cache.
+ */
+export function cachedDraftAttachments(draftId: string): DraftAttachment[] {
+  const cached = getCachedDecryption(draftId)
+  if (cached?.status !== "decrypted") return []
+  return (cached.content?.attachmentRefs ?? []).map(attachmentFromRef)
 }
 
 // --- List-preview presentation (stash picker, /drafts explorer) ---

--- a/apps/frontend/src/sync/draft-e2e-roam.test.ts
+++ b/apps/frontend/src/sync/draft-e2e-roam.test.ts
@@ -173,6 +173,15 @@ describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
       streamId
     )
     await vi.waitFor(() => expect(getAttachmentRef("att_1")).not.toBeNull())
-    expect(getAttachmentRef("att_1")).toMatchObject({ attachmentId: "att_1", filename: "secret.pdf", sizeBytes: 1234 })
+    // The re-registered ref must carry the crypto material (key/iv), not just
+    // display metadata — otherwise B couldn't view or re-seal the attachment.
+    expect(getAttachmentRef("att_1")).toEqual({
+      attachmentId: "att_1",
+      key: "a2V5",
+      iv: "aXY=",
+      filename: "secret.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1234,
+    })
   })
 })

--- a/apps/frontend/src/sync/draft-e2e-roam.test.ts
+++ b/apps/frontend/src/sync/draft-e2e-roam.test.ts
@@ -5,6 +5,9 @@ import { db } from "@/db"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { sealDraftContent } from "@/lib/crypto/seal-draft"
 import { tryDecryptMessagePayload } from "@/lib/crypto/message-envelope"
+import { clearAttachmentRefCache, getAttachmentRef, rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { clearDecryptCache } from "@/lib/crypto/decrypt-cache"
+import { requestDraftDecryption } from "@/lib/drafts/decryption"
 import { applyDraftUpserted } from "./draft-sync"
 import * as sessionStore from "@/stores/e2e-session-store"
 import * as streamKeyCache from "@/lib/crypto/stream-key-cache"
@@ -41,6 +44,8 @@ const session = {
 beforeEach(async () => {
   vi.restoreAllMocks()
   resetDraftStoreCache()
+  clearDecryptCache()
+  clearAttachmentRefCache()
   await db.drafts.clear()
   await db.composerLoaded.clear()
   await db.pendingOperations.clear()
@@ -107,5 +112,67 @@ describe("E2E draft roam (seal → wire → apply → decrypt)", () => {
       }
     )
     expect(opened?.contentJson).toEqual(parseMarkdown("roaming secret"))
+  })
+
+  it("a sealed draft's attachments roam and their keys re-register on the receiving device (Stage 4d)", async () => {
+    // Device A: the per-file key/iv were minted at upload and held in memory.
+    rememberAttachmentRef({
+      attachmentId: "att_1",
+      key: "a2V5",
+      iv: "aXY=",
+      filename: "secret.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1234,
+    })
+    const sealed = await sealDraftContent({
+      workspaceId,
+      senderId: userId,
+      streamId,
+      draftId: "draft_att",
+      contentJson: makeDoc("see attached"),
+      attachmentIds: ["att_1"],
+    })
+
+    const wire: Draft = {
+      id: "draft_att",
+      workspaceId,
+      userId,
+      scope,
+      rootStreamId: streamId,
+      contentJson: null,
+      contentMarkdown: null,
+      // No plaintext attachment linkage on the wire — it rides sealed in the body.
+      attachmentIds: [],
+      command: null,
+      contextRefs: null,
+      ciphertext: sealed.ciphertext,
+      envelope: sealed.envelope,
+      e2eVersion: sealed.e2eVersion,
+      version: 1,
+      clientUpdatedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    // Device B: fresh — the in-memory ref cache is empty, so the file can't be
+    // fetched or re-sealed until the draft decrypts and re-registers its key.
+    clearAttachmentRefCache()
+    expect(getAttachmentRef("att_1")).toBeNull()
+
+    await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wire }, workspaceId)
+    const stored = await db.drafts.get("draft_att")
+    // At rest the row carries no plaintext attachment metadata (E2EE-4).
+    expect(stored?.attachments).toEqual([])
+
+    // The composer's decrypt-on-read recovers the refs and re-registers them so a
+    // later send on THIS device can re-seal the attachment by id.
+    requestDraftDecryption(
+      stored!,
+      { privateKey: session.privateKey!, recipientKeyId: session.keyId! },
+      workspaceId,
+      streamId
+    )
+    await vi.waitFor(() => expect(getAttachmentRef("att_1")).not.toBeNull())
+    expect(getAttachmentRef("att_1")).toMatchObject({ attachmentId: "att_1", filename: "secret.pdf", sizeBytes: 1234 })
   })
 })

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -253,11 +253,12 @@ frontend-only:
 - Call sites (`message-input.tsx`, `thread/stream-panel.tsx`) pass the encrypted
   root (`rootStreamId ?? id`); `use-draft-composer.ts` threads `e2eStreamId`.
 
-**Scope boundary (v1) — deferred follow-up, non-regressing vs. pre-4c:**
+**Scope boundary (v1 / 4c cut) — attachments addressed in 4d (below):**
 
-- **E2E-draft attachments / context refs / slash commands are not sealed yet** —
-  only the body roams. They stay session-local exactly as before (per-file
-  attachment-key roaming across devices is its own design).
+- **E2E-draft attachments / context refs / slash commands were not sealed in 4c** —
+  only the body roamed; they stayed session-local. Stage 4d (below) seals
+  attachments. Context refs / slash commands remain session-local (their own
+  design — they have no message-payload field to ride in).
 
 **Shipped beyond the initial cut, so the feature is usable end-to-end:**
 
@@ -277,7 +278,50 @@ frontend-only:
   composer via a late-hydrate effect (no stream reopen required), guarded by
   `userEngagedRef` so it never clobbers typed content.
 
-**Reuse:** `sealOutgoingMessage` E2E path; existing `promoteDraft` / `setParentThreadId`; resolve CAS from Stage 1.
+#### Stage 4d — E2E draft attachment sealing — DONE
+
+E2E draft attachments now roam. Reuses the message attachment-seal path end to
+end (INV-35), so there is **no backend / types / wire / migration change** — the
+attachment linkage rides _inside_ the body's SSK ciphertext, and the wire
+`attachmentIds` stays `[]` for E2E (the server holds opaque bytes only).
+
+- `lib/crypto/seal-draft.ts`: `sealDraftContent` carries `attachmentIds` into
+  `sealOutgoingMessage`, which seals each file's `attachmentRef`
+  (key/iv/filename/mime/size) into the payload exactly as a message does; the
+  refs are returned so the write path can seed the decrypt cache.
+- `lib/drafts/decryption.ts`: `DraftDecryption` surfaces `attachments` (a
+  plaintext draft's own, or a sealed draft's refs mapped to display metadata).
+  On decrypt, `requestDraftDecryption` re-registers the recovered refs via
+  `rememberAttachmentRef` — on a fresh device the per-file keys were minted on
+  the authoring device, so without this a roamed draft could neither view nor
+  re-seal its attachments on send. `cachedDraftBody` / `cachedDraftAttachments`
+  expose the in-memory plaintext authority the write path re-seals from.
+- `hooks/use-draft-message.ts`: the seal write path carries the attachment set
+  (kept `[]` at rest, E2EE-4 — the real filename is sealed, never on disk);
+  `saveDraft` / `addAttachment` / `removeAttachment` E2E branches re-seal
+  body+attachments together, reading the current body + attachments back from the
+  decrypt cache so a keystroke or an attachment change preserves the other.
+  Returned `attachments` come from the decrypt read (empty while locked/decrypting).
+- `hooks/use-draft-composer.ts`: attachments late-hydrate alongside the body on
+  the unlock-after-open path (they decrypt together).
+
+**Scope boundary (4d):** context refs / slash commands on E2E drafts remain
+session-local — they have no field in the message sealed-payload schema to ride
+in, so sealing them would mean extending the shared `@threa/crypto` payload (and
+the enclave) for a draft-only concept; deferred as its own design.
+
+**Reuse:** `sealOutgoingMessage` + `serializeSealedPayload` attachment-ref path;
+`rememberAttachmentRef` / `getAttachmentRef` in-memory ref cache; the shared
+decrypt-cache + draft decrypt core from 4c.
+
+**Verification:** `seal-draft.test.ts` (attachment refs seal + recover on
+decrypt); `draft-e2e-roam.test.ts` (attachments survive the wire and their keys
+re-register on the receiving device); `use-draft-message.test.ts` (seal carries
+attachmentIds, never at rest; add/remove re-seal; content-only save preserves
+them; locked is a no-op); `use-decrypted-draft-content.test.ts` (attachments
+surfaced from refs). `bun run test`.
+
+**Reuse (4c):** `sealOutgoingMessage` E2E path; existing `promoteDraft` / `setParentThreadId`; resolve CAS from Stage 1.
 
 **Verification:** Backend test: resolve declines on drift, deletes on match; thread-conversion re-points drafts. Frontend/E2E (`test:e2e`): send clears draft; drifted draft survives send; reply draft follows a message into its new thread; E2E draft round-trips without plaintext at rest. `bun run test` + `bun run test:e2e`.
 


### PR DESCRIPTION
**Design doc:** `docs/plans/centralized-draft-system.md` §Stage 4d. Closes the Stage 4c deferral ("E2E-draft attachments … are not sealed yet — only the body roams").

## Problem

Stage 4c made E2E draft **bodies** roam (sealed before disk, decrypted on read), but left attachments behind: `addAttachment` / `removeAttachment` early-returned when `e2eEnabled`, and the seal write path passed `attachments: []`. So an encrypted-stream draft with a file attached lost the attachment the moment you picked the draft up on another device — the body crossed, the file reference didn't.

The 4c doc flagged this as "its own design" because of per-file key roaming: an E2E attachment's bytes are uploaded as opaque ciphertext and its decryption key (`key`/`iv`) is minted at upload and held **only in memory** (`attachment-crypto.ts`'s `pendingRefs`, cleared on lock). A second device has the ciphertext in S3 but none of the keys, so it can neither view nor re-send the attachment.

## Solution

It turns out messages already solved this. `sealOutgoingMessage` seals each attachment's `AttachmentRef` (`key`/`iv`/`filename`/`mimeType`/`sizeBytes`) **inside** the SSK ciphertext via `serializeSealedPayload`, and `tryDecryptMessagePayload` recovers them through `parseSealedPayload`. Stage 4d routes E2E draft attachments through that exact path (INV-35) instead of inventing a parallel one — so the refs ride sealed in the draft body's ciphertext, and the receiving device gets the keys back on decrypt.

Because the linkage lives inside the ciphertext, there is **no backend / types / wire / migration change**: the wire `attachmentIds` stays `[]` for E2E (`executeDraftUpsert` already forces this), and the server keeps holding opaque bytes only.

### How it works

1. **Seal** (`seal-draft.ts`): `sealDraftContent` carries `attachmentIds` into `sealOutgoingMessage` (which resolves each id → ref from the in-memory cache and seals them) and returns the sealed `attachmentRefs`.
2. **At rest** (`use-draft-message.ts`): the sealed row keeps `contentJson: EMPTY_DOC` **and** `attachments: []` — neither the body nor the real filename touches disk (E2EE-4). The decrypt cache is re-seeded with the just-sealed body + refs so the authoring device reads them back with no self-decrypt.
3. **Decrypt + re-register** (`decryption.ts`): `requestDraftDecryption` re-registers the recovered refs via `rememberAttachmentRef` once decrypt lands. This is the load-bearing new step — without it a roamed draft on a fresh device could neither fetch/decrypt its attachment for view nor re-seal it on send (the send path resolves refs by id).
4. **Read** (`decryption.ts` → `use-draft-message.ts`): `DraftDecryption` surfaces `attachments` — a plaintext draft's own, or a sealed draft's refs mapped to `{id, filename, mimeType, sizeBytes}`. Empty while locked/decrypting, like the body.
5. **Edit** (`use-draft-message.ts`): `saveDraft` / `addAttachment` / `removeAttachment` E2E branches re-seal body+attachments **together**, reading the current body + attachments back from the in-memory decrypt cache (the plaintext authority) so a keystroke preserves the attachments and an attachment change preserves the body.
6. **Late-hydrate** (`use-draft-composer.ts`): attachments restore alongside the body on the unlock-after-open path (they decrypt together).

### Key design decisions

**1. No plaintext attachment metadata at rest.** The sealed row stores `attachments: []`; the real filename rides sealed in the ciphertext, recovered into the in-memory cache on decrypt. Storing `{filename, ...}` on the row at rest would leak the filename the server deliberately hides via its placeholder row (E2EE-4). Consequence, called out so it isn't "fixed" by accident: a sealed draft's attachment chips render only **after** the body decrypts — the same model as the body itself.

**2. Reuse the message seal path, don't fork it (INV-35).** `serializeSealedPayload`/`parseSealedPayload` already carry `attachmentRefs`; a draft is just another sealed payload bound by the draft id in the AAD's message-id slot. No new crypto, no schema change.

**3. The in-memory decrypt cache is the write path's source of truth for E2E.** `addAttachment`/`removeAttachment` read the current body + attachments from `getCachedDecryption(id)` rather than the row (which holds only ciphertext). Safe because the composer only fires these post-decrypt (chips/persistence are gated on `hasInitialized`, which waits for the decrypt to settle).

**4. Context refs / slash commands stay session-local.** They have no field in the message sealed-payload schema (`E2eSealedPayload`) to ride in. Sealing them would mean extending the shared `@threa/crypto` payload + the enclave parser for a draft-only concept — genuinely its own design. Per the scope confirmation on this PR, deferred. See Out of scope.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/crypto/seal-draft.ts` | `sealDraftContent` takes `attachmentIds`, seals them via `sealOutgoingMessage`, returns the sealed `attachmentRefs`. |
| `apps/frontend/src/lib/drafts/decryption.ts` | `DraftDecryption` surfaces `attachments`; re-register recovered refs on decrypt (`rememberAttachmentRef`); add `cachedDraftBody`/`cachedDraftAttachments`. |
| `apps/frontend/src/hooks/use-draft-message.ts` | Seal path carries attachments (`[]` at rest); `saveDraft`/`addAttachment`/`removeAttachment` E2E branches re-seal body+attachments from the decrypt cache; return decrypted attachments. |
| `apps/frontend/src/hooks/use-draft-composer.ts` | `hydrateAttachments` + `savedAttachmentsRef`: attachments late-hydrate with the body on unlock-after-open. |
| `docs/plans/centralized-draft-system.md` | §Stage 4d section; narrow the 4c deferral note to context-refs/slash-commands. |
| `apps/frontend/src/lib/crypto/seal-draft.test.ts` | Attachment refs seal + recover on decrypt. |
| `apps/frontend/src/sync/draft-e2e-roam.test.ts` | Attachments survive the wire; keys re-register on the receiving device. |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | Seal carries `attachmentIds` (never at rest); add/remove re-seal; content-only save preserves attachments; locked is a no-op. |
| `apps/frontend/src/hooks/use-decrypted-draft-content.test.ts` | Attachments surfaced from decrypted refs; shape updated. |

## Out of scope (deliberate)

- **Context refs / slash commands on E2E drafts** — remain session-local (decision 4). Follow-up if they should roam: extend `E2eSealedPayload` + the enclave parser.

## Test plan

- [x] `seal-draft.test.ts` — 5 pass (incl. attachment-ref seal→recover round-trip)
- [x] `draft-e2e-roam.test.ts` — 2 pass (full A→wire→B roam; keys re-register on B)
- [x] `use-draft-message.test.ts` — attachment-sealing suite (seal carries ids/not-at-rest, add/remove re-seal, content-only preserves, locked no-op)
- [x] `use-decrypted-draft-content.test.ts` / `use-draft-composer.test.ts` / previews — pass (composer's 6 hydration guards untouched and re-verified green)
- [x] Full frontend suite — 254 files / 2799 tests pass
- [x] Pre-commit hook: all-workspace `eslint` + `tsc --noEmit` (types/crypto/backend/frontend/…) + migration & API-doc checks clean
- [x] CodeRabbit review (ASSERTIVE): 3 findings, all fixed in `b4587b9` — attachment-only late-hydrate after unlock (Major; the previously-deferred edge, now closed) + two tests assert the full `AttachmentRef` incl. `key`/`iv` (INV-24).

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Make E2E draft attachments roam across the author's devices (Stage 4d), closing the Stage 4c deferral.

**What was built:** Attachment refs (key/iv/filename/mime/size) seal into the draft body's SSK ciphertext via the existing message path; recovered + re-registered in the in-memory ref cache on decrypt so a roamed draft is viewable and sendable on a fresh device. Write/read/edit paths in `use-draft-message` carry attachments for E2E; composer late-hydrates them with the body.

**Design decisions:** (1) no plaintext attachment metadata at rest — chips render post-decrypt; (2) reuse `serializeSealedPayload` rather than fork crypto (INV-35); (3) decrypt cache is the write-path source of truth for E2E, safe because edits fire post-decrypt; (4) context refs/slash commands deferred — no payload field to ride in.

**Schema changes:** none — no backend/types/wire/migration change; the linkage rides inside the ciphertext and the wire `attachmentIds` stays `[]` for E2E.

**What's NOT included:** context refs / slash-command roaming on E2E drafts (the attachment-only chip-hydration edge was closed in review, `b4587b9`).

**Status:** committed (`75a26dd`), full frontend suite + all-workspace lint/typecheck green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
