### PR TITLE
fix(frontend): make code block copy button always visible

### DIFF
--- a/apps/frontend/src/lib/markdown/code-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.test.tsx
@@ -212,6 +212,26 @@ describe("CodeBlock collapse behavior", () => {
     await waitFor(() => expect(document.querySelector("pre")).toBeInTheDocument())
   })
 
+  it("always renders a copy button (not hover-gated) that copies the code", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
+
+    renderCodeBlock("const x = 1\nconst y = 2")
+
+    const copyButton = screen.getByRole("button", { name: /copy code/i })
+    // The button must be visible at rest — no `opacity-0` gate that would hide
+    // it on touch devices where there's no hover.
+    expect(copyButton.className).not.toContain("opacity-0")
+
+    await user.click(copyButton)
+    expect(writeText).toHaveBeenCalledWith("const x = 1\nconst y = 2")
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /copied/i })).toBeInTheDocument())
+
+    vi.unstubAllGlobals()
+  })
+
   it("scopes collapse state per messageId", async () => {
     const user = userEvent.setup()
     measure = { lineCount: 15, lineHeightPx: 20 }

--- a/apps/frontend/src/lib/markdown/code-block.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.tsx
@@ -167,7 +167,7 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
         onClick={handleCopy}
         className={cn(
           // Always visible (not hover-gated): touch devices have no hover, so a
-          // group-hover-only button would be unreachable there.
+          // hover-only button would be unreachable there.
           "flex h-5 w-5 items-center justify-center rounded transition-all duration-150 shrink-0",
           copied
             ? "bg-green-500/15 text-green-600 dark:text-green-400"
@@ -188,7 +188,7 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
 
   return (
     <div
-      className="group my-2 rounded-md overflow-hidden border border-border bg-muted/50 select-text [-webkit-touch-callout:default]"
+      className="my-2 rounded-md overflow-hidden border border-border bg-muted/50 select-text [-webkit-touch-callout:default]"
       data-native-context="true"
     >
       {header}

--- a/apps/frontend/src/lib/markdown/code-block.tsx
+++ b/apps/frontend/src/lib/markdown/code-block.tsx
@@ -166,8 +166,9 @@ export default function CodeBlock({ language, children }: CodeBlockProps) {
         type="button"
         onClick={handleCopy}
         className={cn(
+          // Always visible (not hover-gated): touch devices have no hover, so a
+          // group-hover-only button would be unreachable there.
           "flex h-5 w-5 items-center justify-center rounded transition-all duration-150 shrink-0",
-          "opacity-0 group-hover:opacity-100",
           copied
             ? "bg-green-500/15 text-green-600 dark:text-green-400"
             : "text-muted-foreground hover:bg-primary/15 hover:text-primary"


### PR DESCRIPTION
## Problem

Rendered code blocks already had a copy button, but it was hidden until hover. In `apps/frontend/src/lib/markdown/code-block.tsx` the button carried `opacity-0 group-hover:opacity-100`, so it only appeared when the pointer was over the block. On touch devices — which have no hover state — it never became visible and was effectively unreachable. `CodeBlock` is the single component every rendered fenced block flows through (`markdownComponents.code` → `CodeBlock` in `apps/frontend/src/lib/markdown/components.tsx`), so this affected code blocks everywhere they render: message timelines, the gallery markdown viewer (`MarkdownViewer` → `MarkdownContent`), trace steps, and shared-message views.

## Solution

Drop the hover gate so the copy button is always visible, and remove the wrapper's now-unused `group` class.

- Removed `"opacity-0 group-hover:opacity-100"` from the copy button's class list. The button keeps its color states: muted at rest, `hover:bg-primary/15 hover:text-primary` on hover, and the green "copied" state.
- The in-place icon swap (Copy → Check, same `h-5 w-5` footprint) on copy is unchanged, so confirmation stays in place with no layout shift (INV-63 / INV-21) — no toast.
- The wrapper `<div>`'s `group` class existed only to drive that one `group-hover:` rule. With the button always visible nothing consumes it, so it's removed as dead code (INV-38).

The header language-label toggle and the collapse/expand affordance are untouched.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/markdown/code-block.tsx` | Remove `opacity-0 group-hover:opacity-100` from the copy button; remove the now-dead `group` class from the wrapper |
| `apps/frontend/src/lib/markdown/code-block.test.tsx` | Add a test: copy button is always present (no `opacity-0`), copies the code, and flips to the "Copied" state |

## Out of scope (deliberate)

- `apps/frontend/src/components/editor/code-block.tsx` (`CodeBlockComponent`) is the editable ProseMirror composer node, not a read-only render — the user already holds the source there, so it gets no copy button.

## Test plan

- [x] `bun run test apps/frontend/src/lib/markdown/code-block.test.tsx` — 11 pass (10 existing + 1 new)
- [x] Pre-commit hooks on both commits: ESLint across all apps, `tsc --noEmit` across every workspace, migration/dockerfile/API-doc checks — all clean
- [x] Self-review: removing the hover gate left `group` on the wrapper with no consumer; removed it in a follow-up commit (INV-38)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011uVzTLymnzCNSLu1TMob6Y)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784181841&installation_id=129946197&pr_number=962&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F962&signature=01692b2c888248fd37486a68f061b4a414772d8924b59bf1a5423b25beeee37f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->