### PR TITLE
feat(composer): convert large pastes into snippet attachments

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -32,6 +32,8 @@ import { useMentionables } from "@/hooks/use-mentionables"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useGiphyEnabled } from "@/hooks/use-giphy-enabled"
 import { GiphyPickerDialog } from "./giphy-picker-dialog"
+import { SnippetEditorDialog } from "./snippet-editor-dialog"
+import { shouldConvertPasteToSnippet, defaultSnippetFilename } from "./snippet-paste"
 import type { GiphyGif } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { usePreferences } from "@/contexts"
@@ -244,6 +246,14 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   const giphyEnabled = useGiphyEnabled(workspaceId) && enableCommands
   const [giphyOpen, setGiphyOpen] = useState(false)
 
+  // A large paste opens the snippet editor instead of inserting inline; on save
+  // it becomes a `.txt` attachment chip at the original paste position. The
+  // draft holds the pasted text + suggested filename; the caret position and a
+  // per-session counter live in refs so they don't re-render the editor.
+  const [snippetDraft, setSnippetDraft] = useState<{ text: string; filename: string } | null>(null)
+  const snippetInsertPosRef = useRef<number | null>(null)
+  const snippetCountRef = useRef(0)
+
   // Unfiltered for type-lookup: ensures all broadcast slugs always resolve correctly
   const { mentionables } = useMentionables()
   // Filtered for autocomplete dropdown only
@@ -437,6 +447,35 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     }
   }, [])
 
+  // Save the snippet editor's contents as a text attachment, inserting the chip
+  // back at the caret position the paste happened at. Reuses the same
+  // upload-and-insert path as pasted images/files (handleFileInsert), so E2E
+  // encryption, scope-drift guarding, and the inline chip all come for free.
+  const handleSnippetSave = useCallback(
+    ({ text, filename }: { text: string; filename: string }) => {
+      const editorInstance = editorRef.current
+      const insertPos = snippetInsertPosRef.current
+      setSnippetDraft(null)
+      snippetInsertPosRef.current = null
+      const uploadFn = onFileUploadRef.current
+      if (!editorInstance || editorInstance.isDestroyed || !uploadFn) return
+
+      const safeName = filename.trim() || "snippet.txt"
+      const file = new File([text], safeName, { type: "text/plain" })
+
+      // Restore the caret to where the paste landed (the dialog stole focus).
+      const chain = editorInstance.chain().focus()
+      if (insertPos != null) {
+        const clamped = Math.min(insertPos, editorInstance.state.doc.content.size)
+        chain.setTextSelection(clamped)
+      }
+      chain.run()
+
+      void handleFileInsert(file, editorInstance)
+    },
+    [handleFileInsert]
+  )
+
   // Insert the chosen GIF as an inline embed rendered straight from Giphy's CDN
   // (no download/upload — that's how Giphy intends embeds to work). Synchronous,
   // so there's no scope-drift window to guard against.
@@ -530,6 +569,17 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
             event.preventDefault()
             return true
           }
+        }
+
+        // Text too large to read inline becomes a snippet attachment: open the
+        // editor seeded with the paste, remembering the caret so the chip lands
+        // where the paste did. Needs an upload handler to attach through.
+        if (onFileUploadRef.current && shouldConvertPasteToSnippet(text)) {
+          event.preventDefault()
+          snippetInsertPosRef.current = editorRef.current.state.selection.from
+          snippetCountRef.current += 1
+          setSnippetDraft({ text, filename: defaultSnippetFilename(snippetCountRef.current) })
+          return true
         }
 
         const handled = insertPastedText(
@@ -994,6 +1044,20 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           onOpenChange={setGiphyOpen}
           workspaceId={workspaceId}
           onSelect={handleGifSelect}
+        />
+      ) : null}
+      {onFileUpload ? (
+        <SnippetEditorDialog
+          open={snippetDraft !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSnippetDraft(null)
+              snippetInsertPosRef.current = null
+            }
+          }}
+          initialText={snippetDraft?.text ?? ""}
+          defaultFilename={snippetDraft?.filename ?? "snippet.txt"}
+          onSave={handleSnippetSave}
         />
       ) : null}
     </div>

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -33,7 +33,7 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useGiphyEnabled } from "@/hooks/use-giphy-enabled"
 import { GiphyPickerDialog } from "./giphy-picker-dialog"
 import { SnippetEditorDialog } from "./snippet-editor-dialog"
-import { shouldConvertPasteToSnippet, defaultSnippetFilename } from "./snippet-paste"
+import { shouldConvertPasteToSnippet, defaultSnippetFilename, SNIPPET_FALLBACK_FILENAME } from "./snippet-paste"
 import type { GiphyGif } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { usePreferences } from "@/contexts"
@@ -460,7 +460,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       const uploadFn = onFileUploadRef.current
       if (!editorInstance || editorInstance.isDestroyed || !uploadFn) return
 
-      const safeName = filename.trim() || "snippet.txt"
+      const safeName = filename.trim() || SNIPPET_FALLBACK_FILENAME
       const file = new File([text], safeName, { type: "text/plain" })
 
       // Restore the caret to where the paste landed (the dialog stole focus).
@@ -1056,7 +1056,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
             }
           }}
           initialText={snippetDraft?.text ?? ""}
-          defaultFilename={snippetDraft?.filename ?? "snippet.txt"}
+          defaultFilename={snippetDraft?.filename ?? SNIPPET_FALLBACK_FILENAME}
           onSave={handleSnippetSave}
         />
       ) : null}

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { SnippetEditorDialog } from "./snippet-editor-dialog"
+import * as useMobileModule from "@/hooks/use-mobile"
+
+beforeEach(() => {
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("SnippetEditorDialog", () => {
+  it("seeds the textarea and filename from the incoming paste", () => {
+    render(
+      <SnippetEditorDialog
+        open
+        onOpenChange={() => {}}
+        initialText={"const x = 1\nconst y = 2"}
+        defaultFilename="snippet-1.txt"
+        onSave={() => {}}
+      />
+    )
+
+    expect((screen.getByLabelText("Snippet contents") as HTMLTextAreaElement).value).toBe("const x = 1\nconst y = 2")
+    expect((screen.getByLabelText("Snippet filename") as HTMLInputElement).value).toBe("snippet-1.txt")
+  })
+
+  it("saves the edited text and filename", () => {
+    const onSave = vi.fn()
+    render(
+      <SnippetEditorDialog
+        open
+        onOpenChange={() => {}}
+        initialText="original"
+        defaultFilename="snippet-1.txt"
+        onSave={onSave}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("Snippet contents"), { target: { value: "edited body" } })
+    fireEvent.change(screen.getByLabelText("Snippet filename"), { target: { value: "  query.sql  " } })
+    fireEvent.click(screen.getByRole("button", { name: "Attach snippet" }))
+
+    expect(onSave).toHaveBeenCalledWith({ text: "edited body", filename: "query.sql" })
+  })
+
+  it("disables save when the body or filename is empty", () => {
+    render(<SnippetEditorDialog open onOpenChange={() => {}} initialText="" defaultFilename="" onSave={() => {}} />)
+    expect((screen.getByRole("button", { name: "Attach snippet" }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it("closes without saving on Cancel", () => {
+    const onOpenChange = vi.fn()
+    const onSave = vi.fn()
+    render(
+      <SnippetEditorDialog
+        open
+        onOpenChange={onOpenChange}
+        initialText="body"
+        defaultFilename="snippet-1.txt"
+        onSave={onSave}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react"
+import { FileCode2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+
+interface SnippetEditorDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Pasted text the editor is seeded with each time it opens. */
+  initialText: string
+  /** Suggested filename (e.g. `snippet-1.txt`); the user can rename it. */
+  defaultFilename: string
+  /** Save the (possibly edited) snippet as a `.txt` attachment. */
+  onSave: (args: { text: string; filename: string }) => void
+}
+
+/**
+ * A deliberately plain editor for text that's too large to sit inline in a
+ * message. It's a native `<textarea>` — not ProseMirror — so the browser
+ * handles arbitrarily large content and scrolling natively (the "infinite
+ * scroller" requirement); a rich editor would choke on a multi-megabyte blob.
+ * Monospace, no syntax highlighting, no wrapping — just enough to glance over
+ * and tweak before it becomes a snippet attachment.
+ *
+ * `disableSnapPoints`: this is a keyboard form, so on mobile it rides above the
+ * keyboard as a content-height drawer rather than the h-[100dvh] snap drawer
+ * (see ResponsiveDialog docs / SavedEditDialog).
+ */
+export function SnippetEditorDialog({
+  open,
+  onOpenChange,
+  initialText,
+  defaultFilename,
+  onSave,
+}: SnippetEditorDialogProps) {
+  const [text, setText] = useState(initialText)
+  const [filename, setFilename] = useState(defaultFilename)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Re-seed from the incoming paste each time the dialog opens so a previously
+  // cancelled snippet can't leak into the next one.
+  useEffect(() => {
+    if (open) {
+      setText(initialText)
+      setFilename(defaultFilename)
+    }
+  }, [open, initialText, defaultFilename])
+
+  const trimmedFilename = filename.trim()
+  const canSave = text.length > 0 && trimmedFilename.length > 0
+
+  const handleSave = () => {
+    if (!canSave) return
+    onSave({ text, filename: trimmedFilename })
+  }
+
+  // Cmd/Ctrl+Enter saves — plain Enter has to stay free for newlines in a
+  // code-style editor.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault()
+      handleSave()
+    }
+  }
+
+  const charCount = text.length
+  const lineCount = text ? (text.match(/\n/g)?.length ?? 0) + 1 : 0
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
+      <ResponsiveDialogContent
+        desktopClassName="max-w-[760px] gap-0 p-0 overflow-hidden"
+        drawerClassName="flex max-h-[92dvh] flex-col gap-0 p-0 overflow-hidden"
+        aria-describedby={undefined}
+      >
+        <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4">
+          <ResponsiveDialogHeader>
+            <div className="flex items-center gap-2.5">
+              <div className="flex items-center justify-center h-9 w-9 rounded-lg bg-primary/10">
+                <FileCode2 className="h-4.5 w-4.5 text-primary" />
+              </div>
+              <div>
+                <ResponsiveDialogTitle className="text-base">Add as snippet</ResponsiveDialogTitle>
+                <ResponsiveDialogDescription className="text-xs mt-0.5">
+                  This is too long to paste inline — it'll be attached as a file you can edit first.
+                </ResponsiveDialogDescription>
+              </div>
+            </div>
+          </ResponsiveDialogHeader>
+        </div>
+
+        <div className="border-t border-border" />
+
+        <div className="flex-1 min-h-0 flex flex-col gap-3 px-4 sm:px-6 py-4">
+          <Input
+            aria-label="Snippet filename"
+            value={filename}
+            onChange={(e) => setFilename(e.target.value)}
+            placeholder="snippet.txt"
+            className="text-sm font-mono"
+          />
+          {/* wrap="off": long lines scroll horizontally so code keeps its
+              column layout rather than reflowing. */}
+          <Textarea
+            ref={textareaRef}
+            aria-label="Snippet contents"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            wrap="off"
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            className="flex-1 min-h-[280px] sm:min-h-[360px] resize-none font-mono text-xs leading-relaxed whitespace-pre overflow-auto"
+          />
+        </div>
+
+        <div className="border-t border-border px-4 sm:px-6 pt-4 pb-[max(16px,env(safe-area-inset-bottom))] flex items-center justify-between gap-3 bg-muted/30">
+          <span className="text-[11px] text-muted-foreground tabular-nums">
+            {charCount.toLocaleString()} chars · {lineCount.toLocaleString()} lines
+          </span>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!canSave} className="min-w-20">
+              Attach snippet
+            </Button>
+          </div>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
+import { SNIPPET_FALLBACK_FILENAME } from "./snippet-paste"
 
 interface SnippetEditorDialogProps {
   open: boolean
@@ -44,14 +45,23 @@ export function SnippetEditorDialog({
   const [text, setText] = useState(initialText)
   const [filename, setFilename] = useState(defaultFilename)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const wasOpenRef = useRef(false)
 
-  // Re-seed from the incoming paste each time the dialog opens so a previously
-  // cancelled snippet can't leak into the next one.
+  // Re-seed from the incoming paste only on the closed→open transition, then
+  // focus the body so the user lands on their pasted content (Radix would
+  // otherwise focus the filename input, the first tabbable element). Keying on
+  // the transition rather than the prop values means a re-render while the
+  // dialog is open can't clobber in-progress edits.
   useEffect(() => {
-    if (open) {
+    if (open && !wasOpenRef.current) {
       setText(initialText)
       setFilename(defaultFilename)
+      // Defer past Radix's open-focus so the move to the textarea wins.
+      const raf = requestAnimationFrame(() => textareaRef.current?.focus())
+      wasOpenRef.current = true
+      return () => cancelAnimationFrame(raf)
     }
+    if (!open) wasOpenRef.current = false
   }, [open, initialText, defaultFilename])
 
   const trimmedFilename = filename.trim()
@@ -79,7 +89,6 @@ export function SnippetEditorDialog({
       <ResponsiveDialogContent
         desktopClassName="max-w-[760px] gap-0 p-0 overflow-hidden"
         drawerClassName="flex max-h-[92dvh] flex-col gap-0 p-0 overflow-hidden"
-        aria-describedby={undefined}
       >
         <div className="px-4 sm:px-6 pt-4 sm:pt-6 pb-4">
           <ResponsiveDialogHeader>
@@ -99,12 +108,15 @@ export function SnippetEditorDialog({
 
         <div className="border-t border-border" />
 
-        <div className="flex-1 min-h-0 flex flex-col gap-3 px-4 sm:px-6 py-4">
+        {/* overflow-y-auto so a shrunken visual viewport (mobile keyboard) can
+            scroll the fields into reach instead of clipping them off-screen,
+            per the ResponsiveDialog disableSnapPoints contract. */}
+        <div className="flex-1 min-h-0 flex flex-col gap-3 px-4 sm:px-6 py-4 overflow-y-auto">
           <Input
             aria-label="Snippet filename"
             value={filename}
             onChange={(e) => setFilename(e.target.value)}
-            placeholder="snippet.txt"
+            placeholder={SNIPPET_FALLBACK_FILENAME}
             className="text-sm font-mono"
           />
           {/* wrap="off": long lines scroll horizontally so code keeps its

--- a/apps/frontend/src/components/editor/snippet-paste.test.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import {
+  shouldConvertPasteToSnippet,
+  defaultSnippetFilename,
+  SNIPPET_PASTE_CHAR_THRESHOLD,
+  SNIPPET_PASTE_LINE_THRESHOLD,
+} from "./snippet-paste"
+
+describe("shouldConvertPasteToSnippet", () => {
+  it("leaves ordinary short pastes inline", () => {
+    expect(shouldConvertPasteToSnippet("just a normal sentence")).toBe(false)
+    expect(shouldConvertPasteToSnippet("")).toBe(false)
+    expect(shouldConvertPasteToSnippet("line one\nline two\nline three")).toBe(false)
+  })
+
+  it("converts a long single-blob paste on character count", () => {
+    const blob = "x".repeat(SNIPPET_PASTE_CHAR_THRESHOLD)
+    expect(shouldConvertPasteToSnippet(blob)).toBe(true)
+    expect(shouldConvertPasteToSnippet("x".repeat(SNIPPET_PASTE_CHAR_THRESHOLD - 1))).toBe(false)
+  })
+
+  it("converts a tall paste on line count even when short", () => {
+    const tall = Array.from({ length: SNIPPET_PASTE_LINE_THRESHOLD }, (_, i) => `l${i}`).join("\n")
+    expect(shouldConvertPasteToSnippet(tall)).toBe(true)
+    const justUnder = Array.from({ length: SNIPPET_PASTE_LINE_THRESHOLD - 1 }, (_, i) => `l${i}`).join("\n")
+    expect(shouldConvertPasteToSnippet(justUnder)).toBe(false)
+  })
+
+  it("counts CRLF newlines the same as LF", () => {
+    const tall = Array.from({ length: SNIPPET_PASTE_LINE_THRESHOLD }, (_, i) => `l${i}`).join("\r\n")
+    expect(shouldConvertPasteToSnippet(tall)).toBe(true)
+  })
+})
+
+describe("defaultSnippetFilename", () => {
+  it("numbers snippets per session", () => {
+    expect(defaultSnippetFilename(1)).toBe("snippet-1.txt")
+    expect(defaultSnippetFilename(3)).toBe("snippet-3.txt")
+  })
+})

--- a/apps/frontend/src/components/editor/snippet-paste.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.ts
@@ -30,3 +30,6 @@ export function shouldConvertPasteToSnippet(text: string): boolean {
 export function defaultSnippetFilename(index: number): string {
   return `snippet-${index}.txt`
 }
+
+/** Filename used when the snippet's name field is left blank on save. */
+export const SNIPPET_FALLBACK_FILENAME = "snippet.txt"

--- a/apps/frontend/src/components/editor/snippet-paste.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.ts
@@ -1,0 +1,32 @@
+/**
+ * Heuristics for deciding when a pasted blob is "too large to reasonably live
+ * inside a message" and should become a snippet attachment instead of inline
+ * text. Kept as a pure module (no React) so the rich-editor paste handler and
+ * the unit tests share one source of truth (INV-33).
+ */
+
+/** A paste this long (characters) converts to a snippet, regardless of shape. */
+export const SNIPPET_PASTE_CHAR_THRESHOLD = 1500
+
+/** ...or a paste with at least this many lines, whichever trips first. */
+export const SNIPPET_PASTE_LINE_THRESHOLD = 12
+
+/**
+ * True when a pasted plain-text blob should open the snippet editor rather than
+ * being inserted inline. Either a long single blob (char count) or a tall one
+ * (line count) qualifies, so both a 2000-char paragraph and a 20-line script
+ * are caught.
+ */
+export function shouldConvertPasteToSnippet(text: string): boolean {
+  if (!text) return false
+  if (text.length >= SNIPPET_PASTE_CHAR_THRESHOLD) return true
+  // `\n` is present in both LF and CRLF, so counting it covers either newline
+  // style; a lone trailing `\r` (classic Mac) is rare enough to ignore.
+  const lineCount = (text.match(/\n/g)?.length ?? 0) + 1
+  return lineCount >= SNIPPET_PASTE_LINE_THRESHOLD
+}
+
+/** Default filename for the Nth snippet pasted into a given editor session. */
+export function defaultSnippetFilename(index: number): string {
+  return `snippet-${index}.txt`
+}


### PR DESCRIPTION
## Problem

Pasting a large blob into the composer — a stack trace, a config file, a few hundred lines of code — dumps the whole thing inline. ProseMirror has to parse and render every line as editable rich text, the message becomes unreadable, and the editor bogs down on genuinely large clipboards. There was no "this is too big to be a message, make it a file" path the way Slack snippets work.

## Solution

Intercept oversized text pastes in the composer and route them through a plain snippet editor; on save the content becomes a `.txt` attachment chip at the exact spot it was pasted. The editor is a native `<textarea>`, not a rich editor, so the browser renders and scrolls arbitrarily large content natively — no virtualization, no parse cost.

The whole feature rides the attachment path that pasted images and dropped files already use (`handleFileInsert` → `onFileUpload`), so the inline chip, upload-scope-drift guarding, and E2E client-side encryption all come for free — a snippet pasted into an E2E stream is encrypted exactly like any other attachment.

### How it works

1. **Detection** — `shouldConvertPasteToSnippet(text)` (`snippet-paste.ts`) returns true when a paste is `>= 1500` chars OR `>= 12` lines (`SNIPPET_PASTE_CHAR_THRESHOLD` / `SNIPPET_PASTE_LINE_THRESHOLD`). Line count is `(text.match(/\n/g)?.length ?? 0) + 1`, which counts both LF and CRLF.
2. **Trigger** — in `RichEditor`'s `handlePaste`, after the file-paste and memo-link branches, a large text paste calls `event.preventDefault()`, records the caret (`editor.state.selection.from`) in `snippetInsertPosRef`, bumps a per-session counter, and sets `snippetDraft`. Gated on `onFileUploadRef.current` being present — composers without attachment support (edit forms) fall through to the existing inline-paste behavior.
3. **Editor** — `SnippetEditorDialog` is a `ResponsiveDialog` (centered Dialog on desktop, keyboard-safe content-height Drawer on mobile via `disableSnapPoints`). Monospace `<textarea wrap="off">` for code-column layout, an editable filename input (defaults `snippet-N.txt`), a live char/line counter, and Cmd/Ctrl+Enter to save (plain Enter stays free for newlines). It re-seeds from the incoming paste on each open so a cancelled snippet can't leak into the next.
4. **Save** — `handleSnippetSave` synthesizes `new File([text], filename, { type: "text/plain" })`, restores the caret to the remembered paste position (clamped to `doc.content.size`, since the dialog stole focus), and hands the file to `handleFileInsert` — the same call pasted files make. The chip uploads, swaps its temp id for the real attachment id, and sends as a normal attachment; the backend runs text extraction on it like any uploaded text file.

### Key design decisions

**1. Native `<textarea>`, not ProseMirror** — the trigger for this feature is "the clipboard is too big to render as rich text", so the editor cannot itself be a rich-text surface. A `<textarea>` is the one widget browsers virtualize natively, which is what "works with a silly amount of text" requires. No syntax highlighting (out of scope, and highlighting megabytes would reintroduce the cost we're avoiding).

**2. Trigger on lines OR characters** — the two have opposite blind spots. A 2,000-char single-line minified blob has one line; a 30-line shell script can be under 1,500 chars. Either alone misses half the cases, so both thresholds are checked.

**3. Convert even inside code blocks** — a user ruling. The intuition that a code block "wants" inline code loses to the fact that the paste is still too large to read inline regardless of cursor context; the snippet attachment is the better home either way.

**4. Reuse `handleFileInsert` rather than a parallel path** — the alternative was a bespoke snippet upload, which would have to re-implement temp-id tracking, scope-drift guarding (`uploadScopeVersionRef`), and E2E encryption, and would drift from the file path over time. Routing a synthesized `File` through the existing path means a snippet *is* an attachment, with no new backend surface.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/editor/snippet-paste.ts` | Pure trigger heuristic (`shouldConvertPasteToSnippet`), thresholds, and `defaultSnippetFilename` — shared by the paste handler and tests (INV-33). |
| `apps/frontend/src/components/editor/snippet-editor-dialog.tsx` | The monospace snippet editor (responsive Dialog/Drawer, filename field, char/line counter). |
| `apps/frontend/src/components/editor/snippet-paste.test.ts` | Unit tests for the threshold logic (char, line, CRLF, filename numbering). |
| `apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx` | Component tests: seeding, save payload (with filename trim), disabled-save guard, cancel-without-save. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Detect large pastes in `handlePaste`; hold `snippetDraft` state + caret/counter refs; `handleSnippetSave` synthesizes the `File` and inserts at the paste caret via `handleFileInsert`; render `SnippetEditorDialog` (only when `onFileUpload` is wired). |

## Out of scope (deliberate)

- **Syntax highlighting** — explicitly excluded; see decision 1.
- **Tab-to-indent in the editor** — would trap keyboard focus (a11y); left out of the "very simple" v1.
- **Cancel does not re-insert the text inline** — the paste is discarded (the clipboard still holds it, so re-paste works). No "insert as plain text anyway" escape hatch in v1.
- **No backend changes** — a snippet is an ordinary `text/plain` attachment; the upload, storage, extraction, and timeline-rendering paths are untouched.

## Test plan

- [x] `bun run test src/components/editor/snippet-paste.test.ts src/components/editor/snippet-editor-dialog.test.ts` — 9 pass
- [x] `bun run test src/components/editor` (full editor suite incl. paste path) — 326 pass
- [x] `bun run test src/components/composer/message-composer.test.tsx` — passes (composer host unaffected)
- [x] `tsc --noEmit` across the monorepo — clean (pre-commit hook)
- [x] `eslint` on all touched files + monorepo lint (pre-commit hook) — clean
- [x] Self-review of the diff against the claims above — verified (reuse of `handleFileInsert`, `onFileUpload` gating, no code-block guard, caret clamp)
- [ ] Manual in-app paste of a large blob — not run in this session; the flow is covered by unit/component tests but not yet exercised end-to-end in the browser

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHrmfPn1MYURXRM26FyCSi)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784185504&installation_id=129946197&pr_number=963&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F963&signature=1835eec922877ca926000a6cea299cffc4c6f28c2635dabbcd6f59ebb4977eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->