### PR TITLE
feat(composer): sniff snippet format for a smarter default extension

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -33,7 +33,13 @@ import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useGiphyEnabled } from "@/hooks/use-giphy-enabled"
 import { GiphyPickerDialog } from "./giphy-picker-dialog"
 import { SnippetEditorDialog } from "./snippet-editor-dialog"
-import { shouldConvertPasteToSnippet, defaultSnippetFilename, SNIPPET_FALLBACK_FILENAME } from "./snippet-paste"
+import {
+  shouldConvertPasteToSnippet,
+  defaultSnippetFilename,
+  detectSnippetFormat,
+  snippetMimeForFilename,
+  SNIPPET_FALLBACK_FILENAME,
+} from "./snippet-paste"
 import type { GiphyGif } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { usePreferences } from "@/contexts"
@@ -461,7 +467,9 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       if (!editorInstance || editorInstance.isDestroyed || !uploadFn) return
 
       const safeName = filename.trim() || SNIPPET_FALLBACK_FILENAME
-      const file = new File([text], safeName, { type: "text/plain" })
+      // Mime follows the final (possibly renamed) extension, not the original
+      // sniff, so the filename stays the single source of truth.
+      const file = new File([text], safeName, { type: snippetMimeForFilename(safeName) })
 
       // Restore the caret to where the paste landed (the dialog stole focus).
       const chain = editorInstance.chain().focus()
@@ -578,7 +586,8 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           event.preventDefault()
           snippetInsertPosRef.current = editorRef.current.state.selection.from
           snippetCountRef.current += 1
-          setSnippetDraft({ text, filename: defaultSnippetFilename(snippetCountRef.current) })
+          const detected = detectSnippetFormat(text)
+          setSnippetDraft({ text, filename: defaultSnippetFilename(snippetCountRef.current, detected.extension) })
           return true
         }
 

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
@@ -36,9 +36,10 @@ describe("SnippetEditorDialog", () => {
       />
     )
 
-    expect(screen.getByLabelText("Detected format: JSON")).toBeTruthy()
+    expect(screen.getByText("JSON")).toBeTruthy()
     fireEvent.change(screen.getByLabelText("Snippet filename"), { target: { value: "data.csv" } })
-    expect(screen.getByLabelText("Detected format: CSV")).toBeTruthy()
+    expect(screen.getByText("CSV")).toBeTruthy()
+    expect(screen.queryByText("JSON")).toBeNull()
   })
 
   it("saves the edited text and filename", () => {

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
@@ -25,6 +25,22 @@ describe("SnippetEditorDialog", () => {
     expect((screen.getByLabelText("Snippet filename") as HTMLInputElement).value).toBe("snippet-1.txt")
   })
 
+  it("shows a format badge that tracks the filename extension", () => {
+    render(
+      <SnippetEditorDialog
+        open
+        onOpenChange={() => {}}
+        initialText={`{ "a": 1 }`}
+        defaultFilename="snippet-1.json"
+        onSave={() => {}}
+      />
+    )
+
+    expect(screen.getByLabelText("Detected format: JSON")).toBeTruthy()
+    fireEvent.change(screen.getByLabelText("Snippet filename"), { target: { value: "data.csv" } })
+    expect(screen.getByLabelText("Detected format: CSV")).toBeTruthy()
+  })
+
   it("saves the edited text and filename", () => {
     const onSave = vi.fn()
     render(

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { FileCode2 } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -10,16 +11,16 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { SNIPPET_FALLBACK_FILENAME } from "./snippet-paste"
+import { SNIPPET_FALLBACK_FILENAME, snippetFormatForFilename } from "./snippet-paste"
 
 interface SnippetEditorDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /** Pasted text the editor is seeded with each time it opens. */
   initialText: string
-  /** Suggested filename (e.g. `snippet-1.txt`); the user can rename it. */
+  /** Suggested filename (e.g. `snippet-1.json`); the user can rename it. */
   defaultFilename: string
-  /** Save the (possibly edited) snippet as a `.txt` attachment. */
+  /** Save the (possibly edited) snippet; its mime follows the filename. */
   onSave: (args: { text: string; filename: string }) => void
 }
 
@@ -66,6 +67,9 @@ export function SnippetEditorDialog({
 
   const trimmedFilename = filename.trim()
   const canSave = text.length > 0 && trimmedFilename.length > 0
+  // Reads off the live filename (not the original sniff) so the badge always
+  // matches the extension that will actually be attached.
+  const format = snippetFormatForFilename(trimmedFilename || SNIPPET_FALLBACK_FILENAME)
 
   const handleSave = () => {
     if (!canSave) return
@@ -112,13 +116,18 @@ export function SnippetEditorDialog({
             scroll the fields into reach instead of clipping them off-screen,
             per the ResponsiveDialog disableSnapPoints contract. */}
         <div className="flex-1 min-h-0 flex flex-col gap-3 px-4 sm:px-6 py-4 overflow-y-auto">
-          <Input
-            aria-label="Snippet filename"
-            value={filename}
-            onChange={(e) => setFilename(e.target.value)}
-            placeholder={SNIPPET_FALLBACK_FILENAME}
-            className="text-sm font-mono"
-          />
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Snippet filename"
+              value={filename}
+              onChange={(e) => setFilename(e.target.value)}
+              placeholder={SNIPPET_FALLBACK_FILENAME}
+              className="flex-1 text-sm font-mono"
+            />
+            <Badge variant="secondary" className="shrink-0 font-normal" aria-label={`Detected format: ${format.label}`}>
+              {format.label}
+            </Badge>
+          </div>
           {/* wrap="off": long lines scroll horizontally so code keeps its
               column layout rather than reflowing. */}
           <Textarea

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -124,7 +124,11 @@ export function SnippetEditorDialog({
               placeholder={SNIPPET_FALLBACK_FILENAME}
               className="flex-1 text-sm font-mono"
             />
-            <Badge variant="secondary" className="shrink-0 font-normal" aria-label={`Detected format: ${format.label}`}>
+            <Badge
+              variant="secondary"
+              className="shrink-0 justify-center min-w-24 font-normal pointer-events-none select-none"
+            >
+              <span className="sr-only">Detected format: </span>
               {format.label}
             </Badge>
           </div>

--- a/apps/frontend/src/components/editor/snippet-paste.test.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { categoryFromMime } from "@threa/types"
 import {
   shouldConvertPasteToSnippet,
   defaultSnippetFilename,
@@ -109,5 +110,19 @@ describe("snippetFormatForFilename", () => {
     expect(snippetMimeForFilename("mydata")).toBe("text/plain")
     expect(snippetMimeForFilename("archive.unknownext")).toBe("text/plain")
     expect(snippetMimeForFilename(".bashrc")).toBe("text/plain")
+  })
+
+  // Guards the "mimes align with categoryFromMime" design claim so a future mime
+  // edit can't silently land a snippet in the wrong attachment category.
+  it.each([
+    ["snippet.json", "code"],
+    ["snippet.xml", "code"],
+    ["snippet.html", "code"],
+    ["snippet.md", "code"],
+    ["snippet.yaml", "code"],
+    ["snippet.csv", "sheet"],
+    ["snippet.txt", "doc"],
+  ])("%s mime buckets as %s via categoryFromMime", (filename, category) => {
+    expect(categoryFromMime(snippetMimeForFilename(filename))).toBe(category)
   })
 })

--- a/apps/frontend/src/components/editor/snippet-paste.test.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest"
 import {
   shouldConvertPasteToSnippet,
   defaultSnippetFilename,
+  detectSnippetFormat,
+  snippetFormatForFilename,
+  snippetMimeForFilename,
   SNIPPET_PASTE_CHAR_THRESHOLD,
   SNIPPET_PASTE_LINE_THRESHOLD,
 } from "./snippet-paste"
@@ -33,8 +36,78 @@ describe("shouldConvertPasteToSnippet", () => {
 })
 
 describe("defaultSnippetFilename", () => {
-  it("numbers snippets per session", () => {
+  it("defaults to a .txt extension", () => {
     expect(defaultSnippetFilename(1)).toBe("snippet-1.txt")
     expect(defaultSnippetFilename(3)).toBe("snippet-3.txt")
+  })
+
+  it("uses the detected extension when given one", () => {
+    expect(defaultSnippetFilename(2, "json")).toBe("snippet-2.json")
+    expect(defaultSnippetFilename(5, "md")).toBe("snippet-5.md")
+  })
+})
+
+describe("detectSnippetFormat", () => {
+  it("falls back to plain text for empty or prose input", () => {
+    expect(detectSnippetFormat("").key).toBe("text")
+    expect(detectSnippetFormat("   ").key).toBe("text")
+    expect(detectSnippetFormat("Just an ordinary paragraph, with a comma or two.").key).toBe("text")
+  })
+
+  it("detects parse-verified JSON objects and arrays", () => {
+    expect(detectSnippetFormat(`{ "a": 1, "b": [2, 3] }`).key).toBe("json")
+    expect(detectSnippetFormat(`[\n  { "id": 1 },\n  { "id": 2 }\n]`).key).toBe("json")
+  })
+
+  it("does not call almost-JSON that fails to parse JSON", () => {
+    expect(detectSnippetFormat(`{ a: 1, b: 2, }`).key).toBe("text")
+  })
+
+  it("detects HTML and XML markup", () => {
+    expect(detectSnippetFormat("<!DOCTYPE html>\n<html><body>hi</body></html>").key).toBe("html")
+    expect(detectSnippetFormat('<html lang="en"><head></head></html>').key).toBe("html")
+    expect(detectSnippetFormat('<?xml version="1.0"?>\n<root><a>1</a></root>').key).toBe("xml")
+    expect(detectSnippetFormat("<note><to>x</to><from>y</from></note>").key).toBe("xml")
+  })
+
+  it("detects CSV only when delimiter counts are consistent", () => {
+    expect(detectSnippetFormat("a,b,c\n1,2,3\n4,5,6").key).toBe("csv")
+    expect(detectSnippetFormat("name\temail\tage\nAda\ta@x\t30\nBob\tb@y\t41").key).toBe("csv")
+    // Prose lines with stray, uneven commas are not CSV.
+    expect(detectSnippetFormat("Hello, there.\nThis line, however, has more.\nAnd this one none").key).toBe("text")
+  })
+
+  it("detects markdown only with multiple structural signals", () => {
+    const md = "# Title\n\nSome intro text.\n\n- one\n- two\n- three\n\nMore prose here."
+    expect(detectSnippetFormat(md).key).toBe("markdown")
+    const fenced = "## Setup\n\n```bash\nbun install\nbun run dev\n```\n"
+    expect(detectSnippetFormat(fenced).key).toBe("markdown")
+    // A single `#`-commented script line is one signal, not markdown.
+    const script = "# build script\nset -e\nfor f in *.ts; do\n  echo $f\ndone\n"
+    expect(detectSnippetFormat(script).key).not.toBe("markdown")
+  })
+
+  it("detects YAML via a document marker or a key-dominated body", () => {
+    expect(detectSnippetFormat("---\nname: threa\nversion: 1\nitems:\n  - a\n  - b").key).toBe("yaml")
+    expect(detectSnippetFormat("host: localhost\nport: 5432\nuser: admin\ndebug: false").key).toBe("yaml")
+    expect(detectSnippetFormat("The quick brown fox.\nJumped over the lazy dog.\nAgain and again.").key).toBe("text")
+  })
+})
+
+describe("snippetFormatForFilename", () => {
+  it("maps known extensions to their format and mime", () => {
+    expect(snippetFormatForFilename("snippet-1.json").label).toBe("JSON")
+    expect(snippetMimeForFilename("snippet-1.json")).toBe("application/json")
+    expect(snippetMimeForFilename("data.csv")).toBe("text/csv")
+    expect(snippetMimeForFilename("config.yml")).toBe("application/x-yaml")
+    expect(snippetMimeForFilename("page.htm")).toBe("text/html")
+    expect(snippetMimeForFilename("notes.md")).toBe("text/markdown")
+  })
+
+  it("treats unknown or missing extensions as plain text", () => {
+    expect(snippetMimeForFilename("snippet-1.txt")).toBe("text/plain")
+    expect(snippetMimeForFilename("mydata")).toBe("text/plain")
+    expect(snippetMimeForFilename("archive.unknownext")).toBe("text/plain")
+    expect(snippetMimeForFilename(".bashrc")).toBe("text/plain")
   })
 })

--- a/apps/frontend/src/components/editor/snippet-paste.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.ts
@@ -1,8 +1,10 @@
 /**
  * Heuristics for deciding when a pasted blob is "too large to reasonably live
  * inside a message" and should become a snippet attachment instead of inline
- * text. Kept as a pure module (no React) so the rich-editor paste handler and
- * the unit tests share one source of truth (INV-33).
+ * text, plus conservative format sniffing so the attachment gets a meaningful
+ * extension/mime rather than always `.txt`. Kept as a pure module (no React) so
+ * the rich-editor paste handler, the dialog, and the unit tests share one
+ * source of truth (INV-33).
  */
 
 /** A paste this long (characters) converts to a snippet, regardless of shape. */
@@ -26,10 +28,155 @@ export function shouldConvertPasteToSnippet(text: string): boolean {
   return lineCount >= SNIPPET_PASTE_LINE_THRESHOLD
 }
 
+export type SnippetFormatKey = "text" | "json" | "xml" | "html" | "csv" | "markdown" | "yaml"
+
+export interface SnippetFormat {
+  key: SnippetFormatKey
+  /** Filename extension without the dot, e.g. `json`. */
+  extension: string
+  /** Mime aligned with `categoryFromMime` so non-E2E uploads bucket correctly. */
+  mimeType: string
+  /** Short human label for the dialog badge. */
+  label: string
+}
+
+const SNIPPET_FORMATS: Record<SnippetFormatKey, SnippetFormat> = {
+  text: { key: "text", extension: "txt", mimeType: "text/plain", label: "Plain text" },
+  json: { key: "json", extension: "json", mimeType: "application/json", label: "JSON" },
+  xml: { key: "xml", extension: "xml", mimeType: "application/xml", label: "XML" },
+  html: { key: "html", extension: "html", mimeType: "text/html", label: "HTML" },
+  csv: { key: "csv", extension: "csv", mimeType: "text/csv", label: "CSV" },
+  markdown: { key: "markdown", extension: "md", mimeType: "text/markdown", label: "Markdown" },
+  yaml: { key: "yaml", extension: "yaml", mimeType: "application/x-yaml", label: "YAML" },
+}
+
+/** The conservative fallback: anything not confidently recognised stays text. */
+export const SNIPPET_TEXT_FORMAT = SNIPPET_FORMATS.text
+
+const EXTENSION_TO_FORMAT: Record<string, SnippetFormat> = {
+  txt: SNIPPET_FORMATS.text,
+  json: SNIPPET_FORMATS.json,
+  xml: SNIPPET_FORMATS.xml,
+  html: SNIPPET_FORMATS.html,
+  htm: SNIPPET_FORMATS.html,
+  csv: SNIPPET_FORMATS.csv,
+  md: SNIPPET_FORMATS.markdown,
+  markdown: SNIPPET_FORMATS.markdown,
+  yaml: SNIPPET_FORMATS.yaml,
+  yml: SNIPPET_FORMATS.yaml,
+}
+
+function extensionOf(filename: string): string {
+  const base = filename.trim().toLowerCase()
+  const dot = base.lastIndexOf(".")
+  // A leading dot (dotfile) or trailing dot carries no usable extension.
+  if (dot <= 0 || dot === base.length - 1) return ""
+  return base.slice(dot + 1)
+}
+
+/**
+ * Resolve the snippet format from a filename's extension. The (possibly
+ * renamed) filename is the single source of truth for both the dialog badge and
+ * the attachment's mime, so a user rename to `.csv` is honoured over whatever
+ * was originally sniffed. Unknown extensions fall back to plain text.
+ */
+export function snippetFormatForFilename(filename: string): SnippetFormat {
+  return EXTENSION_TO_FORMAT[extensionOf(filename)] ?? SNIPPET_FORMATS.text
+}
+
+/** Mime type for the attachment, derived from the final filename's extension. */
+export function snippetMimeForFilename(filename: string): string {
+  return snippetFormatForFilename(filename).mimeType
+}
+
 /** Default filename for the Nth snippet pasted into a given editor session. */
-export function defaultSnippetFilename(index: number): string {
-  return `snippet-${index}.txt`
+export function defaultSnippetFilename(index: number, extension: string = SNIPPET_FORMATS.text.extension): string {
+  return `snippet-${index}.${extension}`
 }
 
 /** Filename used when the snippet's name field is left blank on save. */
 export const SNIPPET_FALLBACK_FILENAME = "snippet.txt"
+
+/**
+ * Best-effort structural format sniff for a pasted blob. Deliberately
+ * conservative: every detector demands a hard structural signal and anything
+ * ambiguous falls through to plain text — a wrong rename is worse than a `.txt`
+ * (the chosen posture). Detection is structural only (JSON parse, markup tags,
+ * delimiter consistency, markdown/yaml shape); it never guesses a programming
+ * language from keywords, which would be the English-only semantic heuristic
+ * INV-54 forbids. Order runs most-definitive first.
+ */
+export function detectSnippetFormat(text: string): SnippetFormat {
+  const trimmed = text.trim()
+  if (!trimmed) return SNIPPET_FORMATS.text
+  if (looksLikeJson(trimmed)) return SNIPPET_FORMATS.json
+  const markup = detectMarkup(trimmed)
+  if (markup) return markup
+  if (looksLikeCsv(text)) return SNIPPET_FORMATS.csv
+  if (looksLikeMarkdown(text)) return SNIPPET_FORMATS.markdown
+  if (looksLikeYaml(text)) return SNIPPET_FORMATS.yaml
+  return SNIPPET_FORMATS.text
+}
+
+function looksLikeJson(trimmed: string): boolean {
+  const first = trimmed[0]
+  if (first !== "{" && first !== "[") return false
+  try {
+    const parsed = JSON.parse(trimmed)
+    return typeof parsed === "object" && parsed !== null
+  } catch {
+    return false
+  }
+}
+
+function detectMarkup(trimmed: string): SnippetFormat | null {
+  if (trimmed[0] !== "<") return null
+  const head = trimmed.slice(0, 100).toLowerCase()
+  if (head.startsWith("<!doctype html") || head.startsWith("<html")) return SNIPPET_FORMATS.html
+  if (head.startsWith("<?xml")) return SNIPPET_FORMATS.xml
+  // Generic markup: opens with a real tag that also has a matching close tag.
+  const open = trimmed.match(/^<([a-zA-Z][\w:-]*)(?:\s[^>]*)?>/)
+  if (open) {
+    const tag = open[1].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    if (new RegExp(`</${tag}\\s*>`).test(trimmed)) return SNIPPET_FORMATS.xml
+  }
+  return null
+}
+
+function looksLikeCsv(text: string): boolean {
+  const lines = text.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  if (lines.length < 2) return false
+  // A real CSV has the same number of a single delimiter on every row; prose
+  // with stray commas won't hold a constant count across many lines.
+  for (const delimiter of [",", "\t", ";"]) {
+    const counts = lines.map((line) => line.split(delimiter).length - 1)
+    if (counts[0] >= 1 && counts.every((count) => count === counts[0])) return true
+  }
+  return false
+}
+
+function looksLikeMarkdown(text: string): boolean {
+  const lines = text.split(/\r?\n/)
+  let hasHeading = false
+  let hasFence = false
+  let hasList = false
+  for (const line of lines) {
+    if (/^#{1,6}\s+\S/.test(line)) hasHeading = true
+    else if (/^\s*(```|~~~)/.test(line)) hasFence = true
+    else if (/^\s*([-*+]\s+\S|\d+\.\s+\S)/.test(line)) hasList = true
+  }
+  // Require two distinct structural signals: a single `#` comment or one dash in
+  // otherwise-plain text shouldn't tip a paste into `.md`.
+  return Number(hasHeading) + Number(hasFence) + Number(hasList) >= 2
+}
+
+function looksLikeYaml(text: string): boolean {
+  const lines = text.split(/\r?\n/)
+  const content = lines.filter((line) => line.trim() && !line.trim().startsWith("#"))
+  if (content.length < 2) return false
+  const keyLike = content.filter((line) => /^[ \t]*[\w.-]+:(\s|$)/.test(line) || /^[ \t]*-\s+\S/.test(line))
+  // A `---` document marker is a hard YAML signal; without one, demand that the
+  // blob is overwhelmingly `key:`/list lines so prose can't slip through.
+  if (lines.some((line) => line.trim() === "---")) return keyLike.length >= 1
+  return keyLike.length >= 3 && keyLike.length / content.length >= 0.8
+}

--- a/apps/frontend/src/components/editor/snippet-paste.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.ts
@@ -50,9 +50,6 @@ const SNIPPET_FORMATS: Record<SnippetFormatKey, SnippetFormat> = {
   yaml: { key: "yaml", extension: "yaml", mimeType: "application/x-yaml", label: "YAML" },
 }
 
-/** The conservative fallback: anything not confidently recognised stays text. */
-export const SNIPPET_TEXT_FORMAT = SNIPPET_FORMATS.text
-
 const EXTENSION_TO_FORMAT: Record<string, SnippetFormat> = {
   txt: SNIPPET_FORMATS.text,
   json: SNIPPET_FORMATS.json,


### PR DESCRIPTION
Follow-up to #963 (Slack-style snippet attachments). That PR made large composer pastes become a `.txt` attachment with a hardcoded `text/plain` mime. This PR sniffs the content and picks a smarter default extension/mime.

## Problem

In #963, `defaultSnippetFilename` baked `.txt` into the suggested name and `handleSnippetSave` constructed the `File` with a hardcoded `{ type: "text/plain" }`. Pasting a JSON blob, a CSV export, or an HTML document produced `snippet-1.txt` / `text/plain` regardless of what it actually was — a worse download name, the wrong icon, and the wrong attachment category for non-E2E extraction.

## Solution

Add a conservative, pure structural sniff (`detectSnippetFormat`) that runs on paste to seed a smarter default extension, and make the final (possibly renamed) filename the single source of truth for the attachment's mime and the dialog's format badge. No backend or wire change — the better extension/mime are sealed into the message `attachmentRefs` client-side, so this improves the E2E render path for free.

### How it works

- `detectSnippetFormat(text)` in `snippet-paste.ts` returns a `SnippetFormat` (`{ key, extension, mimeType, label }`) from a `SNIPPET_FORMATS` registry. Detectors run most-definitive first and each demands a hard structural signal:
  - **JSON** — trimmed starts with `{`/`[` and `JSON.parse` succeeds (definitive).
  - **HTML / XML** — `<!doctype html>`/`<html` → HTML; `<?xml` → XML; otherwise an opening tag with a matching close tag → XML.
  - **CSV** — ≥2 non-empty lines with the same count of a single delimiter (`,`/tab/`;`) on every line.
  - **Markdown** — ≥2 distinct structural signals among ATX heading, fenced block, list marker (so a lone `#` comment in a script doesn't qualify).
  - **YAML** — a `---` document marker, or a body that's ≥80% `key:`/list lines (≥3 of them).
  - Anything ambiguous returns the `text` fallback.
- The paste branch in `rich-editor.tsx` calls the detector and passes `detected.extension` to `defaultSnippetFilename(index, extension)`, so the dialog opens pre-filled with e.g. `snippet-1.json`.
- `handleSnippetSave` derives the `File` mime from the final filename via `snippetMimeForFilename(safeName)` — not from the original sniff — so a manual rename to `.csv` is honoured.
- `SnippetEditorDialog` shows an always-present format badge computed from the live filename via `snippetFormatForFilename(...)`.

### Key design decisions

**1. Filename is the single source of truth, not the sniff.** The sniff only seeds the default extension; the mime and the badge both derive from the current filename. The user can rename freely in the dialog and the attachment follows. This avoids drift between what the badge says and what actually gets attached, and keeps one ext→format map (`snippet-paste.ts`) feeding both (INV-33).

**2. Structural detection only — no language guessing.** JSON parse, markup tags, delimiter consistency, and markdown/yaml shape are all structural. Detecting a programming language by keywords would be exactly the English-only semantic heuristic INV-54 forbids, so code-language detection is out.

**3. Conservative posture (prefer `.txt` on doubt).** Each detector requires a strong signal and falls through to plain text otherwise — a wrong rename is more annoying than a plain `.txt`. CSV demands a constant delimiter count across rows; markdown demands two distinct signals; YAML demands a `---` marker or an overwhelmingly key-shaped body.

**4. Mimes align with `categoryFromMime`.** `application/json`, `application/xml`, `text/html`, `text/csv`, `text/markdown`, and `application/x-yaml` all bucket into the right attachment category (`code`/`sheet`) in `packages/types/src/attachment-categories.ts`, so non-E2E snippet uploads categorise correctly.

**5. Always-present badge (INV-21).** The badge renders for every format including "Plain text", so swapping formats never shifts layout.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/snippet-paste.ts` | Add `SnippetFormat`/`SNIPPET_FORMATS` registry, `detectSnippetFormat`, `snippetFormatForFilename`/`snippetMimeForFilename`, and an `extension` arg on `defaultSnippetFilename` |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Call the detector on paste to seed the extension; derive the `File` mime from the final filename |
| `apps/frontend/src/components/editor/snippet-editor-dialog.tsx` | Render a live format badge next to the filename input; update prop docs |
| `apps/frontend/src/components/editor/snippet-paste.test.ts` | Unit tests for every detector + ext→mime mapping + false-positive cases |
| `apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx` | Test that the badge tracks the live filename |

## Out of scope (deliberate)

- **Code-language detection** (ts/py/sh/sql/…) — would need a highlight/linguist dependency and trips INV-54. Not in v1.
- **Quoted-field CSV with embedded delimiters** — the conservative delimiter-count check won't match these; they fall back to `.txt` (accepted false-negative).
- **HTML fragments** that don't start with `<!doctype`/`<html` (e.g. a bare `<div>…</div>`) are labelled XML, not HTML — both bucket to `code`, so the practical impact is the extension/label only.
- The badge is read-only (no override dropdown); the editable filename is the override mechanism.

## Test plan

- [x] `bun run test src/components/editor/snippet-paste.test.ts src/components/editor/snippet-editor-dialog.test.tsx` — 20 pass
- [x] `bun run test src/components/editor` (full editor dir) — 337 pass
- [x] `bun run typecheck` (frontend `tsc --noEmit`) — clean
- [x] `bunx eslint` on the 5 touched files — clean
- [x] Pre-commit hook (prettier + lint + monorepo typecheck + astro check + OpenAPI doc check) — passed
- [ ] Manual paste-flow check in a running app — not done here; staging env per-PR is the place to try it on mobile

Self-review (claim-verification pass): each named symbol, mime, and invariant reference checked against the diff; mime↔category alignment verified against `attachment-categories.ts`. No findings. A full `/code-review` pass is running next.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcDQbE4o79wx6SCgp8aRWP)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204695&installation_id=129946197&pr_number=965&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F965&signature=354cc62f8013b442ec66910b5e43bae0a84e8a9353342d0095397620214ab1fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->