### PR TITLE
docs(deslopify): add eight structural slop tells from skill-deslop

### DIFF
--- a/.agents/skills/deslopify/SKILL.md
+++ b/.agents/skills/deslopify/SKILL.md
@@ -49,7 +49,33 @@ strings. Not for code identifiers, log lines, or internal comments.
 8. **Naming competitors** — even when one motivated the product. Describe the gap,
    not the rival.
 9. **Aspirational claims stated as present fact** — see the honesty rule below.
-10. **Formulaic colorized highlights** — one accent-colored word in every heading
+10. **Throat-clearing openers** — "Here's the thing:", "Here's what X does", "It
+    turns out", "The truth is", "What you need to know:". Filler before the
+    point. Delete it and open on the point itself.
+11. **Self-posed rhetorical questions** — "Want faster builds?", "The result?
+    Faster builds." Question-then-answer is a setup, not information. State the
+    thing. A genuine question to the reader is fine; the manufactured one isn't.
+12. **The "serves as" dodge** — "serves as", "stands as", "acts as",
+    "represents"/"marks" when they just mean *is*. Use "is", or better, say what
+    the thing does. ("This endpoint serves as the entry point" → "Start here.")
+13. **False agency** — inanimate subjects doing human things to dodge the actor:
+    "errors surface themselves", "the config decides", "the data tells us". Name
+    who or what acts (the worker, the user, the query). Deliberate
+    personification as voice is fine; the tell is the reflexive dodge.
+14. **Listicle in prose** — "The first… The second… The third…": a list wearing
+    a sentence costume. Weave the points into real prose, or make it a real
+    list. A genuine enumerated list is fine.
+15. **Vague attributions** — "experts agree", "studies show", "it's widely
+    known", "many teams". No nameable source means no source: cut the claim or
+    name it.
+16. **Invented concept labels** — christening a plain idea to sound deep: "the
+    calibration paradox", "the X effect", a quoted neologism. Describe the
+    mechanic instead of naming it.
+17. **Bold-first bullets** — every bullet led by a `**bolded phrase** —` then a
+    gloss. One or two for genuine emphasis is fine; a whole list of them is a
+    template tell. Like the accent spans it's markup, so hunt it (`grep -rn
+    '^[[:space:]]*[-*] \*\*' <files>`), not the prose.
+18. **Formulaic colorized highlights** — one accent-colored word in every heading
     (and pull-quote), e.g. `<span class="accent">…</span>` on a word per `<h2>`.
     It reads as generated even when the words are fine, because the *placement* is
     mechanical: every heading, always one phrase. Reserve the accent for rare,
@@ -84,8 +110,10 @@ strings. Not for code identifiers, log lines, or internal comments.
    structural (cadence, contrast, triples), not a single word.
 3. **Rewrite in place**, one tell at a time, keeping voice and accuracy.
 4. **Re-scan mechanically.** At minimum `grep -rn '—' <files>` for stray
-   em-dashes; spot-check for the cliché list. Em-dashes hide in page `<title>`s
-   and alt text too.
+   em-dashes; `grep -rn 'class="accent"' <files>` for highlight tells and
+   `grep -rn '^[[:space:]]*[-*] \*\*' <files>` for bold-first bullets; spot-check
+   the cliché list and openers ("Here's", "It turns out"). Em-dashes hide in page
+   `<title>`s and alt text too.
 5. **Report** what changed: the notable before→after rewrites and anything you
    flagged as a possibly-false claim rather than edited.
 
@@ -103,6 +131,11 @@ strings. Not for code identifiers, log lines, or internal comments.
   ciphertext and produce no memos.`
 - Six headings each with `<span class="accent">one word</span>` → accent only the
   hero and the closing CTA; the rest plain. (Trim the highlight, keep the words.)
+- `Here's the thing: setup is one command.` → `Setup is one command.`
+- `This service serves as the entry point for auth.` → `Authenticate here.`
+- `Want faster builds? Here's how.` → (cut the question; lead with the steps.)
+- `The first benefit is speed; the second is caching.` → `It's faster, and it
+  caches results between runs.`
 
 ## Guardrails
 
@@ -111,3 +144,8 @@ strings. Not for code identifiers, log lines, or internal comments.
   a terse but vague one.
 - When the only honest fix is structural (the claim is wrong, not just sloppy),
   say so and propose the corrected claim rather than quietly rewording.
+
+## Credits
+
+Part of the tell catalog cross-pollinated from Stephen Turner's `skill-deslop`
+(github.com/stephenturner/skill-deslop, MIT) and tropes.fyi.


### PR DESCRIPTION
## Problem

The `deslopify` skill caught word- and markup-level slop (em-dashes, hype
adjectives, "X, not Y", formulaic accent highlights) but missed a class of
structural AI tells that show up constantly in docs, READMEs, and PR
descriptions: throat-clearing openers, self-posed rhetorical questions,
pompous "serves as" verbs, agency dodges, listicles wearing a sentence
costume, and bold-first bullet templates.

Stephen Turner's `skill-deslop` (github.com/stephenturner/skill-deslop, MIT)
catalogs these well. The goal was to borrow the genuinely-new, non-conflicting
tells without diluting this skill's deliberately conservative, copy-focused
philosophy.

## Solution

Surgical merge into `.agents/skills/deslopify/SKILL.md` — eight new tells, each
carrying this skill's existing "but X is fine" caveat so they don't over-trigger
(a real numbered list, a genuine reader question, deliberate personification all
stay allowed).

Tells added (10–17), with the existing colorized-highlights tell renumbered to 18:

| # | Tell | Fix |
| - | ---- | --- |
| 10 | Throat-clearing openers | "Here's the thing:" / "It turns out" → state the point |
| 11 | Self-posed rhetorical questions | "The result? Faster builds." → say it |
| 12 | The "serves as" dodge | pompous verbs for *is* → "is", or what it does |
| 13 | False agency | "errors surface themselves" → name the actor |
| 14 | Listicle in prose | "The first… The second…" → real prose or real list |
| 15 | Vague attributions | "experts agree" → name the source or cut it |
| 16 | Invented concept labels | "the calibration paradox" → describe the mechanic |
| 17 | Bold-first bullets | `**phrase** —` gloss template → markup tell, grep it |

Also: four matching before/after examples, two greps added to the mechanical
re-scan step (`class="accent"` for highlight tells and `^[[:space:]]*[-*] \*\*`
for bold-first bullets), and a Credits line pointing at the upstream (MIT) and
tropes.fyi.

Bold-first bullets slots in next to the existing accent-span tell as a second
"hunt the markup, not the prose" check — relevant because READMEs and changelogs
are explicitly in this skill's scope.

## Out of scope (deliberate)

Three upstream rules fight this skill's stated philosophy and were left out on
purpose, so a reviewer doesn't "restore" them:

- **"Kill all adverbs / no -ly words"** — conflicts with the skill's "be
  conservative; change a sentence only if it carries a tell." A blanket ban
  flattens clean copy.
- **Mandatory active voice / inserting "we"/"you"** — conflicts with "preserve
  the author's voice and any first-person framing."
- **The 1–10 scoring rubric** — heavier ceremony than this surgical,
  copy-focused skill wants.

This skill's unique strength — the visual/markup slop insight — has no upstream
equivalent and stays the headline differentiator.

## Files changed

| File | Change |
| ---- | ------ |
| `.agents/skills/deslopify/SKILL.md` | +8 structural tells, +4 examples, extended re-scan greps, Credits line (+41 / -3) |

## Test plan

- [x] Pre-push husky hook (lint + typecheck across all workspaces + Dockerfile/migration/API-doc checks) — clean
- [ ] No automated test covers agent-skill markdown content; nothing to run beyond the above. Change is docs-only, no product code touched.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9fkYxF17T9z2fqeSPtpP5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784214973&installation_id=129946197&pr_number=966&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F966&signature=317f965b367c941eafb4e6aff17dc26fea9c7bc6c1f413bcc8661433bec6b94f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->