### PR TITLE
feat(e2ee): sealed claim payload type + builder for external bot turns (§2.6)

### DIFF
--- a/apps/backend/src/features/public-api/sealed-turn-context.test.ts
+++ b/apps/backend/src/features/public-api/sealed-turn-context.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test"
+import type { Message } from "../messaging"
+import type { E2eStream, StreamE2eKeyWrap } from "../e2e-streams"
+import { buildSealedTurnContext, type BuildSealedTurnContextInputs } from "./sealed-turn-context"
+
+const E2E: E2eStream = {
+  streamId: "stream_1",
+  workspaceId: "ws_1",
+  enabledAt: new Date(),
+  ownerUserId: "usr_owner",
+  ownerUserKeyId: "e2ek_owner",
+  currentKeyGeneration: 1,
+  hasSealedName: false,
+}
+
+function botWrap(keyId: string, gen: number): StreamE2eKeyWrap {
+  return {
+    keyGeneration: gen,
+    recipientKeyId: keyId,
+    recipientKind: "bot",
+    wrapEnc: `enc_${keyId}_${gen}`,
+    wrapCt: `ct_${keyId}_${gen}`,
+  }
+}
+
+let seq = 0n
+function msg(id: string, authorId: string, text: string, gen = 1): Message {
+  return {
+    id,
+    authorType: authorId.startsWith("bot_") ? "bot" : "user",
+    authorId,
+    sequence: ++seq,
+    createdAt: new Date("2026-06-02T09:27:00.000Z"),
+    ciphertext: Buffer.from(`cipher:${text}`),
+    envelope: { v: 2, keyGeneration: gen, iv: "aXY=", aad: "YWFk" },
+  } as unknown as Message
+}
+
+function inputs(over: Partial<BuildSealedTurnContextInputs> = {}): BuildSealedTurnContextInputs {
+  return {
+    e2e: E2E,
+    bikKeyId: "bik_live",
+    wraps: [botWrap("bik_live", 1)],
+    trigger: msg("msg_trigger", "usr_kris", "hello"),
+    triggerAuthorName: "Kris",
+    priorMessages: [],
+    replySenderId: "bot_pi",
+    callbackToken: "cbtok_test",
+    ...over,
+  }
+}
+
+describe("buildSealedTurnContext", () => {
+  it("builds the sealed context for the claiming BIK", () => {
+    const ctx = buildSealedTurnContext(inputs())
+    expect(ctx).toMatchObject({
+      callbackToken: "cbtok_test",
+      reply: { keyGeneration: 1, senderId: "bot_pi" },
+      prompt: { ciphertext: Buffer.from("cipher:hello").toString("base64") },
+      wraps: [{ keyGeneration: 1, wrapEnc: "enc_bik_live_1", wrapCt: "ct_bik_live_1" }],
+      trigger: { messageId: "msg_trigger", authorName: "Kris", authorType: "user" },
+    })
+  })
+
+  it("is leaner than the enclave assignment — the bot owns its own model and prompt", () => {
+    const ctx = buildSealedTurnContext(inputs())!
+    // The bot runs its own agent loop, so the server never ships these.
+    expect(ctx).not.toHaveProperty("system")
+    expect(ctx).not.toHaveProperty("model")
+    expect(ctx).not.toHaveProperty("temperature")
+    expect(ctx).not.toHaveProperty("maxTokens")
+  })
+
+  it("omits the trigger metadata when the author name can't be resolved", () => {
+    expect(buildSealedTurnContext(inputs({ triggerAuthorName: undefined }))).not.toHaveProperty("trigger")
+  })
+
+  it("returns null when the trigger isn't sealed", () => {
+    const plaintextTrigger = {
+      id: "msg_t",
+      authorId: "usr_kris",
+      ciphertext: null,
+      envelope: null,
+    } as unknown as Message
+    expect(buildSealedTurnContext(inputs({ trigger: plaintextTrigger }))).toBeNull()
+  })
+
+  it("returns null when the claiming BIK has no wrap for the current generation", () => {
+    // The claim predicate normally filters this out; the build re-checks the
+    // revoke/rotation race. Only an older-generation wrap exists.
+    expect(buildSealedTurnContext(inputs({ wraps: [botWrap("bik_live", 0)] }))).toBeNull()
+  })
+
+  it("ships only the claiming BIK's wraps, never another instance's", () => {
+    const ctx = buildSealedTurnContext(inputs({ wraps: [botWrap("bik_other", 1), botWrap("bik_live", 1)] }))
+    expect(ctx!.wraps.every((w) => w.wrapEnc.includes("bik_live"))).toBe(true)
+  })
+
+  it("ignores non-bot wraps even at the same key id and generation", () => {
+    // An enclave (or user) wrap addressed to the same id must never satisfy a
+    // bot claim — only `recipient_kind = 'bot'` wraps count.
+    const enclaveWrap: StreamE2eKeyWrap = { ...botWrap("bik_live", 1), recipientKind: "enclave" }
+    expect(buildSealedTurnContext(inputs({ wraps: [enclaveWrap] }))).toBeNull()
+  })
+
+  it("requires the claiming BIK to open the trigger generation too (rotated-key case)", () => {
+    // Stream rotated to gen 1 after the user turn (sealed under gen 0) was stored.
+    const trigger = msg("msg_trigger", "usr_kris", "hello", 0)
+
+    // BIK wrapped only at the current gen (1) can seal the reply but can't open
+    // the gen-0 prompt → unservable.
+    expect(buildSealedTurnContext(inputs({ trigger, wraps: [botWrap("bik_live", 1)] }))).toBeNull()
+
+    // BIK wrapped at both generations → the context ships both wraps.
+    const ctx = buildSealedTurnContext(inputs({ trigger, wraps: [botWrap("bik_live", 0), botWrap("bik_live", 1)] }))
+    expect(ctx).not.toBeNull()
+    expect(ctx!.wraps.map((w) => w.keyGeneration).sort()).toEqual([0, 1])
+    expect(ctx!.reply.keyGeneration).toBe(1) // reply still seals under current
+  })
+
+  it("maps prior messages to roles by author and drops non-E2E rows", () => {
+    const plaintext = { id: "msg_plain", authorId: "usr_kris", ciphertext: null, envelope: null } as unknown as Message
+    const ctx = buildSealedTurnContext(
+      inputs({
+        // The bot's own prior replies (authorId === replySenderId) are "assistant".
+        priorMessages: [msg("msg_a", "usr_kris", "q"), msg("msg_b", "bot_pi", "a"), plaintext],
+      })
+    )
+    expect(ctx!.history.map((h) => h.role)).toEqual(["user", "assistant"]) // plaintext dropped
+  })
+})

--- a/apps/backend/src/features/public-api/sealed-turn-context.ts
+++ b/apps/backend/src/features/public-api/sealed-turn-context.ts
@@ -1,0 +1,93 @@
+import type { SealedTurnContext, EnclaveStreamEnvelope } from "@threa/types"
+import type { E2eStream, StreamE2eKeyWrap } from "../e2e-streams"
+import type { Message } from "../messaging"
+
+/**
+ * Builds the {@link SealedTurnContext} the bot claim endpoint hands an
+ * owner-granted external runner when the delivery verdict is `sealed` — the
+ * external analog of `buildEnclaveSessionAssignment`. Pure, so the
+ * wrap-coverage and history-mapping logic is unit-testable without a DB; the
+ * claim handler fetches the inputs, creates the session row with the callback
+ * binding, and returns the result on the claim response.
+ *
+ * The backend never decrypts: it ships ciphertext + the SSK wraps addressed to
+ * the claiming bot's BIK, and the bot unwraps with its identity private key.
+ * Returns `null` when the turn can't be served (the claiming key can't cover the
+ * prompt's and reply's generations — a revoke/rotation race after the claim
+ * predicate passed), so the caller fails the claim loudly rather than handing
+ * over a context the bot can't open.
+ */
+export interface BuildSealedTurnContextInputs {
+  e2e: E2eStream
+  /** The claiming bot instance's BIK key id — the assignment seals to this key. */
+  bikKeyId: string
+  /** All SSK wraps for the stream (any recipient kind); bot wraps for `bikKeyId` are filtered out here. */
+  wraps: StreamE2eKeyWrap[]
+  /** The triggering message (its ciphertext becomes the prompt). */
+  trigger: Message
+  /**
+   * Display name of the trigger's author, for the bot's "Triggered by" context
+   * step. Omitted when the author can't be resolved — the bot then suppresses
+   * the row rather than rendering a misleading placeholder.
+   */
+  triggerAuthorName?: string
+  /** Prior messages, oldest→newest, for context. */
+  priorMessages: Message[]
+  /** The bot id the replies are authored by + bound to in their seal AAD. */
+  replySenderId: string
+  /** Claim-minted secret the bot echoes on every sealed callback (model A). */
+  callbackToken: string
+}
+
+export function buildSealedTurnContext(inputs: BuildSealedTurnContextInputs): SealedTurnContext | null {
+  const { e2e, bikKeyId, wraps, trigger, priorMessages } = inputs
+  if (!trigger.ciphertext || !trigger.envelope) return null
+
+  const botWraps = wraps.filter((w) => w.recipientKind === "bot")
+  const currentGen = e2e.currentKeyGeneration
+  const triggerGen = (trigger.envelope as EnclaveStreamEnvelope).keyGeneration
+  const hasWrap = (generation: number) =>
+    botWraps.some((w) => w.recipientKeyId === bikKeyId && w.keyGeneration === generation)
+
+  // The claiming BIK must both open the prompt (its generation can lag `current`
+  // if the stream rotated after the turn was stored) and seal the reply (under
+  // `current`). The claim predicate already proved both against the same wraps
+  // table; this re-check guards the revoke/rotation race between claim and build.
+  if (!hasWrap(currentGen) || !hasWrap(triggerGen)) return null
+
+  // Send every wrap addressed to the claiming BIK (all generations) so it can
+  // also open older history; the bot skips any generation it has no wrap for.
+  const chosenWraps = botWraps
+    .filter((w) => w.recipientKeyId === bikKeyId)
+    .map((w) => ({ keyGeneration: w.keyGeneration, wrapEnc: w.wrapEnc, wrapCt: w.wrapCt }))
+
+  const history = priorMessages
+    .filter((m) => m.ciphertext && m.envelope)
+    .map((m) => ({
+      ciphertext: m.ciphertext!.toString("base64"),
+      envelope: m.envelope as EnclaveStreamEnvelope,
+      role: m.authorId === inputs.replySenderId ? ("assistant" as const) : ("user" as const),
+      sequence: m.sequence.toString(),
+    }))
+
+  return {
+    callbackToken: inputs.callbackToken,
+    wraps: chosenWraps,
+    history,
+    prompt: {
+      ciphertext: trigger.ciphertext.toString("base64"),
+      envelope: trigger.envelope as EnclaveStreamEnvelope,
+    },
+    reply: { keyGeneration: currentGen, senderId: inputs.replySenderId },
+    ...(inputs.triggerAuthorName
+      ? {
+          trigger: {
+            messageId: trigger.id,
+            authorName: inputs.triggerAuthorName,
+            authorType: trigger.authorType,
+            createdAt: trigger.createdAt.toISOString(),
+          },
+        }
+      : {}),
+  }
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -795,6 +795,62 @@ export interface EnclaveSessionAssignment {
 }
 
 /**
+ * The sealed work handed to an owner-granted *external* sealed runner (a
+ * third-party / self-hosted bot harness) as the body of a winning claim, when
+ * the delivery verdict resolves to `sealed` (`resolveDeliveryVerdict`). It is the
+ * external sibling of {@link EnclaveSessionAssignment} and §2.6's `SealedTurnContext`:
+ * the shared shape any sealed-capable driver consumes, deliberately NOT
+ * enclave-named so the bot path reuses it without re-prefixing the vocabulary.
+ *
+ * It is **leaner than the enclave assignment on purpose**: an external harness
+ * runs its OWN agent loop (its own model, system prompt, sampling), so the
+ * server ships only the material the bot can't derive — the SSK `wraps` addressed
+ * to the claiming bot's BIK, the sealed `history`/`prompt` ciphertext, the
+ * `reply` generation + sender id each seal binds to, and the per-claim
+ * `callbackToken` (model A) that authorizes the sealed callbacks. It omits the
+ * enclave's `system`/`model`/`temperature`/`maxTokens` (the bot owns those) and,
+ * for now, the C-1/C-2 continuity fields (`recentDigests`, `priorSummary`, …) and
+ * attachments — additive later, kept out per INV-36 until the harness consumes them.
+ *
+ * The backend never decrypts: it ships ciphertext the owner sealed under the
+ * stream SSK and the wraps for the claiming BIK. The bot unwraps the SSK with its
+ * identity private key, opens history/prompt, runs its turn, and seals each
+ * reply/step back under the same SSK — exactly as the enclave does.
+ */
+export interface SealedTurnContext {
+  /**
+   * Per-claim secret binding this turn's sealed callbacks to the bot instance
+   * that won the claim (model A, mirroring {@link EnclaveSessionAssignment.callbackToken}).
+   * Delivered only inside this claim response and echoed on every sealed
+   * `/steps`/`/complete` callback; the backend rejects a mismatch or absent
+   * token. A sealed turn carries the owner's plaintext, so this is what stops a
+   * leaked workspace bot key alone from hijacking another in-flight session's
+   * callbacks (the E2EE-21/22 class).
+   */
+  callbackToken: string
+  /**
+   * SSK wraps addressed to the claiming bot's BIK, covering the reply (current)
+   * and trigger generations — the same pair the claim predicate verified, so the
+   * bot can open both the history it's handed and seal its reply under the
+   * current generation.
+   */
+  wraps: EnclaveSskWrap[]
+  /** Prior turns, oldest→newest; `role` tells the model who spoke, `sequence` is clear metadata. */
+  history: (EnclaveSealedMessage & { role: "user" | "assistant"; sequence: string })[]
+  /** The sealed trigger message — the bot opens it to get its instructions. */
+  prompt: EnclaveSealedMessage
+  /** The generation every reply/step must seal under, plus the bot's sender id (bound into the seal AAD). */
+  reply: { keyGeneration: number; senderId: string }
+  /**
+   * Non-secret trigger metadata, so the bot can emit the same "Triggered by"
+   * context step the enclave does. The body (decrypted prompt) is sealed
+   * separately as the step content; only id/author/time travel in clear.
+   * Omitted when there is no resolvable trigger author.
+   */
+  trigger?: { messageId: string; authorName: string; authorType: AuthorType; createdAt: string }
+}
+
+/**
  * The completion ack, posted to `POST .../sessions/:id/complete` after the loop
  * finishes. The replies themselves were already streamed via `.../messages`, so
  * this carries only the ids the enclave sent (oldest→newest, for the session's

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -388,6 +388,7 @@ export type {
   SealedStepStart,
   EnclaveSealedSubstep,
   EnclaveSessionAssignment,
+  SealedTurnContext,
   EnclaveSessionResult,
   EnclaveSessionFailure,
   EnclaveClaimResponse,


### PR DESCRIPTION
**Design doc:** [`agent-runtimes-unification-redesign.md` §2.6](docs/plans/agent-runtimes-unification-redesign.md) — *Forward-compatibility: E2EE for external agents.* No Linear ticket.

## Problem

The agent-runtimes redesign built the **key half** of E2EE participation by external / self-hosted bot harnesses — BIK registration at `bot:hello`, `kind:"bot"` rows in `e2e_stream_actors`, owner-minted SSK wraps pinned by `bot_id` that survive key rolls — but not the **wire half**: there is no sealed claim payload an external runner can be handed, and no sealed `/steps` / `/complete`. The delivery gate already encodes the policy: `resolveDeliveryVerdict` (`packages/agent-runtime/src/runtime/negotiate-capabilities.ts`) routes an E2E stream + a granted `THIRD_PARTY` actor to `sealed` only when `EXTERNAL_SEALED_DELIVERY` is `true` (it's `false` today), otherwise `denied`. Per §2.6, turning the feature on is "build the sealed wire variants, add the consent UX, flip one gate" — explicitly *not* a rewrite.

This is the first slice of those wire variants: the shared claim-payload **type** and its pure **builder**. It is intentionally inert — nothing references the builder yet, so the feature stays dark behind `EXTERNAL_SEALED_DELIVERY=false`.

## Solution

Add `SealedTurnContext` — the shared, deliberately non-enclave-named claim payload §2.6 rule 1 calls for ("design `EnclaveSessionAssignment`'s successor as `SealedTurnContext` consumed by any sealed-capable driver") — and `buildSealedTurnContext`, the external/bot analog of `buildEnclaveSessionAssignment`. The builder is pure and DB-free so the security-critical wrap-coverage logic is unit-testable in isolation, mirroring how the enclave keeps `dispatch/request-builder.ts` (pure) separate from `claim-service.ts` (DB-coupled).

### How it works

- **`SealedTurnContext`** (`packages/types/src/api.ts`) carries only what the bot can't derive: the per-claim `callbackToken` (model A), the SSK `wraps` addressed to the claiming BIK, sealed `history`/`prompt`, the `reply` generation + sender id each seal binds to, and optional clear `trigger` metadata. It reuses the existing shared sealed leaf types (`EnclaveSealedMessage`, `EnclaveSskWrap`, `EnclaveStreamEnvelope`).
- It is **leaner than `EnclaveSessionAssignment` on purpose**: no `system` / `model` / `temperature` / `maxTokens` (an external harness runs its *own* agent loop), and — for now — no C-1/C-2 continuity fields or attachment ciphertext.
- **`buildSealedTurnContext`** (`apps/backend/src/features/public-api/sealed-turn-context.ts`) filters wraps to `recipientKind === "bot"` and the claiming `bikKeyId`, re-checks coverage for **both** the reply (current) and trigger generations, maps prior messages to roles by author (`m.authorId === replySenderId` → `"assistant"`), and drops non-sealed rows. It returns `null` when the claiming BIK can't cover both generations (the revoke/rotation race), so the eventual caller fails the claim loudly rather than handing over a context the bot can't open.

### Key design decisions

**1. A distinct, leaner type — not reuse of `EnclaveSessionAssignment`.** Reusing the enclave shape would force meaningless `system: ""` / `model: ""` fields onto the external wire, since the bot owns its own model and sampling. §2.6 rule 1 explicitly calls for a separate successor type; this is it.

**2. Pure builder, split from the DB.** Mirrors `request-builder.ts` / `request-builder.test.ts`. The wrap-coverage and history-mapping logic — the part where a mistake would hand a bot a context it shouldn't get — is unit-tested without a DB harness. The DB-coupled claim path (BIK-keyed predicate, session row, callback binding) is the next slice.

**3. Two-generation wrap-coverage re-check.** The claim predicate (next slice) will gate this in SQL, but the builder re-checks anyway — exactly as `buildEnclaveSessionAssignment` does (`if (!hasWrap(currentGen) || !hasWrap(triggerGen)) return null`) — to guard the revoke/rotation race between claim and build. A bot whose BIK can seal the reply (current gen) but can't open a prompt sealed under an older gen is unservable, and the builder says so.

**4. Reuse the shared sealed leaf types as-is.** `EnclaveSealedMessage` / `EnclaveSskWrap` / `EnclaveStreamEnvelope` are still enclave-prefixed — a known residual; renaming them is a cross-cutting cleanup, out of scope here. Per decision-history #6, the *new* vocabulary (`SealedReply`, `SealedTurnContext`) stays shared-named, which this honors.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/public-api/sealed-turn-context.ts` | Pure `buildSealedTurnContext` — external/bot analog of `buildEnclaveSessionAssignment` |
| `apps/backend/src/features/public-api/sealed-turn-context.test.ts` | 9 unit cases over the builder (wrap coverage, BIK isolation, rotated-key race, role mapping) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts` | Add the `SealedTurnContext` interface |
| `packages/types/src/index.ts` | Export `SealedTurnContext` from the barrel |

## Out of scope (deliberate)

Everything that makes the feature *live* lands in later slices, and the builder is referenced by nothing, so this PR changes no behavior:

- The **BIK-keyed claim predicate** (conditional `plaintext-stream OR both-generation BIK wrap` in `claimOne`).
- The **model-A callback binding** — extracting `hashCallbackToken` to a neutral home (`agents`), a shared verify helper, a neutral header — and wiring it into the `agent_sessions` row at claim.
- Handler wiring in `claimBotInvocation`, the `verdictAllowsExternalDispatch` flip to enqueue `sealed`, and the sealed `/steps` / `/complete` callbacks.
- **Consent UX** (`StreamBotsSection` E2E grant/revoke + wrap-on-grant / re-roll-on-revoke) and the **Pi client** sealed harness.
- Flipping `EXTERNAL_SEALED_DELIVERY` to `true` — last, after all of the above.
- C-1/C-2 continuity fields and attachment ciphertext on `SealedTurnContext` — deferred additive fields (INV-36), added when the Pi harness consumes them.

## Test plan

- [x] `bun test apps/backend/src/features/public-api/sealed-turn-context.test.ts` — **9 pass / 0 fail** (15 assertions)
- [x] `tsc --noEmit` — `@threa/types` and `apps/backend` both clean
- [x] Verified `buildSealedTurnContext` is referenced by nothing but its own test (`grep`), so the gate stays dark and behavior is unchanged
- [ ] No DB-coupled claim path in this slice, so there is no integration test here — it lands with the BIK-keyed predicate + handler wiring, which is where a live DB is needed

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Let an owner-granted external / self-hosted bot harness (concretely: our own Pi remote-control plugin) participate in an E2E (sealed) stream — the one designed-but-deferred extension from the agent-runtimes redesign. Architected as a policy flip + sealed wire variants + consent UX, never a rewrite (§2.6).

**Settled decisions (this session).**
- **Go**, trigger = the self-hosted **Pi plugin** as the harness (satisfies INV-36 — a real non-Threa harness pulling for it).
- **Identity model A** + refinement: the bot is an **entity that binds once** via a persisted BIK (like a user UIK / the enclave EIK), with the per-session callback token as an invisible transport layer on top. The protocol forecloses neither stable nor ephemeral keys — that's a pure client choice; the backend pins the grant to `bot_id` and re-wraps to whatever live BIK exists. *Identity* binds once; *access* is granted per encrypted stream (the consent act).
- Reuse `@threa/crypto` (runtime-agnostic) everywhere; `apps/enclave/` is the reference for an external sealed harness.

**Phases.**
1. **Backend — sealed claim** *(this PR = the pure core; DB-coupled half next)*: `SealedTurnContext` + `buildSealedTurnContext` ✅ → then BIK-keyed claim predicate, callback-token binding, handler wiring, dispatch-gate flip, integration tests.
2. **Backend — sealed `/steps` + `/steps/started`** (`SealedStep`/`SealedStepStart` → `agent_session_steps` sealed columns, callback-token verified).
3. **Backend — sealed `/complete`** (`SealedReply` → ciphertext message via the EventService sink, `e2eVersion: 2`).
4. **Frontend — consent UX** (`StreamBotsSection` E2E grant/revoke + wrap / re-roll).
5. **Pi client — sealed harness** (`extensions/pi-remote`): persisted BIK, unwrap+decrypt the sealed claim, seal reply/steps, callback-token header — porting the enclave agent loop via `@threa/crypto`.
6. **Flip `EXTERNAL_SEALED_DELIVERY=true`** + design-doc §2.6 status note + full E2E test through Pi.

**What's NOT included (yet).** Anything past phase 1's pure core — see "Out of scope". The feature is dark until phase 6.

**Status.** Phase 1 pure core: built, unit-tested, dark. Delivery shape (staged PRs vs. one) to be confirmed once phases 1–3 form a coherent reviewable unit; this PR is the first stage of the "staged PRs" approach.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019fytYP5To8RXCHQMSLVPzJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215648&installation_id=129946197&pr_number=967&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F967&signature=049485fc8af1bc302bc50cc122a9bd962a6f83b0befb4b1df7be97571e76c163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->