### PR TITLE
feat(drafts): seal E2E draft body as contentJson, not markdown (lossless roam)

### DIFF
--- a/apps/enclave/src/agent/run-turn.test.ts
+++ b/apps/enclave/src/agent/run-turn.test.ts
@@ -829,7 +829,7 @@ describe("runEnclaveTurn", () => {
     // ride here, inside the SSK ciphertext — never on the wire).
     const prompt = await sealUnder(
       ssk,
-      serializeSealedPayload("review these", [img.ref, pdf.ref]),
+      serializeSealedPayload("review these", { attachmentRefs: [img.ref, pdf.ref] }),
       "msg_user",
       "usr_owner"
     )
@@ -889,7 +889,12 @@ describe("runEnclaveTurn", () => {
       sizeBytes: 16,
     }
     const history = [
-      await sealUnder(ssk, serializeSealedPayload("here's the plan", [ref]), "msg_old", "usr_owner"),
+      await sealUnder(
+        ssk,
+        serializeSealedPayload("here's the plan", { attachmentRefs: [ref] }),
+        "msg_old",
+        "usr_owner"
+      ),
     ].map((m, i) => ({ ...m, role: "user" as const, sequence: String(i + 1) }))
     const prompt = await sealUnder(ssk, "what does the plan file say?", "msg_user", "usr_owner")
 
@@ -968,7 +973,7 @@ describe("runEnclaveTurn", () => {
 
     const prompt = await sealUnder(
       ssk,
-      serializeSealedPayload("read these", [md.ref, bin.ref]),
+      serializeSealedPayload("read these", { attachmentRefs: [md.ref, bin.ref] }),
       "msg_user",
       "usr_owner"
     )
@@ -1007,7 +1012,12 @@ describe("runEnclaveTurn", () => {
       mimeType: "application/pdf",
       sizeBytes: 10,
     }
-    const prompt = await sealUnder(ssk, serializeSealedPayload("see file", [ref]), "msg_user", "usr_owner")
+    const prompt = await sealUnder(
+      ssk,
+      serializeSealedPayload("see file", { attachmentRefs: [ref] }),
+      "msg_user",
+      "usr_owner"
+    )
     const chat = stubChat(textReply("ok"))
     const { onMessage, onStepStarted, onStep, onSubstep } = collector()
 

--- a/apps/enclave/src/agent/run-turn.ts
+++ b/apps/enclave/src/agent/run-turn.ts
@@ -380,7 +380,7 @@ export async function runEnclaveTurn(
       const sealed = await sealMessage({
         key: replySsk,
         keyGeneration: request.reply.keyGeneration,
-        payload: serializeSealedPayload(content, undefined, sources),
+        payload: serializeSealedPayload(content, { sources }),
         aad: buildMessageAad({
           streamId: request.streamId,
           messageId,

--- a/apps/enclave/src/agent/trace-observer.ts
+++ b/apps/enclave/src/agent/trace-observer.ts
@@ -87,7 +87,7 @@ class EnclaveSealingSink implements TraceStepSink<EnclaveOpenStep> {
     // open trace dialog sees the content (and sources) the moment the step opens.
     const stepId = mintStepId()
     const sealed = await this.seal(
-      serializeSealedPayload(step.content, undefined, toSealedSources(step.sources)),
+      serializeSealedPayload(step.content, { sources: toSealedSources(step.sources) }),
       stepId
     )
     await this.openStep({ stepId, stepType: step.stepType, ...sealed })
@@ -110,7 +110,7 @@ class EnclaveSealingSink implements TraceStepSink<EnclaveOpenStep> {
 
   async complete(step: EnclaveOpenStep, final: TraceStepFinalize): Promise<void> {
     const sealed = await this.seal(
-      serializeSealedPayload(final.content, undefined, toSealedSources(final.sources)),
+      serializeSealedPayload(final.content, { sources: toSealedSources(final.sources) }),
       step.stepId
     )
     await this.deps.sendStep({

--- a/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts
@@ -323,6 +323,7 @@ describe("parseSealedPayload", () => {
       contentMarkdown: "hello **world**",
       attachmentRefs: [],
       sources: [],
+      draftContentJson: null,
     })
   })
 
@@ -331,32 +332,45 @@ describe("parseSealedPayload", () => {
       contentMarkdown: "{not json at all",
       attachmentRefs: [],
       sources: [],
+      draftContentJson: null,
     })
     const jsonButNotOurs = JSON.stringify({ foo: "bar" })
     expect(parseSealedPayload(jsonButNotOurs)).toEqual({
       contentMarkdown: jsonButNotOurs,
       attachmentRefs: [],
       sources: [],
+      draftContentJson: null,
     })
   })
 
   it("extracts contentMarkdown and refs from the versioned wrapper", () => {
     const wrapper = JSON.stringify({ __e2ePayload: 1, contentMarkdown: "see attached", attachmentRefs: refs })
-    expect(parseSealedPayload(wrapper)).toEqual({ contentMarkdown: "see attached", attachmentRefs: refs, sources: [] })
+    expect(parseSealedPayload(wrapper)).toEqual({
+      contentMarkdown: "see attached",
+      attachmentRefs: refs,
+      sources: [],
+      draftContentJson: null,
+    })
   })
 
   it("falls back to no refs when a wrapper's attachmentRefs is not an array", () => {
     const malformed = JSON.stringify({ __e2ePayload: 1, contentMarkdown: "body", attachmentRefs: "oops" })
-    expect(parseSealedPayload(malformed)).toEqual({ contentMarkdown: "body", attachmentRefs: [], sources: [] })
+    expect(parseSealedPayload(malformed)).toEqual({
+      contentMarkdown: "body",
+      attachmentRefs: [],
+      sources: [],
+      draftContentJson: null,
+    })
   })
 
   it("extracts citation sources sealed into the wrapper (agent replies, E2EE-9)", () => {
     const sources = [{ type: "web", title: "Tide Atlas", url: "https://tides.example/atlas" }]
-    const wrapper = serializeSealedPayload("Tides come from the moon.", undefined, sources)
+    const wrapper = serializeSealedPayload("Tides come from the moon.", { sources })
     expect(parseSealedPayload(wrapper)).toEqual({
       contentMarkdown: "Tides come from the moon.",
       attachmentRefs: [],
       sources,
+      draftContentJson: null,
     })
   })
 
@@ -371,11 +385,36 @@ describe("parseSealedPayload", () => {
       contentMarkdown: "body",
       attachmentRefs: [],
       sources: [{ title: "Valid", url: "https://example.com" }],
+      draftContentJson: null,
     })
   })
 
-  it("seals bare markdown (no wrapper) when there are no refs and no sources", () => {
+  it("round-trips a draft's lossless contentJson and drops a non-doc one (Stage 4e)", () => {
+    const contentJson = {
+      type: "doc",
+      content: [
+        { type: "slashCommand", attrs: { name: "discuss-with-ariadne", clientActionId: "discuss-with-ariadne" } },
+      ],
+    }
+    const wrapper = serializeSealedPayload("/discuss-with-ariadne", { draftContentJson: contentJson })
+    expect(parseSealedPayload(wrapper)).toEqual({
+      contentMarkdown: "/discuss-with-ariadne",
+      attachmentRefs: [],
+      sources: [],
+      draftContentJson: contentJson,
+    })
+    // A malformed (non-doc) draft body falls back to null — the reader reconstructs from markdown.
+    const bad = JSON.stringify({
+      __e2ePayload: 1,
+      contentMarkdown: "x",
+      attachmentRefs: [],
+      draftContentJson: { type: "paragraph" },
+    })
+    expect(parseSealedPayload(bad).draftContentJson).toBeNull()
+  })
+
+  it("seals bare markdown (no wrapper) when there are no refs, sources, or a draft body", () => {
     expect(serializeSealedPayload("plain body")).toBe("plain body")
-    expect(serializeSealedPayload("plain body", [], [])).toBe("plain body")
+    expect(serializeSealedPayload("plain body", { attachmentRefs: [], sources: [] })).toBe("plain body")
   })
 })

--- a/apps/frontend/src/lib/crypto/message-envelope.ts
+++ b/apps/frontend/src/lib/crypto/message-envelope.ts
@@ -45,6 +45,13 @@ export interface SealStreamMessageInput {
    * wire — the server only holds opaque bytes and a placeholder row.
    */
   attachmentRefs?: AttachmentRef[]
+  /**
+   * A draft's authoritative ProseMirror body, sealed losslessly alongside the
+   * markdown (E2E draft seal only — messages never set it). See
+   * `E2eSealedPayload.draftContentJson`: drafts are internal state, so per INV-58
+   * they seal `contentJson` rather than relying on the lossy markdown round-trip.
+   */
+  draftContentJson?: unknown
 }
 
 export interface SealStreamMessageResult {
@@ -70,7 +77,10 @@ export async function sealStreamMessage(input: SealStreamMessageInput): Promise<
   const { envelope, ciphertext } = await sealMessage({
     key: input.ssk,
     keyGeneration: input.keyGeneration,
-    payload: serializeSealedPayload(input.contentMarkdown, input.attachmentRefs),
+    payload: serializeSealedPayload(input.contentMarkdown, {
+      attachmentRefs: input.attachmentRefs,
+      draftContentJson: input.draftContentJson,
+    }),
     aad,
   })
   return { ciphertext: bytesToBase64(ciphertext), envelope, e2eVersion: STREAM_ENVELOPE_VERSION }
@@ -219,8 +229,12 @@ async function tryOpenStreamMessage(
     // the markdown for the body, the refs (key/iv/filename/mime) so the viewer
     // can fetch + decrypt the opaque S3 ciphertext on view, and the sources so
     // an agent reply renders its citations (E2EE-9).
-    const { contentMarkdown, attachmentRefs, sources } = parseSealedPayload(raw)
-    return { contentMarkdown, contentJson: parseMarkdown(contentMarkdown), attachmentRefs, sources }
+    const { contentMarkdown, attachmentRefs, sources, draftContentJson } = parseSealedPayload(raw)
+    // A draft seals its lossless `contentJson` (INV-58); prefer it so node attrs
+    // markdown can't carry — e.g. a slash command's `clientActionId` — survive the
+    // roam. Messages never set it, so they reconstruct from markdown exactly as before.
+    const contentJson = draftContentJson != null ? (draftContentJson as JSONContent) : parseMarkdown(contentMarkdown)
+    return { contentMarkdown, contentJson, attachmentRefs, sources }
   } catch {
     return null
   }

--- a/apps/frontend/src/lib/crypto/seal-draft.test.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.test.ts
@@ -67,6 +67,38 @@ describe("seal-draft", () => {
     expect(opened?.contentJson).toEqual(parseMarkdown("hello e2e world"))
   })
 
+  it("seals the lossless contentJson so a slash command's clientActionId survives the roam (Stage 4e)", async () => {
+    vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(unlockedSession)
+    vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })
+    vi.spyOn(streamKeyCache, "resolveStreamKey").mockResolvedValue(ssk)
+
+    // A slashCommand node's clientActionId has no markdown representation — the
+    // markdown round-trip drops it (only `/name` survives). Sealing contentJson
+    // carries it whole, so a roamed `/discuss-with-ariadne` still routes locally.
+    const commandDoc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "slashCommand", attrs: { name: "discuss-with-ariadne", clientActionId: "discuss-with-ariadne" } },
+      ],
+    }
+
+    const sealed = await sealDraftContent({ workspaceId, senderId, streamId, draftId, contentJson: commandDoc })
+
+    const opened = await tryDecryptMessagePayload(
+      { contentMarkdown: "", ciphertext: sealed.ciphertext, envelope: sealed.envelope, e2eVersion: sealed.e2eVersion },
+      {
+        privateKey: unlockedSession.privateKey!,
+        recipientKeyId: unlockedSession.keyId!,
+        workspaceId,
+        streamId,
+        rootStreamId: streamId,
+      }
+    )
+    // The whole node round-trips — not the lossy markdown reconstruction, which
+    // would surface `{ name }` with no clientActionId.
+    expect(opened?.contentJson).toEqual(commandDoc)
+  })
+
   it("seals attachment refs into the body and recovers them on decrypt (Stage 4d)", async () => {
     vi.spyOn(sessionStore, "getE2eSessionState").mockReturnValue(unlockedSession)
     vi.spyOn(streamKeyCache, "resolveCurrentStreamKey").mockResolvedValue({ keyGeneration: 1, key: ssk })

--- a/apps/frontend/src/lib/crypto/seal-draft.ts
+++ b/apps/frontend/src/lib/crypto/seal-draft.ts
@@ -29,8 +29,14 @@ export interface SealedDraftFields {
  * ride inside the SSK ciphertext (as `attachmentRefs`) exactly as a message's
  * do, so a roamed draft's attachments decrypt + send on the receiving device.
  * The plaintext attachment linkage never lands on disk or the wire — only the
- * opaque ciphertext does. (Context refs / slash commands remain session-local —
- * their own design, deferred.)
+ * opaque ciphertext does.
+ *
+ * Stage 4e seals the body as `contentJson`, not just markdown. A draft is the
+ * author's own internal composer state, so per INV-58 the canonical form is
+ * `contentJson` — and the markdown round-trip messages use is lossy for node
+ * attrs markdown can't represent (a slash command's `clientActionId`, etc.). The
+ * lossless `contentJson` rides in `draftContentJson` (the markdown stays as the
+ * readable mirror), so a roamed draft re-hydrates byte-for-byte.
  *
  * Throws (locked session, missing SSK, an attachment key lost on reload) the
  * same way `sealOutgoingMessage` does; the caller treats a throw as "can't
@@ -55,6 +61,7 @@ export async function sealDraftContent(input: {
     messageId: input.draftId,
     contentMarkdown,
     attachmentIds: input.attachmentIds,
+    draftContentJson: input.contentJson,
   })
   return {
     ciphertext: e2eFields.ciphertext,

--- a/apps/frontend/src/lib/crypto/seal-send.ts
+++ b/apps/frontend/src/lib/crypto/seal-send.ts
@@ -19,6 +19,12 @@ export interface SealOutgoingMessageInput {
   messageId: string
   contentMarkdown: string
   attachmentIds?: string[]
+  /**
+   * A draft's authoritative ProseMirror body, sealed losslessly into the payload
+   * alongside the markdown (E2E draft seal only — the live message send path never
+   * sets it). See `E2eSealedPayload.draftContentJson`.
+   */
+  draftContentJson?: unknown
 }
 
 export interface SealOutgoingMessageResult {
@@ -76,6 +82,7 @@ export async function sealOutgoingMessage(input: SealOutgoingMessageInput): Prom
     ssk: streamKey.key,
     keyGeneration: streamKey.keyGeneration,
     attachmentRefs,
+    draftContentJson: input.draftContentJson,
   })
   return { e2eFields, attachmentRefs, owner: { keyId: session.keyId, privateKey: session.privateKey } }
 }

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -306,9 +306,9 @@ attachment linkage rides _inside_ the body's SSK ciphertext, and the wire
   the unlock-after-open path (they decrypt together).
 
 **Scope boundary (4d):** context refs / slash commands on E2E drafts remain
-session-local — they have no field in the message sealed-payload schema to ride
-in, so sealing them would mean extending the shared `@threa/crypto` payload (and
-the enclave) for a draft-only concept; deferred as its own design.
+session-local at 4d. Stage 4e (below) seals the lossless `contentJson`, which makes
+slash commands roam; context refs were investigated and intentionally left unsealed
+(no flow produces one on an E2E draft — INV-36).
 
 **Reuse:** `sealOutgoingMessage` + `serializeSealedPayload` attachment-ref path;
 `rememberAttachmentRef` / `getAttachmentRef` in-memory ref cache; the shared
@@ -325,165 +325,111 @@ surfaced from refs). `bun run test`.
 
 **Verification:** Backend test: resolve declines on drift, deletes on match; thread-conversion re-points drafts. Frontend/E2E (`test:e2e`): send clears draft; drifted draft survives send; reply draft follows a message into its new thread; E2E draft round-trips without plaintext at rest. `bun run test` + `bun run test:e2e`.
 
-#### Stage 4e — E2E drafts seal `contentJson` (lossless) + context refs — PROPOSED
+#### Stage 4e — E2E drafts seal `contentJson` (lossless body) — DONE
 
-4d closed attachments. Two pieces of composer state still don't roam on E2E
-drafts, and the root cause of one of them is a body-seal choice 4c made that's
-worth correcting first.
+4d closed attachments. The remaining E2E-draft gap was a body-seal choice 4c made:
+it sealed **markdown**, not `contentJson`, so node attrs markdown can't represent
+were silently dropped on roam. 4e seals the lossless `contentJson`.
 
-**Root cause: E2E drafts seal markdown, not `contentJson`.** `seal-draft.ts`
-serializes the body to markdown (`serializeToMarkdown(contentJson)`) before
-sealing, and the decrypt rebuilds it with `parseMarkdown(contentMarkdown)`
-(`message-envelope.ts`). So an E2E draft body does a `contentJson → markdown →
-contentJson` round-trip. 4c chose this purely to reuse the message seal path
-(INV-35), and it's correct **for messages** — a sent message genuinely crosses
-the system boundary (server, enclave-for-agents, public API, other recipients
-all consume the markdown wire form). But a **draft** is the author's own internal
-composer state synced to their own devices; no external consumer reads its
-plaintext. Per INV-58, internal state is canonically `contentJson` — and
-plaintext drafts already honor this (they store/roam `contentJson` verbatim end
-to end; the backend derives `content_markdown` server-side but never round-trips
-it back). The E2E path is the lone exception, and the round-trip is lossy: it
-drops any node attr markdown can't represent.
+**Root cause: E2E drafts sealed markdown, not `contentJson`.** `seal-draft.ts`
+serialized the body to markdown (`serializeToMarkdown(contentJson)`) before
+sealing, and the decrypt rebuilt it with `parseMarkdown(contentMarkdown)`
+(`message-envelope.ts`) — a `contentJson → markdown → contentJson` round-trip. 4c
+chose this purely to reuse the message seal path (INV-35), and it's correct **for
+messages** — a sent message genuinely crosses the system boundary (server,
+enclave-for-agents, public API, other recipients all consume the markdown wire
+form). But a **draft** is the author's own internal composer state synced to their
+own devices; no external consumer reads its plaintext. Per INV-58, internal state
+is canonically `contentJson` — and plaintext drafts already honor this (they
+store/roam `contentJson` verbatim end to end; the backend derives `content_markdown`
+server-side but never round-trips it back). The E2E path was the lone exception,
+and the round-trip was lossy.
 
-**What that lossiness costs, concretely — slash commands.** The `slashCommand`
-node serializes to `/${name}` (`packages/prosemirror/markdown.ts`) and re-parses
-to `{ name }` on decrypt, dropping `clientActionId`. A roamed
-`/discuss-with-ariadne` decrypts with `clientActionId: null`, and
-`message-input.tsx` routes on `clientActionId === DISCUSS_WITH_ARIADNE_COMMAND`,
-so it misroutes to server dispatch (`queueCommand`) instead of the local
-`startDiscussWithAriadne`. **Sealing `contentJson` fixes this for free** — the
-whole node, `clientActionId` and all, round-trips losslessly. No command sidecar,
-no re-injection. (The frontend never writes the backend `command` column anyway;
+**What that lossiness cost, concretely — slash commands.** The `slashCommand` node
+serializes to `/${name}` (`packages/prosemirror/markdown.ts`) and re-parses to
+`{ name }` on decrypt, dropping `clientActionId`. A roamed `/discuss-with-ariadne`
+decrypted with `clientActionId: null`, and `message-input.tsx` routes on
+`clientActionId === DISCUSS_WITH_ARIADNE_COMMAND`, so it misrouted to server
+dispatch (`queueCommand`) instead of the local `startDiscussWithAriadne`. Sealing
+`contentJson` fixes this for free — the whole node, `clientActionId` and all,
+round-trips losslessly. (The frontend never writes the backend `command` column;
 commands live only as the node in `contentJson`.)
 
-**What `contentJson` does NOT cover — context refs.** A draft's `contextRefs` is
-a separate `DraftContextRef[]` sidecar, never part of `contentJson`.
-`seedDraftWithContextRef` (`lib/context-bag/seed-draft.ts`) is its _only_ producer
-(every other reference is a pass-through read), called only by
-`useDiscussWithAriadne`, which mints a `companionMode: "on"` scratchpad that can
-be E2E. So a "Discuss with Ariadne" chip lands on an E2E draft today and vanishes
-on roam — the E2E seal branch writes `contextRefs` neither at rest nor sealed.
-Context refs remain a genuine sidecar regardless of body format.
+**Context refs were investigated and deliberately NOT sealed (INV-36).** A draft's
+`contextRefs` is a separate `DraftContextRef[]` sidecar, never in `contentJson`.
+Its _only_ producer is `seedDraftWithContextRef` (`lib/context-bag/seed-draft.ts`)
+— every other reference is a pass-through read — called _only_ by
+`useDiscussWithAriadne`, which mints the scratchpad via plain
+`useCreateStream({ type: "scratchpad" })` and **never sets `e2eEnabled`**. The only
+place `e2eEnabled: true` is ever set is `useCreateEncryptedScratchpad`, a separate
+flow that does not seed context refs, and there is **no path that enables
+encryption on an existing stream** (`e2eEnabled` is creation-only). So no current
+flow lands a context ref on an E2E draft — sealing them would be dead code for a
+nonexistent producer (INV-36). If a future flow makes discuss-with-ariadne (or
+another producer) create E2E streams, revisit: context refs would then ride as a
+structured sidecar alongside the body (seal only the durable identity —
+`refKind`/`streamId`/`fromMessageId`/`toMessageId`/`originMessageId` — and
+re-resolve `status`/`fingerprint`/`errorMessage` on the receiving device).
 
-**Design.** Seal the draft body as `contentJson` (authoritative, lossless,
-INV-58-aligned) and the context refs as a structured sidecar — both inside the
-same SSK ciphertext, alongside the attachment refs 4d already seals. This brings
-E2E drafts into line with plaintext drafts (both lossless `contentJson`); the
-markdown odd-one-out goes away. The message seal/decrypt path stays markdown,
-untouched.
+**`@threa/crypto` payload change (`sealed-payload.ts`).** Added one optional
+top-level field — `draftContentJson?: unknown` (typed `unknown` because the package
+is dependency-free; the frontend casts to `JSONContent`):
 
-**`@threa/crypto` payload change (`sealed-payload.ts`).** Extend `E2eSealedPayload`
-/ `ParsedSealedPayload` with one optional **draft-scoped** namespace:
-
-```ts
-draft?: {
-  contentJson?: JSONContent      // typed `unknown` in the dependency-free crypto pkg; cast on the FE
-  contextRefs?: SealedDraftContextRef[]
-}
-```
-
-- **Why namespaced under `draft`, not top-level fields:** these are draft-only —
-  they never appear in a message or an agent reply, and the enclave reader must
-  never confuse them with content. A single `draft` key signals "ignore unless
-  you are the authoring composer," keeps the message/enclave mental model clean
-  (the enclave keeps destructuring only `{ contentMarkdown, attachmentRefs }` and
-  is forward-compatible by ignoring the field), and groups the two adjuncts that
-  always travel together.
-- `contentMarkdown` stays populated for drafts too (derived from `contentJson`),
-  so the payload remains shaped like a message and old/preview readers keep a
-  fallback. The draft decrypt **prefers `draft.contentJson`**, falling back to
-  `parseMarkdown(contentMarkdown)` — so 4c/4d-era sealed drafts still open
-  (lossily, as today) with no migration.
-- `SealedDraftContextRef` mirrors `DraftContextRef` structurally (the crypto
-  package stays dependency-free — same mirror-and-bridge discipline as
-  `SealedSourceItem` ↔ `SourceItem`). **Only the durable identity fields ride
-  sealed** — `refKind`, `streamId`, `fromMessageId`, `toMessageId`,
-  `originMessageId`. The transient resolution fields (`status`, `fingerprint`,
-  `errorMessage`) are device-local / re-derivable and are NOT sealed: the
-  receiving device re-resolves against the shared server bag, so the recovered
-  ref reconstructs `status: "ready"` (the bag is server-side and shared; a roamed
-  device resolves it the same way the authoring device did) with the rest null.
-- `isSealedDraftContextRef` (and a light `isDocLike` check for `contentJson`)
-  mirror `isAttachmentRef` — drop malformed elements (decrypted ≠ trusted). No
-  `E2E_PAYLOAD_VERSION` bump: the discrimination is structural and additive (old
-  payloads simply lack `draft`), exactly as `sources?` was added.
-- **Serializer signature:** `serializeSealedPayload` is
-  `(contentMarkdown, attachmentRefs?, sources?)` today; a structured `draft`
-  object would make it a 4th positional. Refactor the extras into an options bag —
-  `serializeSealedPayload(contentMarkdown, extras?: { attachmentRefs?; sources?; draft? })`
-  — touching the ~4 call sites (`message-envelope.ts`, enclave `run-turn.ts`,
-  `trace-observer.ts`); mechanical, additive, well-tested, and the named shape
-  stops the positional sprawl (INV-12 spirit). The enclave/message call sites
-  keep passing only what they pass today.
+- A **flat** field, not a `draft: {}` namespace: with context refs out of scope it
+  carries exactly one thing, so a namespace would be speculative structure (INV-36).
+  The name signals draft-scope; the message/enclave reader ignores it (it
+  destructures only `{ contentMarkdown, attachmentRefs }`).
+- `contentMarkdown` stays populated for drafts (the readable mirror + fallback). The
+  decrypt **prefers `draftContentJson`**, falling back to `parseMarkdown(contentMarkdown)`
+  — so 4c/4d-era sealed drafts still open (lossily, as before) with no migration.
+- `isDocLike` (exported, mirrors `isAttachmentRef`) validates the decrypted body is
+  a `{ type: "doc", content: [...] }` before it's surfaced; a non-doc falls back to
+  null (reader reconstructs from markdown). No `E2E_PAYLOAD_VERSION` bump —
+  structural + additive, exactly as `sources?` was added.
+- **Serializer refactored to an options bag:** `serializeSealedPayload(contentMarkdown,
+extras?: { attachmentRefs?; sources?; draftContentJson? })`, replacing the
+  positional `(contentMarkdown, attachmentRefs?, sources?)`. Touched the 4 call
+  sites (`message-envelope.ts`, enclave `run-turn.ts` + `trace-observer.ts` ×2) and
+  their tests; named shape stops the positional sprawl (INV-12 spirit).
 
 **Frontend wiring (no backend / types / wire / migration change).**
 
-- `seal-draft.ts` `sealDraftContent`: forward `contentJson` (unchanged input) and
-  `contextRefs: DraftContextRef[]` into the `draft` namespace; still derive
-  `contentMarkdown` for the payload's markdown slot. `SealedDraftFields` gains
-  `contextRefs` (the recovered plaintext, to seed the decrypt cache, same contract
-  as `attachmentRefs`). No `command` field.
-- `message-envelope.ts` decrypt: `tryOpenStreamMessage` reads
-  `contentJson = parsed.draft?.contentJson ?? parseMarkdown(contentMarkdown)`, so
-  the **message path is byte-identical** (messages never set `draft`) while a draft
-  gets its lossless `contentJson`. `DecryptedMessageContent` gains an optional
-  `draftContextRefs?` (same optionality contract as `attachmentRefs?` / `sources?`;
-  messages leave it empty).
-- `decryption.ts`: `DraftDecryption` gains `contextRefs: DraftContextRef[]`, mapped
-  from `cached.content.draftContextRefs` (status reconstructed). Context refs carry
-  **no secret material**, so — unlike attachment keys — they need no
-  `rememberAttachmentRef` re-registration on a fresh device. New
-  `cachedDraftContextRefs(draftId)` mirrors `cachedDraftBody` /
-  `cachedDraftAttachments` as the in-memory plaintext authority the write path
-  re-seals from. **No command handling at all** — it rides inside `contentJson`.
-- `use-draft-message.ts` seal branches (`upsertLoadedDraft` seal branch +
-  `saveDraft` / `addAttachment` / `removeAttachment` re-seal): read current context
-  refs from `cachedDraftContextRefs` so a keystroke or attachment change preserves
-  them (exactly as 4d does for attachments). Keep the at-rest row's `contextRefs`
-  undefined (E2EE-4 — never plaintext at rest); seed the decrypt cache with the
-  sealed refs.
-- `use-draft-composer.ts`: extend the 4d late-hydrate effect (unlock-after-open) to
-  carry context refs alongside body + attachments, so a sealed discuss-with-ariadne
-  draft's `<ContextRefStrip>` chip re-appears on unlock. The command rides inside
-  `contentJson`, so it hydrates with the body — no extra handling.
-- **Wire/sync: unchanged.** `executeDraftUpsert` (`draft-sync.ts`) already forces
-  `attachmentIds: []` for E2E and sends `contextRefs: row.contextRefs ?? null`; an
-  E2E row's at-rest `contextRefs` stays undefined → wire `null`, while the sealed
-  copy rides inside the ciphertext. The plaintext path is untouched. The backend
-  `command` / `context_refs` columns stay for the plaintext path and are simply
-  null for E2E.
+- `seal-draft.ts` `sealDraftContent`: passes `draftContentJson: input.contentJson`
+  through `sealOutgoingMessage` → `sealStreamMessage`; still derives `contentMarkdown`
+  for the payload's markdown slot. `SealOutgoingMessageInput` / `SealStreamMessageInput`
+  gained `draftContentJson?: unknown` (the live message send path never sets it).
+- `message-envelope.ts` decrypt (`tryOpenStreamMessage`):
+  `contentJson = draftContentJson != null ? (draftContentJson as JSONContent) :
+parseMarkdown(contentMarkdown)`. The **message path is byte-identical** (messages
+  never set it) while a draft gets its lossless body.
+- The write path (`use-draft-message.ts`) and read path (`decryption.ts`,
+  `use-draft-composer.ts`) needed **no change**: the write path already seeds the
+  decrypt cache with the just-authored `contentJson` (so the authoring device never
+  round-trips), and the read path already serves `cached.content.contentJson` — now
+  lossless for a roamed draft.
 
-**Scope boundary (4e):** the body-format fix makes slash commands (and any other
-node attr markdown can't represent) roam losslessly; the only explicit sidecar is
-context refs, for the producers that exist today (discuss-with-ariadne). No
-speculative support for future context-ref kinds (INV-36): the seal carries the
-whole `DraftContextRef` identity, so new kinds ride free. `status` / `fingerprint`
-/ `errorMessage` are deliberately not sealed (transient, re-resolved). Command
-dispatch is unchanged. Pre-4e sealed drafts keep opening via the markdown
-fallback (no backfill).
+**Scope boundary (4e):** body-format only. Slash commands (and any other node attr
+markdown can't represent) now roam losslessly. Context refs deliberately not sealed
+(no producer reaches an E2E draft — INV-36). Command dispatch unchanged. Pre-4e
+sealed drafts keep opening via the markdown fallback (no backfill).
 
 **Reuse:** `serializeSealedPayload` / `parseSealedPayload` attachment-ref + sources
-pattern (validators, structural-mirror discipline); the 4c/4d decrypt-cache + draft
-decrypt core; the 4d late-hydrate effect.
+pattern (the `isDocLike` validator mirrors `isAttachmentRef`); the 4c/4d
+decrypt-cache + draft decrypt core; the message seal chain end to end (INV-35).
 
-**Verification:** `sealed-payload.test.ts` (round-trip `draft.contentJson` +
-`draft.contextRefs`; malformed elements dropped; pre-4e payloads — no `draft` —
-parse and fall back to markdown; message/enclave destructuring unaffected).
-`seal-draft.test.ts` (seal carries `contentJson` + context refs; full `toEqual`
-recovery on decrypt, INV-24; a `slashCommand` node's `clientActionId` survives the
-round-trip). `draft-e2e-roam.test.ts` (a discuss-with-ariadne E2E draft's context
-ref survives the wire and re-renders; `/discuss-with-ariadne` keeps its
-`clientActionId` on the receiving device and routes locally). `use-draft-message.test.ts`
-(seal carries context refs, never at rest; content-only save and add/remove
-attachment preserve them; locked is a no-op). `use-decrypted-draft-content.test.ts`
-(context refs surfaced from the decrypted payload). `bun run test` +
-`bun run test:e2e`.
+**Verification:** `message-envelope.test.ts` (serialize/parse round-trip of
+`draftContentJson`; a non-doc falls back to null; bare-markdown unchanged; existing
+attachment/source cases still green under the options-bag signature).
+`seal-draft.test.ts` (a `slashCommand` node's `clientActionId` survives the
+seal→decrypt round-trip — the lossy markdown reconstruction would have dropped it).
+Crypto package (37) + enclave (38) + the four frontend crypto/draft suites (33) all
+green; `tsc --noEmit` clean across crypto, enclave, frontend.
 
 **Invariant notes (4e):** INV-58 (`contentJson` is the canonical internal body;
 markdown is the boundary form — drafts are internal, so they seal `contentJson`),
-INV-35 (reuse the seal/parse/decrypt path), INV-36 (no speculative ref kinds),
-INV-24 (full-object asserts), E2EE-4 (context refs undefined at rest, sealed only).
+INV-35 (reuse the seal/parse/decrypt path), INV-36 (no speculative context-ref
+sealing — no producer), INV-12 (named options bag over positional sprawl), INV-24
+(full-object asserts), E2EE-4 (nothing plaintext at rest).
 
 ## Invariant Notes
 

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -325,6 +325,152 @@ surfaced from refs). `bun run test`.
 
 **Verification:** Backend test: resolve declines on drift, deletes on match; thread-conversion re-points drafts. Frontend/E2E (`test:e2e`): send clears draft; drifted draft survives send; reply draft follows a message into its new thread; E2E draft round-trips without plaintext at rest. `bun run test` + `bun run test:e2e`.
 
+#### Stage 4e — E2E draft context refs + slash-command routing — PROPOSED
+
+4d closed attachments. Two pieces of composer state still stay session-local on
+E2E drafts, and this stage seals both into the same SSK ciphertext so they roam.
+
+**What's actually missing (verified against the code, not assumed):**
+
+- **Context refs are a true gap.** `seedDraftWithContextRef`
+  (`lib/context-bag/seed-draft.ts`) is the _only_ producer of a draft's
+  `contextRefs` sidecar — every other reference is a pass-through read — and it's
+  called only by `useDiscussWithAriadne`, which mints a `companionMode: "on"`
+  scratchpad. Those scratchpads can be E2E, so a "Discuss with Ariadne" chip
+  genuinely lands on an E2E draft today. The seal branch in
+  `use-draft-message.ts` writes neither `contextRefs` at rest nor into the
+  ciphertext, so the chip vanishes when the draft roams.
+- **Slash commands are _mostly_ already covered — the gap is one field.** The
+  `slashCommand` node serializes to `/${name}` (`packages/prosemirror/markdown.ts`
+  `serializeNode`) and re-parses to a `slashCommand` node on decrypt
+  (`parseInline`, the `/[\w-]+` match), so 4d's body seal already roams the
+  _visible_ command. What the markdown round-trip drops is `clientActionId` — the
+  opaque routing discriminator. A roamed `/discuss-with-ariadne` decrypts to a
+  node with `name` but `clientActionId: null`, and `message-input.tsx` routes on
+  `clientActionId === DISCUSS_WITH_ARIADNE_COMMAND`, so the recovered draft
+  misroutes to server dispatch (`queueCommand`) instead of the local
+  `startDiscussWithAriadne`. The frontend never writes the backend `command`
+  draft column — commands live only as the node in `contentJson` — so this is the
+  whole of the slash-command work: recover `clientActionId` across the seal.
+
+**Design — markdown body + structured sidecars (the 4d pattern, extended).**
+Markdown is the lossy external boundary: it carries `/name` but not
+`clientActionId`, and has no representation for a context ref at all. The
+established shape (INV-35, INV-58) is to seal the markdown body for the
+human-readable content and ride everything markdown can't represent losslessly as
+**structured sidecars inside the same SSK ciphertext** — exactly how
+`attachmentRefs` already work. Context refs and the command join `attachmentRefs`
+as sidecars; nothing new lands on the wire or at rest.
+
+**`@threa/crypto` payload change (`sealed-payload.ts`).** Extend `E2eSealedPayload`
+/ `ParsedSealedPayload` with one optional **draft-scoped** namespace:
+
+```ts
+draft?: {
+  contextRefs?: SealedDraftContextRef[]
+  command?: SealedDraftCommand
+}
+```
+
+- **Why namespaced under `draft`, not two new top-level fields:** context refs and
+  the command are draft-only — they never appear in a message or an agent reply,
+  and the enclave reader must never confuse them with content. A single `draft`
+  key signals "ignore unless you are the authoring composer," keeps the
+  message/enclave mental model clean (the enclave keeps destructuring only
+  `{ contentMarkdown, attachmentRefs }` and is forward-compatible by ignoring
+  the field), and groups the two adjuncts that always travel together.
+- `SealedDraftContextRef` mirrors `DraftContextRef` structurally (the crypto
+  package stays dependency-free — the same mirror-and-bridge discipline as
+  `SealedSourceItem` ↔ `SourceItem`). **Only the durable identity fields ride
+  sealed** — `refKind`, `streamId`, `fromMessageId`, `toMessageId`,
+  `originMessageId`. The transient resolution fields (`status`, `fingerprint`,
+  `errorMessage`) are device-local / re-derivable and are NOT sealed: the
+  receiving device re-resolves against the shared server bag, so the recovered
+  ref reconstructs `status: "ready"` (the bag is server-side and shared; a roamed
+  device resolves it the same way the authoring device did) with the other
+  transient fields null.
+- `SealedDraftCommand = { name: string; clientActionId: string | null }` —
+  structural twin of `@threa/types`' `DraftCommand` / `commands.ts`'
+  `ExtractedCommand`.
+- `isSealedDraftContextRef` / `isSealedDraftCommand` validators mirror
+  `isAttachmentRef` — drop malformed elements (decrypted ≠ trusted). No
+  `E2E_PAYLOAD_VERSION` bump: the discrimination is structural and additive (old
+  payloads simply lack `draft`), exactly as `sources?` was added — old
+  drafts/messages decrypt unchanged with an empty `draft`.
+- **Serializer signature (decision):** `serializeSealedPayload` is
+  `(contentMarkdown, attachmentRefs?, sources?)` today; a 4th optional positional
+  pushes it to four. **Recommended:** refactor the extras into an options bag —
+  `serializeSealedPayload(contentMarkdown, extras?: { attachmentRefs?; sources?; draft? })`
+  — touching the ~4 call sites (`message-envelope.ts`, enclave `run-turn.ts`,
+  `trace-observer.ts`); it's mechanical, additive, well-tested, and the named
+  shape stops the positional sprawl (INV-12 spirit). **Fallback** (smaller blast
+  radius, keeps the enclave/message paths byte-untouched): append `draft?` as a
+  4th positional and have only the draft seal path pass it.
+
+**Frontend wiring (no backend / types / wire / migration change).**
+
+- `seal-draft.ts` `sealDraftContent`: accept `contextRefs: DraftContextRef[]` and
+  `command: { name; clientActionId } | null`; map context refs to their identity
+  fields and forward both into the serialize path. `SealedDraftFields` gains
+  `contextRefs` + `command` (the recovered plaintext, to seed the decrypt cache,
+  same contract as `attachmentRefs`).
+- `decryption.ts`: `DraftDecryption` gains `contextRefs: DraftContextRef[]`.
+  `resolveDraftDecryption` maps the decrypted `draft.contextRefs` →
+  `DraftContextRef[]` (status reconstructed). Context refs carry **no secret
+  material**, so — unlike attachment keys — they need no `rememberAttachmentRef`
+  re-registration on a fresh device. New `cachedDraftContextRefs(draftId)` mirrors
+  `cachedDraftBody` / `cachedDraftAttachments` as the in-memory plaintext authority
+  the write path re-seals from. **Command recovery (decision):** on decrypt,
+  re-inject `clientActionId` onto the hydrated `slashCommand` node in `contentJson`
+  (a small content walk) so `extractCommandNode` at send recovers it and the node
+  stays the single source of truth — preferred over surfacing a separate decrypted
+  command the send path must consult.
+- `use-draft-message.ts` seal branches (`upsertLoadedDraft` seal branch +
+  `saveDraft` / `addAttachment` / `removeAttachment` re-seal): read current context
+  refs from `cachedDraftContextRefs` (so a keystroke or attachment change preserves
+  them, exactly as 4d does for attachments) and extract the command from
+  `contentJson` via `extractCommandNode` at seal time. Keep the at-rest row's
+  `contextRefs` undefined (E2EE-4 — never plaintext at rest); seed the decrypt
+  cache with the sealed refs + command.
+- `use-draft-composer.ts`: extend the 4d late-hydrate effect (unlock-after-open) to
+  carry context refs alongside body + attachments, so a sealed discuss-with-ariadne
+  draft's `<ContextRefStrip>` chip re-appears on unlock. The command rides inside
+  `contentJson`, so it hydrates with the body once `clientActionId` is re-injected
+  on decrypt.
+- **Wire/sync: unchanged.** `executeDraftUpsert` (`draft-sync.ts`) already forces
+  `attachmentIds: []` for E2E and sends `contextRefs: row.contextRefs ?? null`; an
+  E2E row's at-rest `contextRefs` stays undefined → wire `null`, while the sealed
+  copy rides inside the ciphertext. The plaintext path is untouched. The backend
+  `command` / `context_refs` columns stay for the plaintext path and are simply
+  null for E2E.
+
+**Scope boundary (4e):** only the producers that exist today — discuss-with-ariadne
+context refs and the `/discuss-with-ariadne` `clientActionId`. No speculative
+support for future context-ref kinds (INV-36): the seal carries the whole
+`DraftContextRef` identity, so new kinds ride free. `status` / `fingerprint` /
+`errorMessage` are deliberately not sealed (transient, re-resolved). Command
+dispatch is unchanged — only `clientActionId` recovery across roam is added.
+
+**Reuse:** `serializeSealedPayload` / `parseSealedPayload` attachment-ref + sources
+pattern (validators, structural-mirror discipline); the 4c/4d decrypt-cache + draft
+decrypt core; `extractCommandNode`; the 4d late-hydrate effect.
+
+**Verification:** `sealed-payload.test.ts` (round-trip `draft.contextRefs` +
+`draft.command`; malformed elements dropped; pre-4e payloads parse with empty
+`draft`; message/enclave destructuring unaffected). `seal-draft.test.ts` (seal
+carries context refs + command; full `toEqual` recovery on decrypt, INV-24).
+`draft-e2e-roam.test.ts` (a discuss-with-ariadne E2E draft's context ref survives
+the wire and re-renders; `/discuss-with-ariadne` recovers `clientActionId` on the
+receiving device and routes locally). `use-draft-message.test.ts` (seal carries
+context refs/command, never at rest; content-only save and add/remove attachment
+preserve them; locked is a no-op). `use-decrypted-draft-content.test.ts` (context
+refs surfaced from the decrypted payload). `bun run test` + `bun run test:e2e`.
+
+**Invariant notes (4e):** INV-35 (reuse the seal/parse/decrypt path), INV-36 (no
+speculative ref kinds), INV-58 (markdown body + structured sidecars), INV-24
+(full-object asserts), E2EE-4 (context refs / command undefined at rest, sealed
+only).
+
 ## Invariant Notes
 
 - INV-1/2/3/8/50: drafts are workspace- + user-scoped, prefixed-ULID, no FKs/enums.

--- a/docs/plans/centralized-draft-system.md
+++ b/docs/plans/centralized-draft-system.md
@@ -325,118 +325,128 @@ surfaced from refs). `bun run test`.
 
 **Verification:** Backend test: resolve declines on drift, deletes on match; thread-conversion re-points drafts. Frontend/E2E (`test:e2e`): send clears draft; drifted draft survives send; reply draft follows a message into its new thread; E2E draft round-trips without plaintext at rest. `bun run test` + `bun run test:e2e`.
 
-#### Stage 4e — E2E draft context refs + slash-command routing — PROPOSED
+#### Stage 4e — E2E drafts seal `contentJson` (lossless) + context refs — PROPOSED
 
-4d closed attachments. Two pieces of composer state still stay session-local on
-E2E drafts, and this stage seals both into the same SSK ciphertext so they roam.
+4d closed attachments. Two pieces of composer state still don't roam on E2E
+drafts, and the root cause of one of them is a body-seal choice 4c made that's
+worth correcting first.
 
-**What's actually missing (verified against the code, not assumed):**
+**Root cause: E2E drafts seal markdown, not `contentJson`.** `seal-draft.ts`
+serializes the body to markdown (`serializeToMarkdown(contentJson)`) before
+sealing, and the decrypt rebuilds it with `parseMarkdown(contentMarkdown)`
+(`message-envelope.ts`). So an E2E draft body does a `contentJson → markdown →
+contentJson` round-trip. 4c chose this purely to reuse the message seal path
+(INV-35), and it's correct **for messages** — a sent message genuinely crosses
+the system boundary (server, enclave-for-agents, public API, other recipients
+all consume the markdown wire form). But a **draft** is the author's own internal
+composer state synced to their own devices; no external consumer reads its
+plaintext. Per INV-58, internal state is canonically `contentJson` — and
+plaintext drafts already honor this (they store/roam `contentJson` verbatim end
+to end; the backend derives `content_markdown` server-side but never round-trips
+it back). The E2E path is the lone exception, and the round-trip is lossy: it
+drops any node attr markdown can't represent.
 
-- **Context refs are a true gap.** `seedDraftWithContextRef`
-  (`lib/context-bag/seed-draft.ts`) is the _only_ producer of a draft's
-  `contextRefs` sidecar — every other reference is a pass-through read — and it's
-  called only by `useDiscussWithAriadne`, which mints a `companionMode: "on"`
-  scratchpad. Those scratchpads can be E2E, so a "Discuss with Ariadne" chip
-  genuinely lands on an E2E draft today. The seal branch in
-  `use-draft-message.ts` writes neither `contextRefs` at rest nor into the
-  ciphertext, so the chip vanishes when the draft roams.
-- **Slash commands are _mostly_ already covered — the gap is one field.** The
-  `slashCommand` node serializes to `/${name}` (`packages/prosemirror/markdown.ts`
-  `serializeNode`) and re-parses to a `slashCommand` node on decrypt
-  (`parseInline`, the `/[\w-]+` match), so 4d's body seal already roams the
-  _visible_ command. What the markdown round-trip drops is `clientActionId` — the
-  opaque routing discriminator. A roamed `/discuss-with-ariadne` decrypts to a
-  node with `name` but `clientActionId: null`, and `message-input.tsx` routes on
-  `clientActionId === DISCUSS_WITH_ARIADNE_COMMAND`, so the recovered draft
-  misroutes to server dispatch (`queueCommand`) instead of the local
-  `startDiscussWithAriadne`. The frontend never writes the backend `command`
-  draft column — commands live only as the node in `contentJson` — so this is the
-  whole of the slash-command work: recover `clientActionId` across the seal.
+**What that lossiness costs, concretely — slash commands.** The `slashCommand`
+node serializes to `/${name}` (`packages/prosemirror/markdown.ts`) and re-parses
+to `{ name }` on decrypt, dropping `clientActionId`. A roamed
+`/discuss-with-ariadne` decrypts with `clientActionId: null`, and
+`message-input.tsx` routes on `clientActionId === DISCUSS_WITH_ARIADNE_COMMAND`,
+so it misroutes to server dispatch (`queueCommand`) instead of the local
+`startDiscussWithAriadne`. **Sealing `contentJson` fixes this for free** — the
+whole node, `clientActionId` and all, round-trips losslessly. No command sidecar,
+no re-injection. (The frontend never writes the backend `command` column anyway;
+commands live only as the node in `contentJson`.)
 
-**Design — markdown body + structured sidecars (the 4d pattern, extended).**
-Markdown is the lossy external boundary: it carries `/name` but not
-`clientActionId`, and has no representation for a context ref at all. The
-established shape (INV-35, INV-58) is to seal the markdown body for the
-human-readable content and ride everything markdown can't represent losslessly as
-**structured sidecars inside the same SSK ciphertext** — exactly how
-`attachmentRefs` already work. Context refs and the command join `attachmentRefs`
-as sidecars; nothing new lands on the wire or at rest.
+**What `contentJson` does NOT cover — context refs.** A draft's `contextRefs` is
+a separate `DraftContextRef[]` sidecar, never part of `contentJson`.
+`seedDraftWithContextRef` (`lib/context-bag/seed-draft.ts`) is its _only_ producer
+(every other reference is a pass-through read), called only by
+`useDiscussWithAriadne`, which mints a `companionMode: "on"` scratchpad that can
+be E2E. So a "Discuss with Ariadne" chip lands on an E2E draft today and vanishes
+on roam — the E2E seal branch writes `contextRefs` neither at rest nor sealed.
+Context refs remain a genuine sidecar regardless of body format.
+
+**Design.** Seal the draft body as `contentJson` (authoritative, lossless,
+INV-58-aligned) and the context refs as a structured sidecar — both inside the
+same SSK ciphertext, alongside the attachment refs 4d already seals. This brings
+E2E drafts into line with plaintext drafts (both lossless `contentJson`); the
+markdown odd-one-out goes away. The message seal/decrypt path stays markdown,
+untouched.
 
 **`@threa/crypto` payload change (`sealed-payload.ts`).** Extend `E2eSealedPayload`
 / `ParsedSealedPayload` with one optional **draft-scoped** namespace:
 
 ```ts
 draft?: {
+  contentJson?: JSONContent      // typed `unknown` in the dependency-free crypto pkg; cast on the FE
   contextRefs?: SealedDraftContextRef[]
-  command?: SealedDraftCommand
 }
 ```
 
-- **Why namespaced under `draft`, not two new top-level fields:** context refs and
-  the command are draft-only — they never appear in a message or an agent reply,
-  and the enclave reader must never confuse them with content. A single `draft`
-  key signals "ignore unless you are the authoring composer," keeps the
-  message/enclave mental model clean (the enclave keeps destructuring only
-  `{ contentMarkdown, attachmentRefs }` and is forward-compatible by ignoring
-  the field), and groups the two adjuncts that always travel together.
+- **Why namespaced under `draft`, not top-level fields:** these are draft-only —
+  they never appear in a message or an agent reply, and the enclave reader must
+  never confuse them with content. A single `draft` key signals "ignore unless
+  you are the authoring composer," keeps the message/enclave mental model clean
+  (the enclave keeps destructuring only `{ contentMarkdown, attachmentRefs }` and
+  is forward-compatible by ignoring the field), and groups the two adjuncts that
+  always travel together.
+- `contentMarkdown` stays populated for drafts too (derived from `contentJson`),
+  so the payload remains shaped like a message and old/preview readers keep a
+  fallback. The draft decrypt **prefers `draft.contentJson`**, falling back to
+  `parseMarkdown(contentMarkdown)` — so 4c/4d-era sealed drafts still open
+  (lossily, as today) with no migration.
 - `SealedDraftContextRef` mirrors `DraftContextRef` structurally (the crypto
-  package stays dependency-free — the same mirror-and-bridge discipline as
+  package stays dependency-free — same mirror-and-bridge discipline as
   `SealedSourceItem` ↔ `SourceItem`). **Only the durable identity fields ride
   sealed** — `refKind`, `streamId`, `fromMessageId`, `toMessageId`,
   `originMessageId`. The transient resolution fields (`status`, `fingerprint`,
   `errorMessage`) are device-local / re-derivable and are NOT sealed: the
   receiving device re-resolves against the shared server bag, so the recovered
   ref reconstructs `status: "ready"` (the bag is server-side and shared; a roamed
-  device resolves it the same way the authoring device did) with the other
-  transient fields null.
-- `SealedDraftCommand = { name: string; clientActionId: string | null }` —
-  structural twin of `@threa/types`' `DraftCommand` / `commands.ts`'
-  `ExtractedCommand`.
-- `isSealedDraftContextRef` / `isSealedDraftCommand` validators mirror
-  `isAttachmentRef` — drop malformed elements (decrypted ≠ trusted). No
+  device resolves it the same way the authoring device did) with the rest null.
+- `isSealedDraftContextRef` (and a light `isDocLike` check for `contentJson`)
+  mirror `isAttachmentRef` — drop malformed elements (decrypted ≠ trusted). No
   `E2E_PAYLOAD_VERSION` bump: the discrimination is structural and additive (old
-  payloads simply lack `draft`), exactly as `sources?` was added — old
-  drafts/messages decrypt unchanged with an empty `draft`.
-- **Serializer signature (decision):** `serializeSealedPayload` is
-  `(contentMarkdown, attachmentRefs?, sources?)` today; a 4th optional positional
-  pushes it to four. **Recommended:** refactor the extras into an options bag —
+  payloads simply lack `draft`), exactly as `sources?` was added.
+- **Serializer signature:** `serializeSealedPayload` is
+  `(contentMarkdown, attachmentRefs?, sources?)` today; a structured `draft`
+  object would make it a 4th positional. Refactor the extras into an options bag —
   `serializeSealedPayload(contentMarkdown, extras?: { attachmentRefs?; sources?; draft? })`
   — touching the ~4 call sites (`message-envelope.ts`, enclave `run-turn.ts`,
-  `trace-observer.ts`); it's mechanical, additive, well-tested, and the named
-  shape stops the positional sprawl (INV-12 spirit). **Fallback** (smaller blast
-  radius, keeps the enclave/message paths byte-untouched): append `draft?` as a
-  4th positional and have only the draft seal path pass it.
+  `trace-observer.ts`); mechanical, additive, well-tested, and the named shape
+  stops the positional sprawl (INV-12 spirit). The enclave/message call sites
+  keep passing only what they pass today.
 
 **Frontend wiring (no backend / types / wire / migration change).**
 
-- `seal-draft.ts` `sealDraftContent`: accept `contextRefs: DraftContextRef[]` and
-  `command: { name; clientActionId } | null`; map context refs to their identity
-  fields and forward both into the serialize path. `SealedDraftFields` gains
-  `contextRefs` + `command` (the recovered plaintext, to seed the decrypt cache,
-  same contract as `attachmentRefs`).
-- `decryption.ts`: `DraftDecryption` gains `contextRefs: DraftContextRef[]`.
-  `resolveDraftDecryption` maps the decrypted `draft.contextRefs` →
-  `DraftContextRef[]` (status reconstructed). Context refs carry **no secret
-  material**, so — unlike attachment keys — they need no `rememberAttachmentRef`
-  re-registration on a fresh device. New `cachedDraftContextRefs(draftId)` mirrors
-  `cachedDraftBody` / `cachedDraftAttachments` as the in-memory plaintext authority
-  the write path re-seals from. **Command recovery (decision):** on decrypt,
-  re-inject `clientActionId` onto the hydrated `slashCommand` node in `contentJson`
-  (a small content walk) so `extractCommandNode` at send recovers it and the node
-  stays the single source of truth — preferred over surfacing a separate decrypted
-  command the send path must consult.
+- `seal-draft.ts` `sealDraftContent`: forward `contentJson` (unchanged input) and
+  `contextRefs: DraftContextRef[]` into the `draft` namespace; still derive
+  `contentMarkdown` for the payload's markdown slot. `SealedDraftFields` gains
+  `contextRefs` (the recovered plaintext, to seed the decrypt cache, same contract
+  as `attachmentRefs`). No `command` field.
+- `message-envelope.ts` decrypt: `tryOpenStreamMessage` reads
+  `contentJson = parsed.draft?.contentJson ?? parseMarkdown(contentMarkdown)`, so
+  the **message path is byte-identical** (messages never set `draft`) while a draft
+  gets its lossless `contentJson`. `DecryptedMessageContent` gains an optional
+  `draftContextRefs?` (same optionality contract as `attachmentRefs?` / `sources?`;
+  messages leave it empty).
+- `decryption.ts`: `DraftDecryption` gains `contextRefs: DraftContextRef[]`, mapped
+  from `cached.content.draftContextRefs` (status reconstructed). Context refs carry
+  **no secret material**, so — unlike attachment keys — they need no
+  `rememberAttachmentRef` re-registration on a fresh device. New
+  `cachedDraftContextRefs(draftId)` mirrors `cachedDraftBody` /
+  `cachedDraftAttachments` as the in-memory plaintext authority the write path
+  re-seals from. **No command handling at all** — it rides inside `contentJson`.
 - `use-draft-message.ts` seal branches (`upsertLoadedDraft` seal branch +
   `saveDraft` / `addAttachment` / `removeAttachment` re-seal): read current context
-  refs from `cachedDraftContextRefs` (so a keystroke or attachment change preserves
-  them, exactly as 4d does for attachments) and extract the command from
-  `contentJson` via `extractCommandNode` at seal time. Keep the at-rest row's
-  `contextRefs` undefined (E2EE-4 — never plaintext at rest); seed the decrypt
-  cache with the sealed refs + command.
+  refs from `cachedDraftContextRefs` so a keystroke or attachment change preserves
+  them (exactly as 4d does for attachments). Keep the at-rest row's `contextRefs`
+  undefined (E2EE-4 — never plaintext at rest); seed the decrypt cache with the
+  sealed refs.
 - `use-draft-composer.ts`: extend the 4d late-hydrate effect (unlock-after-open) to
   carry context refs alongside body + attachments, so a sealed discuss-with-ariadne
   draft's `<ContextRefStrip>` chip re-appears on unlock. The command rides inside
-  `contentJson`, so it hydrates with the body once `clientActionId` is re-injected
-  on decrypt.
+  `contentJson`, so it hydrates with the body — no extra handling.
 - **Wire/sync: unchanged.** `executeDraftUpsert` (`draft-sync.ts`) already forces
   `attachmentIds: []` for E2E and sends `contextRefs: row.contextRefs ?? null`; an
   E2E row's at-rest `contextRefs` stays undefined → wire `null`, while the sealed
@@ -444,32 +454,36 @@ draft?: {
   `command` / `context_refs` columns stay for the plaintext path and are simply
   null for E2E.
 
-**Scope boundary (4e):** only the producers that exist today — discuss-with-ariadne
-context refs and the `/discuss-with-ariadne` `clientActionId`. No speculative
-support for future context-ref kinds (INV-36): the seal carries the whole
-`DraftContextRef` identity, so new kinds ride free. `status` / `fingerprint` /
-`errorMessage` are deliberately not sealed (transient, re-resolved). Command
-dispatch is unchanged — only `clientActionId` recovery across roam is added.
+**Scope boundary (4e):** the body-format fix makes slash commands (and any other
+node attr markdown can't represent) roam losslessly; the only explicit sidecar is
+context refs, for the producers that exist today (discuss-with-ariadne). No
+speculative support for future context-ref kinds (INV-36): the seal carries the
+whole `DraftContextRef` identity, so new kinds ride free. `status` / `fingerprint`
+/ `errorMessage` are deliberately not sealed (transient, re-resolved). Command
+dispatch is unchanged. Pre-4e sealed drafts keep opening via the markdown
+fallback (no backfill).
 
 **Reuse:** `serializeSealedPayload` / `parseSealedPayload` attachment-ref + sources
 pattern (validators, structural-mirror discipline); the 4c/4d decrypt-cache + draft
-decrypt core; `extractCommandNode`; the 4d late-hydrate effect.
+decrypt core; the 4d late-hydrate effect.
 
-**Verification:** `sealed-payload.test.ts` (round-trip `draft.contextRefs` +
-`draft.command`; malformed elements dropped; pre-4e payloads parse with empty
-`draft`; message/enclave destructuring unaffected). `seal-draft.test.ts` (seal
-carries context refs + command; full `toEqual` recovery on decrypt, INV-24).
-`draft-e2e-roam.test.ts` (a discuss-with-ariadne E2E draft's context ref survives
-the wire and re-renders; `/discuss-with-ariadne` recovers `clientActionId` on the
-receiving device and routes locally). `use-draft-message.test.ts` (seal carries
-context refs/command, never at rest; content-only save and add/remove attachment
-preserve them; locked is a no-op). `use-decrypted-draft-content.test.ts` (context
-refs surfaced from the decrypted payload). `bun run test` + `bun run test:e2e`.
+**Verification:** `sealed-payload.test.ts` (round-trip `draft.contentJson` +
+`draft.contextRefs`; malformed elements dropped; pre-4e payloads — no `draft` —
+parse and fall back to markdown; message/enclave destructuring unaffected).
+`seal-draft.test.ts` (seal carries `contentJson` + context refs; full `toEqual`
+recovery on decrypt, INV-24; a `slashCommand` node's `clientActionId` survives the
+round-trip). `draft-e2e-roam.test.ts` (a discuss-with-ariadne E2E draft's context
+ref survives the wire and re-renders; `/discuss-with-ariadne` keeps its
+`clientActionId` on the receiving device and routes locally). `use-draft-message.test.ts`
+(seal carries context refs, never at rest; content-only save and add/remove
+attachment preserve them; locked is a no-op). `use-decrypted-draft-content.test.ts`
+(context refs surfaced from the decrypted payload). `bun run test` +
+`bun run test:e2e`.
 
-**Invariant notes (4e):** INV-35 (reuse the seal/parse/decrypt path), INV-36 (no
-speculative ref kinds), INV-58 (markdown body + structured sidecars), INV-24
-(full-object asserts), E2EE-4 (context refs / command undefined at rest, sealed
-only).
+**Invariant notes (4e):** INV-58 (`contentJson` is the canonical internal body;
+markdown is the boundary form — drafts are internal, so they seal `contentJson`),
+INV-35 (reuse the seal/parse/decrypt path), INV-36 (no speculative ref kinds),
+INV-24 (full-object asserts), E2EE-4 (context refs undefined at rest, sealed only).
 
 ## Invariant Notes
 

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -54,7 +54,9 @@ export {
   parseSealedPayload,
   isAttachmentRef,
   isSealedSourceItem,
+  isDocLike,
   type E2eSealedPayload,
   type ParsedSealedPayload,
   type SealedSourceItem,
+  type SealedPayloadExtras,
 } from "./sealed-payload"

--- a/packages/crypto/src/sealed-payload.ts
+++ b/packages/crypto/src/sealed-payload.ts
@@ -19,13 +19,12 @@ export interface SealedSourceItem {
 }
 
 /**
- * The structured E2E message payload. Messages with no attachments and no
- * sources seal the bare markdown string (byte-identical to every E2E message
- * already written), so this wrapper only appears once attachments or sources
- * ride along. The `__e2ePayload` marker + version lets the open path tell a
- * wrapper apart from a user's markdown that merely happens to start with `{` —
- * the same structurally-disjoint discrimination the backend's envelope union
- * uses.
+ * The structured E2E message payload. Messages with no attachments, sources, or
+ * a sealed draft body seal the bare markdown string (byte-identical to every E2E
+ * message already written), so this wrapper only appears once one of those rides
+ * along. The `__e2ePayload` marker + version lets the open path tell a wrapper
+ * apart from a user's markdown that merely happens to start with `{` — the same
+ * structurally-disjoint discrimination the backend's envelope union uses.
  *
  * Shared so the browser (seal on send, strip on view) and the enclave (strip
  * to feed the model clean markdown + read attachmentRefs, seal replies with
@@ -37,24 +36,44 @@ export interface E2eSealedPayload {
   attachmentRefs: AttachmentRef[]
   /** Citation sources for agent replies. Absent on user messages and older payloads. */
   sources?: SealedSourceItem[]
+  /**
+   * A draft's authoritative ProseMirror body. Set ONLY on E2E draft payloads —
+   * never on a message or an agent reply, and the message/enclave reader ignores
+   * it. A draft is the author's own internal composer state, so per INV-58 it
+   * seals the lossless `contentJson` rather than depending on the markdown
+   * round-trip (which drops node attrs markdown can't represent, e.g. a slash
+   * command's `clientActionId`); `contentMarkdown` stays populated as the readable
+   * mirror + fallback. Typed `unknown` because this package is dependency-free —
+   * the frontend casts to `JSONContent`.
+   */
+  draftContentJson?: unknown
 }
 
 export const E2E_PAYLOAD_VERSION = 1
 
-/** Build the bytes to seal: bare markdown, or the wrapper when refs/sources ride along. */
-export function serializeSealedPayload(
-  contentMarkdown: string,
-  attachmentRefs?: AttachmentRef[],
+/** Optional adjuncts that turn a bare-markdown seal into the versioned wrapper. */
+export interface SealedPayloadExtras {
+  attachmentRefs?: AttachmentRef[]
   sources?: SealedSourceItem[]
-): string {
+  /** A draft's authoritative ProseMirror body — see `E2eSealedPayload.draftContentJson`. */
+  draftContentJson?: unknown
+}
+
+/** Build the bytes to seal: bare markdown, or the wrapper when an adjunct rides along. */
+export function serializeSealedPayload(contentMarkdown: string, extras?: SealedPayloadExtras): string {
+  const attachmentRefs = extras?.attachmentRefs
+  const sources = extras?.sources
+  const draftContentJson = extras?.draftContentJson
   const hasRefs = attachmentRefs !== undefined && attachmentRefs.length > 0
   const hasSources = sources !== undefined && sources.length > 0
-  if (!hasRefs && !hasSources) return contentMarkdown
+  const hasDraftBody = draftContentJson !== undefined && draftContentJson !== null
+  if (!hasRefs && !hasSources && !hasDraftBody) return contentMarkdown
   return JSON.stringify({
     __e2ePayload: E2E_PAYLOAD_VERSION,
     contentMarkdown,
     attachmentRefs: attachmentRefs ?? [],
     ...(hasSources ? { sources } : {}),
+    ...(hasDraftBody ? { draftContentJson } : {}),
   } satisfies E2eSealedPayload)
 }
 
@@ -62,6 +81,8 @@ export interface ParsedSealedPayload {
   contentMarkdown: string
   attachmentRefs: AttachmentRef[]
   sources: SealedSourceItem[]
+  /** A draft's sealed ProseMirror body (lossless); null for a message or bare-markdown payload. */
+  draftContentJson: unknown | null
 }
 
 /**
@@ -100,10 +121,26 @@ export function isSealedSourceItem(value: unknown): value is SealedSourceItem {
 }
 
 /**
+ * Validate a decrypted `draftContentJson` before it's surfaced as a ProseMirror
+ * doc — same defence as `isAttachmentRef`. It's decrypted text we authored, but a
+ * malformed or mixed-version payload could carry a non-doc here, which must not
+ * reach the editor (or it would render `undefined` where a node tree is expected).
+ * A light structural check (`{ type: "doc", content: [...] }`) is enough; the
+ * editor validates the node tree itself.
+ */
+export function isDocLike(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return v.type === "doc" && Array.isArray(v.content)
+}
+
+/**
  * Inverse of `serializeSealedPayload`. A decrypted string is either the bare
  * markdown body (the legacy/no-attachment shape) or the versioned wrapper;
  * anything that doesn't parse as our wrapper is treated as raw markdown so old
- * messages keep opening unchanged. Malformed ref/source elements are dropped.
+ * messages keep opening unchanged. Malformed ref/source elements are dropped, and
+ * a non-doc `draftContentJson` falls back to null (the reader reconstructs from
+ * markdown).
  */
 export function parseSealedPayload(raw: string): ParsedSealedPayload {
   if (raw.startsWith("{")) {
@@ -112,11 +149,12 @@ export function parseSealedPayload(raw: string): ParsedSealedPayload {
       if (parsed.__e2ePayload === E2E_PAYLOAD_VERSION && typeof parsed.contentMarkdown === "string") {
         const attachmentRefs = Array.isArray(parsed.attachmentRefs) ? parsed.attachmentRefs.filter(isAttachmentRef) : []
         const sources = Array.isArray(parsed.sources) ? parsed.sources.filter(isSealedSourceItem) : []
-        return { contentMarkdown: parsed.contentMarkdown, attachmentRefs, sources }
+        const draftContentJson = isDocLike(parsed.draftContentJson) ? parsed.draftContentJson : null
+        return { contentMarkdown: parsed.contentMarkdown, attachmentRefs, sources, draftContentJson }
       }
     } catch {
       // Not our wrapper — fall through and treat the whole string as markdown.
     }
   }
-  return { contentMarkdown: raw, attachmentRefs: [], sources: [] }
+  return { contentMarkdown: raw, attachmentRefs: [], sources: [], draftContentJson: null }
 }


### PR DESCRIPTION
**Design doc:** `docs/plans/centralized-draft-system.md` §Stage 4e _(no Linear ticket; this stage is tracked in the centralized-draft plan)_

## Problem

E2E drafts roam across the author's devices by sealing their body to the stream SSK (Stage 4c/4d). But the body was sealed as **markdown**: `seal-draft.ts` did `serializeToMarkdown(contentJson)` before sealing, and the decrypt rebuilt it with `parseMarkdown(contentMarkdown)`. That's a `contentJson → markdown → contentJson` round-trip on every roamed draft, and it's **lossy** — markdown can't represent every ProseMirror node attr.

4c reused the *message* seal path to get this cheaply (INV-35), which is correct for a message: a sent message genuinely crosses the system boundary (server, enclave-for-agents, public API, other recipients all consume the markdown wire form). But a **draft is the author's own internal composer state**, synced only to their own devices — no external consumer reads its plaintext. Per INV-58, internal state is canonically `contentJson`, and plaintext drafts already honor this (they store/roam `contentJson` verbatim; the backend derives `content_markdown` server-side but never round-trips it back). The E2E path was the lone exception.

The concrete cost: a `slashCommand` node serializes to `/${name}` and re-parses to `{ name }`, dropping `clientActionId`. A roamed `/discuss-with-ariadne` decrypted with `clientActionId: null`, and `message-input.tsx` routes on `clientActionId === DISCUSS_WITH_ARIADNE_COMMAND` — so it misrouted to server dispatch (`queueCommand`, which rejects an unknown command) instead of the local `startDiscussWithAriadne`.

## Solution

Seal the draft body as the lossless `contentJson`, the way plaintext drafts already do — bringing the E2E path into line with INV-58 instead of working around the lossy round-trip. The whole node tree round-trips byte-for-byte, so `clientActionId` (and any other attr markdown can't carry) survives the roam for free.

### How it works

1. **`@threa/crypto/sealed-payload.ts`** gains one optional field, `E2eSealedPayload.draftContentJson?: unknown` (typed `unknown` — the package is dependency-free; the frontend casts to `JSONContent`). It's set **only** on E2E draft payloads; messages and agent replies never set it, and the message/enclave reader ignores it.
2. The draft seal chain threads `contentJson` straight through: `seal-draft.ts sealDraftContent` → `seal-send.ts sealOutgoingMessage` → `message-envelope.ts sealStreamMessage` → `serializeSealedPayload`. `contentMarkdown` is still derived and sealed as the readable mirror.
3. On decrypt, `tryOpenStreamMessage` reads `contentJson = draftContentJson != null ? (draftContentJson as JSONContent) : parseMarkdown(contentMarkdown)`. A draft gets its lossless body; a message has no `draftContentJson`, so it reconstructs from markdown **exactly as before** — the message path is byte-identical.
4. `isDocLike` (mirrors `isAttachmentRef`) guards the decrypted field: a non-doc value falls back to `null` so the reader reconstructs from markdown rather than handing a malformed node tree to the editor.
5. **Pre-4e sealed drafts keep opening** via the markdown fallback (`draftContentJson` absent → `null` → `parseMarkdown`). No migration, no `E2E_PAYLOAD_VERSION` bump — the field is additive and old clients ignore it.

The frontend draft write/read paths needed **no change**: the write path already seeds the decrypt cache with the just-authored `contentJson` (the authoring device never round-trips), and the read path already serves `cached.content.contentJson` — now lossless for a roamed draft.

### Key design decisions

**1. Seal `contentJson`, not a `command` sidecar.** The earlier proposal recovered `clientActionId` via a separate sealed `command` field + re-injection onto the decrypted node. Sealing the whole `contentJson` makes that unnecessary and fixes *every* lossy attr at once, not just commands. It's also the INV-58-correct framing: a draft is internal state. (Decision made with the user after the markdown round-trip was identified as the root cause.)

**2. A flat `draftContentJson` field, not a `draft: {}` namespace.** The proposal namespaced draft-only fields together (it was going to also hold context refs). With context refs out of scope (below), the namespace would hold exactly one field — speculative structure (INV-36). The flat field's name already signals draft-scope, and the message/enclave reader ignores it regardless.

**3. Context refs deliberately NOT sealed (INV-36).** A draft's `contextRefs` sidecar is never part of `contentJson`, so it would need its own sealed channel. But its only producer — `seedDraftWithContextRef` ← `useDiscussWithAriadne` — creates the scratchpad via plain `useCreateStream({ type: "scratchpad" })`, which never sets `e2eEnabled`. The only flow that sets `e2eEnabled: true` is `useCreateEncryptedScratchpad` (which doesn't seed context refs), and there is no path that enables encryption on an existing stream. So **no current flow lands a context ref on an E2E draft** — sealing them would be dead code for a nonexistent producer. Recorded in the doc with a revisit note if a future flow makes discuss-with-ariadne E2E.

**4. Serializer refactored to an options bag.** `serializeSealedPayload(contentMarkdown, attachmentRefs?, sources?)` → `(contentMarkdown, extras?: { attachmentRefs?, sources?, draftContentJson? })`. A 4th positional optional is the exact "positional sprawl" smell (INV-12 spirit); the named shape reads better. Mechanical, additive — touched the 4 call sites (`message-envelope.ts`, enclave `run-turn.ts`, `trace-observer.ts` ×2) and their tests.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/crypto/src/sealed-payload.ts` | Add `E2eSealedPayload.draftContentJson?`, `SealedPayloadExtras`, `isDocLike`; refactor `serializeSealedPayload` to options bag; `parseSealedPayload` surfaces `draftContentJson` (validated, null when absent) |
| `packages/crypto/src/index.ts` | Export `isDocLike`, `SealedPayloadExtras` |
| `apps/frontend/src/lib/crypto/message-envelope.ts` | `SealStreamMessageInput.draftContentJson?`; pass it to serialize; decrypt prefers it over `parseMarkdown` (message path unchanged) |
| `apps/frontend/src/lib/crypto/seal-send.ts` | `SealOutgoingMessageInput.draftContentJson?`; thread to `sealStreamMessage` |
| `apps/frontend/src/lib/crypto/seal-draft.ts` | Pass `draftContentJson: input.contentJson`; doc comment updated |
| `apps/enclave/src/agent/run-turn.ts` | `serializeSealedPayload(content, { sources })` (options-bag call) |
| `apps/enclave/src/agent/trace-observer.ts` | Two `serializeSealedPayload(…, { sources })` call sites |
| `apps/frontend/src/lib/crypto/__tests__/message-envelope.test.ts` | Update parse assertions for `draftContentJson`; new draft-body round-trip + non-doc-fallback test; options-bag call sites |
| `apps/frontend/src/lib/crypto/seal-draft.test.ts` | New test: a `slashCommand` node's `clientActionId` survives seal→decrypt |
| `apps/enclave/src/agent/run-turn.test.ts` | Options-bag call sites |
| `docs/plans/centralized-draft-system.md` | §Stage 4e marked DONE; context-refs investigation + INV-36 rationale recorded; §4d boundary note updated |

## Out of scope (deliberate)

- **Context refs on E2E drafts** — not sealed; no flow produces one (see decision 3). Revisit if discuss-with-ariadne becomes E2E.
- **No backend / types / wire / migration change.** The sealed copy rides inside the existing `ciphertext`; the wire `attachmentIds`/`contextRefs`/`command` columns are untouched (E2E rows leave them null, as before).
- **Pre-4e sealed drafts are not backfilled** — they open losslessly going forward only when re-sealed (next edit); until then they use the markdown fallback, same as today.

## Test plan

- [x] `apps/frontend` full suite — **255 files / 2806 tests pass**
- [x] `packages/crypto` — 37 pass
- [x] `apps/enclave` `run-turn` + `trace-observer` — 38 pass
- [x] New: `seal-draft.test.ts` asserts a `slashCommand` node's `clientActionId` survives the round-trip (the markdown reconstruction would drop it)
- [x] New: `message-envelope.test.ts` round-trips `draftContentJson` and asserts a non-doc value falls back to null; bare-markdown + attachment/source cases still green under the options-bag signature
- [x] `tsc --noEmit` clean across `packages/crypto`, `apps/enclave`, `apps/frontend`
- [x] Pre-commit hook: full lint + typecheck across all workspaces
- [x] Pre-PR review (2 reviewer agents over the diff): crypto-payload + frontend/enclave-wiring — clean (back-compat, no-version-bump safety, message-path byte-identity, no stragglers on the old signature all verified)

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phwc1Ch8CeRQdw1SqnmfrD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784215873&installation_id=129946197&pr_number=968&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F968&signature=38470f36080841c5d7305c73ae5694ccbe1007e0d35a55cba65a9f8325b7ef09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->