### PR TITLE
feat(e2ee): gate bot claims on BIK wrap coverage for sealed streams

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -198,6 +198,37 @@ describe("BotInvocationRepository.claimOne", () => {
     expect(captured.text).toContain("attempts = attempts + 1")
     expect(captured.values).toContain(BOT_CLAIM_MAX_ATTEMPTS)
   })
+
+  it("gates sealed streams on the claiming instance's BIK covering both generations (§2.6)", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeInvocationRow()])
+
+    await BotInvocationRepository.claimOne(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      instanceId: "inst_42",
+      runtimeKind: "pi-local",
+      claimToken: "tok_1",
+      supportedCapabilities: ["active-scratchpad"],
+      claimTtlSeconds: 60,
+      maxAttempts: BOT_CLAIM_MAX_ATTEMPTS,
+    })
+
+    // Plaintext streams (no e2e_streams row for the root) stay claimable as
+    // before; the BIK requirement is only the OR's second arm.
+    expect(captured.text).toContain("NOT EXISTS")
+    expect(captured.text).toContain("FROM e2e_streams e")
+    // Bot wraps, keyed to the claiming instance's registered BIK — not a passed
+    // key id (a keyless instance never matches, so it can't claim a sealed turn).
+    expect(captured.text).toContain("w.recipient_kind = 'bot'")
+    expect(captured.text).toContain("w.recipient_key_id = ri.public_key_id")
+    // Both generations must be covered: the reply's (current) and the prompt's
+    // (the trigger envelope's), mirroring the enclave's claimNext two-EXISTS.
+    expect(captured.text).toContain("w.key_generation = e.current_key_generation")
+    expect(captured.text).toContain("w.key_generation = (m.envelope ->> 'keyGeneration')::int")
+    // The trigger ciphertext is keyed off the invocation's source message.
+    expect(captured.text).toContain("JOIN messages m ON m.id = i.source_message_id")
+  })
 })
 
 describe("BotInvocationRepository.parkExhausted", () => {

--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -226,8 +226,13 @@ describe("BotInvocationRepository.claimOne", () => {
     // (the trigger envelope's), mirroring the enclave's claimNext two-EXISTS.
     expect(captured.text).toContain("w.key_generation = e.current_key_generation")
     expect(captured.text).toContain("w.key_generation = (m.envelope ->> 'keyGeneration')::int")
-    // The trigger ciphertext is keyed off the invocation's source message.
-    expect(captured.text).toContain("JOIN messages m ON m.id = i.source_message_id")
+    // The trigger ciphertext is keyed off the invocation's source message,
+    // workspace-scoped like every other table the gate touches (INV-8).
+    expect(captured.text).toContain("m.workspace_id = i.workspace_id AND m.id = i.source_message_id")
+    // Race-safe claim target: lock only the bot_invocations candidate row (INV-20).
+    expect(captured.text).toContain("FOR UPDATE OF i SKIP LOCKED")
+    // The claiming instance is bound twice (one per generation EXISTS).
+    expect(captured.values).toContain("inst_42")
   })
 })
 
@@ -280,10 +285,16 @@ describe("BotInvocationRepository.findBootstrapInvocations", () => {
 
     const availableQuery = texts.find((t) => t.includes("attempts < "))
     expect(availableQuery).toBeDefined()
+    // The available list mirrors claimOne's sealed-stream gate, so a row
+    // advertised here is one a follow-up claim can actually win (no keyless
+    // runtime is told sealed work is available it can't open).
+    expect(availableQuery).toContain("w.recipient_key_id = ri.public_key_id")
     // The owned-claims query must NOT be attempt-bounded: a runtime keeps its
-    // own in-flight claim regardless of how many times it's been re-dispatched.
+    // own in-flight claim regardless of how many times it's been re-dispatched,
+    // and it is never re-gated on wrap coverage (the claim already succeeded).
     const ownedClaimsQuery = texts.find((t) => t.includes("claimed_by_instance_id ="))
     expect(ownedClaimsQuery).toBeDefined()
     expect(ownedClaimsQuery).not.toContain("attempts < ")
+    expect(ownedClaimsQuery).not.toContain("w.recipient_key_id = ri.public_key_id")
   })
 })

--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -226,9 +226,9 @@ describe("BotInvocationRepository.claimOne", () => {
     // (the trigger envelope's), mirroring the enclave's claimNext two-EXISTS.
     expect(captured.text).toContain("w.key_generation = e.current_key_generation")
     expect(captured.text).toContain("w.key_generation = (m.envelope ->> 'keyGeneration')::int")
-    // The trigger ciphertext is keyed off the invocation's source message,
-    // workspace-scoped like every other table the gate touches (INV-8).
-    expect(captured.text).toContain("m.workspace_id = i.workspace_id AND m.id = i.source_message_id")
+    // The trigger ciphertext is keyed off the invocation's own source message
+    // (messages has no workspace_id column — it is scoped by stream_id).
+    expect(captured.text).toContain("JOIN messages m ON m.id = i.source_message_id")
     // Race-safe claim target: lock only the bot_invocations candidate row (INV-20).
     expect(captured.text).toContain("FOR UPDATE OF i SKIP LOCKED")
     // The claiming instance is bound twice (one per generation EXISTS).

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -582,11 +582,11 @@ export const BotInvocationRepository = {
     }
   ): Promise<BotInvocation | null> {
     const result = await db.query<BotInvocationRow>(sql`WITH candidate AS (
-        SELECT id FROM bot_invocations
-        WHERE workspace_id = ${params.workspaceId}
-          AND actor_type = 'bot'
-          AND actor_id = ${params.botId}
-          AND required_capability = ANY(${params.supportedCapabilities})
+        SELECT i.id FROM bot_invocations i
+        WHERE i.workspace_id = ${params.workspaceId}
+          AND i.actor_type = 'bot'
+          AND i.actor_id = ${params.botId}
+          AND i.required_capability = ANY(${params.supportedCapabilities})
           AND EXISTS (
             SELECT 1 FROM bot_runtime_instances r
             WHERE r.workspace_id = ${params.workspaceId}
@@ -594,12 +594,50 @@ export const BotInvocationRepository = {
               AND r.instance_id = ${params.instanceId}
               AND r.runtime_kind = ${params.runtimeKind}
           )
-          AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
-          AND (target_runtime_session_id IS NULL OR target_runtime_session_id = ${params.runtimeSessionId ?? null})
-          AND (status = 'pending' OR (status = 'claimed' AND claim_expires_at < NOW()))
-          AND attempts < ${params.maxAttempts}
-        ORDER BY created_at ASC, id ASC
-        FOR UPDATE SKIP LOCKED
+          AND (i.target_instance_id IS NULL OR i.target_instance_id = ${params.instanceId})
+          AND (i.target_runtime_session_id IS NULL OR i.target_runtime_session_id = ${params.runtimeSessionId ?? null})
+          AND (i.status = 'pending' OR (i.status = 'claimed' AND i.claim_expires_at < NOW()))
+          AND i.attempts < ${params.maxAttempts}
+          -- Sealed-stream gate (§2.6): a plaintext invocation (no e2e_streams row
+          -- for the root) is claimable by any instance, as today; an E2E one only
+          -- by the claiming instance's BIK when the stream's wraps cover BOTH the
+          -- reply generation (current) and the prompt's (the trigger envelope's),
+          -- mirroring the enclave's claimNext two-EXISTS. A keyless instance
+          -- (public_key_id NULL) never matches, so it can't claim a sealed turn it
+          -- can't open. Conditional because this same claimOne serves plaintext.
+          AND (
+            NOT EXISTS (
+              SELECT 1 FROM e2e_streams e
+              WHERE e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
+            )
+            OR (
+              EXISTS (
+                SELECT 1 FROM stream_e2e_key_wraps w
+                JOIN e2e_streams e
+                  ON e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
+                JOIN bot_runtime_instances ri
+                  ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${params.instanceId}
+                WHERE w.workspace_id = i.workspace_id
+                  AND w.stream_id = i.root_stream_id
+                  AND w.recipient_kind = 'bot'
+                  AND w.recipient_key_id = ri.public_key_id
+                  AND w.key_generation = e.current_key_generation
+              )
+              AND EXISTS (
+                SELECT 1 FROM stream_e2e_key_wraps w
+                JOIN messages m ON m.id = i.source_message_id
+                JOIN bot_runtime_instances ri
+                  ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${params.instanceId}
+                WHERE w.workspace_id = i.workspace_id
+                  AND w.stream_id = i.root_stream_id
+                  AND w.recipient_kind = 'bot'
+                  AND w.recipient_key_id = ri.public_key_id
+                  AND w.key_generation = (m.envelope ->> 'keyGeneration')::int
+              )
+            )
+          )
+        ORDER BY i.created_at ASC, i.id ASC
+        FOR UPDATE OF i SKIP LOCKED
         LIMIT 1
       )
       UPDATE bot_invocations i

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -13,7 +13,8 @@ import {
   type BotRuntimeSessionLinkStatus,
   type BotRuntimeStatus,
 } from "@threa/types"
-import { sql, type Querier } from "../../db"
+import type { QueryConfig } from "pg"
+import { composeSql, sql, type Querier } from "../../db"
 
 export type RuntimeSessionLinkStatus = BotRuntimeSessionLinkStatus
 
@@ -537,6 +538,59 @@ export const BotRuntimeSessionLinkRepository = {
   },
 }
 
+/**
+ * Canonical sealed-stream claim gate (§2.6), as a reusable predicate fragment
+ * correlated to a `bot_invocations` row source aliased `i`. Single source of
+ * truth shared by `claimOne` (which acts on a row) and `findBootstrapInvocations`
+ * (which advertises the same rows as available) so the two can never diverge —
+ * a row offered as available must be one a follow-up claim can actually win.
+ *
+ * A plaintext invocation (no `e2e_streams` row for the root) is claimable by any
+ * instance, as before; an E2E one only by the claiming instance's registered BIK
+ * when the stream's wraps cover BOTH the reply generation (current) and the
+ * prompt's (the trigger envelope's), mirroring the enclave's `claimNext`
+ * two-EXISTS. A keyless instance (`public_key_id` NULL) never matches, so it
+ * cannot claim a sealed turn it has no key to open. Conditional because this
+ * gate is applied on a path that also serves plaintext streams.
+ *
+ * Built with squid `sql` so it carries `$1..$k` placeholders that
+ * {@link composeSql} renumbers when splicing it into a larger query.
+ */
+function sealedStreamClaimGateSql(instanceId: string): QueryConfig {
+  return sql`(
+    NOT EXISTS (
+      SELECT 1 FROM e2e_streams e
+      WHERE e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
+    )
+    OR (
+      EXISTS (
+        SELECT 1 FROM stream_e2e_key_wraps w
+        JOIN e2e_streams e
+          ON e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
+        JOIN bot_runtime_instances ri
+          ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${instanceId}
+        WHERE w.workspace_id = i.workspace_id
+          AND w.stream_id = i.root_stream_id
+          AND w.recipient_kind = 'bot'
+          AND w.recipient_key_id = ri.public_key_id
+          AND w.key_generation = e.current_key_generation
+      )
+      AND EXISTS (
+        SELECT 1 FROM stream_e2e_key_wraps w
+        JOIN messages m
+          ON m.workspace_id = i.workspace_id AND m.id = i.source_message_id
+        JOIN bot_runtime_instances ri
+          ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${instanceId}
+        WHERE w.workspace_id = i.workspace_id
+          AND w.stream_id = i.root_stream_id
+          AND w.recipient_kind = 'bot'
+          AND w.recipient_key_id = ri.public_key_id
+          AND w.key_generation = (m.envelope ->> 'keyGeneration')::int
+      )
+    )
+  )`
+}
+
 export const BotInvocationRepository = {
   async insertIdempotent(
     db: Querier,
@@ -581,7 +635,7 @@ export const BotInvocationRepository = {
       maxAttempts: number
     }
   ): Promise<BotInvocation | null> {
-    const result = await db.query<BotInvocationRow>(sql`WITH candidate AS (
+    const result = await db.query<BotInvocationRow>(composeSql`WITH candidate AS (
         SELECT i.id FROM bot_invocations i
         WHERE i.workspace_id = ${params.workspaceId}
           AND i.actor_type = 'bot'
@@ -598,44 +652,7 @@ export const BotInvocationRepository = {
           AND (i.target_runtime_session_id IS NULL OR i.target_runtime_session_id = ${params.runtimeSessionId ?? null})
           AND (i.status = 'pending' OR (i.status = 'claimed' AND i.claim_expires_at < NOW()))
           AND i.attempts < ${params.maxAttempts}
-          -- Sealed-stream gate (§2.6): a plaintext invocation (no e2e_streams row
-          -- for the root) is claimable by any instance, as today; an E2E one only
-          -- by the claiming instance's BIK when the stream's wraps cover BOTH the
-          -- reply generation (current) and the prompt's (the trigger envelope's),
-          -- mirroring the enclave's claimNext two-EXISTS. A keyless instance
-          -- (public_key_id NULL) never matches, so it can't claim a sealed turn it
-          -- can't open. Conditional because this same claimOne serves plaintext.
-          AND (
-            NOT EXISTS (
-              SELECT 1 FROM e2e_streams e
-              WHERE e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
-            )
-            OR (
-              EXISTS (
-                SELECT 1 FROM stream_e2e_key_wraps w
-                JOIN e2e_streams e
-                  ON e.workspace_id = i.workspace_id AND e.stream_id = i.root_stream_id
-                JOIN bot_runtime_instances ri
-                  ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${params.instanceId}
-                WHERE w.workspace_id = i.workspace_id
-                  AND w.stream_id = i.root_stream_id
-                  AND w.recipient_kind = 'bot'
-                  AND w.recipient_key_id = ri.public_key_id
-                  AND w.key_generation = e.current_key_generation
-              )
-              AND EXISTS (
-                SELECT 1 FROM stream_e2e_key_wraps w
-                JOIN messages m ON m.id = i.source_message_id
-                JOIN bot_runtime_instances ri
-                  ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${params.instanceId}
-                WHERE w.workspace_id = i.workspace_id
-                  AND w.stream_id = i.root_stream_id
-                  AND w.recipient_kind = 'bot'
-                  AND w.recipient_key_id = ri.public_key_id
-                  AND w.key_generation = (m.envelope ->> 'keyGeneration')::int
-              )
-            )
-          )
+          AND ${sealedStreamClaimGateSql(params.instanceId)}
         ORDER BY i.created_at ASC, i.id ASC
         FOR UPDATE OF i SKIP LOCKED
         LIMIT 1
@@ -771,17 +788,18 @@ export const BotInvocationRepository = {
     }
   ): Promise<{ available: BotInvocation[]; ownedClaims: BotInvocation[] }> {
     const [availableResult, ownedClaimsResult] = await Promise.all([
-      db.query<BotInvocationRow>(sql`SELECT * FROM bot_invocations
-        WHERE workspace_id = ${params.workspaceId}
-          AND actor_type = 'bot'
-          AND actor_id = ${params.botId}
-          AND required_capability = ANY(${params.supportedCapabilities})
-          AND (target_instance_id IS NULL OR target_instance_id = ${params.instanceId})
-          AND (target_runtime_session_id IS NULL OR target_runtime_session_id = ${params.runtimeSessionId})
-          AND (status = 'pending' OR (status = 'claimed' AND claim_expires_at < NOW()))
-          AND attempts < ${params.maxAttempts}
-          AND (${params.since}::timestamptz IS NULL OR created_at >= ${params.since})
-        ORDER BY created_at ASC, id ASC
+      db.query<BotInvocationRow>(composeSql`SELECT i.* FROM bot_invocations i
+        WHERE i.workspace_id = ${params.workspaceId}
+          AND i.actor_type = 'bot'
+          AND i.actor_id = ${params.botId}
+          AND i.required_capability = ANY(${params.supportedCapabilities})
+          AND (i.target_instance_id IS NULL OR i.target_instance_id = ${params.instanceId})
+          AND (i.target_runtime_session_id IS NULL OR i.target_runtime_session_id = ${params.runtimeSessionId})
+          AND (i.status = 'pending' OR (i.status = 'claimed' AND i.claim_expires_at < NOW()))
+          AND i.attempts < ${params.maxAttempts}
+          AND (${params.since}::timestamptz IS NULL OR i.created_at >= ${params.since})
+          AND ${sealedStreamClaimGateSql(params.instanceId)}
+        ORDER BY i.created_at ASC, i.id ASC
         LIMIT 200`),
       db.query<BotInvocationRow>(sql`SELECT * FROM bot_invocations
         WHERE workspace_id = ${params.workspaceId}

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -577,8 +577,10 @@ function sealedStreamClaimGateSql(instanceId: string): QueryConfig {
       )
       AND EXISTS (
         SELECT 1 FROM stream_e2e_key_wraps w
-        JOIN messages m
-          ON m.workspace_id = i.workspace_id AND m.id = i.source_message_id
+        -- messages has no workspace_id column (it is scoped by stream_id); the
+        -- join on the globally-unique source message id is the invocation's own
+        -- trigger, so it stays tenant-safe without one (as enclave claimNext does).
+        JOIN messages m ON m.id = i.source_message_id
         JOIN bot_runtime_instances ri
           ON ri.workspace_id = i.workspace_id AND ri.bot_id = i.actor_id AND ri.instance_id = ${instanceId}
         WHERE w.workspace_id = i.workspace_id


### PR DESCRIPTION
## Summary

Adds the **claim-side gate** for sealed external-bot turns: `BotInvocationRepository.claimOne` now refuses to hand an E2E (sealed) invocation to a bot instance whose registered identity key (BIK) can't actually open it. This is the next slice of the "wire half" for letting an owner-granted external/self-hosted bot harness participate in an E2E stream (follows #967, which shipped the `SealedTurnContext` type + pure builder).

Everything stays **dark in production** — see "Inert today" below.

## What changed

`apps/backend/src/features/bot-runtimes/repository.ts` — `claimOne` gains a conditional sealed-stream predicate that mirrors the enclave's `EnclaveInvocationsRepository.claimNext` two-`EXISTS`:

- **Plaintext invocation** (no `e2e_streams` row for the root) → claimable by any instance of the bot, exactly as before.
- **E2E invocation** → claimable only when the *claiming instance's* registered BIK (`bot_runtime_instances.public_key_id`) has `stream_e2e_key_wraps` (`recipient_kind = 'bot'`) covering **both**:
  - the reply generation — `e.current_key_generation` (what the bot must seal its reply under), and
  - the prompt generation — `(m.envelope ->> 'keyGeneration')::int` for the trigger `source_message_id` (what the bot must open).

The candidate is aliased to `i` and the lock is now explicit (`FOR UPDATE OF i SKIP LOCKED`), since the new arm joins `e2e_streams`, `stream_e2e_key_wraps`, `messages`, and `bot_runtime_instances` — all inside `EXISTS` subqueries, so only `bot_invocations` is locked.

## Design decisions

- **Conditional, not unconditional.** Unlike the enclave's `claimNext` (which only ever serves E2E streams), this same `claimOne` serves plaintext streams too — hence the `NOT EXISTS (e2e_streams) OR (...both wraps...)` shape. Plaintext behavior is byte-unchanged.
- **Keyed to the instance's BIK, not a passed key id.** The bot path resolves the recipient key from the claiming instance row (`ri.public_key_id`), so a keyless instance (`public_key_id` NULL) never matches and can't claim a sealed turn it has no key to open.
- **Both generations, like the enclave.** Re-evaluated at claim time against the live wraps table (never snapshotted) so a key roll / revoke between enqueue and claim is reflected.

## Inert today

External bot dispatch into E2E streams is still off by policy: `verdictAllowsExternalDispatch` (`invocation-outbox-handler.ts`) is plaintext-only and `EXTERNAL_SEALED_DELIVERY = false`, so **no E2E bot invocations are ever enqueued**. The new OR-arm is dead until the policy flip in a later phase. Safe to land standalone.

## Testing

- New SQL-string test in `bot-runtimes/repository.test.ts` (house style — fake querier capturing query text) asserting the conditional gate, `recipient_key_id = ri.public_key_id`, both generation predicates, and the `source_message_id` join. `bun test` → **9/9 pass**.
- `tsc --noEmit -p apps/backend` clean; prettier clean; pre-commit hook passed.

## Follow-ups (rest of the slice, separate PRs)

1. Relocate `hashCallbackToken` → `agents` feature (+ neutral `X-Threa-Callback-Token` header / shared verify helper); pass `callbackTokenHash` + `replyKeyGeneration` into the bot claim's `insertRunningOrSkip`.
2. Wire `claimBotInvocation` to build `SealedTurnContext` and return `sealedContext` on a `sealed` verdict.
3. Flip `verdictAllowsExternalDispatch` to allow `delivery === "sealed"`.
4. Add optional `sealedContext` to the claim response schema.

https://claude.ai/code/session_01Az72N8G8UbQy9ZCS26vVr1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Az72N8G8UbQy9ZCS26vVr1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784227488&installation_id=129946197&pr_number=969&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F969&signature=7790efe3f08ca43fa9cea1b92c93fc560dc29c8659ba4cb1608d387aa240d692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->