### PR TITLE
fix(composer): restore pre-overflow action order and reverse overflow menu

### DIFF
--- a/apps/frontend/src/components/composer/composer-action-bar.test.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.test.tsx
@@ -4,11 +4,11 @@ import { planActionOverflow, planTriggerVisibility } from "./composer-action-bar
 // Mirrors the real bar's secondary actions: array order is the left-to-right
 // display order; `collapsePriority` (lower folds first) is independent of it.
 const ACTIONS = [
+  { key: "expand", collapsePriority: 1 },
   { key: "emoji", collapsePriority: 2 },
   { key: "mention", collapsePriority: 3 },
   { key: "command", collapsePriority: 0 },
   { key: "attach", collapsePriority: 4 },
-  { key: "expand", collapsePriority: 1 },
 ]
 
 const keys = (list: { key: string }[]) => list.map((a) => a.key)
@@ -33,7 +33,7 @@ describe("planActionOverflow", () => {
     // ~360px: room for 4 inline → only the single lowest priority (command) folds.
     const narrow = planActionOverflow(ACTIONS, 360, PINNED)
     expect(keys(narrow.overflow)).toEqual(["command"])
-    expect(keys(narrow.inline)).toEqual(["emoji", "mention", "attach", "expand"])
+    expect(keys(narrow.inline)).toEqual(["expand", "emoji", "mention", "attach"])
 
     // ~300px: room for 2 inline → the three lowest priorities fold.
     const narrower = planActionOverflow(ACTIONS, 300, PINNED)

--- a/apps/frontend/src/components/composer/composer-action-bar.tsx
+++ b/apps/frontend/src/components/composer/composer-action-bar.tsx
@@ -134,7 +134,18 @@ export function ComposerActionBar({
   const width = useElementWidth(barRef)
 
   const actions = useMemo<CollapsibleAction[]>(() => {
-    const list: CollapsibleAction[] = [
+    const list: CollapsibleAction[] = []
+    if (onExpandClick) {
+      list.push({
+        key: "expand",
+        label: "Expand editor",
+        ariaLabel: "Expand to fullscreen editor",
+        icon: <Maximize2 className="h-3.5 w-3.5" />,
+        onSelect: onExpandClick,
+        collapsePriority: 1,
+      })
+    }
+    list.push(
       {
         key: "emoji",
         label: "Emoji",
@@ -162,18 +173,8 @@ export function ComposerActionBar({
         icon: <Paperclip className="h-4 w-4" />,
         onSelect: onAttachClick,
         collapsePriority: 4,
-      },
-    ]
-    if (onExpandClick) {
-      list.push({
-        key: "expand",
-        label: "Expand editor",
-        ariaLabel: "Expand to fullscreen editor",
-        icon: <Maximize2 className="h-3.5 w-3.5" />,
-        onSelect: onExpandClick,
-        collapsePriority: 1,
-      })
-    }
+      }
+    )
     return list
   }, [onInsertEmoji, onInsertMention, onInsertCommand, onAttachClick, onExpandClick])
 
@@ -199,6 +200,11 @@ export function ComposerActionBar({
     () => planActionOverflow(actions, width, pinnedCount),
     [actions, width, pinnedCount]
   )
+
+  // Expand sits immediately before Formatting (Aa) to match the pre-overflow
+  // toolbar order; the rest of the collapsible actions render after Aa.
+  const expandAction = inlineActions.find((a) => a.key === "expand")
+  const mainInlineActions = inlineActions.filter((a) => a.key !== "expand")
 
   return (
     <div ref={barRef} className="flex items-center gap-1">
@@ -228,7 +234,10 @@ export function ComposerActionBar({
               className="min-w-[168px]"
               onCloseAutoFocus={(e) => e.preventDefault()}
             >
-              {overflowActions.map((action) => (
+              {/* Render collapsed actions bottom-up so the leftmost toolbar item
+                  sits closest to the "+" trigger and the rightmost item is
+                  farthest away — matching the spatial order of the bar. */}
+              {[...overflowActions].reverse().map((action) => (
                 <DropdownMenuItem key={action.key} className="gap-2 cursor-pointer" onSelect={action.onSelect}>
                   <span className="flex h-4 w-4 items-center justify-center text-muted-foreground">{action.icon}</span>
                   {action.label}
@@ -244,6 +253,27 @@ export function ComposerActionBar({
         <span className="text-[11px] text-muted-foreground flex-1 truncate select-none pointer-events-none">
           Select text to format
         </span>
+      )}
+
+      {expandAction && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={expandAction.ariaLabel ?? expandAction.label}
+              className="h-7 w-7 shrink-0"
+              onClick={expandAction.onSelect}
+              disabled={disabled}
+            >
+              {expandAction.icon}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {expandAction.label}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       <Tooltip>
@@ -266,7 +296,7 @@ export function ComposerActionBar({
         </TooltipContent>
       </Tooltip>
 
-      {inlineActions.map((action) => (
+      {mainInlineActions.map((action) => (
         <Tooltip key={action.key}>
           <TooltipTrigger asChild>
             <Button


### PR DESCRIPTION
## Problem

The recent overflow-menu refactor for the desktop composer action bar moved the fullscreen expand button to the right of the attachment button. That differs from the original order, where expand sat immediately to the left of Formatting (Aa).

## Solution

Restore the pre-overflow toolbar order and make the collapsed "+" menu mirror the bar's spatial layout.

### How it works

1. **`ComposerActionBar`** now builds the collapsible action list with `expand` first, so the left-to-right inline order is `expand → emoji → mention → command → attach`.
2. The expand button is rendered separately, immediately before the Formatting (Aa) button, so the visible order matches the pre-refactor layout: `[hint/+] … expand | Aa | emoji | mention | command | attach | triggers | send`.
3. The "+" overflow menu renders collapsed actions in reverse order (rightmost first, leftmost last). Because the menu opens above the trigger, the leftmost toolbar item ends up closest to the `+` button and the rightmost item farthest away.

### Key design decisions

- **Keep expand collapsible.** It still folds into the "+" menu under narrow widths with the same `collapsePriority` as before; only its inline position changes.
- **Reverse only the menu rendering, not the planning logic.** `planActionOverflow` still returns lists in display order, keeping it pure and easy to unit-test. The UI layer reverses for presentation.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/composer/composer-action-bar.tsx` | Move `expand` to before `Aa`; reverse overflow menu rendering. |
| `apps/frontend/src/components/composer/composer-action-bar.test.tsx` | Update test fixtures to match the new display order. |

## Test plan

- [x] `composer-action-bar.test.tsx` — 11 pass
- [x] `message-composer.test.tsx` — 24 pass
- [x] `editor-action-bar.test.tsx` — 4 pass
- [x] `apps/frontend` `tsc --noEmit` — clean
- [x] `apps/frontend` `eslint` — clean

---

🤖 _PR by [OpenCode](https://opencode.ai) / Kimi K2.7 Code_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784231496&installation_id=129946197&pr_number=970&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F970&signature=dd8d5b390102c7ffc10fd592c93d097a79e4e81f7cff5a021825fc4a7b8843a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->