### PR TITLE
fix(pi-remote): handle session-control commands that arrive as regular scratchpad messages

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -20,16 +20,17 @@ import {
   StashedDraftsPicker,
 } from "@/components/composer"
 import type { ComposerControlHandle } from "@/components/composer"
-import { useScheduleMessage } from "@/hooks"
+import { useScheduleMessage, useStreamBootstrap } from "@/hooks"
+import { useWorkspaceMetadata } from "@/stores/workspace-store"
 import { EMPTY_DOC } from "@/lib/prosemirror-utils"
-import { extractCommandNode } from "@/lib/commands"
+import { extractCommandNode, extractCommandFromRawText } from "@/lib/commands"
 import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, type QuoteReplyData } from "./quote-reply-context"
 import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
 import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
-import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent } from "@threa/types"
+import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent, type CommandInfo } from "@threa/types"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { ComposerEncryptionNotice } from "@/components/encryption/stream-encryption-affordance"
 
@@ -220,6 +221,22 @@ function MessageInputComponent({
   const scheduleMessageMutation = useScheduleMessage(workspaceId)
   const { queueCommand } = useCommandDispatchQueue(workspaceId, streamId)
   const draftKey = getDraftMessageKey({ type: "stream", streamId })
+
+  // Resolve the effective command list for this stream so raw-text slash
+  // commands (e.g. `/model ` with a trailing space) can be dispatched even
+  // when the editor did not materialize a `slashCommand` node.
+  const metadata = useWorkspaceMetadata(workspaceId)
+  const { data: streamBootstrap } = useStreamBootstrap(workspaceId, streamId, { enabled: false })
+  const availableCommands = useMemo<CommandInfo[]>(() => {
+    return streamBootstrap?.commands ?? metadata?.commands ?? []
+  }, [streamBootstrap?.commands, metadata?.commands])
+  const availableCommandByName = useMemo(() => {
+    const map = new Map<string, CommandInfo>()
+    for (const cmd of availableCommands) {
+      map.set(cmd.name.toLowerCase(), cmd)
+    }
+    return map
+  }, [availableCommands])
 
   // Broadcast/mention filtering, member/bot allow-lists, and the admin gate
   // for bot invites all live in `useMentionStreamContext`. Threads route
@@ -487,11 +504,17 @@ function MessageInputComponent({
       const liveContent = editorContent ?? composer.content
       const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
 
-      // Dispatch as a command only when the editor produced a slashCommand node.
-      // Plain text starting with "/" (e.g. "/s") should send as a regular message.
+      // Dispatch as a command when the editor produced a slashCommand node,
+      // or when the message is raw text that matches an available slash command
+      // (e.g. `/model ` with a trailing space that never became a node). Plain
+      // text like "/s" that does not match a known command still sends normally.
       const commandNode = extractCommandNode(normalizedContent)
-      if (commandNode !== null) {
-        const { clientActionId } = commandNode
+      const rawTextCommand = commandNode === null ? extractCommandFromRawText(normalizedContent) : null
+      const resolvedCommand =
+        commandNode ?? (rawTextCommand ? (availableCommandByName.get(rawTextCommand.name) ?? null) : null)
+      if (resolvedCommand !== null) {
+        const commandName = commandNode?.name ?? rawTextCommand!.name
+        const clientActionId = commandNode?.clientActionId ?? resolvedCommand.clientActionId ?? null
 
         // Clear input immediately for responsiveness — same reset the server
         // path does. Either branch below consumes the command, so the user
@@ -518,9 +541,11 @@ function MessageInputComponent({
           return
         }
 
-        const commandMarkdown = serializeToMarkdown(normalizedContent).trim()
+        const commandMarkdown = rawTextCommand
+          ? `/${commandName}${rawTextCommand.args ? ` ${rawTextCommand.args}` : ""}`
+          : serializeToMarkdown(normalizedContent).trim()
         try {
-          await queueCommand({ commandMarkdown, commandName: commandNode.name })
+          await queueCommand({ commandMarkdown, commandName })
         } catch {
           setError("Failed to queue command. Please try again.")
         } finally {
@@ -563,7 +588,16 @@ function MessageInputComponent({
         composer.setIsSending(false)
       }
     },
-    [composer, sendMessage, navigate, workspaceId, streamId, startDiscussWithAriadne, queueCommand]
+    [
+      composer,
+      sendMessage,
+      navigate,
+      workspaceId,
+      streamId,
+      startDiscussWithAriadne,
+      queueCommand,
+      availableCommandByName,
+    ]
   )
 
   /**

--- a/apps/frontend/src/lib/commands.test.ts
+++ b/apps/frontend/src/lib/commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import type { JSONContent } from "@threa/types"
-import { extractCommandNode } from "./commands"
+import { extractCommandNode, extractCommandFromRawText } from "./commands"
 
 describe("extractCommandNode", () => {
   it("extracts name + clientActionId from the first slashCommand node", () => {
@@ -51,6 +51,22 @@ describe("extractCommandNode", () => {
       content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
     }
     expect(extractCommandNode(doc)).toBeNull()
+  })
+
+  it("extracts a slashCommand node even when followed by trailing whitespace", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "slashCommand", attrs: { name: "model", clientActionId: null } },
+            { type: "text", text: " " },
+          ],
+        },
+      ],
+    }
+    expect(extractCommandNode(doc)).toEqual({ name: "model", clientActionId: null })
   })
 
   it("returns null for plain text that starts with a slash (no materialized node)", () => {
@@ -110,5 +126,66 @@ describe("extractCommandNode", () => {
       ],
     }
     expect(extractCommandNode(doc)?.name).toBe("help")
+  })
+})
+
+describe("extractCommandFromRawText", () => {
+  it("extracts a command with trailing whitespace", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "/model " }] }],
+    }
+    expect(extractCommandFromRawText(doc)).toEqual({ name: "model", args: "" })
+  })
+
+  it("extracts a command with arguments", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "  /thinking high  " }] }],
+    }
+    expect(extractCommandFromRawText(doc)).toEqual({ name: "thinking", args: "high" })
+  })
+
+  it("is case-insensitive", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "/MODEL" }] }],
+    }
+    expect(extractCommandFromRawText(doc)).toEqual({ name: "model", args: "" })
+  })
+
+  it("returns null for multi-paragraph messages", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "/model" }] },
+        { type: "paragraph", content: [{ type: "text", text: "more" }] },
+      ],
+    }
+    expect(extractCommandFromRawText(doc)).toBeNull()
+  })
+
+  it("returns null when other nodes are present", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "/model" },
+            { type: "mention", attrs: { slug: "alice" } },
+          ],
+        },
+      ],
+    }
+    expect(extractCommandFromRawText(doc)).toBeNull()
+  })
+
+  it("returns null for plain text that does not start with a slash", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "I tried /model" }] }],
+    }
+    expect(extractCommandFromRawText(doc)).toBeNull()
   })
 })

--- a/apps/frontend/src/lib/commands.ts
+++ b/apps/frontend/src/lib/commands.ts
@@ -6,6 +6,13 @@
  * are represented as structural nodes rather than raw text matches. Raw text
  * like "/s" is NOT a command — nodes must be materialized by the editor's
  * slash trigger.
+ *
+ * As a send-time fallback, the composer also recognizes a message that is
+ * *only* raw text matching `/command [args]` (e.g. `/model ` with a trailing
+ * space). This recovers when auto-complete or quick typing leaves a command as
+ * plain text instead of a `slashCommand` node. The caller is responsible for
+ * verifying the extracted name against the commands available in the current
+ * context.
  */
 
 import type { JSONContent } from "@threa/types"
@@ -20,6 +27,11 @@ export interface ExtractedCommand {
    * have to maintain a list of per-`name` client-action switches.
    */
   clientActionId: string | null
+}
+
+export interface RawTextCommand {
+  name: string
+  args: string
 }
 
 /**
@@ -43,4 +55,31 @@ export function extractCommandNode(content: JSONContent): ExtractedCommand | nul
     if (found !== null) return found
   }
   return null
+}
+
+/**
+ * Extract a slash command from raw text when the editor did not materialize a
+ * `slashCommand` node. Only matches a message that is a single paragraph
+ * containing a single text node, so a message like "I tried /model" is not
+ * mistaken for a command.
+ */
+export function extractCommandFromRawText(content: JSONContent): RawTextCommand | null {
+  if (content.type !== "doc") return null
+  const paragraphs = content.content ?? []
+  if (paragraphs.length !== 1) return null
+  const paragraph = paragraphs[0]
+  if (paragraph.type !== "paragraph") return null
+  const nodes = paragraph.content ?? []
+  if (nodes.length !== 1) return null
+  const textNode = nodes[0]
+  if (textNode.type !== "text" || typeof textNode.text !== "string") return null
+
+  const trimmed = textNode.text.trim()
+  const match = trimmed.match(/^\/([\w-]+)(?:\s+(.*))?$/s)
+  if (!match) return null
+
+  return {
+    name: match[1].toLowerCase(),
+    args: (match[2] ?? "").trim(),
+  }
 }

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -114,6 +114,91 @@ describe("Pi remote trace safety", () => {
     ).toEqual({ id: "cmd_1", name: "thinking", args: "high", executionKind: "bot-runtime" })
   })
 
+  test("parses session-control commands from prompt markdown", () => {
+    expect(__testing.parseSessionControlCommand("/model ")).toEqual({ name: "model", args: "" })
+    expect(__testing.parseSessionControlCommand("/model anthropic/claude-sonnet-4-6")).toEqual({
+      name: "model",
+      args: "anthropic/claude-sonnet-4-6",
+    })
+    expect(__testing.parseSessionControlCommand("  /thinking high  ")).toEqual({ name: "thinking", args: "high" })
+    expect(__testing.parseSessionControlCommand("/shell echo hello")).toEqual({ name: "shell", args: "echo hello" })
+  })
+
+  test("rejects prompts that do not look like session-control commands", () => {
+    expect(__testing.parseSessionControlCommand("/remote-control status")).toBeNull()
+    expect(__testing.parseSessionControlCommand("not a command")).toBeNull()
+    expect(__testing.parseSessionControlCommand("I tried /model but it failed")).toBeNull()
+    expect(__testing.parseSessionControlCommand("/")).toBeNull()
+  })
+
+  test("resolves session-control command from metadata when present", () => {
+    const invocation = {
+      id: "binv_1",
+      activeStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "/model ",
+      claimToken: "claim",
+      claimExpiresAt: null,
+      requiredCapability: "active-scratchpad",
+      metadata: { command: { id: "cmd_1", name: "thinking", args: "high", executionKind: "bot-runtime" } },
+    }
+    expect(__testing.resolveSessionControlCommand(invocation)).toEqual({
+      id: "cmd_1",
+      name: "thinking",
+      args: "high",
+      executionKind: "bot-runtime",
+    })
+  })
+
+  test("falls back to parsing prompt for active-scratchpad invocations", () => {
+    const invocation = {
+      id: "binv_1",
+      activeStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "/model ",
+      claimToken: "claim",
+      claimExpiresAt: null,
+      requiredCapability: "active-scratchpad",
+    }
+    expect(__testing.resolveSessionControlCommand(invocation)).toEqual({
+      id: "msg_1",
+      name: "model",
+      args: "",
+      executionKind: "bot-runtime",
+    })
+  })
+
+  test("does not treat mention invocations as session-control commands", () => {
+    const invocation = {
+      id: "binv_1",
+      activeStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "/model ",
+      claimToken: "claim",
+      claimExpiresAt: null,
+      requiredCapability: "mentionable",
+    }
+    expect(__testing.resolveSessionControlCommand(invocation)).toBeNull()
+  })
+
+  test("falls back to parsing prompt for session-control invocations missing metadata", () => {
+    const invocation = {
+      id: "binv_1",
+      activeStreamId: "stream_1",
+      sourceMessageId: "msg_1",
+      promptMarkdown: "/thinking high",
+      claimToken: "claim",
+      claimExpiresAt: null,
+      requiredCapability: "session-control",
+    }
+    expect(__testing.resolveSessionControlCommand(invocation)).toEqual({
+      id: "msg_1",
+      name: "thinking",
+      args: "high",
+      executionKind: "bot-runtime",
+    })
+  })
+
   test("normalizes thinking level aliases", () => {
     expect(__testing.normalizeThinkingLevel("x-high")).toBe("xhigh")
     expect(__testing.normalizeThinkingLevel("none")).toBe("off")

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -34,6 +34,7 @@ const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000
 const MAX_RETRY_ATTEMPTS = 3
 const PI_TOOL_TRACE_FORMAT = "pi_tool_trace"
 const SESSION_CONTROL_CAPABILITY = "session-control"
+const ACTIVE_SCRATCHPAD_CAPABILITY = "active-scratchpad"
 const SESSION_CONTROL_COMMANDS = ["compact", "model", "thinking", "skill", "reload", "shell"] as const
 const SHELL_TIMEOUT_MS = 60_000
 // 32K chars per stream — large enough for typical output, small enough to avoid
@@ -1314,8 +1315,34 @@ function getRuntimeCommand(invocation: ClaimedInvocation): RuntimeCommandMetadat
   return { id: value.id, name: value.name, args: value.args, executionKind: "bot-runtime" }
 }
 
+function parseSessionControlCommand(promptMarkdown: string): { name: string; args: string } | null {
+  const trimmed = promptMarkdown.trim()
+  const match = trimmed.match(/^\/([\w-]+)(?:\s+(.*))?$/s)
+  if (!match) return null
+  const name = match[1].toLowerCase()
+  if (!SESSION_CONTROL_COMMANDS.includes(name as PiSessionControlCommandName)) return null
+  return { name, args: (match[2] ?? "").trim() }
+}
+
+function resolveSessionControlCommand(invocation: ClaimedInvocation): RuntimeCommandMetadata | null {
+  const runtimeCommand = getRuntimeCommand(invocation)
+  if (runtimeCommand) return runtimeCommand
+  const canParseFromPrompt =
+    invocation.requiredCapability === SESSION_CONTROL_CAPABILITY ||
+    invocation.requiredCapability === ACTIVE_SCRATCHPAD_CAPABILITY
+  if (!canParseFromPrompt) return null
+  const parsed = parseSessionControlCommand(invocation.promptMarkdown)
+  if (!parsed) return null
+  return {
+    id: invocation.sourceMessageId,
+    name: parsed.name,
+    args: parsed.args,
+    executionKind: "bot-runtime",
+  }
+}
+
 function isSessionControlInvocation(invocation: ClaimedInvocation): boolean {
-  return invocation.requiredCapability === SESSION_CONTROL_CAPABILITY || getRuntimeCommand(invocation) !== null
+  return resolveSessionControlCommand(invocation) !== null
 }
 
 function normalizeThinkingLevel(input: string): ThinkingLevel | null {
@@ -1766,7 +1793,7 @@ async function handleSessionControlInvocation(
   ctx: ExtensionContext,
   invocation: ClaimedInvocation
 ): Promise<void> {
-  const command = getRuntimeCommand(invocation)
+  const command = resolveSessionControlCommand(invocation)
   if (!command) {
     await failInvocation(invocation, "Missing runtime command metadata")
     return
@@ -2250,6 +2277,8 @@ export const __testing = {
   buildClaimInvocationPayload,
   buildRuntimeCapabilities,
   getRuntimeCommand,
+  parseSessionControlCommand,
+  resolveSessionControlCommand,
   normalizeThinkingLevel,
   migrateSessionState,
   buildScratchpadUrl,


### PR DESCRIPTION
## Problem

Typing `/model` in the Threa composer auto-completes with a trailing space. When the message is sent as raw text `/model ` instead of being materialized as a `slashCommand` node, it bypasses the composer's command dispatch and either gets forwarded to the linked LLM (Pi remote) or sent as a regular message.

## Solution

Fix the issue on both sides:

1. **Frontend composer** (`message-input.tsx`): when the editor did not produce a `slashCommand` node, check whether the message is raw text matching an available slash command and dispatch it. This trims `/model ` and triggers the slash command as expected.
2. **Pi remote extension** (`threa-remote.ts`): as a safety net, detect session-control commands in active-scratchpad invocations even when the server did not attach formal command metadata.

### How it works — frontend

1. `extractCommandFromRawText` in `apps/frontend/src/lib/commands.ts` parses a single-paragraph, single-text-node message for `/command [args]`.
2. `MessageInput` resolves the effective command list for the current stream (`streamBootstrap.commands ?? workspaceMetadata.commands`) and checks the extracted name against it.
3. If the raw text matches an available command, it is dispatched via the existing `queueCommand` path (or handled locally for client-action commands like `/discuss-with-ariadne`).
4. Plain text like `/s` that does not match a known command still sends as a regular message.

### How it works — Pi remote fallback

1. `parseSessionControlCommand` in `extensions/pi-remote/src/threa-remote.ts` parses `promptMarkdown` for `/command [args]`, restricted to the six advertised session-control command names (`compact`, `model`, `thinking`, `skill`, `reload`, `shell`).
2. `resolveSessionControlCommand` prefers the backend-supplied `metadata.command` and falls back to parsing the prompt for active-scratchpad and session-control invocations.
3. `isSessionControlInvocation` now delegates to `resolveSessionControlCommand`.
4. `handleSessionControlInvocation` uses `resolveSessionControlCommand` to obtain the command name and args, so `/model `, `/thinking high`, `/shell echo hi`, etc. run locally instead of being injected into the LLM turn.

### Key design decisions

- **Only available commands trigger the frontend fallback.** The raw-text parser is gated by the stream's effective command list, so arbitrary `/foo` text still sends as a message.
- **Only active-scratchpad and session-control invocations trigger the Pi remote fallback.** Mention invocations (`requiredCapability: "mentionable"`) are left alone so `/model` in a channel mention does not get silently intercepted.
- **Backend metadata remains authoritative.** When the server dispatches a command properly, `metadata.command` is used unchanged; the prompt parser is a fallback for the trailing-space / raw-text case.
- **`sourceMessageId` is used as the synthetic command id** for fallback-parsed commands because no formal `commandId` exists.

## New files

_None._

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/commands.ts` | Added `extractCommandFromRawText` and updated the module docstring to document the send-time fallback. |
| `apps/frontend/src/lib/commands.test.ts` | Added tests for `extractCommandFromRawText`; retained the trailing-whitespace `slashCommand` regression test. |
| `apps/frontend/src/components/timeline/message-input.tsx` | Resolves effective stream commands and dispatches raw-text slash commands as a fallback. |
| `extensions/pi-remote/src/threa-remote.ts` | Added `parseSessionControlCommand`, `resolveSessionControlCommand`, and `ACTIVE_SCRATCHPAD_CAPABILITY`; wired them into `isSessionControlInvocation` and `handleSessionControlInvocation`. |
| `extensions/pi-remote/src/threa-remote.test.ts` | Added unit tests for parsing, rejection of non-session-control text, metadata precedence, active-scratchpad fallback, session-control fallback without metadata, and mention invocations. |

## Out of scope (deliberate)

- Changing the Threa composer to auto-dispatch *any* raw text that looks like a slash command. The fallback is gated by the commands available in the current context.
- Backend-side interception of session-control messages before they become regular `message:created` events. The Pi remote extension is the natural place to recover from this client-side edge case.
- Scheduled messages: `handleSchedule` does not yet apply the raw-text command fallback.

## Test plan

- [x] `bun test ./extensions/pi-remote/src/threa-remote.test.ts` — 82 pass
- [x] `bun test ./apps/frontend/src/lib/commands.test.ts` — 15 pass
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] Pre-commit hooks: `eslint`, `tsc --noEmit`, migration checks, Dockerfile workspace checks — all clean
- [ ] `bun test ./apps/frontend/src/components/timeline/message-input.test.tsx` — requires a DOM test environment (jsdom/happy-dom); the existing failures are pre-existing environment issues, not related to this change
- [ ] Live end-to-end test with a running Threa backend and Pi session — not run locally (requires running services)

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
