### PR TITLE
feat(timeline): in-stream day dividers + jump-to-date

### DIFF
--- a/apps/backend/src/db/migrations/20260616204509_index_stream_events_created_at.sql
+++ b/apps/backend/src/db/migrations/20260616204509_index_stream_events_created_at.sql
@@ -2,6 +2,12 @@
 -- The events table is otherwise indexed only on (stream_id, sequence); resolving
 -- "first message on or after <instant>" (findFirstMessageOnOrAfter) needs an
 -- ordered scan by created_at within a stream.
+--
+-- CONCURRENTLY so the build doesn't take a write-blocking lock on a hot table
+-- (matches the prior stream_events index migrations; the migration runner runs
+-- each file outside a transaction, so CONCURRENTLY is allowed). Partial on the
+-- two message event types the lookup filters by, mirroring idx_stream_events_message_seq.
 
-CREATE INDEX IF NOT EXISTS idx_stream_events_stream_created
-    ON stream_events (stream_id, created_at);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_stream_events_stream_created
+    ON stream_events (stream_id, created_at)
+    WHERE event_type IN ('message_created', 'companion_response');

--- a/apps/backend/src/db/migrations/20260616204509_index_stream_events_created_at.sql
+++ b/apps/backend/src/db/migrations/20260616204509_index_stream_events_created_at.sql
@@ -1,0 +1,7 @@
+-- Index stream_events by (stream_id, created_at) for jump-to-date lookups.
+-- The events table is otherwise indexed only on (stream_id, sequence); resolving
+-- "first message on or after <instant>" (findFirstMessageOnOrAfter) needs an
+-- ordered scan by created_at within a stream.
+
+CREATE INDEX IF NOT EXISTS idx_stream_events_stream_created
+    ON stream_events (stream_id, created_at);

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -4,7 +4,7 @@ import { EventService } from "./event-service"
 import { MessageRepository } from "./repository"
 import { SharedMessageRepository } from "./sharing/repository"
 import { MessageVersionRepository } from "./version-repository"
-import { StreamEventRepository, StreamMemberRepository, StreamRepository } from "../streams"
+import { StreamEventRepository, StreamMemberRepository, StreamRepository, type StreamEvent } from "../streams"
 import { AttachmentRepository, AttachmentReferenceRepository } from "../attachments"
 import { OutboxRepository } from "../../lib/outbox"
 import * as db from "../../db"
@@ -843,5 +843,53 @@ describe("EventService INV-E1 sink guard", () => {
     ).rejects.toMatchObject({ status: 400, code: "E2E_STREAM_EDIT_UNSUPPORTED" })
     // Refused before loading or mutating the message.
     expect(findForUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe("EventService.listEventsAroundDate", () => {
+  beforeEach(() => {
+    spyOn(db, "withClient").mockImplementation(((_pool: unknown, cb: (client: any) => Promise<unknown>) =>
+      cb({})) as any)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("returns an empty window with a null anchor when no message lands on or after the date", async () => {
+    spyOn(StreamEventRepository, "findFirstMessageOnOrAfter").mockResolvedValue(null)
+    const listAround = spyOn(StreamEventRepository, "listAround")
+
+    const service = new EventService({} as any)
+    const result = await service.listEventsAroundDate("stream_1", new Date("2026-06-16T00:00:00.000Z"))
+
+    expect(result).toEqual({ events: [], hasOlder: false, hasNewer: false, anchorMessageId: null })
+    expect(listAround).not.toHaveBeenCalled()
+  })
+
+  it("centers the window on the first message and returns its messageId as the anchor", async () => {
+    const anchor: StreamEvent = {
+      id: "evt_anchor",
+      streamId: "stream_1",
+      sequence: 42n,
+      broadcastSequence: 10n,
+      eventType: "message_created",
+      payload: { messageId: "msg_anchor" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date("2026-06-16T09:00:00.000Z"),
+    }
+    spyOn(StreamEventRepository, "findFirstMessageOnOrAfter").mockResolvedValue(anchor)
+    const around = { events: [anchor], hasOlder: true, hasNewer: true }
+    const listAround = spyOn(StreamEventRepository, "listAround").mockResolvedValue(around)
+
+    const service = new EventService({} as any)
+    const result = await service.listEventsAroundDate("stream_1", new Date("2026-06-16T00:00:00.000Z"), {
+      limit: 20,
+      viewerId: "usr_1",
+    })
+
+    expect(listAround).toHaveBeenCalledWith(expect.anything(), "stream_1", 42n, { limit: 20, viewerId: "usr_1" })
+    expect(result).toEqual({ ...around, anchorMessageId: "msg_anchor" })
   })
 })

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1496,6 +1496,28 @@ export class EventService {
     })
   }
 
+  /**
+   * Fetch events surrounding the first message at or after a calendar instant
+   * (jump-to-date). `anchorMessageId` is the message the client scrolls to —
+   * null when the date is past the stream's last message, in which case the
+   * window is empty and the client falls back to the live tail.
+   */
+  async listEventsAroundDate(
+    streamId: string,
+    date: Date,
+    options?: { limit?: number; viewerId?: string }
+  ): Promise<{ events: StreamEvent[]; hasOlder: boolean; hasNewer: boolean; anchorMessageId: string | null }> {
+    return withClient(this.pool, async (client) => {
+      const anchor = await StreamEventRepository.findFirstMessageOnOrAfter(client, streamId, date)
+      if (!anchor) {
+        return { events: [], hasOlder: false, hasNewer: false, anchorMessageId: null }
+      }
+      const around = await StreamEventRepository.listAround(client, streamId, anchor.sequence, options)
+      const anchorMessageId = (anchor.payload as { messageId?: string })?.messageId ?? null
+      return { ...around, anchorMessageId }
+    })
+  }
+
   async getReplyCountsBatch(messageIds: string[]): Promise<Map<string, number>> {
     return MessageRepository.getReplyCountsBatch(this.pool, messageIds)
   }

--- a/apps/backend/src/features/streams/event-repository.test.ts
+++ b/apps/backend/src/features/streams/event-repository.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, mock } from "bun:test"
+import { StreamEventRepository } from "./event-repository"
+import type { Querier } from "../../db"
+
+function makeDb(rows: Record<string, unknown>[]) {
+  const query = mock(() => Promise.resolve({ rows, rowCount: rows.length }))
+  return { query, _query: query } as unknown as Querier & { _query: ReturnType<typeof mock> }
+}
+
+describe("StreamEventRepository.findFirstMessageOnOrAfter", () => {
+  test("maps the first row to an event", async () => {
+    const db = makeDb([
+      {
+        id: "evt_1",
+        stream_id: "stream_1",
+        sequence: "42",
+        broadcast_sequence: "10",
+        event_type: "message_created",
+        payload: { messageId: "msg_1" },
+        actor_id: "usr_1",
+        actor_type: "user",
+        created_at: new Date("2026-06-16T09:00:00.000Z"),
+      },
+    ])
+
+    const event = await StreamEventRepository.findFirstMessageOnOrAfter(
+      db,
+      "stream_1",
+      new Date("2026-06-16T00:00:00.000Z")
+    )
+
+    expect(event?.id).toBe("evt_1")
+    expect(event?.sequence).toBe(42n)
+    expect(db._query).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns null when no message lands on or after the date", async () => {
+    const db = makeDb([])
+    const event = await StreamEventRepository.findFirstMessageOnOrAfter(db, "stream_1", new Date())
+    expect(event).toBeNull()
+    expect(db._query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -349,6 +349,27 @@ export const StreamEventRepository = {
     return result.rows[0] ? mapRowToEvent(result.rows[0]) : null
   },
 
+  /**
+   * The first message row (`message_created` / `companion_response`) created
+   * at or after `date`, by creation time — the anchor for a jump-to-date.
+   * Returns null when no message lands on or after the date (the date is past
+   * the stream's last message). Ordered by `created_at` then `sequence` so a
+   * timestamp tie resolves deterministically; backed by the
+   * `(stream_id, created_at)` index.
+   */
+  async findFirstMessageOnOrAfter(db: Querier, streamId: string, date: Date): Promise<StreamEvent | null> {
+    const result = await db.query<StreamEventRow>(sql`
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
+      FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type IN ('message_created', 'companion_response')
+        AND created_at >= ${date}
+      ORDER BY created_at ASC, sequence ASC
+      LIMIT 1
+    `)
+    return result.rows[0] ? mapRowToEvent(result.rows[0]) : null
+  },
+
   /** Find the message_created event for a given message ID within a stream. */
   async findByMessageId(db: Querier, streamId: string, messageId: string): Promise<StreamEvent | null> {
     const result = await db.query<StreamEventRow>(sql`

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -276,14 +276,12 @@ const listEventsAroundQuerySchema = z
   .object({
     eventId: z.string().optional(),
     messageId: z.string().optional(),
+    /** ISO datetime — jump to the first message on or after this instant. */
+    date: z.string().datetime().optional(),
     limit: z.coerce.number().int().min(2).max(100).optional(),
   })
-  .refine((d) => d.eventId ?? d.messageId, {
-    message: "eventId or messageId is required",
-    path: ["eventId"],
-  })
-  .refine((d) => !(d.eventId && d.messageId), {
-    message: "provide eventId or messageId, not both",
+  .refine((d) => [d.eventId, d.messageId, d.date].filter(Boolean).length === 1, {
+    message: "exactly one of eventId, messageId, or date is required",
     path: ["eventId"],
   })
 
@@ -676,16 +674,29 @@ export function createStreamHandlers({
       const workspaceId = req.workspaceId!
       const { streamId } = req.params
 
-      const { eventId, messageId, limit } = validateRequest(listEventsAroundQuerySchema, req.query)
-      const targetId = (eventId ?? messageId)!
+      const { eventId, messageId, date, limit } = validateRequest(listEventsAroundQuerySchema, req.query)
 
       await streamService.validateStreamAccess(streamId, workspaceId, userId)
 
-      const result = await eventService.listEventsAround(streamId, targetId, {
-        idType: eventId ? "event" : "message",
-        limit,
-        viewerId: userId,
-      })
+      // Date jumps resolve to the first message on/after the instant and carry
+      // an explicit scroll anchor; id jumps center on the given event/message.
+      let result: Awaited<ReturnType<typeof eventService.listEventsAround>>
+      let anchorMessageId: string | null | undefined
+      if (date) {
+        const dateResult = await eventService.listEventsAroundDate(streamId, new Date(date), {
+          limit,
+          viewerId: userId,
+        })
+        anchorMessageId = dateResult.anchorMessageId
+        result = dateResult
+      } else {
+        const targetId = (eventId ?? messageId)!
+        result = await eventService.listEventsAround(streamId, targetId, {
+          idType: eventId ? "event" : "message",
+          limit,
+          viewerId: userId,
+        })
+      }
 
       const enrichedEvents = await eventService.enrichBootstrapEvents(result.events, new Map())
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(
@@ -701,6 +712,7 @@ export function createStreamHandlers({
         sharedMessages,
         hasOlder: result.hasOlder,
         hasNewer: result.hasNewer,
+        ...(anchorMessageId !== undefined ? { anchorMessageId } : {}),
       })
     },
 

--- a/apps/frontend/src/api/streams.ts
+++ b/apps/frontend/src/api/streams.ts
@@ -6,6 +6,7 @@ import type {
   StreamType,
   StreamBootstrap,
   EventsAroundResponse,
+  EventsAroundDateResponse,
   CreateStreamInput,
   UpdateStreamInput,
   NotificationLevel,
@@ -131,6 +132,24 @@ export const streamsApi = {
     const searchParams = new URLSearchParams({ messageId: targetId })
     if (limit) searchParams.set("limit", limit.toString())
     return api.get<EventsAroundResponse>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/events/around?${searchParams.toString()}`
+    )
+  },
+
+  /**
+   * Jump-to-date: events around the first message on or after `isoDate`, plus
+   * the `anchorMessageId` to scroll to (null when the date is past the last
+   * message). Shares the `/events/around` endpoint with the id-based jump.
+   */
+  async getEventsAroundDate(
+    workspaceId: string,
+    streamId: string,
+    isoDate: string,
+    limit?: number
+  ): Promise<EventsAroundDateResponse> {
+    const searchParams = new URLSearchParams({ date: isoDate })
+    if (limit) searchParams.set("limit", limit.toString())
+    return api.get<EventsAroundDateResponse>(
       `/api/workspaces/${workspaceId}/streams/${streamId}/events/around?${searchParams.toString()}`
     )
   },

--- a/apps/frontend/src/components/timeline/day-divider.tsx
+++ b/apps/frontend/src/components/timeline/day-divider.tsx
@@ -1,0 +1,24 @@
+import { formatDayDivider } from "@/lib/dates"
+
+interface DayDividerProps {
+  /** Local start-of-day timestamp (ms) for the day this divider opens. */
+  dayStartMs: number
+}
+
+/**
+ * In-flow day boundary between messages from different calendar days. Unlike
+ * `UnreadDivider` (which overlays the gap above a row), this occupies its own
+ * timeline row so the virtualizer measures it. The label resolves at render
+ * time so "Today"/"Yesterday" track the device's current day (INV-42).
+ */
+export function DayDivider({ dayStartMs }: DayDividerProps) {
+  return (
+    <div className="flex items-center gap-3 px-3 sm:px-6 py-2 select-none">
+      <div className="flex-1 border-t border-border" />
+      <span className="rounded-full border bg-background px-3 py-0.5 text-xs font-medium text-muted-foreground">
+        {formatDayDivider(new Date(dayStartMs))}
+      </span>
+      <div className="flex-1 border-t border-border" />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -8,6 +8,7 @@ import {
   getTimelineItemKey,
   groupTimelineItems,
   injectGapItems,
+  injectDayDividers,
   timelineItemEqual,
   timelineRowPropsEqual,
   OLDER_SKELETON_COUNT,
@@ -15,6 +16,7 @@ import {
   type TimelineItem,
   type TimelineItemRenderContext,
 } from "./event-list"
+import { localStartOfDayMs } from "@/lib/dates"
 
 interface CreateEventParams {
   id: string
@@ -633,5 +635,60 @@ describe("timelineRowPropsEqual (memoized row comparator)", () => {
     const prev = { item, ctx: makeCtx({ newMessageIds: new Set(["evt_x"]) }), deferSecondaryHydration: false }
     const next = { item, ctx: makeCtx({ newMessageIds: new Set(["evt_y"]) }), deferSecondaryHydration: false }
     expect(timelineRowPropsEqual(prev, next)).toBe(true)
+  })
+})
+
+describe("injectDayDividers", () => {
+  // Local constructors so the day a message lands on is evaluated in the
+  // runner's timezone — the same calendar the divider renders in (INV-42).
+  const isoOn = (y: number, m: number, d: number, h: number) => new Date(y, m, d, h, 0, 0).toISOString()
+
+  function dayItem(id: string, y: number, m: number, d: number, h: number): TimelineItem {
+    return toEventItem(createMessageEvent({ id, actorId: "user_a", createdAt: isoOn(y, m, d, h) }))
+  }
+
+  it("inserts a divider before the first row of each new day, but never above the first row", () => {
+    const items = [
+      dayItem("1", 2026, 5, 15, 9),
+      dayItem("2", 2026, 5, 15, 18),
+      dayItem("3", 2026, 5, 16, 8),
+      dayItem("4", 2026, 5, 16, 9),
+      dayItem("5", 2026, 5, 17, 10),
+    ]
+
+    const result = injectDayDividers(items)
+    const types = result.map((item) => item.type)
+
+    // No leading divider; one before the first June-16 row and one before June-17.
+    expect(types).toEqual(["event", "event", "day_divider", "event", "event", "day_divider", "event"])
+
+    const dividers = result.filter((item) => item.type === "day_divider")
+    expect(dividers.map((d) => (d as { dayStartMs: number }).dayStartMs)).toEqual([
+      localStartOfDayMs(new Date(2026, 5, 16, 0, 0, 0)),
+      localStartOfDayMs(new Date(2026, 5, 17, 0, 0, 0)),
+    ])
+  })
+
+  it("does not insert dividers when every row is on the same day", () => {
+    const items = [dayItem("1", 2026, 5, 16, 1), dayItem("2", 2026, 5, 16, 12), dayItem("3", 2026, 5, 16, 23)]
+    expect(injectDayDividers(items).some((item) => item.type === "day_divider")).toBe(false)
+  })
+
+  it("passes timestamp-less rows (gaps, skeletons) through without opening a day", () => {
+    const gap: TimelineItem = { type: "gap", afterEventId: "1", missingCount: 2 }
+    const items = [dayItem("1", 2026, 5, 16, 9), gap, dayItem("2", 2026, 5, 16, 10)]
+
+    const result = injectDayDividers(items)
+    // The gap sits between two same-day rows: no divider, gap preserved in place.
+    expect(result.map((item) => item.type)).toEqual(["event", "gap", "event"])
+  })
+
+  it("keys dividers stably so equal day buckets compare equal", () => {
+    const a = injectDayDividers([dayItem("1", 2026, 5, 15, 9), dayItem("2", 2026, 5, 16, 9)])
+    const b = injectDayDividers([dayItem("1", 2026, 5, 15, 9), dayItem("2", 2026, 5, 16, 9)])
+    const dividerA = a.find((item) => item.type === "day_divider")!
+    const dividerB = b.find((item) => item.type === "day_divider")!
+    expect(getTimelineItemKey(dividerA)).toBe(getTimelineItemKey(dividerB))
+    expect(timelineItemEqual(dividerA, dividerB)).toBe(true)
   })
 })

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -19,6 +19,8 @@ import { EventItem } from "./event-item"
 import { AgentSessionEvent } from "./agent-session-event"
 import { CommandEvent } from "./command-event"
 import { UnreadDivider } from "./unread-divider"
+import { DayDivider } from "./day-divider"
+import { localStartOfDayMs } from "@/lib/dates"
 import { Skeleton } from "@/components/ui/skeleton"
 import { ConversationOverlayRow } from "./conversation-overlay/conversation-overlay"
 import type {
@@ -139,6 +141,14 @@ export type TimelineItem =
    * separate item types.
    */
   | { type: "skeleton"; index: number }
+  /**
+   * A day boundary between rows from different local calendar days (INV-42).
+   * Purely client-derived — not a server event, so it consumes no
+   * `broadcastSequence` and never participates in contiguity/hole detection
+   * (INV-61). `dayStartMs` is the local start-of-day key; the renderer formats
+   * the label ("Today"/"Yesterday"/date) at render time so it stays current.
+   */
+  | { type: "day_divider"; dayStartMs: number }
 
 /** Event types that participate in author-grouping (render as message bodies). */
 const MESSAGE_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["message_created", "companion_response"])
@@ -287,6 +297,8 @@ export function getTimelineItemKey(item: TimelineItem): string {
       return `gap:${item.afterEventId}`
     case "skeleton":
       return `skeleton:older:${item.index}`
+    case "day_divider":
+      return `day:${item.dayStartMs}`
     default:
       return item.event.id
   }
@@ -314,6 +326,7 @@ function itemContainsEvent(item: TimelineItem, eventId: string): boolean {
       return item.events.some((event) => event.id === eventId)
     case "gap":
     case "skeleton":
+    case "day_divider":
       return false
     default:
       return item.event.id === eventId
@@ -345,6 +358,56 @@ export function injectGapItems(
         holesByAnchor.delete(anchorId)
       }
     }
+  }
+  return result
+}
+
+/**
+ * Representative local-day key (start-of-day ms) for a row, or null for rows
+ * that carry no timestamp (gaps, skeletons, dividers). Command/session groups
+ * key off their first event so a card that opens a new day draws a boundary.
+ */
+function itemDayStartMs(item: TimelineItem): number | null {
+  switch (item.type) {
+    case "event":
+      return localStartOfDayMs(new Date(item.event.createdAt))
+    case "command_group":
+    case "session_group": {
+      const first = item.events[0]
+      return first ? localStartOfDayMs(new Date(first.createdAt)) : null
+    }
+    default:
+      return null
+  }
+}
+
+/**
+ * Insert a `day_divider` before the first row of each local calendar day
+ * (INV-42). Walks render-ordered items; rows without a timestamp (gaps,
+ * skeletons) pass through without opening or resetting the current day. Pure
+ * and export-only for isolated coverage, mirroring `annotateAuthorGroups`.
+ *
+ * Run AFTER `filterVisibleItems` so a boundary lands above the first *visible*
+ * row of a day, not above a zero-height event that never renders.
+ */
+export function injectDayDividers(items: TimelineItem[]): TimelineItem[] {
+  const result: TimelineItem[] = []
+  let currentDayMs: number | null = null
+  for (const item of items) {
+    const dayMs = itemDayStartMs(item)
+    if (dayMs !== null) {
+      // Never emit a divider above the very first timestamped row. Keeping a
+      // real event at index 0 means its key changes on every older-page
+      // prepend, so useTimelineScroll's first-key prepend detection still fires
+      // and virtua holds the viewport (INV-21). A leading divider whose
+      // `day:<ms>` key repeats across a same-day prepend would silently break
+      // that hold.
+      if (currentDayMs !== null && dayMs !== currentDayMs) {
+        result.push({ type: "day_divider", dayStartMs: dayMs })
+      }
+      currentDayMs = dayMs
+    }
+    result.push(item)
   }
   return result
 }
@@ -476,7 +539,7 @@ export interface TimelineItemRenderContext {
 
 function isFirstUnread(item: TimelineItem, firstUnreadEventId?: string): boolean {
   if (!firstUnreadEventId) return false
-  if (item.type === "gap" || item.type === "skeleton") return false
+  if (item.type === "gap" || item.type === "skeleton" || item.type === "day_divider") return false
   if (item.type === "command_group" || item.type === "session_group") {
     return item.events[0]?.id === firstUnreadEventId
   }
@@ -532,6 +595,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
   return (
     <>
       {showUnreadDivider && <UnreadDivider isFading={ctx.isDividerFading} />}
+      {item.type === "day_divider" && <DayDivider dayStartMs={item.dayStartMs} />}
       {item.type === "command_group" && (
         <div className="px-3 sm:px-6">
           <CommandEvent events={item.events} />
@@ -634,6 +698,10 @@ export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
     case "skeleton": {
       const other = b as Extract<TimelineItem, { type: "skeleton" }>
       return a.index === other.index
+    }
+    case "day_divider": {
+      const other = b as Extract<TimelineItem, { type: "day_divider" }>
+      return a.dayStartMs === other.dayStartMs
     }
   }
 }
@@ -764,6 +832,11 @@ export function EventList({
     [abortResearch, workspaceId]
   )
 
+  // Day boundaries between rows from different local days (INV-42). Threads
+  // render all events with no zero-height filtering, so dividers go straight
+  // onto the grouped list.
+  const itemsWithDividers = useMemo(() => injectDayDividers(timelineItems), [timelineItems])
+
   if (isLoading) {
     return (
       <div className="flex flex-col gap-4 px-4 py-6 sm:px-6">
@@ -824,7 +897,7 @@ export function EventList({
 
   return (
     <div className="flex flex-col py-3 sm:py-6 mx-auto max-w-[800px] w-full min-w-0">
-      {timelineItems.map((item) => {
+      {itemsWithDividers.map((item) => {
         const itemKey = getTimelineItemKey(item)
         return (
           <div key={itemKey} className={isFirstUnread(item, firstUnreadEventId) ? "relative" : undefined}>

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -363,11 +363,12 @@ export function injectGapItems(
 }
 
 /**
- * Representative local-day key (start-of-day ms) for a row, or null for rows
- * that carry no timestamp (gaps, skeletons, dividers). Command/session groups
- * key off their first event so a card that opens a new day draws a boundary.
+ * Local-day key (start-of-day ms) the row belongs to, or null for rows that
+ * carry no day (gaps, skeletons). A `day_divider` reports the day it opens, so
+ * the floating date header can read the topmost visible day off either a
+ * message row or a divider. Command/session groups key off their first event.
  */
-function itemDayStartMs(item: TimelineItem): number | null {
+export function itemDayStartMs(item: TimelineItem): number | null {
   switch (item.type) {
     case "event":
       return localStartOfDayMs(new Date(item.event.createdAt))
@@ -376,6 +377,8 @@ function itemDayStartMs(item: TimelineItem): number | null {
       const first = item.events[0]
       return first ? localStartOfDayMs(new Date(first.createdAt)) : null
     }
+    case "day_divider":
+      return item.dayStartMs
     default:
       return null
   }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -58,6 +58,7 @@ import {
   annotateConversationRows,
   injectGapItems,
   injectDayDividers,
+  itemDayStartMs,
   findFirstMessageId,
   findMessageItemIndex,
   getTimelineItemKey,
@@ -71,6 +72,7 @@ import { ConversationOverlayPanel } from "./conversation-overlay/conversation-ov
 import { useConversationOverlay } from "./conversation-overlay/use-conversation-overlay"
 import type { ConversationOverlayContext } from "./conversation-overlay/model"
 import { MessageInput } from "./message-input"
+import { StreamDateHeader } from "./stream-date-header"
 import { ActiveBotStatusStrip } from "./active-bot-status-strip"
 import { JoinChannelBar } from "./join-channel-bar"
 import { ThreadParentMessage } from "../thread/thread-parent-message"
@@ -82,6 +84,7 @@ import { StreamSearchBar } from "./stream-search-bar"
 import { useStreamSearch } from "@/hooks/use-stream-search"
 import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
+import { localStartOfDayMs } from "@/lib/dates"
 import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
 
 /** Membership events; suppressed in threads (see displayEvents memo). */
@@ -421,6 +424,7 @@ export function StreamContent({
     hasNewerEvents,
     isFetchingNewer,
     jumpToEvent,
+    jumpToEventByDate,
     exitJumpMode,
     isJumpMode,
   } = useEvents(workspaceId, streamId, { enabled: !isDraft, loadAll: isThread })
@@ -1222,6 +1226,37 @@ export function StreamContent({
     [events, jumpToEvent, disableAutoScroll, scrollToMessage]
   )
 
+  // Jump to a calendar date from the floating date header. Scrolls to the first
+  // message on or after the local day: in-window targets scroll directly (no
+  // round-trip, no jump mode); older targets load a window then scroll to the
+  // server-resolved anchor via the existing pendingScrollTarget driver.
+  const handleJumpToDate = useCallback(
+    async (date: Date) => {
+      userInteractedAtRef.current = 0
+      const targetDayMs = localStartOfDayMs(date)
+      const loaded = events.find((event) => {
+        if (event.eventType !== "message_created" && event.eventType !== "companion_response") return false
+        return localStartOfDayMs(new Date(event.createdAt)) >= targetDayMs
+      })
+      disableAutoScroll()
+      if (loaded) {
+        const messageId = (loaded.payload as { messageId?: string })?.messageId
+        if (messageId) {
+          pendingScrollTarget.current = null
+          scrollToMessage(messageId)
+          return
+        }
+      }
+      const anchorId = await jumpToEventByDate(date.toISOString())
+      if (anchorId) {
+        pendingScrollTarget.current = anchorId
+      } else {
+        toast.info("No messages on or after that date")
+      }
+    },
+    [events, disableAutoScroll, scrollToMessage, jumpToEventByDate]
+  )
+
   // Highlight search matches in the DOM via CSS Custom Highlight API
   useSearchHighlight(
     scrollContainerRef,
@@ -1607,6 +1642,7 @@ export function StreamContent({
                     batch={batchState}
                     batchPointerHandlers={batchPointerHandlers}
                     conversationOverlay={activeConversationOverlay}
+                    onJumpToDate={handleJumpToDate}
                   />
                   {/* Overlay loading indicators — absolutely positioned so they
                     don't cause layout shift when prepending older messages. */}
@@ -1835,6 +1871,7 @@ function TimelineMessageList({
   batch,
   batchPointerHandlers,
   conversationOverlay,
+  onJumpToDate,
 }: {
   visibleItems: TimelineItem[]
   isLoading: boolean
@@ -1885,6 +1922,8 @@ function TimelineMessageList({
   batch?: BatchTimelineState
   batchPointerHandlers?: React.HTMLAttributes<HTMLElement>
   conversationOverlay?: ConversationOverlayContext
+  /** Jump to the first message on or after a date (floating date header). */
+  onJumpToDate: (date: Date) => void
 }) {
   const { phase } = useCoordinatedLoading()
   const socket = useSocket()
@@ -1897,6 +1936,14 @@ function TimelineMessageList({
   // regression. Sticky across stream switches so fast switches keep the
   // existing blank behaviour (no skeleton flash on top of prior chrome).
   const hasRenderedContentRef = useRef(false)
+
+  // Floating date header (INV-42): the local day of the topmost visible row,
+  // and whether the pill is shown. Updated from the scroll handler so it tracks
+  // the day as the user scrolls, like Slack's sticky date.
+  const [topDayMs, setTopDayMs] = useState<number | null>(null)
+  const [datePillVisible, setDatePillVisible] = useState(false)
+  const visibleItemsRef = useRef(visibleItems)
+  visibleItemsRef.current = visibleItems
 
   const { sessionLiveCounts, sessionLiveSubsteps, sessionCanAbort } = useMemo(() => {
     const counts = new Map<string, { stepCount: number; messageCount: number }>()
@@ -2024,12 +2071,37 @@ function TimelineMessageList({
     }
   }, [hasNewerEvents, isFetchingNewer, fetchNewerEvents])
 
+  // Refresh the floating date header: the topmost visible day (nearest item to
+  // the scroll offset, scanning for the first row that carries a day) and the
+  // pill's visibility. Reads visibleItems off a ref so it stays stable across
+  // data ticks and doesn't churn the scroll handler it's called from.
+  const updateDatePill = useCallback(() => {
+    const list = listRef.current
+    const el = scrollerRef.current
+    if (!list || !el) return
+    let idx: number
+    try {
+      idx = list.findItemIndex(list.scrollOffset)
+    } catch {
+      return
+    }
+    const items = visibleItemsRef.current
+    let day: number | null = null
+    for (let i = Math.max(0, idx); i < items.length && day == null; i++) day = itemDayStartMs(items[i])
+    if (day == null)
+      for (let i = Math.min(idx, items.length - 1); i >= 0 && day == null; i--) day = itemDayStartMs(items[i])
+    setTopDayMs((prev) => (prev === day ? prev : day))
+    const show = el.scrollTop > 40 && !isSearchOpen && !batch?.enabled && !isFetchingOlder && !isInitialSettling
+    setDatePillVisible((prev) => (prev === show ? prev : show))
+  }, [listRef, scrollerRef, isSearchOpen, batch?.enabled, isFetchingOlder, isInitialSettling])
+
   // Pagination is driven off the owned scroller's native scroll. virtua has no
   // rangeChanged, so we measure distance from each edge in px and prefetch when
   // within a lead distance. Gated so a programmatic deep-link scroll never
   // kicks off pagination (its reflow would fight the refine loop).
   const handleScroll = useCallback(() => {
     onTimelineScroll()
+    updateDatePill()
     if (scrollAbortRef.current !== null) return
     const el = scrollerRef.current
     if (!el) return
@@ -2041,7 +2113,7 @@ function TimelineMessageList({
     })
     if (reachedStart) handleStartReached()
     if (reachedEnd) handleEndReached()
-  }, [onTimelineScroll, scrollAbortRef, scrollerRef, handleStartReached, handleEndReached])
+  }, [onTimelineScroll, updateDatePill, scrollAbortRef, scrollerRef, handleStartReached, handleEndReached])
 
   // virtua has no rangeChanged, so a window that fits the viewport (not
   // scrollable) would never fire a scroll to page in older history the user
@@ -2207,6 +2279,7 @@ function TimelineMessageList({
           <ComposerFooterSpacer />
         </div>
       </div>
+      <StreamDateHeader dayStartMs={topDayMs} visible={datePillVisible} onJumpToDate={onJumpToDate} />
       {isInitialSettling && (
         <div aria-hidden className="pointer-events-none absolute inset-0 z-10 bg-background">
           {skeleton}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -57,6 +57,7 @@ import {
   annotateAuthorGroups,
   annotateConversationRows,
   injectGapItems,
+  injectDayDividers,
   findFirstMessageId,
   findMessageItemIndex,
   getTimelineItemKey,
@@ -907,7 +908,10 @@ export function StreamContent({
   // passes `shift` to virtua for that render, holding the viewport exactly
   // like a real older-page prepend (INV-21).
   const visibleItems = useMemo(() => {
-    const base = useVirtualized ? filterVisibleItems(timelineItems, isChannel) : timelineItems
+    const filtered = useVirtualized ? filterVisibleItems(timelineItems, isChannel) : timelineItems
+    // Day dividers go on the post-filter list so a boundary lands above the
+    // first *visible* row of a day (INV-42), then skeletons prepend above all.
+    const base = injectDayDividers(filtered)
     return showOlderSkeletons ? [...OLDER_SKELETON_ITEMS, ...base] : base
   }, [timelineItems, useVirtualized, isChannel, showOlderSkeletons])
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2279,7 +2279,12 @@ function TimelineMessageList({
           <ComposerFooterSpacer />
         </div>
       </div>
-      <StreamDateHeader dayStartMs={topDayMs} visible={datePillVisible} onJumpToDate={onJumpToDate} />
+      <StreamDateHeader
+        dayStartMs={topDayMs}
+        visible={datePillVisible}
+        onJumpToDate={onJumpToDate}
+        scrollerRef={scrollerRef}
+      />
       {isInitialSettling && (
         <div aria-hidden className="pointer-events-none absolute inset-0 z-10 bg-background">
           {skeleton}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1247,7 +1247,7 @@ export function StreamContent({
           return
         }
       }
-      const anchorId = await jumpToEventByDate(date.toISOString())
+      const anchorId = await jumpToEventByDate(new Date(targetDayMs).toISOString())
       if (anchorId) {
         pendingScrollTarget.current = anchorId
       } else {

--- a/apps/frontend/src/components/timeline/stream-date-header.test.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { StreamDateHeader } from "./stream-date-header"
+import { localStartOfDayMs } from "@/lib/dates"
+
+describe("StreamDateHeader", () => {
+  const todayMs = localStartOfDayMs(new Date())
+
+  it("renders nothing when the day is unknown", () => {
+    const { container } = render(<StreamDateHeader dayStartMs={null} visible onJumpToDate={() => {}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("labels the pill with the topmost visible day", () => {
+    render(<StreamDateHeader dayStartMs={todayMs} visible onJumpToDate={() => {}} />)
+    expect(screen.getByRole("button", { name: /jump to date/i })).toHaveTextContent("Today")
+  })
+
+  it("jumps to a preset's date when chosen", async () => {
+    const user = userEvent.setup()
+    const onJumpToDate = vi.fn()
+    render(<StreamDateHeader dayStartMs={todayMs} visible onJumpToDate={onJumpToDate} />)
+
+    await user.click(screen.getByRole("button", { name: /jump to date/i }))
+    await user.click(screen.getByRole("button", { name: "Yesterday" }))
+
+    expect(onJumpToDate).toHaveBeenCalledTimes(1)
+    const [date] = onJumpToDate.mock.calls[0]
+    // The "Yesterday" preset resolves to ~24h before now.
+    const dayDiff = Math.round((Date.now() - (date as Date).getTime()) / 86_400_000)
+    expect(dayDiff).toBe(1)
+  })
+
+  it("reveals the calendar from the jump menu", async () => {
+    const user = userEvent.setup()
+    render(<StreamDateHeader dayStartMs={todayMs} visible onJumpToDate={() => {}} />)
+
+    await user.click(screen.getByRole("button", { name: /jump to date/i }))
+    expect(screen.queryByRole("grid")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /jump to a specific date/i }))
+    // react-day-picker renders the month grid as a table with role="grid".
+    expect(screen.getByRole("grid")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/timeline/stream-date-header.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { CalendarDays, ChevronDown, ChevronLeft } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
@@ -30,6 +30,11 @@ interface StreamDateHeaderProps {
 export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRef }: StreamDateHeaderProps) {
   const [open, setOpen] = useState(false)
   const [showCalendar, setShowCalendar] = useState(false)
+  // Touch-drag start Y for forwarding a touch scroll begun on the pill to the
+  // scroller (the touch equivalent of onWheel — a touch starting on the
+  // pointer-events-auto button would otherwise be trapped and not scroll the
+  // timeline on mobile). A tap doesn't move, so it never scrolls.
+  const touchStartY = useRef<number | null>(null)
 
   if (dayStartMs == null) return null
   const label = formatDayDivider(new Date(dayStartMs))
@@ -58,17 +63,32 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
           <button
             type="button"
             aria-label={`Jump to date — showing ${label}`}
+            // Drop out of the tab order while faded out — otherwise keyboard
+            // focus lands on an invisible control with a focus ring.
+            tabIndex={visible ? undefined : -1}
             // Forward wheel to the scroller (see scrollerRef doc): without this,
             // wheeling over the pill leaves the timeline stuck. Skipped while the
             // jump menu is open so the popover handles its own scroll.
             onWheel={(e) => {
               if (!open) scrollerRef?.current?.scrollBy({ top: e.deltaY })
             }}
+            onTouchStart={(e) => {
+              touchStartY.current = open ? null : (e.touches[0]?.clientY ?? null)
+            }}
+            onTouchMove={(e) => {
+              if (touchStartY.current == null) return
+              const y = e.touches[0]?.clientY ?? touchStartY.current
+              scrollerRef?.current?.scrollBy({ top: touchStartY.current - y })
+              touchStartY.current = y
+            }}
+            onTouchEnd={() => {
+              touchStartY.current = null
+            }}
             className={cn(
               // A faded-out pill must not capture clicks or wheel — drop pointer
               // events so they reach the scroller beneath it.
               visible ? "pointer-events-auto" : "pointer-events-none",
-              "inline-flex items-center gap-1 rounded-full border bg-background/95 px-3 py-1",
+              "inline-flex items-center gap-1 rounded-full border bg-background/95 px-3 py-1.5",
               "text-xs font-medium text-muted-foreground shadow-sm backdrop-blur",
               "transition-colors hover:bg-accent hover:text-foreground",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
@@ -78,7 +98,7 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
             <ChevronDown className="h-3 w-3 -mr-0.5 opacity-60" aria-hidden />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="center" className="w-56 p-0">
+        <PopoverContent align="center" className="w-64 p-0">
           {showCalendar ? (
             <div>
               <button

--- a/apps/frontend/src/components/timeline/stream-date-header.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.tsx
@@ -12,6 +12,13 @@ interface StreamDateHeaderProps {
   visible: boolean
   /** Jump the timeline to the first message on or after the chosen date. */
   onJumpToDate: (date: Date) => void
+  /**
+   * The timeline scroller. The pill is an overlay sibling of the scroller (not a
+   * descendant), so a wheel landing on its `pointer-events-auto` button would
+   * otherwise scroll the wrong ancestor and leave the timeline stuck. Forward
+   * the wheel to the scroller so wheeling over the pill scrolls the messages.
+   */
+  scrollerRef?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -20,7 +27,7 @@ interface StreamDateHeaderProps {
  * scroll area (absolute, pointer-events only on the control) so it never shifts
  * timeline layout (INV-21). Labels render in the device's local time (INV-42).
  */
-export function StreamDateHeader({ dayStartMs, visible, onJumpToDate }: StreamDateHeaderProps) {
+export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRef }: StreamDateHeaderProps) {
   const [open, setOpen] = useState(false)
   const [showCalendar, setShowCalendar] = useState(false)
 
@@ -51,8 +58,17 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate }: StreamDa
           <button
             type="button"
             aria-label={`Jump to date — showing ${label}`}
+            // Forward wheel to the scroller (see scrollerRef doc): without this,
+            // wheeling over the pill leaves the timeline stuck. Skipped while the
+            // jump menu is open so the popover handles its own scroll.
+            onWheel={(e) => {
+              if (!open) scrollerRef?.current?.scrollBy({ top: e.deltaY })
+            }}
             className={cn(
-              "pointer-events-auto inline-flex items-center gap-1 rounded-full border bg-background/95 px-3 py-1",
+              // A faded-out pill must not capture clicks or wheel — drop pointer
+              // events so they reach the scroller beneath it.
+              visible ? "pointer-events-auto" : "pointer-events-none",
+              "inline-flex items-center gap-1 rounded-full border bg-background/95 px-3 py-1",
               "text-xs font-medium text-muted-foreground shadow-sm backdrop-blur",
               "transition-colors hover:bg-accent hover:text-foreground",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"

--- a/apps/frontend/src/components/timeline/stream-date-header.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react"
+import { CalendarDays, ChevronDown, ChevronLeft } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Calendar } from "@/components/ui/calendar"
+import { formatDayDivider, getPastDatePresets } from "@/lib/dates"
+import { cn } from "@/lib/utils"
+
+interface StreamDateHeaderProps {
+  /** Local start-of-day (ms) of the topmost visible row, or null when unknown. */
+  dayStartMs: number | null
+  /** Whether the pill is shown (faded out while parked near the top/tail). */
+  visible: boolean
+  /** Jump the timeline to the first message on or after the chosen date. */
+  onJumpToDate: (date: Date) => void
+}
+
+/**
+ * Slack-style floating date pill: shows the day of the topmost visible row and,
+ * on click, opens a jump menu (quick presets + a calendar). Positioned over the
+ * scroll area (absolute, pointer-events only on the control) so it never shifts
+ * timeline layout (INV-21). Labels render in the device's local time (INV-42).
+ */
+export function StreamDateHeader({ dayStartMs, visible, onJumpToDate }: StreamDateHeaderProps) {
+  const [open, setOpen] = useState(false)
+  const [showCalendar, setShowCalendar] = useState(false)
+
+  if (dayStartMs == null) return null
+  const label = formatDayDivider(new Date(dayStartMs))
+
+  const jump = (date: Date) => {
+    onJumpToDate(date)
+    setOpen(false)
+    setShowCalendar(false)
+  }
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2 transition-opacity duration-200",
+        visible ? "opacity-100" : "opacity-0"
+      )}
+    >
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+          if (!next) setShowCalendar(false)
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Jump to date — showing ${label}`}
+            className={cn(
+              "pointer-events-auto inline-flex items-center gap-1 rounded-full border bg-background/95 px-3 py-1",
+              "text-xs font-medium text-muted-foreground shadow-sm backdrop-blur",
+              "transition-colors hover:bg-accent hover:text-foreground",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            )}
+          >
+            <span>{label}</span>
+            <ChevronDown className="h-3 w-3 -mr-0.5 opacity-60" aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="center" className="w-56 p-0">
+          {showCalendar ? (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowCalendar(false)}
+                className="flex w-full items-center gap-1.5 border-b px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
+                Back
+              </button>
+              <Calendar
+                mode="single"
+                defaultMonth={new Date(dayStartMs)}
+                onSelect={(date) => date && jump(date)}
+                disabled={{ after: new Date() }}
+                className="p-2"
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col py-1">
+              {getPastDatePresets().map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => jump(preset.date)}
+                  className="px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                >
+                  {preset.label}
+                </button>
+              ))}
+              <div className="my-1 border-t" />
+              <button
+                type="button"
+                onClick={() => setShowCalendar(true)}
+                className="flex items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+              >
+                <CalendarDays className="h-4 w-4 text-muted-foreground" aria-hidden />
+                Jump to a specific date…
+              </button>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -41,6 +41,7 @@ export interface StreamService {
   unarchive: typeof streamsApi.unarchive
   getEvents: typeof streamsApi.getEvents
   getEventsAround: typeof streamsApi.getEventsAround
+  getEventsAroundDate: typeof streamsApi.getEventsAroundDate
   markAsRead: typeof streamsApi.markAsRead
   checkSlugAvailable: typeof streamsApi.checkSlugAvailable
   setNotificationLevel: typeof streamsApi.setNotificationLevel

--- a/apps/frontend/src/hooks/use-events.ts
+++ b/apps/frontend/src/hooks/use-events.ts
@@ -636,6 +636,41 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     [streamService, workspaceId, streamId, queryClient]
   )
 
+  /**
+   * Jump to a calendar date: load events around the first message on/after the
+   * instant and switch to bidirectional pagination. Returns the `anchorMessageId`
+   * the caller should scroll to, or null when no message lands on/after the date
+   * (the date is past the last message — caller stays on the live tail).
+   */
+  const jumpToEventByDate = useCallback(
+    async (isoDate: string): Promise<string | null> => {
+      const result = await streamService.getEventsAroundDate(workspaceId, streamId, isoDate, EVENT_PAGE_SIZE)
+      if (result.events.length === 0) return null
+
+      await cacheToIndexedDB(workspaceId, result.events)
+
+      // No newer events means the anchor sits at the live tail — skip jump mode
+      // and let IDB render the tail; the caller still scrolls to the anchor.
+      if (!result.hasNewer) return result.anchorMessageId
+
+      const sorted = sortBySequence([...result.events])
+      setJumpState({
+        events: sorted,
+        hasOlder: result.hasOlder,
+        hasNewer: result.hasNewer,
+        oldestSequence: sorted[0].sequence,
+        newestSequence: sorted[sorted.length - 1].sequence,
+        sharedMessages: result.sharedMessages,
+      })
+
+      queryClient.removeQueries({ queryKey: eventKeys.list(workspaceId, streamId) })
+      queryClient.removeQueries({ queryKey: eventKeys.newer(workspaceId, streamId) })
+
+      return result.anchorMessageId
+    },
+    [streamService, workspaceId, streamId, queryClient]
+  )
+
   /** Exit jump mode and return to live tail (latest messages from IDB). */
   const exitJumpMode = useCallback(() => {
     setJumpState(null)
@@ -694,6 +729,7 @@ export function useEvents(workspaceId: string, streamId: string, options?: { ena
     hasNewerEvents,
     isFetchingNewer,
     jumpToEvent,
+    jumpToEventByDate,
     exitJumpMode,
     isJumpMode: !!jumpState,
     addEvent,

--- a/apps/frontend/src/lib/dates.test.ts
+++ b/apps/frontend/src/lib/dates.test.ts
@@ -7,9 +7,11 @@ import {
   formatRelativeTime,
   formatFullDateTime,
   formatFutureTime,
+  formatDayDivider,
   getPastDatePresets,
   getFutureDatePresets,
   localStartOfDayISO,
+  localStartOfDayMs,
 } from "./dates"
 
 describe("dates", () => {
@@ -259,6 +261,48 @@ describe("dates", () => {
         timezone: "America/Los_Angeles",
       })
       expect(label).toBe("11:30")
+    })
+  })
+
+  describe("formatDayDivider", () => {
+    // Local constructors so day boundaries are evaluated in the runner's
+    // timezone, matching how the divider renders on the device (INV-42).
+    const now = new Date(2026, 5, 16, 12, 0, 0)
+
+    it("labels the current day as Today", () => {
+      expect(formatDayDivider(new Date(2026, 5, 16, 8, 0, 0), now)).toBe("Today")
+    })
+
+    it("labels the prior day as Yesterday", () => {
+      expect(formatDayDivider(new Date(2026, 5, 15, 23, 30, 0), now)).toBe("Yesterday")
+    })
+
+    it("labels an earlier same-year day with weekday and date, no year", () => {
+      const date = new Date(2026, 1, 3, 9, 0, 0)
+      expect(formatDayDivider(date, now)).toBe(
+        date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" })
+      )
+    })
+
+    it("includes the year for a different calendar year", () => {
+      const date = new Date(2024, 10, 20, 9, 0, 0)
+      expect(formatDayDivider(date, now)).toBe(
+        date.toLocaleDateString(undefined, { weekday: "long", year: "numeric", month: "long", day: "numeric" })
+      )
+    })
+  })
+
+  describe("localStartOfDayMs", () => {
+    it("collapses two instants on the same local day to one key", () => {
+      const morning = new Date(2026, 5, 16, 1, 0, 0)
+      const evening = new Date(2026, 5, 16, 23, 0, 0)
+      expect(localStartOfDayMs(morning)).toBe(localStartOfDayMs(evening))
+    })
+
+    it("produces distinct keys across a local-day boundary", () => {
+      expect(localStartOfDayMs(new Date(2026, 5, 16, 23, 59, 0))).not.toBe(
+        localStartOfDayMs(new Date(2026, 5, 17, 0, 1, 0))
+      )
     })
   })
 })

--- a/apps/frontend/src/lib/dates.ts
+++ b/apps/frontend/src/lib/dates.ts
@@ -71,6 +71,14 @@ export function isSameDay(a: Date, b: Date): boolean {
   return dateFnsIsSameDay(a, b)
 }
 
+/**
+ * Local start-of-day timestamp (ms) — the stable per-day key for grouping
+ * timeline rows into day buckets in the device's timezone (INV-42).
+ */
+export function localStartOfDayMs(date: Date): number {
+  return startOfDay(date).getTime()
+}
+
 interface RelativeTimeOptions {
   /** Use terse format (e.g., "2m ago") vs verbose (e.g., "yesterday 14:30") */
   terse?: boolean
@@ -185,6 +193,29 @@ export function formatFullDateTime(date: Date, prefs?: TimePrefs): string {
   })
   const timePart = formatTime(date, prefs)
   return `${datePart}, ${timePart}`
+}
+
+/**
+ * Label for an in-stream day divider, in the device's local calendar (INV-42).
+ *
+ *   today                 → "Today"
+ *   yesterday             → "Yesterday"
+ *   same calendar year    → "Monday, June 16"
+ *   other year            → "Monday, June 16, 2024"
+ *
+ * Future days (rare — clock skew, a message dated ahead) fall through to the
+ * absolute date. Weekday/month names come from the runtime locale.
+ */
+export function formatDayDivider(date: Date, now: Date = new Date()): string {
+  if (isSameDay(date, now)) return "Today"
+
+  const daysAgo = differenceInDays(startOfDay(now), startOfDay(date))
+  if (daysAgo === 1) return "Yesterday"
+
+  if (date.getFullYear() === now.getFullYear()) {
+    return date.toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" })
+  }
+  return date.toLocaleDateString(undefined, { weekday: "long", year: "numeric", month: "long", day: "numeric" })
 }
 
 /**

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -247,6 +247,17 @@ export interface EventsAroundResponse {
   sharedMessages?: Record<string, SharedMessageHydration>
 }
 
+/**
+ * Response for jump-to-date (`?date=`). Same window shape as
+ * `EventsAroundResponse` plus the message the client should scroll to: the
+ * first message at or after the requested calendar instant. `null` when the
+ * date is past the stream's last message (the client falls back to the live
+ * tail).
+ */
+export interface EventsAroundDateResponse extends EventsAroundResponse {
+  anchorMessageId: string | null
+}
+
 // Sync log catch-up — GET /api/workspaces/:workspaceId/sync
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -403,6 +403,7 @@ export type {
   StreamContextRef,
   StreamContextRefSource,
   EventsAroundResponse,
+  EventsAroundDateResponse,
   SharedMessageHydration,
   // Sync log catch-up
   SyncCatchUpEntry,


### PR DESCRIPTION
## Problem

A stream timeline is a flat run of messages with no day boundaries and no way to move through it by time. Author-grouping (`annotateAuthorGroups`) and the unread divider exist, but there's no "—— Yesterday ——" separator and no affordance to jump to a date. Reaching an older day means scrolling and waiting for older pages to page in one at a time; "what did we say last month" is effectively unreachable. The backend only paginates events by `sequence` (`StreamEventRepository.list` / `listAround`), with no way to resolve a calendar instant to a position.

## Solution

Two surfaces, one new backend lookup.

1. **Inline day dividers** — a client-derived `day_divider` timeline row between messages from different local calendar days, in the spirit of the existing `UnreadDivider`.
2. **A floating date pill** (Slack-style) over the timeline that shows the topmost visible day and opens a jump menu: quick presets (Today / Yesterday / Last week / Last month / …) plus a calendar.
3. **A date→sequence lookup** on the existing `/events/around` endpoint so a jump to a date outside the loaded window reuses the same window-load + scroll machinery as a deep link.

### How it works

**Dividers (`event-list.tsx`).** A new `TimelineItem` variant `{ type: "day_divider"; dayStartMs }`. `injectDayDividers(items)` walks render-ordered items and inserts a divider before the first row of each new local day, keying days off `localStartOfDayMs` (device-local, INV-42). It runs *after* `filterVisibleItems` in both the virtualized path (`visibleItems` memo in `stream-content.tsx`) and the non-virtualized `EventList` (threads), so a boundary lands above the first *visible* row of a day rather than above a zero-height event. The `DayDivider` component formats its label (`formatDayDivider`) at render time, so "Today"/"Yesterday" stay current as rows mount.

Dividers are purely client-derived: they consume no `broadcastSequence` and are injected after `injectGapItems`, so contiguity/hole detection (INV-61) — computed over raw `events` in `useEvents` — never sees them.

**Backend date lookup.** `StreamEventRepository.findFirstMessageOnOrAfter(db, streamId, date)` selects the first `message_created`/`companion_response` with `created_at >= date`, ordered `created_at ASC, sequence ASC`, backed by a new partial `(stream_id, created_at)` index. `EventService.listEventsAroundDate` resolves that anchor, then delegates to the existing `listAround(anchor.sequence)` and returns the window plus `anchorMessageId` (the row to scroll to). When no message lands on/after the date (date past the last message) it returns an empty window so the client stays on the live tail. The `/events/around` handler gains a `?date=` branch; the Zod schema now requires exactly one of `{eventId, messageId, date}`.

**The pill (`stream-date-header.tsx` + `TimelineMessageList`).** On scroll, `updateDatePill` reads the top item via virtua's `findItemIndex(scrollOffset)` and scans for the nearest row carrying a day (`itemDayStartMs`, which also reports a `day_divider`'s own day). The pill is an `absolute` overlay (no layout shift, INV-21), shown once scrolled past 40px and hidden while a top bar (search/batch) or older-page fetch is active. Selecting a date calls `handleJumpToDate`: it floors the date to the local day start, then an in-window day scrolls directly via the existing `scrollToMessage`; an out-of-window day loads through `useEvents.jumpToEventByDate` and lands on the server `anchorMessageId` via the existing `pendingScrollTarget` driver — no new scroll logic.

### Key design decisions

**1. No divider above the very first row.** The reverse-infinite-scroll viewport hold in `use-timeline-scroll.ts` keys `shift` off `visibleItems[0]`'s key. A leading `day_divider` with a stable `day:<ms>` key would not change when a *same-day* older page prepends, silently breaking the hold and jumping the viewport. `injectDayDividers` seeds the current day from the first row and emits no divider above it, so index 0 stays a real event whose id changes on every prepend — preserving the existing detection exactly (verified against `use-timeline-scroll.ts:213-221`).

**2. Reuse `/events/around`, don't add an endpoint.** A date jump and a message-id jump produce the same window shape and the same enrichment (link previews, shared-message hydration). Branching the existing handler keeps one response path; `EventsAroundDateResponse` only adds `anchorMessageId`.

**3. Jumps land on the local calendar day's first message.** Both jump paths floor to `localStartOfDayMs(date)` (decision reinforced by self-review — see below), matching where the divider for that day renders.

**4. Label freshness over memo purity.** `day_divider` carries only `dayStartMs`; the relative label is computed in `DayDivider` at render. A long-open tab could show a stale "Today" past midnight — accepted (rows recompute on the next mount/scroll) rather than wiring a midnight timer.

### Design evolution (self-review)

A pre-PR review pass (one reviewer agent over the full diff) confirmed INV-61/INV-42/INV-21, the first-key/viewport-hold preservation, the comparator coverage (`getTimelineItemKey`/`itemContainsEvent`/`isFirstUnread`/`timelineItemEqual`/`timelineRowPropsEqual` all handle `day_divider`), and the backend access/validation paths. It found two should-fix items, both fixed in `c846dac`:

1. **Preset jumps were inconsistent.** The in-window branch floored to the local calendar day, but the out-of-window branch sent the raw instant — and presets carry the *current time-of-day* (`subWeeks(now,1)` = `…T12:34`). So an in-window "Last week" landed on the day's first message while an out-of-window "Last week" skipped to the first message after 12:34. Fixed by sending `new Date(localStartOfDayMs(date)).toISOString()` so both paths resolve to the same row. (The calendar picker already passed local midnight, so it was unaffected.)
2. **Migration would block writes.** The first version used a plain `CREATE INDEX` — a write-blocking lock on the hot `stream_events` table. The runner executes each migration file outside a transaction (`packages/backend-common/src/db/migrations.ts:16`), and the two prior `stream_events` index migrations use `CREATE INDEX CONCURRENTLY`. Switched to `CONCURRENTLY IF NOT EXISTS`, and made it partial on `event_type IN ('message_created','companion_response')` (the lookup's filter) to match `idx_stream_events_message_seq`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/timeline/day-divider.tsx` | In-flow day boundary row; formats its label at render (INV-42) |
| `apps/frontend/src/components/timeline/stream-date-header.tsx` | Floating date pill + presets/calendar jump menu |
| `apps/frontend/src/components/timeline/stream-date-header.test.tsx` | Mounts the pill, exercises preset + calendar selection (INV-39) |
| `apps/backend/src/features/streams/event-repository.test.ts` | `findFirstMessageOnOrAfter` mapping + null |
| `apps/backend/src/db/migrations/20260616204509_index_stream_events_created_at.sql` | Partial `(stream_id, created_at)` index, built CONCURRENTLY, for the date lookup (INV-17) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/dates.ts` (+ `.test.ts`) | `formatDayDivider`, `localStartOfDayMs` |
| `apps/frontend/src/components/timeline/event-list.tsx` (+ `.test.ts`) | `day_divider` variant + `injectDayDividers` + `itemDayStartMs`; wired into key/equality/unread/containment switches and the thread render |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Divider injection in `visibleItems`; `handleJumpToDate`; pill scroll-tracking + render in `TimelineMessageList` |
| `apps/frontend/src/hooks/use-events.ts` | `jumpToEventByDate` |
| `apps/frontend/src/api/streams.ts`, `contexts/services-context.tsx` | `getEventsAroundDate` client |
| `apps/backend/src/features/streams/event-repository.ts` | `findFirstMessageOnOrAfter` |
| `apps/backend/src/features/messaging/event-service.ts` (+ `.test.ts`) | `listEventsAroundDate` |
| `apps/backend/src/features/streams/handlers.ts` | `?date=` branch + exactly-one-of `{eventId,messageId,date}` refine |
| `packages/types/src/api.ts`, `index.ts` | `EventsAroundDateResponse` |

## Out of scope (deliberate)

- **No URL persistence of the jump.** A date jump is a one-shot scroll action (like search-result navigation), not a persistent view, so it carries no query param — INV-59 doesn't apply.
- **No midnight refresh timer** for the "Today" label (see decision 4).
- **E2E (Playwright) not run** — see test plan.

## Test plan

- [x] Frontend full suite — 2851 pass (`bun run --filter @threa/frontend test`), incl. new `injectDayDividers`, `formatDayDivider`/`localStartOfDayMs`, and `StreamDateHeader` tests
- [x] Backend `src/features/streams` + `src/features/messaging` — 194 pass, incl. new `findFirstMessageOnOrAfter` and `listEventsAroundDate` tests
- [x] Monorepo `tsc --noEmit` clean (runs in the pre-commit hook on every commit)
- [x] `bun scripts/check-migrations.ts` — 170 migrations clean (INV-1/3/17)
- [x] Pre-PR self-review (1 reviewer agent over the diff): 2 should-fixes found and fixed (preset-jump consistency, migration CONCURRENTLY/partial), 1 nit applied; INV-61/42/21, viewport-hold, and comparator coverage verified clean
- [ ] Playwright `test:e2e` — not run; needs the app + browsers running, impractical in this session. The new UI is covered by the mounted `StreamDateHeader` integration test instead.
- [ ] `findFirstMessageOnOrAfter` SQL is unit-tested with a stubbed `Querier` (no live-DB harness in these suites), so the index path is not integration-tested against Postgres.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHmqwGBSymHPEocuPWYZ37)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784238733&installation_id=129946197&pr_number=975&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F975&signature=c23a08538353c19ae301ee33399e22ce5ae91728b35525ad30c09223c9a10ee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->