### PR TITLE
feat(channels): drive Claude Code from a Threa scratchpad (claude-code-channel runtime)

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -263,4 +263,20 @@ describe("BotInvocationOutboxHandler active-scratchpad session-link policy", () 
       expect.objectContaining({ actorId: "bot_1", trigger: "active-scratchpad" })
     )
   })
+
+  it("posts the Claude Code channel notice and skips dispatch when an unlinked claude-code-channel bot is active", async () => {
+    const { createInvocation, createMessage } = setupActiveScratchpad({
+      instance: { runtimeKind: "claude-code-channel" },
+    })
+
+    await runProcessMessageCreated(plainUserMessage)
+
+    expect(createInvocation).not.toHaveBeenCalled()
+    expect(createMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentMarkdown: expect.stringContaining("Claude Code with the Threa channel"),
+        metadata: { "bot_runtime.notice": "missing_session_link" },
+      })
+    )
+  })
 })

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -486,18 +486,22 @@ export const BotRuntimeSessionLinkRepository = {
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
 
+  // A runtime client is identified by (instanceId, runtimeSessionId) — that pair is
+  // unique per client regardless of runtimeKind. The lookup must NOT filter on kind:
+  // doing so made session reuse miss a non-pi-local link and re-run the create path,
+  // which then violated the (…, runtime_kind, instance_id, runtime_session_id) unique
+  // constraint on the runtime's second launch.
   async findActiveByRuntimeSession(
     db: Querier,
     params: {
       workspaceId: string
       botId: string
-      runtimeKind: BotRuntimeKind
       instanceId: string
       runtimeSessionId: string
     }
   ): Promise<BotRuntimeSessionLink | null> {
     const result = await db.query<BotRuntimeSessionLinkRow>(
-      sql`SELECT * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND runtime_kind = ${params.runtimeKind} AND instance_id = ${params.instanceId} AND runtime_session_id = ${params.runtimeSessionId} AND status = 'active'`
+      sql`SELECT * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND instance_id = ${params.instanceId} AND runtime_session_id = ${params.runtimeSessionId} AND status = 'active'`
     )
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -486,11 +486,13 @@ export const BotRuntimeSessionLinkRepository = {
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
 
-  // A runtime client is identified by (instanceId, runtimeSessionId) — that pair is
-  // unique per client regardless of runtimeKind. The lookup must NOT filter on kind:
-  // doing so made session reuse miss a non-pi-local link and re-run the create path,
-  // which then violated the (…, runtime_kind, instance_id, runtime_session_id) unique
-  // constraint on the runtime's second launch.
+  // A runtime client is identified by (instanceId, runtimeSessionId). Callers that
+  // know the kind they're acting for (session create) pass it so reuse is kind-exact
+  // — the original bug was the inverse, a hardcoded `runtime_kind = 'pi-local'` that
+  // made a claude-code-channel relaunch miss its own link and re-run the create path,
+  // violating the (…, runtime_kind, instance_id, runtime_session_id) unique key.
+  // `runtimeKind` omitted (rename) matches any kind; ORDER BY keeps that deterministic
+  // even though the (instance, session) pair is unique per kind in practice.
   async findActiveByRuntimeSession(
     db: Querier,
     params: {
@@ -498,10 +500,20 @@ export const BotRuntimeSessionLinkRepository = {
       botId: string
       instanceId: string
       runtimeSessionId: string
+      runtimeKind?: BotRuntimeKind
     }
   ): Promise<BotRuntimeSessionLink | null> {
+    const kind = params.runtimeKind ?? null
     const result = await db.query<BotRuntimeSessionLinkRow>(
-      sql`SELECT * FROM bot_runtime_session_links WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND instance_id = ${params.instanceId} AND runtime_session_id = ${params.runtimeSessionId} AND status = 'active'`
+      sql`SELECT * FROM bot_runtime_session_links
+        WHERE workspace_id = ${params.workspaceId}
+          AND bot_id = ${params.botId}
+          AND instance_id = ${params.instanceId}
+          AND runtime_session_id = ${params.runtimeSessionId}
+          AND status = 'active'
+          AND (${kind}::text IS NULL OR runtime_kind = ${kind})
+        ORDER BY updated_at DESC
+        LIMIT 1`
     )
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -486,13 +486,11 @@ export const BotRuntimeSessionLinkRepository = {
     return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
 
-  // A runtime client is identified by (instanceId, runtimeSessionId). Callers that
-  // know the kind they're acting for (session create) pass it so reuse is kind-exact
-  // — the original bug was the inverse, a hardcoded `runtime_kind = 'pi-local'` that
-  // made a claude-code-channel relaunch miss its own link and re-run the create path,
-  // violating the (…, runtime_kind, instance_id, runtime_session_id) unique key.
-  // `runtimeKind` omitted (rename) matches any kind; ORDER BY keeps that deterministic
-  // even though the (instance, session) pair is unique per kind in practice.
+  // A runtime client is identified by (instanceId, runtimeSessionId). Session-create
+  // callers pass `runtimeKind` so reuse matches the link of the kind being created —
+  // the unique key includes runtime_kind, so two kinds can hold the same instance/
+  // session pair. Rename callers omit it to match that runtime identity across kinds;
+  // `ORDER BY updated_at DESC LIMIT 1` keeps the kindless case deterministic.
   async findActiveByRuntimeSession(
     db: Querier,
     params: {

--- a/apps/backend/src/features/bot-runtimes/runtime-kind-config.test.ts
+++ b/apps/backend/src/features/bot-runtimes/runtime-kind-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { resolveRuntimeKindConfig } from "./runtime-kind-config"
+
+describe("resolveRuntimeKindConfig", () => {
+  it("requires a session link for pi-local and the Claude Code channel", () => {
+    const pi = resolveRuntimeKindConfig("pi-local")
+    const cc = resolveRuntimeKindConfig("claude-code-channel")
+    expect(pi.sessionLinking).toBe("required")
+    expect(cc.sessionLinking).toBe("required")
+    if (cc.sessionLinking === "required") {
+      const notice = cc.missingSessionLinkNotice("Scout")
+      expect(notice).toContain("Scout")
+      expect(notice).toContain("Claude Code")
+    }
+  })
+
+  it("leaves untargeted kinds link-free", () => {
+    expect(resolveRuntimeKindConfig("hermes").sessionLinking).toBe("none")
+    expect(resolveRuntimeKindConfig("openclaw").sessionLinking).toBe("none")
+    expect(resolveRuntimeKindConfig("custom").sessionLinking).toBe("none")
+  })
+
+  it("defaults a bot with no runtime instance to the pi-local policy", () => {
+    expect(resolveRuntimeKindConfig(null).sessionLinking).toBe("required")
+  })
+})

--- a/apps/backend/src/features/bot-runtimes/runtime-kind-config.ts
+++ b/apps/backend/src/features/bot-runtimes/runtime-kind-config.ts
@@ -1,11 +1,12 @@
 /**
  * Per-runtime-kind dispatch policy for the active-scratchpad path.
  *
- * Pi drives long-lived local sessions, so its active-scratchpad turns must be
- * pinned to an explicit session link (created via Pi's `/remote-control`
- * flow) — without one we post a notice telling the user how to link. Other
- * kinds never create session links; their invocations dispatch untargeted and
- * any live instance of the bot may claim them.
+ * Pi and the Claude Code channel drive long-lived local sessions, so their
+ * active-scratchpad turns must be pinned to an explicit session link (created
+ * via Pi's `/remote-control` flow or the Claude Code channel's startup) —
+ * without one we post a notice telling the user how to link. Other kinds never
+ * create session links; their invocations dispatch untargeted and any live
+ * instance of the bot may claim them.
  */
 
 import type { BotRuntimeKind } from "@threa/types"
@@ -26,7 +27,11 @@ const BOT_RUNTIME_KIND_CONFIGS: Record<BotRuntimeKind, BotRuntimeKindConfig> = {
   },
   hermes: { sessionLinking: "none" },
   openclaw: { sessionLinking: "none" },
-  "claude-code-channel": { sessionLinking: "none" },
+  "claude-code-channel": {
+    sessionLinking: "required",
+    missingSessionLinkNotice: (botName) =>
+      `**${botName} is not linked to this scratchpad.** Start Claude Code with the Threa channel (\`claude --channels …\`) to link a session.`,
+  },
   custom: { sessionLinking: "none" },
 }
 

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -179,10 +179,7 @@ export class BotRuntimeService {
     instanceId: string
     runtimeSessionId: string
   }): Promise<BotRuntimeSessionLink | null> {
-    return BotRuntimeSessionLinkRepository.findActiveByRuntimeSession(this.pool, {
-      ...params,
-      runtimeKind: "pi-local",
-    })
+    return BotRuntimeSessionLinkRepository.findActiveByRuntimeSession(this.pool, params)
   }
 
   async findActivePiRemoteSessionsForStreams(params: {
@@ -224,6 +221,7 @@ export class BotRuntimeService {
   async createOrLinkPiRemoteSession(params: {
     workspaceId: string
     botId: string
+    runtimeKind: BotRuntimeKind
     instanceId: string
     runtimeSessionId: string
     rootStreamId: string
@@ -239,6 +237,7 @@ export class BotRuntimeService {
     params: {
       workspaceId: string
       botId: string
+      runtimeKind: BotRuntimeKind
       instanceId: string
       runtimeSessionId: string
       rootStreamId: string
@@ -260,7 +259,7 @@ export class BotRuntimeService {
       id: botRuntimeSessionLinkId(),
       workspaceId: params.workspaceId,
       botId: params.botId,
-      runtimeKind: "pi-local",
+      runtimeKind: params.runtimeKind,
       instanceId: params.instanceId,
       runtimeSessionId: params.runtimeSessionId,
       rootStreamId: params.rootStreamId,
@@ -292,6 +291,7 @@ export class BotRuntimeService {
       await this.upsertPiRemoteSessionPresenceInTransaction(db, {
         workspaceId: params.workspaceId,
         botId: params.botId,
+        runtimeKind: "pi-local",
         instanceId: params.newInstanceId,
         runtimeSessionId: params.runtimeSessionId,
       })
@@ -301,22 +301,26 @@ export class BotRuntimeService {
 
   private async upsertPiRemoteSessionPresenceInTransaction(
     db: Querier,
-    params: { workspaceId: string; botId: string; instanceId: string; runtimeSessionId: string }
+    params: { workspaceId: string; botId: string; runtimeKind: BotRuntimeKind; instanceId: string; runtimeSessionId: string }
   ): Promise<void> {
     await BotRuntimeInstanceRepository.upsertPresence(db, {
       id: botRuntimeInstanceId(),
       workspaceId: params.workspaceId,
       botId: params.botId,
-      runtimeKind: "pi-local",
+      runtimeKind: params.runtimeKind,
       instanceId: params.instanceId,
       status: "available",
       acceptingInvocations: true,
+      // Bootstrap capabilities until the runtime's own heartbeat lands. Only Pi
+      // advertises session-control commands; the Claude Code channel can't drive
+      // the host session, so it must not offer /compact, /model, etc.
       capabilities: {
         runtimeSessionId: params.runtimeSessionId,
         supportsActiveScratchpad: true,
         supportsPersistentSessions: true,
-        supportsSessionControlCommands: true,
-        sessionControlCommands: ["compact", "model", "thinking", "skill"],
+        ...(params.runtimeKind === "pi-local"
+          ? { supportsSessionControlCommands: true, sessionControlCommands: ["compact", "model", "thinking", "skill"] }
+          : {}),
       },
       // Session-link writes don't carry the runtime's BIK; keep the key the
       // live session registered via bot:hello rather than nulling it.

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -178,6 +178,8 @@ export class BotRuntimeService {
     botId: string
     instanceId: string
     runtimeSessionId: string
+    /** Passed by session-create so reuse is kind-exact; omitted by rename (any kind). */
+    runtimeKind?: BotRuntimeKind
   }): Promise<BotRuntimeSessionLink | null> {
     return BotRuntimeSessionLinkRepository.findActiveByRuntimeSession(this.pool, params)
   }
@@ -301,7 +303,13 @@ export class BotRuntimeService {
 
   private async upsertPiRemoteSessionPresenceInTransaction(
     db: Querier,
-    params: { workspaceId: string; botId: string; runtimeKind: BotRuntimeKind; instanceId: string; runtimeSessionId: string }
+    params: {
+      workspaceId: string
+      botId: string
+      runtimeKind: BotRuntimeKind
+      instanceId: string
+      runtimeSessionId: string
+    }
   ): Promise<void> {
     await BotRuntimeInstanceRepository.upsertPresence(db, {
       id: botRuntimeInstanceId(),

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -981,6 +981,7 @@ export function createPublicApiHandlers({
         botId: bot.id,
         instanceId: data.instanceId,
         runtimeSessionId: data.runtimeSessionId,
+        runtimeKind: data.runtimeKind,
       })
       if (existingLink) {
         await withTransaction(pool, (client) =>

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1016,6 +1016,7 @@ export function createPublicApiHandlers({
         return botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: bot.id,
+          runtimeKind: data.runtimeKind,
           instanceId: data.instanceId,
           runtimeSessionId: data.runtimeSessionId,
           rootStreamId: stream.id,

--- a/apps/backend/src/features/public-api/schemas.test.ts
+++ b/apps/backend/src/features/public-api/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { upsertPresenceSchema } from "./schemas"
+import { createRuntimeSessionSchema, upsertPresenceSchema } from "./schemas"
 
 const BASE = {
   runtimeKind: "pi-local" as const,
@@ -39,5 +39,23 @@ describe("upsertPresenceSchema BIK registration", () => {
       publicKeyId: "bik_short",
     })
     expect(result.success).toBe(false)
+  })
+})
+
+describe("createRuntimeSessionSchema runtimeKind", () => {
+  const base = {
+    instanceId: "inst_1",
+    runtimeSessionId: "sess_1",
+    displayName: "Claude Code - threa",
+  }
+
+  it("accepts the session-linking runtime kinds", () => {
+    expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "pi-local" }).success).toBe(true)
+    expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "claude-code-channel" }).success).toBe(true)
+  })
+
+  it("rejects link-free kinds that have no business creating a session", () => {
+    expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "openclaw" }).success).toBe(false)
+    expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "custom" }).success).toBe(false)
   })
 })

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -84,7 +84,10 @@ export const upsertPresenceSchema = z
   })
 
 export const createRuntimeSessionSchema = z.object({
-  runtimeKind: z.literal("pi-local"),
+  // The runtime kinds whose active-scratchpad turns are pinned to a session
+  // link (see runtime-kind-config). Other kinds dispatch untargeted and never
+  // create a link, so they have no business calling this endpoint.
+  runtimeKind: z.enum(["pi-local", "claude-code-channel"]),
   instanceId: z.string().min(1).max(128),
   runtimeSessionId: z.string().min(1).max(256),
   displayName: z.string().min(1).max(100),

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -1,13 +1,11 @@
 /**
- * E2E coverage for the `claude-code-channel` runtime kind (the Claude Code
+ * E2E coverage for `claude-code-channel` runtime sessions (the Claude Code
  * channel in `extensions/claude-code-remote/`).
  *
- * Proves the backend accepts a session for the new kind and — the regression
- * that matters — that creating the same session twice is idempotent. The second
- * call is what every channel restart in the same directory does; it previously
- * 500'd because `findActivePiRemoteSession` hardcoded `runtime_kind = 'pi-local'`,
- * missed the existing claude-code-channel link, re-ran the create path, and
- * violated the (…, runtime_kind, instance_id, runtime_session_id) unique key.
+ * Verifies the session API for the new kind: create, idempotent reuse on a
+ * repeat create (what every channel restart in the same directory does — it
+ * must return the same scratchpad, not a fresh one or a 500), rejection of
+ * link-free kinds, and the dispatch → claim → complete round-trip.
  */
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test"

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -1,0 +1,171 @@
+/**
+ * E2E coverage for the `claude-code-channel` runtime kind (the Claude Code
+ * channel in `extensions/claude-code-remote/`).
+ *
+ * Proves the backend accepts a session for the new kind and — the regression
+ * that matters — that creating the same session twice is idempotent. The second
+ * call is what every channel restart in the same directory does; it previously
+ * 500'd because `findActivePiRemoteSession` hardcoded `runtime_kind = 'pi-local'`,
+ * missed the existing claude-code-channel link, re-ran the create path, and
+ * violated the (…, runtime_kind, instance_id, runtime_session_id) unique key.
+ */
+
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+import { BotTraits, WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { botApiPost, createBot, createBotKey, createWorkspace, loginAs, sendMessage, TestClient } from "../client"
+
+setDefaultTimeout(60_000)
+
+const testRunId = Math.random().toString(36).substring(7)
+
+interface SessionLinkData {
+  linkId: string
+  rootStreamId: string
+  activeStreamId: string
+  runtimeSessionId: string
+  streamUrlPath: string
+}
+
+interface ClaimedInvocationData {
+  id: string
+  claimToken: string
+  promptMarkdown: string
+  requiredCapability: string
+}
+
+describe("claude-code-channel runtime sessions", () => {
+  test("creates a session for the new kind and reuses it idempotently on relaunch", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-session-${testRunId}@test.com`, "CC Session User")
+    const workspace = await createWorkspace(client, `CC Session WS ${testRunId}`)
+
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CC ${testRunId}`,
+      slug: `cc-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+    ])
+
+    const body = {
+      runtimeKind: "claude-code-channel",
+      instanceId: `cc-inst-${testRunId}`,
+      runtimeSessionId: `cc-sess-${testRunId}`,
+      displayName: "Claude Code - test",
+      localCwd: "/tmp/threa-cc-test",
+    }
+
+    const first = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      body
+    )
+    expect(first.status).toBe(200)
+    expect(first.data.data.linkId).toBeTruthy()
+    expect(first.data.data.activeStreamId).toBeTruthy()
+
+    const second = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      body
+    )
+    expect(second.status).toBe(200)
+    // Same scratchpad, not a fresh one (and not a 500).
+    expect(second.data.data.linkId).toBe(first.data.data.linkId)
+    expect(second.data.data.activeStreamId).toBe(first.data.data.activeStreamId)
+  })
+
+  test("rejects a link-free runtime kind", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-reject-${testRunId}@test.com`, "CC Reject User")
+    const workspace = await createWorkspace(client, `CC Reject WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCR ${testRunId}`,
+      slug: `ccr-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE])
+
+    const res = await botApiPost(client, workspace.id, "/bot-runtime/sessions", apiKey, {
+      runtimeKind: "openclaw",
+      instanceId: `oc-inst-${testRunId}`,
+      runtimeSessionId: `oc-sess-${testRunId}`,
+      displayName: "Openclaw",
+    })
+    expect(res.status).toBe(400)
+  })
+
+  test("a user message round-trips: active-scratchpad dispatch → claim → reply", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-rt-${testRunId}@test.com`, "CC Roundtrip User")
+    const workspace = await createWorkspace(client, `CC Roundtrip WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCRT ${testRunId}`,
+      slug: `ccrt-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE,
+    ])
+
+    const instanceId = `ccrt-inst-${testRunId}`
+    const runtimeSessionId = `ccrt-sess-${testRunId}`
+    const session = await botApiPost<{ data: SessionLinkData }>(client, workspace.id, "/bot-runtime/sessions", apiKey, {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      displayName: "Claude Code - rt",
+      localCwd: "/tmp/threa-cc-rt",
+    })
+    expect(session.status).toBe(200)
+    const streamId = session.data.data.activeStreamId
+
+    // The user posts in the scratchpad; the bot is its active actor, so this
+    // dispatches an active-scratchpad invocation targeted to our session.
+    await sendMessage(client, workspace.id, streamId, "Reply with exactly: forty-two")
+
+    const claimBody = {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      supportedCapabilities: ["active-scratchpad", "mentionable"],
+      claimTtlSeconds: 120,
+    }
+    let claimed: ClaimedInvocationData | null = null
+    for (let i = 0; i < 30 && !claimed; i++) {
+      const res = await botApiPost<{ data: ClaimedInvocationData | null }>(
+        client,
+        workspace.id,
+        "/bot-invocations/claim",
+        apiKey,
+        claimBody
+      )
+      if (res.status === 200 && res.data.data) claimed = res.data.data
+      else await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    expect(claimed).not.toBeNull()
+    expect(claimed!.requiredCapability).toBe("active-scratchpad")
+    expect(claimed!.promptMarkdown).toContain("forty-two")
+
+    const completed = await botApiPost<{ data: { invocationId: string; message: { content: string } | null } }>(
+      client,
+      workspace.id,
+      `/bot-invocations/${claimed!.id}/complete`,
+      apiKey,
+      { instanceId, claimToken: claimed!.claimToken, finalMessageMarkdown: "forty-two" }
+    )
+    expect(completed.status).toBe(200)
+    expect(completed.data.data.message?.content).toContain("forty-two")
+  })
+})

--- a/docs/claude-code-channel.md
+++ b/docs/claude-code-channel.md
@@ -37,7 +37,7 @@ The extension is a single MCP server (`src/index.ts` → `ChannelServer`). Claud
 - `ChannelServer` (`src/channel-server.ts`) owns the MCP `Server`, a socket.io connection to the `/bot` namespace, and the bridge logic.
 - `config.ts` resolves credentials and derives stable ids.
 
-It talks to production Threa over HTTPS and a websocket. There are **no backend changes**: it uses the public bot-runtime API that already exists for Pi.
+It talks to Threa over HTTPS and a websocket, reusing the public bot-runtime API that already serves Pi. The only backend change is making `claude-code-channel` a first-class linked runtime kind (see [A first-class runtime kind](#a-first-class-runtime-kind) below) — small and additive; everything else rides the existing rails.
 
 ## Startup: linking a scratchpad
 

--- a/docs/claude-code-channel.md
+++ b/docs/claude-code-channel.md
@@ -1,0 +1,122 @@
+# Driving Claude Code from Threa (the channel extension)
+
+This explains how `extensions/claude-code-remote/` lets you control a local Claude Code session from a Threa scratchpad, the same way `extensions/pi-remote/` does for Pi. Read this to understand the mechanism; the README covers setup.
+
+## The two halves, and why they're inverted
+
+There are two independent systems to bridge, and they push in opposite directions.
+
+**Claude Code channels** are a _push-into-the-session_ mechanism. A "channel" is an MCP server that Claude Code launches as a subprocess and talks to over stdio. The channel pushes events into the running session as MCP notifications, and Claude reads them as `<channel source="…">…</channel>` blocks. If the channel exposes a `reply` tool, Claude can call it to send something back out. The channel is the active party: it decides when to inject an event.
+
+**Threa's bot-runtime** is a _pull-from-the-queue_ mechanism. A runtime (like the Pi extension) registers presence, then claims work from Threa. When a human posts a message in a scratchpad whose "active actor" is the bot, the backend writes a `bot_invocation` row and notifies the runtime over a `/bot` websocket. The runtime claims the invocation, does the work, streams trace steps, and completes it with a final reply that posts back into the scratchpad. Threa is the queue; the runtime is a worker that pulls.
+
+So Claude Code wants to _receive pushes_, and Threa wants to _be pulled from_. The channel extension is the adapter that sits between them: it is a Threa worker on one side and a Claude Code channel on the other, turning each claimed invocation into a pushed channel event, and each `reply` tool call into an invocation completion.
+
+```
+  Threa web/mobile                    your machine
+ ┌────────────────┐        ┌──────────────────────────────────────────┐
+ │  scratchpad     │       │  claude (the running session)             │
+ │  "fix the bug"  │       │      ▲  pushes <channel> events            │
+ └───────┬─────────┘       │      │  + exposes the reply tool           │
+         │ message         │  ┌───┴───────────────────────────┐        │
+         ▼                 │  │ threa channel (MCP subprocess) │        │
+ ┌─────────────────┐       │  │  - claims invocations          │        │
+ │  Threa backend   │◄──────┼──┤  - pushes them into the session│        │
+ │  bot-runtime API │  HTTP │  │  - reply tool -> /complete     │        │
+ │  + /bot socket   │──────►│  │  - relays permission prompts   │        │
+ └─────────────────┘ claim  │  └────────────────────────────────┘        │
+        pushes              └──────────────────────────────────────────┘
+   bot_invocation:available
+```
+
+## What runs where
+
+The extension is a single MCP server (`src/index.ts` → `ChannelServer`). Claude Code spawns it with `bun src/index.ts` when you start with `--dangerously-load-development-channels server:threa`. Inside that one process:
+
+- `ThreaClient` (`src/threa-client.ts`) is a thin HTTP client for the Threa bot-runtime API plus a websocket-hint resolver.
+- `ChannelServer` (`src/channel-server.ts`) owns the MCP `Server`, a socket.io connection to the `/bot` namespace, and the bridge logic.
+- `config.ts` resolves credentials and derives stable ids.
+
+It talks to production Threa over HTTPS and a websocket. There are **no backend changes**: it uses the public bot-runtime API that already exists for Pi.
+
+## Startup: linking a scratchpad
+
+When the process starts it:
+
+1. Reads `THREA_WORKSPACE_ID` / `THREA_API_KEY` (env or `~/.claude/threa-channel/config.json`) and derives an `instanceId` and `runtimeSessionId` by hashing `hostname + cwd`. Deriving them from the directory means relaunching Claude Code in the same project reuses the same scratchpad instead of spawning a new one each time.
+2. `POST /bot-runtime/sessions`, which **creates a scratchpad**, sets the bot as that scratchpad's **active actor**, registers presence, and returns the session link (and the scratchpad URL, which it logs).
+3. Resolves the region websocket URL (`GET /api/workspaces/:ws/config`) and connects the `/bot` socket, sending `bot:hello`.
+4. Marks presence `available` and starts a backstop claim poll.
+
+### A first-class runtime kind
+
+The channel reports `runtimeKind: "claude-code-channel"`. Originally only `pi-local` could create a session link (the session-create schema was pinned to it, and `claude-code-channel` was configured `sessionLinking: "none"`), so the first cut rode the Pi rails by presenting as `pi-local`. The backend now treats `claude-code-channel` as a first-class linked kind: the session-create schema accepts it, the service stamps the presence and link rows with it, and `runtime-kind-config` gives it `sessionLinking: "required"` with its own "not linked" notice. The only Pi-specific bit withheld is session-control (`/compact`, `/model`, …), which a channel can't drive and so doesn't advertise. The backend change was small and additive — see `apps/backend/src/features/public-api/schemas.ts`, `bot-runtimes/runtime-kind-config.ts`, and `bot-runtimes/service.ts`.
+
+## Inbound: a Threa message becomes a Claude prompt
+
+1. You type in the scratchpad. Because the bot is the active actor, the backend writes a `bot_invocation` (trigger `active-scratchpad`) targeted at this session and emits `bot_invocation:available` over the socket.
+2. The channel claims it (`POST /bot-invocations/claim`). The claim response already carries the prompt **and** the hydrated recent conversation, so no extra fetch is needed.
+3. The channel pushes it into the session:
+
+   ```
+   mcp.notification({
+     method: 'notifications/claude/channel',
+     params: {
+       content: "<the prompt + compact history>",
+       meta: { invocation_id, stream_id, source_message_id },
+     },
+   })
+   ```
+
+   Claude sees `<channel source="threa" invocation_id="…">…</channel>` and starts working against your real files.
+
+4. The channel tracks the invocation as "in-flight", flips presence to `busy`, and records one trace step so the scratchpad's session card shows activity.
+
+A claim holds a lease (`claimTtlSeconds`, max 300) that expires if not renewed, so the channel renews every in-flight claim on a timer for as long as Claude is still working.
+
+The channel handles one turn at a time. A message you send while Claude is still working waits in Threa until the current turn completes, then gets claimed and pushed. The one exception is a permission verdict (below), which is pulled through immediately so a blocked turn can continue.
+
+## Outbound: the reply tool completes the invocation
+
+The channel exposes one tool, `reply(invocation_id, text)`. Claude is told (via the server's `instructions`, which land in its system prompt) to call it exactly once per `<channel>` event. When Claude calls it:
+
+1. The channel looks up the in-flight invocation by `invocation_id`.
+2. It calls `POST /bot-invocations/:id/complete` with `finalMessageMarkdown: text`. That posts the reply into the scratchpad and closes the invocation.
+3. It clears the in-flight entry, and when nothing is in flight, flips presence back to `available`.
+
+The `reply` tool is the only path back to Threa, which is why the instructions insist on it. As a safety net, an in-flight invocation that is never answered is force-closed after `replyTimeoutMs` (default 30 minutes) with a short notice, so a session can't get wedged in `busy` forever.
+
+## Permission relay: approving tools from Threa
+
+When Claude calls a tool that needs approval and you're not at the terminal, the session would normally stall. The channel opts into permission relay (`claude/channel/permission`). The loop:
+
+1. Claude Code sends the channel a `notifications/claude/channel/permission_request` with a five-letter `request_id`, the tool name, and a short description.
+2. The channel posts that into the scratchpad as a normal message: _"Claude Code wants to run `Bash`… Reply `yes abcde` or `no abcde`."_
+3. You reply in the scratchpad. That reply is itself a scratchpad message, so it comes back to the channel as another claimed invocation. The channel recognizes the `yes <id>` / `no <id>` shape against its open requests and, instead of pushing it to Claude as a new prompt, sends Claude Code the verdict (`notifications/claude/channel/permission`) and silently closes that invocation.
+
+The local terminal dialog stays open the whole time, so whichever answer arrives first wins. Because anyone who can post in the scratchpad can approve, only enable relay in workspaces you trust. Disable it with `THREA_PERMISSION_RELAY=0`, or skip prompts entirely with `--dangerously-skip-permissions` for unattended use.
+
+## Resilience
+
+- If the `/bot` socket can't connect (or drops), the backstop poll keeps claiming work; the socket just makes delivery near-instant.
+- If linking the scratchpad fails at startup (Threa briefly unreachable), the poll loop retries the link on its next tick.
+- The MCP transport is stdout, so the extension never writes there: all diagnostics go to stderr, surfaced in `~/.claude/debug/<session-id>.txt` and `/mcp`.
+- On shutdown it fails any in-flight invocations and marks presence `offline`.
+
+## Pi extension vs. this channel
+
+| Concern                                   | Pi extension (`pi-remote`)                                | This channel (`claude-code-remote`)                                  |
+| ----------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| Where it runs                             | Inside Pi, via Pi's extension API                         | A subprocess Claude Code spawns over stdio                           |
+| How it gets a prompt                      | Claims invocation, injects via `pi.sendUserMessage`       | Claims invocation, pushes a `notifications/claude/channel` event     |
+| How it returns a reply                    | Hooks Pi's `agent_end`, posts the captured assistant text | Claude calls the `reply` tool, which completes the invocation        |
+| Trace detail                              | Rich per-tool steps (it hooks Pi's tool events)           | One "working" step (a channel can't see Claude's tool calls)         |
+| Session control (`/compact`, `/model`, …) | Yes                                                       | No (a channel can't drive Claude's session)                          |
+| Permission prompts                        | N/A (Pi runs the model in-process)                        | Relayed into the scratchpad as messages                              |
+| Backend changes                           | None                                                      | Small — `claude-code-channel` made a first-class linked runtime kind |
+
+## Limits today
+
+- Single "working" trace step rather than a per-tool trace.
+- Threa attachments aren't downloaded into the working directory.
+- No session-control commands (a channel can't drive Claude's host session).

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1038,7 +1038,7 @@
                 "$schema": "https://json-schema.org/draft/2020-12/schema",
                 "type": "object",
                 "properties": {
-                  "runtimeKind": { "type": "string", "const": "pi-local" },
+                  "runtimeKind": { "type": "string", "enum": ["pi-local", "claude-code-channel"] },
                   "instanceId": { "type": "string", "minLength": 1, "maxLength": 128 },
                   "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "displayName": { "type": "string", "minLength": 1, "maxLength": 100 },

--- a/extensions/claude-code-remote/.mcp.json.example
+++ b/extensions/claude-code-remote/.mcp.json.example
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "threa": {
+      "command": "bun",
+      "args": ["/ABSOLUTE/PATH/TO/threa/extensions/claude-code-remote/src/index.ts"],
+      "env": {
+        "THREA_WORKSPACE_ID": "ws_replace_me",
+        "THREA_API_KEY": "threa_bk_replace_me"
+      }
+    }
+  }
+}

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -1,0 +1,129 @@
+# Threa channel for Claude Code
+
+A [Claude Code channel](https://code.claude.com/docs/en/channels) that links a running Claude Code session to a Threa scratchpad. You type in the scratchpad (from the web app or your phone), the message lands in your local Claude Code session, Claude does the work against your real files, and the reply posts back into the scratchpad.
+
+It is the Claude Code counterpart to `extensions/pi-remote/` and rides the same Threa bot-runtime API, so a linked Claude Code session shows up in Threa exactly like a linked Pi session: a presence pill on the scratchpad, an agent-session trace card, and a `BOT`-tagged reply.
+
+See [`docs/claude-code-channel.md`](../../docs/claude-code-channel.md) for how it works end to end.
+
+## Requirements
+
+- [Bun](https://bun.sh)
+- Claude Code 2.1.80 or later (channels are a research-preview feature)
+- A Threa **personal** bot with a bot API key (steps below)
+- Anthropic auth via claude.ai or a Console API key (channels are not available on Bedrock/Vertex/Foundry)
+
+## Setup
+
+### 1. Create a Threa bot and key
+
+In Threa: **Workspace settings → Bots**.
+
+1. Create a **personal** bot (e.g. "Claude Code"). Give it the **Active scratchpad** trait. Add **Mentionable** too if you also want to reach it with `@`.
+2. Open the bot, add an **API key**, and grant these scopes:
+   - `bot-runtime:write`
+   - `bot-invocations:write`
+   - `messages:read`
+   - `messages:write` (only needed for permission relay)
+   - `streams:read`
+   - `attachments:read`
+3. Copy the key (`threa_bk_…`, shown once) and your workspace id (`ws_…`).
+
+The bot must be **personal**: the session-link endpoint that creates the scratchpad and makes the bot its active actor rejects shared bots. Linking auto-repairs the `active-scratchpad` trait if you forgot it.
+
+### 2. Install dependencies
+
+```bash
+cd extensions/claude-code-remote
+bun install
+```
+
+### 3. Configure credentials
+
+Either set environment variables, or write `~/.claude/threa-channel/config.json`. Environment variables win over the file.
+
+```bash
+export THREA_WORKSPACE_ID=ws_...
+export THREA_API_KEY=threa_bk_...
+# optional
+export THREA_BASE_URL=https://app.threa.io        # default
+export THREA_DISPLAY_NAME="Claude Code"           # prefix; the project dir is appended
+export THREA_PERMISSION_RELAY=1                    # 1 (default) to relay approvals, 0 to disable
+```
+
+`~/.claude/threa-channel/config.json`:
+
+```json
+{
+  "baseUrl": "https://app.threa.io",
+  "workspaceId": "ws_...",
+  "apiKey": "threa_bk_...",
+  "displayName": "Claude Code",
+  "permissionRelay": true
+}
+```
+
+### 4. Register the channel with Claude Code
+
+Add the server to your MCP config. Use `.mcp.json.example` as a template. For a project, drop it in `.mcp.json`; for all projects, add the block to `~/.claude.json`. User-level config needs the **absolute** path to `src/index.ts`. You can put the credentials in the `env` block instead of the shell.
+
+### 5. Launch Claude Code with the channel
+
+Custom channels are not on the research-preview allowlist, so start Claude Code with the development flag:
+
+```bash
+claude --dangerously-load-development-channels server:threa
+```
+
+A dim line under the banner confirms the channel registered. The channel logs the scratchpad URL to stderr on startup (see `~/.claude/debug/<session-id>.txt`); the scratchpad also appears in the Threa sidebar as `Claude Code - <project>`.
+
+### 6. Drive it from Threa
+
+Open the scratchpad in Threa and type a message. No `@`-mention needed: the bot is the scratchpad's active actor, so every message you post is forwarded to your Claude Code session. The presence pill shows **Available** / **Working**. Claude's answer posts back as a `BOT` message.
+
+## Permission relay
+
+Away from the terminal, a tool that needs approval would normally stall the session. With `THREA_PERMISSION_RELAY=1` (default), the approval prompt is posted into the scratchpad as a message:
+
+> **Claude Code wants to run `Bash`**: list the project files
+> Reply `yes abcde` to allow or `no abcde` to deny.
+
+Reply `yes <id>` or `no <id>` in the scratchpad and the channel forwards your verdict to Claude Code. The local terminal dialog also stays open, so whichever answer arrives first wins. Anyone who can post in the scratchpad can approve, so only relay in workspaces you trust.
+
+For fully unattended use you can instead skip prompts entirely:
+
+```bash
+claude --dangerously-load-development-channels server:threa --dangerously-skip-permissions
+```
+
+Only do that in a directory you trust. Also consider pre-allowing the `mcp__threa__reply` tool so posting replies never prompts.
+
+## Configuration reference
+
+| Env var                    | Config key         | Default                | Meaning                                         |
+| -------------------------- | ------------------ | ---------------------- | ----------------------------------------------- |
+| `THREA_BASE_URL`           | `baseUrl`          | `https://app.threa.io` | Threa app origin                                |
+| `THREA_WORKSPACE_ID`       | `workspaceId`      | (required)             | `ws_…`                                          |
+| `THREA_API_KEY`            | `apiKey`           | (required)             | `threa_bk_…` bot key                            |
+| `THREA_DISPLAY_NAME`       | `displayName`      | `Claude Code`          | Scratchpad name prefix; project dir appended    |
+| `THREA_PERMISSION_RELAY`   | `permissionRelay`  | `true`                 | Relay tool-approval prompts into the scratchpad |
+| `THREA_POLL_MS`            | `pollMs`           | `3000`                 | Backstop claim poll (the socket pushes faster)  |
+| `THREA_REPLY_TIMEOUT_MS`   | `replyTimeoutMs`   | `1800000`              | Close an unanswered request after this many ms  |
+| `THREA_INSTANCE_ID`        | `instanceId`       | derived                | Override the per-directory instance id          |
+| `THREA_RUNTIME_SESSION_ID` | `runtimeSessionId` | derived                | Override the per-directory session id           |
+
+By default the instance and session ids are derived from your hostname and the working directory, so re-launching Claude Code in the same project reuses the same scratchpad.
+
+## Tests
+
+```bash
+bun test
+bun run typecheck
+```
+
+## Limitations
+
+- A channel only sees the inbound message and the reply, not Claude's individual tool calls, so the Threa trace card shows a single "working" step rather than the per-tool trace a Pi session produces.
+- Attachments posted in Threa are not downloaded into the working directory yet.
+- Claude must call the `reply` tool to close a request. If a turn ends without a reply, the request is force-closed after `replyTimeoutMs` with a short notice.
+- One turn at a time: a message sent while Claude is still working is handled after the current reply (a permission verdict is the exception and goes through immediately).

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -124,6 +124,16 @@ bun run typecheck
 ## Limitations
 
 - A channel only sees the inbound message and the reply, not Claude's individual tool calls, so the Threa trace card shows a single "working" step rather than the per-tool trace a Pi session produces.
-- Attachments posted in Threa are not downloaded into the working directory yet.
 - Claude must call the `reply` tool to close a request. If a turn ends without a reply, the request is force-closed after `replyTimeoutMs` with a short notice.
 - One turn at a time: a message sent while Claude is still working is handled after the current reply (a permission verdict is the exception and goes through immediately).
+
+## Roadmap (parity with `pi-remote`)
+
+- **Attachments, both directions** — download attachments posted in the scratchpad into the working directory so Claude can read them, and send local files back as attachments on the reply (Pi does this with a `THREA_ATTACH: <path>` directive that uploads the file and rewrites it to an attachment link). This is the main remaining gap.
+- Per-tool trace steps — a channel can't observe Claude's tool calls, so matching Pi's rich trace needs a different mechanism than Pi's lifecycle hooks.
+
+## Troubleshooting
+
+- **The channel doesn't show in `/mcp` and never prompts.** If you ever answered "No" to the _"Use this MCP server?"_ prompt for `threa` in a project, Claude Code records it in `disabledMcpjsonServers` in that project's `.claude/settings.local.json` and then silently skips it — no prompt, no `/mcp` entry, no hint. Remove `"threa"` from `disabledMcpjsonServers` (or add it to `enabledMcpjsonServers`) there, or re-enable it from the `/mcp` menu, then restart.
+- **`--channels server:threa` warns it's "not on the approved list."** That flag only loads allowlisted plugins; a custom channel is loaded with `--dangerously-load-development-channels server:threa` instead — drop `--channels`.
+- **Logs.** Diagnostics go to stderr, captured by Claude Code in `~/.claude/debug/<session-id>.txt`: `[threa-channel] linked to scratchpad …` means it connected; `could not link …` means the backend is unreachable (check `THREA_BASE_URL`).

--- a/extensions/claude-code-remote/bun.lock
+++ b/extensions/claude-code-remote/bun.lock
@@ -1,0 +1,229 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@threa/claude-code-remote",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "socket.io-client": "^4.8.1",
+        "zod": "^3.23.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.9.3",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "engine.io-client": ["engine.io-client@6.6.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+  }
+}

--- a/extensions/claude-code-remote/package.json
+++ b/extensions/claude-code-remote/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@threa/claude-code-remote",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "A Claude Code channel that bridges a running Claude Code session to a Threa scratchpad, so you can drive Claude Code remotely from Threa the same way you drive Pi.",
+  "bin": {
+    "threa-channel": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "bun run ./src/index.ts",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "socket.io-client": "^4.8.1",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.9.3"
+  }
+}

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { buildInstructions, formatInvocationContent, parsePermissionVerdict } from "./channel-server"
+import type { ClaimedInvocation } from "./threa-client"
+
+function makeInvocation(partial: Partial<ClaimedInvocation>): ClaimedInvocation {
+  return {
+    id: "binv_1",
+    workspaceId: "ws_1",
+    rootStreamId: "stream_root",
+    activeStreamId: "stream_root",
+    sourceMessageId: "src",
+    responseStreamId: "stream_root",
+    actor: { type: "bot", id: "bot_1", slug: "claude" },
+    trigger: "active-scratchpad",
+    requiredCapability: "active-scratchpad",
+    promptMarkdown: "Do the thing",
+    authorUserId: "user_1",
+    mentionedActorSlugs: [],
+    claimToken: "tok",
+    claimExpiresAt: "2026-06-16T00:00:00.000Z",
+    runtimeSessionId: "ccs_1",
+    metadata: {},
+    ...partial,
+  }
+}
+
+describe("parsePermissionVerdict", () => {
+  test("parses allow/deny in long and short forms", () => {
+    expect(parsePermissionVerdict("yes abcde")).toEqual({ behavior: "allow", requestId: "abcde" })
+    expect(parsePermissionVerdict("y abcde")).toEqual({ behavior: "allow", requestId: "abcde" })
+    expect(parsePermissionVerdict("no abcde")).toEqual({ behavior: "deny", requestId: "abcde" })
+    expect(parsePermissionVerdict("n abcde")).toEqual({ behavior: "deny", requestId: "abcde" })
+  })
+
+  test("tolerates surrounding whitespace and autocorrect caps", () => {
+    expect(parsePermissionVerdict("  YES ABCDE  ")).toEqual({ behavior: "allow", requestId: "abcde" })
+  })
+
+  test("rejects ids using 'l' (outside Claude Code's id alphabet)", () => {
+    expect(parsePermissionVerdict("yes ablde")).toBeNull()
+  })
+
+  test("rejects ordinary chat that isn't a verdict", () => {
+    expect(parsePermissionVerdict("yes please do it")).toBeNull()
+    expect(parsePermissionVerdict("approve it")).toBeNull()
+    expect(parsePermissionVerdict("yes")).toBeNull()
+  })
+})
+
+describe("formatInvocationContent", () => {
+  test("returns just the prompt when there is no prior context", () => {
+    expect(formatInvocationContent(makeInvocation({ promptMarkdown: "Fix the bug" }))).toBe("Fix the bug")
+  })
+
+  test("falls back to a placeholder for an empty prompt", () => {
+    expect(formatInvocationContent(makeInvocation({ promptMarkdown: "   " }))).toBe("(empty message)")
+  })
+
+  test("appends history but excludes the source message itself", () => {
+    const content = formatInvocationContent(
+      makeInvocation({
+        promptMarkdown: "Now do Y",
+        sourceMessageId: "src",
+        context: {
+          kind: "inline",
+          messages: [
+            {
+              messageId: "m1",
+              role: "user",
+              authorId: "u",
+              authorType: "user",
+              authorDisplayName: "Alice",
+              contentMarkdown: "did X",
+              createdAt: "t1",
+            },
+            {
+              messageId: "src",
+              role: "user",
+              authorId: "u",
+              authorType: "user",
+              authorDisplayName: "Alice",
+              contentMarkdown: "Now do Y",
+              createdAt: "t2",
+            },
+          ],
+        },
+      })
+    )
+    expect(content).toContain("Now do Y")
+    expect(content).toContain("Earlier in this scratchpad")
+    expect(content).toContain("- Alice: did X")
+    // the source message must not be duplicated into the history block
+    expect(content.match(/Now do Y/g)?.length).toBe(1)
+  })
+
+  test("truncates an over-long history message", () => {
+    const content = formatInvocationContent(
+      makeInvocation({
+        context: {
+          kind: "inline",
+          messages: [
+            {
+              messageId: "m1",
+              role: "user",
+              authorId: "u",
+              authorType: "user",
+              contentMarkdown: "z".repeat(5000),
+              createdAt: "t1",
+            },
+          ],
+        },
+      })
+    )
+    expect(content.includes("z".repeat(2000))).toBe(true)
+    expect(content.includes("z".repeat(2001))).toBe(false)
+  })
+})
+
+describe("buildInstructions", () => {
+  test("always tells Claude to reply with the invocation_id", () => {
+    const text = buildInstructions(false)
+    expect(text).toContain("reply")
+    expect(text).toContain("invocation_id")
+  })
+
+  test("mentions permission forwarding only when relay is enabled", () => {
+    expect(buildInstructions(true).toLowerCase()).toContain("approv")
+    expect(buildInstructions(false).toLowerCase()).not.toContain("approv")
+  })
+})

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -115,6 +115,12 @@ export class ChannelServer {
   private renewTimer: ReturnType<typeof setInterval> | undefined
   private readonly inflight = new Map<string, Inflight>()
   private readonly openPermissions = new Map<string, { cleanup: ReturnType<typeof setTimeout> }>()
+  // The invocation whose turn is executing — the stream a relayed permission
+  // prompt belongs in. Set when a non-verdict invocation is pushed to Claude;
+  // it's the turn that can trigger a tool-approval prompt. Tracking it beats
+  // guessing from the in-flight map, where a follow-up message claimed during
+  // an open-permission window would otherwise be picked as the (wrong) target.
+  private activeTurnStreamId: string | undefined
 
   constructor(
     private readonly config: ThreaChannelConfig,
@@ -314,6 +320,9 @@ export class ChannelServer {
 
     const deadline = setTimeout(() => void this.onReplyTimeout(invocation.id), this.config.replyTimeoutMs)
     this.inflight.set(invocation.id, { invocation, deadline })
+    // This is the turn Claude is now executing; a permission prompt it triggers
+    // belongs in this invocation's stream (see handlePermissionRequest).
+    this.activeTurnStreamId = invocation.responseStreamId
     await this.syncPresence()
     await this.client
       .recordStep(invocation.id, {
@@ -375,6 +384,7 @@ export class ChannelServer {
         ],
       }
     }
+    if (this.activeTurnStreamId === entry.invocation.responseStreamId) this.activeTurnStreamId = undefined
     await this.syncPresence()
     return { content: [{ type: "text", text: "sent" }] }
   }
@@ -391,6 +401,7 @@ export class ChannelServer {
         metadata: { "cc.channel.invocationId": invocationId, "cc.channel.timedOut": "true" },
       })
       .catch((error) => log(`timeout completion failed: ${this.summarize(error)}`))
+    if (this.activeTurnStreamId === entry.invocation.responseStreamId) this.activeTurnStreamId = undefined
     await this.syncPresence()
   }
 
@@ -404,9 +415,9 @@ export class ChannelServer {
   // --- Permission relay -----------------------------------------------------
 
   private async handlePermissionRequest(params: z.infer<typeof PermissionRequestSchema>["params"]): Promise<void> {
-    // Post into the stream the in-flight turn is conversing in (where the user
-    // is reading and will reply), falling back to the scratchpad root.
-    const targetStreamId = [...this.inflight.values()].at(-1)?.invocation.responseStreamId ?? this.link?.rootStreamId
+    // Post into the executing turn's stream (where the user is reading and will
+    // reply), falling back to the scratchpad root.
+    const targetStreamId = this.activeTurnStreamId ?? this.link?.rootStreamId
     if (!targetStreamId) return
     // Drop the open request after the same window we give a reply, so an
     // abandoned/cancelled prompt the user never answers doesn't leak forever.
@@ -521,10 +532,16 @@ export class ChannelServer {
             claimTtlSeconds: CLAIM_TTL_SECONDS,
           })
           .catch((error) => {
-            if (error instanceof ThreaApiError && error.status === 404) this.clearInflight(id)
-            // Surface other failures: a swallowed renew error can let the claim
-            // lapse silently, after which the eventual reply 404s and is lost.
-            else log(`renew ${id} failed: ${this.summarize(error)}`)
+            if (error instanceof ThreaApiError && error.status === 404) {
+              // The claim's gone server-side; drop it and resync presence so a
+              // last-in-flight 404 doesn't strand the runtime as busy.
+              this.clearInflight(id)
+              void this.syncPresence()
+            } else {
+              // Surface other failures: a swallowed renew error can let the claim
+              // lapse silently, after which the eventual reply 404s and is lost.
+              log(`renew ${id} failed: ${this.summarize(error)}`)
+            }
           })
       }
     }, RENEW_INTERVAL_MS)

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -1,0 +1,587 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import { io as openSocket, type Socket } from "socket.io-client"
+import { z } from "zod"
+import type { ThreaChannelConfig } from "./config"
+import {
+  buildBotSocketUrl,
+  isObject,
+  ThreaApiError,
+  ThreaClient,
+  type ClaimedInvocation,
+  type RuntimeSessionLink,
+  type WsHint,
+} from "./threa-client"
+
+const RUNTIME_KIND = "claude-code-channel"
+const SUPPORTED_CAPABILITIES = ["active-scratchpad", "mentionable"] as const
+export const CHANNEL_SOURCE = "threa"
+const CLAIM_TTL_SECONDS = 120
+// Renew at a third of the lease so a single transient renew failure can't let
+// the claim expire (two misses still leaves a full interval of margin).
+const RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
+const WS_BACKSTOP_POLL_MS = 30_000
+const MAX_CLAIMS_PER_DRAIN = 20
+const MAX_CONTEXT_MESSAGES = 12
+const MAX_MESSAGE_CHARS = 2_000
+
+/** "y abcde" / "yes abcde" / "n abcde" / "no abcde". The id alphabet skips 'l' (Claude Code's convention). */
+export const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
+
+const PermissionRequestSchema = z.object({
+  method: z.literal("notifications/claude/channel/permission_request"),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
+  }),
+})
+
+export interface PermissionVerdict {
+  behavior: "allow" | "deny"
+  requestId: string
+}
+
+export function parsePermissionVerdict(text: string): PermissionVerdict | null {
+  const match = PERMISSION_REPLY_RE.exec(text)
+  if (!match) return null
+  return {
+    behavior: match[1]!.toLowerCase().startsWith("y") ? "allow" : "deny",
+    requestId: match[2]!.toLowerCase(),
+  }
+}
+
+/**
+ * Turn a claimed invocation into the body Claude reads. The source message is
+ * the request; any hydrated history follows as compact context. The body is
+ * delivered inside `<channel source="threa" invocation_id="…">…</channel>`.
+ */
+export function formatInvocationContent(invocation: ClaimedInvocation): string {
+  const prompt = invocation.promptMarkdown.trim() || "(empty message)"
+  const history = (invocation.context?.messages ?? [])
+    .filter((message) => message.messageId !== invocation.sourceMessageId)
+    .slice(-MAX_CONTEXT_MESSAGES)
+    .map((message) => {
+      const author = message.authorDisplayName?.trim() || message.role
+      const content = message.contentMarkdown.trim().slice(0, MAX_MESSAGE_CHARS)
+      return `- ${author}: ${content}`
+    })
+
+  if (history.length === 0) return prompt
+  return [prompt, "", "Earlier in this scratchpad (oldest first, for context):", ...history].join("\n")
+}
+
+export function buildInstructions(permissionRelay: boolean): string {
+  const lines = [
+    `You are linked to a Threa scratchpad through the "${CHANNEL_SOURCE}" channel.`,
+    "",
+    `Messages a user posts in that scratchpad arrive as <channel source="${CHANNEL_SOURCE}" invocation_id="…" stream_id="…">…the message…</channel>.`,
+    "",
+    "For each such event:",
+    "- Do the work it asks for in this session, against the real files.",
+    "- Then call the `reply` tool exactly once, passing the `invocation_id` from that event's tag and your answer as `text`. The reply tool is the ONLY way your answer reaches the user, and it closes the request on Threa — so always reply, even with a short acknowledgement.",
+    "- One reply per invocation_id. If several events arrive together, reply to each by its own id.",
+  ]
+  if (permissionRelay) {
+    lines.push(
+      "",
+      "When you use a tool that needs approval, Claude Code forwards the prompt to the Threa scratchpad for the user to approve there. Proceed normally; you don't need to do anything special."
+    )
+  }
+  return lines.join("\n")
+}
+
+interface Inflight {
+  invocation: ClaimedInvocation
+  deadline: ReturnType<typeof setTimeout>
+}
+
+function log(message: string): void {
+  // stdout is the MCP transport — everything diagnostic goes to stderr.
+  process.stderr.write(`[threa-channel] ${message}\n`)
+}
+
+export class ChannelServer {
+  private readonly mcp: Server
+  private link: RuntimeSessionLink | undefined
+  private socket: Socket | undefined
+  private socketConnected = false
+  private connectingSocket = false
+  private claiming = false
+  private stopped = false
+  private pollTimer: ReturnType<typeof setTimeout> | undefined
+  private renewTimer: ReturnType<typeof setInterval> | undefined
+  private readonly inflight = new Map<string, Inflight>()
+  private readonly openPermissions = new Map<string, { cleanup: ReturnType<typeof setTimeout> }>()
+
+  constructor(
+    private readonly config: ThreaChannelConfig,
+    private readonly client: ThreaClient
+  ) {
+    const capabilities: Record<string, unknown> = {
+      experimental: { "claude/channel": {} },
+      tools: {},
+    }
+    if (config.permissionRelay) {
+      ;(capabilities.experimental as Record<string, unknown>)["claude/channel/permission"] = {}
+    }
+    this.mcp = new Server(
+      { name: CHANNEL_SOURCE, version: "0.1.0" },
+      { capabilities, instructions: buildInstructions(config.permissionRelay) }
+    )
+    this.registerHandlers()
+  }
+
+  /** Connect the stdio transport so Claude Code can talk to the server and discover tools. */
+  async connectStdio(): Promise<void> {
+    await this.mcp.connect(new StdioServerTransport())
+  }
+
+  private registerHandlers(): void {
+    this.mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: "reply",
+          description:
+            "Send your answer back to the Threa scratchpad and close the request. Call once per invocation_id.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              invocation_id: {
+                type: "string",
+                description: "The invocation_id from the <channel> event you are answering.",
+              },
+              text: { type: "string", description: "Your reply, as markdown." },
+            },
+            required: ["invocation_id", "text"],
+          },
+        },
+      ],
+    }))
+
+    this.mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
+      if (req.params.name !== "reply") {
+        return { isError: true, content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }] }
+      }
+      const args = (req.params.arguments ?? {}) as { invocation_id?: unknown; text?: unknown }
+      const invocationId = typeof args.invocation_id === "string" ? args.invocation_id : ""
+      const text = typeof args.text === "string" ? args.text : ""
+      if (!invocationId || !text.trim()) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: "reply requires a non-empty invocation_id and text." }],
+        }
+      }
+      return this.handleReply(invocationId, text)
+    })
+
+    if (this.config.permissionRelay) {
+      this.mcp.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
+        await this.handlePermissionRequest(params)
+      })
+    }
+  }
+
+  // --- Lifecycle ------------------------------------------------------------
+
+  async start(): Promise<void> {
+    await this.verifyPrincipal()
+    await this.ensureLink()
+    await this.connectSocket()
+    this.startRenewTimer()
+    this.startPoll()
+    await this.claimDrain()
+  }
+
+  /** Create (or recover) the scratchpad link. Best-effort so a transient Threa outage self-heals on the next poll tick. */
+  private async ensureLink(): Promise<void> {
+    if (this.link || this.stopped) return
+    try {
+      this.link = await this.createSession()
+      log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
+      await this.syncPresence()
+    } catch (error) {
+      log(`could not link to Threa (will retry): ${this.summarize(error)}`)
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.stopped) return
+    this.stopped = true
+    if (this.pollTimer) clearTimeout(this.pollTimer)
+    if (this.renewTimer) clearInterval(this.renewTimer)
+    for (const [, open] of this.openPermissions) clearTimeout(open.cleanup)
+    this.openPermissions.clear()
+    // Fast, idempotent teardown first so SIGTERM cleanup isn't held hostage by
+    // slow fail() calls when Threa is the thing that's unreachable.
+    if (this.socket) {
+      try {
+        this.socket.removeAllListeners()
+        this.socket.disconnect()
+      } catch {
+        // already closed
+      }
+    }
+    const inflight = [...this.inflight]
+    for (const [, entry] of inflight) clearTimeout(entry.deadline)
+    this.inflight.clear()
+    await this.client.upsertPresence(this.presenceBody("offline")).catch(() => undefined)
+    await Promise.allSettled(
+      inflight.map(([id, entry]) =>
+        this.client.fail(id, {
+          instanceId: this.config.instanceId,
+          claimToken: entry.invocation.claimToken,
+          errorMessage: "Claude Code channel shut down",
+        })
+      )
+    )
+  }
+
+  private async verifyPrincipal(): Promise<void> {
+    try {
+      const me = await this.client.getMe()
+      if (me.kind !== "bot") {
+        log("WARNING: the configured API key is not a bot key (threa_bk_…). Bot-runtime endpoints will reject it.")
+      }
+    } catch (error) {
+      log(`could not verify principal (continuing): ${this.summarize(error)}`)
+    }
+  }
+
+  private async createSession(): Promise<RuntimeSessionLink> {
+    return this.client.createSession({
+      runtimeKind: RUNTIME_KIND,
+      instanceId: this.config.instanceId,
+      runtimeSessionId: this.config.runtimeSessionId,
+      displayName: this.config.displayName,
+      localCwd: process.cwd(),
+    })
+  }
+
+  // --- Claiming -------------------------------------------------------------
+
+  private async claimDrain(): Promise<void> {
+    if (this.stopped || this.claiming) return
+    this.claiming = true
+    try {
+      for (let i = 0; i < MAX_CLAIMS_PER_DRAIN; i++) {
+        // One turn at a time: once something is in flight, stop pulling new work
+        // and let the queue wait — unless a permission request is open. Its
+        // verdict arrives as an ordinary message (a claimable invocation) and the
+        // in-flight turn is blocked until we route it, so we keep draining. (A
+        // non-verdict message sent in that window is forwarded too and simply
+        // queues behind the blocked turn in Claude's session.)
+        if (this.inflight.size > 0 && this.openPermissions.size === 0) break
+        const invocation = await this.client.claim(this.claimBody())
+        if (!invocation) break
+        await this.handleClaimed(invocation)
+      }
+    } catch (error) {
+      log(`claim failed: ${this.summarize(error)}`)
+    } finally {
+      this.claiming = false
+    }
+  }
+
+  private async handleClaimed(invocation: ClaimedInvocation): Promise<void> {
+    // A relayed permission verdict ("yes abcde") arrives as an ordinary message,
+    // hence as a claimed invocation. Recognize it and route it to Claude Code as
+    // a verdict instead of pushing it into the session as a fresh prompt.
+    if (this.config.permissionRelay) {
+      const verdict = parsePermissionVerdict(invocation.promptMarkdown)
+      if (verdict) {
+        const open = this.openPermissions.get(verdict.requestId)
+        if (open) {
+          clearTimeout(open.cleanup)
+          this.openPermissions.delete(verdict.requestId)
+          await this.notify("notifications/claude/channel/permission", {
+            request_id: verdict.requestId,
+            behavior: verdict.behavior,
+          })
+          await this.client
+            .complete(invocation.id, {
+              instanceId: this.config.instanceId,
+              claimToken: invocation.claimToken,
+              noResponse: true,
+            })
+            .catch((error) => log(`verdict ack failed: ${this.summarize(error)}`))
+          return
+        }
+      }
+    }
+
+    const deadline = setTimeout(() => void this.onReplyTimeout(invocation.id), this.config.replyTimeoutMs)
+    this.inflight.set(invocation.id, { invocation, deadline })
+    await this.syncPresence()
+    await this.client
+      .recordStep(invocation.id, {
+        instanceId: this.config.instanceId,
+        claimToken: invocation.claimToken,
+        stepType: "thinking",
+        content: "Forwarded to Claude Code.",
+        statusText: "Working in Claude Code…",
+      })
+      .catch(() => undefined)
+    await this.notify("notifications/claude/channel", {
+      content: formatInvocationContent(invocation),
+      meta: {
+        invocation_id: invocation.id,
+        stream_id: invocation.responseStreamId,
+        source_message_id: invocation.sourceMessageId,
+      },
+    })
+  }
+
+  // --- Reply ----------------------------------------------------------------
+
+  private async handleReply(
+    invocationId: string,
+    text: string
+  ): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `No open request with invocation_id ${invocationId} (already answered, expired, or unknown).`,
+          },
+        ],
+      }
+    }
+    // Clear the entry (and its deadline) before awaiting complete(), so the
+    // reply-timeout can't fire mid-await and double-complete the invocation.
+    this.clearInflight(invocationId)
+    try {
+      await this.client.complete(invocationId, {
+        instanceId: this.config.instanceId,
+        claimToken: entry.invocation.claimToken,
+        finalMessageMarkdown: text,
+        metadata: { "cc.channel.invocationId": invocationId, "cc.channel.instanceId": this.config.instanceId },
+      })
+    } catch (error) {
+      // Re-arm (with a fresh deadline) so Claude can retry the reply. Safe from
+      // double-complete because the original deadline was already cleared.
+      const deadline = setTimeout(() => void this.onReplyTimeout(invocationId), this.config.replyTimeoutMs)
+      this.inflight.set(invocationId, { invocation: entry.invocation, deadline })
+      await this.syncPresence()
+      return {
+        isError: true,
+        content: [
+          { type: "text", text: `Failed to post reply to Threa (will stay open for retry): ${this.summarize(error)}` },
+        ],
+      }
+    }
+    await this.syncPresence()
+    return { content: [{ type: "text", text: "sent" }] }
+  }
+
+  private async onReplyTimeout(invocationId: string): Promise<void> {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) return
+    this.clearInflight(invocationId)
+    await this.client
+      .complete(invocationId, {
+        instanceId: this.config.instanceId,
+        claimToken: entry.invocation.claimToken,
+        finalMessageMarkdown: "_Claude Code ended the turn without sending a reply._",
+        metadata: { "cc.channel.invocationId": invocationId, "cc.channel.timedOut": "true" },
+      })
+      .catch((error) => log(`timeout completion failed: ${this.summarize(error)}`))
+    await this.syncPresence()
+  }
+
+  private clearInflight(invocationId: string): void {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) return
+    clearTimeout(entry.deadline)
+    this.inflight.delete(invocationId)
+  }
+
+  // --- Permission relay -----------------------------------------------------
+
+  private async handlePermissionRequest(params: z.infer<typeof PermissionRequestSchema>["params"]): Promise<void> {
+    // Post into the stream the in-flight turn is conversing in (where the user
+    // is reading and will reply), falling back to the scratchpad root.
+    const targetStreamId = [...this.inflight.values()].at(-1)?.invocation.responseStreamId ?? this.link?.rootStreamId
+    if (!targetStreamId) return
+    // Drop the open request after the same window we give a reply, so an
+    // abandoned/cancelled prompt the user never answers doesn't leak forever.
+    const existing = this.openPermissions.get(params.request_id)
+    if (existing) clearTimeout(existing.cleanup)
+    const cleanup = setTimeout(() => this.openPermissions.delete(params.request_id), this.config.replyTimeoutMs)
+    this.openPermissions.set(params.request_id, { cleanup })
+    const preview = params.input_preview ? `\n\n\`${params.input_preview.slice(0, 200)}\`` : ""
+    const content = [
+      `**Claude Code wants to run \`${params.tool_name}\`**`,
+      params.description,
+      preview,
+      "",
+      `Reply \`yes ${params.request_id}\` to allow or \`no ${params.request_id}\` to deny.`,
+    ]
+      .filter(Boolean)
+      .join("\n")
+    await this.client
+      .sendMessage(targetStreamId, {
+        content,
+        clientMessageId: `ccperm-${params.request_id}`,
+        metadata: { "cc.channel.permissionRequest": params.request_id },
+      })
+      .catch((error) => log(`permission relay send failed: ${this.summarize(error)}`))
+  }
+
+  // --- Socket ---------------------------------------------------------------
+
+  private async connectSocket(): Promise<void> {
+    // resolveWsHint is a network call; guard so the boot call and the first
+    // poll tick can't both pass it and open two sockets.
+    if (this.socket || this.connectingSocket || this.stopped) return
+    this.connectingSocket = true
+    try {
+      let hint: WsHint | undefined
+      try {
+        hint = await this.client.resolveWsHint()
+      } catch (error) {
+        log(`ws hint resolve failed (falling back to polling): ${this.summarize(error)}`)
+      }
+      if (hint) this.attachSocket(hint)
+    } finally {
+      this.connectingSocket = false
+    }
+  }
+
+  private attachSocket(hint: WsHint): void {
+    if (this.socket || this.stopped) return
+    let socket: Socket
+    try {
+      socket = openSocket(buildBotSocketUrl(hint), {
+        path: hint.path,
+        auth: { token: this.config.apiKey },
+        transports: ["websocket"],
+        reconnection: true,
+        reconnectionDelayMax: 30_000,
+      })
+    } catch (error) {
+      log(`socket attach failed (polling only): ${this.summarize(error)}`)
+      return
+    }
+    this.socket = socket
+    socket.on("connect", () => {
+      this.socketConnected = true
+      this.sendHello()
+    })
+    socket.on("disconnect", () => {
+      this.socketConnected = false
+    })
+    socket.on("connect_error", (error) => {
+      this.socketConnected = false
+      log(`socket connect_error: ${this.summarize(error)}`)
+    })
+    socket.on("bot_invocation:available", () => void this.claimDrain())
+    socket.on("bot:resync", () => this.sendHello())
+  }
+
+  private sendHello(): void {
+    if (!this.socket) return
+    this.socket.emit(
+      "bot:hello",
+      {
+        instanceId: this.config.instanceId,
+        runtimeKind: RUNTIME_KIND,
+        runtimeSessionId: this.config.runtimeSessionId,
+        displayName: this.config.displayName,
+        supportedCapabilities: [...SUPPORTED_CAPABILITIES],
+        capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
+        manifest: { output: { reply: true, trace: true, sources: false } },
+      },
+      (ack: unknown) => {
+        if (!isObject(ack) || ack.ok !== true) {
+          log(`bot:hello rejected: ${isObject(ack) ? String(ack.error) : "no ack"}`)
+          return
+        }
+        const available = Array.isArray(ack.availableInvocations) ? ack.availableInvocations.length : 0
+        const owned = Array.isArray(ack.ownedClaims) ? ack.ownedClaims.length : 0
+        if (available > 0 || owned > 0) void this.claimDrain()
+      }
+    )
+  }
+
+  // --- Timers ---------------------------------------------------------------
+
+  private startRenewTimer(): void {
+    this.renewTimer = setInterval(() => {
+      for (const [id, entry] of [...this.inflight]) {
+        this.client
+          .renew(id, {
+            instanceId: this.config.instanceId,
+            claimToken: entry.invocation.claimToken,
+            claimTtlSeconds: CLAIM_TTL_SECONDS,
+          })
+          .catch((error) => {
+            if (error instanceof ThreaApiError && error.status === 404) this.clearInflight(id)
+            // Surface other failures: a swallowed renew error can let the claim
+            // lapse silently, after which the eventual reply 404s and is lost.
+            else log(`renew ${id} failed: ${this.summarize(error)}`)
+          })
+      }
+    }, RENEW_INTERVAL_MS)
+  }
+
+  private startPoll(): void {
+    const tick = async () => {
+      if (this.stopped) return
+      if (!this.link) await this.ensureLink()
+      if (!this.socket) await this.connectSocket()
+      await this.claimDrain()
+      const delay = this.socketConnected ? WS_BACKSTOP_POLL_MS : this.config.pollMs
+      this.pollTimer = setTimeout(() => void tick(), delay)
+    }
+    this.pollTimer = setTimeout(() => void tick(), this.config.pollMs)
+  }
+
+  // --- Helpers --------------------------------------------------------------
+
+  /** Push presence derived from the current in-flight count, so rapid transitions converge on the truth. */
+  private async syncPresence(): Promise<void> {
+    const busy = this.inflight.size > 0
+    await this.client
+      .upsertPresence(this.presenceBody(busy ? "busy" : "available", busy ? "Working in Claude Code…" : undefined))
+      .catch(() => undefined)
+  }
+
+  private presenceBody(status: "available" | "busy" | "offline", statusText?: string): Record<string, unknown> {
+    return {
+      runtimeKind: RUNTIME_KIND,
+      instanceId: this.config.instanceId,
+      runtimeSessionId: this.config.runtimeSessionId,
+      displayName: this.config.displayName,
+      status,
+      acceptingInvocations: status === "available",
+      capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
+      ...(statusText ? { statusText } : {}),
+    }
+  }
+
+  private claimBody(): Record<string, unknown> {
+    return {
+      runtimeKind: RUNTIME_KIND,
+      instanceId: this.config.instanceId,
+      runtimeSessionId: this.config.runtimeSessionId,
+      supportedCapabilities: [...SUPPORTED_CAPABILITIES],
+      claimTtlSeconds: CLAIM_TTL_SECONDS,
+    }
+  }
+
+  private async notify(method: string, params: Record<string, unknown>): Promise<void> {
+    await this.mcp
+      .notification({ method, params })
+      .catch((error) => log(`notify ${method} failed: ${this.summarize(error)}`))
+  }
+
+  private summarize(error: unknown): string {
+    return (error instanceof Error ? error.message : String(error)).slice(0, 200)
+  }
+}

--- a/extensions/claude-code-remote/src/config.test.ts
+++ b/extensions/claude-code-remote/src/config.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test"
+import { defaultDisplayName, deriveStableId, loadConfig, sanitizeId } from "./config"
+
+const ID_CHARSET = /^[A-Za-z0-9_-]+$/
+
+describe("deriveStableId", () => {
+  test("is deterministic for the same seed and prefixed", () => {
+    const a = deriveStableId("cc", "host:/Users/kris/dev/threa")
+    const b = deriveStableId("cc", "host:/Users/kris/dev/threa")
+    expect(a).toBe(b)
+    expect(a.startsWith("cc-")).toBe(true)
+  })
+
+  test("differs for different seeds", () => {
+    expect(deriveStableId("cc", "host:/a")).not.toBe(deriveStableId("cc", "host:/b"))
+  })
+
+  test("stays within the hello-schema charset and 64-char cap", () => {
+    const id = deriveStableId("ccs", "kristoffers-mbp.lan:/Users/kris/dev/threa")
+    expect(id).toMatch(ID_CHARSET)
+    expect(id.length).toBeLessThanOrEqual(64)
+  })
+})
+
+describe("sanitizeId", () => {
+  test("replaces unsafe chars and trims separators", () => {
+    expect(sanitizeId("kristoffers-mbp.lan")).toBe("kristoffers-mbp-lan")
+    expect(sanitizeId("--abc--")).toBe("abc")
+    expect(sanitizeId("a..b..c")).toBe("a-b-c")
+  })
+})
+
+describe("defaultDisplayName", () => {
+  test("appends the project dir to a default prefix", () => {
+    expect(defaultDisplayName("/Users/kris/dev/threa")).toBe("Claude Code - threa")
+  })
+  test("uses a configured override as the prefix", () => {
+    expect(defaultDisplayName("/Users/kris/dev/threa", "Work")).toBe("Work - threa")
+  })
+  test("ignores a trailing slash and clamps to 100 chars", () => {
+    expect(defaultDisplayName("/Users/kris/dev/threa/")).toBe("Claude Code - threa")
+    expect(defaultDisplayName("/a", "x".repeat(200)).length).toBe(100)
+  })
+})
+
+describe("loadConfig", () => {
+  const base = { cwd: "/Users/kris/dev/threa", hostname: "host" }
+
+  test("errors when required credentials are missing", () => {
+    const result = loadConfig({ ...base, env: {} })
+    expect("error" in result).toBe(true)
+    if ("error" in result) {
+      expect(result.error).toContain("THREA_WORKSPACE_ID")
+      expect(result.error).toContain("THREA_API_KEY")
+    }
+  })
+
+  test("resolves from env and derives stable ids", () => {
+    const result = loadConfig({
+      ...base,
+      env: { THREA_WORKSPACE_ID: "ws_1", THREA_API_KEY: "threa_bk_x" },
+    })
+    expect("config" in result).toBe(true)
+    if ("config" in result) {
+      expect(result.config.workspaceId).toBe("ws_1")
+      expect(result.config.apiKey).toBe("threa_bk_x")
+      expect(result.config.baseUrl).toBe("https://app.threa.io")
+      expect(result.config.instanceId).toMatch(ID_CHARSET)
+      expect(result.config.runtimeSessionId).toMatch(ID_CHARSET)
+      expect(result.config.permissionRelay).toBe(true)
+      // Same host+cwd resolves to the same scratchpad on the next launch.
+      const again = loadConfig({ ...base, env: { THREA_WORKSPACE_ID: "ws_1", THREA_API_KEY: "threa_bk_x" } })
+      if ("config" in again) expect(again.config.instanceId).toBe(result.config.instanceId)
+    }
+  })
+
+  test("appends the project dir to the display name (default prefix and override)", () => {
+    const def = loadConfig({ ...base, env: { THREA_WORKSPACE_ID: "ws_1", THREA_API_KEY: "threa_bk_x" } })
+    if ("config" in def) expect(def.config.displayName).toBe("Claude Code - threa")
+    const override = loadConfig({
+      ...base,
+      env: { THREA_WORKSPACE_ID: "ws_1", THREA_API_KEY: "threa_bk_x", THREA_DISPLAY_NAME: "Work" },
+    })
+    if ("config" in override) expect(override.config.displayName).toBe("Work - threa")
+  })
+
+  test("env overrides file values", () => {
+    const result = loadConfig({
+      ...base,
+      env: { THREA_WORKSPACE_ID: "ws_env", THREA_API_KEY: "threa_bk_env" },
+      file: { workspaceId: "ws_file", apiKey: "threa_bk_file", baseUrl: "https://staging.threa.io" },
+    })
+    if ("config" in result) {
+      expect(result.config.workspaceId).toBe("ws_env")
+      expect(result.config.baseUrl).toBe("https://staging.threa.io")
+    }
+  })
+
+  test("parses permissionRelay off and clamps pollMs", () => {
+    const result = loadConfig({
+      ...base,
+      env: {
+        THREA_WORKSPACE_ID: "ws_1",
+        THREA_API_KEY: "threa_bk_x",
+        THREA_PERMISSION_RELAY: "0",
+        THREA_POLL_MS: "10",
+      },
+    })
+    if ("config" in result) {
+      expect(result.config.permissionRelay).toBe(false)
+      expect(result.config.pollMs).toBe(1000)
+    }
+  })
+
+  test("honors explicit instanceId / runtimeSessionId overrides", () => {
+    const result = loadConfig({
+      ...base,
+      env: {
+        THREA_WORKSPACE_ID: "ws_1",
+        THREA_API_KEY: "threa_bk_x",
+        THREA_INSTANCE_ID: "my.instance",
+        THREA_RUNTIME_SESSION_ID: "my.session",
+      },
+    })
+    if ("config" in result) {
+      expect(result.config.instanceId).toBe("my-instance")
+      expect(result.config.runtimeSessionId).toBe("my-session")
+    }
+  })
+})

--- a/extensions/claude-code-remote/src/config.ts
+++ b/extensions/claude-code-remote/src/config.ts
@@ -1,0 +1,139 @@
+import { createHash } from "node:crypto"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export const CONFIG_DIR = join(homedir(), ".claude", "threa-channel")
+export const CONFIG_PATH = join(CONFIG_DIR, "config.json")
+
+export interface ThreaChannelConfig {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+  /** Scratchpad display name: the configured prefix (default "Claude Code") with the project directory appended. */
+  displayName: string
+  /** `^[A-Za-z0-9_-]+$`, ≤64 — must satisfy the `/bot` hello schema. */
+  instanceId: string
+  runtimeSessionId: string
+  /** Relay Claude Code permission prompts into the scratchpad for remote approval. */
+  permissionRelay: boolean
+  /** Backstop claim-poll cadence; the `/bot` socket pushes work faster than this. */
+  pollMs: number
+  /** Safety net: an in-flight invocation with no `reply` is force-closed after this. */
+  replyTimeoutMs: number
+}
+
+const UNSAFE_ID_CHARS = /[^A-Za-z0-9_-]+/g
+
+export function sanitizeId(raw: string): string {
+  return raw.replace(UNSAFE_ID_CHARS, "-").replace(/^-+|-+$/g, "")
+}
+
+/**
+ * Deterministic id from a seed (host + cwd), so the same project directory
+ * always maps back to the same Threa scratchpad across Claude Code restarts —
+ * no on-disk session state to keep in sync.
+ */
+export function deriveStableId(prefix: string, seed: string): string {
+  const hash = createHash("sha256").update(seed).digest("hex").slice(0, 16)
+  return `${prefix}-${hash}`.slice(0, 64)
+}
+
+export function defaultDisplayName(cwd: string, override?: string): string {
+  const prefix = override?.trim() ? override.trim() : "Claude Code"
+  const dir = cwd.split("/").filter(Boolean).pop() ?? "session"
+  const name = `${prefix} - ${dir}`
+  // upsertPresenceSchema caps displayName at 100 chars.
+  return name.length > 100 ? name.slice(0, 100) : name
+}
+
+export interface RawConfig {
+  baseUrl?: unknown
+  workspaceId?: unknown
+  apiKey?: unknown
+  displayName?: unknown
+  permissionRelay?: unknown
+  pollMs?: unknown
+  replyTimeoutMs?: unknown
+  instanceId?: unknown
+  runtimeSessionId?: unknown
+}
+
+export function parseConfigFile(text: string): RawConfig {
+  const parsed = JSON.parse(text) as unknown
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("config file must be a JSON object")
+  }
+  return parsed as RawConfig
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function parseBool(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value
+  const s = str(value)?.toLowerCase()
+  if (s === undefined) return fallback
+  if (["0", "false", "no", "off"].includes(s)) return false
+  if (["1", "true", "yes", "on"].includes(s)) return true
+  return fallback
+}
+
+function parseNum(value: unknown, fallback: number, min: number): number {
+  const n = typeof value === "number" ? value : Number(str(value))
+  return Number.isFinite(n) ? Math.max(min, Math.floor(n)) : fallback
+}
+
+export interface LoadConfigInput {
+  env: Record<string, string | undefined>
+  cwd: string
+  hostname: string
+  file?: RawConfig
+}
+
+export type LoadConfigResult = { config: ThreaChannelConfig } | { error: string }
+
+/**
+ * Pure config resolver: file values are the base, environment variables win.
+ * Kept side-effect-free so it can be unit-tested without touching disk/env.
+ */
+export function loadConfig(input: LoadConfigInput): LoadConfigResult {
+  const { env, cwd, hostname, file = {} } = input
+
+  const baseUrl = str(env.THREA_BASE_URL) ?? str(file.baseUrl) ?? "https://app.threa.io"
+  const workspaceId = str(env.THREA_WORKSPACE_ID) ?? str(file.workspaceId)
+  const apiKey = str(env.THREA_API_KEY) ?? str(file.apiKey)
+
+  const missing = [!workspaceId && "THREA_WORKSPACE_ID", !apiKey && "THREA_API_KEY"].filter(Boolean)
+  if (missing.length > 0) {
+    return { error: `Missing required config: ${missing.join(", ")}. Set env vars or ${CONFIG_PATH}.` }
+  }
+
+  const displayName = defaultDisplayName(cwd, str(env.THREA_DISPLAY_NAME) ?? str(file.displayName))
+  const seed = `${hostname}:${cwd}`
+  const instanceId = sanitizeId(str(env.THREA_INSTANCE_ID) ?? str(file.instanceId) ?? deriveStableId("cc", seed)).slice(
+    0,
+    64
+  )
+  const runtimeSessionId = sanitizeId(
+    str(env.THREA_RUNTIME_SESSION_ID) ?? str(file.runtimeSessionId) ?? deriveStableId("ccs", seed)
+  ).slice(0, 64)
+
+  if (!instanceId || !runtimeSessionId) {
+    return { error: "Could not derive a valid instanceId/runtimeSessionId (empty after sanitization)." }
+  }
+
+  return {
+    config: {
+      baseUrl: baseUrl.replace(/\/$/, ""),
+      workspaceId: workspaceId!,
+      apiKey: apiKey!,
+      displayName,
+      instanceId,
+      runtimeSessionId,
+      permissionRelay: parseBool(env.THREA_PERMISSION_RELAY ?? file.permissionRelay, true),
+      pollMs: parseNum(env.THREA_POLL_MS ?? file.pollMs, 3000, 1000),
+      replyTimeoutMs: parseNum(env.THREA_REPLY_TIMEOUT_MS ?? file.replyTimeoutMs, 1_800_000, 60_000),
+    },
+  }
+}

--- a/extensions/claude-code-remote/src/index.ts
+++ b/extensions/claude-code-remote/src/index.ts
@@ -41,9 +41,11 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => void shutdown())
   process.on("SIGTERM", () => void shutdown())
 
-  await server.start().catch((error) => {
-    process.stderr.write(`[threa-channel] start failed: ${error instanceof Error ? error.message : String(error)}\n`)
-  })
+  // start() is best-effort internally (link/socket/presence self-heal on the
+  // poll loop); an error escaping it is an unexpected init failure, so fail loud
+  // — let it propagate to main().catch below, which logs and exits non-zero
+  // rather than leaving a connected-but-dead channel Claude can't detect.
+  await server.start()
 }
 
 main().catch((error) => {

--- a/extensions/claude-code-remote/src/index.ts
+++ b/extensions/claude-code-remote/src/index.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+import { existsSync, readFileSync } from "node:fs"
+import { hostname } from "node:os"
+import { ChannelServer } from "./channel-server"
+import { CONFIG_PATH, loadConfig, parseConfigFile, type RawConfig } from "./config"
+import { ThreaClient } from "./threa-client"
+
+function readFileConfig(): RawConfig | undefined {
+  if (!existsSync(CONFIG_PATH)) return undefined
+  try {
+    return parseConfigFile(readFileSync(CONFIG_PATH, "utf8"))
+  } catch (error) {
+    process.stderr.write(
+      `[threa-channel] ignoring ${CONFIG_PATH}: ${error instanceof Error ? error.message : String(error)}\n`
+    )
+    return undefined
+  }
+}
+
+async function main(): Promise<void> {
+  const result = loadConfig({ env: process.env, cwd: process.cwd(), hostname: hostname(), file: readFileConfig() })
+  if ("error" in result) {
+    process.stderr.write(`[threa-channel] ${result.error}\n`)
+    process.exit(1)
+  }
+
+  const client = new ThreaClient(result.config)
+  const server = new ChannelServer(result.config, client)
+
+  // Connect stdio first so Claude Code registers the channel and discovers the
+  // reply tool even while the Threa bridge is still spinning up.
+  await server.connectStdio()
+
+  let shuttingDown = false
+  const shutdown = async () => {
+    if (shuttingDown) return
+    shuttingDown = true
+    await server.shutdown().catch(() => undefined)
+    process.exit(0)
+  }
+  process.on("SIGINT", () => void shutdown())
+  process.on("SIGTERM", () => void shutdown())
+
+  await server.start().catch((error) => {
+    process.stderr.write(`[threa-channel] start failed: ${error instanceof Error ? error.message : String(error)}\n`)
+  })
+}
+
+main().catch((error) => {
+  process.stderr.write(`[threa-channel] fatal: ${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+})

--- a/extensions/claude-code-remote/src/threa-client.test.ts
+++ b/extensions/claude-code-remote/src/threa-client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test"
+import { buildBotSocketUrl, parseWsHint } from "./threa-client"
+
+describe("parseWsHint", () => {
+  test("accepts a wsUrl and defaults the socket.io path + /bot namespace", () => {
+    expect(parseWsHint({ url: "wss://eu.threa.io" })).toEqual({
+      url: "wss://eu.threa.io",
+      path: "/socket.io/",
+      namespace: "/bot",
+    })
+  })
+
+  test("preserves explicit path and namespace", () => {
+    expect(parseWsHint({ url: "wss://eu.threa.io", path: "/p/", namespace: "/bot" })).toEqual({
+      url: "wss://eu.threa.io",
+      path: "/p/",
+      namespace: "/bot",
+    })
+  })
+
+  test("rejects payloads without a usable url", () => {
+    expect(parseWsHint({ path: "/socket.io/" })).toBeUndefined()
+    expect(parseWsHint({ url: "   " })).toBeUndefined()
+    expect(parseWsHint(null)).toBeUndefined()
+    expect(parseWsHint("wss://eu.threa.io")).toBeUndefined()
+  })
+})
+
+describe("buildBotSocketUrl", () => {
+  test("appends the namespace to the pathname", () => {
+    expect(buildBotSocketUrl({ url: "https://eu.threa.io", path: "/socket.io/", namespace: "/bot" })).toBe(
+      "https://eu.threa.io/bot"
+    )
+  })
+
+  test("does not double the slash on a trailing-slash url", () => {
+    expect(buildBotSocketUrl({ url: "https://eu.threa.io/", path: "/socket.io/", namespace: "/bot" })).toBe(
+      "https://eu.threa.io/bot"
+    )
+  })
+
+  test("keeps a query string while appending the namespace (staging routes ?region=)", () => {
+    expect(
+      buildBotSocketUrl({ url: "https://ws-staging.threa.io?region=staging", path: "/socket.io/", namespace: "/bot" })
+    ).toBe("https://ws-staging.threa.io/bot?region=staging")
+  })
+})

--- a/extensions/claude-code-remote/src/threa-client.ts
+++ b/extensions/claude-code-remote/src/threa-client.ts
@@ -1,0 +1,192 @@
+const FETCH_TIMEOUT_MS = 30_000
+
+export interface WsHint {
+  url: string
+  path: string
+  namespace: string
+}
+
+export interface RuntimeSessionLink {
+  linkId: string
+  rootStreamId: string
+  activeStreamId: string
+  runtimeSessionId: string
+  streamUrlPath: string
+}
+
+export interface ExternalHistoryMessage {
+  messageId: string
+  role: "user" | "assistant"
+  authorId: string
+  authorType: string
+  authorDisplayName?: string
+  contentMarkdown: string
+  createdAt: string
+}
+
+export interface ClaimedInvocation {
+  id: string
+  workspaceId: string
+  rootStreamId: string
+  activeStreamId: string
+  sourceMessageId: string
+  responseStreamId: string
+  actor: { type: "bot"; id: string; slug: string }
+  trigger: string
+  requiredCapability: string
+  promptMarkdown: string
+  authorUserId: string
+  mentionedActorSlugs: string[]
+  claimToken: string
+  claimExpiresAt: string
+  runtimeSessionId: string | null
+  metadata: Record<string, unknown>
+  context?: { kind: "inline"; messages: ExternalHistoryMessage[] }
+}
+
+export class ThreaApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message)
+    this.name = "ThreaApiError"
+  }
+}
+
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+export function parseWsHint(value: unknown): WsHint | undefined {
+  if (!isObject(value)) return undefined
+  const url = typeof value.url === "string" ? value.url.trim() : ""
+  if (!url) return undefined
+  const path = typeof value.path === "string" && value.path.trim() ? value.path : "/socket.io/"
+  const namespace = typeof value.namespace === "string" && value.namespace.trim() ? value.namespace : "/bot"
+  return { url, path, namespace }
+}
+
+/**
+ * Append the `/bot` namespace to the pathname while preserving any query string.
+ * Naive `${url}${namespace}` concat breaks staging URLs that carry `?region=…`.
+ */
+export function buildBotSocketUrl(hint: WsHint): string {
+  const parsed = new URL(hint.url)
+  const trimmedPath = parsed.pathname.replace(/\/$/, "")
+  parsed.pathname = `${trimmedPath}${hint.namespace}`
+  return parsed.toString()
+}
+
+export interface ThreaClientOptions {
+  baseUrl: string
+  workspaceId: string
+  apiKey: string
+}
+
+export class ThreaClient {
+  constructor(private readonly opts: ThreaClientOptions) {}
+
+  private get base(): string {
+    return this.opts.baseUrl.replace(/\/$/, "")
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await fetch(`${this.base}${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${this.opts.apiKey}`,
+          "Content-Type": "application/json",
+          ...init?.headers,
+        },
+      })
+    } finally {
+      clearTimeout(timeout)
+    }
+    if (!response.ok) {
+      // Don't read the body: proxy/server errors can return large HTML pages.
+      throw new ThreaApiError(`Threa API ${response.status}: ${response.statusText}`, response.status)
+    }
+    if (response.status === 204) return undefined as T
+    return (await response.json()) as T
+  }
+
+  private workspacePath(suffix: string): string {
+    return `/api/v1/workspaces/${this.opts.workspaceId}${suffix}`
+  }
+
+  /** Returns the authenticated principal; only `.kind` (`"bot"` vs `"user"`) is consumed today. */
+  async getMe(): Promise<{ kind: string }> {
+    const body = await this.request<{ data: { kind: string } }>(this.workspacePath("/me"))
+    return body.data
+  }
+
+  /** The wsUrl hint is served by the edge workspace-router at `/api/workspaces/:id/config` (NOT /api/v1). */
+  async resolveWsHint(): Promise<WsHint | undefined> {
+    const body = await this.request<{ wsUrl?: string }>(`/api/workspaces/${this.opts.workspaceId}/config`)
+    return parseWsHint({ url: body.wsUrl })
+  }
+
+  async upsertPresence(body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath("/bot-runtime/presence"), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async createSession(body: Record<string, unknown>): Promise<RuntimeSessionLink> {
+    const result = await this.request<{ data: RuntimeSessionLink }>(this.workspacePath("/bot-runtime/sessions"), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+    return result.data
+  }
+
+  async claim(body: Record<string, unknown>): Promise<ClaimedInvocation | null> {
+    const result = await this.request<{ data: ClaimedInvocation | null }>(
+      this.workspacePath("/bot-invocations/claim"),
+      { method: "POST", body: JSON.stringify(body) }
+    )
+    return result.data
+  }
+
+  async renew(invocationId: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath(`/bot-invocations/${invocationId}/renew`), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async recordStep(invocationId: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath(`/bot-invocations/${invocationId}/steps`), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async complete(invocationId: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath(`/bot-invocations/${invocationId}/complete`), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async fail(invocationId: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath(`/bot-invocations/${invocationId}/fail`), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  async sendMessage(streamId: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(this.workspacePath(`/streams/${streamId}/messages`), {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+}

--- a/extensions/claude-code-remote/tsconfig.json
+++ b/extensions/claude-code-remote/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Problem

You can drive **Pi** from a Threa scratchpad (`extensions/pi-remote/`): type in the scratchpad, Pi works against your real files, the reply posts back. There was no equivalent for **Claude Code**, even though Claude Code's [channels](https://code.claude.com/docs/en/channels) feature (research preview, ≥ 2.1.80) is built for exactly this — an MCP server that pushes events into a running session and lets Claude reply through a tool.

The backend half-anticipated it: `claude-code-channel` already existed in `BOT_RUNTIME_KINDS`, but as a stub — `runtime-kind-config` had it as `sessionLinking: "none"` and `createRuntimeSessionSchema` was pinned to `z.literal("pi-local")`. So the only runtime kind that could create a scratchpad, become its active actor, and receive targeted active-scratchpad turns was `pi-local`. A Claude Code channel had no first-class way onto those rails.

## Solution

Two halves:

1. **`extensions/claude-code-remote/`** — a Claude Code *channel* (an MCP stdio server Claude Code spawns) that bridges a running session to a Threa scratchpad. It's the Claude Code counterpart to `pi-remote`, riding the same bot-runtime API.
2. **Make `claude-code-channel` a first-class linked runtime kind** on the backend, so the channel uses its real kind rather than masquerading as `pi-local`.

The two systems push opposite ways — a Claude Code channel *pushes* events into the session and exposes a reply tool; Threa's bot-runtime is a *pull/claim* queue. The extension is the adapter between them.

### How it works

**The bridge (`extensions/claude-code-remote/src/channel-server.ts`).** On start it reads config, derives a per-cwd-stable `instanceId`/`runtimeSessionId` (so relaunching in the same directory reuses the same scratchpad), creates a runtime session (scratchpad + active-actor link), registers presence, connects the `/bot` socket (falling back to a poll if there's no `wsUrl`), and drains claims. For each claimed invocation it pushes `notifications/claude/channel` with the prompt + the claim's hydrated context, so Claude reads it as `<channel source="threa" invocation_id="…">…</channel>`; Claude calls the `reply` tool, whose handler calls `…/bot-invocations/:id/complete` and the answer posts into the scratchpad. Claims are renewed at ⅓ of the 120s lease while in flight; an unanswered turn is force-closed after `replyTimeoutMs` (default 30 min).

**Permission relay (opt-in, default on).** The channel declares `claude/channel/permission`. When Claude hits a tool-approval prompt, the request is posted into the scratchpad ("Reply `yes <id>` / `no <id>`"); the user's reply comes back as an ordinary scratchpad message — hence a claimed invocation — which the channel recognizes as a verdict (`parsePermissionVerdict`) and routes to Claude Code as `notifications/claude/channel/permission` instead of pushing it as a fresh prompt.

**Backend — `claude-code-channel` as a linked kind.**
- `createRuntimeSessionSchema` now accepts `z.enum(["pi-local", "claude-code-channel"])` — the two kinds whose turns are pinned to a session link.
- `createOrLinkPiRemoteSession[InTransaction]` takes a required `runtimeKind` and stamps it on both the presence and link rows, gating the Pi-only session-control capabilities (`/compact`, `/model`, …) the channel can't drive.
- `runtime-kind-config` gives `claude-code-channel` `sessionLinking: "required"` with its own missing-session-link notice.
- No migration: `runtime_kind` is `TEXT` (INV-3) and `claude-code-channel` was already a valid `BOT_RUNTIME_KINDS` value.

### Key design decisions

**1. Report the real `claude-code-channel` kind, not `pi-local`.** The first cut presented as `pi-local` to ride the active-scratchpad rails with zero backend change — but that's a masquerade that would mis-attribute the runtime and offer it Pi-only session-control commands. Making the kind first-class is a small, additive backend change and is the honest shape. The kind is invisible in the UI (the presence pill shows the display name).

**2. The session-link finder identifies a client by `(instanceId, runtimeSessionId)`, not by kind.** `findActivePiRemoteSession` hardcoded `runtime_kind = 'pi-local'`. A runtime client is uniquely identified by its instance+session; the kind is an attribute of that client, and the `(workspace_id, bot_id, runtime_kind, instance_id, runtime_session_id)` unique key already keeps rows distinct. Filtering the lookup on kind is what caused the reuse bug below.

**3. One turn at a time.** The channel can't observe Claude's turn lifecycle, only inbound + the reply. It claims serially (a follow-up sent mid-turn waits for the current reply), with one exception: while a permission request is open it keeps draining so the verdict can reach the blocked turn.

## Design evolution (found in live testing)

Running the real channel against a live local stack surfaced a bug the unit tests and typecheck missed: the **second** `createSession` for the same channel (i.e. every restart in the same directory) returned **500 — `duplicate key value violates unique constraint "bot_runtime_session_links_workspace_id_bot_id_runtime_kind__key"`**. Cause: `findActivePiRemoteSession` hardcoded `runtime_kind = 'pi-local'`, so it never found the existing `claude-code-channel` link, re-ran the create path, and the link insert (whose `ON CONFLICT` targets `(…, root_stream_id, active_stream_id)`) violated the `(…, runtime_kind, instance_id, runtime_session_id)` unique key. Fixed by dropping the kind filter from `findActiveByRuntimeSession` (decision 2); re-verified live (the second launch now reuses the same scratchpad) and locked with an idempotency e2e test. A side effect of the 500 loop — `createScratchpad` runs before the transaction, so each failed attempt left an empty scratchpad — is noted in Out of scope.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/channel-server.ts` | The MCP channel ⇄ bot-runtime bridge (claim → push → reply tool → complete, renewal, permission relay) |
| `extensions/claude-code-remote/src/threa-client.ts` | Bearer HTTP client for the bot-runtime API + `/bot` ws-hint helpers |
| `extensions/claude-code-remote/src/config.ts` | Env/file config + per-cwd-stable id derivation |
| `extensions/claude-code-remote/src/index.ts` | Entry: load config, connect stdio, start, signal handling |
| `extensions/claude-code-remote/src/*.test.ts` | Unit tests (config, ws-hint/socket-url, verdict regex, prompt format, instructions) |
| `extensions/claude-code-remote/{package.json,tsconfig.json,README.md,.mcp.json.example}` | Standalone package (outside the bun workspaces, like `pi-remote`) + setup docs |
| `docs/claude-code-channel.md` | End-to-end explainer of the mechanism |
| `apps/backend/src/features/bot-runtimes/runtime-kind-config.test.ts` | Unit test: `claude-code-channel` is `required` + has its notice; link-free kinds stay `none` |
| `apps/backend/tests/e2e/claude-code-channel-session.test.ts` | e2e: session create, idempotent reuse, reject link-free kind, full round-trip |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/public-api/schemas.ts` | `createRuntimeSessionSchema.runtimeKind` → `z.enum(["pi-local","claude-code-channel"])` |
| `apps/backend/src/features/public-api/handlers.ts` | Pass `runtimeKind: data.runtimeKind` into the session-link create |
| `apps/backend/src/features/bot-runtimes/runtime-kind-config.ts` | `claude-code-channel` → `sessionLinking: "required"` + missing-link notice |
| `apps/backend/src/features/bot-runtimes/service.ts` | `createOrLinkPiRemoteSession*` takes `runtimeKind` (presence + link rows, gates session-control caps); `findActivePiRemoteSession` no longer injects `pi-local` |
| `apps/backend/src/features/bot-runtimes/repository.ts` | `findActiveByRuntimeSession` drops the `runtime_kind` filter (the reuse-bug fix) |
| `apps/backend/src/features/public-api/schemas.test.ts` | Cases: accepts both linked kinds, rejects link-free kinds |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts` | Case: unlinked `claude-code-channel` posts its notice |
| `docs/public-api/openapi.json` | Regenerated (the `runtimeKind` enum) |

## Out of scope (deliberate)

- **Per-tool trace.** A channel sees only inbound + reply, not Claude's tool calls, so the Threa trace card shows one "working" step, not the per-tool trace a Pi session produces.
- **Session-control commands** (`/compact`, `/model`, …) — a channel can't drive Claude's host session, so the kind doesn't advertise them.
- **`renameBotRuntimeSession` for `claude-code-channel`.** The finder fix makes rename kind-agnostic, but the channel doesn't call rename; only Pi does today.
- **`createScratchpad` runs before the link transaction**, so a failed link orphans an empty scratchpad. Pre-existing structure shared with `pi-local`; the finder fix removes the only path that hit it repeatedly. Not refactored here.

## Follow-ups (planned)

The next milestone is real parity with `pi-remote`:

- **Attachments, both directions** — download attachments posted in the scratchpad into the working directory so Claude can read them, and send local files back as attachments on the reply (Pi does this with a `THREA_ATTACH: <path>` directive that uploads the file and rewrites it to an attachment link). This is the main remaining gap to "on-par with Pi for real".
- **Per-tool trace** — a channel can't observe Claude's tool calls, so matching Pi's rich trace card needs a different mechanism than Pi's lifecycle hooks.

The README now carries a `Roadmap` and a `Troubleshooting` section — the latter documenting the rough edge that bit during live testing: declining the *"Use this MCP server?"* prompt silently blacklists the server in `disabledMcpjsonServers`, after which it never appears in `/mcp`.

## Test plan

- [x] **Run live against a local stack** — the channel links its scratchpad, registers presence as `claude-code-channel`, and claims active-scratchpad invocations; the full claim→push→reply→complete path is covered by the e2e round-trip test
- [x] Extension `bun test` — 29 pass; `bunx tsc --noEmit` clean
- [x] Backend e2e `tests/e2e/claude-code-channel-session.test.ts` — 3 pass (session create, idempotent reuse, reject link-free, full round-trip dispatch→claim→reply)
- [x] Backend regression: pi-local `tests/e2e/bot-runtime-websocket.test.ts` + `commands.test.ts` + the new file — 11 pass across 3 files (pi-local flows unaffected)
- [x] Backend unit: `schemas.test.ts`, `runtime-kind-config.test.ts`, `service.test.ts`, `invocation-outbox-handler.test.ts` — 32 pass
- [x] Full monorepo `tsc --noEmit` + `tsc -p tsconfig.tests.json` clean (enforced by the pre-commit hook); `eslint` clean on changed files; OpenAPI `generate:api-docs:check` clean
- [x] **Live**: the real channel run against a local stack creates a `claude-code-channel` session and reuses the same scratchpad on relaunch (the 500 is gone); presence + link rows persist `runtime_kind = 'claude-code-channel'`
- [x] Self-review: 3 parallel reviewer workflows (Threa-contract conformance, channel-protocol conformance, correctness/concurrency, design). Findings fixed: double-complete race (clear deadline before `complete`), renew cadence vs lease, shutdown bounding, socket double-attach guard, permission-map leak, dead `defaultDisplayName` (wired in). The reuse-500 was caught later in live testing and fixed (above).
- [ ] Live full round-trip with a real Claude Code reply in the browser — **not done**: local dev uses real WorkOS, so a user message couldn't be posted autonomously. The full dispatch→claim→reply path is instead proven by the e2e round-trip test against the in-process test server. See the morning runbook in the PR thread.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784240232&installation_id=129946197&pr_number=978&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F978&signature=57057675cd175e6263610ed49982952351b889ef9a5498a58da191ee6afb5ad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->