### PR TITLE
refactor(frontend/e2ee): shared decrypted-cache primitive + lock-clear registry (slice 1)

### DIFF
--- a/apps/frontend/src/lib/crypto/__tests__/decrypted-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypted-cache.test.ts
@@ -70,6 +70,15 @@ describe("createDecryptedCache", () => {
     expect(cache.peek("k")).toBeUndefined()
   })
 
+  it("recovers after a rejected decrypt (no sticky in-flight)", async () => {
+    const cache = makeCache()
+    await expect(cache.request("k", () => Promise.reject(new Error("boom")))).rejects.toThrow("boom")
+    // The rejected attempt must not leave a stuck pending entry or in-flight promise.
+    expect(cache.peek("k")).toBeUndefined()
+    await cache.request("k", async () => ({ status: "decrypted", value: "recovered" }))
+    expect(cache.peek("k")).toEqual({ status: "decrypted", value: "recovered" })
+  })
+
   it("primes a known entry and skips a later decrypt", async () => {
     const cache = makeCache()
     cache.prime("k", { status: "decrypted", value: "seed" })
@@ -141,5 +150,21 @@ describe("lock-clear registry", () => {
     registerDecryptedCache(clear)
     clearAllDecrypted()
     expect(clear).toHaveBeenCalled()
+  })
+
+  it("runs every registered clear even when one throws, then surfaces the failure", async () => {
+    const cache = makeCache()
+    await cache.request("k", async () => ({ status: "decrypted", value: "x" }))
+    // Throw once so the registered clear doesn't poison later clearAllDecrypted calls.
+    let armed = true
+    registerDecryptedCache(() => {
+      if (armed) {
+        armed = false
+        throw new Error("boom")
+      }
+    })
+    expect(() => clearAllDecrypted()).toThrow()
+    // The healthy cache was still cleared despite the sibling throwing.
+    expect(cache.peek("k")).toBeUndefined()
   })
 })

--- a/apps/frontend/src/lib/crypto/__tests__/decrypted-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypted-cache.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest"
+import { clearAllDecrypted, createDecryptedCache, registerDecryptedCache, type DecryptStatus } from "../decrypted-cache"
+
+interface Entry {
+  status: DecryptStatus
+  value: string | null
+}
+
+function makeCache(overrides: Partial<Parameters<typeof createDecryptedCache<Entry>>[0]> = {}) {
+  return createDecryptedCache<Entry>({
+    subscription: "per-key",
+    pending: () => ({ status: "pending", value: null }),
+    ...overrides,
+  })
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe("createDecryptedCache", () => {
+  it("caches the settled entry and short-circuits a later request", async () => {
+    const cache = makeCache()
+    const run = vi.fn().mockResolvedValue({ status: "decrypted", value: "hi" } satisfies Entry)
+    await cache.request("k", run)
+    expect(cache.peek("k")).toEqual({ status: "decrypted", value: "hi" })
+    await cache.request("k", run)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent requests for the same key into one decrypt", async () => {
+    const cache = makeCache()
+    const run = vi.fn().mockResolvedValue({ status: "decrypted", value: "x" } satisfies Entry)
+    await Promise.all([cache.request("k", run), cache.request("k", run), cache.request("k", run)])
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats a failed entry as terminal when retryFailed is false", async () => {
+    const cache = makeCache({ retryFailed: false })
+    const run = vi.fn().mockResolvedValue({ status: "failed", value: null } satisfies Entry)
+    await cache.request("k", run)
+    await cache.request("k", run)
+    expect(cache.peek("k")).toEqual({ status: "failed", value: null })
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-attempts a failed entry when retryFailed is true", async () => {
+    const cache = makeCache({ retryFailed: true })
+    const run = vi.fn().mockResolvedValue({ status: "failed", value: null } satisfies Entry)
+    await cache.request("k", run)
+    await cache.request("k", run)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it("drops an in-flight decrypt that resolves after clear (no plaintext past lock)", async () => {
+    const cache = makeCache()
+    const d = deferred<Entry>()
+    const pending = cache.request("k", () => d.promise)
+    expect(cache.peek("k")).toEqual({ status: "pending", value: null })
+
+    cache.clear()
+    expect(cache.peek("k")).toBeUndefined()
+
+    d.resolve({ status: "decrypted", value: "secret" })
+    await pending
+    expect(cache.peek("k")).toBeUndefined()
+  })
+
+  it("primes a known entry and skips a later decrypt", async () => {
+    const cache = makeCache()
+    cache.prime("k", { status: "decrypted", value: "seed" })
+    expect(cache.peek("k")).toEqual({ status: "decrypted", value: "seed" })
+    const run = vi.fn().mockResolvedValue({ status: "decrypted", value: "crypto" } satisfies Entry)
+    await cache.request("k", run)
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it("honors skipPrime to avoid clobbering a decrypted entry", () => {
+    const cache = makeCache({ skipPrime: (existing) => existing?.status === "decrypted" })
+    cache.prime("k", { status: "decrypted", value: "first" })
+    cache.prime("k", { status: "decrypted", value: "second" })
+    expect(cache.peek("k")).toEqual({ status: "decrypted", value: "first" })
+  })
+
+  it("notifies a per-key listener for its key only, plus any global listener", async () => {
+    const cache = makeCache({ subscription: "per-key" })
+    const keyListener = vi.fn()
+    const otherListener = vi.fn()
+    const globalListener = vi.fn()
+    cache.subscribe("k", keyListener)
+    cache.subscribe("other", otherListener)
+    cache.subscribe(null, globalListener)
+    await cache.request("k", async () => ({ status: "decrypted", value: "x" }))
+    expect(keyListener).toHaveBeenCalledTimes(1)
+    expect(globalListener).toHaveBeenCalledTimes(1)
+    expect(otherListener).not.toHaveBeenCalled()
+  })
+
+  it("bumps the version on every change", async () => {
+    const cache = makeCache()
+    const before = cache.getVersion()
+    await cache.request("k", async () => ({ status: "decrypted", value: "x" }))
+    expect(cache.getVersion()).toBeGreaterThan(before)
+  })
+
+  it("evicts the least-recently-touched entry past the lru cap", async () => {
+    const cache = makeCache({ lru: 2 })
+    await cache.request("a", async () => ({ status: "decrypted", value: "a" }))
+    await cache.request("b", async () => ({ status: "decrypted", value: "b" }))
+    await cache.request("c", async () => ({ status: "decrypted", value: "c" }))
+    expect(cache.peek("a")).toBeUndefined()
+    expect(cache.peek("c")).toEqual({ status: "decrypted", value: "c" })
+  })
+
+  it("a global-subscription cache notifies its global listener on clear", async () => {
+    const cache = makeCache({ subscription: "global" })
+    await cache.request("k", async () => ({ status: "decrypted", value: "x" }))
+    const listener = vi.fn()
+    cache.subscribe(null, listener)
+    cache.clear()
+    expect(cache.peek("k")).toBeUndefined()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("lock-clear registry", () => {
+  it("clearAllDecrypted clears an auto-registered cache instance", async () => {
+    const cache = makeCache()
+    await cache.request("k", async () => ({ status: "decrypted", value: "x" }))
+    expect(cache.peek("k")).toEqual({ status: "decrypted", value: "x" })
+    clearAllDecrypted()
+    expect(cache.peek("k")).toBeUndefined()
+  })
+
+  it("clearAllDecrypted invokes an explicitly registered clear", () => {
+    const clear = vi.fn()
+    registerDecryptedCache(clear)
+    clearAllDecrypted()
+    expect(clear).toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/lib/crypto/attachment-crypto.ts
+++ b/apps/frontend/src/lib/crypto/attachment-crypto.ts
@@ -6,6 +6,7 @@ import {
   sealMessage,
   type AttachmentRef,
 } from "@threa/crypto"
+import { registerDecryptedCache } from "./decrypted-cache"
 
 // The `AttachmentRef` type and the `decryptAttachmentBytes` open primitive are
 // canonical in @threa/crypto so the enclave shares them (INV-35). Re-export them
@@ -59,3 +60,7 @@ export function getAttachmentRef(attachmentId: string): AttachmentRef | null {
 export function clearAttachmentRefCache(): void {
   pendingRefs.clear()
 }
+
+// The pre-send key bridge holds AES key material, so it dies on the same lock
+// boundary as decrypted plaintext via the single `clearAllDecrypted()` call site.
+registerDecryptedCache(clearAttachmentRefCache)

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -1,89 +1,53 @@
 import { tryDecryptMessagePayload, type DecryptedMessageContent, type DecryptMessageOpts } from "./message-envelope"
+import { createDecryptedCache, type DecryptStatus } from "./decrypted-cache"
 
 /**
- * In-memory cache for decrypted E2E message payloads.
+ * In-memory cache for decrypted E2E message payloads — a per-key instance of the
+ * shared {@link createDecryptedCache} primitive (which owns the inflight-dedup,
+ * lock-epoch guard, subscribe/version signal, LRU, and lock-clear registration).
  *
  * Ciphertext + envelope stay at rest in `db.events.payload` and decrypt only on
  * demand at render time. Each rendered message hits this cache; on miss, the
  * caller kicks off a decrypt and the cache notifies subscribers when it lands.
- *
- * Lifecycle:
- *  - Entries are inserted on successful (or failed) decrypt.
- *  - LRU eviction caps memory regardless of how many messages the user scrolls.
- *  - `clearDecryptCache()` drops everything; call it on session lock and on
- *    account switch so plaintext never outlives the unlocked session.
+ * `clearDecryptCache()` (also fired by `clearAllDecrypted` on lock) drops
+ * everything so plaintext never outlives the unlocked session.
  */
 
-export type DecryptStatus = "pending" | "decrypted" | "failed"
+export type { DecryptStatus }
 
 export interface DecryptCacheEntry {
   status: DecryptStatus
   content: DecryptedMessageContent | null
 }
 
-const MAX_ENTRIES = 500
-
-const entries = new Map<string, DecryptCacheEntry>()
-const inflight = new Map<string, Promise<DecryptCacheEntry>>()
-const listeners = new Map<string, Set<() => void>>()
-
-// Bumped by clearDecryptCache so in-flight decrypts that resolve after a lock
-// can detect they're stale and refuse to write plaintext back into the cache.
-let generation = 0
-
-// A monotonic version bumped on EVERY cache change, with its own listener set.
-// Per-id subscriptions (`subscribeToDecryption`) suit a single rendered message;
-// a batch reader (e.g. decrypted draft previews across a list) instead watches
-// this one signal and re-reads the ids it cares about.
-let cacheVersion = 0
-const versionListeners = new Set<() => void>()
-
-function emit(eventId: string): void {
-  cacheVersion++
-  for (const listener of versionListeners) listener()
-  const set = listeners.get(eventId)
-  if (!set) return
-  for (const listener of set) listener()
-}
+const cache = createDecryptedCache<DecryptCacheEntry>({
+  subscription: "per-key",
+  // LRU caps memory regardless of how many messages the user scrolls.
+  lru: 500,
+  // A message id is immutable: a decrypt that fails (wrong recipient, tampered
+  // AAD) is terminal, so a re-request must not retry.
+  retryFailed: false,
+  pending: () => ({ status: "pending", content: null }),
+  // A message id's first good decrypt is final, so a later seed must not clobber it.
+  skipPrime: (existing) => existing?.status === "decrypted",
+})
 
 /** Snapshot of the global cache version — changes on any insert/seed/invalidate/clear. */
 export function getDecryptCacheVersion(): number {
-  return cacheVersion
+  return cache.getVersion()
 }
 
 /** Subscribe to ANY cache change (for batch readers like draft-preview lists). */
 export function subscribeDecryptCacheVersion(listener: () => void): () => void {
-  versionListeners.add(listener)
-  return () => versionListeners.delete(listener)
-}
-
-function touch(eventId: string, entry: DecryptCacheEntry): void {
-  // Map iteration order is insertion order; re-inserting bumps it to MRU.
-  entries.delete(eventId)
-  entries.set(eventId, entry)
-  if (entries.size > MAX_ENTRIES) {
-    const oldest = entries.keys().next().value
-    if (oldest !== undefined) entries.delete(oldest)
-  }
+  return cache.subscribe(null, listener)
 }
 
 export function getCachedDecryption(eventId: string): DecryptCacheEntry | undefined {
-  return entries.get(eventId)
+  return cache.peek(eventId)
 }
 
 export function subscribeToDecryption(eventId: string, listener: () => void): () => void {
-  let set = listeners.get(eventId)
-  if (!set) {
-    set = new Set()
-    listeners.set(eventId, set)
-  }
-  set.add(listener)
-  return () => {
-    const current = listeners.get(eventId)
-    if (!current) return
-    current.delete(listener)
-    if (current.size === 0) listeners.delete(eventId)
-  }
+  return cache.subscribe(eventId, listener)
 }
 
 export interface RequestDecryptionInput {
@@ -98,39 +62,10 @@ export function requestDecryption(
   payload: RequestDecryptionInput,
   opts: DecryptMessageOpts
 ): Promise<DecryptCacheEntry> {
-  const existing = entries.get(eventId)
-  if (existing && existing.status !== "pending") return Promise.resolve(existing)
-
-  const pending = inflight.get(eventId)
-  if (pending) return pending
-
-  touch(eventId, { status: "pending", content: null })
-
-  const startGeneration = generation
-  // A holder so the async body can compare against its own promise identity
-  // (`holder.promise` is assigned synchronously below, before any await resolves).
-  const holder: { promise?: Promise<DecryptCacheEntry> } = {}
-  holder.promise = (async (): Promise<DecryptCacheEntry> => {
+  return cache.request(eventId, async () => {
     const decrypted = await tryDecryptMessagePayload(payload, opts)
-    const entry: DecryptCacheEntry = decrypted
-      ? { status: "decrypted", content: decrypted }
-      : { status: "failed", content: null }
-    // If the cache was cleared (lock / account switch) while this decrypt was
-    // in flight, drop the result — writing it back would leak plaintext past
-    // the lock boundary.
-    if (startGeneration !== generation) return entry
-    // A concurrent `invalidateDecryption` (or a fresh `seedDecryption`) may have
-    // replaced this id's slot while we were decrypting; only the current inflight
-    // writes back, so a stale decrypt can never clobber freshly-authored content.
-    if (inflight.get(eventId) !== holder.promise) return entry
-    touch(eventId, entry)
-    inflight.delete(eventId)
-    emit(eventId)
-    return entry
-  })()
-
-  inflight.set(eventId, holder.promise)
-  return holder.promise
+    return decrypted ? { status: "decrypted", content: decrypted } : { status: "failed", content: null }
+  })
 }
 
 /**
@@ -142,11 +77,7 @@ export function requestDecryption(
  * sent row. No-op if the event already has a decrypted entry.
  */
 export function seedDecryption(eventId: string, content: DecryptedMessageContent): void {
-  const existing = entries.get(eventId)
-  if (existing && existing.status === "decrypted") return
-  touch(eventId, { status: "decrypted", content })
-  inflight.delete(eventId)
-  emit(eventId)
+  cache.prime(eventId, { status: "decrypted", content })
 }
 
 /**
@@ -162,15 +93,9 @@ export function seedDecryption(eventId: string, content: DecryptedMessageContent
  * write path therefore invalidates this id, then seeds the fresh plaintext.
  */
 export function invalidateDecryption(eventId: string): void {
-  const had = entries.delete(eventId)
-  const wasInflight = inflight.delete(eventId)
-  if (had || wasInflight) emit(eventId)
+  cache.invalidate(eventId)
 }
 
 export function clearDecryptCache(): void {
-  generation++
-  const ids = Array.from(entries.keys())
-  entries.clear()
-  inflight.clear()
-  for (const id of ids) emit(id)
+  cache.clear()
 }

--- a/apps/frontend/src/lib/crypto/decrypted-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypted-cache.ts
@@ -74,7 +74,19 @@ export function registerDecryptedCache(clear: () => void): void {
 
 /** Clear every registered cache — the single lock / account-switch boundary. */
 export function clearAllDecrypted(): void {
-  for (const clear of lockClearRegistry) clear()
+  // A security boundary (E2EE-4): one cache's clear throwing must not skip the
+  // rest, so run them all and surface any failures only afterwards.
+  const errors: unknown[] = []
+  for (const clear of lockClearRegistry) {
+    try {
+      clear()
+    } catch (error) {
+      errors.push(error)
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "One or more decrypted caches failed to clear")
+  }
 }
 
 export function createDecryptedCache<E extends BaseEntry>(options: CreateDecryptedCacheOptions<E>): DecryptedCache<E> {
@@ -129,18 +141,30 @@ export function createDecryptedCache<E extends BaseEntry>(options: CreateDecrypt
     // (`holder.promise` is assigned synchronously below, before any await resolves).
     const holder: { promise?: Promise<E> } = {}
     holder.promise = (async (): Promise<E> => {
-      const entry = await run()
-      // Dropped if the cache was cleared (lock / account switch) mid-flight —
-      // writing plaintext back would leak it past the lock boundary.
-      if (startGeneration !== generation) return entry
-      // A concurrent prime/invalidate may have replaced this key's slot while we
-      // decrypted; only the current in-flight writes back, so a stale decrypt
-      // can't clobber freshly-authored content.
-      if (inflight.get(key) !== holder.promise) return entry
-      touch(key, entry)
-      inflight.delete(key)
-      emit(key)
-      return entry
+      try {
+        const entry = await run()
+        // Dropped if the cache was cleared (lock / account switch) mid-flight —
+        // writing plaintext back would leak it past the lock boundary.
+        if (startGeneration !== generation) return entry
+        // A concurrent prime/invalidate may have replaced this key's slot while we
+        // decrypted; only the current in-flight writes back, so a stale decrypt
+        // can't clobber freshly-authored content.
+        if (inflight.get(key) !== holder.promise) return entry
+        touch(key, entry)
+        inflight.delete(key)
+        emit(key)
+        return entry
+      } catch (error) {
+        // A rejected decrypt must not leave a sticky in-flight promise (every later
+        // request would return the same rejection) or a stranded pending entry —
+        // drop both so the key can recover on a later request.
+        if (startGeneration === generation && inflight.get(key) === holder.promise) {
+          inflight.delete(key)
+          entries.delete(key)
+          emit(key)
+        }
+        throw error
+      }
     })()
     inflight.set(key, holder.promise)
     return holder.promise

--- a/apps/frontend/src/lib/crypto/decrypted-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypted-cache.ts
@@ -1,0 +1,204 @@
+/**
+ * Shared in-memory cache primitive for decrypted E2E content.
+ *
+ * Every encrypted field (message bodies, stream names, …) decrypts on demand and
+ * holds the plaintext in memory only — ciphertext stays at rest in IDB, plaintext
+ * is cleared on lock (E2EE-4). Each field re-implemented the same lifecycle: a
+ * Map keyed by a ciphertext id, in-flight dedup, a lock-epoch guard so a decrypt
+ * resolving after lock can't write plaintext back, a subscribe/version signal,
+ * and a clear. This factory captures that lifecycle once; `decrypt-cache` and
+ * `stream-name-cache` are thin instances over it.
+ *
+ * Two subscription models share the core: "global" (one version counter; few
+ * keys, e.g. names — the overlay maps the whole list) and "per-key" (per-key
+ * listener sets; hundreds of keys, e.g. message bodies — a global bump would
+ * re-render every row). A global version + global listeners exist in BOTH modes
+ * (batch readers watch them); "per-key" additionally maintains per-key sets.
+ *
+ * Every instance auto-registers its `clear` in the module lock-clear registry, so
+ * a new encrypted field cannot forget a clear site: `clearAllDecrypted()` (called
+ * on lock / account switch) wipes them all. A cache can only hold plaintext if its
+ * module is loaded, and loading registers it — so any cache with data is cleared.
+ */
+
+export type DecryptStatus = "pending" | "decrypted" | "failed"
+
+interface BaseEntry {
+  status: DecryptStatus
+}
+
+export interface DecryptedCache<E extends BaseEntry> {
+  /** The raw cached entry, or undefined if this key was never requested/primed. */
+  peek(key: string): E | undefined
+  /**
+   * Decrypt-and-cache for a key, deduping concurrent callers. Guards the
+   * write-back against a `clear()` (lock) or a concurrent `prime`/`invalidate`
+   * that landed mid-flight. Returns the settled entry the decrypt produced — even
+   * when the guard dropped the write-back — so callers can react to the result.
+   */
+  request(key: string, run: () => Promise<E>): Promise<E>
+  /** Seed a known entry without crypto (optimistic echo / local rename). */
+  prime(key: string, entry: E): void
+  /** Drop a single key (entry + in-flight) and notify, so a reused id can be replaced. */
+  invalidate(key: string): void
+  /** Subscribe to changes for one key, or — with `key === null` — to any change. */
+  subscribe(key: string | null, listener: () => void): () => void
+  /** Monotonic version, bumped on every change; the snapshot batch readers watch. */
+  getVersion(): number
+  /** Drop everything and bump the lock epoch so in-flight decrypts can't write back. */
+  clear(): void
+}
+
+export interface CreateDecryptedCacheOptions<E extends BaseEntry> {
+  subscription: "global" | "per-key"
+  /** Cap on cached entries; least-recently-touched evicted past it. Unbounded if omitted. */
+  lru?: number
+  /**
+   * Whether a later `request` re-attempts after a `failed` entry. Message bodies
+   * treat failure as terminal (false). Stream names treat a null open as
+   * transient — locked, or a wrap not yet resolvable — and retry (true).
+   */
+  retryFailed?: boolean
+  /** The placeholder inserted while a decrypt is in flight. */
+  pending: () => E
+  /** When this returns true for the current entry, `prime` is a no-op (idempotency / don't-clobber). */
+  skipPrime?: (existing: E | undefined, next: E) => boolean
+}
+
+const lockClearRegistry = new Set<() => void>()
+
+/** Register a cache's clear so `clearAllDecrypted()` wipes it on lock. */
+export function registerDecryptedCache(clear: () => void): void {
+  lockClearRegistry.add(clear)
+}
+
+/** Clear every registered cache — the single lock / account-switch boundary. */
+export function clearAllDecrypted(): void {
+  for (const clear of lockClearRegistry) clear()
+}
+
+export function createDecryptedCache<E extends BaseEntry>(options: CreateDecryptedCacheOptions<E>): DecryptedCache<E> {
+  const { subscription, lru, retryFailed = false, pending, skipPrime } = options
+
+  const entries = new Map<string, E>()
+  const inflight = new Map<string, Promise<E>>()
+  const globalListeners = new Set<() => void>()
+  const keyListeners = subscription === "per-key" ? new Map<string, Set<() => void>>() : null
+
+  let version = 0
+  // Bumped by clear() so an in-flight decrypt that resolves after a lock detects
+  // it's stale and refuses to write plaintext back (no leak past the lock).
+  let generation = 0
+
+  function emit(key: string): void {
+    version++
+    for (const listener of globalListeners) listener()
+    if (!keyListeners) return
+    const set = keyListeners.get(key)
+    if (!set) return
+    for (const listener of set) listener()
+  }
+
+  function touch(key: string, entry: E): void {
+    // Map iteration order is insertion order; re-inserting bumps it to MRU.
+    entries.delete(key)
+    entries.set(key, entry)
+    if (lru !== undefined && entries.size > lru) {
+      const oldest = entries.keys().next().value
+      if (oldest !== undefined) entries.delete(oldest)
+    }
+  }
+
+  function peek(key: string): E | undefined {
+    return entries.get(key)
+  }
+
+  function request(key: string, run: () => Promise<E>): Promise<E> {
+    const existing = entries.get(key)
+    if (existing) {
+      if (existing.status === "decrypted") return Promise.resolve(existing)
+      if (existing.status === "failed" && !retryFailed) return Promise.resolve(existing)
+      // pending, or a retryable failed entry → fall through to (re-)decrypt.
+    }
+    const current = inflight.get(key)
+    if (current) return current
+
+    touch(key, pending())
+    const startGeneration = generation
+    // A holder so the async body can compare against its own promise identity
+    // (`holder.promise` is assigned synchronously below, before any await resolves).
+    const holder: { promise?: Promise<E> } = {}
+    holder.promise = (async (): Promise<E> => {
+      const entry = await run()
+      // Dropped if the cache was cleared (lock / account switch) mid-flight —
+      // writing plaintext back would leak it past the lock boundary.
+      if (startGeneration !== generation) return entry
+      // A concurrent prime/invalidate may have replaced this key's slot while we
+      // decrypted; only the current in-flight writes back, so a stale decrypt
+      // can't clobber freshly-authored content.
+      if (inflight.get(key) !== holder.promise) return entry
+      touch(key, entry)
+      inflight.delete(key)
+      emit(key)
+      return entry
+    })()
+    inflight.set(key, holder.promise)
+    return holder.promise
+  }
+
+  function prime(key: string, entry: E): void {
+    if (skipPrime?.(entries.get(key), entry)) return
+    touch(key, entry)
+    inflight.delete(key)
+    emit(key)
+  }
+
+  function invalidate(key: string): void {
+    const had = entries.delete(key)
+    const wasInflight = inflight.delete(key)
+    if (had || wasInflight) emit(key)
+  }
+
+  function subscribe(key: string | null, listener: () => void): () => void {
+    if (key === null || !keyListeners) {
+      globalListeners.add(listener)
+      return () => {
+        globalListeners.delete(listener)
+      }
+    }
+    let set = keyListeners.get(key)
+    if (!set) {
+      set = new Set()
+      keyListeners.set(key, set)
+    }
+    set.add(listener)
+    return () => {
+      const current = keyListeners.get(key)
+      if (!current) return
+      current.delete(listener)
+      if (current.size === 0) keyListeners.delete(key)
+    }
+  }
+
+  function getVersion(): number {
+    return version
+  }
+
+  function clear(): void {
+    generation++
+    // Per-key subscribers re-render only when their own key emits, so notify each
+    // previously-present key. A global cache fires one emit regardless.
+    const keys = keyListeners ? Array.from(entries.keys()) : null
+    entries.clear()
+    inflight.clear()
+    if (keys) {
+      for (const key of keys) emit(key)
+    } else {
+      emit("")
+    }
+  }
+
+  const api: DecryptedCache<E> = { peek, request, prime, invalidate, subscribe, getVersion, clear }
+  registerDecryptedCache(clear)
+  return api
+}

--- a/apps/frontend/src/lib/crypto/stream-key-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-key-cache.ts
@@ -8,6 +8,7 @@ import {
 } from "@threa/crypto"
 import type { E2eKeyRollRecipient, E2eKeyWrapsResponse } from "@threa/types"
 import { e2eKeyWrapsApi } from "@/api/e2e-key-wraps"
+import { registerDecryptedCache } from "./decrypted-cache"
 
 /**
  * In-memory cache for per-stream symmetric keys (SSKs).
@@ -427,3 +428,7 @@ export function clearStreamKeyCache(): void {
   currentGenerations.clear()
   inflight.clear()
 }
+
+// SSK material dies on the same lock boundary as decrypted plaintext, so the
+// single `clearAllDecrypted()` call site can't forget it.
+registerDecryptedCache(clearStreamKeyCache)

--- a/apps/frontend/src/lib/crypto/stream-name-cache.ts
+++ b/apps/frontend/src/lib/crypto/stream-name-cache.ts
@@ -1,81 +1,71 @@
 import { tryOpenStreamName, type DecryptMessageOpts } from "./message-envelope"
+import { createDecryptedCache, type DecryptStatus } from "./decrypted-cache"
 
 /**
- * In-memory cache for decrypted E2E stream names.
+ * In-memory cache for decrypted E2E stream names — a global-subscription instance
+ * of the shared {@link createDecryptedCache} primitive (which owns the
+ * inflight-dedup, lock-epoch guard, version signal, and lock-clear registration).
  *
  * The enclave seals a scratchpad's auto-title (and a manual rename re-seals it)
  * under the stream's SSK, AAD-bound to the stream. The ciphertext lives at rest
  * in `db.streams` (`sealedNameCiphertext`/`sealedNameEnvelope`); the decrypted
- * plaintext is held ONLY here and is never persisted, mirroring `decrypt-cache`
- * for message bodies. This keeps a single decrypt authority for names so every
- * surface that resolves a label (sidebar, search, breadcrumbs, …) reflects the
- * tamper-evident name without each re-implementing the decrypt.
+ * plaintext is held ONLY here and is never persisted. A single global version
+ * counter drives re-renders: the store-read overlay (`useWorkspaceStreams`) and
+ * the open-stream header subscribe once and re-read when any name lands. Keyed by
+ * `${workspaceId}:${streamId}:${ciphertext}` so a rename (fresh ciphertext)
+ * supersedes the prior plaintext without a manual purge, and a never-decrypted key
+ * reads `null` rather than a stale value.
  *
- * A single global version counter drives re-renders: the store-read overlay
- * (`useWorkspaceStreams`) and the open-stream header subscribe once and re-read
- * when any name lands. Keyed by `${workspaceId}:${streamId}:${ciphertext}` so a
- * rename (fresh ciphertext) supersedes the prior plaintext without a manual
- * purge, and a never-decrypted key reads `null` rather than a stale value.
- *
- * Lifecycle: `clearStreamNameCache()` drops everything and bumps the lock epoch
- * so an in-flight decrypt that resolves after a lock refuses to write plaintext
- * back — call it on session lock / account switch, the same boundary
- * `clearDecryptCache` / `clearStreamKeyCache` enforce.
+ * Unlike message bodies, a null open is transient (locked / not a recipient yet /
+ * wrap not resolvable), so the instance uses `retryFailed` — a later request
+ * retries instead of pinning the placeholder. `clearStreamNameCache()` (also
+ * fired by `clearAllDecrypted` on lock) drops everything.
  */
 
-/** Decrypted plaintext names keyed by `${workspaceId}:${streamId}:${ciphertext}`. */
-const names = new Map<string, string>()
-const inflight = new Map<string, Promise<void>>()
-// Keys whose decrypt has settled at least once (success or failure). Lets the UI
-// tell "still decrypting on cold load" (show a loader, not the placeholder) from
-// "decrypt finished with no name" (a non-recipient / forged AAD — show the
-// placeholder). Cleared with the cache on lock.
-const attempted = new Set<string>()
-const listeners = new Set<() => void>()
+interface NameEntry {
+  status: DecryptStatus
+  /** The decrypted name; null while pending or after a failed/locked open. */
+  value: string | null
+}
 
-// Monotonic snapshot for useSyncExternalStore — bumped on every cache change so
-// subscribers (the overlay, the open-stream header) re-read.
-let version = 0
-// Bumped by clearStreamNameCache so an in-flight decrypt that resolves after a
-// lock detects it's stale and refuses to write plaintext back into the cache.
-let generation = 0
+const cache = createDecryptedCache<NameEntry>({
+  subscription: "global",
+  // A null open is transient (locked, or a wrap that becomes resolvable later),
+  // so a later request must retry rather than pin the placeholder forever.
+  retryFailed: true,
+  pending: () => ({ status: "pending", value: null }),
+  // Keys are content-addressed by ciphertext, so a primed name is idempotent;
+  // skip the redundant emit when the cached value already matches.
+  skipPrime: (existing, next) => existing?.status === "decrypted" && existing.value === next.value,
+})
 
 export function streamNameCacheKey(workspaceId: string, streamId: string, ciphertext: string): string {
   return `${workspaceId}:${streamId}:${ciphertext}`
 }
 
-function emit(): void {
-  version++
-  for (const listener of listeners) listener()
-}
-
 export function subscribeStreamNameCache(listener: () => void): () => void {
-  listeners.add(listener)
-  return () => {
-    listeners.delete(listener)
-  }
+  return cache.subscribe(null, listener)
 }
 
 export function getStreamNameCacheVersion(): number {
-  return version
+  return cache.getVersion()
 }
 
 /** The decrypted name for a key, or `null` if not yet decrypted / decrypt failed. */
 export function getCachedStreamName(key: string): string | null {
-  return names.get(key) ?? null
+  return cache.peek(key)?.value ?? null
 }
 
 /**
- * Whether a sealed name is still resolving: no plaintext cached yet, and either
- * a decrypt is in flight or none has been attempted (so one is imminent). Once a
- * decrypt settles without a name (non-recipient / forged AAD) this returns false,
- * so the UI can stop showing a loader and fall back to the placeholder rather
- * than spinning forever. A surface uses this to avoid flashing the placeholder
- * during the cold-load decrypt window.
+ * Whether a sealed name is still resolving: no entry yet (a decrypt is imminent)
+ * or one is in flight. Once a decrypt settles — with a name, or without one
+ * (non-recipient / forged AAD) — this returns false, so the UI can stop showing a
+ * loader and fall back to the placeholder rather than spinning forever. A surface
+ * uses this to avoid flashing the placeholder during the cold-load decrypt window.
  */
 export function isStreamNamePending(key: string): boolean {
-  if (names.has(key)) return false
-  return inflight.has(key) || !attempted.has(key)
+  const entry = cache.peek(key)
+  return entry === undefined || entry.status === "pending"
 }
 
 export interface RequestStreamNameInput {
@@ -88,39 +78,22 @@ export interface RequestStreamNameInput {
 /**
  * Decrypt a sealed stream name and cache the plaintext, deduped per key. A
  * no-op when the key is already decrypted or in flight. A decrypt that returns
- * null (locked, not a recipient, forged AAD) is not cached, so a later unlock
- * (or a wrap that becomes resolvable) retries instead of pinning the
- * placeholder — callers fall back to the plaintext label meanwhile.
+ * null (locked, not a recipient, forged AAD) records a `failed` entry but does
+ * not pin it: because the instance is `retryFailed`, a later unlock (or a wrap
+ * that becomes resolvable) retries instead of pinning the placeholder — callers
+ * fall back to the plaintext label meanwhile.
  */
 export function requestStreamName(
   key: string,
   payload: RequestStreamNameInput,
   opts: DecryptMessageOpts
 ): Promise<void> {
-  const existing = inflight.get(key)
-  if (existing) return existing
-  if (names.has(key)) return Promise.resolve()
-
-  const startGeneration = generation
-  const promise = (async () => {
-    const decrypted = await tryOpenStreamName({ ciphertext: payload.ciphertext, envelope: payload.envelope }, opts)
-    // Dropped if the cache was cleared (lock / account switch) mid-flight —
-    // writing plaintext back would leak it past the lock boundary.
-    if (startGeneration !== generation) return
-    inflight.delete(key)
-    attempted.add(key)
-    // Emit on both outcomes: success lands the name; a null result still flips
-    // the pending state so a loader can fall back to the placeholder.
-    if (decrypted == null) {
-      emit()
-      return
-    }
-    names.set(key, decrypted)
-    emit()
-  })()
-
-  inflight.set(key, promise)
-  return promise
+  return cache
+    .request(key, async () => {
+      const decrypted = await tryOpenStreamName({ ciphertext: payload.ciphertext, envelope: payload.envelope }, opts)
+      return decrypted == null ? { status: "failed", value: null } : { status: "decrypted", value: decrypted }
+    })
+    .then(() => {})
 }
 
 /**
@@ -152,11 +125,7 @@ export function applyDecryptedNameOverlay<
 }
 
 export function clearStreamNameCache(): void {
-  generation++
-  names.clear()
-  inflight.clear()
-  attempted.clear()
-  emit()
+  cache.clear()
 }
 
 /**
@@ -168,7 +137,5 @@ export function clearStreamNameCache(): void {
  * round-trips. Memory-only and cleared on lock like every other entry.
  */
 export function primeStreamName(key: string, name: string): void {
-  if (names.get(key) === name) return
-  names.set(key, name)
-  emit()
+  cache.prime(key, { status: "decrypted", value: name })
 }

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -1,9 +1,6 @@
 import { useSyncExternalStore } from "react"
 import { e2eKeysApi } from "@/api/e2e-keys"
-import { clearDecryptCache } from "@/lib/crypto/decrypt-cache"
-import { clearStreamKeyCache } from "@/lib/crypto/stream-key-cache"
-import { clearStreamNameCache } from "@/lib/crypto/stream-name-cache"
-import { clearAttachmentRefCache } from "@/lib/crypto/attachment-crypto"
+import { clearAllDecrypted } from "@/lib/crypto/decrypted-cache"
 import { base64ToBytes, bytesToBase64 } from "@threa/crypto"
 import { generateUIK, unwrapPrivate, wrapPrivate } from "@/lib/crypto/keys"
 import { unwrapPrivateKeyFromDevice, wrapPrivateKeyForDevice } from "@/lib/crypto/device-wrap-key"
@@ -908,12 +905,10 @@ export async function revokeKeyForUser(workspaceId: string, userId: string): Pro
 export async function lock(workspaceId: string, userId: string): Promise<void> {
   const scope = getOrCreateScope(workspaceId, userId)
   // Drop every decrypted payload from memory — Phase 3.5 keeps ciphertext at
-  // rest in IDB and decrypts at render time, so the in-memory cache is the
-  // only surface holding plaintext for this session.
-  clearDecryptCache()
-  clearStreamKeyCache()
-  clearStreamNameCache()
-  clearAttachmentRefCache()
+  // rest in IDB and decrypts at render time, so the in-memory caches are the
+  // only surfaces holding plaintext for this session. The registry clears every
+  // registered decrypt/key cache, so a new encrypted field can't be forgotten here.
+  clearAllDecrypted()
   // Bump the generation so a concurrent loadE2eKeyForUser can't restore the
   // device key we're about to delete back into an unlocked state.
   scope.loadGeneration++
@@ -1077,8 +1072,5 @@ export function useE2eSession(workspaceId: string, userId: string): E2eSessionSt
 export function resetE2eSessionStoreCache(): void {
   scopes.clear()
   listeners.clear()
-  clearDecryptCache()
-  clearStreamKeyCache()
-  clearStreamNameCache()
-  clearAttachmentRefCache()
+  clearAllDecrypted()
 }

--- a/apps/frontend/src/stores/e2e-session-store.ts
+++ b/apps/frontend/src/stores/e2e-session-store.ts
@@ -904,27 +904,33 @@ export async function revokeKeyForUser(workspaceId: string, userId: string): Pro
  */
 export async function lock(workspaceId: string, userId: string): Promise<void> {
   const scope = getOrCreateScope(workspaceId, userId)
-  // Drop every decrypted payload from memory — Phase 3.5 keeps ciphertext at
-  // rest in IDB and decrypts at render time, so the in-memory caches are the
-  // only surfaces holding plaintext for this session. The registry clears every
-  // registered decrypt/key cache, so a new encrypted field can't be forgotten here.
-  clearAllDecrypted()
-  // Bump the generation so a concurrent loadE2eKeyForUser can't restore the
-  // device key we're about to delete back into an unlocked state.
-  scope.loadGeneration++
-  if (!scope.cachedKey) {
-    setState(workspaceId, userId, INITIAL_STATE)
-  } else {
-    setState(workspaceId, userId, {
-      status: "locked",
-      keyId: scope.cachedKey.keyId,
-      publicKey: scope.cachedKey.publicKey,
-      privateKey: null,
-      deviceTrusted: false,
-      error: null,
-    })
+  try {
+    // Drop every decrypted payload from memory — Phase 3.5 keeps ciphertext at
+    // rest in IDB and decrypts at render time, so the in-memory caches are the
+    // only surfaces holding plaintext for this session. The registry clears every
+    // registered decrypt/key cache, so a new encrypted field can't be forgotten here.
+    clearAllDecrypted()
+  } finally {
+    // The lock-state teardown must complete even if a cache clear throws, so the
+    // device key is always deleted and the session always flips to locked (the
+    // error, if any, still propagates after this runs).
+    // Bump the generation so a concurrent loadE2eKeyForUser can't restore the
+    // device key we're about to delete back into an unlocked state.
+    scope.loadGeneration++
+    if (!scope.cachedKey) {
+      setState(workspaceId, userId, INITIAL_STATE)
+    } else {
+      setState(workspaceId, userId, {
+        status: "locked",
+        keyId: scope.cachedKey.keyId,
+        publicKey: scope.cachedKey.publicKey,
+        privateKey: null,
+        deviceTrusted: false,
+        error: null,
+      })
+    }
+    await deleteDeviceKey(workspaceId, userId)
   }
-  await deleteDeviceKey(workspaceId, userId)
 }
 
 /**

--- a/docs/plans/client-decrypt-layer-unification.md
+++ b/docs/plans/client-decrypt-layer-unification.md
@@ -165,10 +165,13 @@ function clearAllDecrypted(): void // called once on lock / account switch
 
 - **Slice 0 — DONE (PR #955):** sealed-name loading-state collapsed into one
   authority. Proves the status-drift and the fix.
-- **Slice 1 — cache primitive + registry.** Extract `createDecryptedCache` and
-  the lock-clear registry; refactor `decrypt-cache` and `stream-name-cache` to be
-  instances. Pure internal refactor; behavior identical; existing tests are the
-  guard. No surface changes.
+- **Slice 1 — DONE.** `createDecryptedCache` (`lib/crypto/decrypted-cache.ts`)
+  and the lock-clear registry (`registerDecryptedCache` / `clearAllDecrypted`)
+  are extracted; `decrypt-cache` (per-key, LRU 500, terminal failures) and
+  `stream-name-cache` (global version, `retryFailed`) are thin instances over it.
+  The two divergences are options: `subscription` ("global" | "per-key") and
+  `retryFailed`. Behavior is identical — the existing wrapper tests are the guard,
+  plus a focused `decrypted-cache.test.ts` for the primitive and registry.
 - **Slice 2 — unified decode entry.** Extract `resolveDecryptContext` (session +
   root-SSK + hydration guard); route `useDecryptedMessageContent`,
   `useDecryptedStepContent`, `useStreamSearch`, and the draft decrypt
@@ -234,9 +237,14 @@ absorbs. The draft read path joins slices 2–3.
 
 ## Open questions
 
-1. Does `clearStreamKeyCache` join the registry, or stay explicit (it's a key
-   cache, not content)? Leaning: register it too, so "lock clears everything" is
-   one call — but it has different semantics (keys vs plaintext). Decide in slice 1.
+1. ~~Does `clearStreamKeyCache` join the registry, or stay explicit?~~
+   **Resolved (slice 1): all four register.** `clearStreamKeyCache` and
+   `clearAttachmentRefCache` call `registerDecryptedCache(...)` at module load, so
+   `e2e-session-store`'s two clear sites each became a single `clearAllDecrypted()`.
+   The constraint "one call site, no field forgotten" wins over the keys-vs-plaintext
+   distinction: registration is orthogonal to what a cache does (the SSK layer's
+   resolution logic is untouched), and a cache can only hold material if its module
+   is loaded — and loading registers it — so any cache with data is cleared on lock.
 2. Do steps keep sharing `messageCache` (keyed by `step.id`) or get their own
    instance? Leaning: keep sharing — same shape, same LRU pressure profile.
 3. Is a single `useDecryptedField` hook worth it, or do the per-domain hooks stay

--- a/docs/plans/client-decrypt-layer-unification.md
+++ b/docs/plans/client-decrypt-layer-unification.md
@@ -1,7 +1,7 @@
 # Client-side decrypt layer unification (design)
 
-**Status:** Draft for review — no implementation yet. PR #955 (sealed-name
-loading-state authority) is slice 0 of the sequencing below. Targets current
+**Status:** In progress — slice 0 (PR #955, sealed-name loading-state authority)
+and slice 1 are implemented; later slices pending. Targets current
 `origin/main` (post-#946, Stage 4c E2E draft roaming); the implementing branch
 must rebase onto it (the inventory below reflects post-#946 reality).
 


### PR DESCRIPTION
**Design doc:** [`docs/plans/client-decrypt-layer-unification.md`](https://github.com/threahq/threa/blob/main/docs/plans/client-decrypt-layer-unification.md) — **slice 1** of that plan. Slice 0 was #955; the design doc was #961.

## Problem

Every client-side encrypted field decrypts through its own hand-rolled machinery. The skeleton is the same each time — a Map keyed by a ciphertext id, in-flight dedup, a lock-epoch guard so a decrypt resolving after lock can't write plaintext back, a subscribe/version signal, and a clear — but it was copied per field with subtly different shapes. `decrypt-cache.ts` (message bodies, agent steps, drafts) and `stream-name-cache.ts` (sealed stream names) each reimplemented all of it. New fields copy the nearest example, so "fix one surface, miss another" drift is structural.

Lock-clear had the same shape problem: `e2e-session-store`'s two clear sites (`lock`, `resetE2eSessionStoreCache`) each enumerated a 4-call list (`clearDecryptCache`, `clearStreamKeyCache`, `clearStreamNameCache`, `clearAttachmentRefCache`). A fifth memory-resident cache means remembering both sites — and forgetting one leaks plaintext past lock (E2EE-4: plaintext is memory-only, cleared on lock).

## Solution

Extract the shared lifecycle into one factory, `createDecryptedCache<E>()`, and a module lock-clear registry; make the two caches thin instances over it. **Public APIs of both wrappers are unchanged**, so the existing wrapper test files (`decrypt-cache.test.ts`, `stream-name-cache.test.ts`) are untouched by this PR and remain the behavior guard. This is the intentionally pure internal refactor the slice-1 spec calls for — no read-surface or behavior changes.

### How it works

1. **`apps/frontend/src/lib/crypto/decrypted-cache.ts`** — `createDecryptedCache<E extends { status }>()` owns the entry map, in-flight dedup, the lock-epoch (`generation`) guard, the in-flight-identity guard (a concurrent `prime`/`invalidate` mid-decrypt can't be clobbered by the stale result), the subscribe/version signal, optional LRU eviction, and `clear`. `request(key, run)` returns the settled entry even when a guard drops the write-back, so callers like the draft path (`requestDraftDecryption(...).then(entry => …)`) keep working.

2. **Two divergences are options, not separate code paths.** `subscription: "global" | "per-key"` — names use a single version counter (few streams; the overlay maps the whole list), message bodies use per-key listener sets (hundreds of rows; a global bump would re-render every one). A global version + global listeners exist in *both* modes, because batch readers (`useDecryptedDraftPreviews`) watch the global version while per-row hooks watch one key. `retryFailed` — message bodies treat a failed decrypt as terminal (wrong recipient / tampered AAD never recovers); stream names treat a null open as transient (locked, or a wrap not yet resolvable) and retry on the next request.

3. **`decrypt-cache.ts`** becomes a `subscription: "per-key", lru: 500, retryFailed: false` instance; `skipPrime` keeps `seedDecryption` from clobbering a real decrypt (a message id's first good decrypt is final). All exports kept: `getCachedDecryption`, `requestDecryption`, `seedDecryption`, `invalidateDecryption`, `subscribeToDecryption`, `getDecryptCacheVersion`, `subscribeDecryptCacheVersion`, `clearDecryptCache`, `DecryptCacheEntry { status, content }`.

4. **`stream-name-cache.ts`** becomes a `subscription: "global", retryFailed: true` instance; `isStreamNamePending` is derived (`peek` undefined or `status === "pending"`), replacing the old `attempted` set. `applyDecryptedNameOverlay` is unchanged. All exports kept: `getCachedStreamName`, `requestStreamName`, `primeStreamName`, `isStreamNamePending`, `streamNameCacheKey`, `subscribeStreamNameCache`, `getStreamNameCacheVersion`, `clearStreamNameCache`.

5. **Lock-clear registry.** `registerDecryptedCache(clear)` / `clearAllDecrypted()`. Each `createDecryptedCache` instance auto-registers; `stream-key-cache.ts` and `attachment-crypto.ts` call `registerDecryptedCache(...)` at module load. `e2e-session-store`'s two 4-call blocks each collapse to a single `clearAllDecrypted()`.

### Key design decisions

**1. Entry-generic, not value-generic — to avoid a slice-3 surface change.** The primitive is generic over the whole entry `E extends { status }`, not over a `value`. `decrypt-cache` keeps its public `DecryptCacheEntry { status; content }` shape (consumers read `cached.content`; `peek` returns the *exact* stored object, preserving the referential stability `useSyncExternalStore` snapshots depend on). Unifying every field on a `{ value, status }` read shape is explicitly slice 3 in the design doc, so renaming `content → value` now would be an out-of-scope surface change. `stream-name-cache` adopts `{ status; value }` internally because it never exposed a raw entry object publicly.

**2. `retryFailed` is the one knob that reconciles the two failure philosophies.** Both caches now store a `failed` entry on a null decrypt (names dropped the separate `attempted` set). The only behavioral difference is whether a later `request` re-attempts a `failed` entry. Modeling it as a flag — rather than two clear-it-or-keep-it code paths — is what lets one `request` implementation serve both. The design doc's risk note blesses falling back to "two thin instances over a shared core" if a single primitive gets ugly; with only `subscription` + `retryFailed` branching, it stayed clean enough to be one factory.

**3. Q1 resolved: register all four caches, including the SSK and attachment-ref caches.** The design doc left this open ("register them too, or stay explicit — decide in slice 1"). Registered all four. The constraint "one call site, no field forgotten" outweighs the keys-vs-plaintext semantic distinction: registration is orthogonal to what a cache does (the SSK resolution layer is untouched — only its existing `clearStreamKeyCache` joins the registry), and the load-order is sound by construction — **a cache can only hold material if its module is loaded, and loading runs its registration, so any cache with data is registered and cleared on lock.** Recorded in the design doc's Open Questions.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crypto/decrypted-cache.ts` | The shared cache primitive (`createDecryptedCache`) + lock-clear registry (`registerDecryptedCache` / `clearAllDecrypted`). |
| `apps/frontend/src/lib/crypto/__tests__/decrypted-cache.test.ts` | Direct tests for the primitive contract and the registry. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/crypto/decrypt-cache.ts` | Reduced to a per-key/LRU-500/terminal-failure instance; all exports preserved. |
| `apps/frontend/src/lib/crypto/stream-name-cache.ts` | Reduced to a global/`retryFailed` instance; `isStreamNamePending` derived from entry status; `applyDecryptedNameOverlay` unchanged; all exports preserved. |
| `apps/frontend/src/lib/crypto/stream-key-cache.ts` | `registerDecryptedCache(clearStreamKeyCache)` at module load; resolution logic untouched. |
| `apps/frontend/src/lib/crypto/attachment-crypto.ts` | `registerDecryptedCache(clearAttachmentRefCache)` at module load. |
| `apps/frontend/src/stores/e2e-session-store.ts` | Both clear sites collapse the 4-call list to one `clearAllDecrypted()`; drops the four per-function imports. |
| `docs/plans/client-decrypt-layer-unification.md` | Slice 1 marked done; Q1 recorded as resolved. |

## Out of scope (deliberate)

- **Slice 2 (unified decode entry).** `resolveDecryptContext` — the session + root-SSK + hydration-guard logic that `useDecryptedMessageContent`, `useDecryptedStepContent`, `useStreamSearch`, and the draft path still each copy — is the next PR. Untouched here.
- **Slice 3 (uniform read shape + attachments).** The `{ value, status }` unification across names/attachments/drafts, and giving attachments a real read cache, stay deferred. This is why `DecryptCacheEntry.content` was *not* renamed to `value`.
- **The SSK key layer (`stream-key-cache`) semantics** stay as-is per the design doc — only its existing clear joins the registry.

## Test plan

- [x] `decrypted-cache.test.ts` (new) — primitive + registry: dedup, both `retryFailed` modes, clear-mid-flight no-leak, prime/`skipPrime`, per-key vs global notification, LRU eviction, `clearAllDecrypted`.
- [x] Existing wrapper tests **unmodified** and green: `decrypt-cache.test.ts`, `stream-name-cache.test.ts`, `stream-rename.test.ts`.
- [x] Consumer surfaces green: message/step/draft content + previews, `use-draft-message`, `use-all-drafts`, `use-stream-search`, `use-stream-or-draft`, coordinated-loading, trace-step, general-tab rename, `stream-sync`, `draft-e2e-roam`, `seal-draft`, `e2e-session-store`.
- [x] **Full frontend unit suite: 2850 passed, 0 failing** (`bun run test`).
- [x] `bun run typecheck` clean; `eslint` clean on all changed files.
- [x] Pre-commit hook ran the full monorepo lint + typecheck (all workspaces) and passed.
- [x] Self-review of the diff: confirmed every preserved export, the referential-stability contract for `getCachedDecryption` (`peek` returns the stored object), and that `e2e-session-store` is no longer a per-function clear caller.

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_015rYADpcjfCeXqZKH4hDqdR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784266911&installation_id=129946197&pr_number=980&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F980&signature=98dd0b331d4874cb975064f3b5eb44b0e12f2467d93628dfb627782248d5faa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->