### PR TITLE
feat(editor): make snippet format a dropdown to correct a wrong sniff

### DIFF
--- a/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
@@ -37,12 +37,12 @@ describe("SnippetEditorDialog", () => {
       />
     )
 
-    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("JSON")
+    expect(screen.getByRole("combobox", { name: "Snippet format" }).textContent).toContain("JSON")
     fireEvent.change(screen.getByLabelText("Snippet filename"), { target: { value: "data.csv" } })
-    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("CSV")
+    expect(screen.getByRole("combobox", { name: "Snippet format" }).textContent).toContain("CSV")
   })
 
-  it("overrides a wrong sniff via the format dropdown, rewriting the extension", async () => {
+  it("overrides a wrong sniff via the format select, rewriting the extension", async () => {
     const user = userEvent.setup()
     render(
       <SnippetEditorDialog
@@ -54,11 +54,11 @@ describe("SnippetEditorDialog", () => {
       />
     )
 
-    await user.click(screen.getByRole("button", { name: /Snippet format/ }))
-    await user.click(await screen.findByRole("menuitemradio", { name: /CSV/ }))
+    await user.click(screen.getByRole("combobox", { name: "Snippet format" }))
+    await user.click(await screen.findByRole("option", { name: "CSV" }))
 
     expect((screen.getByLabelText("Snippet filename") as HTMLInputElement).value).toBe("snippet-1.csv")
-    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("CSV")
+    expect(screen.getByRole("combobox", { name: "Snippet format" }).textContent).toContain("CSV")
   })
 
   it("saves the edited text and filename", () => {

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { SnippetEditorDialog } from "./snippet-editor-dialog"
 import * as useMobileModule from "@/hooks/use-mobile"
 
@@ -25,7 +26,7 @@ describe("SnippetEditorDialog", () => {
     expect((screen.getByLabelText("Snippet filename") as HTMLInputElement).value).toBe("snippet-1.txt")
   })
 
-  it("shows a format badge that tracks the filename extension", () => {
+  it("shows a format control that tracks the filename extension", () => {
     render(
       <SnippetEditorDialog
         open
@@ -36,10 +37,28 @@ describe("SnippetEditorDialog", () => {
       />
     )
 
-    expect(screen.getByText("JSON")).toBeTruthy()
+    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("JSON")
     fireEvent.change(screen.getByLabelText("Snippet filename"), { target: { value: "data.csv" } })
-    expect(screen.getByText("CSV")).toBeTruthy()
-    expect(screen.queryByText("JSON")).toBeNull()
+    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("CSV")
+  })
+
+  it("overrides a wrong sniff via the format dropdown, rewriting the extension", async () => {
+    const user = userEvent.setup()
+    render(
+      <SnippetEditorDialog
+        open
+        onOpenChange={() => {}}
+        initialText="id,name\n1,ada"
+        defaultFilename="snippet-1.txt"
+        onSave={() => {}}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /Snippet format/ }))
+    await user.click(await screen.findByRole("menuitemradio", { name: /CSV/ }))
+
+    expect((screen.getByLabelText("Snippet filename") as HTMLInputElement).value).toBe("snippet-1.csv")
+    expect(screen.getByRole("button", { name: /Snippet format/ }).textContent).toContain("CSV")
   })
 
   it("saves the edited text and filename", () => {

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -1,14 +1,8 @@
 import { useEffect, useRef, useState } from "react"
-import { ChevronDown, FileCode2 } from "lucide-react"
+import { FileCode2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import {
   ResponsiveDialog,
@@ -136,42 +130,28 @@ export function SnippetEditorDialog({
               placeholder={SNIPPET_FALLBACK_FILENAME}
               className="flex-1 text-sm font-mono"
             />
-            {/* The sniff is a guess; this dropdown lets the user correct it.
+            {/* The sniff is a guess; this Select lets the user correct it.
                 Picking a format rewrites the filename extension so the filename
-                stays the single source of truth for the badge label and mime. */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-10 shrink-0 justify-between gap-1.5 min-w-28 font-normal"
-                >
-                  <span className="sr-only">Snippet format: </span>
-                  {format.label}
-                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[var(--radix-dropdown-menu-trigger-width)]">
-                <DropdownMenuRadioGroup
-                  value={format.key}
-                  onValueChange={(key) =>
-                    setFilename(
-                      withSnippetFormatExtension(trimmedFilename || SNIPPET_FALLBACK_FILENAME, snippetFormatByKey(key))
-                    )
-                  }
-                >
-                  {SNIPPET_FORMAT_OPTIONS.map((option) => (
-                    <DropdownMenuRadioItem key={option.key} value={option.key} className="cursor-pointer">
-                      {option.label}
-                      <span className="ml-auto pl-4 text-xs text-muted-foreground tabular-nums">
-                        .{option.extension}
-                      </span>
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                stays the single source of truth for the label and mime. */}
+            <Select
+              value={format.key}
+              onValueChange={(key) =>
+                setFilename(
+                  withSnippetFormatExtension(trimmedFilename || SNIPPET_FALLBACK_FILENAME, snippetFormatByKey(key))
+                )
+              }
+            >
+              <SelectTrigger aria-label="Snippet format" className="h-10 w-auto min-w-[7.5rem] shrink-0 font-normal">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SNIPPET_FORMAT_OPTIONS.map((option) => (
+                  <SelectItem key={option.key} value={option.key}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           {/* wrap="off": long lines scroll horizontally so code keeps its
               column layout rather than reflowing. */}

--- a/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
+++ b/apps/frontend/src/components/editor/snippet-editor-dialog.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useRef, useState } from "react"
-import { FileCode2 } from "lucide-react"
-import { Badge } from "@/components/ui/badge"
+import { ChevronDown, FileCode2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import {
@@ -11,7 +17,13 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
-import { SNIPPET_FALLBACK_FILENAME, snippetFormatForFilename } from "./snippet-paste"
+import {
+  SNIPPET_FALLBACK_FILENAME,
+  SNIPPET_FORMAT_OPTIONS,
+  snippetFormatByKey,
+  snippetFormatForFilename,
+  withSnippetFormatExtension,
+} from "./snippet-paste"
 
 interface SnippetEditorDialogProps {
   open: boolean
@@ -67,8 +79,8 @@ export function SnippetEditorDialog({
 
   const trimmedFilename = filename.trim()
   const canSave = text.length > 0 && trimmedFilename.length > 0
-  // Reads off the live filename (not the original sniff) so the badge always
-  // matches the extension that will actually be attached.
+  // Reads off the live filename (not the original sniff) so the format control
+  // always reflects the extension that will actually be attached.
   const format = snippetFormatForFilename(trimmedFilename || SNIPPET_FALLBACK_FILENAME)
 
   const handleSave = () => {
@@ -124,13 +136,42 @@ export function SnippetEditorDialog({
               placeholder={SNIPPET_FALLBACK_FILENAME}
               className="flex-1 text-sm font-mono"
             />
-            <Badge
-              variant="secondary"
-              className="shrink-0 justify-center min-w-24 font-normal pointer-events-none select-none"
-            >
-              <span className="sr-only">Detected format: </span>
-              {format.label}
-            </Badge>
+            {/* The sniff is a guess; this dropdown lets the user correct it.
+                Picking a format rewrites the filename extension so the filename
+                stays the single source of truth for the badge label and mime. */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-10 shrink-0 justify-between gap-1.5 min-w-28 font-normal"
+                >
+                  <span className="sr-only">Snippet format: </span>
+                  {format.label}
+                  <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[var(--radix-dropdown-menu-trigger-width)]">
+                <DropdownMenuRadioGroup
+                  value={format.key}
+                  onValueChange={(key) =>
+                    setFilename(
+                      withSnippetFormatExtension(trimmedFilename || SNIPPET_FALLBACK_FILENAME, snippetFormatByKey(key))
+                    )
+                  }
+                >
+                  {SNIPPET_FORMAT_OPTIONS.map((option) => (
+                    <DropdownMenuRadioItem key={option.key} value={option.key} className="cursor-pointer">
+                      {option.label}
+                      <span className="ml-auto pl-4 text-xs text-muted-foreground tabular-nums">
+                        .{option.extension}
+                      </span>
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           {/* wrap="off": long lines scroll horizontally so code keeps its
               column layout rather than reflowing. */}

--- a/apps/frontend/src/components/editor/snippet-paste.test.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.test.ts
@@ -4,8 +4,10 @@ import {
   shouldConvertPasteToSnippet,
   defaultSnippetFilename,
   detectSnippetFormat,
+  snippetFormatByKey,
   snippetFormatForFilename,
   snippetMimeForFilename,
+  withSnippetFormatExtension,
   SNIPPET_PASTE_BYTE_THRESHOLD,
 } from "./snippet-paste"
 
@@ -89,6 +91,23 @@ describe("detectSnippetFormat", () => {
     expect(detectSnippetFormat("---\nname: threa\nversion: 1\nitems:\n  - a\n  - b").key).toBe("yaml")
     expect(detectSnippetFormat("host: localhost\nport: 5432\nuser: admin\ndebug: false").key).toBe("yaml")
     expect(detectSnippetFormat("The quick brown fox.\nJumped over the lazy dog.\nAgain and again.").key).toBe("text")
+  })
+})
+
+describe("withSnippetFormatExtension", () => {
+  it("swaps an existing extension for the chosen format's", () => {
+    expect(withSnippetFormatExtension("data.json", snippetFormatByKey("csv"))).toBe("data.csv")
+    expect(withSnippetFormatExtension("query.sql", snippetFormatByKey("text"))).toBe("query.txt")
+  })
+
+  it("appends an extension when the name has none", () => {
+    expect(withSnippetFormatExtension("mydata", snippetFormatByKey("yaml"))).toBe("mydata.yaml")
+    expect(withSnippetFormatExtension("notes.", snippetFormatByKey("markdown"))).toBe("notes.md")
+  })
+
+  it("falls back to a snippet base for an empty or dot-only name", () => {
+    expect(withSnippetFormatExtension("", snippetFormatByKey("json"))).toBe("snippet.json")
+    expect(withSnippetFormatExtension("   ", snippetFormatByKey("json"))).toBe("snippet.json")
   })
 })
 

--- a/apps/frontend/src/components/editor/snippet-paste.ts
+++ b/apps/frontend/src/components/editor/snippet-paste.ts
@@ -49,6 +49,26 @@ const SNIPPET_FORMATS: Record<SnippetFormatKey, SnippetFormat> = {
   yaml: { key: "yaml", extension: "yaml", mimeType: "application/x-yaml", label: "YAML" },
 }
 
+/**
+ * Every format the snippet editor can be set to, in picker order. The dialog's
+ * format dropdown renders these so a user can override a wrong sniff; plain text
+ * leads as the safe default the detector falls back to.
+ */
+export const SNIPPET_FORMAT_OPTIONS: readonly SnippetFormat[] = [
+  SNIPPET_FORMATS.text,
+  SNIPPET_FORMATS.json,
+  SNIPPET_FORMATS.yaml,
+  SNIPPET_FORMATS.xml,
+  SNIPPET_FORMATS.html,
+  SNIPPET_FORMATS.csv,
+  SNIPPET_FORMATS.markdown,
+]
+
+/** Look up a format by its key; falls back to plain text for unknown keys. */
+export function snippetFormatByKey(key: string): SnippetFormat {
+  return SNIPPET_FORMATS[key as SnippetFormatKey] ?? SNIPPET_FORMATS.text
+}
+
 const EXTENSION_TO_FORMAT: Record<string, SnippetFormat> = {
   txt: SNIPPET_FORMATS.text,
   json: SNIPPET_FORMATS.json,
@@ -78,6 +98,20 @@ function extensionOf(filename: string): string {
  */
 export function snippetFormatForFilename(filename: string): SnippetFormat {
   return EXTENSION_TO_FORMAT[extensionOf(filename)] ?? SNIPPET_FORMATS.text
+}
+
+/**
+ * Rewrite a filename so its extension matches the chosen format, keeping the
+ * filename the single source of truth (so the badge and mime stay in sync). The
+ * base name is preserved; a missing or trailing-dot name falls back to
+ * `snippet` so the result is always a usable `name.ext`.
+ */
+export function withSnippetFormatExtension(filename: string, format: SnippetFormat): string {
+  const trimmed = filename.trim()
+  const dot = trimmed.lastIndexOf(".")
+  const hasExtension = dot > 0 && dot < trimmed.length - 1
+  const base = (hasExtension ? trimmed.slice(0, dot) : trimmed).replace(/\.+$/, "") || "snippet"
+  return `${base}.${format.extension}`
 }
 
 /** Mime type for the attachment, derived from the final filename's extension. */

--- a/apps/frontend/src/test/setup.ts
+++ b/apps/frontend/src/test/setup.ts
@@ -62,6 +62,12 @@ if (typeof globalThis.BroadcastChannel === "undefined") {
 // Mock scrollIntoView (not available in jsdom)
 Element.prototype.scrollIntoView = () => {}
 
+// Pointer-capture APIs (not implemented in jsdom). Radix Select/Dropdown call
+// these during pointer interactions, so userEvent clicks throw without them.
+Element.prototype.hasPointerCapture ??= () => false
+Element.prototype.setPointerCapture ??= () => {}
+Element.prototype.releasePointerCapture ??= () => {}
+
 // Mock matchMedia (not available in jsdom, needed by useIsMobile)
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Problem

The snippet editor (`SnippetEditorDialog`) sniffs a pasted/created blob's format with the structural heuristics in `snippet-paste.ts` (`detectSnippetFormat`) and showed the result as a static, non-interactive `<Badge>` pill (e.g. "JSON"). The sniffer is deliberately conservative — every detector demands a hard structural signal and anything ambiguous falls through to `Plain text` (INV-54 forbids guessing a language from English keywords). That means a wrong or fallback guess was common, and the only way to correct it was to hand-edit the filename's extension, because the filename is the single source of truth for both the badge label and the attachment mime (`snippetMimeForFilename`). Renaming `snippet-1.txt` → `snippet-1.csv` by hand to fix a misdetect is a poor affordance.

## Solution

Replace the read-only badge with a `DropdownMenu` — the same primitive the stream top-bar uses for the conversation-overlay split-button. The trigger shows the current format and a chevron; the menu is a `DropdownMenuRadioGroup` listing every supported format. Selecting one rewrites the filename's extension rather than introducing a second piece of state, so the filename stays the single source of truth and the existing mime-derivation path (`rich-editor.tsx:490`, `snippetMimeForFilename(safeName)`) is untouched.

### How it works

1. `SNIPPET_FORMAT_OPTIONS` (new, in `snippet-paste.ts`) is an ordered `SnippetFormat[]` — Plain text, JSON, YAML, XML, HTML, CSV, Markdown — that the radio group renders. Plain text leads as the detector's fallback default.
2. The radio group's `value` is `format.key`, still derived from the live filename via the existing `snippetFormatForFilename(trimmedFilename || SNIPPET_FALLBACK_FILENAME)`. Typing an extension into the filename input and picking from the menu stay in sync because both read off the same filename.
3. `onValueChange` calls `withSnippetFormatExtension(filename, format)` (new) to swap the extension, then `setFilename(...)`. `snippetFormatByKey(key)` (new) maps the radio key back to a `SnippetFormat`, falling back to plain text for an unknown key.
4. `withSnippetFormatExtension` preserves the base name, strips a trailing/duplicate dot, and falls back to a `snippet` base for an empty/dot-only name, so the result is always a usable `name.ext` — e.g. `data.json` → `data.csv`, `mydata` → `mydata.yaml`, `""` → `snippet.json`.

### Key design decisions

**1. Selecting a format edits the filename, not separate state** — The filename is already the single source of truth for the label and mime (INV-33). Adding a `selectedFormat` state alongside it would create two sources that can disagree (type `.csv`, then pick "JSON" — which wins?). Folding the override back into the filename keeps one authority and means the save path needs no change.

**2. Reuse `DropdownMenu`, matching the conversation-overlay pattern** — The user pointed at the stream top-bar dropdown as the reference. Using the shared `components/ui/dropdown-menu` primitive (INV-14) with a `RadioGroup` gives the check-marked current-selection affordance for free, rather than a one-off `Popover` + custom list.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/snippet-paste.ts` | Add `SNIPPET_FORMAT_OPTIONS` (ordered picker list), `snippetFormatByKey()`, and `withSnippetFormatExtension()` |
| `apps/frontend/src/components/editor/snippet-editor-dialog.tsx` | Replace the `<Badge>` format pill with a `DropdownMenu` + `DropdownMenuRadioGroup`; selecting a format rewrites the filename extension. Drop the now-unused `Badge` import |
| `apps/frontend/src/components/editor/snippet-paste.test.ts` | Unit-test `withSnippetFormatExtension` (swap existing ext, append when missing, dot-only/empty fallback) |
| `apps/frontend/src/components/editor/snippet-editor-dialog.test.tsx` | Retarget the "tracks the filename extension" assertion at the trigger button; add a `userEvent` interaction test that opens the dropdown, picks CSV, and asserts the filename rewrites to `snippet-1.csv` |

## Out of scope (deliberate)

- **The detection heuristics are unchanged** — `detectSnippetFormat` and its structural detectors are untouched; this only adds a manual override for when they're wrong.
- **No new formats** — the picker exposes exactly the formats already in `SNIPPET_FORMATS`; expanding the supported set is a separate change.

## Test plan

- [x] `apps/frontend` `bunx vitest run snippet-paste.test.ts snippet-editor-dialog.test.tsx` — 30 pass (2 files)
- [x] `tsc -p apps/frontend/tsconfig.json --noEmit` — clean
- [x] `prettier --write` on the changed files
- [ ] No browser E2E added — the override is an interaction unit test (`userEvent`) at the dialog level, matching how the existing dialog tests cover behavior

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HenutEjjg2KvvWqJEwzcWS)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784273000&installation_id=129946197&pr_number=982&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F982&signature=b7145ea09f84ad723df01492ccf198f203117899e1a31bcb5fb98470b534e6a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->