### PR TITLE
feat(e2ee): sealed bot trace steps (/sealed-steps + /started) behind the policy flag

### DIFF
--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -113,6 +113,7 @@ export { AgentConfigOverrideRepository } from "./agent-config-override-repositor
 export type { AgentConfigOverride } from "./agent-config-override-repository"
 
 export { hashCallbackToken } from "./callback-token"
+export { assertSessionRunning, verifyCallbackToken, assertReplyKeyGeneration } from "./sealed-session-guards"
 
 export { AgentSessionRepository, SessionStatuses } from "./session-repository"
 export type {

--- a/apps/backend/src/features/agents/sealed-session-guards.ts
+++ b/apps/backend/src/features/agents/sealed-session-guards.ts
@@ -1,0 +1,64 @@
+import { timingSafeEqual } from "node:crypto"
+import { HttpError } from "@threa/backend-common"
+import { hashCallbackToken } from "./callback-token"
+import { SessionStatuses, type AgentSession } from "./session-repository"
+
+/**
+ * The guards every sealed session callback must pass, shared by every
+ * sealed-capable driver — the enclave's session callbacks today and an
+ * owner-granted external bot harness's sealed `/steps`/`/complete` next (§2.6).
+ * They live in the neutral agents feature because each one is a property of the
+ * `agent_sessions` row, not of any one transport: only the header the token
+ * rides in differs between drivers, so each call site reads its own header and
+ * hands the value here.
+ */
+
+export function assertSessionRunning(session: AgentSession | null): asserts session is AgentSession {
+  if (!session) throw new HttpError("Session not found", { status: 404, code: "SESSION_NOT_FOUND" })
+  if (session.status !== SessionStatuses.RUNNING) {
+    throw new HttpError("Session is not running", { status: 409, code: "SESSION_NOT_RUNNING" })
+  }
+}
+
+/**
+ * Bind a sealed callback to the runner the session was assigned to (Phase 2.4b,
+ * E2EE-21). The cleartext token was minted at claim and delivered only inside
+ * the sealed assignment/claim to the winning instance — possession proves the
+ * caller is that runner, a stronger binding than a self-reported instance id
+ * that any workspace-key holder could copy. The row holds only the sha256
+ * digest, so the presented value is hashed before the timing-safe compare (both
+ * sides are fixed-length hex). The token is mandatory: an absent token — like a
+ * NULL row hash, which no token can match — is rejected outright.
+ */
+export function verifyCallbackToken(
+  session: Pick<AgentSession, "callbackTokenHash">,
+  presented: string | undefined
+): void {
+  if (!presented) {
+    throw new HttpError("Missing callback token", { status: 403, code: "CALLBACK_TOKEN_MISSING" })
+  }
+  const expected = session.callbackTokenHash
+  const presentedHash = Buffer.from(hashCallbackToken(presented))
+  if (!expected || !timingSafeEqual(presentedHash, Buffer.from(expected))) {
+    throw new HttpError("Callback token mismatch", { status: 403, code: "CALLBACK_TOKEN_MISMATCH" })
+  }
+}
+
+/**
+ * A seal under any generation other than the one the assignment/claim prescribed
+ * would persist as a permanently undecryptable row — reject it loudly so the turn
+ * fails visibly instead (E2EE-21). Sessions dispatched before the column shipped
+ * (NULL) are exempt.
+ */
+export function assertReplyKeyGeneration(
+  session: Pick<AgentSession, "replyKeyGeneration">,
+  envelope: { keyGeneration: number } | undefined
+): void {
+  if (!envelope || session.replyKeyGeneration == null) return
+  if (envelope.keyGeneration !== session.replyKeyGeneration) {
+    throw new HttpError(
+      `Sealed payload uses key generation ${envelope.keyGeneration}; this session seals under ${session.replyKeyGeneration}`,
+      { status: 400, code: "E2E_WRONG_KEY_GENERATION" }
+    )
+  }
+}

--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -739,6 +739,13 @@ export const AgentSessionRepository = {
       messageId?: string
       completedAt?: Date
       /**
+       * Scope the update to one session so a caller-controlled `stepId` can only
+       * touch a step of the session it owns. The public bot sealed-step callback
+       * passes the authorized session id (the step id is fully caller-supplied
+       * there); omitted on the trusted internal enclave path, where it no-ops.
+       */
+      sessionId?: string
+      /**
        * Guard against overwriting a finalized step. A mid-run substep snapshot can
        * race a finalize (`/steps`): network reordering or a retry can land the
        * snapshot after completion, clobbering the final content with a partial one.
@@ -759,6 +766,7 @@ export const AgentSessionRepository = {
           message_id = COALESCE(${params.messageId ?? null}, message_id),
           completed_at = COALESCE(${params.completedAt ?? null}, completed_at)
         WHERE id = ${stepId}
+          AND (${params.sessionId ?? null}::text IS NULL OR session_id = ${params.sessionId ?? null})
           ${sql.raw(params.requireRunning ? "AND completed_at IS NULL" : "")}
         RETURNING ${sql.raw(STEP_SELECT_FIELDS)}
       `

--- a/apps/backend/src/features/enclave-runtimes/session-handlers.ts
+++ b/apps/backend/src/features/enclave-runtimes/session-handlers.ts
@@ -2,7 +2,6 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import type { Server } from "socket.io"
-import { timingSafeEqual } from "node:crypto"
 import {
   AGENT_STEP_TYPES,
   AuthorTypes,
@@ -26,7 +25,9 @@ import {
   SessionStatuses,
   ARIADNE_AGENT_ID,
   getBuiltInAgentConfig,
-  hashCallbackToken,
+  assertSessionRunning as assertRunning,
+  verifyCallbackToken,
+  assertReplyKeyGeneration as assertReplyGeneration,
   failSessionWithLifecycle,
   type AgentSession,
 } from "../agents"
@@ -174,50 +175,13 @@ interface Dependencies {
 }
 
 /**
- * Phase 2.4b (E2EE-21): bind callbacks to the session's assigned runner. The
- * cleartext token was minted at dispatch and delivered only inside the sealed
- * assignment to the pinned EIK's instance — possession proves the caller is
- * the runner this session was assigned to (a stronger binding than a
- * self-reported keyId, which any internal-key holder could copy). The row
- * holds only the sha256 digest, so the presented value is hashed before the
- * timing-safe compare (both sides are fixed-length hex). The token is
- * mandatory: the rollout-phase tolerance for tokenless in-flight sessions has
- * drained (all pre-2.4b rows are terminal), so an absent token — like a NULL
- * row hash, which no token can match — is rejected outright.
+ * Read the enclave's callback token from its own header and verify it against
+ * the session's binding (shared `verifyCallbackToken`, Phase 2.4b/E2EE-21). The
+ * binding rule lives in the agents feature because it's a property of the
+ * session row, not of the enclave transport; only the header differs per driver.
  */
 function assertCallbackBound(session: AgentSession, req: Request): void {
-  const presented = req.header(ENCLAVE_CALLBACK_TOKEN_HEADER)
-  if (!presented) {
-    throw new HttpError("Missing callback token", { status: 403, code: "CALLBACK_TOKEN_MISSING" })
-  }
-  const expected = session.callbackTokenHash
-  const presentedHash = Buffer.from(hashCallbackToken(presented))
-  if (!expected || !timingSafeEqual(presentedHash, Buffer.from(expected))) {
-    throw new HttpError("Callback token mismatch", { status: 403, code: "CALLBACK_TOKEN_MISMATCH" })
-  }
-}
-
-/**
- * Phase 2.4b (E2EE-21): a seal under any generation other than the one the
- * assignment prescribed would persist as a permanently undecryptable row —
- * reject it loudly so the turn fails visibly instead. Sessions dispatched
- * before the column shipped (NULL) are exempt.
- */
-function assertReplyGeneration(session: AgentSession, envelope: { keyGeneration: number } | undefined): void {
-  if (!envelope || session.replyKeyGeneration == null) return
-  if (envelope.keyGeneration !== session.replyKeyGeneration) {
-    throw new HttpError(
-      `Sealed payload uses key generation ${envelope.keyGeneration}; this session seals under ${session.replyKeyGeneration}`,
-      { status: 400, code: "E2E_WRONG_KEY_GENERATION" }
-    )
-  }
-}
-
-function assertRunning(session: AgentSession | null): asserts session is AgentSession {
-  if (!session) throw new HttpError("Session not found", { status: 404, code: "SESSION_NOT_FOUND" })
-  if (session.status !== SessionStatuses.RUNNING) {
-    throw new HttpError("Session is not running", { status: 409, code: "SESSION_NOT_RUNNING" })
-  }
+  verifyCallbackToken(session, req.header(ENCLAVE_CALLBACK_TOKEN_HEADER))
 }
 
 /**

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -46,6 +46,7 @@ import {
   PI_TOOL_TRACE_FORMAT,
   PI_TOOL_TRACE_SECTION_LABELS,
   PiToolTraceSectionLabels,
+  THREA_CALLBACK_TOKEN_HEADER,
   sentViaApiKey,
   type AuthorType,
   type PiToolTraceSectionLabel,
@@ -73,7 +74,15 @@ import { botId, eventId } from "../../lib/id"
 import { withTransaction } from "../../db"
 import { OutboxRepository } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
-import { AgentSessionRepository, hashCallbackToken, type AgentSessionStep } from "../agents"
+import {
+  AgentSessionRepository,
+  hashCallbackToken,
+  assertSessionRunning,
+  verifyCallbackToken,
+  assertReplyKeyGeneration,
+  type AgentSession,
+  type AgentSessionStep,
+} from "../agents"
 import { buildSealedTurnContext } from "./sealed-turn-context"
 import { encodeCursor, decodeCursor } from "./cursor"
 import {
@@ -118,6 +127,8 @@ import {
   completeInvocationSchema,
   failInvocationSchema,
   recordInvocationStepSchema,
+  recordSealedInvocationStepSchema,
+  startSealedInvocationStepSchema,
 } from "./schemas"
 
 function serializeStream(stream: Stream, context?: DisplayNameContext): WireStream {
@@ -686,6 +697,51 @@ export function createPublicApiHandlers({
     }
   }
 
+  /**
+   * Resolve and authorize a sealed bot step callback (the external sibling of
+   * the enclave's session-callback guards). Bot invocations reuse the invocation
+   * id as the agent session id, so the path's `invocationId` is the session id.
+   * The neutral callback token (model A — the claim token, delivered only inside
+   * the winning sealed claim) is the binding; the workspace + persona checks are
+   * defense-in-depth isolation (INV-8) on top of it. Mirrors the enclave's
+   * `assertRunning`/`assertCallbackBound` + stream resolution.
+   */
+  async function authorizeSealedStepCallback(req: Request) {
+    if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
+    const session = await AgentSessionRepository.findById(pool, req.params.invocationId)
+    assertSessionRunning(session)
+    verifyCallbackToken(session, req.header(THREA_CALLBACK_TOKEN_HEADER))
+    const stream = await StreamRepository.findById(pool, session.streamId)
+    if (!stream || stream.workspaceId !== req.workspaceId) {
+      throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
+    }
+    const bot = await BotRepository.findById(pool, req.workspaceId!, req.botApiKey.botId)
+    if (!bot || bot.archivedAt) throw new HttpError("Bot not found or archived", { status: 404, code: "NOT_FOUND" })
+    if (session.personaId !== bot.id) {
+      throw new HttpError("Session does not belong to this bot", { status: 403, code: "FORBIDDEN" })
+    }
+    return { session, stream, bot }
+  }
+
+  /**
+   * Drive the inline stream-view indicator at a sealed step boundary — the same
+   * `agent_session:progress` payload the plaintext sink emits, step type only
+   * (never sealed content). Emitted at step start (and on the finalize fallback
+   * when the start was dropped) so "<bot> is …" tracks the live step.
+   */
+  function emitBotSealedProgress(stream: Stream, session: AgentSession, bot: Bot, step: AgentSessionStep): void {
+    io.to(`ws:${stream.workspaceId}:stream:${session.streamId}`).emit("agent_session:progress", {
+      workspaceId: stream.workspaceId,
+      streamId: session.streamId,
+      sessionId: session.id,
+      triggerMessageId: session.triggerMessageId,
+      personaName: bot.name,
+      stepCount: step.stepNumber,
+      messageCount: 0,
+      currentStepType: step.stepType,
+    })
+  }
+
   /** Find a message, verify stream access, and verify ownership. Used by update/delete. */
   async function resolveOwnedMessage(messageId: string, req: Request) {
     const message = await eventService.getMessageById(messageId)
@@ -1237,6 +1293,95 @@ export function createPublicApiHandlers({
         statusText: sanitizeStatusText(data.statusText),
       })
       res.json({ data: { invocationId: claim.id, sessionId: claim.id, stepId: step.id } })
+    },
+
+    /**
+     * Open one in-flight sealed trace step the moment the bot's loop starts it —
+     * the external sibling of the enclave's `/steps/started`. Content is sealed
+     * when already known (reasoning/reply) and absent for tools (no result yet);
+     * only `stepType` is clear. A later sealed `/steps` finalizes this `stepId` in
+     * place. The whole sealed path is dark until `externalSealedDelivery` flips.
+     */
+    async startBotInvocationSealedStep(req: Request, res: Response) {
+      const data = validateRequest(startSealedInvocationStepSchema, req.body)
+      const { session, stream, bot } = await authorizeSealedStepCallback(req)
+      assertReplyKeyGeneration(session, data.envelope)
+
+      // Insert the in-flight row (no completed_at) + current_step_type in one
+      // transaction (INV-6) so a reader never sees the step without its type;
+      // step_number is computed atomically in the INSERT (INV-20).
+      const persisted = await withTransaction(pool, async (tx) => {
+        const created = await AgentSessionRepository.appendStep(tx, {
+          id: data.stepId,
+          sessionId: session.id,
+          stepType: data.stepType,
+          messageId: data.messageId,
+          contentCiphertext: data.ciphertext,
+          contentEnvelope: data.envelope,
+          startedAt: new Date(),
+        })
+        await AgentSessionRepository.updateCurrentStepType(tx, session.id, data.stepType)
+        return created
+      })
+
+      io.to(`ws:${stream.workspaceId}:agent_session:${session.id}`).emit("agent_session:step:started", {
+        sessionId: session.id,
+        step: serializeTraceStep(persisted),
+      })
+      emitBotSealedProgress(stream, session, bot, persisted)
+
+      res.json({ data: { invocationId: session.id, sessionId: session.id, stepId: persisted.id } })
+    },
+
+    /**
+     * Finalize one sealed trace step in place when it completes — set the sealed
+     * content + completed_at on the row opened at sealed `/steps/started`, keeping
+     * its original started_at so the duration is real. The content is ciphertext
+     * only; the owner's browser decrypts it (INV-E7). If the start POST was
+     * dropped, fall back to a race-safe completed insert so the trace still lands.
+     * The external sibling of the enclave's `/steps`.
+     */
+    async recordBotInvocationSealedStep(req: Request, res: Response) {
+      const data = validateRequest(recordSealedInvocationStepSchema, req.body)
+      const { session, stream, bot } = await authorizeSealedStepCallback(req)
+      assertReplyKeyGeneration(session, data.envelope)
+
+      const completedAt = new Date()
+      let persisted = await AgentSessionRepository.updateStep(pool, data.stepId, {
+        contentCiphertext: data.ciphertext,
+        contentEnvelope: data.envelope,
+        messageId: data.messageId,
+        completedAt,
+      })
+
+      // Fallback: the start POST never landed (dropped/raced), so there's no row
+      // to finalize. Insert a completed row + advance current_step_type (INV-6,
+      // INV-20) so the trace and inline indicator still reflect this step.
+      if (!persisted) {
+        const startedAt = new Date(completedAt.getTime() - (data.durationMs ?? 0))
+        persisted = await withTransaction(pool, async (tx) => {
+          const created = await AgentSessionRepository.appendStep(tx, {
+            id: data.stepId,
+            sessionId: session.id,
+            stepType: data.stepType,
+            messageId: data.messageId,
+            contentCiphertext: data.ciphertext,
+            contentEnvelope: data.envelope,
+            startedAt,
+            completedAt,
+          })
+          await AgentSessionRepository.updateCurrentStepType(tx, session.id, data.stepType)
+          return created
+        })
+        emitBotSealedProgress(stream, session, bot, persisted)
+      }
+
+      io.to(`ws:${stream.workspaceId}:agent_session:${session.id}`).emit("agent_session:step:completed", {
+        sessionId: session.id,
+        step: serializeTraceStep(persisted),
+      })
+
+      res.json({ data: { invocationId: session.id, sessionId: session.id, stepId: persisted.id } })
     },
 
     async completeBotInvocation(req: Request, res: Response) {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1347,7 +1347,10 @@ export function createPublicApiHandlers({
       assertReplyKeyGeneration(session, data.envelope)
 
       const completedAt = new Date()
+      // Scope the finalize to this session: data.stepId is caller-supplied, so an
+      // unscoped update would let a bot overwrite another session's step row.
       let persisted = await AgentSessionRepository.updateStep(pool, data.stepId, {
+        sessionId: session.id,
         contentCiphertext: data.ciphertext,
         contentEnvelope: data.envelope,
         messageId: data.messageId,

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -19,6 +19,7 @@ import {
   KNOWLEDGE_TYPES,
   PROCESSING_STATUSES,
   EXTRACTION_CONTENT_TYPES,
+  THREA_CALLBACK_TOKEN_HEADER,
 } from "@threa/types"
 import type { WorkspacePermissionSlug } from "@threa/types"
 import {
@@ -42,6 +43,8 @@ import {
   completeInvocationSchema,
   failInvocationSchema,
   recordInvocationStepSchema,
+  recordSealedInvocationStepSchema,
+  startSealedInvocationStepSchema,
 } from "./schemas"
 
 // Response schemas — the single source of truth for public API wire shapes.
@@ -464,6 +467,14 @@ const attachmentIdParam = {
   description: "Attachment ID (prefixed ULID)",
 }
 
+const callbackTokenHeaderParam = {
+  name: THREA_CALLBACK_TOKEN_HEADER,
+  in: "header" as const,
+  required: true,
+  schema: { type: "string" as const },
+  description: "Per-claim callback token from the sealed claim response (binds the caller to the assigned session).",
+}
+
 export interface PublicApiRoute {
   method: "get" | "post" | "patch" | "delete"
   path: string
@@ -474,7 +485,7 @@ export interface PublicApiRoute {
   scopes: WorkspacePermissionSlug[]
   parameters?: Array<{
     name: string
-    in: "path" | "query"
+    in: "path" | "query" | "header"
     required: boolean
     schema: { type: string }
     description: string
@@ -672,6 +683,44 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
       { name: "invocationId", in: "path", required: true, schema: { type: "string" }, description: "Invocation ID" },
     ],
     requestSchema: recordInvocationStepSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(invocationStepSchema),
+    canReturn404: true,
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-steps/started",
+    operationId: "startBotInvocationSealedStep",
+    summary: "Open an in-flight sealed bot invocation trace step",
+    description:
+      "Sealed variant of the trace-step start, for an owner-granted E2E bot harness: the content is ciphertext the server never decrypts. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+    tags: ["Bot invocations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE],
+    parameters: [
+      workspaceIdParam,
+      { name: "invocationId", in: "path", required: true, schema: { type: "string" }, description: "Invocation ID" },
+      callbackTokenHeaderParam,
+    ],
+    requestSchema: startSealedInvocationStepSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(invocationStepSchema),
+    canReturn404: true,
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-steps",
+    operationId: "recordBotInvocationSealedStep",
+    summary: "Finalize a sealed bot invocation trace step",
+    description:
+      "Sealed variant of the trace-step finalize, for an owner-granted E2E bot harness: sets the sealed content + completion on the step opened at sealed-steps/started (or inserts a completed row if the start was dropped). Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+    tags: ["Bot invocations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE],
+    parameters: [
+      workspaceIdParam,
+      { name: "invocationId", in: "path", required: true, schema: { type: "string" }, description: "Invocation ID" },
+      callbackTokenHeaderParam,
+    ],
+    requestSchema: recordSealedInvocationStepSchema,
     requestIn: "body",
     responseSchema: dataEnvelope(invocationStepSchema),
     canReturn404: true,

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -156,6 +156,44 @@ export const recordInvocationStepSchema = z.object({
   statusText: z.string().max(200).optional(),
 })
 
+// These base64 fields are persisted verbatim and only decrypted later (in the
+// owner's browser), so decodability is validated at the boundary — malformed
+// base64 that slips through becomes a permanently unreadable step. Mirrors the
+// enclave's sealed-step validation (session-handlers.ts).
+const sealedStreamEnvelopeSchema = z.object({
+  v: z.number(),
+  keyGeneration: z.number().int().min(0),
+  iv: z.base64().min(1),
+  aad: z.base64().min(1),
+})
+
+// One sealed trace step a sealed-capable bot harness finalized (the external
+// sibling of the enclave's `/steps`). `stepType` + `messageId` + timing are
+// clear; the content is ciphertext the server can't read (INV-E7). Auth is the
+// bot API key + the neutral callback token header, not body fields — the body is
+// exactly the `SealedStep` wire shape.
+export const recordSealedInvocationStepSchema = z.object({
+  stepId: z.string().min(1).max(128),
+  stepType: z.enum(AGENT_STEP_TYPES),
+  messageId: z.string().min(1).max(128).optional(),
+  ciphertext: z.base64().min(1),
+  envelope: sealedStreamEnvelopeSchema,
+  durationMs: z.number().int().min(0).optional(),
+})
+
+// One in-flight sealed trace step *start* (the external sibling of the enclave's
+// `/steps/started`). Content is sealed when already known (reasoning/reply) and
+// absent for tools whose result isn't known yet, so ciphertext + envelope are
+// optional here; a matching `recordSealedInvocationStep` finalizes the same
+// `stepId` in place.
+export const startSealedInvocationStepSchema = z.object({
+  stepId: z.string().min(1).max(128),
+  stepType: z.enum(AGENT_STEP_TYPES),
+  messageId: z.string().min(1).max(128).optional(),
+  ciphertext: z.base64().min(1).optional(),
+  envelope: sealedStreamEnvelopeSchema.optional(),
+})
+
 export const listMessagesSchema = z
   .object({
     before: z.string().regex(/^\d+$/, "must be a numeric sequence").optional(),

--- a/apps/backend/src/features/public-api/sealed-steps.test.ts
+++ b/apps/backend/src/features/public-api/sealed-steps.test.ts
@@ -218,7 +218,12 @@ describe("recordBotInvocationSealedStep", () => {
     )
 
     const updateParams = update.mock.calls[0]?.[2] as unknown as Record<string, unknown>
-    expect(updateParams).toMatchObject({ contentCiphertext: "c2VhbGVk", contentEnvelope: REPLY_ENVELOPE })
+    // sessionId scopes the finalize so a caller-supplied stepId can't touch another session's step.
+    expect(updateParams).toMatchObject({
+      sessionId: "binv_1",
+      contentCiphertext: "c2VhbGVk",
+      contentEnvelope: REPLY_ENVELOPE,
+    })
     expect(updateParams.completedAt).toBeInstanceOf(Date)
     // No fallback insert when the in-flight row was finalized.
     expect(append).not.toHaveBeenCalled()

--- a/apps/backend/src/features/public-api/sealed-steps.test.ts
+++ b/apps/backend/src/features/public-api/sealed-steps.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { THREA_CALLBACK_TOKEN_HEADER } from "@threa/types"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { BotRepository } from "./bot-repository"
+import { StreamRepository } from "../streams"
+import { AgentSessionRepository, hashCallbackToken, type AgentSession, type AgentSessionStep } from "../agents"
+import * as dbModule from "../../db"
+
+// Phase 2 sealed bot `/steps` + `/steps/started`: the external sibling of the
+// enclave's session-callback steps. A sealed-capable bot harness streams sealed
+// trace steps back; the server persists ciphertext it can't read and broadcasts
+// the live trace frames. Auth is the bot API key + the neutral
+// `X-Threa-Callback-Token` header verified against the session's binding.
+
+const CALLBACK_TOKEN = "tok_1"
+const REPLY_ENVELOPE = { v: 2, keyGeneration: 3, iv: "aXY=", aad: "YWFk" }
+
+const session: AgentSession = {
+  id: "binv_1",
+  streamId: "stream_thread",
+  personaId: "bot_1",
+  triggerMessageId: "msg_trigger",
+  triggerMessageRevision: null,
+  supersedesSessionId: null,
+  status: "running",
+  currentStep: 0,
+  currentStepType: null,
+  serverId: null,
+  callbackTokenHash: hashCallbackToken(CALLBACK_TOKEN),
+  replyKeyGeneration: 3,
+  heartbeatAt: new Date("2026-06-12T09:00:00.000Z"),
+  abortRequestedAt: null,
+  responseMessageId: null,
+  error: null,
+  lastSeenSequence: 0n,
+  sentMessageIds: [],
+  contextMessageIds: [],
+  createdAt: new Date("2026-06-12T09:00:00.000Z"),
+  completedAt: null,
+}
+
+function stepRow(overrides: Partial<AgentSessionStep>): AgentSessionStep {
+  return {
+    id: "step_1",
+    sessionId: "binv_1",
+    stepNumber: 1,
+    stepType: "thinking",
+    content: null,
+    contentCiphertext: "c2VhbGVk",
+    contentEnvelope: REPLY_ENVELOPE,
+    sources: null,
+    messageId: null,
+    tokensUsed: null,
+    startedAt: new Date("2026-06-12T09:00:01.000Z"),
+    completedAt: null,
+    ...overrides,
+  }
+}
+
+function createResponse() {
+  const payloads: unknown[] = []
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock((body: unknown) => {
+    payloads.push(body)
+    return res
+  }) as unknown as Response["json"]
+  return { res, payloads }
+}
+
+function createEmitSpy() {
+  const emitted: { room: string; event: string; payload: unknown }[] = []
+  const io = {
+    to: (room: string) => ({
+      emit: (event: string, payload: unknown) => {
+        emitted.push({ room, event, payload })
+      },
+    }),
+  } as unknown as PublicApiDeps["io"]
+  return { io, emitted }
+}
+
+function arrange(sessionOverride?: Partial<AgentSession>) {
+  spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...session, ...sessionOverride } as never)
+  spyOn(StreamRepository, "findById").mockResolvedValue({
+    id: "stream_thread",
+    workspaceId: "ws_1",
+  } as never)
+  spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Pi", archivedAt: null } as never)
+  spyOn(dbModule, "withTransaction").mockImplementation(((_pool: unknown, fn: (c: unknown) => unknown) =>
+    fn({})) as never)
+  spyOn(AgentSessionRepository, "updateCurrentStepType").mockResolvedValue(undefined as never)
+
+  const { io, emitted } = createEmitSpy()
+  const handlers = createPublicApiHandlers({
+    eventService: {} as PublicApiDeps["eventService"],
+    streamService: {} as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService: {} as PublicApiDeps["botRuntimeService"],
+    pool: {} as PublicApiDeps["pool"],
+    io,
+  })
+  return { handlers, emitted }
+}
+
+function req(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = { [THREA_CALLBACK_TOKEN_HEADER]: CALLBACK_TOKEN }
+) {
+  return {
+    workspaceId: "ws_1",
+    botApiKey: { botId: "bot_1" },
+    params: { invocationId: "binv_1" },
+    header: (name: string) => headers[name],
+    body,
+  } as unknown as Request
+}
+
+describe("startBotInvocationSealedStep", () => {
+  afterEach(() => mock.restore())
+
+  it("persists the in-flight sealed step and broadcasts the started frame", async () => {
+    const { handlers, emitted } = arrange()
+    const append = spyOn(AgentSessionRepository, "appendStep").mockResolvedValue(stepRow({}) as never)
+    const { res, payloads } = createResponse()
+
+    await handlers.startBotInvocationSealedStep(
+      req({ stepId: "step_1", stepType: "thinking", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE }),
+      res
+    )
+
+    const appendParams = append.mock.calls[0]?.[1] as unknown as Record<string, unknown>
+    expect(appendParams).toMatchObject({
+      id: "step_1",
+      sessionId: "binv_1",
+      stepType: "thinking",
+      contentCiphertext: "c2VhbGVk",
+      contentEnvelope: REPLY_ENVELOPE,
+    })
+    expect(appendParams.completedAt).toBeUndefined()
+    expect(emitted.map((e) => e.event)).toContain("agent_session:step:started")
+    expect((payloads[0] as { data: { stepId: string } }).data.stepId).toBe("step_1")
+  })
+
+  it("rejects a missing callback token (403)", async () => {
+    const { handlers } = arrange()
+    const { res } = createResponse()
+    await expect(
+      handlers.startBotInvocationSealedStep(
+        req({ stepId: "step_1", stepType: "thinking", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE }, {}),
+        res
+      )
+    ).rejects.toMatchObject({ status: 403, code: "CALLBACK_TOKEN_MISSING" })
+  })
+
+  it("rejects a mismatched callback token (403)", async () => {
+    const { handlers } = arrange()
+    const { res } = createResponse()
+    await expect(
+      handlers.startBotInvocationSealedStep(
+        req(
+          { stepId: "step_1", stepType: "thinking", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE },
+          {
+            [THREA_CALLBACK_TOKEN_HEADER]: "wrong",
+          }
+        ),
+        res
+      )
+    ).rejects.toMatchObject({ status: 403, code: "CALLBACK_TOKEN_MISMATCH" })
+  })
+
+  it("rejects a non-running session (409)", async () => {
+    const { handlers } = arrange({ status: "completed" })
+    const { res } = createResponse()
+    await expect(
+      handlers.startBotInvocationSealedStep(
+        req({ stepId: "step_1", stepType: "thinking", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE }),
+        res
+      )
+    ).rejects.toMatchObject({ status: 409, code: "SESSION_NOT_RUNNING" })
+  })
+
+  it("rejects a seal under the wrong key generation (400)", async () => {
+    const { handlers } = arrange()
+    spyOn(AgentSessionRepository, "appendStep").mockResolvedValue(stepRow({}) as never)
+    const { res } = createResponse()
+    await expect(
+      handlers.startBotInvocationSealedStep(
+        req({
+          stepId: "step_1",
+          stepType: "thinking",
+          ciphertext: "c2VhbGVk",
+          envelope: { ...REPLY_ENVELOPE, keyGeneration: 4 },
+        }),
+        res
+      )
+    ).rejects.toMatchObject({ status: 400, code: "E2E_WRONG_KEY_GENERATION" })
+  })
+})
+
+describe("recordBotInvocationSealedStep", () => {
+  afterEach(() => mock.restore())
+
+  it("finalizes the in-flight step in place and broadcasts the completed frame", async () => {
+    const { handlers, emitted } = arrange()
+    const completed = stepRow({ completedAt: new Date("2026-06-12T09:00:05.000Z") })
+    const update = spyOn(AgentSessionRepository, "updateStep").mockResolvedValue(completed as never)
+    const append = spyOn(AgentSessionRepository, "appendStep").mockResolvedValue(completed as never)
+    const { res, payloads } = createResponse()
+
+    await handlers.recordBotInvocationSealedStep(
+      req({ stepId: "step_1", stepType: "thinking", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE }),
+      res
+    )
+
+    const updateParams = update.mock.calls[0]?.[2] as unknown as Record<string, unknown>
+    expect(updateParams).toMatchObject({ contentCiphertext: "c2VhbGVk", contentEnvelope: REPLY_ENVELOPE })
+    expect(updateParams.completedAt).toBeInstanceOf(Date)
+    // No fallback insert when the in-flight row was finalized.
+    expect(append).not.toHaveBeenCalled()
+    expect(emitted.map((e) => e.event)).toContain("agent_session:step:completed")
+    expect((payloads[0] as { data: { stepId: string } }).data.stepId).toBe("step_1")
+  })
+
+  it("falls back to a completed insert when the start POST was dropped", async () => {
+    const { handlers, emitted } = arrange()
+    spyOn(AgentSessionRepository, "updateStep").mockResolvedValue(null as never)
+    const inserted = stepRow({ completedAt: new Date("2026-06-12T09:00:05.000Z") })
+    const append = spyOn(AgentSessionRepository, "appendStep").mockResolvedValue(inserted as never)
+    const { res } = createResponse()
+
+    await handlers.recordBotInvocationSealedStep(
+      req({
+        stepId: "step_1",
+        stepType: "thinking",
+        ciphertext: "c2VhbGVk",
+        envelope: REPLY_ENVELOPE,
+        durationMs: 200,
+      }),
+      res
+    )
+
+    const appendParams = append.mock.calls[0]?.[1] as unknown as Record<string, unknown>
+    expect(appendParams).toMatchObject({ id: "step_1", contentCiphertext: "c2VhbGVk" })
+    expect(appendParams.completedAt).toBeInstanceOf(Date)
+    // The fallback advances the inline indicator (progress) plus the completed frame.
+    expect(emitted.map((e) => e.event)).toEqual(
+      expect.arrayContaining(["agent_session:progress", "agent_session:step:completed"])
+    )
+  })
+})

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -860,6 +860,18 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     publicApi.recordBotInvocationStep
   )
   app.post(
+    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-steps/started",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
+    publicApi.startBotInvocationSealedStep
+  )
+  app.post(
+    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-steps",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
+    publicApi.recordBotInvocationSealedStep
+  )
+  app.post(
     "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/complete",
     ...publicMiddleware,
     requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1770,6 +1770,311 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-steps/started": {
+      "post": {
+        "operationId": "startBotInvocationSealedStep",
+        "summary": "Open an in-flight sealed bot invocation trace step",
+        "tags": ["Bot invocations"],
+        "description": "Sealed variant of the trace-step start, for an owner-granted E2E bot harness: the content is ciphertext the server never decrypts. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+        "security": [{ "apiKey": ["bot-invocations:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "invocationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Invocation ID"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim callback token from the sealed claim response (binds the caller to the assigned session)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "stepId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "stepType": {
+                    "type": "string",
+                    "enum": [
+                      "context_received",
+                      "thinking",
+                      "reconsidering",
+                      "web_search",
+                      "visit_page",
+                      "workspace_search",
+                      "research",
+                      "github_access",
+                      "linear_access",
+                      "message_sent",
+                      "message_edited",
+                      "response",
+                      "tool_call",
+                      "tool_error",
+                      "rate_limited",
+                      "rate_limit_retry",
+                      "turn_digest"
+                    ]
+                  },
+                  "messageId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "ciphertext": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "base64",
+                    "contentEncoding": "base64",
+                    "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                  },
+                  "envelope": {
+                    "type": "object",
+                    "properties": {
+                      "v": { "type": "number" },
+                      "keyGeneration": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+                      "iv": {
+                        "type": "string",
+                        "minLength": 1,
+                        "format": "base64",
+                        "contentEncoding": "base64",
+                        "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                      },
+                      "aad": {
+                        "type": "string",
+                        "minLength": 1,
+                        "format": "base64",
+                        "contentEncoding": "base64",
+                        "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                      }
+                    },
+                    "required": ["v", "keyGeneration", "iv", "aad"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["stepId", "stepType"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "invocationId": { "type": "string" },
+                        "sessionId": { "type": "string" },
+                        "stepId": { "type": "string" }
+                      },
+                      "required": ["invocationId", "sessionId", "stepId"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
+    "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-steps": {
+      "post": {
+        "operationId": "recordBotInvocationSealedStep",
+        "summary": "Finalize a sealed bot invocation trace step",
+        "tags": ["Bot invocations"],
+        "description": "Sealed variant of the trace-step finalize, for an owner-granted E2E bot harness: sets the sealed content + completion on the step opened at sealed-steps/started (or inserts a completed row if the start was dropped). Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+        "security": [{ "apiKey": ["bot-invocations:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "invocationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Invocation ID"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim callback token from the sealed claim response (binds the caller to the assigned session)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "stepId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "stepType": {
+                    "type": "string",
+                    "enum": [
+                      "context_received",
+                      "thinking",
+                      "reconsidering",
+                      "web_search",
+                      "visit_page",
+                      "workspace_search",
+                      "research",
+                      "github_access",
+                      "linear_access",
+                      "message_sent",
+                      "message_edited",
+                      "response",
+                      "tool_call",
+                      "tool_error",
+                      "rate_limited",
+                      "rate_limit_retry",
+                      "turn_digest"
+                    ]
+                  },
+                  "messageId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                  "ciphertext": {
+                    "type": "string",
+                    "minLength": 1,
+                    "format": "base64",
+                    "contentEncoding": "base64",
+                    "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                  },
+                  "envelope": {
+                    "type": "object",
+                    "properties": {
+                      "v": { "type": "number" },
+                      "keyGeneration": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+                      "iv": {
+                        "type": "string",
+                        "minLength": 1,
+                        "format": "base64",
+                        "contentEncoding": "base64",
+                        "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                      },
+                      "aad": {
+                        "type": "string",
+                        "minLength": 1,
+                        "format": "base64",
+                        "contentEncoding": "base64",
+                        "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                      }
+                    },
+                    "required": ["v", "keyGeneration", "iv", "aad"],
+                    "additionalProperties": false
+                  },
+                  "durationMs": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 }
+                },
+                "required": ["stepId", "stepType", "ciphertext", "envelope"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "invocationId": { "type": "string" },
+                        "sessionId": { "type": "string" },
+                        "stepId": { "type": "string" }
+                      },
+                      "required": ["invocationId", "sessionId", "stepId"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/complete": {
       "post": {
         "operationId": "completeBotInvocation",

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -658,6 +658,16 @@ export const INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key"
 // the session was assigned to — the internal key alone proves only "internal".
 export const ENCLAVE_CALLBACK_TOKEN_HEADER = "X-Enclave-Callback-Token"
 
+// Per-session callback binding for sealed turns delivered to an owner-granted
+// external runner (a third-party / self-hosted bot harness). The claim-minted
+// token (the claim token itself, model A) is echoed on every sealed
+// `/steps`/`/complete` callback so the backend can verify the caller is the
+// instance the session was assigned to — the workspace bot key alone proves only
+// "this workspace". Deliberately not enclave-named (§2.6 rule 1): the enclave
+// keeps its own `X-Enclave-Callback-Token`, and this is the same binding for the
+// bot transport, shared by every sealed-capable external driver.
+export const THREA_CALLBACK_TOKEN_HEADER = "X-Threa-Callback-Token"
+
 // Original client-facing host (e.g. `admin.threa.io`, `pr-204-staging.threa.io`)
 // carried from the Cloudflare routers to the control-plane.
 //

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -176,6 +176,7 @@ export {
   // Inter-service authentication
   INTERNAL_API_KEY_HEADER,
   ENCLAVE_CALLBACK_TOKEN_HEADER,
+  THREA_CALLBACK_TOKEN_HEADER,
   // Original client host forwarded through the CF routers (survives Railway)
   ORIGINAL_HOST_HEADER,
   // Socket heartbeat


### PR DESCRIPTION
**Workstream:** E2EE for external bot harnesses — `docs/plans/agent-runtimes-unification-redesign.md` §2.6. Builds on #981 (sealed bot **claim**) and #969/#967. Phase 2 of 6.

## Problem

A sealed-capable external bot harness that wins a sealed claim (#981) has nowhere to send its trace steps. The enclave streams sealed steps back over `POST /internal/enclave-runtimes/sessions/:id/steps` and `/steps/started` (`session-handlers.ts`), persisting ciphertext the backend can't read; the public bot API has only the **plaintext** `/bot-invocations/:invocationId/steps` path, which runs content through the `TraceProjector` and stores cleartext. There is no sealed wire variant for bots, so an owner-granted E2E bot's reasoning/tool trace can't land at all.

§2.6 also names the binding the plaintext path lacks: per-runner callback identity. The plaintext `/steps` authenticates with `claimToken` in the body matched against `bot_invocations.claim_token`; a sealed turn carries the owner's plaintext, so it needs the stronger model-A binding the enclave already uses — a per-claim token verified against `agent_sessions.callback_token_hash` (E2EE-21/22).

## Solution

Add the external siblings of the enclave's sealed step callbacks, reusing the machinery #981 already built (the `callback_token_hash` / `reply_key_generation` columns set at claim, the `content_ciphertext` / `content_envelope` step columns from migration `20260530051907`). The whole path stays dark: no delivery verdict resolves to `sealed` until `externalSealedDelivery` flips (Phase 6), so these routes are unreachable in production.

### How it works

1. **Neutral callback header.** `THREA_CALLBACK_TOKEN_HEADER = "X-Threa-Callback-Token"` (`packages/types/src/constants.ts`) — the per-claim binding for *any* sealed external driver, deliberately **not** enclave-named (§2.6 rule 1). The enclave keeps its own `X-Enclave-Callback-Token`; this is a separate header for the bot transport.

2. **Shared sealed-session guards.** The three guards a sealed callback must pass — `assertSessionRunning`, `verifyCallbackToken`, `assertReplyKeyGeneration` — move into `apps/backend/src/features/agents/sealed-session-guards.ts` and are exported from the agents barrel. Each is a property of the `agent_sessions` row, not of one transport, so only the *header* the token rides in differs between drivers. The enclave's `assertCallbackBound` now reads its own header and delegates to `verifyCallbackToken`; its `assertRunning` / `assertReplyGeneration` become aliased imports of the shared functions (no call-site churn).

3. **`POST /bot-invocations/:invocationId/sealed-steps/started`** (`startBotInvocationSealedStep`) — opens an in-flight sealed step: insert the row (no `completed_at`) + `updateCurrentStepType` in one transaction (INV-6; `step_number` computed atomically in the INSERT, INV-20), then broadcast `agent_session:step:started` to the session room and `agent_session:progress` to the stream room. Content ciphertext/envelope are optional here (a tool step has no result yet), mirroring the enclave.

4. **`POST /bot-invocations/:invocationId/sealed-steps`** (`recordBotInvocationSealedStep`) — finalizes that step in place via `updateStep` (sealed content + `completed_at`, preserving `started_at` so duration is real). If the start POST was dropped, fall back to a race-safe completed `appendStep` + `updateCurrentStepType` so the trace still lands. Broadcasts `agent_session:step:completed`.

5. **Auth.** Both go through `authorizeSealedStepCallback`: bot invocations reuse the invocation id as the agent session id, so the path's `:invocationId` is the session id. The callback-token verify is the binding (a NULL row hash — every plaintext session — is rejected); on top of it, `stream.workspaceId !== req.workspaceId` and `session.personaId !== bot.id` enforce workspace/persona isolation (INV-8). The server only ever persists or relays ciphertext (INV-E7).

6. **Schemas + docs.** `recordSealedInvocationStepSchema` / `startSealedInvocationStepSchema` (`schemas.ts`) validate the body as the `SealedStep` / `SealedStepStart` wire shapes, with base64 decodability checked at the boundary (a malformed byte that slips through is a permanently unreadable step). Route descriptors declare the required `X-Threa-Callback-Token` header param; `docs/public-api/openapi.json` regenerated via `bun run generate:api-docs`.

### Key design decisions

**1. Header-bound auth, not body `claimToken`** — the sealed steps authenticate with the per-claim callback token in `X-Threa-Callback-Token` verified against `agent_sessions.callback_token_hash`, not the plaintext path's `claimToken`-in-body matched against `bot_invocations.claim_token`. §2.6: "per-runner identity so the grant binds to the bot it names … the callback auth … E2EE-21/22's fix covers both." Possession of the per-claim secret (delivered only inside the winning sealed claim, #981 Decision #1) is a stronger binding than a self-reported instance id any workspace-key holder could copy.

**2. Two dedicated routes, not a union-branch on `/steps`** — the plaintext `/steps` runs the `TraceProjector` and doubles as a busy-presence heartbeat; the sealed path writes ciphertext rows and emits start/completed frames directly. They share almost nothing, and `/steps/started` has no plaintext equivalent. Mirroring the enclave's start/finalize split keeps each wire format clean rather than overloading one schema with a discriminated union.

**3. Guards shared, not duplicated (INV-35/37)** — rather than reimplement the running/token/generation checks for bots, the enclave's locals were lifted into one module both drivers import. This is also what §2.6 rule 1 asks for structurally: a shared sealed vocabulary, not an enclave-owned one re-prefixed per consumer.

**4. No presence touch on sealed steps** — unlike plaintext `/steps`, the sealed handlers don't refresh presence; that would require `instanceId` in the body, which the header-auth model deliberately omits. The bot's `/renew` loop owns claim liveness, exactly as the enclave's heartbeat does. Mirrors the enclave (its step callbacks touch no presence).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/sealed-session-guards.ts` | The three sealed session-callback guards, shared by enclave + bots |
| `apps/backend/src/features/public-api/sealed-steps.test.ts` | Unit coverage for both new handlers |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | Add `THREA_CALLBACK_TOKEN_HEADER` |
| `packages/types/src/index.ts` | Export the new constant |
| `apps/backend/src/features/agents/index.ts` | Barrel-export the three guards |
| `apps/backend/src/features/enclave-runtimes/session-handlers.ts` | Delegate `assertCallbackBound` to `verifyCallbackToken`; alias-import `assertRunning`/`assertReplyGeneration` from the shared module; drop the local definitions + the now-unused `timingSafeEqual`/`hashCallbackToken` imports |
| `apps/backend/src/features/public-api/handlers.ts` | Add `startBotInvocationSealedStep`, `recordBotInvocationSealedStep`, and the `authorizeSealedStepCallback` / `emitBotSealedProgress` closures |
| `apps/backend/src/features/public-api/schemas.ts` | Add `recordSealedInvocationStepSchema` + `startSealedInvocationStepSchema` |
| `apps/backend/src/features/public-api/routes.ts` | Route descriptors for both endpoints + the callback-token header param; widen the `parameters` type to allow `in: "header"` |
| `apps/backend/src/routes.ts` | Wire the two express routes |
| `docs/public-api/openapi.json` | Regenerated spec |

## Out of scope (deliberate)

- **Sealed `/complete`** (Phase 3): accept `SealedReply` → `eventService.createMessage` with ciphertext/envelope/`e2eVersion:2`. The plaintext `completeBotInvocation` keeps its `assertNotE2eStream` guard (E2EE-2) — that gate is correct for the plaintext sink and stays until the sealed completion lands.
- **Consent UX** (Phase 4), **Pi client sealed harness** (Phase 5), **flipping `externalSealedDelivery`** (Phase 6).
- **No DB-backed e2e for the sealed path** — the policy const is hardcoded off and the HTTP e2e harness has no crypto-seeding helpers, so the sealed verdict can't be produced end-to-end yet (same constraint as #981). Coverage is unit-level; DB-backed e2e waits until the flag is injectable (Phase 6).

## Test plan

- [x] `bun test src/features/public-api/sealed-steps.test.ts` — 7 pass (sealed persistence, dropped-start fallback, all four rejection codes: missing/mismatched token, non-running session, wrong key generation)
- [x] `bun test src/features/public-api src/features/bot-runtimes` — 127 pass (no regression)
- [x] `bun test src/features/agents src/features/enclave-runtimes` — 426 pass (guards refactor preserves enclave behavior)
- [x] `bun run typecheck` — clean across all packages incl. `tsconfig.tests.json`
- [x] `eslint` clean on all changed backend files
- [x] `bun run generate:api-docs` — OpenAPI regenerated, no drift
- [x] Pre-PR review (2 reviewer agents — correctness/data-flow + spec/§2.6/invariant): **0 findings**. Confirmed: aliased `asserts` import preserves narrowing at all enclave call sites; `SessionStatuses` still imported where used; workspace/persona isolation chain sound; INV-E7 (ciphertext-only) and INV-6/20 (atomic step insert) hold.
- [ ] No live-DB harness in this environment, so the step-insert SQL is exercised via stubbed repos like its siblings — not integration-tested here (runs in CI).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADPwawiQ84QhHS8o7DoRB4)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784273371&installation_id=129946197&pr_number=983&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F983&signature=3184cdba470df76683187de5c952cefdf21a8b92d505fbc445d8dfa346f47655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->