### PR TITLE
test(sync): de-flake "resumes the gate when the batch flush throws"

### DIFF
--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1268,6 +1268,25 @@ describe("SyncEngine sync cursor (active mode)", () => {
       .mockImplementationOnce(() => new Promise<SyncCatchUpResponse>((resolve) => (resolveFirstPage = resolve)))
       .mockResolvedValue(emptyPage("11"))
     const deps = makeCounterDeps(catchUp)
+    // The forceFull reseed re-fetches the authoritative server snapshot. By the
+    // time it runs, the buffered user (added at syncId 12) already exists
+    // server-side, so the real snapshot carries it and its stale-entity cleanup
+    // keeps the row the buffer drain wrote. Model that here: an empty pre-add
+    // snapshot would instead let cleanup race the drain and delete user_resumed.
+    const snapshotBootstrap = deps.workspaceService.bootstrap
+    let bootstrapCalls = 0
+    deps.workspaceService.bootstrap = vi.fn(async () => {
+      const snapshot = await snapshotBootstrap()
+      bootstrapCalls += 1
+      if (bootstrapCalls === 1) return snapshot
+      return {
+        ...snapshot,
+        users: [
+          ...snapshot.users,
+          userAddedLivePayload("12", "user_resumed").user as WorkspaceBootstrap["users"][number],
+        ],
+      }
+    })
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
     // Force the flush's preview write to reject → the whole flush rejects.


### PR DESCRIPTION
## Problem

The frontend unit suite was flaky in CI ([run 27673456767](https://github.com/threahq/threa/actions/runs/27673456767/job/81843009965)). One test in `apps/frontend/src/sync/sync-engine.test.ts` failed intermittently:

> `SyncEngine sync cursor (active mode) > resumes the gate (drains the buffer) even when the batch flush throws`
> `AssertionError: expected undefined to be defined` at `sync-engine.test.ts:1294`

Reproduced locally at ~50% (5/10 runs failing). The `vi.waitFor` on `db.workspaceUsers.get("user_resumed")` timed out — the buffered live event the test expects to be drained was missing from IndexedDB.

The flake is a **test-mock artifact, not a product bug**. The failing path:

1. On a catch-up batch flush failure, `performActiveCatchUp`'s `finally` fires a fire-and-forget forceFull reseed (`sync-engine.ts:1255` — `void this.runBootstrap(true, { forceFull: true })`), then calls `gate.resume(...)` (`sync-engine.ts:1266-1268`) to drain the buffered live `workspace_user:added` event (`user_resumed`, syncId 12) into IDB.
2. The reseed runs `applyWorkspaceBootstrap` → `cleanupStaleEntities` → `deleteStale` (`workspace-sync.ts:2244`), which deletes any `workspaceUsers` row **not in the snapshot** whose `_cachedAt < fetchStartedAt` (`workspace-sync.ts:2268`).
3. The reseed samples `fetchStartedAt` only after an `await joinRoomBestEffort` (`sync-engine.ts:512`), so it races the drain. When the drained `user_resumed` put lands before `fetchStartedAt`, cleanup deletes it.

The test's mock reseed returned `makeWorkspaceBootstrap()` with `users: []`, so `user_resumed` was never in `keepIds` and was eligible for deletion. In production the reseed fetches a fresh **server** snapshot that already contains the just-added user (added server-side during the pause window, before `fetchStartedAt`), so it lands in `keepIds` and survives — the race can't strand it.

## Solution

Model the realistic reseed snapshot. The second (reseed) `workspaceService.bootstrap` call now carries `user_resumed` in `users`, matching what the real server would return for a snapshot taken after that user was added. The first (connect) bootstrap is unchanged, so the test still genuinely exercises the buffer-drain path — `user_resumed` only enters IDB via the gate drain on that first cycle, and the reseed's cleanup no longer deletes it.

No production code changed.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.test.ts` | Wrap the counter-deps `bootstrap` mock so the forceFull reseed (call ≥2) returns `user_resumed` in `users`, mirroring the real post-add server snapshot. Connect bootstrap (call 1) unchanged. |

## Test plan

- [x] `vitest run sync-engine.test.ts -t "resumes the gate"` — 10/10 runs pass (was ~5/10 before the fix)
- [x] `vitest run src/sync/sync-engine.test.ts` — full file 52 pass
- [x] `tsc --noEmit` (apps/frontend, app + test projects) clean
- [x] `prettier --write` applied; pre-commit hook ran the full monorepo typecheck suite clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUBJwdt9Rr5L8zxzPVDDTm)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784277272&installation_id=129946197&pr_number=985&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F985&signature=1d7c1d306f9013ea05912c706f6cb0d27f65d31502a54bee01267a98e88ee256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->