### PR TITLE
fix(pwa): self-heal a wedged resume instead of forcing a manual restart

### DIFF
--- a/apps/frontend/src/lib/crash-recovery.test.ts
+++ b/apps/frontend/src/lib/crash-recovery.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+
+const originalLocation = window.location
+
+let dispose: () => void = () => {}
+let now = 1_700_000_000_000
+
+async function install() {
+  vi.resetModules()
+  const mod = await import("./crash-recovery")
+  dispose = mod.installCrashRecovery()
+}
+
+function resume() {
+  document.dispatchEvent(new Event("resume"))
+}
+
+function emitError(error: unknown, message: string) {
+  window.dispatchEvent(new ErrorEvent("error", { error, message }))
+}
+
+function emitRejection(reason: unknown) {
+  const event = new Event("unhandledrejection")
+  Object.defineProperty(event, "reason", { value: reason, configurable: true })
+  window.dispatchEvent(event)
+}
+
+describe("installCrashRecovery", () => {
+  beforeEach(() => {
+    now = 1_700_000_000_000
+    vi.spyOn(Date, "now").mockImplementation(() => now)
+    sessionStorage.clear()
+    // jsdom's location.reload() throws "Not implemented" — replace it with a spy
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: vi.fn() },
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("")))
+    )
+  })
+
+  afterEach(() => {
+    dispose()
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation })
+    sessionStorage.clear()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("reloads when a non-ignorable error fires shortly after a resume", async () => {
+    await install()
+    resume()
+    emitRejection(new TypeError("Cannot read properties of undefined"))
+
+    expect(window.location.reload).toHaveBeenCalledOnce()
+    expect(sessionStorage.getItem("crash-reload-count")).toBe("1")
+  })
+
+  it("does not reload for an error that fires long after the last resume", async () => {
+    await install()
+    resume()
+    now += 20_000
+    emitError(new TypeError("boom"), "boom")
+
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it("does not reload without any prior resume", async () => {
+    await install()
+    // lastResumeAt is still 0, so any real timestamp is far outside the window.
+    emitRejection(new TypeError("boom"))
+
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it("ignores routine ResizeObserver and aborted-request noise", async () => {
+    await install()
+    resume()
+    emitError(undefined, "ResizeObserver loop completed with undelivered notifications.")
+    emitRejection(new DOMException("The user aborted a request.", "AbortError"))
+    emitRejection(new TypeError("Failed to fetch"))
+
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it("stops reloading once the per-session cap is reached", async () => {
+    sessionStorage.setItem("crash-reload-count", "2")
+    sessionStorage.setItem("crash-reload-last", String(now))
+    await install()
+    resume()
+    emitRejection(new TypeError("boom"))
+
+    expect(window.location.reload).not.toHaveBeenCalled()
+  })
+
+  it("resets the reload budget when the last attempt is long past", async () => {
+    sessionStorage.setItem("crash-reload-count", "2")
+    sessionStorage.setItem("crash-reload-last", String(now - 120_000))
+    await install()
+    resume()
+    emitRejection(new TypeError("boom"))
+
+    expect(window.location.reload).toHaveBeenCalledOnce()
+    expect(sessionStorage.getItem("crash-reload-count")).toBe("1")
+  })
+
+  it("routes chunk-load failures into sw-recovery instead of the resume-crash path", async () => {
+    await install()
+    // No resume needed — a stale-deploy chunk failure recovers regardless of timing.
+    emitRejection(new TypeError("Failed to fetch dynamically imported module: https://app.threa.io/assets/x-AbC123.js"))
+
+    await vi.waitFor(() => expect(window.location.reload).toHaveBeenCalledOnce())
+    // sw-recovery uses its own counter; the resume-crash counter stays untouched.
+    expect(sessionStorage.getItem("sw-recovery-attempts")).toBe("1")
+    expect(sessionStorage.getItem("crash-reload-count")).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/crash-recovery.ts
+++ b/apps/frontend/src/lib/crash-recovery.ts
@@ -1,0 +1,138 @@
+import { chunkUrlFromError, isChunkLoadError, runSwRecovery } from "@/lib/sw-recovery"
+
+/**
+ * Last-resort recovery for uncaught errors that leave the app wedged after the
+ * PWA returns from the background.
+ *
+ * The reported failure: the user opens a link, escapes to the system browser
+ * ("Open in Firefox"), and comes back to a dead PWA that needs a manual
+ * restart. When the OS hard-kills the renderer there is no JS left to recover
+ * (the browser reloads a discarded tab on its own), but the softer variant —
+ * the page survives frozen and then throws during the resume burst (socket
+ * reprobe → reconnect → bootstrap + catch-up + IDB, all at once) — leaves a
+ * broken in-memory app that React error boundaries can't catch, because the
+ * throw is async / in an event handler, not in render. That is the case this
+ * converts from "needs restart" into "reloads itself".
+ *
+ * Scope is deliberately tight so this can never nuke a user mid-action:
+ *   - chunk-load failures (stale deploy) route into the shared sw-recovery,
+ *     covering the async/import path the router error boundary misses;
+ *   - any other uncaught error only triggers a reload inside a short window
+ *     after a page resume — never during steady foreground use, so in-progress
+ *     composer text is never thrown away;
+ *   - reloads are loop-guarded, so a crash that reproduces on every load falls
+ *     through to the broken app rather than reload-looping forever.
+ */
+
+const RESUME_RECOVERY_WINDOW_MS = 12_000
+const RELOAD_COUNT_KEY = "crash-reload-count"
+const RELOAD_LAST_KEY = "crash-reload-last"
+const RELOAD_COUNT_RESET_MS = 60_000
+const MAX_RELOADS = 2
+
+let lastResumeAt = 0
+
+/**
+ * Errors that fire routinely (or that a reload can't fix) and so must never
+ * trigger recovery. A reload only makes sense for a genuine programming fault
+ * that wedged the app on resume — not for layout notices, opaque cross-origin
+ * errors, aborted in-flight requests, or a network that simply isn't back yet
+ * (reloading then just discards state and fails again).
+ */
+function isIgnorableError(message: string): boolean {
+  return (
+    message.includes("ResizeObserver loop") ||
+    message.startsWith("Script error") ||
+    message.includes("AbortError") ||
+    message.includes("aborted") ||
+    message.includes("Failed to fetch") ||
+    message.includes("NetworkError") ||
+    message.includes("Load failed")
+  )
+}
+
+function canReload(): boolean {
+  const last = Number.parseInt(sessionStorage.getItem(RELOAD_LAST_KEY) ?? "0", 10)
+  // A crash long after the last recovery is unrelated — reset the budget so an
+  // old attempt can't block a fresh, genuinely-stuck reload.
+  const count =
+    Date.now() - last > RELOAD_COUNT_RESET_MS ? 0 : Number.parseInt(sessionStorage.getItem(RELOAD_COUNT_KEY) ?? "0", 10)
+  if (count >= MAX_RELOADS) return false
+  sessionStorage.setItem(RELOAD_COUNT_KEY, String(count + 1))
+  sessionStorage.setItem(RELOAD_LAST_KEY, String(Date.now()))
+  return true
+}
+
+function recoverFromResumeCrash(): void {
+  if (Date.now() - lastResumeAt > RESUME_RECOVERY_WINDOW_MS) return
+  if (!canReload()) return
+  window.location.reload()
+}
+
+/**
+ * Best-effort message for an arbitrary thrown value. Covers `Error`,
+ * `DOMException` (a real `AbortError` is one, and is NOT `instanceof Error`),
+ * and any `{ name, message }` shape — so the ignore filter sees enough text to
+ * classify benign rejections instead of treating them as fatal.
+ */
+function messageOf(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value && typeof value === "object") {
+    const obj = value as { name?: unknown; message?: unknown }
+    return [obj.name, obj.message].filter((part): part is string => typeof part === "string").join(": ")
+  }
+  return ""
+}
+
+function handleError(value: unknown, fallbackMessage: string): void {
+  const message = messageOf(value) || fallbackMessage
+  if (isChunkLoadError(value) || isChunkLoadError(message)) {
+    const bustUrl = chunkUrlFromError(value) ?? chunkUrlFromError(message)
+    void runSwRecovery({ bustUrls: bustUrl ? [bustUrl] : undefined })
+    return
+  }
+  if (isIgnorableError(message)) return
+  recoverFromResumeCrash()
+}
+
+/**
+ * Install global crash recovery. Call once at startup, before React mounts.
+ * Idempotent guard so a hot-reload or double-import can't stack listeners.
+ * Returns a disposer (production ignores it; tests use it to tear down).
+ */
+let installed = false
+export function installCrashRecovery(): () => void {
+  if (installed || typeof window === "undefined") return () => {}
+  installed = true
+
+  const markResume = () => {
+    lastResumeAt = Date.now()
+  }
+  const onPageShow = (event: PageTransitionEvent) => {
+    if (event.persisted) markResume()
+  }
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "visible") markResume()
+  }
+  const onError = (event: ErrorEvent) => {
+    handleError(event.error ?? event.message, event.message ?? "")
+  }
+  const onRejection = (event: PromiseRejectionEvent) => {
+    handleError(event.reason, "")
+  }
+
+  document.addEventListener("resume", markResume)
+  window.addEventListener("pageshow", onPageShow)
+  document.addEventListener("visibilitychange", onVisibilityChange)
+  window.addEventListener("error", onError)
+  window.addEventListener("unhandledrejection", onRejection)
+
+  return () => {
+    document.removeEventListener("resume", markResume)
+    window.removeEventListener("pageshow", onPageShow)
+    document.removeEventListener("visibilitychange", onVisibilityChange)
+    window.removeEventListener("error", onError)
+    window.removeEventListener("unhandledrejection", onRejection)
+    installed = false
+  }
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -6,7 +6,14 @@ import { SW_MSG_NOTIFICATION_CLICK, SW_MSG_SUBSCRIPTION_CHANGED } from "./lib/sw
 import { setNotificationIntent } from "./lib/notification-intent"
 import { hydrateCollapseCache } from "./lib/markdown/collapse-cache"
 import { applyPersistedComposerHeight } from "./lib/composer-height-storage"
+import { installCrashRecovery } from "./lib/crash-recovery"
 import "./index.css"
+
+// Catch uncaught errors that wedge the app after the PWA returns from the
+// background (e.g. resuming after "Open in Firefox") and reload instead of
+// leaving a dead window that needs a manual restart. Installed before React
+// mounts so resume tracking is live from the first lifecycle transition.
+installCrashRecovery()
 
 // Apply the last-observed composer height to `:root` so the timeline's footer
 // spacer paints at roughly the correct size on first render. The composer's


### PR DESCRIPTION
## Problem

Opening a link from inside the installed PWA and escaping it to the system browser ("Open in Firefox" from the native long-press menu) backgrounds the Chromium-hosted PWA. Returning to it could leave a wedged window that has to be manually restarted.

A true OS renderer kill leaves no JS to recover from (the browser reloads a discarded tab itself; a hard "Aw, Snap" still needs a manual reload). The variant we *can* recover is the softer one: the page survives but throws during the resume burst (reconnect → bootstrap + catch-up + IDB, all at once). Those throws are async / in event handlers, so React error boundaries can't catch them — the app is left broken in memory with nothing to restore it.

## Solution

Add a global crash-recovery net — `installCrashRecovery()` (`apps/frontend/src/lib/crash-recovery.ts`), wired in `main.tsx` before React mounts. It tracks the last resume signal (`resume`, persisted `pageshow`, `visibilitychange` → visible) and, on an uncaught `error`/`unhandledrejection` within `RESUME_RECOVERY_WINDOW_MS` (12s) of a resume, triggers a single `window.location.reload()`.

A full reload is a **clean restart**, not a partial-state patch: the `SyncEngine` is reconstructed fresh, the sync-log cursor is persisted in IDB, and derived projection state self-heals from the bootstrap snapshot (per `sync-engine.ts` — "this state is derived, never authoritative"). The offline operation queue (edits/reactions/drafts) is IDB-backed and replays on the next connect. So recovery never leaves the sync engine in a half-applied state.

Scope is deliberately narrow so it can never nuke a user mid-action:
- chunk-load failures route into the existing `runSwRecovery` (`apps/frontend/src/lib/sw-recovery.ts`), covering the async/import path the router error boundary misses;
- benign noise is ignored — `ResizeObserver loop`, `Script error`, `AbortError`/`aborted`, `Failed to fetch`, `NetworkError`, `Load failed` (a real `AbortError` is a `DOMException`, not `instanceof Error`, so messages are extracted off any `{ name, message }` shape, not just `Error`);
- reloads only fire inside the post-resume window, never during steady foreground use, so in-progress composer text is never thrown away;
- reloads are loop-guarded via `sessionStorage` (`crash-reload-count`, max 2, reset after 60s of no attempt), so a crash that reproduces every load falls through to the broken app rather than reload-looping.

## Deliberately omitted: socket freeze/release

The first version of this PR also dropped the WebSocket on Chromium's `freeze` event (and reconnected on `resume`) to shrink the background footprint and make the page bfcache-eligible. **Removed after review** (`socket-context.tsx` is back to identical-with-`main`): it added a second resume actor competing with `SyncEngine.handlePageResume`, which `workspace-layout.tsx:285-292` documents as the *sole* owner of the resume window ("there is no separate lighter freshness hook"). Forcing `socket.disconnect()`/`connect()` on every freeze would have bypassed that hook's probe-first design, raced it on the same resume tick, and pushed resume through extra concurrent bootstrap/catch-up cycles — the catch-up error path already has a known race, so this risked making sync state *less* reliable, not more. If the bfcache/OOM-kill win is worth pursuing later, it should be designed to route through the engine's resume path, not around it.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crash-recovery.ts` | `installCrashRecovery()` — global error net, resume-windowed loop-guarded reload, chunk-load → sw-recovery |
| `apps/frontend/src/lib/crash-recovery.test.ts` | 7 tests: resume-window reload, outside-window/no-resume no-op, benign-noise ignore, cap + budget reset, chunk-load → sw-recovery |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/main.tsx` | Call `installCrashRecovery()` before React mounts |

## Out of scope (deliberate)

- **External-link rendering is unchanged.** `target="_blank"` + the native long-press menu stays — that's the intended UX (documented in `markdown/components.tsx`). This PR makes returning graceful; it doesn't change how links open.
- **No socket / sync-engine changes** (see "Deliberately omitted" above). `socket-context.tsx` is untouched relative to `main`.
- **No backend / schema change.** Frontend-only, additive.

## Test plan

- [x] `bun run test` (frontend) `crash-recovery` — 7 pass
- [x] `bun run typecheck` across the monorepo — clean
- [x] `eslint` on touched files — clean; pre-commit hooks (lint, typecheck, dockerfile/migration checks, OpenAPI) green
- [ ] On-device repro (Android PWA → "Open in Firefox" → return) — not possible from this environment; the change is built to be safe without it, and default error logging is left intact to capture the real throw if it persists

### Note on CI

A `Tests` failure on the prior push was a **pre-existing flaky test** unrelated to this PR — `sync-engine.test.ts:1294` ("resumes the gate … even when the batch flush throws"), a race in the catch-up error path between the fire-and-forget `forceFull` reseed and the gate-resume drain. Confirmed by running it on a clean `origin/main` (3/10 failures) vs. this branch (4/10) — statistically identical. Not addressed here.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_