### PR TITLE
refactor(frontend/crypto): unify client decrypt decode entry (slice 2)

### DIFF
--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -6,6 +6,7 @@ import {
   subscribeToDecryption,
   type DecryptCacheEntry,
 } from "@/lib/crypto/decrypt-cache"
+import { resolveDecryptContext } from "@/lib/crypto/decrypt-context"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { useStreamFromStore } from "@/stores/stream-store"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
@@ -70,17 +71,12 @@ export function useDecryptedMessageContent(
 ): DecryptedMessageContent {
   const session = useE2eSession(workspaceId, userId ?? "")
   const eventId = event.id
-  // A thread shares its root scratchpad's SSK and carries no wraps of its own,
-  // so the key must be resolved against the root (the wrap AAD is bound to the
-  // root id). `undefined` here is ambiguous: a top-level stream (its own root,
-  // resolve against self) reads the same as a thread whose row hasn't hydrated
-  // yet (root unknown). Resolving the latter against the thread id finds no
-  // wrap and fails — and the failure is cached permanently. So gate the decrypt
-  // on the stream row being present: until then we don't know the root and hold
-  // at `pending` rather than poison the cache with a doomed attempt.
+  // The session + root-SSK resolution and the "hold until the stream row hydrates"
+  // guard (a doomed thread-id decrypt poisons the cache forever) live in
+  // `resolveDecryptContext` — see it for why an unhydrated row must hold.
   const stream = useStreamFromStore(event.streamId)
-  const streamHydrated = stream !== undefined
-  const rootStreamId = stream?.rootStreamId ?? undefined
+  const ctx = resolveDecryptContext(workspaceId, event.streamId, session, stream)
+  const opts = ctx.ready ? ctx.opts : null
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(eventId, listener),
@@ -91,12 +87,10 @@ export function useDecryptedMessageContent(
   // Memoize so useEffect deps don't churn on every render — a fresh wrapper
   // object every render would re-fire the effect even though nothing changed.
   const envelopePayload = useMemo(() => readEnvelopePayload(event), [event])
-  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
-  const canDecrypt = !!envelopePayload && sessionUnlocked && streamHydrated
-  const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
+  const needsDecrypt = !!envelopePayload && opts !== null && (cached === undefined || cached.status === "pending")
 
   useEffect(() => {
-    if (!needsDecrypt || !envelopePayload || !session.privateKey || !session.keyId) return
+    if (!needsDecrypt || !envelopePayload || !opts) return
     void requestDecryption(
       eventId,
       {
@@ -104,23 +98,19 @@ export function useDecryptedMessageContent(
         envelope: envelopePayload.envelope,
         ciphertext: envelopePayload.ciphertext,
       },
-      {
-        privateKey: session.privateKey,
-        recipientKeyId: session.keyId,
-        workspaceId,
-        streamId: event.streamId,
-        rootStreamId,
-      }
+      opts
     )
+    // Depend on the opts fields (primitives) rather than the per-render opts object
+    // so an unrelated stream-row update doesn't re-fire a settled decrypt.
   }, [
     needsDecrypt,
     envelopePayload,
-    session.privateKey,
-    session.keyId,
+    opts?.privateKey,
+    opts?.recipientKeyId,
+    opts?.workspaceId,
+    opts?.streamId,
+    opts?.rootStreamId,
     eventId,
-    workspaceId,
-    event.streamId,
-    rootStreamId,
   ])
 
   if (!envelopePayload) {
@@ -136,7 +126,7 @@ export function useDecryptedMessageContent(
   // unlocked but the stream row hasn't hydrated (root still unknown), fall
   // through to `pending` — the decrypt fires once the row lands and `rootStreamId`
   // is trustworthy, never against the bare thread id.
-  if (!sessionUnlocked) return { status: "locked" }
+  if (!ctx.ready && ctx.reason === "locked") return { status: "locked" }
   if (cached?.status === "decrypted" && cached.content) {
     return {
       status: "decrypted",

--- a/apps/frontend/src/hooks/use-decrypted-step-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.ts
@@ -7,6 +7,7 @@ import {
   subscribeToDecryption,
   type DecryptCacheEntry,
 } from "@/lib/crypto/decrypt-cache"
+import { resolveDecryptContext } from "@/lib/crypto/decrypt-context"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { useStreamFromStore } from "@/stores/stream-store"
 
@@ -53,15 +54,12 @@ export function useDecryptedStepContent(
 ): DecryptedStepContent {
   const session = useE2eSession(workspaceId, userId ?? "")
   const cacheKey = step.id
-  // A thread shares its root scratchpad's SSK; resolve the key against the root.
-  // Until the stream row hydrates the root is unknown, and `undefined` is
-  // indistinguishable from a top-level stream — resolving a thread step against
-  // the bare thread id finds no wrap, fails, and caches that failure forever. So
-  // gate on the row being present (mirrors `useDecryptedMessageContent`): hold
-  // at `pending` rather than attempt a doomed decrypt.
+  // Session + root-SSK resolution and the "hold until the row hydrates" guard
+  // (a doomed thread-id decrypt poisons the cache forever) live in
+  // `resolveDecryptContext`, shared with the message and search read paths.
   const stream = useStreamFromStore(streamId)
-  const streamHydrated = stream !== undefined
-  const rootStreamId = stream?.rootStreamId ?? undefined
+  const ctx = resolveDecryptContext(workspaceId, streamId, session, stream)
+  const opts = ctx.ready ? ctx.opts : null
 
   const cached = useSyncExternalStore<DecryptCacheEntry | undefined>(
     (listener) => subscribeToDecryption(cacheKey, listener),
@@ -73,24 +71,33 @@ export function useDecryptedStepContent(
   // `useDecryptedMessageContent`'s `readEnvelopePayload` memo, giving `sealed` a
   // stable identity it can enter the dep array with directly.
   const sealed = useMemo(() => readSealedStep(step), [step])
-  const sessionUnlocked = session.status === "unlocked" && !!session.privateKey && !!session.keyId
-  const canDecrypt = !!sealed && sessionUnlocked && streamHydrated
-  const needsDecrypt = canDecrypt && (cached === undefined || cached.status === "pending")
+  const needsDecrypt = !!sealed && opts !== null && (cached === undefined || cached.status === "pending")
 
   useEffect(() => {
-    if (!needsDecrypt || !sealed || !session.privateKey || !session.keyId) return
+    if (!needsDecrypt || !sealed || !opts) return
     void requestDecryption(
       cacheKey,
       { contentMarkdown: "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
-      { privateKey: session.privateKey, recipientKeyId: session.keyId, workspaceId, streamId, rootStreamId }
+      opts
     )
-  }, [needsDecrypt, sealed, session.privateKey, session.keyId, cacheKey, workspaceId, streamId, rootStreamId])
+    // Primitive opts fields, not the per-render object, so a settled decrypt
+    // doesn't re-fire on an unrelated stream-row update.
+  }, [
+    needsDecrypt,
+    sealed,
+    opts?.privateKey,
+    opts?.recipientKeyId,
+    opts?.workspaceId,
+    opts?.streamId,
+    opts?.rootStreamId,
+    cacheKey,
+  ])
 
   if (!sealed) return { status: "plaintext", content: step.content }
   // `locked` means the session isn't unlocked. Unlocked-but-not-yet-hydrated
   // falls through to `pending`: the decrypt fires once the row lands and the
   // root is known, never against the bare thread id.
-  if (!sessionUnlocked) return { status: "locked", content: undefined }
+  if (!ctx.ready && ctx.reason === "locked") return { status: "locked", content: undefined }
   if (cached?.status === "decrypted" && cached.content) {
     return {
       status: "decrypted",

--- a/apps/frontend/src/hooks/use-stream-search.test.ts
+++ b/apps/frontend/src/hooks/use-stream-search.test.ts
@@ -5,6 +5,7 @@ import type { CachedEvent } from "@/db"
 import * as dbModule from "@/db"
 import * as decryptCache from "@/lib/crypto/decrypt-cache"
 import * as e2eStore from "@/stores/e2e-session-store"
+import * as streamStore from "@/stores/stream-store"
 import * as api from "@/api"
 
 function event(overrides: Partial<CachedEvent> & { id: string; _sequenceNum: number }): CachedEvent {
@@ -109,6 +110,9 @@ describe("useStreamSearch hook integration", () => {
       privateKey: {} as CryptoKey,
       keyId: "e2ek_self",
     } as never)
+    // The decrypt gate holds until the stream row hydrates (root known); the open
+    // stream being searched is always present, so stub a top-level row.
+    vi.spyOn(streamStore, "useStreamFromStore").mockReturnValue({ rootStreamId: null } as never)
     searchMessagesSpy = vi.spyOn(api, "searchMessages").mockResolvedValue({ results: [] } as never)
   })
 

--- a/apps/frontend/src/hooks/use-stream-search.ts
+++ b/apps/frontend/src/hooks/use-stream-search.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useMemo } from "react"
 import { searchMessages, type SearchFilters, type SearchResultItem } from "@/api"
 import { db, type CachedEvent } from "@/db"
 import { requestDecryption } from "@/lib/crypto/decrypt-cache"
+import { resolveDecryptContext } from "@/lib/crypto/decrypt-context"
 import { useE2eSession } from "@/stores/e2e-session-store"
 import { useStreamFromStore } from "@/stores/stream-store"
 
@@ -183,14 +184,15 @@ export function useStreamSearch({
   // E2E search reads decrypted bodies on demand. For a plaintext stream the
   // session is irrelevant (sealed-payload resolution returns null and the row
   // falls through to its plaintext `contentMarkdown`), so this is a no-op there.
+  // The search runs in a callback, so snapshot the session + stream row into refs
+  // and feed them to the shared `resolveDecryptContext` (session + root-SSK + the
+  // hold-until-hydrated guard) — the same gate the message/step read paths use.
   const session = useE2eSession(workspaceId, userId ?? "")
   const sessionRef = useRef(session)
   sessionRef.current = session
-  // A thread shares its root's SSK; resolve the key against the root (the search
-  // is scoped to this one stream, so every result carries `streamId`).
-  const rootStreamId = useStreamFromStore(streamId)?.rootStreamId ?? undefined
-  const rootStreamIdRef = useRef(rootStreamId)
-  rootStreamIdRef.current = rootStreamId
+  const streamRow = useStreamFromStore(streamId)
+  const streamRowRef = useRef(streamRow)
+  streamRowRef.current = streamRow
 
   // Resolve an event's searchable body. Sealed rows decrypt on demand (warming
   // the shared decrypt cache the timeline also reads); plaintext rows return
@@ -204,18 +206,12 @@ export function useStreamSearch({
         const payload = event.payload as { contentMarkdown?: string }
         return typeof payload.contentMarkdown === "string" ? payload.contentMarkdown : null
       }
-      const s = sessionRef.current
-      if (s.status !== "unlocked" || !s.privateKey || !s.keyId) return null
+      const ctx = resolveDecryptContext(workspaceId, event.streamId, sessionRef.current, streamRowRef.current)
+      if (!ctx.ready) return null
       const entry = await requestDecryption(
         event.id,
         { contentMarkdown: sealed.contentMarkdown ?? "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
-        {
-          privateKey: s.privateKey,
-          recipientKeyId: s.keyId,
-          workspaceId,
-          streamId: event.streamId,
-          rootStreamId: rootStreamIdRef.current,
-        }
+        ctx.opts
       )
       return entry.status === "decrypted" && entry.content ? entry.content.contentMarkdown : null
     },

--- a/apps/frontend/src/lib/crypto/__tests__/decrypt-context.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypt-context.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import type { CachedStream } from "@/db"
+import type { E2eSessionState } from "@/stores/e2e-session-store"
+import { isSessionUnlocked, resolveDecryptContext } from "../decrypt-context"
+
+function session(overrides: Partial<E2eSessionState>): E2eSessionState {
+  return {
+    status: "unlocked",
+    keyId: "e2ek_self",
+    publicKey: null,
+    privateKey: {} as CryptoKey,
+    deviceTrusted: false,
+    error: null,
+    ...overrides,
+  }
+}
+
+function streamRow(rootStreamId: string | null): CachedStream {
+  return { rootStreamId } as unknown as CachedStream
+}
+
+describe("isSessionUnlocked", () => {
+  it("is true only for an unlocked session with both keys present", () => {
+    expect(isSessionUnlocked(session({}))).toBe(true)
+    expect(isSessionUnlocked(session({ status: "locked" }))).toBe(false)
+    expect(isSessionUnlocked(session({ privateKey: null }))).toBe(false)
+    expect(isSessionUnlocked(session({ keyId: null }))).toBe(false)
+  })
+})
+
+describe("resolveDecryptContext", () => {
+  it("reports locked when the session can't decrypt", () => {
+    const ctx = resolveDecryptContext("ws_1", "stream_1", session({ status: "locked" }), streamRow(null))
+    expect(ctx).toEqual({ ready: false, reason: "locked" })
+  })
+
+  it("holds at unhydrated when the stream row is absent — the root is unknown", () => {
+    const ctx = resolveDecryptContext("ws_1", "stream_thread", session({}), undefined)
+    expect(ctx).toEqual({ ready: false, reason: "unhydrated" })
+  })
+
+  it("resolves a thread's key against its root once the row hydrates", () => {
+    const ctx = resolveDecryptContext("ws_1", "stream_thread", session({}), streamRow("stream_root"))
+    expect(ctx).toMatchObject({
+      ready: true,
+      opts: {
+        workspaceId: "ws_1",
+        streamId: "stream_thread",
+        recipientKeyId: "e2ek_self",
+        rootStreamId: "stream_root",
+      },
+    })
+  })
+
+  it("leaves rootStreamId undefined for a top-level stream (it is its own root)", () => {
+    const ctx = resolveDecryptContext("ws_1", "stream_root", session({}), streamRow(null))
+    expect(ctx.ready && ctx.opts.rootStreamId).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/lib/crypto/decrypt-context.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-context.ts
@@ -1,0 +1,70 @@
+import type { CachedStream } from "@/db"
+import type { E2eSessionState } from "@/stores/e2e-session-store"
+import type { DecryptMessageOpts } from "./message-envelope"
+
+/**
+ * The session + key + hydration gate every render-time content decrypt shares.
+ *
+ * Each read surface over an encrypted field (message bodies, trace steps,
+ * in-stream search, drafts) must answer the same question before it can decrypt:
+ * is the session unlocked, and — for content keyed under a stream's SSK — is the
+ * stream row hydrated so the root is known? That logic was copy-pasted across the
+ * message, step, and search hooks, including the subtle footgun below. This module
+ * owns it once.
+ *
+ * The footgun: a thread shares its root scratchpad's SSK and carries no wraps of
+ * its own, so the key resolves against the root (the wrap AAD is bound to the root
+ * id). Until the stream row hydrates the root is unknown, and an absent row is
+ * indistinguishable from a top-level stream. Decrypting a thread's content against
+ * its own (thread) id finds no wrap, fails, and — because a message/step id is
+ * immutable — caches that failure permanently. So a decrypt must hold until the
+ * row is present rather than attempt a doomed one.
+ */
+
+/** A session that can actually open sealed content: unlocked, with keys in memory. */
+export interface UnlockedSession extends E2eSessionState {
+  status: "unlocked"
+  privateKey: CryptoKey
+  keyId: string
+}
+
+/** The single predicate for "this session can decrypt" — narrows the key fields non-null. */
+export function isSessionUnlocked(session: E2eSessionState): session is UnlockedSession {
+  return session.status === "unlocked" && session.privateKey !== null && session.keyId !== null
+}
+
+export type DecryptContext =
+  | { ready: false; reason: "locked" | "unhydrated" }
+  | { ready: true; opts: DecryptMessageOpts }
+
+/**
+ * Resolve whether `streamId`'s content can be decrypted right now, and the opts to
+ * do it. `streamRow` is the stream the content belongs to (the caller reads it via
+ * `useStreamFromStore`); an `undefined` row means the root is not yet known and the
+ * caller must hold (see the footgun above) rather than decrypt against the bare id.
+ *
+ *  - `{ ready: false, reason: "locked" }`     — session not unlocked.
+ *  - `{ ready: false, reason: "unhydrated" }` — unlocked, stream row not yet present.
+ *  - `{ ready: true, opts }`                  — decrypt with `opts` (root resolved).
+ */
+export function resolveDecryptContext(
+  workspaceId: string,
+  streamId: string,
+  session: E2eSessionState,
+  streamRow: CachedStream | undefined
+): DecryptContext {
+  if (!isSessionUnlocked(session)) return { ready: false, reason: "locked" }
+  if (streamRow === undefined) return { ready: false, reason: "unhydrated" }
+  return {
+    ready: true,
+    opts: {
+      privateKey: session.privateKey,
+      recipientKeyId: session.keyId,
+      workspaceId,
+      streamId,
+      // A thread resolves its SSK against the root; a top-level stream is its own
+      // root, so `undefined` lets `DecryptMessageOpts` default rootStreamId to streamId.
+      rootStreamId: streamRow.rootStreamId ?? undefined,
+    },
+  }
+}

--- a/apps/frontend/src/lib/crypto/decrypt-context.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-context.ts
@@ -22,7 +22,7 @@ import type { DecryptMessageOpts } from "./message-envelope"
  */
 
 /** A session that can actually open sealed content: unlocked, with keys in memory. */
-export interface UnlockedSession extends E2eSessionState {
+interface UnlockedSession extends E2eSessionState {
   status: "unlocked"
   privateKey: CryptoKey
   keyId: string

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -3,6 +3,7 @@ import type { JSONContent } from "@threa/types"
 import type { AttachmentRef } from "@threa/crypto"
 import type { CachedDraft, DraftAttachment } from "@/db"
 import { getCachedDecryption, requestDecryption, type DecryptCacheEntry } from "@/lib/crypto/decrypt-cache"
+import { isSessionUnlocked } from "@/lib/crypto/decrypt-context"
 import { rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { isEmptyContent } from "@/lib/prosemirror-utils"
 import { stripMarkdownToInline } from "@/lib/markdown"
@@ -40,7 +41,7 @@ function attachmentFromRef(ref: AttachmentRef): DraftAttachment {
 
 /** A session that can actually open sealed content (unlocked, keys present). */
 export function isE2eUnlocked(session: E2eSession): boolean {
-  return session.status === "unlocked" && !!session.privateKey && !!session.keyId
+  return isSessionUnlocked(session)
 }
 
 /**

--- a/docs/plans/client-decrypt-layer-unification.md
+++ b/docs/plans/client-decrypt-layer-unification.md
@@ -1,7 +1,7 @@
 # Client-side decrypt layer unification (design)
 
-**Status:** In progress — slice 0 (PR #955, sealed-name loading-state authority)
-and slice 1 are implemented; later slices pending. Targets current
+**Status:** In progress — slices 0 (PR #955, sealed-name loading-state authority),
+1, and 2 are implemented; slice 3 pending. Targets current
 `origin/main` (post-#946, Stage 4c E2E draft roaming); the implementing branch
 must rebase onto it (the inventory below reflects post-#946 reality).
 
@@ -172,11 +172,23 @@ function clearAllDecrypted(): void // called once on lock / account switch
   The two divergences are options: `subscription` ("global" | "per-key") and
   `retryFailed`. Behavior is identical — the existing wrapper tests are the guard,
   plus a focused `decrypted-cache.test.ts` for the primitive and registry.
-- **Slice 2 — unified decode entry.** Extract `resolveDecryptContext` (session +
-  root-SSK + hydration guard); route `useDecryptedMessageContent`,
-  `useDecryptedStepContent`, `useStreamSearch`, and the draft decrypt
-  (`use-draft-message`'s `decryptDraftContent` path) through it. Removes the four
-  copies of the session/viewer-id + hydration wiring (drafts included, post-#946).
+- **Slice 2 — DONE.** `resolveDecryptContext` (`lib/crypto/decrypt-context.ts`)
+  owns the session-unlocked check, root-SSK resolution, and the hold-until-the-
+  row-hydrates guard (a doomed thread-id decrypt poisons the cache forever).
+  `useDecryptedMessageContent`, `useDecryptedStepContent`, and `useStreamSearch`
+  route their per-render/per-callback decrypt through it — the three copies of the
+  footgun collapse to one. The unlocked predicate is exported as `isSessionUnlocked`
+  (a type guard narrowing the key fields non-null); `lib/drafts/decryption.ts`'s
+  `isE2eUnlocked` delegates to it, so the draft path shares the 4th copy of the
+  session check. The draft does **not** route through `resolveDecryptContext`'s
+  row→root step: its root (`e2eStreamId`) is already resolved at the composer
+  (`stream?.rootStreamId ?? streamId`) before reaching the draft layer, which then
+  operates on a pre-resolved root in batch with no per-draft stream row — so it
+  carries no row→root footgun to share. Behavior-preserving; the existing
+  message/step/search/draft tests are the guard, plus a focused
+  `__tests__/decrypt-context.test.ts`. (One test artifact changed: the search
+  integration test now stubs a hydrated stream row, since the hold-until-hydrated
+  guard — previously absent from search — now applies there too.)
 - **Slice 3 — attachments onto the layer + uniform read.** Give attachment-bytes
   a real cache (`attachmentBytesCache`), move `e2e-attachment-list` off
   per-mount re-decrypt, and align names / attachments / drafts on the


### PR DESCRIPTION
## Summary

Slice 2 of the client decrypt-layer unification ([design doc](https://github.com/threahq/threa/blob/main/docs/plans/client-decrypt-layer-unification.md)). Slice 1 (PR #980) extracted the shared cache primitive; this slice extracts the **unified decode entry** that the read surfaces over encrypted content each hand-rolled.

Three read paths (`useDecryptedMessageContent`, `useDecryptedStepContent`, `useStreamSearch`) independently called `useE2eSession`, resolved `rootStreamId` from the stream row, and copied the same cache-poisoning guard: *a thread shares its root scratchpad's SSK and carries no wraps of its own, so a decrypt against the bare (thread) id finds no wrap, fails, and — because the id is immutable — caches that failure permanently.* Three copies of one footgun.

This collapses them to one `resolveDecryptContext`.

## What changed

- **New `apps/frontend/src/lib/crypto/decrypt-context.ts`:**
  - `resolveDecryptContext(workspaceId, streamId, session, streamRow)` → `{ ready: false, reason: "locked" | "unhydrated" }` or `{ ready: true, opts }`. Owns the session-unlocked check, root-SSK resolution (`streamRow.rootStreamId ?? undefined`), and the hold-until-the-row-hydrates guard.
  - `isSessionUnlocked(session)` — a type guard narrowing `privateKey`/`keyId` non-null; the single unlocked predicate.
- **`useDecryptedMessageContent` / `useDecryptedStepContent`:** drop their inline `sessionUnlocked` + `streamHydrated` + root resolution and route through `resolveDecryptContext`. Effect deps stay primitive (opts fields, not the per-render opts object), so a settled decrypt doesn't re-fire on an unrelated stream-row update.
- **`useStreamSearch`:** its decrypt callback now resolves context through the same gate (session + stream row snapshotted into refs). This *adds* the hold-until-hydrated guard to search, which previously lacked it.
- **`lib/drafts/decryption.ts`:** `isE2eUnlocked` now delegates to `isSessionUnlocked` — the 4th copy of the session check folds into the shared predicate.

## Design decision: why drafts don't route through the row→root step

Drafts share the session predicate but **not** `resolveDecryptContext`'s row→root resolution. Their root (`e2eStreamId`) is already resolved at the composer (`stream?.rootStreamId ?? streamId`) before reaching the draft layer, which then operates on a pre-resolved root in batch with no per-draft stream row. So drafts carry no row→root footgun to share — forcing them through the row step would mean re-deriving a root they already hold. Recorded in the design doc.

## Behavior preservation & tests

Behavior-preserving for the message/step paths; the existing suites are the guard. All affected tests pass (`use-decrypted-message-content`, `use-decrypted-step-content`, `use-stream-search`, `use-draft-message`, draft content/previews, crypto).

- New `__tests__/decrypt-context.test.ts` covers the predicate and the locked/unhydrated/ready resolution.
- One test-artifact change: the `useStreamSearch` integration test now stubs a hydrated stream row, since the hold-until-hydrated guard now applies to search too (it previously decrypted against an unhydrated row).

Pre-commit ran the full monorepo lint + typecheck clean.

## Reviewer notes

- Search gains the hydration guard it lacked — in production search runs on the open (hydrated) stream, so no user-visible change, but it now skips a sealed row whose stream row hasn't hydrated rather than risk a doomed thread-id decrypt.
- Next: slice 3 (attachments onto the layer + the uniform `{ value, status }` read shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FowoQvmZxVq4HUZcqFJhs1)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784286551&installation_id=129946197&pr_number=987&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F987&signature=382f45d0a82556fb55731d0b8d9a86725e7f714460922925d4ee80183ac8a601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->