### PR TITLE
feat(e2ee): sealed bot completion (/sealed-complete) behind the policy flag

### DIFF
--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -729,13 +729,18 @@ export const BotInvocationRepository = {
     return result.rows[0] ? mapInvocation(result.rows[0]) : null
   },
 
+  // `instanceId` is optional and null-guarded: the plaintext path scopes the
+  // completion to the claiming instance, while the sealed bot path authenticates
+  // by the per-claim callback token (the `claim_token` filter below) and omits
+  // it — the token is the unique per-claim secret, so the instance is redundant
+  // there. Identical SQL when an instance is supplied.
   async completeClaim(
     db: Querier,
-    params: { workspaceId: string; botId: string; invocationId: string; instanceId: string; claimToken: string }
+    params: { workspaceId: string; botId: string; invocationId: string; instanceId?: string; claimToken: string }
   ): Promise<BotInvocation | null> {
     const result =
       await db.query<BotInvocationRow>(sql`UPDATE bot_invocations SET status = 'completed', completed_at = NOW(), updated_at = NOW()
-      WHERE id = ${params.invocationId} AND workspace_id = ${params.workspaceId} AND actor_type = 'bot' AND actor_id = ${params.botId} AND status = 'claimed' AND claimed_by_instance_id = ${params.instanceId} AND claim_token = ${params.claimToken} AND claim_expires_at > NOW()
+      WHERE id = ${params.invocationId} AND workspace_id = ${params.workspaceId} AND actor_type = 'bot' AND actor_id = ${params.botId} AND status = 'claimed' AND claim_token = ${params.claimToken} AND (${params.instanceId ?? null}::text IS NULL OR claimed_by_instance_id = ${params.instanceId ?? null}) AND claim_expires_at > NOW()
       RETURNING *`)
     return result.rows[0] ? mapInvocation(result.rows[0]) : null
   },

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -563,13 +563,15 @@ export class BotRuntimeService {
     return BotInvocationRepository.completeClaim(this.pool, params)
   }
 
+  // `instanceId` is optional: the sealed bot completion authenticates by the
+  // per-claim callback token and omits it (see `completeClaim`).
   async completeInvocationInTransaction(
     db: Querier,
     params: {
       workspaceId: string
       botId: string
       invocationId: string
-      instanceId: string
+      instanceId?: string
       claimToken: string
     }
   ): Promise<BotInvocation | null> {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -43,12 +43,14 @@ import {
   AuthorTypes,
   BotInvocationCapabilities,
   BotRuntimeKinds,
+  E2E_PLACEHOLDER_CONTENT_MARKDOWN,
   PI_TOOL_TRACE_FORMAT,
   PI_TOOL_TRACE_SECTION_LABELS,
   PiToolTraceSectionLabels,
   THREA_CALLBACK_TOKEN_HEADER,
   sentViaApiKey,
   type AuthorType,
+  type JSONContent,
   type PiToolTraceSectionLabel,
   type SealedTurnContext,
 } from "@threa/types"
@@ -129,7 +131,16 @@ import {
   recordInvocationStepSchema,
   recordSealedInvocationStepSchema,
   startSealedInvocationStepSchema,
+  completeSealedInvocationSchema,
 } from "./schemas"
+
+// Same opaque placeholder the enclave reply path and the user-send path store for
+// E2E rows (INV-E1: the canonical payload is the ciphertext; plaintext consumers
+// see this). Mirrors the local const in the enclave session-handlers.
+const E2E_PLACEHOLDER_CONTENT_JSON: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: E2E_PLACEHOLDER_CONTENT_MARKDOWN }] }],
+}
 
 function serializeStream(stream: Stream, context?: DisplayNameContext): WireStream {
   const effective = getEffectiveDisplayName(stream, context)
@@ -698,19 +709,24 @@ export function createPublicApiHandlers({
   }
 
   /**
-   * Resolve and authorize a sealed bot step callback (the external sibling of
-   * the enclave's session-callback guards). Bot invocations reuse the invocation
-   * id as the agent session id, so the path's `invocationId` is the session id.
-   * The neutral callback token (model A — the claim token, delivered only inside
-   * the winning sealed claim) is the binding; the workspace + persona checks are
-   * defense-in-depth isolation (INV-8) on top of it. Mirrors the enclave's
-   * `assertRunning`/`assertCallbackBound` + stream resolution.
+   * Resolve and authorize a sealed bot session callback — shared by the sealed
+   * `/steps`, `/steps/started`, and `/sealed-complete` handlers (the external
+   * siblings of the enclave's session-callback guards). Bot invocations reuse the
+   * invocation id as the agent session id, so the path's `invocationId` is the
+   * session id. The neutral callback token (model A — the claim token, delivered
+   * only inside the winning sealed claim) is the binding; the workspace + persona
+   * checks are defense-in-depth isolation (INV-8) on top of it. Mirrors the
+   * enclave's `assertRunning`/`assertCallbackBound` + stream resolution.
    */
-  async function authorizeSealedStepCallback(req: Request) {
+  async function authorizeSealedInvocationCallback(req: Request) {
     if (!req.botApiKey) throw new HttpError("Bot API key required", { status: 403, code: "FORBIDDEN" })
     const session = await AgentSessionRepository.findById(pool, req.params.invocationId)
     assertSessionRunning(session)
-    verifyCallbackToken(session, req.header(THREA_CALLBACK_TOKEN_HEADER))
+    // The verified token IS the per-claim claim token (model A); return it so the
+    // `/sealed-complete` claim flip scopes by it without re-reading the header,
+    // keeping that security dependency explicit rather than an implicit `!`.
+    const callbackToken = req.header(THREA_CALLBACK_TOKEN_HEADER)
+    verifyCallbackToken(session, callbackToken)
     const stream = await StreamRepository.findById(pool, session.streamId)
     if (!stream || stream.workspaceId !== req.workspaceId) {
       throw new HttpError("Stream not found", { status: 404, code: "STREAM_NOT_FOUND" })
@@ -720,7 +736,7 @@ export function createPublicApiHandlers({
     if (session.personaId !== bot.id) {
       throw new HttpError("Session does not belong to this bot", { status: 403, code: "FORBIDDEN" })
     }
-    return { session, stream, bot }
+    return { session, stream, bot, callbackToken: callbackToken! }
   }
 
   /**
@@ -1304,7 +1320,7 @@ export function createPublicApiHandlers({
      */
     async startBotInvocationSealedStep(req: Request, res: Response) {
       const data = validateRequest(startSealedInvocationStepSchema, req.body)
-      const { session, stream, bot } = await authorizeSealedStepCallback(req)
+      const { session, stream, bot } = await authorizeSealedInvocationCallback(req)
       assertReplyKeyGeneration(session, data.envelope)
 
       // Insert the in-flight row (no completed_at) + current_step_type in one
@@ -1343,7 +1359,7 @@ export function createPublicApiHandlers({
      */
     async recordBotInvocationSealedStep(req: Request, res: Response) {
       const data = validateRequest(recordSealedInvocationStepSchema, req.body)
-      const { session, stream, bot } = await authorizeSealedStepCallback(req)
+      const { session, stream, bot } = await authorizeSealedInvocationCallback(req)
       assertReplyKeyGeneration(session, data.envelope)
 
       const completedAt = new Date()
@@ -1385,6 +1401,113 @@ export function createPublicApiHandlers({
       })
 
       res.json({ data: { invocationId: session.id, sessionId: session.id, stepId: persisted.id } })
+    },
+
+    /**
+     * Complete a sealed bot turn — the external sibling of the enclave's
+     * `/complete` and the sealed variant of the plaintext `completeBotInvocation`.
+     * Unlike the enclave (which streams each reply to `/messages` and acks here),
+     * the bot path delivers its single sealed reply inline, exactly as the
+     * plaintext bot complete does — only the body is ciphertext the server can't
+     * read (INV-E7). In one transaction (INV-7): persist the sealed reply (when
+     * present), flip the `bot_invocations` claim, and finalize the session
+     * lifecycle (status + the `agent_session:completed` event/outbox), so the
+     * claimable set, the message, and the lifecycle event can never diverge. No
+     * reply-only trace synthesis (the plaintext floor needs cleartext we don't
+     * have); the trace is whatever sealed steps the harness already POSTed. The
+     * whole path is dark until `externalSealedDelivery` flips.
+     *
+     * Two things the plaintext sibling does are deliberately absent: the
+     * runtime-command `command:completed` event (a runtime command requires the
+     * SESSION_CONTROL capability, and the claim path never seals a session-control
+     * invocation — so a sealed completion is never a runtime command), and the
+     * `assertManifestAllows` reject-undeclared gate (it keys off the runtime's
+     * declared manifest, looked up by `instanceId`, which the header-auth model
+     * omits — the sealed grant is the capability proof here).
+     */
+    async completeBotInvocationSealed(req: Request, res: Response) {
+      const data = validateRequest(completeSealedInvocationSchema, req.body)
+      const { session, stream, bot, callbackToken } = await authorizeSealedInvocationCallback(req)
+      if (data.reply) assertReplyKeyGeneration(session, data.reply.envelope)
+
+      const { message, sessionFinalized } = await withTransaction(pool, async (client) => {
+        const reply = data.reply
+        const message = reply
+          ? await eventService.createMessageInTransaction(client, {
+              id: reply.messageId,
+              workspaceId: stream.workspaceId,
+              streamId: session.streamId,
+              sessionId: session.id,
+              authorId: bot.id,
+              authorType: AuthorTypes.BOT,
+              contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
+              contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+              ciphertext: Buffer.from(reply.ciphertext, "base64"),
+              envelope: reply.envelope,
+              e2eVersion: 2,
+              // Restrict the bot's reach to this scratchpad and dedupe a redelivered
+              // completion (one reply per invocation), mirroring the enclave reply.
+              accessibleStreamIds: [session.streamId],
+              clientMessageId: `bot-invocation:${session.id}`,
+            })
+          : null
+
+        // Flip the claim atomically (INV-20): the `status = 'claimed'` predicate
+        // makes a raced/redelivered completion no-op (→ 404), and rolling back
+        // here drops the message insert above with it.
+        const completed = await botRuntimeService.completeInvocationInTransaction(client, {
+          workspaceId: req.workspaceId!,
+          botId: bot.id,
+          invocationId: session.id,
+          claimToken: callbackToken,
+        })
+        if (!completed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
+
+        // Finalize the session lifecycle in the same transaction (INV-7), gated on
+        // winning the RUNNING→COMPLETED transition so a raced redelivery can't
+        // double-emit. Plaintext-free: counts + timing only.
+        const latestSequence = await eventService.getLatestSequence(session.streamId)
+        const finalized = await AgentSessionRepository.completeSession(client, session.id, {
+          lastSeenSequence: latestSequence ?? 0n,
+          responseMessageId: message?.id ?? null,
+          sentMessageIds: message ? [message.id] : [],
+        })
+        if (!finalized) return { message, sessionFinalized: false }
+
+        const completedAt = finalized.completedAt ?? new Date()
+        const steps = await AgentSessionRepository.findStepsBySession(client, session.id)
+        const streamEvent = await StreamEventRepository.insert(client, {
+          id: eventId(),
+          streamId: session.streamId,
+          eventType: "agent_session:completed",
+          payload: {
+            sessionId: session.id,
+            stepCount: steps.length,
+            messageCount: message ? 1 : 0,
+            duration: completedAt.getTime() - finalized.createdAt.getTime(),
+            completedAt: completedAt.toISOString(),
+          },
+          actorId: bot.id,
+          actorType: AuthorTypes.BOT,
+        })
+        await OutboxRepository.insert(client, "agent_session:completed", {
+          workspaceId: stream.workspaceId,
+          streamId: session.streamId,
+          event: streamEvent,
+        })
+        return { message, sessionFinalized: true }
+      })
+
+      // Live-update an open trace dialog (session room) the way the enclave/in-process
+      // completes do — the outbox broadcast only reaches the stream room, so the
+      // dialog wouldn't otherwise transition until a refetch.
+      if (sessionFinalized) {
+        io.to(`ws:${stream.workspaceId}:agent_session:${session.id}`).emit("agent_session:completed", {
+          sessionId: session.id,
+        })
+      }
+
+      res.json({ data: { invocationId: session.id, sessionId: session.id, messageId: message?.id ?? null } })
     },
 
     async completeBotInvocation(req: Request, res: Response) {

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -45,6 +45,7 @@ import {
   recordInvocationStepSchema,
   recordSealedInvocationStepSchema,
   startSealedInvocationStepSchema,
+  completeSealedInvocationSchema,
 } from "./schemas"
 
 // Response schemas — the single source of truth for public API wire shapes.
@@ -405,6 +406,11 @@ const invocationStatusSchema = z.object({ invocationId: z.string(), status: z.st
 const invocationStepSchema = z.object({ invocationId: z.string(), sessionId: z.string(), stepId: z.string() })
 const renewedInvocationSchema = invocationStatusSchema.extend({ claimExpiresAt: z.string().datetime().nullable() })
 const completedInvocationSchema = z.object({ invocationId: z.string(), message: messageSchema.nullable() })
+const sealedCompletedInvocationSchema = z.object({
+  invocationId: z.string(),
+  sessionId: z.string(),
+  messageId: z.string().nullable(),
+})
 
 const errorSchema = z.object({
   error: z.string(),
@@ -723,6 +729,25 @@ export const PUBLIC_API_ROUTES: PublicApiRoute[] = [
     requestSchema: recordSealedInvocationStepSchema,
     requestIn: "body",
     responseSchema: dataEnvelope(invocationStepSchema),
+    canReturn404: true,
+  },
+  {
+    method: "post",
+    path: "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-complete",
+    operationId: "completeBotInvocationSealed",
+    summary: "Complete a sealed bot invocation",
+    description:
+      "Sealed variant of the completion, for an owner-granted E2E bot harness: persists the turn's final sealed reply (ciphertext the server never decrypts) or noResponse, flips the claim, and finalizes the agent session. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+    tags: ["Bot invocations"],
+    scopes: [WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE],
+    parameters: [
+      workspaceIdParam,
+      { name: "invocationId", in: "path", required: true, schema: { type: "string" }, description: "Invocation ID" },
+      callbackTokenHeaderParam,
+    ],
+    requestSchema: completeSealedInvocationSchema,
+    requestIn: "body",
+    responseSchema: dataEnvelope(sealedCompletedInvocationSchema),
     canReturn404: true,
   },
   {

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -194,6 +194,28 @@ export const startSealedInvocationStepSchema = z.object({
   envelope: sealedStreamEnvelopeSchema.optional(),
 })
 
+// The sealed variant of `completeInvocationSchema` (the external sibling of the
+// enclave's `/complete`). Carries the turn's final sealed reply — `messageId` is
+// clear (it keys the row and binds the seal AAD) while the content is ciphertext
+// the server can't read (INV-E7) — or `noResponse` when the turn produced none.
+// Auth is the bot API key + the neutral callback token header, not body claim
+// fields, so neither `instanceId` nor `claimToken` appears here.
+export const completeSealedInvocationSchema = z
+  .object({
+    reply: z
+      .object({
+        messageId: z.string().min(1).max(128),
+        ciphertext: z.base64().min(1),
+        envelope: sealedStreamEnvelopeSchema,
+      })
+      .optional(),
+    noResponse: z.boolean().optional(),
+  })
+  .refine((value) => value.noResponse === true || value.reply != null, {
+    message: "Either reply or noResponse is required",
+    path: ["reply"],
+  })
+
 export const listMessagesSchema = z
   .object({
     before: z.string().regex(/^\d+$/, "must be a numeric sequence").optional(),

--- a/apps/backend/src/features/public-api/sealed-complete.test.ts
+++ b/apps/backend/src/features/public-api/sealed-complete.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { THREA_CALLBACK_TOKEN_HEADER } from "@threa/types"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { BotRepository } from "./bot-repository"
+import { StreamRepository, StreamEventRepository } from "../streams"
+import { AgentSessionRepository, hashCallbackToken, type AgentSession } from "../agents"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+// Phase 3 sealed bot `/sealed-complete`: the external sibling of the enclave's
+// `/complete` and the sealed variant of the plaintext bot complete. A
+// sealed-capable bot harness delivers its single sealed reply inline; the server
+// persists ciphertext it can't read, flips the claim, and finalizes the session —
+// all in one transaction. Auth is the bot API key + the neutral
+// `X-Threa-Callback-Token` header verified against the session's binding.
+
+const CALLBACK_TOKEN = "tok_1"
+const REPLY_ENVELOPE = { v: 2, keyGeneration: 3, iv: "aXY=", aad: "YWFk" }
+
+const session: AgentSession = {
+  id: "binv_1",
+  streamId: "stream_thread",
+  personaId: "bot_1",
+  triggerMessageId: "msg_trigger",
+  triggerMessageRevision: null,
+  supersedesSessionId: null,
+  status: "running",
+  currentStep: 0,
+  currentStepType: null,
+  serverId: null,
+  callbackTokenHash: hashCallbackToken(CALLBACK_TOKEN),
+  replyKeyGeneration: 3,
+  heartbeatAt: new Date("2026-06-12T09:00:00.000Z"),
+  abortRequestedAt: null,
+  responseMessageId: null,
+  error: null,
+  lastSeenSequence: 0n,
+  sentMessageIds: [],
+  contextMessageIds: [],
+  createdAt: new Date("2026-06-12T09:00:00.000Z"),
+  completedAt: null,
+}
+
+function createResponse() {
+  const payloads: unknown[] = []
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock((body: unknown) => {
+    payloads.push(body)
+    return res
+  }) as unknown as Response["json"]
+  return { res, payloads }
+}
+
+function createEmitSpy() {
+  const emitted: { room: string; event: string; payload: unknown }[] = []
+  const io = {
+    to: (room: string) => ({
+      emit: (event: string, payload: unknown) => {
+        emitted.push({ room, event, payload })
+      },
+    }),
+  } as unknown as PublicApiDeps["io"]
+  return { io, emitted }
+}
+
+function arrange(
+  opts: {
+    sessionOverride?: Partial<AgentSession>
+    claimCompleted?: boolean
+    sessionFinalized?: boolean
+  } = {}
+) {
+  const claimCompleted = opts.claimCompleted ?? true
+  const sessionFinalized = opts.sessionFinalized ?? true
+
+  spyOn(AgentSessionRepository, "findById").mockResolvedValue({ ...session, ...opts.sessionOverride } as never)
+  spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_thread", workspaceId: "ws_1" } as never)
+  spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Pi", archivedAt: null } as never)
+  spyOn(dbModule, "withTransaction").mockImplementation(((_pool: unknown, fn: (c: unknown) => unknown) =>
+    fn({})) as never)
+  spyOn(AgentSessionRepository, "completeSession").mockResolvedValue(
+    (sessionFinalized
+      ? { ...session, status: "completed", completedAt: new Date("2026-06-12T09:00:05.000Z") }
+      : null) as never
+  )
+  spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([] as never)
+  const insertEvent = spyOn(StreamEventRepository, "insert").mockResolvedValue({ id: "evt_1" } as never)
+  const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+  const createMessageInTransaction = mock(async (_client: unknown, params: { id: string }) => ({
+    id: params.id,
+    streamId: session.streamId,
+  }))
+  const getLatestSequence = mock(async () => 5n)
+  const completeInvocationInTransaction = mock(async (_db: unknown, _params: unknown) =>
+    claimCompleted ? { id: "binv_1" } : null
+  )
+
+  const { io, emitted } = createEmitSpy()
+  const handlers = createPublicApiHandlers({
+    eventService: { createMessageInTransaction, getLatestSequence } as unknown as PublicApiDeps["eventService"],
+    streamService: {} as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService: { completeInvocationInTransaction } as unknown as PublicApiDeps["botRuntimeService"],
+    pool: {} as PublicApiDeps["pool"],
+    io,
+  })
+  return { handlers, emitted, createMessageInTransaction, completeInvocationInTransaction, insertEvent, insertOutbox }
+}
+
+function req(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = { [THREA_CALLBACK_TOKEN_HEADER]: CALLBACK_TOKEN }
+) {
+  return {
+    workspaceId: "ws_1",
+    botApiKey: { botId: "bot_1" },
+    params: { invocationId: "binv_1" },
+    header: (name: string) => headers[name],
+    body,
+  } as unknown as Request
+}
+
+describe("completeBotInvocationSealed", () => {
+  afterEach(() => mock.restore())
+
+  it("persists the sealed reply, flips the claim, and finalizes the session", async () => {
+    const {
+      handlers,
+      emitted,
+      createMessageInTransaction,
+      completeInvocationInTransaction,
+      insertEvent,
+      insertOutbox,
+    } = arrange()
+    const { res, payloads } = createResponse()
+
+    await handlers.completeBotInvocationSealed(
+      req({ reply: { messageId: "msg_reply", ciphertext: "c2VhbGVk", envelope: REPLY_ENVELOPE } }),
+      res
+    )
+
+    const createParams = createMessageInTransaction.mock.calls[0]?.[1] as unknown as Record<string, unknown>
+    expect(createParams).toMatchObject({
+      id: "msg_reply",
+      streamId: "stream_thread",
+      authorType: "bot",
+      e2eVersion: 2,
+      accessibleStreamIds: ["stream_thread"],
+      clientMessageId: "bot-invocation:binv_1",
+    })
+    expect(createParams.ciphertext).toBeInstanceOf(Buffer)
+    // The claim flip omits instanceId — the callback token scopes it (model A).
+    const completeParams = completeInvocationInTransaction.mock.calls[0]?.[1] as unknown as Record<string, unknown>
+    expect(completeParams).toMatchObject({ invocationId: "binv_1", botId: "bot_1", claimToken: CALLBACK_TOKEN })
+    expect(completeParams.instanceId).toBeUndefined()
+    // The completed event/outbox land with the message count it carried.
+    expect(insertEvent.mock.calls[0]?.[1]).toMatchObject({
+      eventType: "agent_session:completed",
+      payload: expect.objectContaining({ sessionId: "binv_1", messageCount: 1 }),
+    })
+    expect(insertOutbox).toHaveBeenCalled()
+    expect(emitted.map((e) => e.event)).toContain("agent_session:completed")
+    expect((payloads[0] as { data: { messageId: string } }).data.messageId).toBe("msg_reply")
+  })
+
+  it("completes with no reply (noResponse) without creating a message", async () => {
+    const { handlers, createMessageInTransaction, completeInvocationInTransaction, insertEvent } = arrange()
+    const { res, payloads } = createResponse()
+
+    await handlers.completeBotInvocationSealed(req({ noResponse: true }), res)
+
+    expect(createMessageInTransaction).not.toHaveBeenCalled()
+    expect(completeInvocationInTransaction).toHaveBeenCalled()
+    expect(insertEvent.mock.calls[0]?.[1]).toMatchObject({
+      payload: expect.objectContaining({ messageCount: 0 }),
+    })
+    expect((payloads[0] as { data: { messageId: string | null } }).data.messageId).toBeNull()
+  })
+
+  it("skips the lifecycle event when the session lost the finalize race", async () => {
+    // The claim flip won but completeSession returns null (a concurrent terminal
+    // transition slipped in after the pre-tx running check): the message + claim
+    // commit, but no agent_session:completed event/outbox/socket frame is emitted —
+    // the racing terminal transition carries its own lifecycle event.
+    const { handlers, emitted, insertEvent, insertOutbox } = arrange({ sessionFinalized: false })
+    const { res, payloads } = createResponse()
+
+    await handlers.completeBotInvocationSealed(req({ noResponse: true }), res)
+
+    expect(insertEvent).not.toHaveBeenCalled()
+    expect(insertOutbox).not.toHaveBeenCalled()
+    expect(emitted.map((e) => e.event)).not.toContain("agent_session:completed")
+    expect((payloads[0] as { data: { invocationId: string } }).data.invocationId).toBe("binv_1")
+  })
+
+  it("rejects when the claim is already gone (404)", async () => {
+    const { handlers } = arrange({ claimCompleted: false })
+    const { res } = createResponse()
+
+    await expect(handlers.completeBotInvocationSealed(req({ noResponse: true }), res)).rejects.toMatchObject({
+      status: 404,
+      code: "NOT_FOUND",
+    })
+  })
+
+  it("rejects a reply sealed under the wrong key generation (400)", async () => {
+    const { handlers } = arrange()
+    const { res } = createResponse()
+
+    await expect(
+      handlers.completeBotInvocationSealed(
+        req({
+          reply: { messageId: "msg_reply", ciphertext: "c2VhbGVk", envelope: { ...REPLY_ENVELOPE, keyGeneration: 4 } },
+        }),
+        res
+      )
+    ).rejects.toMatchObject({ status: 400, code: "E2E_WRONG_KEY_GENERATION" })
+  })
+
+  it("rejects a missing callback token (403)", async () => {
+    const { handlers } = arrange()
+    const { res } = createResponse()
+
+    await expect(handlers.completeBotInvocationSealed(req({ noResponse: true }, {}), res)).rejects.toMatchObject({
+      status: 403,
+      code: "CALLBACK_TOKEN_MISSING",
+    })
+  })
+
+  it("rejects a non-running session (409)", async () => {
+    const { handlers } = arrange({ sessionOverride: { status: "completed" } })
+    const { res } = createResponse()
+
+    await expect(handlers.completeBotInvocationSealed(req({ noResponse: true }), res)).rejects.toMatchObject({
+      status: 409,
+      code: "SESSION_NOT_RUNNING",
+    })
+  })
+})

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -872,6 +872,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     publicApi.recordBotInvocationSealedStep
   )
   app.post(
+    "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/sealed-complete",
+    ...publicMiddleware,
+    requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),
+    publicApi.completeBotInvocationSealed
+  )
+  app.post(
     "/api/v1/workspaces/:workspaceId/bot-invocations/:invocationId/complete",
     ...publicMiddleware,
     requireApiKeyScope(WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE),

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -2075,6 +2075,142 @@
         }
       }
     },
+    "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-complete": {
+      "post": {
+        "operationId": "completeBotInvocationSealed",
+        "summary": "Complete a sealed bot invocation",
+        "tags": ["Bot invocations"],
+        "description": "Sealed variant of the completion, for an owner-granted E2E bot harness: persists the turn's final sealed reply (ciphertext the server never decrypts) or noResponse, flips the claim, and finalizes the agent session. Authenticated with the per-claim callback token in the X-Threa-Callback-Token header.",
+        "security": [{ "apiKey": ["bot-invocations:write"] }],
+        "parameters": [
+          {
+            "name": "workspaceId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Workspace ID (prefixed ULID)"
+          },
+          {
+            "name": "invocationId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Invocation ID"
+          },
+          {
+            "name": "X-Threa-Callback-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Per-claim callback token from the sealed claim response (binds the caller to the assigned session)."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "properties": {
+                  "reply": {
+                    "type": "object",
+                    "properties": {
+                      "messageId": { "type": "string", "minLength": 1, "maxLength": 128 },
+                      "ciphertext": {
+                        "type": "string",
+                        "minLength": 1,
+                        "format": "base64",
+                        "contentEncoding": "base64",
+                        "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                      },
+                      "envelope": {
+                        "type": "object",
+                        "properties": {
+                          "v": { "type": "number" },
+                          "keyGeneration": { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+                          "iv": {
+                            "type": "string",
+                            "minLength": 1,
+                            "format": "base64",
+                            "contentEncoding": "base64",
+                            "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                          },
+                          "aad": {
+                            "type": "string",
+                            "minLength": 1,
+                            "format": "base64",
+                            "contentEncoding": "base64",
+                            "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$"
+                          }
+                        },
+                        "required": ["v", "keyGeneration", "iv", "aad"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": ["messageId", "ciphertext", "envelope"],
+                    "additionalProperties": false
+                  },
+                  "noResponse": { "type": "boolean" }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "invocationId": { "type": "string" },
+                        "sessionId": { "type": "string" },
+                        "messageId": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
+                      },
+                      "required": ["invocationId", "sessionId", "messageId"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "https://json-schema.org/draft/2020-12/schema",
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" },
+                    "details": {
+                      "type": "object",
+                      "propertyNames": { "type": "string" },
+                      "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                    }
+                  },
+                  "required": ["error"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": { "description": "Missing or invalid API key" },
+          "403": { "description": "Insufficient permissions or inaccessible resource" },
+          "404": { "description": "Resource not found" }
+        }
+      }
+    },
     "/api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/complete": {
       "post": {
         "operationId": "completeBotInvocation",

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -575,6 +575,22 @@ export interface SealedReply {
 }
 
 /**
+ * The sealed turn completion an owner-granted bot harness POSTs to
+ * `POST .../bot-invocations/:invocationId/sealed-complete` — the external sibling
+ * of the enclave's `/complete` and the sealed variant of the plaintext bot
+ * complete. Carries the turn's final sealed reply (ciphertext the server can't
+ * read, INV-E7) or `noResponse` when the turn produced none. Unlike the enclave —
+ * which streams each reply to `/messages` and sends `/complete` as a bare ack —
+ * the bot path delivers its single reply inline here, mirroring the plaintext
+ * bot complete. Auth is the bot API key + the per-claim callback token in
+ * `X-Threa-Callback-Token`, never body claim fields.
+ */
+export interface SealedComplete {
+  reply?: SealedReply
+  noResponse?: boolean
+}
+
+/**
  * A sealed auto-generated stream title the enclave produced this turn, POSTed to
  * `POST .../sessions/:id/sealed-name`. The server can't read message content, so
  * it can't title an encrypted scratchpad — the enclave (which sees plaintext)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -383,6 +383,7 @@ export type {
   EnclaveSealedMessage,
   EnclaveSskWrap,
   SealedReply,
+  SealedComplete,
   EnclaveSealedName,
   EnclaveSealedSummary,
   SealedStep,


### PR DESCRIPTION
## Summary

Phase 3 of E2EE for external bot harnesses. Adds a sealed completion endpoint so an owner-granted external bot harness can complete a **sealed** turn the way the enclave does. **Inert in production** — no delivery verdict resolves to `sealed` until `externalSealedDelivery` flips (Phase 6), so this endpoint is dark today.

Builds on #983 (sealed trace steps), #981 (sealed claim), #969/#967. Workstream: design doc `docs/plans/agent-runtimes-unification-redesign.md` §2.6.

New route: `POST /api/v1/workspaces/{workspaceId}/bot-invocations/{invocationId}/sealed-complete` — the external sibling of the enclave `/complete` and the sealed variant of the plaintext bot `/complete`.

## What it does

`completeBotInvocationSealed` (`apps/backend/src/features/public-api/handlers.ts`): in **one transaction** (INV-7) it persists the turn's final sealed reply (or `noResponse`), flips the `bot_invocations` claim, and finalizes the agent session (`completeSession` + the `agent_session:completed` stream event/outbox), then emits the live session-room frame **outside** the tx (INV-41). Race-safe on the `status = 'claimed'` predicate (INV-20); the server only ever persists/relays ciphertext (INV-E7). Auth is the bot API key + the per-claim callback token in `X-Threa-Callback-Token`, verified against the session's `callback_token_hash` binding, plus workspace/persona isolation (INV-8) — no `instanceId`/`claimToken` body fields (the header-auth model, "model A").

Unlike the enclave (which streams each reply to `/messages` and acks here), the bot path delivers its single sealed reply **inline**, exactly as the plaintext bot complete does — only the body is ciphertext.

## Design decisions

- **Neutral, shared sealed vocabulary (§2.6 rule 1):** adds `SealedComplete` (reusing `SealedReply`), not an enclave-named type. No `assertNotE2eStream` sprinkle and no `instanceof` branch on the sealed path (§2.6 rule 2) — the route inherits darkness because no sealed claim is ever issued while the flag is off.
- **Shared claim completion (INV-27):** `BotInvocationRepository.completeClaim` now scopes by the per-claim `claim_token` with an optional **null-guarded** `instanceId` (`($n::text IS NULL OR claimed_by_instance_id = $n)`), so the sealed path (which omits `instanceId`) and the plaintext path share one method. Plaintext behavior is unchanged when an instance is supplied. The `claim_token` is the per-claim secret (delivered only inside the winning sealed claim), a strictly stronger binding than a self-reported instance id.
- **Explicit token dependency:** the shared sealed authorize helper (renamed `authorizeSealedStepCallback` → `authorizeSealedInvocationCallback`, now used by `/steps`, `/steps/started`, and `/sealed-complete`) returns the verified callback token, so the claim flip scopes by it explicitly instead of re-reading the header with a `!`.
- **Deliberate omissions vs the plaintext path** (each carries a why-comment): no reply-only **trace synthesis** (the plaintext floor needs cleartext we don't have — the trace is whatever sealed steps the harness already POSTed); no **runtime-command** `command:completed` event (a runtime command requires `SESSION_CONTROL`, and the claim path never seals a session-control invocation); no **manifest gate** (`assertManifestAllows` keys off the runtime manifest looked up by `instanceId`, which the header-auth model omits).

## Files

- `apps/backend/src/features/public-api/handlers.ts` — `completeBotInvocationSealed` handler; authorize helper rename + returns the token; local `E2E_PLACEHOLDER_CONTENT_JSON`.
- `apps/backend/src/features/public-api/schemas.ts` — `completeSealedInvocationSchema` (base64-validated, reply-or-`noResponse`).
- `apps/backend/src/features/public-api/routes.ts` + `apps/backend/src/routes.ts` — route descriptor (with `callbackTokenHeaderParam`) + express wiring.
- `apps/backend/src/features/bot-runtimes/{repository,service}.ts` — `completeClaim` / `completeInvocationInTransaction` optional null-guarded `instanceId`.
- `packages/types/src/api.ts` (+ `index.ts`) — `SealedComplete` wire type.
- `docs/public-api/openapi.json` — regenerated.
- `apps/backend/src/features/public-api/sealed-complete.test.ts` — new (8 tests).

## Testing

- New `sealed-complete.test.ts`: reply persistence, `noResponse`, the finalize-race branch (claim flipped but `completeSession` returns null → no lifecycle event/outbox/emit), and the 404/400/403/409 rejection paths.
- All sealed + public-api + bot-runtimes + agents/enclave-runtimes suites green; full monorepo typecheck clean; backend lint clean; OpenAPI in sync (`generate:api-docs:check`).
- No local Postgres in the dev environment, so backend integration/e2e run in CI only — the `completeClaim` SQL null-guard is unit-asserted at the param level here and exercised against a real DB in CI.

Two self-review passes (correctness/data-flow + spec/§2.6/invariant) returned no blockers; their should-fix items are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdrPkf1HgMYcUn3BSbqLN6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdrPkf1HgMYcUn3BSbqLN6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784286555&installation_id=129946197&pr_number=988&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F988&signature=135f991c566496d95095434f38fde05a9217c3faab03fc16c1a336766d8a0151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->