### PR TITLE
feat(channels): read and send attachments through the Claude Code channel

### DIFF
--- a/apps/backend/tests/client.ts
+++ b/apps/backend/tests/client.ts
@@ -92,14 +92,15 @@ export class TestClient {
    */
   async uploadFile<T = unknown>(
     path: string,
-    file: { content: string | Buffer; filename: string; mimeType: string }
+    file: { content: string | Buffer; filename: string; mimeType: string },
+    extraHeaders?: Record<string, string>
   ): Promise<{ status: number; data: T; headers: Headers }> {
     const formData = new FormData()
     const blobPart: BlobPart = typeof file.content === "string" ? file.content : Uint8Array.from(file.content)
     const blob = new Blob([blobPart], { type: file.mimeType })
     formData.append("file", blob, file.filename)
 
-    const headers: Record<string, string> = {}
+    const headers: Record<string, string> = { ...extraHeaders }
     if (this.cookies.size > 0) {
       headers["Cookie"] = Array.from(this.cookies.entries())
         .map(([k, v]) => `${k}=${v}`)
@@ -831,6 +832,23 @@ export function botApiPost<T = unknown>(
   body: unknown
 ) {
   return client.request<T>("POST", `/api/v1/workspaces/${workspaceId}${path}`, body, {
+    Authorization: `Bearer ${apiKey}`,
+  })
+}
+
+export function botApiGet<T = unknown>(client: TestClient, workspaceId: string, path: string, apiKey: string) {
+  return client.request<T>("GET", `/api/v1/workspaces/${workspaceId}${path}`, undefined, {
+    Authorization: `Bearer ${apiKey}`,
+  })
+}
+
+export function botUploadFile<T = unknown>(
+  client: TestClient,
+  workspaceId: string,
+  apiKey: string,
+  file: { content: string | Buffer; filename: string; mimeType: string }
+) {
+  return client.uploadFile<T>(`/api/v1/workspaces/${workspaceId}/attachments`, file, {
     Authorization: `Bearer ${apiKey}`,
   })
 }

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -10,7 +10,19 @@
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { BotTraits, WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
-import { botApiPost, createBot, createBotKey, createWorkspace, loginAs, sendMessage, TestClient } from "../client"
+import {
+  botApiGet,
+  botApiPost,
+  botUploadFile,
+  createBot,
+  createBotKey,
+  createWorkspace,
+  loginAs,
+  sendMessage,
+  sendMessageWithAttachments,
+  TestClient,
+  uploadAttachment,
+} from "../client"
 
 setDefaultTimeout(60_000)
 
@@ -29,6 +41,32 @@ interface ClaimedInvocationData {
   claimToken: string
   promptMarkdown: string
   requiredCapability: string
+}
+
+interface ListedMessage {
+  id: string
+  content: string
+  attachments?: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>
+}
+
+async function claimInvocation(
+  client: TestClient,
+  workspaceId: string,
+  apiKey: string,
+  body: Record<string, unknown>
+): Promise<ClaimedInvocationData> {
+  for (let i = 0; i < 30; i++) {
+    const res = await botApiPost<{ data: ClaimedInvocationData | null }>(
+      client,
+      workspaceId,
+      "/bot-invocations/claim",
+      apiKey,
+      body
+    )
+    if (res.status === 200 && res.data.data) return res.data.data
+    await new Promise((resolve) => setTimeout(resolve, 200))
+  }
+  throw new Error("no invocation claimed within the poll window")
 }
 
 describe("claude-code-channel runtime sessions", () => {
@@ -165,5 +203,143 @@ describe("claude-code-channel runtime sessions", () => {
     )
     expect(completed.status).toBe(200)
     expect(completed.data.data.message?.content).toContain("forty-two")
+  })
+
+  // The channel discovers inbound attachments by listing recent stream messages
+  // (the claim context omits attachment metadata) and downloads them with its
+  // bot key. This pins both reads the extension relies on.
+  test("inbound: a user's attachment is listed for the channel and downloadable", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-in-${testRunId}@test.com`, "CC Inbound User")
+    const workspace = await createWorkspace(client, `CC Inbound WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCIN ${testRunId}`,
+      slug: `ccin-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.MESSAGES_READ,
+      WORKSPACE_PERMISSION_SCOPES.STREAMS_READ,
+      WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_READ,
+    ])
+
+    const session = await botApiPost<{ data: SessionLinkData }>(client, workspace.id, "/bot-runtime/sessions", apiKey, {
+      runtimeKind: "claude-code-channel",
+      instanceId: `ccin-inst-${testRunId}`,
+      runtimeSessionId: `ccin-sess-${testRunId}`,
+      displayName: "Claude Code - in",
+      localCwd: "/tmp/threa-cc-in",
+    })
+    const streamId = session.data.data.activeStreamId
+
+    const attachment = await uploadAttachment(client, workspace.id, {
+      content: "hello attachment",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+    })
+    await sendMessageWithAttachments(client, workspace.id, streamId, "Please read notes.txt", [attachment.id])
+
+    const listed = await botApiGet<{ data: ListedMessage[] }>(
+      client,
+      workspace.id,
+      `/streams/${streamId}/messages?limit=30`,
+      apiKey
+    )
+    expect(listed.status).toBe(200)
+    const withAttachment = listed.data.data.find((message) => (message.attachments?.length ?? 0) > 0)
+    expect(withAttachment).toBeTruthy()
+    expect(withAttachment!.attachments![0]).toMatchObject({
+      id: attachment.id,
+      filename: "notes.txt",
+      mimeType: "text/plain",
+    })
+
+    const urlRes = await botApiGet<{ data: { url: string } }>(
+      client,
+      workspace.id,
+      `/attachments/${attachment.id}/url`,
+      apiKey
+    )
+    expect(urlRes.status).toBe(200)
+    expect(typeof urlRes.data.data.url).toBe("string")
+  })
+
+  // The channel turns a `THREA_ATTACH:` directive into an upload plus an
+  // `[name](attachment:<id>)` link in the reply; the backend associates the
+  // upload with the posted message purely from that link.
+  test("outbound: an uploaded file is attached to the reply via an attachment link", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-out-${testRunId}@test.com`, "CC Outbound User")
+    const workspace = await createWorkspace(client, `CC Outbound WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCOUT ${testRunId}`,
+      slug: `ccout-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.MESSAGES_READ,
+      WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.STREAMS_READ,
+      WORKSPACE_PERMISSION_SCOPES.ATTACHMENTS_WRITE,
+    ])
+
+    const instanceId = `ccout-inst-${testRunId}`
+    const runtimeSessionId = `ccout-sess-${testRunId}`
+    const session = await botApiPost<{ data: SessionLinkData }>(client, workspace.id, "/bot-runtime/sessions", apiKey, {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      displayName: "Claude Code - out",
+      localCwd: "/tmp/threa-cc-out",
+    })
+    const streamId = session.data.data.activeStreamId
+
+    await sendMessage(client, workspace.id, streamId, "send me a file")
+    const claimed = await claimInvocation(client, workspace.id, apiKey, {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      supportedCapabilities: ["active-scratchpad", "mentionable"],
+      claimTtlSeconds: 120,
+    })
+
+    const upload = await botUploadFile<{ data: { id: string; filename: string } }>(client, workspace.id, apiKey, {
+      content: "generated output",
+      filename: "result.txt",
+      mimeType: "text/plain",
+    })
+    expect(upload.status).toBe(201)
+    const attachmentId = upload.data.data.id
+
+    const completed = await botApiPost<{ data: { message: { id: string; content: string } | null } }>(
+      client,
+      workspace.id,
+      `/bot-invocations/${claimed.id}/complete`,
+      apiKey,
+      {
+        instanceId,
+        claimToken: claimed.claimToken,
+        finalMessageMarkdown: `Here is the file\n\n[result.txt](attachment:${attachmentId})`,
+      }
+    )
+    expect(completed.status).toBe(200)
+    expect(completed.data.data.message?.content).toContain("Here is the file")
+
+    const listed = await botApiGet<{ data: ListedMessage[] }>(
+      client,
+      workspace.id,
+      `/streams/${streamId}/messages?limit=30`,
+      apiKey
+    )
+    const replyMessage = listed.data.data.find((message) =>
+      (message.attachments ?? []).some((attachment) => attachment.id === attachmentId)
+    )
+    expect(replyMessage).toBeTruthy()
   })
 })

--- a/docs/claude-code-channel.md
+++ b/docs/claude-code-channel.md
@@ -86,6 +86,14 @@ The channel exposes one tool, `reply(invocation_id, text)`. Claude is told (via 
 
 The `reply` tool is the only path back to Threa, which is why the instructions insist on it. As a safety net, an in-flight invocation that is never answered is force-closed after `replyTimeoutMs` (default 30 minutes) with a short notice, so a session can't get wedged in `busy` forever.
 
+## Attachments
+
+Attachments cross in both directions, but the claim response doesn't carry them, so each direction needs a little extra work.
+
+**Inbound (scratchpad → working directory).** The claim's hydrated history is text only — no attachment metadata, and the trigger message itself isn't in it. So before pushing the event, the channel lists the recent messages of the invocation's stream (`GET /streams/:id/messages`), picks the attachments on the source message plus any on the history Claude is being shown, downloads each into `.threa-attachments/<invocation_id>/` under the working directory (via a short-lived signed URL from `GET /attachments/:id/url`), and appends a manifest of local paths to the channel content. Claude reads the files straight from disk. The whole step is best-effort: a key without `attachments:read`, or any download failure, is logged and the prompt still goes through without the files.
+
+**Outbound (working directory → scratchpad).** The `reply` tool's text may contain `THREA_ATTACH: <path>` lines. Before completing the invocation, the channel strips those lines, uploads each file (`POST /attachments`, multipart), and appends `[name](attachment:<id>)` links to the reply markdown. The backend associates the uploads with the posted message purely from those links — there is no separate attachment-ids field on `complete`. A failed upload is reported inline rather than dropping the reply.
+
 ## Permission relay: approving tools from Threa
 
 When Claude calls a tool that needs approval and you're not at the terminal, the session would normally stall. The channel opts into permission relay (`claude/channel/permission`). The loop:
@@ -113,10 +121,10 @@ The local terminal dialog stays open the whole time, so whichever answer arrives
 | Trace detail                              | Rich per-tool steps (it hooks Pi's tool events)           | One "working" step (a channel can't see Claude's tool calls)         |
 | Session control (`/compact`, `/model`, …) | Yes                                                       | No (a channel can't drive Claude's session)                          |
 | Permission prompts                        | N/A (Pi runs the model in-process)                        | Relayed into the scratchpad as messages                              |
+| Attachments                               | Downloads inbound, `THREA_ATTACH:` uploads outbound       | Same, but inbound needs an extra stream-messages fetch to find them  |
 | Backend changes                           | None                                                      | Small — `claude-code-channel` made a first-class linked runtime kind |
 
 ## Limits today
 
 - Single "working" trace step rather than a per-tool trace.
-- Threa attachments aren't downloaded into the working directory.
 - No session-control commands (a channel can't drive Claude's host session).

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -26,7 +26,8 @@ In Threa: **Workspace settings → Bots**.
    - `messages:read`
    - `messages:write` (only needed for permission relay)
    - `streams:read`
-   - `attachments:read`
+   - `attachments:read` (download attachments posted in the scratchpad)
+   - `attachments:write` (send local files back with `THREA_ATTACH:`)
 3. Copy the key (`threa_bk_…`, shown once) and your workspace id (`ws_…`).
 
 The bot must be **personal**: the session-link endpoint that creates the scratchpad and makes the bot its active actor rejects shared bots. Linking auto-repairs the `active-scratchpad` trait if you forgot it.
@@ -98,6 +99,20 @@ claude --dangerously-load-development-channels server:threa --dangerously-skip-p
 
 Only do that in a directory you trust. Also consider pre-allowing the `mcp__threa__reply` tool so posting replies never prompts.
 
+## Attachments
+
+Attachments cross in both directions, mirroring `pi-remote`.
+
+**Inbound.** When a message you send carries attachments, the channel downloads them into `.threa-attachments/<invocation_id>/` under the working directory and lists each local path in the channel event, so Claude can read the files straight from disk. Discovery is best-effort: if the bot key lacks `attachments:read` (or the fetch fails), the prompt still reaches Claude without the files.
+
+**Outbound.** To send a local file back, Claude adds a line to its reply:
+
+```
+THREA_ATTACH: ./reports/out.png
+```
+
+The channel uploads the file (one per `THREA_ATTACH:` line; paths resolve against the working directory) and rewrites the line into an `[out.png](attachment:…)` link the reply carries into the scratchpad. An upload that fails is reported inline rather than dropping the reply.
+
 ## Configuration reference
 
 | Env var                    | Config key         | Default                | Meaning                                         |
@@ -129,7 +144,6 @@ bun run typecheck
 
 ## Roadmap (parity with `pi-remote`)
 
-- **Attachments, both directions** — download attachments posted in the scratchpad into the working directory so Claude can read them, and send local files back as attachments on the reply (Pi does this with a `THREA_ATTACH: <path>` directive that uploads the file and rewrites it to an attachment link). This is the main remaining gap.
 - Per-tool trace steps — a channel can't observe Claude's tool calls, so matching Pi's rich trace needs a different mechanism than Pi's lifecycle hooks.
 
 ## Troubleshooting

--- a/extensions/claude-code-remote/src/attachments.test.ts
+++ b/extensions/claude-code-remote/src/attachments.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  buildReplyAttachmentSection,
+  downloadInboundAttachments,
+  extractAttachmentDirectives,
+  formatInboundAttachmentManifest,
+  guessMimeType,
+  safeFilename,
+  selectInboundAttachments,
+  uploadReplyAttachments,
+  type DownloadedAttachment,
+} from "./attachments"
+import type { AttachmentSummary, StreamMessageSummary } from "./threa-client"
+
+function summary(partial: Partial<AttachmentSummary> & { id: string }): AttachmentSummary {
+  return { filename: "f.txt", mimeType: "text/plain", sizeBytes: 1, ...partial }
+}
+
+const tempDirs: string[] = []
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cc-attach-"))
+  tempDirs.push(dir)
+  return dir
+}
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true })
+})
+
+describe("extractAttachmentDirectives", () => {
+  test("pulls THREA_ATTACH lines out and keeps the rest", () => {
+    const result = extractAttachmentDirectives("Here you go\nTHREA_ATTACH: ./out.png\nThanks")
+    expect(result.paths).toEqual(["./out.png"])
+    expect(result.markdown).toBe("Here you go\nThanks")
+  })
+
+  test("trims directive whitespace and collects multiple paths", () => {
+    const result = extractAttachmentDirectives("THREA_ATTACH:   a.txt  \nTHREA_ATTACH: b/c.pdf")
+    expect(result.paths).toEqual(["a.txt", "b/c.pdf"])
+    expect(result.markdown).toBe("")
+  })
+
+  test("leaves text with no directives untouched", () => {
+    expect(extractAttachmentDirectives("just a reply")).toEqual({ markdown: "just a reply", paths: [] })
+  })
+})
+
+describe("guessMimeType", () => {
+  test("maps known extensions and defaults to octet-stream", () => {
+    expect(guessMimeType("/x/y.PNG")).toBe("image/png")
+    expect(guessMimeType("report.pdf")).toBe("application/pdf")
+    expect(guessMimeType("data.json")).toBe("application/json")
+    expect(guessMimeType("noext")).toBe("application/octet-stream")
+  })
+})
+
+describe("safeFilename", () => {
+  test("replaces path separators and other unsafe characters", () => {
+    expect(safeFilename("a/b\\c:d?.txt")).toBe("a_b_c_d_.txt")
+  })
+
+  test("falls back when the name reduces to empty", () => {
+    expect(safeFilename("")).toBe("attachment")
+  })
+})
+
+describe("selectInboundAttachments", () => {
+  const messages: StreamMessageSummary[] = [
+    { id: "m_old", attachments: [summary({ id: "a_old", filename: "old.png" })] },
+    { id: "m_ctx", attachments: [summary({ id: "a_ctx", filename: "ctx.txt" })] },
+    { id: "m_src", attachments: [summary({ id: "a_src", filename: "src.pdf" })] },
+    { id: "m_unrelated", attachments: [summary({ id: "a_unrelated" })] },
+  ]
+
+  test("keeps only source + shown-context messages, source first", () => {
+    const selected = selectInboundAttachments(messages, "m_src", ["m_ctx"])
+    expect(selected.map((s) => s.attachment.id)).toEqual(["a_src", "a_ctx"])
+    expect(selected[0]!.isSource).toBe(true)
+    expect(selected[1]!.isSource).toBe(false)
+  })
+
+  test("de-duplicates an attachment that appears on multiple in-scope messages", () => {
+    const dupe: StreamMessageSummary[] = [
+      { id: "m_src", attachments: [summary({ id: "a_dupe" })] },
+      { id: "m_ctx", attachments: [summary({ id: "a_dupe" })] },
+    ]
+    const selected = selectInboundAttachments(dupe, "m_src", ["m_ctx"])
+    expect(selected).toHaveLength(1)
+    expect(selected[0]!.attachment.id).toBe("a_dupe")
+  })
+
+  test("returns nothing when no in-scope message has attachments", () => {
+    expect(selectInboundAttachments(messages, "m_none", [])).toEqual([])
+  })
+
+  test("keeps the source marker when a file is shared with an earlier-listed context message", () => {
+    const shared: StreamMessageSummary[] = [
+      { id: "m_ctx", attachments: [summary({ id: "a_shared" })] },
+      { id: "m_src", attachments: [summary({ id: "a_shared" })] },
+    ]
+    const selected = selectInboundAttachments(shared, "m_src", ["m_ctx"])
+    expect(selected).toHaveLength(1)
+    expect(selected[0]!.isSource).toBe(true)
+  })
+})
+
+describe("formatInboundAttachmentManifest", () => {
+  test("is empty for no downloads", () => {
+    expect(formatInboundAttachmentManifest([])).toBe("")
+  })
+
+  test("lists each path and marks the source attachment", () => {
+    const downloaded: DownloadedAttachment[] = [
+      {
+        attachment: summary({ id: "a_src", filename: "src.pdf", mimeType: "application/pdf", sizeBytes: 10 }),
+        messageId: "m_src",
+        isSource: true,
+        localPath: ".threa-attachments/binv/src.pdf",
+      },
+      {
+        attachment: summary({ id: "a_ctx", filename: "ctx.txt", mimeType: "text/plain", sizeBytes: 5 }),
+        messageId: "m_ctx",
+        isSource: false,
+        localPath: ".threa-attachments/binv/ctx.txt",
+      },
+    ]
+    const text = formatInboundAttachmentManifest(downloaded)
+    expect(text).toContain("src.pdf (application/pdf, 10 bytes) → .threa-attachments/binv/src.pdf")
+    expect(text).toContain("[attached to the message you just received]")
+    expect(text).toContain("ctx.txt (text/plain, 5 bytes) → .threa-attachments/binv/ctx.txt")
+  })
+})
+
+describe("buildReplyAttachmentSection", () => {
+  test("renders attachment links", () => {
+    const section = buildReplyAttachmentSection([summary({ id: "a_1", filename: "chart.png" })], [])
+    expect(section).toContain("Attachments:")
+    expect(section).toContain("- [chart.png](attachment:a_1)")
+  })
+
+  test("renders failures and is empty when there is nothing", () => {
+    expect(buildReplyAttachmentSection([], ["./missing: not found"])).toContain("Attachment upload failed:")
+    expect(buildReplyAttachmentSection([], [])).toBe("")
+  })
+})
+
+describe("uploadReplyAttachments", () => {
+  test("uploads each directive file and rewrites the reply with links", async () => {
+    const dir = tempDir()
+    const filePath = join(dir, "chart.png")
+    writeFileSync(filePath, new Uint8Array([1, 2, 3]))
+    const uploads: Array<{ filename: string; type: string }> = []
+    const client = {
+      async uploadAttachment(form: FormData): Promise<AttachmentSummary> {
+        const file = form.get("file") as Blob & { name?: string }
+        uploads.push({ filename: file.name ?? "", type: file.type })
+        return summary({ id: "att_1", filename: "chart.png", mimeType: "image/png", sizeBytes: 3 })
+      },
+    }
+    const result = await uploadReplyAttachments(client, `Here is the chart\nTHREA_ATTACH: ${filePath}`, dir)
+    expect(uploads).toEqual([{ filename: "chart.png", type: "image/png" }])
+    expect(result.uploaded.map((a) => a.id)).toEqual(["att_1"])
+    expect(result.markdown).toContain("Here is the chart")
+    expect(result.markdown).toContain("- [chart.png](attachment:att_1)")
+    expect(result.markdown).not.toContain("THREA_ATTACH")
+  })
+
+  test("records a failure for a missing file without throwing", async () => {
+    const dir = tempDir()
+    const client = {
+      async uploadAttachment(): Promise<AttachmentSummary> {
+        throw new Error("should not be called")
+      },
+    }
+    const result = await uploadReplyAttachments(client, "Done\nTHREA_ATTACH: ./nope.txt", dir)
+    expect(result.uploaded).toEqual([])
+    expect(result.failed).toHaveLength(1)
+    expect(result.markdown).toContain("Done")
+    expect(result.markdown).toContain("Attachment upload failed:")
+  })
+
+  test("returns the reply unchanged when there are no directives", async () => {
+    const client = {
+      async uploadAttachment(): Promise<AttachmentSummary> {
+        throw new Error("should not be called")
+      },
+    }
+    const result = await uploadReplyAttachments(client, "plain reply", "/tmp")
+    expect(result).toEqual({ markdown: "plain reply", uploaded: [], failed: [] })
+  })
+})
+
+describe("downloadInboundAttachments", () => {
+  test("downloads in-scope attachments to disk and reports their paths", async () => {
+    const dir = tempDir()
+    const client = {
+      async listStreamMessages(): Promise<StreamMessageSummary[]> {
+        return [{ id: "m_src", attachments: [summary({ id: "a_src", filename: "src.pdf" })] }]
+      },
+      async getAttachmentDownloadUrl(id: string): Promise<string> {
+        return `https://signed.example/${id}`
+      },
+    }
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array([9, 8, 7])))
+    try {
+      const downloaded = await downloadInboundAttachments(client, {
+        streamId: "stream_1",
+        sourceMessageId: "m_src",
+        contextMessageIds: [],
+        invocationId: "binv_1",
+        cwd: dir,
+        scanLimit: 30,
+        log: () => undefined,
+      })
+      expect(downloaded).toHaveLength(1)
+      const localPath = downloaded[0]!.localPath
+      expect(localPath).toBe(join(dir, ".threa-attachments", "binv_1", "src.pdf"))
+      expect(existsSync(localPath)).toBe(true)
+      expect(Array.from(readFileSync(localPath))).toEqual([9, 8, 7])
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("skips an attachment whose download fails and keeps the rest", async () => {
+    const dir = tempDir()
+    const client = {
+      async listStreamMessages(): Promise<StreamMessageSummary[]> {
+        return [
+          {
+            id: "m_src",
+            attachments: [summary({ id: "a_ok", filename: "ok.txt" }), summary({ id: "a_bad", filename: "bad.txt" })],
+          },
+        ]
+      },
+      async getAttachmentDownloadUrl(id: string): Promise<string> {
+        return `https://signed.example/${id}`
+      },
+    }
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input: string | URL | Request) => {
+      return String(input).endsWith("a_bad") ? new Response("nope", { status: 500 }) : new Response(new Uint8Array([1]))
+    }) as typeof fetch)
+    const logs: string[] = []
+    try {
+      const downloaded = await downloadInboundAttachments(client, {
+        streamId: "stream_1",
+        sourceMessageId: "m_src",
+        contextMessageIds: [],
+        invocationId: "binv_2",
+        cwd: dir,
+        scanLimit: 30,
+        log: (m) => logs.push(m),
+      })
+      expect(downloaded.map((d) => d.attachment.id)).toEqual(["a_ok"])
+      expect(logs.join("\n")).toContain("a_bad")
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  test("returns nothing (and writes nothing) when no in-scope message has attachments", async () => {
+    const dir = tempDir()
+    const client = {
+      async listStreamMessages(): Promise<StreamMessageSummary[]> {
+        return [{ id: "m_other", attachments: [summary({ id: "a_x" })] }]
+      },
+      async getAttachmentDownloadUrl(): Promise<string> {
+        throw new Error("should not be called")
+      },
+    }
+    const downloaded = await downloadInboundAttachments(client, {
+      streamId: "stream_1",
+      sourceMessageId: "m_src",
+      contextMessageIds: [],
+      invocationId: "binv_3",
+      cwd: dir,
+      scanLimit: 30,
+      log: () => undefined,
+    })
+    expect(downloaded).toEqual([])
+    expect(existsSync(join(dir, ".threa-attachments"))).toBe(false)
+  })
+})

--- a/extensions/claude-code-remote/src/attachments.ts
+++ b/extensions/claude-code-remote/src/attachments.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs"
+import { basename, join, resolve } from "node:path"
+import type { AttachmentSummary, StreamMessageSummary, ThreaClient } from "./threa-client"
+
+/** A reply line `THREA_ATTACH: ./out.png` tells the channel to upload that file and attach it to the reply. */
+export const ATTACH_DIRECTIVE_RE = /^THREA_ATTACH:\s*(.+?)\s*$/
+/** Inbound attachments land under `<cwd>/.threa-attachments/<invocationId>/`, fresh per turn. */
+export const ATTACHMENT_DIR = ".threa-attachments"
+
+export interface SelectedAttachment {
+  attachment: AttachmentSummary
+  messageId: string
+  /** True when the attachment is on the message that triggered this turn. */
+  isSource: boolean
+}
+
+export interface DownloadedAttachment extends SelectedAttachment {
+  localPath: string
+}
+
+// --- Pure helpers ---------------------------------------------------------
+
+/** Strip `THREA_ATTACH:` directive lines out of a reply, returning the remaining text and the paths. */
+export function extractAttachmentDirectives(markdown: string): { markdown: string; paths: string[] } {
+  const paths: string[] = []
+  const lines = markdown.split("\n").filter((line) => {
+    const match = line.match(ATTACH_DIRECTIVE_RE)
+    if (!match) return true
+    paths.push(match[1]!)
+    return false
+  })
+  return { markdown: lines.join("\n").trim(), paths }
+}
+
+export function guessMimeType(path: string): string {
+  const lower = path.toLowerCase()
+  if (lower.endsWith(".png")) return "image/png"
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg"
+  if (lower.endsWith(".gif")) return "image/gif"
+  if (lower.endsWith(".webp")) return "image/webp"
+  if (lower.endsWith(".svg")) return "image/svg+xml"
+  if (lower.endsWith(".html")) return "text/html"
+  if (lower.endsWith(".md")) return "text/markdown"
+  if (lower.endsWith(".txt")) return "text/plain"
+  if (lower.endsWith(".csv")) return "text/csv"
+  if (lower.endsWith(".json")) return "application/json"
+  if (lower.endsWith(".pdf")) return "application/pdf"
+  return "application/octet-stream"
+}
+
+export function safeFilename(filename: string): string {
+  return filename.replace(/[\\/:*?"<>|]/g, "_").slice(0, 180) || "attachment"
+}
+
+/**
+ * Pick the attachments worth downloading: those on the source message (the
+ * request) plus any on the history messages Claude is being shown. De-duplicated
+ * by attachment id, source first so the manifest leads with the current request.
+ */
+export function selectInboundAttachments(
+  messages: StreamMessageSummary[],
+  sourceMessageId: string,
+  contextMessageIds: readonly string[]
+): SelectedAttachment[] {
+  const inScope = new Set<string>([sourceMessageId, ...contextMessageIds])
+  // Process the source message first so it leads the manifest and so a file
+  // shared with an older context message keeps its source marker regardless of
+  // the order the stream listing returned.
+  const ordered = [...messages].sort((a, b) => Number(b.id === sourceMessageId) - Number(a.id === sourceMessageId))
+  const seen = new Set<string>()
+  const selected: SelectedAttachment[] = []
+  for (const message of ordered) {
+    if (!inScope.has(message.id)) continue
+    for (const attachment of message.attachments ?? []) {
+      if (seen.has(attachment.id)) continue
+      seen.add(attachment.id)
+      selected.push({ attachment, messageId: message.id, isSource: message.id === sourceMessageId })
+    }
+  }
+  return selected
+}
+
+/** The block appended to the channel event so Claude knows where the files landed. */
+export function formatInboundAttachmentManifest(downloaded: DownloadedAttachment[]): string {
+  if (downloaded.length === 0) return ""
+  const lines = downloaded.map((entry) => {
+    const marker = entry.isSource ? " [attached to the message you just received]" : ""
+    const { filename, mimeType, sizeBytes } = entry.attachment
+    return `- ${filename} (${mimeType}, ${sizeBytes} bytes) → ${entry.localPath}${marker}`
+  })
+  return ["Attachments saved into this session's working directory — read them from these paths:", ...lines].join("\n")
+}
+
+/** The attachment links / failure notes appended to an outbound reply. */
+export function buildReplyAttachmentSection(uploaded: AttachmentSummary[], failed: string[]): string {
+  const parts: string[] = []
+  if (uploaded.length > 0) {
+    parts.push(["Attachments:", ...uploaded.map((a) => `- [${a.filename}](attachment:${a.id})`)].join("\n"))
+  }
+  if (failed.length > 0) {
+    parts.push(["Attachment upload failed:", ...failed.map((f) => `- ${f}`)].join("\n"))
+  }
+  return parts.join("\n\n")
+}
+
+// --- IO orchestration -----------------------------------------------------
+
+async function fetchAttachmentBytes(url: string): Promise<Uint8Array> {
+  // The url is a short-lived pre-signed storage URL, so it carries its own auth
+  // — a plain fetch, not the bearer-authenticated client request.
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`download failed with ${response.status}`)
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+/**
+ * Discover the attachments on the messages Claude is being shown, download them
+ * into `<cwd>/.threa-attachments/<invocationId>/`, and return what landed. A
+ * per-attachment failure is logged and skipped rather than aborting the turn.
+ */
+export async function downloadInboundAttachments(
+  client: Pick<ThreaClient, "listStreamMessages" | "getAttachmentDownloadUrl">,
+  params: {
+    streamId: string
+    sourceMessageId: string
+    contextMessageIds: readonly string[]
+    invocationId: string
+    cwd: string
+    scanLimit: number
+    log: (message: string) => void
+  }
+): Promise<DownloadedAttachment[]> {
+  const messages = await client.listStreamMessages(params.streamId, { limit: params.scanLimit })
+  const selected = selectInboundAttachments(messages, params.sourceMessageId, params.contextMessageIds)
+  if (selected.length === 0) return []
+  const dir = join(params.cwd, ATTACHMENT_DIR, params.invocationId)
+  mkdirSync(dir, { recursive: true })
+  const downloaded: DownloadedAttachment[] = []
+  for (const item of selected) {
+    try {
+      const url = await client.getAttachmentDownloadUrl(item.attachment.id)
+      const bytes = await fetchAttachmentBytes(url)
+      const localPath = join(dir, safeFilename(item.attachment.filename))
+      writeFileSync(localPath, bytes)
+      downloaded.push({ ...item, localPath })
+    } catch (error) {
+      params.log(`attachment ${item.attachment.id} download failed: ${String(error)}`)
+    }
+  }
+  return downloaded
+}
+
+async function uploadFile(
+  client: Pick<ThreaClient, "uploadAttachment">,
+  path: string,
+  cwd: string
+): Promise<AttachmentSummary> {
+  const absolute = resolve(cwd, path)
+  const stats = statSync(absolute)
+  if (!stats.isFile()) throw new Error(`${path} is not a file`)
+  const bytes = readFileSync(absolute)
+  const form = new FormData()
+  form.append("file", new Blob([bytes], { type: guessMimeType(absolute) }), basename(absolute))
+  return client.uploadAttachment(form)
+}
+
+/**
+ * Resolve `THREA_ATTACH:` directives in a reply: upload each referenced file and
+ * rewrite the reply to carry `attachment:<id>` links the backend associates with
+ * the posted message. Upload failures surface as a note rather than throwing.
+ */
+export async function uploadReplyAttachments(
+  client: Pick<ThreaClient, "uploadAttachment">,
+  markdown: string,
+  cwd: string
+): Promise<{ markdown: string; uploaded: AttachmentSummary[]; failed: string[] }> {
+  const { markdown: stripped, paths } = extractAttachmentDirectives(markdown)
+  const uploaded: AttachmentSummary[] = []
+  const failed: string[] = []
+  for (const path of paths) {
+    try {
+      uploaded.push(await uploadFile(client, path, cwd))
+    } catch (error) {
+      failed.push(`${path}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+  const section = buildReplyAttachmentSection(uploaded, failed)
+  const finalMarkdown = [stripped, section].filter(Boolean).join("\n\n") || "Done."
+  return { markdown: finalMarkdown, uploaded, failed }
+}

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
 import { io as openSocket, type Socket } from "socket.io-client"
 import { z } from "zod"
+import { downloadInboundAttachments, formatInboundAttachmentManifest, uploadReplyAttachments } from "./attachments"
 import type { ThreaChannelConfig } from "./config"
 import {
   buildBotSocketUrl,
@@ -25,6 +26,9 @@ const WS_BACKSTOP_POLL_MS = 30_000
 const MAX_CLAIMS_PER_DRAIN = 20
 const MAX_CONTEXT_MESSAGES = 12
 const MAX_MESSAGE_CHARS = 2_000
+// Recent messages to scan for inbound attachments. The trigger message is always
+// the newest, so this comfortably covers it plus the history Claude is shown.
+const ATTACHMENT_SCAN_LIMIT = 30
 
 /** "y abcde" / "yes abcde" / "n abcde" / "no abcde". The id alphabet skips 'l' (Claude Code's convention). */
 export const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i
@@ -83,6 +87,8 @@ export function buildInstructions(permissionRelay: boolean): string {
     "- Do the work it asks for in this session, against the real files.",
     "- Then call the `reply` tool exactly once, passing the `invocation_id` from that event's tag and your answer as `text`. The reply tool is the ONLY way your answer reaches the user, and it closes the request on Threa — so always reply, even with a short acknowledgement.",
     "- One reply per invocation_id. If several events arrive together, reply to each by its own id.",
+    "",
+    "Attachments. If a message has attachments, the channel downloads them into the working directory and lists each local path under the event — read them from those paths. To send a local file back, add a line `THREA_ATTACH: path/to/file` to your reply text (one per file; paths resolve against the working directory); the channel uploads it and replaces the line with an attachment link.",
   ]
   if (permissionRelay) {
     lines.push(
@@ -96,6 +102,9 @@ export function buildInstructions(permissionRelay: boolean): string {
 interface Inflight {
   invocation: ClaimedInvocation
   deadline: ReturnType<typeof setTimeout>
+  // The reply after THREA_ATTACH uploads, cached when a complete() fails so the
+  // retry reuses the same uploads instead of orphaning a fresh copy each time.
+  prepared?: { markdown: string; attachmentIds: string[] }
 }
 
 function log(message: string): void {
@@ -333,14 +342,38 @@ export class ChannelServer {
         statusText: "Working in Claude Code…",
       })
       .catch(() => undefined)
+    const content = await this.buildChannelContent(invocation)
     await this.notify("notifications/claude/channel", {
-      content: formatInvocationContent(invocation),
+      content,
       meta: {
         invocation_id: invocation.id,
         stream_id: invocation.responseStreamId,
         source_message_id: invocation.sourceMessageId,
       },
     })
+  }
+
+  /** The prompt + history Claude reads, with any downloaded attachments appended as a manifest. */
+  private async buildChannelContent(invocation: ClaimedInvocation): Promise<string> {
+    const base = formatInvocationContent(invocation)
+    // Best-effort: a discovery/download failure (e.g. a key without
+    // attachments:read) must never block the prompt from reaching Claude.
+    try {
+      const downloaded = await downloadInboundAttachments(this.client, {
+        streamId: invocation.activeStreamId,
+        sourceMessageId: invocation.sourceMessageId,
+        contextMessageIds: (invocation.context?.messages ?? []).map((message) => message.messageId),
+        invocationId: invocation.id,
+        cwd: process.cwd(),
+        scanLimit: ATTACHMENT_SCAN_LIMIT,
+        log,
+      })
+      const manifest = formatInboundAttachmentManifest(downloaded)
+      return manifest ? `${base}\n\n${manifest}` : base
+    } catch (error) {
+      log(`inbound attachment scan failed: ${this.summarize(error)}`)
+      return base
+    }
   }
 
   // --- Reply ----------------------------------------------------------------
@@ -364,18 +397,31 @@ export class ChannelServer {
     // Clear the entry (and its deadline) before awaiting complete(), so the
     // reply-timeout can't fire mid-await and double-complete the invocation.
     this.clearInflight(invocationId)
+    // Reuse a prior attempt's uploads (cached on a complete() failure) so a
+    // retry doesn't re-upload every THREA_ATTACH file and orphan the first copy.
+    let prepared = entry.prepared
     try {
+      if (!prepared) {
+        // Upload any THREA_ATTACH files first; the reply markdown carries
+        // attachment: links the backend associates with the posted message.
+        const { markdown, uploaded } = await uploadReplyAttachments(this.client, text, process.cwd())
+        prepared = { markdown, attachmentIds: uploaded.map((a) => a.id) }
+      }
       await this.client.complete(invocationId, {
         instanceId: this.config.instanceId,
         claimToken: entry.invocation.claimToken,
-        finalMessageMarkdown: text,
-        metadata: { "cc.channel.invocationId": invocationId, "cc.channel.instanceId": this.config.instanceId },
+        finalMessageMarkdown: prepared.markdown,
+        metadata: {
+          "cc.channel.invocationId": invocationId,
+          "cc.channel.instanceId": this.config.instanceId,
+          ...(prepared.attachmentIds.length > 0 && { "cc.channel.attachmentIds": prepared.attachmentIds.join(",") }),
+        },
       })
     } catch (error) {
       // Re-arm (with a fresh deadline) so Claude can retry the reply. Safe from
       // double-complete because the original deadline was already cleared.
       const deadline = setTimeout(() => void this.onReplyTimeout(invocationId), this.config.replyTimeoutMs)
-      this.inflight.set(invocationId, { invocation: entry.invocation, deadline })
+      this.inflight.set(invocationId, { invocation: entry.invocation, deadline, prepared })
       await this.syncPresence()
       return {
         isError: true,

--- a/extensions/claude-code-remote/src/threa-client.ts
+++ b/extensions/claude-code-remote/src/threa-client.ts
@@ -24,6 +24,19 @@ export interface ExternalHistoryMessage {
   createdAt: string
 }
 
+export interface AttachmentSummary {
+  id: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+}
+
+/** The slice of `GET /streams/:id/messages` we consume — id plus any attachments. */
+export interface StreamMessageSummary {
+  id: string
+  attachments?: AttachmentSummary[]
+}
+
 export interface ClaimedInvocation {
   id: string
   workspaceId: string
@@ -94,6 +107,9 @@ export class ThreaClient {
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    // A FormData body must keep its multipart boundary header, which fetch sets
+    // only when Content-Type is left unset — so never force JSON on uploads.
+    const isFormData = typeof FormData !== "undefined" && init?.body instanceof FormData
     let response: Response
     try {
       response = await fetch(`${this.base}${path}`, {
@@ -101,7 +117,7 @@ export class ThreaClient {
         signal: controller.signal,
         headers: {
           Authorization: `Bearer ${this.opts.apiKey}`,
-          "Content-Type": "application/json",
+          ...(isFormData ? {} : { "Content-Type": "application/json" }),
           ...init?.headers,
         },
       })
@@ -188,5 +204,29 @@ export class ThreaClient {
       method: "POST",
       body: JSON.stringify(body),
     })
+  }
+
+  /** Recent messages for a stream, newest-window first. Used to discover inbound attachments (the claim context omits them). Requires `messages:read` + `streams:read`. */
+  async listStreamMessages(streamId: string, query: { limit?: number } = {}): Promise<StreamMessageSummary[]> {
+    const suffix = query.limit ? `?limit=${query.limit}` : ""
+    const body = await this.request<{ data: StreamMessageSummary[] }>(
+      this.workspacePath(`/streams/${streamId}/messages${suffix}`)
+    )
+    return body.data
+  }
+
+  /** Short-lived signed download URL for an attachment. Requires `attachments:read`. */
+  async getAttachmentDownloadUrl(attachmentId: string): Promise<string> {
+    const body = await this.request<{ data: { url: string } }>(this.workspacePath(`/attachments/${attachmentId}/url`))
+    return body.data.url
+  }
+
+  /** Upload a file (multipart `file` field) and return its summary. Requires `attachments:write`. */
+  async uploadAttachment(form: FormData): Promise<AttachmentSummary> {
+    const body = await this.request<{ data: AttachmentSummary }>(this.workspacePath("/attachments"), {
+      method: "POST",
+      body: form,
+    })
+    return body.data
   }
 }


### PR DESCRIPTION
## Problem

The Claude Code channel (`extensions/claude-code-remote/`) reached feature parity with `pi-remote` in PR #978 except for one thing its README listed as "the main remaining gap": **attachments**. A file you attached to a scratchpad message never reached Claude, and Claude had no way to send a file back. Pi has had both directions for a while (`THREA_ATTACH:` directive + `downloadContextAttachments`); the channel did not.

The non-trivial part is inbound: the channel deliberately avoids extra fetches by reading the hydrated history that rides along in the claim response. But that hydrated history (`context.messages`, built by `buildClaimContext` in `apps/backend/src/features/public-api/handlers.ts`) is **text only** — it carries no attachment metadata, and the trigger message itself isn't even in it (the window is the 30 messages *before* the trigger). So there is no way to discover a message's attachments from the claim alone.

## Solution

Mirror Pi, adapting the inbound half to the channel's claim-driven shape: discover attachments with one extra stream-messages read per turn, download them into the working directory, and tell Claude where they landed. Outbound is the same `THREA_ATTACH:` mechanism Pi uses. **No backend change** — the public bot-runtime endpoints already serve Pi.

### How it works

**Inbound (scratchpad → working directory).** In `ChannelServer.buildChannelContent` (`channel-server.ts`), before pushing the `notifications/claude/channel` event, the channel calls `downloadInboundAttachments`:
1. Lists the invocation's stream (`GET /streams/:id/messages?limit=30` via `ThreaClient.listStreamMessages`). `ATTACHMENT_SCAN_LIMIT = 30` comfortably covers the always-newest trigger message plus the 12-message history Claude is shown.
2. `selectInboundAttachments` keeps the attachments on the source message plus any on the shown history (`invocation.context.messages` ids), de-duplicated by id, source processed first.
3. Each is downloaded — `GET /attachments/:id/url` → plain `fetch` of the short-lived signed URL → written to `<cwd>/.threa-attachments/<invocation_id>/<safeFilename>`.
4. `formatInboundAttachmentManifest` appends a list of local paths (the source attachment marked) to the channel content, so Claude reads the files straight from disk.

The whole step is best-effort: it's wrapped in try/catch and each download failure is caught and logged, so a missing `attachments:read` scope or a transient failure never blocks the prompt from reaching Claude.

**Outbound (working directory → scratchpad).** `handleReply` routes the reply through `uploadReplyAttachments`: it strips `THREA_ATTACH: <path>` lines, uploads each file (`POST /attachments`, multipart `file`), and appends `[name](attachment:<id>)` links. The backend associates the uploads with the posted message **purely from those markdown links** (`collectAttachmentReferenceIds` in `handlers.ts`) — there is no attachment-ids field on `complete`. A failed upload is reported inline rather than dropping the reply.

### Key design decisions

**1. One stream-messages fetch per inbound turn, not a backend change.** The claim could be extended to hydrate attachment metadata, but that's an invasive change to a shared, very active endpoint. Listing the stream is the same read Pi already does (`fetchInvocationContext` uses `activeStreamId`), it's bounded, and it only downloads when attachments actually exist — the no-attachment common case is a single GET. Inbound uses `invocation.activeStreamId` (the stream the source message lives in; equal to `responseStreamId` for the channel's active-scratchpad and mention paths, confirmed in `invocation-outbox-handler.ts`).

**2. Best-effort inbound, fail-loud nowhere it matters.** Attachment enrichment is auxiliary, not the core invocation write, so swallowing-and-logging a discovery failure is correct (and consistent with the channel's existing best-effort presence/step/ws-hint idiom) rather than an INV-11 violation. The prompt always reaches Claude.

**3. Reuse uploads across a reply retry (caught in self-review).** The first cut ran the upload inside the same try as `complete()`; a `complete()` failure re-arms the inflight for retry, and the retry would re-run the upload and orphan the first copy. Fixed by caching the prepared reply (markdown + uploaded ids) on the `Inflight` entry and reusing it on retry, so a transient `complete()` failure can't leak a storage object per attempt.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/attachments.ts` | Pure helpers (`extractAttachmentDirectives`, `guessMimeType`, `safeFilename`, `selectInboundAttachments`, manifest/section formatters) plus the IO orchestration (`downloadInboundAttachments`, `uploadReplyAttachments`) |
| `extensions/claude-code-remote/src/attachments.test.ts` | Unit coverage for the helpers and orchestration (fake client + scoped `spyOn(globalThis, "fetch")`) |

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/channel-server.ts` | `buildChannelContent` downloads inbound attachments + appends the manifest; `handleReply` uploads `THREA_ATTACH:` files and caches the prepared reply across retries; `buildInstructions` documents both directions; `ATTACHMENT_SCAN_LIMIT` |
| `extensions/claude-code-remote/src/threa-client.ts` | `AttachmentSummary`/`StreamMessageSummary` types; `listStreamMessages`, `getAttachmentDownloadUrl`, `uploadAttachment`; skip the JSON `Content-Type` for FormData bodies so fetch sets the multipart boundary |
| `apps/backend/tests/client.ts` | `botApiGet` + `botUploadFile` bot-key helpers; `uploadFile` accepts extra headers (for bearer auth) |
| `apps/backend/tests/e2e/claude-code-channel-session.test.ts` | Two contract tests (inbound discovery + download, outbound upload + attachment-link association) and a `claimInvocation` helper |
| `extensions/claude-code-remote/README.md` | `attachments:write` scope; an Attachments section; removed the attachments roadmap item |
| `docs/claude-code-channel.md` | Attachments mechanism section; comparison-table row; removed the "attachments aren't downloaded" limit |

## Out of scope (deliberate)

- **Per-tool trace steps** — still the one remaining `pi-remote` parity gap; a channel can't observe Claude's tool calls. Left as the sole roadmap item.
- **Inbound attachment cursor / cross-turn dedup** — each turn writes to a fresh `.threa-attachments/<invocation_id>/`, so an attachment that recurs in the shown history across turns is re-downloaded. Bounded by the 30-message scan; not worth per-turn cursor state. Matches Pi's per-invocation directory.
- **At-least-once upload across distinct turns** — the retry-reuse cache (decision 3) is per-inflight; it does not dedupe across separate invocations, which is correct (different turns, different messages).

## Test plan

- [x] `extensions/claude-code-remote` `bun test` — 49 pass (20 new attachment cases)
- [x] `extensions/claude-code-remote` `bun run typecheck` (`tsc --noEmit`) clean
- [x] Backend e2e `tests/e2e/claude-code-channel-session.test.ts` — 5 pass (3 existing + 2 new; the inbound test's uploaded file processed end-to-end against the in-process server)
- [x] `apps/backend` `bun run typecheck` (`tsc --noEmit` + `tsconfig.tests.json`) clean
- [x] `apps/backend` `bun run lint` (`eslint src/`) clean
- [x] Pre-commit hook (full monorepo `tsc`, astro check, `generate:api-docs:check`) passed — no public-schema change, OpenAPI unchanged
- [x] Pre-PR review (1 reviewer agent over the diff): 1 should-fix (retry re-upload) + 1 nit (source-marker ordering) — both fixed; traversal/stream-selection/multipart/invariants checked clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784289814&installation_id=129946197&pr_number=990&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F990&signature=b635f8398af9ba945e0dfc50c43bed52047b858b5cde83027fedbc2ef3041fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->