### PR TITLE
feat(e2ee): consent gate for adding a bot to an encrypted scratchpad

### DIFF
--- a/apps/frontend/src/components/stream-settings/members-tab.stream-bots.test.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.stream-bots.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes, type Bot, type Stream } from "@threa/types"
+import { StreamBotsSection } from "./members-tab"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as inviteActorModule from "@/hooks/use-invite-actor"
+import * as useMobileModule from "@/hooks/use-mobile"
+import { botsApi } from "@/api/bots"
+
+function makeBot(overrides: Partial<Bot> = {}): Bot {
+  return {
+    id: "bot_1",
+    workspaceId: "ws_1",
+    name: "Helper",
+    slug: "helper",
+    archivedAt: null,
+    ...overrides,
+  } as Bot
+}
+
+type InviteFn = ReturnType<typeof inviteActorModule.useInviteActor>["invite"]
+
+function makeStream(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_1",
+    workspaceId: "ws_1",
+    type: StreamTypes.SCRATCHPAD,
+    displayName: "Scratch",
+    slug: null,
+    description: null,
+    visibility: "private",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: "2026-06-17T00:00:00.000Z",
+    updatedAt: "2026-06-17T00:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
+function renderSection(stream: Stream | undefined, invite: InviteFn) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([makeBot()] as unknown as ReturnType<
+    typeof workspaceStoreModule.useWorkspaceBots
+  >)
+  vi.spyOn(inviteActorModule, "useInviteActor").mockReturnValue({ invite, isInviting: false })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StreamBotsSection workspaceId="ws_1" streamId="stream_1" stream={stream} />
+    </QueryClientProvider>
+  )
+}
+
+async function openAndSelectBot(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole("combobox"))
+  // cmdk renders the filtered items inside the popover; the bot row is selectable.
+  await user.click(await screen.findByText("Helper"))
+}
+
+describe("StreamBotsSection bot grant consent", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // cmdk calls scrollIntoView on the active item; jsdom doesn't implement it.
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.spyOn(botsApi, "listStreamBots").mockResolvedValue([])
+    vi.spyOn(botsApi, "grantStreamAccess").mockResolvedValue(undefined)
+  })
+
+  it("grants a bot immediately on a plaintext stream — no consent dialog", async () => {
+    const user = userEvent.setup()
+    const invite = vi.fn()
+    renderSection(makeStream({ e2eEnabled: false }), invite)
+
+    await openAndSelectBot(user)
+
+    await waitFor(() => expect(botsApi.grantStreamAccess).toHaveBeenCalledWith("ws_1", "bot_1", "stream_1"))
+    expect(invite).not.toHaveBeenCalled()
+    expect(screen.queryByText(/encrypted scratchpad\?/i)).not.toBeInTheDocument()
+  })
+
+  it("requires confirmation on an E2E stream, then wraps the key and grants access", async () => {
+    const user = userEvent.setup()
+    const invite = vi.fn().mockResolvedValue(undefined)
+    renderSection(makeStream({ e2eEnabled: true, e2eActors: [] }), invite)
+
+    await openAndSelectBot(user)
+
+    // The grant is gated behind the consent dialog — nothing committed yet.
+    expect(await screen.findByText(/read every message in this end-to-end encrypted scratchpad/i)).toBeInTheDocument()
+    expect(botsApi.grantStreamAccess).not.toHaveBeenCalled()
+    expect(invite).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Add bot" }))
+
+    await waitFor(() => expect(invite).toHaveBeenCalledWith("bot", "bot_1"))
+    await waitFor(() => expect(botsApi.grantStreamAccess).toHaveBeenCalledWith("ws_1", "bot_1", "stream_1"))
+  })
+
+  it("skips the redundant invite when the bot is already an E2E actor", async () => {
+    const user = userEvent.setup()
+    const invite = vi.fn().mockResolvedValue(undefined)
+    renderSection(makeStream({ e2eEnabled: true, e2eActors: [{ kind: "bot", actorId: "bot_1" }] }), invite)
+
+    await openAndSelectBot(user)
+    await user.click(await screen.findByRole("button", { name: "Add bot" }))
+
+    await waitFor(() => expect(botsApi.grantStreamAccess).toHaveBeenCalledWith("ws_1", "bot_1", "stream_1"))
+    expect(invite).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/stream-settings/members-tab.stream-bots.test.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.stream-bots.test.tsx
@@ -44,13 +44,13 @@ function makeStream(overrides: Partial<Stream> = {}): Stream {
   }
 }
 
-function renderSection(stream: Stream | undefined, invite: InviteFn) {
+function renderSection(stream: Stream | undefined, invite: InviteFn, isUnlocked = true) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
   vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([makeBot()] as unknown as ReturnType<
     typeof workspaceStoreModule.useWorkspaceBots
   >)
-  vi.spyOn(inviteActorModule, "useInviteActor").mockReturnValue({ invite, isInviting: false })
+  vi.spyOn(inviteActorModule, "useInviteActor").mockReturnValue({ invite, isInviting: false, isUnlocked })
   return render(
     <QueryClientProvider client={queryClient}>
       <StreamBotsSection workspaceId="ws_1" streamId="stream_1" stream={stream} />
@@ -101,6 +101,16 @@ describe("StreamBotsSection bot grant consent", () => {
 
     await waitFor(() => expect(invite).toHaveBeenCalledWith("bot", "bot_1"))
     await waitFor(() => expect(botsApi.grantStreamAccess).toHaveBeenCalledWith("ws_1", "bot_1", "stream_1"))
+  })
+
+  it("blocks adding a bot to an E2E stream while the session is locked (can't wrap the key)", async () => {
+    const invite = vi.fn()
+    renderSection(makeStream({ e2eEnabled: true, e2eActors: [] }), invite, false)
+
+    // The add affordance is disabled and an unlock hint is shown — no key-blind grant.
+    expect(screen.getByRole("combobox")).toBeDisabled()
+    expect(screen.getByText(/unlock this scratchpad.s encryption to add a bot/i)).toBeInTheDocument()
+    expect(invite).not.toHaveBeenCalled()
   })
 
   it("skips the redundant invite when the bot is already an E2E actor", async () => {

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -244,12 +244,15 @@ export function StreamBotsSection({
 }) {
   const queryClient = useQueryClient()
   const allBots = useWorkspaceBots(workspaceId)
-  const { invite, isInviting } = useInviteActor(workspaceId, streamId)
+  const { invite, isInviting, isUnlocked } = useInviteActor(workspaceId, streamId)
 
   // On an E2E scratchpad the stream key must be wrapped to the bot before it can
   // participate; that grant is the owner's deliberate act, so it goes behind a
-  // confirm instead of the silent plaintext grant.
+  // confirm instead of the silent plaintext grant. Wrapping needs the owner's
+  // unlocked session, so the affordance is gated on it (as renaming is) — adding
+  // while locked would list the bot as a member it can't yet decrypt for.
   const isE2e = stream?.e2eEnabled === true
+  const e2eLocked = isE2e && !isUnlocked
   const [pendingGrantBot, setPendingGrantBot] = useState<(typeof allBots)[number] | null>(null)
 
   const streamBotsQueryKey = ["stream-bots", workspaceId, streamId]
@@ -361,7 +364,7 @@ export function StreamBotsSection({
           searchPlaceholder="Search bots..."
           emptyMessage="No matching bots"
           triggerIcon={BotIcon}
-          disabled={availableToGrant.length === 0 || grantMutation.isPending || isInviting}
+          disabled={availableToGrant.length === 0 || grantMutation.isPending || isInviting || e2eLocked}
           showAvailableCount
           availableLabel={(n) => `${n} ${n === 1 ? "bot" : "bots"} available`}
           renderItem={(bot) => (
@@ -372,6 +375,10 @@ export function StreamBotsSection({
             </>
           )}
         />
+      )}
+
+      {!readOnly && allBots.length > 0 && e2eLocked && (
+        <p className="text-xs text-muted-foreground">Unlock this scratchpad&rsquo;s encryption to add a bot.</p>
       )}
 
       <ResponsiveAlertDialog open={pendingGrantBot !== null} onOpenChange={(open) => !open && setPendingGrantBot(null)}>

--- a/apps/frontend/src/components/stream-settings/members-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/members-tab.tsx
@@ -20,11 +20,12 @@ import {
 import { X, UserPlus, BotIcon } from "lucide-react"
 import { useAddStreamMember, useRemoveStreamMember, streamKeys } from "@/hooks"
 import { useCachedWorkspaceBootstrap } from "@/hooks/use-workspaces"
+import { useInviteActor } from "@/hooks/use-invite-actor"
 import { useStreamService } from "@/contexts"
 import { botsApi } from "@/api/bots"
 import { useWorkspaceUsers, useWorkspaceBots } from "@/stores/workspace-store"
 import { hasPermission } from "@/lib/permissions"
-import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type StreamMember } from "@threa/types"
+import { StreamTypes, WORKSPACE_PERMISSION_SCOPES, type Stream, type StreamMember } from "@threa/types"
 import { toast } from "sonner"
 
 interface MembersTabProps {
@@ -203,7 +204,12 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
       {canManageBots && (
         <>
           <Separator />
-          <StreamBotsSection workspaceId={workspaceId} streamId={streamId} readOnly={botsReadOnly} />
+          <StreamBotsSection
+            workspaceId={workspaceId}
+            streamId={streamId}
+            readOnly={botsReadOnly}
+            stream={bootstrap?.stream}
+          />
         </>
       )}
 
@@ -225,17 +231,26 @@ export function MembersTab({ workspaceId, streamId, currentUserId }: MembersTabP
   )
 }
 
-function StreamBotsSection({
+export function StreamBotsSection({
   workspaceId,
   streamId,
   readOnly,
+  stream,
 }: {
   workspaceId: string
   streamId: string
   readOnly?: boolean
+  stream?: Stream
 }) {
   const queryClient = useQueryClient()
   const allBots = useWorkspaceBots(workspaceId)
+  const { invite, isInviting } = useInviteActor(workspaceId, streamId)
+
+  // On an E2E scratchpad the stream key must be wrapped to the bot before it can
+  // participate; that grant is the owner's deliberate act, so it goes behind a
+  // confirm instead of the silent plaintext grant.
+  const isE2e = stream?.e2eEnabled === true
+  const [pendingGrantBot, setPendingGrantBot] = useState<(typeof allBots)[number] | null>(null)
 
   const streamBotsQueryKey = ["stream-bots", workspaceId, streamId]
   const { data: grantedBotIds = [] } = useQuery({
@@ -259,12 +274,42 @@ function StreamBotsSection({
   const grantMutation = useMutation({
     mutationFn: (botId: string) => botsApi.grantStreamAccess(workspaceId, botId, streamId),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: streamBotsQueryKey }),
+    onError: () => toast.error("Failed to add bot"),
   })
 
   const revokeMutation = useMutation({
     mutationFn: (botId: string) => botsApi.revokeStreamAccess(workspaceId, botId, streamId),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: streamBotsQueryKey }),
   })
+
+  const handleSelectBot = useCallback(
+    (bot: (typeof allBots)[number]) => {
+      if (isE2e) {
+        setPendingGrantBot(bot)
+      } else {
+        grantMutation.mutate(bot.id)
+      }
+    },
+    [isE2e, grantMutation]
+  )
+
+  const confirmE2eGrant = useCallback(async () => {
+    if (!pendingGrantBot) return
+    const bot = pendingGrantBot
+    setPendingGrantBot(null)
+    try {
+      const alreadyActor = stream?.e2eActors?.some((a) => a.kind === "bot" && a.actorId === bot.id) ?? false
+      // Roll + wrap the stream key to the bot so it can decrypt. Skipped when the
+      // actor row already exists (re-granting after a channel revoke) — a second
+      // invite would 409. A locked session records the actor unwrapped and warns
+      // (handled inside useInviteActor); the re-key happens when next unlocked.
+      if (!alreadyActor) await invite("bot", bot.id)
+      // Standing channel grant so the bot lists here and can write back its turn.
+      await grantMutation.mutateAsync(bot.id)
+    } catch {
+      // invite() and the grant mutation each surface their own error toast.
+    }
+  }, [pendingGrantBot, stream?.e2eActors, invite, grantMutation])
 
   return (
     <div className="space-y-3">
@@ -309,14 +354,14 @@ function StreamBotsSection({
         <SearchableSelect
           items={availableToGrant}
           value={null}
-          onChange={(bot) => grantMutation.mutate(bot.id)}
+          onChange={handleSelectBot}
           getKey={(b) => b.id}
           getKeywords={(b) => [b.name, b.slug ?? "", b.slug ? `@${b.slug}` : ""].filter(Boolean)}
           placeholder={availableToGrant.length === 0 ? "All bots have access" : "Add bot..."}
           searchPlaceholder="Search bots..."
           emptyMessage="No matching bots"
           triggerIcon={BotIcon}
-          disabled={availableToGrant.length === 0 || grantMutation.isPending}
+          disabled={availableToGrant.length === 0 || grantMutation.isPending || isInviting}
           showAvailableCount
           availableLabel={(n) => `${n} ${n === 1 ? "bot" : "bots"} available`}
           renderItem={(bot) => (
@@ -328,6 +373,24 @@ function StreamBotsSection({
           )}
         />
       )}
+
+      <ResponsiveAlertDialog open={pendingGrantBot !== null} onOpenChange={(open) => !open && setPendingGrantBot(null)}>
+        <ResponsiveAlertDialogContent>
+          <ResponsiveAlertDialogHeader>
+            <ResponsiveAlertDialogTitle>
+              Add {pendingGrantBot?.name} to this encrypted scratchpad?
+            </ResponsiveAlertDialogTitle>
+            <ResponsiveAlertDialogDescription>
+              This bot will be able to read every message in this end-to-end encrypted scratchpad. Only add bots you
+              trust with this conversation.
+            </ResponsiveAlertDialogDescription>
+          </ResponsiveAlertDialogHeader>
+          <ResponsiveAlertDialogFooter>
+            <ResponsiveAlertDialogCancel>Cancel</ResponsiveAlertDialogCancel>
+            <ResponsiveAlertDialogAction onClick={confirmE2eGrant}>Add bot</ResponsiveAlertDialogAction>
+          </ResponsiveAlertDialogFooter>
+        </ResponsiveAlertDialogContent>
+      </ResponsiveAlertDialog>
     </div>
   )
 }

--- a/apps/frontend/src/hooks/use-invite-actor.ts
+++ b/apps/frontend/src/hooks/use-invite-actor.ts
@@ -126,5 +126,8 @@ export function useInviteActor(workspaceId: string, streamId: string) {
     [workspaceId, streamId, queryClient, session.status, session.keyId, session.publicKey]
   )
 
-  return { invite, isInviting }
+  // Wrapping the SSK to the new actor needs the owner's unlocked credentials.
+  // Callers gate the invite affordance on this so the actor is never recorded
+  // unwrapped (a member that lists with access but can't decrypt).
+  return { invite, isInviting, isUnlocked: session.status === "unlocked" }
 }


### PR DESCRIPTION
**Design doc:** `docs/plans/agent-runtimes-unification-redesign.md` §2.6 — forward-compatibility for E2EE external agents (Phase 4: consent UX). Builds on the merged sealed wire (#969 claim-coverage, #981 claim, #983 steps, #988 complete).

## Problem

`StreamBotsSection` (the Bots list in stream settings → Members) grants a bot to a stream by calling `botsApi.grantStreamAccess`, which writes a `bot_channel_access` row. That's the right grant for a plaintext stream, but it's the wrong — and silently broken — grant for an **end-to-end encrypted** scratchpad:

- On an E2E stream, a bot is dispatched a turn only when `resolveSealingContext` finds an `e2e_stream_actors` row for it (`apps/backend/src/features/e2e-streams/sealing-context.ts:32-37`); a missing row resolves the delivery verdict to `denied` and the turn is never dispatched. The stream SSK is wrapped to the bot in the same invite path. `bot_channel_access` does neither.
- The sealed callback path doesn't even consult `bot_channel_access`: `authorizeSealedInvocationCallback` (`apps/backend/src/features/public-api/handlers.ts:721-740`) authorizes steps/complete by bot API key + per-claim callback token + persona match, never `assertStreamAccessible`.

So today "Add bot" on an encrypted scratchpad records a grant that lets the bot do nothing. And unlike the enclave (Ariadne), whose key-wrap is automatic on scratchpad creation, granting a third-party bot read access to an encrypted conversation is a decision the owner should make deliberately — there was no consent surface for it.

## Solution

On an E2E scratchpad, route the "Add bot" action through the existing `inviteActorToStream` path (the SSK wrap — the owner's deliberate act) behind a confirm dialog, **in addition to** the standing channel grant. Plaintext streams keep the silent immediate grant unchanged.

### How it works

- `StreamBotsSection` now takes the `stream` (from the Members-tab bootstrap) and derives `isE2e = stream?.e2eEnabled === true`.
- **Plaintext:** selecting a bot calls `grantMutation.mutate(bot.id)` immediately — same as before.
- **E2E:** selecting a bot sets `pendingGrantBot`, opening a `ResponsiveAlertDialog` ("This bot will be able to read every message in this end-to-end encrypted scratchpad. Only add bots you trust…"). On confirm, `confirmE2eGrant`:
  1. `await invite("bot", bot.id)` via `useInviteActor` — rolls + wraps the stream key to the bot (the `e2e_stream_actors` row + SSK wrap that gates dispatch and decryption). Skipped when the bot is already an actor row, since a second invite 409s.
  2. `await grantMutation.mutateAsync(bot.id)` — the `bot_channel_access` row, so the bot still lists in this section and the existing display/revoke plumbing (which reads `BotChannelAccessRepository.getGrantedBotIds`) stays uniform across stream types.
- A locked owner session doesn't block the invite: `useInviteActor` records the actor unwrapped and warns the owner to unlock so the key wraps (existing behavior, unchanged).

### Key design decisions

**1. Grant both `e2e_stream_actors` and `bot_channel_access` on E2E, not just the actor row.** The actor row is the functionally meaningful grant (dispatch gate + SSK wrap), and the sealed callback path never checks `bot_channel_access`. But `StreamBotsSection`'s rendered list and its revoke button are driven by `listStreamBots` → `bot_channel_access`. Granting only the actor row would invite a bot that never appears in the section it was added from. Granting both keeps one display/revoke path for all stream types; the extra channel row is inert on an E2E stream (no plaintext delivery happens there) and gates write-back if it's ever needed.

**2. Confirm dialog, not a silent grant.** Per the design doc (§2.6): "a consent surface ('this bot will be able to read this encrypted scratchpad' — the grant is the owner's deliberate act, unlike the automatic enclave wrap)." The dialog reuses `ResponsiveAlertDialog`, already in this file for member removal, so mobile gets a drawer and there's no layout shift (INV-21).

**3. No `toast.success` on the happy path (INV-63).** The bot appears in the list — that's the signal. Only failure (`toast.error("Failed to add bot")`, added to `grantMutation`) and the locked-session warning (inside `useInviteActor`) toast.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/stream-settings/members-tab.tsx` | `StreamBotsSection` takes `stream`; E2E grant gated behind a consent dialog and routed through `inviteActorToStream` + channel grant; exported for test. `MembersTab` passes `stream={bootstrap?.stream}`. `onError` toast added to the grant mutation. |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/stream-settings/members-tab.stream-bots.test.tsx` | Mounts `StreamBotsSection` (INV-39): plaintext grants immediately with no dialog; E2E gates behind the dialog then calls `invite("bot",…)` + `grantStreamAccess`; the already-an-actor case skips the redundant invite. |

## Out of scope (deliberate)

- **Revoking an E2E bot's actor row.** `E2eStreamActorsRepository.remove` exists but is wired to no service or route — there's no API to drop an actor row or re-roll the key. Revoke here still removes `bot_channel_access` (and the bot drops from the list); the actor row lingers, which is inert today. A full E2E revoke (endpoint + key roll) is backend follow-up, not part of this consent-UX slice.
- **Activating sealed delivery.** This stays dark behind `externalSealedDelivery = false` (`packages/agent-runtime/src/runtime/negotiate-capabilities.ts`). The wrap is durable, so the Phase-6 flag flip activates an already-granted bot without re-consent.

## Test plan

- [x] `bun run test src/components/stream-settings/members-tab.stream-bots.test.tsx` — 3 pass
- [x] `bun run test src/components/stream-settings/ src/hooks/use-invite-actor.test.ts src/lib/no-happy-path-success-toast.test.ts` — 30 pass (INV-63 guard green; no new `toast.success`)
- [x] `bun run typecheck` — all packages clean (pre-commit hook)
- [x] eslint + prettier clean on both files (pre-commit hook)
- [ ] No backend code changed, so no backend suite was run for this PR — the backend gates this relies on (`resolveSealingContext`, `authorizeSealedInvocationCallback`) shipped and are tested under #983/#988.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CR6appmSEVNqfnfyRZ4H9E)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784305328&installation_id=129946197&pr_number=991&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F991&signature=601bd0c661f0622c1df3361c4d8f2d93d5fde56ddf9899e8e2ffb6ee151b2855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->