### PR TITLE
refac​tor(frontend): attachments onto the decrypt layer + uniform { status, value } cache shape (decrypt-layer slice 3)

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -107,3 +107,48 @@ always written the sealed columns only.
   searchable only client-side over the decrypted copy. Streams renamed _before_
   this shipped still hold plaintext in `display_name`; the server can't re-seal
   them, so they stay until the owner renames again while unlocked.
+
+## How to add an encrypted field (the decrypt layer)
+
+Every client-side encrypted field (message bodies, trace steps, stream names,
+drafts, attachment bytes) decrypts through one shared layer under
+`lib/crypto/`. Ciphertext stays at rest in IDB; plaintext is memory-only and
+cleared on lock (E2EE-4). Don't hand-roll a new cache, session gate, or
+hydration guard — reuse the three pieces below, and a new field needs no new
+session wiring and no copied footgun.
+
+1. **A cache instance, not a new cache.** Call
+   `createDecryptedCache<{ status, value }>(...)` from `lib/crypto/decrypted-cache.ts`.
+   Every entry is `{ status: "pending" | "decrypted" | "failed"; value: V | null }` —
+   keep that uniform shape (`value`, not a field named after the domain). Pick:
+   - `subscription`: `"per-key"` for many keys where one resolve must not re-render
+     the rest (messages, attachments); `"global"` for few keys read as a list (names).
+   - `retryFailed`: `false` when a miss is terminal (a message id's decrypt can't
+     start succeeding); `true` when a null open is transient (locked / not-yet-a-
+     recipient / a network blip — names, attachment bytes).
+   - `lru`: cap when entries are unbounded in count or large in size (messages 500,
+     attachment blobs 64); omit for a small bounded set (names).
+
+   The instance auto-registers its `clear` in the lock-clear registry, so
+   `clearAllDecrypted()` (the single lock / account-switch site in
+   `e2e-session-store`) wipes it — you do **not** add a clear call. A cache can only
+   hold plaintext if its module is loaded, and loading registers it.
+
+2. **Gate the decrypt through `resolveDecryptContext`** (`lib/crypto/decrypt-context.ts`)
+   for any field keyed under a stream's SSK. It owns the unlocked check
+   (`isSessionUnlocked`), root-SSK resolution, and the hold-until-the-stream-row-
+   hydrates guard — decrypting a thread's content against its own id finds no wrap,
+   fails, and caches that failure **forever**, so never decrypt against a bare
+   `streamId` when the row is unhydrated. Read the row with `useStreamFromStore` and
+   pass it in; `{ ready: false }` means hold at `locked`/`pending`, never attempt.
+
+3. **A per-domain read hook returning a `{ status }` discriminated union**
+   (`plaintext | locked | pending | decrypted | failed`). Subscribe to the cache
+   with `useSyncExternalStore` (per-key) and fire `request(...)` from an effect
+   whose deps are the **primitive opts fields** (`opts?.privateKey`, …,
+   `opts?.rootStreamId`), not the per-render `opts` object — a fresh object every
+   render would re-fire settled decrypts on unrelated row updates. Keep hooks
+   per-domain (typed returns) rather than one generic hook; they share the helpers
+   above, not the hook. `useDecryptedMessageContent` is the reference shape;
+   `useDecryptedAttachment` mirrors it (and owns the object-URL lifecycle so the
+   blob in the cache never leaks past unmount/lock).

--- a/apps/frontend/src/components/timeline/e2e-attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/e2e-attachment-list.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import { Download, FileLock2, Loader2 } from "lucide-react"
-import { attachmentsApi } from "@/api"
-import { decryptAttachmentBytes, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { requestAttachmentBytes } from "@/lib/crypto/attachment-cache"
+import { fetchAndDecryptAttachment, useDecryptedAttachment } from "@/hooks/use-decrypted-attachment"
 import { triggerDownload } from "@/lib/image-utils"
 import { Button } from "@/components/ui/button"
 
@@ -12,20 +13,12 @@ import { Button } from "@/components/ui/button"
  * ciphertext with no thumbnails, variants, or real metadata, so we fetch the
  * raw ciphertext, decrypt it in-memory with the per-file key/iv from the ref,
  * and render from a blob URL. Images preview inline; everything else is a
- * decrypt-on-click download. Real filename/size come from the ref, never the
- * server's placeholder row.
+ * decrypt-on-click download. The fetched bytes live in the shared
+ * `attachment-cache`, so an image re-mounting on scroll doesn't re-fetch and
+ * re-decrypt. Real filename/size come from the ref, never the server's placeholder.
  */
 
 const PREFIX = "🔒 "
-
-async function fetchAndDecrypt(workspaceId: string, ref: AttachmentRef): Promise<Blob> {
-  const url = await attachmentsApi.getDownloadUrl(workspaceId, ref.attachmentId, { variant: "raw" })
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Attachment fetch failed (${res.status})`)
-  const ciphertext = new Uint8Array(await res.arrayBuffer())
-  const plaintext = await decryptAttachmentBytes({ ciphertext, key: ref.key, iv: ref.iv })
-  return new Blob([plaintext], { type: ref.mimeType })
-}
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -34,29 +27,11 @@ function formatSize(bytes: number): string {
 }
 
 function E2eImageAttachment({ workspaceId, attachmentRef }: { workspaceId: string; attachmentRef: AttachmentRef }) {
-  const [url, setUrl] = useState<string | null>(null)
-  const [failed, setFailed] = useState(false)
+  const decrypted = useDecryptedAttachment(workspaceId, attachmentRef)
 
-  useEffect(() => {
-    let cancelled = false
-    let objectUrl: string | null = null
-    fetchAndDecrypt(workspaceId, attachmentRef)
-      .then((blob) => {
-        if (cancelled) return
-        objectUrl = URL.createObjectURL(blob)
-        setUrl(objectUrl)
-      })
-      .catch(() => {
-        if (!cancelled) setFailed(true)
-      })
-    return () => {
-      cancelled = true
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-    }
-  }, [workspaceId, attachmentRef])
-
-  if (failed) return <E2eFileAttachment workspaceId={workspaceId} attachmentRef={attachmentRef} />
-  if (!url) {
+  if (decrypted.status === "failed")
+    return <E2eFileAttachment workspaceId={workspaceId} attachmentRef={attachmentRef} />
+  if (decrypted.status === "pending") {
     return (
       <div className="flex h-40 w-full max-w-sm items-center justify-center rounded-lg border bg-muted/40">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-label="Decrypting attachment" />
@@ -65,7 +40,7 @@ function E2eImageAttachment({ workspaceId, attachmentRef }: { workspaceId: strin
   }
   return (
     <img
-      src={url}
+      src={decrypted.url}
       alt={attachmentRef.filename}
       className="max-h-80 max-w-sm rounded-lg border object-contain"
       title={`${PREFIX}${attachmentRef.filename}`}
@@ -80,8 +55,11 @@ function E2eFileAttachment({ workspaceId, attachmentRef }: { workspaceId: string
     if (busy) return
     setBusy(true)
     try {
-      const blob = await fetchAndDecrypt(workspaceId, attachmentRef)
-      const objectUrl = URL.createObjectURL(blob)
+      const entry = await requestAttachmentBytes(attachmentRef.attachmentId, () =>
+        fetchAndDecryptAttachment(workspaceId, attachmentRef)
+      )
+      if (!entry.value) throw new Error("decrypt failed")
+      const objectUrl = URL.createObjectURL(entry.value)
       triggerDownload(objectUrl, attachmentRef.filename)
       // Give the browser a beat to start the download before reclaiming the URL.
       setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000)

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -520,7 +520,7 @@ describe("TraceStep", () => {
     } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
     vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({
       status: "decrypted",
-      content: {
+      value: {
         contentMarkdown: "tides",
         contentJson: { type: "doc" } as never,
         sources: [{ type: "web", title: "Tide Atlas", url: "https://tides.example/atlas" }],

--- a/apps/frontend/src/hooks/use-decrypted-attachment.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-attachment.test.ts
@@ -64,7 +64,9 @@ describe("useDecryptedAttachment", () => {
     const { result } = renderHook(() => useDecryptedAttachment(WORKSPACE_ID, ref()))
 
     expect(result.current).toEqual({ status: "failed" })
-    // A terminal failure isn't re-requested — the cache's retry is the file-download retry.
+    // The hook's request effect only fires on undefined/pending, so a cached failure
+    // isn't auto-re-requested here; the cache is `retryFailed`, so the retry is driven
+    // by the file-download button calling `requestAttachmentBytes` again.
     expect(request).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/hooks/use-decrypted-attachment.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-attachment.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import * as attachmentCache from "@/lib/crypto/attachment-cache"
+import { useDecryptedAttachment } from "./use-decrypted-attachment"
+
+const WORKSPACE_ID = "ws_1"
+
+function ref(): AttachmentRef {
+  return {
+    attachmentId: "att_1",
+    key: "k",
+    iv: "iv",
+    filename: "photo.png",
+    mimeType: "image/png",
+    sizeBytes: 10,
+  } as AttachmentRef
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement object URLs; stub them so the ready path can render.
+  vi.stubGlobal("URL", { ...URL, createObjectURL: () => "blob:stub", revokeObjectURL: () => {} })
+  vi.spyOn(attachmentCache, "subscribeToAttachmentBytes").mockReturnValue(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe("useDecryptedAttachment", () => {
+  it("reports pending and fires a fetch+decrypt request on a cache miss", () => {
+    vi.spyOn(attachmentCache, "getCachedAttachmentBytes").mockReturnValue(undefined)
+    const request = vi.spyOn(attachmentCache, "requestAttachmentBytes").mockResolvedValue({
+      status: "pending",
+      value: null,
+    })
+
+    const { result } = renderHook(() => useDecryptedAttachment(WORKSPACE_ID, ref()))
+
+    expect(result.current).toEqual({ status: "pending" })
+    expect(request).toHaveBeenCalledWith("att_1", expect.any(Function))
+  })
+
+  it("exposes a ready object URL once the bytes are cached", () => {
+    vi.spyOn(attachmentCache, "getCachedAttachmentBytes").mockReturnValue({
+      status: "decrypted",
+      value: new Blob(["bytes"], { type: "image/png" }),
+    })
+    vi.spyOn(attachmentCache, "requestAttachmentBytes").mockResolvedValue({ status: "pending", value: null })
+
+    const { result } = renderHook(() => useDecryptedAttachment(WORKSPACE_ID, ref()))
+
+    expect(result.current).toEqual({ status: "ready", url: "blob:stub" })
+  })
+
+  it("reports failed when the cached open failed", () => {
+    vi.spyOn(attachmentCache, "getCachedAttachmentBytes").mockReturnValue({ status: "failed", value: null })
+    const request = vi.spyOn(attachmentCache, "requestAttachmentBytes").mockResolvedValue({
+      status: "failed",
+      value: null,
+    })
+
+    const { result } = renderHook(() => useDecryptedAttachment(WORKSPACE_ID, ref()))
+
+    expect(result.current).toEqual({ status: "failed" })
+    // A terminal failure isn't re-requested — the cache's retry is the file-download retry.
+    expect(request).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-decrypted-attachment.ts
+++ b/apps/frontend/src/hooks/use-decrypted-attachment.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from "react"
+import { useEffect, useMemo, useSyncExternalStore } from "react"
 import { attachmentsApi } from "@/api"
 import { decryptAttachmentBytes, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import {
@@ -22,6 +22,13 @@ import {
  * The object URL is created here (not cached) and revoked on unmount or when the
  * underlying blob changes, so plaintext bytes can't outlive the component — the
  * cache itself drops the blob on lock via `clearAllDecrypted`.
+ *
+ * No session gate: an `AttachmentRef` only exists once the message it rode in has
+ * decrypted (its per-file key/iv are sealed in the SSK payload), so the caller —
+ * `E2eAttachmentList`, rendered only while `useDecryptedMessageContent` is
+ * `decrypted` — already holds an unlocked session, and a lock unmounts this hook
+ * (the parent stops passing `attachmentRefs`). The decrypt here uses the ref's own
+ * key, not the SSK, so it needs no `resolveDecryptContext` root/hydration gate.
  */
 export type DecryptedAttachment = { status: "pending" } | { status: "ready"; url: string } | { status: "failed" }
 
@@ -56,18 +63,20 @@ export function useDecryptedAttachment(workspaceId: string, ref: AttachmentRef):
   }, [attachmentId, workspaceId, status])
 
   const blob = cached?.status === "decrypted" ? cached.value : null
-  const [url, setUrl] = useState<string | null>(null)
+  // Derive the URL synchronously from the cached blob so a cache-hit re-mount
+  // (scroll away and back) paints the image on the first render, rather than
+  // flashing the pending spinner for the one commit a `useState` url would lag
+  // the blob that arrives synchronously from `useSyncExternalStore`. The effect
+  // owns revocation: its cleanup runs on unmount and whenever `url` changes (a new
+  // blob, or null when the cache clears on lock), so a blob never outlives the
+  // component or the lock.
+  const url = useMemo(() => (blob ? URL.createObjectURL(blob) : null), [blob])
   useEffect(() => {
-    if (!blob) {
-      setUrl(null)
-      return
-    }
-    const objectUrl = URL.createObjectURL(blob)
-    setUrl(objectUrl)
-    return () => URL.revokeObjectURL(objectUrl)
-  }, [blob])
+    if (!url) return
+    return () => URL.revokeObjectURL(url)
+  }, [url])
 
   if (cached?.status === "failed") return { status: "failed" }
-  if (blob && url) return { status: "ready", url }
+  if (url) return { status: "ready", url }
   return { status: "pending" }
 }

--- a/apps/frontend/src/hooks/use-decrypted-attachment.ts
+++ b/apps/frontend/src/hooks/use-decrypted-attachment.ts
@@ -49,9 +49,11 @@ export function useDecryptedAttachment(workspaceId: string, ref: AttachmentRef):
     if (status === undefined || status === "pending") {
       void requestAttachmentBytes(attachmentId, () => fetchAndDecryptAttachment(workspaceId, ref))
     }
-    // A given attachment id's ref content is immutable, so the ref object's identity
-    // is not a dep — `status` re-fires the request only when it could need one.
-  }, [attachmentId, workspaceId, status, ref])
+    // Deps are the primitives that key/gate the request, not the per-render `ref`
+    // object — a given attachment id's ref content (key/iv/mime) is immutable, so
+    // depending on the object would only add identity churn (mirrors the
+    // primitive-field deps in `useDecryptedMessageContent`).
+  }, [attachmentId, workspaceId, status])
 
   const blob = cached?.status === "decrypted" ? cached.value : null
   const [url, setUrl] = useState<string | null>(null)

--- a/apps/frontend/src/hooks/use-decrypted-attachment.ts
+++ b/apps/frontend/src/hooks/use-decrypted-attachment.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState, useSyncExternalStore } from "react"
+import { attachmentsApi } from "@/api"
+import { decryptAttachmentBytes, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import {
+  getCachedAttachmentBytes,
+  requestAttachmentBytes,
+  subscribeToAttachmentBytes,
+  type AttachmentBytesEntry,
+} from "@/lib/crypto/attachment-cache"
+
+/**
+ * Render-time read of an E2E attachment's decrypted bytes, mirroring
+ * `useDecryptedMessageContent`: the heavy fetch + decrypt runs once and the
+ * resulting `Blob` is held in the shared {@link requestAttachmentBytes} cache, so
+ * re-mounting a previously-decrypted attachment (scroll, tab switch) is free
+ * instead of refetching + redecrypting every time.
+ *
+ *  - `pending`  — bytes not yet decrypted (cache miss / decrypt in flight).
+ *  - `ready`    — decrypted; render from the `url` (a fresh object URL this hook owns).
+ *  - `failed`   — fetch or decrypt failed; the caller falls back to a download chip.
+ *
+ * The object URL is created here (not cached) and revoked on unmount or when the
+ * underlying blob changes, so plaintext bytes can't outlive the component — the
+ * cache itself drops the blob on lock via `clearAllDecrypted`.
+ */
+export type DecryptedAttachment = { status: "pending" } | { status: "ready"; url: string } | { status: "failed" }
+
+/** Fetch an E2E attachment's opaque ciphertext and decrypt it with the ref's key/iv. */
+export async function fetchAndDecryptAttachment(workspaceId: string, ref: AttachmentRef): Promise<Blob> {
+  const url = await attachmentsApi.getDownloadUrl(workspaceId, ref.attachmentId, { variant: "raw" })
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Attachment fetch failed (${res.status})`)
+  const ciphertext = new Uint8Array(await res.arrayBuffer())
+  const plaintext = await decryptAttachmentBytes({ ciphertext, key: ref.key, iv: ref.iv })
+  return new Blob([plaintext], { type: ref.mimeType })
+}
+
+export function useDecryptedAttachment(workspaceId: string, ref: AttachmentRef): DecryptedAttachment {
+  const attachmentId = ref.attachmentId
+
+  const cached = useSyncExternalStore<AttachmentBytesEntry | undefined>(
+    (listener) => subscribeToAttachmentBytes(attachmentId, listener),
+    () => getCachedAttachmentBytes(attachmentId),
+    () => undefined
+  )
+
+  const status = cached?.status
+  useEffect(() => {
+    if (status === undefined || status === "pending") {
+      void requestAttachmentBytes(attachmentId, () => fetchAndDecryptAttachment(workspaceId, ref))
+    }
+    // A given attachment id's ref content is immutable, so the ref object's identity
+    // is not a dep — `status` re-fires the request only when it could need one.
+  }, [attachmentId, workspaceId, status, ref])
+
+  const blob = cached?.status === "decrypted" ? cached.value : null
+  const [url, setUrl] = useState<string | null>(null)
+  useEffect(() => {
+    if (!blob) {
+      setUrl(null)
+      return
+    }
+    const objectUrl = URL.createObjectURL(blob)
+    setUrl(objectUrl)
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [blob])
+
+  if (cached?.status === "failed") return { status: "failed" }
+  if (blob && url) return { status: "ready", url }
+  return { status: "pending" }
+}

--- a/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.test.ts
@@ -98,7 +98,7 @@ describe("useDecryptedMessageContent", () => {
     mockStreamRow({ rootStreamId: "stream_root" })
     vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({
       status: "decrypted",
-      content: { contentMarkdown: "hello from Ariadne", contentJson: { type: "doc" } as never, attachmentRefs: [] },
+      value: { contentMarkdown: "hello from Ariadne", contentJson: { type: "doc" } as never, attachmentRefs: [] },
     })
 
     const { result } = renderHook(() => useDecryptedMessageContent(sealedEvent(), WORKSPACE_ID, USER_ID))

--- a/apps/frontend/src/hooks/use-decrypted-message-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-message-content.ts
@@ -127,13 +127,13 @@ export function useDecryptedMessageContent(
   // through to `pending` — the decrypt fires once the row lands and `rootStreamId`
   // is trustworthy, never against the bare thread id.
   if (!ctx.ready && ctx.reason === "locked") return { status: "locked" }
-  if (cached?.status === "decrypted" && cached.content) {
+  if (cached?.status === "decrypted" && cached.value) {
     return {
       status: "decrypted",
-      contentMarkdown: cached.content.contentMarkdown,
-      contentJson: cached.content.contentJson,
-      attachmentRefs: cached.content.attachmentRefs ?? [],
-      sources: cached.content.sources ?? [],
+      contentMarkdown: cached.value.contentMarkdown,
+      contentJson: cached.value.contentJson,
+      attachmentRefs: cached.value.attachmentRefs ?? [],
+      sources: cached.value.sources ?? [],
     }
   }
   if (cached?.status === "failed") return { status: "failed" }

--- a/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.test.ts
@@ -80,7 +80,7 @@ describe("useDecryptedStepContent", () => {
     } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
     vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({
       status: "decrypted",
-      content: { contentMarkdown: "decrypted reasoning", contentJson: { type: "doc" } as never },
+      value: { contentMarkdown: "decrypted reasoning", contentJson: { type: "doc" } as never },
     })
 
     const { result } = renderHook(() =>
@@ -99,7 +99,7 @@ describe("useDecryptedStepContent", () => {
     unlockedSession()
     vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({
       status: "decrypted",
-      content: {
+      value: {
         contentMarkdown: "tides",
         contentJson: { type: "doc" } as never,
         sources: [
@@ -141,7 +141,7 @@ describe("useDecryptedStepContent", () => {
       privateKey: {} as CryptoKey,
       keyId: "key_1",
     } as unknown as ReturnType<typeof e2eSessionModule.useE2eSession>)
-    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({ status: "failed", content: null })
+    vi.spyOn(decryptCacheModule, "getCachedDecryption").mockReturnValue({ status: "failed", value: null })
 
     const { result } = renderHook(() =>
       useDecryptedStepContent(

--- a/apps/frontend/src/hooks/use-decrypted-step-content.ts
+++ b/apps/frontend/src/hooks/use-decrypted-step-content.ts
@@ -98,11 +98,11 @@ export function useDecryptedStepContent(
   // falls through to `pending`: the decrypt fires once the row lands and the
   // root is known, never against the bare thread id.
   if (!ctx.ready && ctx.reason === "locked") return { status: "locked", content: undefined }
-  if (cached?.status === "decrypted" && cached.content) {
+  if (cached?.status === "decrypted" && cached.value) {
     return {
       status: "decrypted",
-      content: cached.content.contentMarkdown,
-      sources: toTraceSources(cached.content.sources ?? []),
+      content: cached.value.contentMarkdown,
+      sources: toTraceSources(cached.value.sources ?? []),
     }
   }
   if (cached?.status === "failed") return { status: "failed", content: undefined }

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -608,7 +608,7 @@ describe("useDraftMessage", () => {
         { senderId: "user_1", streamId: e2eStreamId }
       )
       const id = (await db.composerLoaded.get(draftKey))!.draftId!
-      expect(getCachedDecryption(id)?.content?.contentJson).toEqual(makeDoc("first edit"))
+      expect(getCachedDecryption(id)?.value?.contentJson).toEqual(makeDoc("first edit"))
 
       await upsertLoadedDraft(
         workspaceId,
@@ -616,7 +616,7 @@ describe("useDraftMessage", () => {
         { contentJson: makeDoc("second edit"), attachments: [] },
         { senderId: "user_1", streamId: e2eStreamId }
       )
-      expect(getCachedDecryption(id)?.content?.contentJson).toEqual(makeDoc("second edit"))
+      expect(getCachedDecryption(id)?.value?.contentJson).toEqual(makeDoc("second edit"))
     })
 
     it("keeps content in the composer (no plaintext written) when the session is locked", async () => {

--- a/apps/frontend/src/hooks/use-stream-search.test.ts
+++ b/apps/frontend/src/hooks/use-stream-search.test.ts
@@ -138,7 +138,7 @@ describe("useStreamSearch hook integration", () => {
     }
     vi.spyOn(decryptCache, "requestDecryption").mockImplementation(
       async (eventId: string) =>
-        ({ status: "decrypted", content: { contentMarkdown: decryptedById[eventId] ?? "" } }) as never
+        ({ status: "decrypted", value: { contentMarkdown: decryptedById[eventId] ?? "" } }) as never
     )
 
     const { result } = renderHook(() =>

--- a/apps/frontend/src/hooks/use-stream-search.ts
+++ b/apps/frontend/src/hooks/use-stream-search.ts
@@ -213,7 +213,7 @@ export function useStreamSearch({
         { contentMarkdown: sealed.contentMarkdown ?? "", envelope: sealed.envelope, ciphertext: sealed.ciphertext },
         ctx.opts
       )
-      return entry.status === "decrypted" && entry.content ? entry.content.contentMarkdown : null
+      return entry.status === "decrypted" && entry.value ? entry.value.contentMarkdown : null
     },
     [workspaceId]
   )

--- a/apps/frontend/src/lib/crypto/__tests__/attachment-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/attachment-cache.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  clearAttachmentBytesCache,
+  getCachedAttachmentBytes,
+  requestAttachmentBytes,
+  subscribeToAttachmentBytes,
+} from "../attachment-cache"
+
+function blob(text: string): Blob {
+  return new Blob([text], { type: "text/plain" })
+}
+
+beforeEach(() => {
+  clearAttachmentBytesCache()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("attachment-cache", () => {
+  it("caches decrypted bytes after the first request", async () => {
+    const fetchDecrypt = vi.fn().mockResolvedValue(blob("file-bytes"))
+    const entry = await requestAttachmentBytes("att_1", fetchDecrypt)
+    expect(entry.status).toBe("decrypted")
+    expect(getCachedAttachmentBytes("att_1")?.value).toBe(entry.value)
+    expect(fetchDecrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent requests for the same id into a single fetch", async () => {
+    const fetchDecrypt = vi.fn().mockResolvedValue(blob("x"))
+    await Promise.all([
+      requestAttachmentBytes("att_dup", fetchDecrypt),
+      requestAttachmentBytes("att_dup", fetchDecrypt),
+      requestAttachmentBytes("att_dup", fetchDecrypt),
+    ])
+    expect(fetchDecrypt).toHaveBeenCalledTimes(1)
+  })
+
+  it("records a failed entry on a throw and retries on a later request (transient)", async () => {
+    const fetchDecrypt = vi.fn().mockRejectedValueOnce(new Error("network")).mockResolvedValueOnce(blob("recovered"))
+    const failed = await requestAttachmentBytes("att_retry", fetchDecrypt)
+    expect(failed.status).toBe("failed")
+    expect(failed.value).toBeNull()
+
+    const recovered = await requestAttachmentBytes("att_retry", fetchDecrypt)
+    expect(recovered.status).toBe("decrypted")
+    expect(fetchDecrypt).toHaveBeenCalledTimes(2)
+  })
+
+  it("notifies subscribers when a decrypt completes", async () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeToAttachmentBytes("att_sub", listener)
+    await requestAttachmentBytes("att_sub", () => Promise.resolve(blob("x")))
+    expect(listener).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+
+  it("drops everything on clear so plaintext bytes don't outlive the lock", async () => {
+    await requestAttachmentBytes("att_clear", () => Promise.resolve(blob("secret")))
+    expect(getCachedAttachmentBytes("att_clear")?.status).toBe("decrypted")
+    clearAttachmentBytesCache()
+    expect(getCachedAttachmentBytes("att_clear")).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
+++ b/apps/frontend/src/lib/crypto/__tests__/decrypt-cache.test.ts
@@ -33,7 +33,7 @@ describe("decrypt-cache", () => {
     await requestDecryption("evt_1", { contentMarkdown: "ph", envelope: { fake: true } }, STUB_OPTS)
     const cached = getCachedDecryption("evt_1")
     expect(cached?.status).toBe("decrypted")
-    expect(cached?.content?.contentMarkdown).toBe("hello")
+    expect(cached?.value?.contentMarkdown).toBe("hello")
     expect(decrypt).toHaveBeenCalledTimes(1)
   })
 
@@ -116,7 +116,7 @@ describe("decrypt-cache", () => {
 
     const cached = getCachedDecryption("evt_seed")
     expect(cached?.status).toBe("decrypted")
-    expect(cached?.content?.contentMarkdown).toBe("from-sender")
+    expect(cached?.value?.contentMarkdown).toBe("from-sender")
 
     // A render-time request for the same event must short-circuit on the seed.
     await requestDecryption("evt_seed", { contentMarkdown: "ph", envelope: {} }, STUB_OPTS)
@@ -137,7 +137,7 @@ describe("decrypt-cache", () => {
       contentMarkdown: "should-not-replace",
       contentJson: { type: "doc", content: [] },
     })
-    expect(getCachedDecryption("evt_decrypted")?.content?.contentMarkdown).toBe("real")
+    expect(getCachedDecryption("evt_decrypted")?.value?.contentMarkdown).toBe("real")
   })
 
   it("evicts the least recently used entry when the cache exceeds its cap", async () => {

--- a/apps/frontend/src/lib/crypto/attachment-cache.ts
+++ b/apps/frontend/src/lib/crypto/attachment-cache.ts
@@ -1,0 +1,69 @@
+import { createDecryptedCache, type DecryptStatus } from "./decrypted-cache"
+
+/**
+ * In-memory cache for decrypted E2E attachment bytes — a per-key instance of the
+ * shared {@link createDecryptedCache} primitive (inflight-dedup, lock-epoch guard,
+ * subscribe/version signal, LRU, lock-clear registration).
+ *
+ * An E2E attachment is opaque ciphertext on the server; the per-file key/iv ride
+ * sealed inside the message payload. Reading one means fetching the ciphertext and
+ * decrypting it in memory — expensive, and previously redone on every mount/scroll
+ * because attachments had no read cache. This caches the decrypted `Blob` keyed by
+ * the server attachment id, so re-mounting a previously-decrypted image is free.
+ *
+ * The cache holds bytes only; the object URL lifecycle (create/revoke) stays in the
+ * read hook (`useDecryptedAttachment`), which is React-managed and can revoke on
+ * unmount — a URL cached here would leak its blob past lock. A null open (fetch or
+ * decrypt failure) is transient (network blip), so the instance uses `retryFailed`:
+ * a later request — e.g. the file-download retry — re-attempts rather than pinning
+ * the failure. `clearAttachmentBytesCache()` (also fired by `clearAllDecrypted` on
+ * lock) drops every blob so plaintext bytes never outlive the unlocked session.
+ */
+
+export interface AttachmentBytesEntry {
+  status: DecryptStatus
+  /** Decrypted file bytes; null while pending or after a failed fetch/decrypt. */
+  value: Blob | null
+}
+
+const cache = createDecryptedCache<AttachmentBytesEntry>({
+  subscription: "per-key",
+  // Blobs are whole files (MBs each), so cap aggressively — the goal is making a
+  // recently-viewed attachment re-render free, not retaining every file scrolled past.
+  lru: 64,
+  // A fetch/decrypt miss is transient (network), so allow a later request to retry.
+  retryFailed: true,
+  pending: () => ({ status: "pending", value: null }),
+})
+
+export function getCachedAttachmentBytes(attachmentId: string): AttachmentBytesEntry | undefined {
+  return cache.peek(attachmentId)
+}
+
+export function subscribeToAttachmentBytes(attachmentId: string, listener: () => void): () => void {
+  return cache.subscribe(attachmentId, listener)
+}
+
+/**
+ * Fetch + decrypt an attachment's bytes once and cache the resulting `Blob`,
+ * deduping concurrent callers. `fetchDecrypt` does the network fetch and in-memory
+ * decrypt (it carries the per-file key/iv); a throw is recorded as a `failed` entry
+ * the UI can react to, and — because the instance is `retryFailed` — a later request
+ * re-runs it. Returns the settled entry so an on-demand caller (download) can use it.
+ */
+export function requestAttachmentBytes(
+  attachmentId: string,
+  fetchDecrypt: () => Promise<Blob>
+): Promise<AttachmentBytesEntry> {
+  return cache.request(attachmentId, async () => {
+    try {
+      return { status: "decrypted", value: await fetchDecrypt() }
+    } catch {
+      return { status: "failed", value: null }
+    }
+  })
+}
+
+export function clearAttachmentBytesCache(): void {
+  cache.clear()
+}

--- a/apps/frontend/src/lib/crypto/decrypt-cache.ts
+++ b/apps/frontend/src/lib/crypto/decrypt-cache.ts
@@ -17,7 +17,8 @@ export type { DecryptStatus }
 
 export interface DecryptCacheEntry {
   status: DecryptStatus
-  content: DecryptedMessageContent | null
+  /** The decrypted payload; null while pending or after a failed open. */
+  value: DecryptedMessageContent | null
 }
 
 const cache = createDecryptedCache<DecryptCacheEntry>({
@@ -27,7 +28,7 @@ const cache = createDecryptedCache<DecryptCacheEntry>({
   // A message id is immutable: a decrypt that fails (wrong recipient, tampered
   // AAD) is terminal, so a re-request must not retry.
   retryFailed: false,
-  pending: () => ({ status: "pending", content: null }),
+  pending: () => ({ status: "pending", value: null }),
   // A message id's first good decrypt is final, so a later seed must not clobber it.
   skipPrime: (existing) => existing?.status === "decrypted",
 })
@@ -64,7 +65,7 @@ export function requestDecryption(
 ): Promise<DecryptCacheEntry> {
   return cache.request(eventId, async () => {
     const decrypted = await tryDecryptMessagePayload(payload, opts)
-    return decrypted ? { status: "decrypted", content: decrypted } : { status: "failed", content: null }
+    return decrypted ? { status: "decrypted", value: decrypted } : { status: "failed", value: null }
   })
 }
 
@@ -77,7 +78,7 @@ export function requestDecryption(
  * sent row. No-op if the event already has a decrypted entry.
  */
 export function seedDecryption(eventId: string, content: DecryptedMessageContent): void {
-  cache.prime(eventId, { status: "decrypted", content })
+  cache.prime(eventId, { status: "decrypted", value: content })
 }
 
 /**

--- a/apps/frontend/src/lib/drafts/decryption.ts
+++ b/apps/frontend/src/lib/drafts/decryption.ts
@@ -58,11 +58,11 @@ export function resolveDraftDecryption(
   if (draft.ciphertext == null)
     return { status: "plaintext", contentJson: draft.contentJson ?? null, attachments: draft.attachments }
   if (!unlocked) return { status: "locked", contentJson: null, attachments: [] }
-  if (cached?.status === "decrypted" && cached.content)
+  if (cached?.status === "decrypted" && cached.value)
     return {
       status: "decrypted",
-      contentJson: cached.content.contentJson,
-      attachments: (cached.content.attachmentRefs ?? []).map(attachmentFromRef),
+      contentJson: cached.value.contentJson,
+      attachments: (cached.value.attachmentRefs ?? []).map(attachmentFromRef),
     }
   if (cached?.status === "failed") return { status: "failed", contentJson: null, attachments: [] }
   return { status: "pending", contentJson: null, attachments: [] }
@@ -109,7 +109,7 @@ export function requestDraftDecryption(
 
 /** Re-register a decrypted entry's attachment refs so a roamed draft is sendable. */
 function rememberDecryptedRefs(entry: DecryptCacheEntry): void {
-  for (const ref of entry.content?.attachmentRefs ?? []) rememberAttachmentRef(ref)
+  for (const ref of entry.value?.attachmentRefs ?? []) rememberAttachmentRef(ref)
 }
 
 /**
@@ -121,7 +121,7 @@ function rememberDecryptedRefs(entry: DecryptCacheEntry): void {
 export function cachedDraftBody(draftId: string): JSONContent | null {
   const cached = getCachedDecryption(draftId)
   if (cached?.status !== "decrypted") return null
-  return cached.content?.contentJson ?? null
+  return cached.value?.contentJson ?? null
 }
 
 /**
@@ -133,7 +133,7 @@ export function cachedDraftBody(draftId: string): JSONContent | null {
 export function cachedDraftAttachments(draftId: string): DraftAttachment[] {
   const cached = getCachedDecryption(draftId)
   if (cached?.status !== "decrypted") return []
-  return (cached.content?.attachmentRefs ?? []).map(attachmentFromRef)
+  return (cached.value?.attachmentRefs ?? []).map(attachmentFromRef)
 }
 
 // --- List-preview presentation (stash picker, /drafts explorer) ---

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1046,8 +1046,8 @@ describe("registerStreamSocketHandlers — E2E send reconciliation seeds the dec
     expect(await db.events.get("evt_server")).toBeDefined()
     const cached = getCachedDecryption("evt_server")
     expect(cached?.status).toBe("decrypted")
-    expect(cached?.content?.contentMarkdown).toBe("secret")
-    expect(cached?.content?.contentJson).toEqual(plaintextJson)
+    expect(cached?.value?.contentMarkdown).toBe("secret")
+    expect(cached?.value?.contentJson).toEqual(plaintextJson)
 
     cleanup()
   })

--- a/docs/plans/client-decrypt-layer-unification.md
+++ b/docs/plans/client-decrypt-layer-unification.md
@@ -1,7 +1,7 @@
 # Client-side decrypt layer unification (design)
 
 **Status:** In progress — slices 0 (PR #955, sealed-name loading-state authority),
-1, and 2 are implemented; slice 3 pending. Targets current
+1, 2, and 3 are implemented. Targets current
 `origin/main` (post-#946, Stage 4c E2E draft roaming); the implementing branch
 must rebase onto it (the inventory below reflects post-#946 reality).
 
@@ -189,11 +189,21 @@ function clearAllDecrypted(): void // called once on lock / account switch
   `__tests__/decrypt-context.test.ts`. (One test artifact changed: the search
   integration test now stubs a hydrated stream row, since the hold-until-hydrated
   guard — previously absent from search — now applies there too.)
-- **Slice 3 — attachments onto the layer + uniform read.** Give attachment-bytes
-  a real cache (`attachmentBytesCache`), move `e2e-attachment-list` off
-  per-mount re-decrypt, and align names / attachments / drafts on the
-  `{ value, status }` read shape. Document the "how to add an encrypted field"
-  recipe in `apps/frontend/AGENTS.md`.
+- **Slice 3 — DONE.** Attachments onto the layer + uniform read.
+  `lib/crypto/attachment-cache.ts` is a per-key `createDecryptedCache` instance
+  (`retryFailed` — a fetch/decrypt miss is transient; `lru: 64` — blobs are whole
+  files); `useDecryptedAttachment` (`hooks/use-decrypted-attachment.ts`) mirrors
+  `useDecryptedMessageContent` and owns the object-URL lifecycle (bytes cached,
+  URL created/revoked in the hook so a blob can't leak past unmount/lock).
+  `e2e-attachment-list` reads through it instead of re-fetching + re-decrypting per
+  mount, and the file-download path warms the same cache. The cache-entry field is
+  unified on `{ status, value }` — `DecryptCacheEntry.content` was renamed to
+  `value` (deferred here from slices 1–2), so message bodies, names, and attachment
+  bytes all carry the same shape; drafts read it via the rename, keeping their
+  domain hook. Q2/Q3 resolved (below). The "how to add an encrypted field" recipe
+  is in `apps/frontend/AGENTS.md`. Behavior-preserving for existing surfaces; new
+  focused tests cover the attachment cache + hook, and the rename is guarded by the
+  existing message/step/search/draft/sync tests.
 
 ## Risks & mitigations
 
@@ -257,8 +267,15 @@ absorbs. The draft read path joins slices 2–3.
    distinction: registration is orthogonal to what a cache does (the SSK layer's
    resolution logic is untouched), and a cache can only hold material if its module
    is loaded — and loading registers it — so any cache with data is cleared on lock.
-2. Do steps keep sharing `messageCache` (keyed by `step.id`) or get their own
-   instance? Leaning: keep sharing — same shape, same LRU pressure profile.
-3. Is a single `useDecryptedField` hook worth it, or do the per-domain hooks stay
-   (thinned to shared helpers)? Leaning: keep per-domain hooks for typed returns;
-   share the helpers, not the hook.
+2. ~~Do steps keep sharing `messageCache` (keyed by `step.id`) or get their own
+   instance?~~ **Resolved (slice 3): keep sharing.** Same entry shape and LRU
+   pressure profile; a separate instance would duplicate the cache for no behavior
+   difference. `useDecryptedStepContent` keeps reading `messageCache` via the
+   `decrypt-cache` wrapper keyed by `step.id`.
+3. ~~Is a single `useDecryptedField` hook worth it, or do the per-domain hooks
+   stay?~~ **Resolved (slice 3): keep per-domain hooks** for typed returns; share
+   the helpers (`createDecryptedCache`, `resolveDecryptContext`), not the hook. The
+   uniformity that mattered — the `{ status, value }` cache-entry shape — is shared
+   at the cache layer; each hook still returns its own typed discriminated union
+   (a message carries `attachmentRefs`/`sources`, an attachment a `url`, a step
+   `TraceSource[]`), which a single generic hook would flatten or widen.


### PR DESCRIPTION
**Design doc:** [`docs/plans/client-decrypt-layer-unification.md`](../blob/claude/decrypt-layer-slice-3-m18r18/docs/plans/client-decrypt-layer-unification.md) — slice 3 (final slice). Follows slice 0 (#955), slice 1, slice 2 (#987).

## Problem

Every client-side encrypted field decrypts through the same skeleton — an in-memory cache keyed by a ciphertext id, inflight-dedup, a lock-epoch guard, a subscribe signal, and a session + key gate — but it was re-implemented per field. Slices 1–2 collapsed the cache primitive (`createDecryptedCache`) and the session/hydration gate (`resolveDecryptContext`). Two divergences remained:

1. **Attachments had no read cache at all.** `e2e-attachment-list.tsx` fetched the opaque S3 ciphertext and decrypted it **on every mount** — so an image re-decrypted each time it scrolled back into view. It was the one surface that most needed a shared cache lifecycle and the only one with none.
2. **The cache-entry shape was not uniform.** `stream-name-cache` already used `{ status, value }`; `decrypt-cache` (message bodies + trace steps + drafts + search) used `{ status, content }`. The rename to unify on `{ status, value }` was deliberately deferred from slices 1–2 to here.

## Solution

Give attachment bytes a real cache instance over the slice-1 primitive, a read hook that mirrors `useDecryptedMessageContent`, and unify the last cache-entry field on `{ status, value }`. No new cache machinery, no new session wiring — the layer already existed; this is the final field moving onto it.

### How it works

1. **`lib/crypto/attachment-cache.ts`** — a per-key `createDecryptedCache<{ status, value: Blob | null }>` instance. `subscription: "per-key"` (one resolve must not re-render every attachment), `retryFailed: true` (a fetch/decrypt miss is a transient network blip, not terminal like a message-id decrypt), `lru: 64` (blobs are whole files — cap memory; the goal is making a recently-viewed image re-render free, not retaining everything scrolled past). It auto-registers its `clear` via the slice-1 registry, so `clearAllDecrypted()` on lock drops attachment plaintext through the single existing call site — no new clear wiring. `requestAttachmentBytes(id, fetchDecrypt)` records a thrown fetch/decrypt as a `failed` entry the UI can react to.

2. **`hooks/use-decrypted-attachment.ts`** — returns a `pending | ready | failed` union. The decrypted `Blob` lives in the shared cache; the object URL is created and revoked **in the hook** (effect keyed on the blob identity), never cached — a cached URL would pin its blob alive past lock. On lock the cache emits, `cached` flips off `decrypted`, the effect cleanup revokes the URL. `fetchAndDecryptAttachment` (the network fetch + in-memory decrypt with the per-file key/iv) moved here from the component.

3. **`e2e-attachment-list.tsx`** — `E2eImageAttachment` reads through the hook instead of its own `useState(url/failed)` + per-mount `useEffect` fetch. `E2eFileAttachment`'s download routes through `requestAttachmentBytes` too, so a previewed image that's then downloaded reuses the cached blob (single fetch, deduped).

4. **Rename `DecryptCacheEntry.content` → `value`** — message bodies, stream names, and attachment bytes now all carry `{ status, value }`. The step/search/draft readers move through the rename; the step hook's own public `content` return field is untouched (only the cache-entry accessor changed). `tsc --noEmit` is the completeness guard — a missed accessor wouldn't compile.

5. **`apps/frontend/AGENTS.md`** — the "how to add an encrypted field" recipe (cache instance → `resolveDecryptContext` gate → per-domain `{ status }` hook), so the next field reuses the layer instead of copying the nearest example.

### Key design decisions

**1. Cache the `Blob`, not the object URL.** A cached object URL leaks: eviction or lock would need to find and revoke every URL. Caching bytes lets the hook own URL lifecycle (React-managed, revoked on unmount/blob-change) while the cache stays a plain GC-friendly byte store. The expensive part — network fetch + decrypt — is what's cached.

**2. `retryFailed: true` for attachments** (vs. `false` for message bodies). A message id's decrypt failure is terminal (wrong recipient / tampered AAD never starts succeeding). An attachment fetch fails on transient network blips, so a later request — the download-chip retry the image fallback offers — must re-attempt. Same reasoning the name cache uses.

**3. Keep per-domain hooks, share the helpers (resolves doc Q3).** A single generic `useDecryptedField` would flatten the typed returns — a message carries `attachmentRefs`/`sources`, an attachment a `url`, a step `TraceSource[]`. The uniformity that mattered is the `{ status, value }` **cache-entry** shape, shared at the cache layer; each hook keeps its own typed discriminated union.

**4. Steps keep sharing `messageCache` keyed by `step.id` (resolves doc Q2).** Same entry shape, same LRU pressure profile; a separate instance would duplicate for no behavior difference.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/crypto/attachment-cache.ts` | Per-key `createDecryptedCache` instance for decrypted attachment bytes |
| `apps/frontend/src/hooks/use-decrypted-attachment.ts` | Read hook (pending/ready/failed) + `fetchAndDecryptAttachment`; owns object-URL lifecycle |
| `apps/frontend/src/lib/crypto/__tests__/attachment-cache.test.ts` | Cache: caching, dedup, transient retry, clear |
| `apps/frontend/src/hooks/use-decrypted-attachment.test.ts` | Hook: pending/ready/failed + object-URL mapping |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/e2e-attachment-list.tsx` | Image reads via the hook (no per-mount re-decrypt); download routes through the shared cache |
| `apps/frontend/src/lib/crypto/decrypt-cache.ts` | `DecryptCacheEntry.content` → `value` |
| `apps/frontend/src/hooks/use-decrypted-message-content.ts` | Read `cached.value` (was `cached.content`) |
| `apps/frontend/src/hooks/use-decrypted-step-content.ts` | Read `cached.value`; public `content` return field unchanged |
| `apps/frontend/src/hooks/use-stream-search.ts` | Read `entry.value` |
| `apps/frontend/src/lib/drafts/decryption.ts` | Read `cached.value` / `entry.value` (4 sites) |
| `apps/frontend/AGENTS.md` | "How to add an encrypted field" recipe |
| `docs/plans/client-decrypt-layer-unification.md` | Slice 3 marked DONE; Q2/Q3 resolved |
| `*.test.ts(x)` (5 files) | Cache-entry mocks/accessors `content` → `value` |

## Out of scope (deliberate)

- **The download path's `setTimeout(revoke, 10_000)`** (`E2eFileAttachment.handleDownload`) is unchanged from before slice 3 — it can retain a downloaded file's object URL up to ~10s past unmount and isn't revoked on lock. Flagged in self-review; left as-is because (a) it's pre-existing, not introduced here, and (b) it covers a file the user explicitly downloaded to disk, where the plaintext is already persisted by user action. A focused hygiene follow-up (clear the timer on unmount) can take it if we want the window gone.
- **E2E-draft attachments / context refs / stash** — sealed-draft *bodies* roam (#946); these stay session-local pending their own design (per the doc's "Out of scope").
- **The `DraftScratchpad` vs `CachedDraft` "draft" naming collision** — a separate non-decrypt-layer rename follow-up the doc tracks.

## Test plan

- [x] `bunx vitest run` over the 17 affected suites (attachment cache + hook, decrypt-cache, decrypt-context, message/step/search content, all draft hooks, trace-step, event-item, message-event, stream-sync, sync-engine) — **290 pass**
- [x] `bun run typecheck` (`tsc --noEmit` across the monorepo incl. astro `public-site`) — clean; this is the rename's completeness guard
- [x] `bunx eslint` + `prettier --check` on all changed files — clean (also enforced by the pre-commit hook on both commits)
- [x] Pre-PR self-review (1 focused correctness agent over the new attachment code): 1 finding fixed (effect depended on the per-render `ref` object; aligned to primitive-field deps per the frontend convention — see second commit), 1 noted as pre-existing/out-of-scope (the download `setTimeout` revoke window above). Cache-clear registration, hook URL revoke on unmount/blob-change, `retryFailed` wiring, no-loop effect guard, no double-fetch, and INV-18 all verified correct.
- [ ] No manual browser pass — behavior-preserving for existing surfaces (the existing message/step/search/draft/sync suites are the regression guard); the only behavior *change* is attachments no longer re-decrypting per mount, covered by the cache + hook tests.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Final slice of the client decrypt-layer unification: move E2E attachment bytes onto the shared decrypt layer and unify every cache entry on `{ status, value }`.

**What was built.**
1. `attachment-cache.ts` — per-key `createDecryptedCache` instance (retryFailed, lru 64), auto-registered for lock-clear.
2. `use-decrypted-attachment.ts` — pending/ready/failed hook mirroring `useDecryptedMessageContent`; owns object-URL lifecycle so bytes never leak past lock; carries `fetchAndDecryptAttachment`.
3. `e2e-attachment-list.tsx` — image preview reads the hook (no per-mount re-decrypt); file download warms the same cache.
4. `DecryptCacheEntry.content` → `value` rename across message/step/search/draft readers + their tests.
5. AGENTS.md recipe; doc slice-3 DONE + Q2/Q3 resolved.

**Design decisions.** Cache the Blob not the URL (leak-free eviction); `retryFailed: true` (transient fetch failures); keep per-domain hooks for typed returns (Q3); steps keep sharing `messageCache` (Q2).

**Design evolution (self-review).** First version of the hook depended on the per-render `ref` object in the request effect; a future caller constructing refs inline could churn it. Fixed to depend on the primitive fields (`attachmentId`, `workspaceId`, `status`), matching `useDecryptedMessageContent`.

**Schema changes.** None (frontend-only; no IDB shape change — ciphertext stays at rest, plaintext stays memory-only).

**What's NOT included.** Draft attachments/context refs/stash; the `DraftScratchpad`/`CachedDraft` rename; the pre-existing download `setTimeout` revoke window.

**Status.** Complete — slice 3 closes the workstream (slices 0–3 all DONE).

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZw7DVoEjgCgp1m7ZwHpPQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784305608&installation_id=129946197&pr_number=992&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F992&signature=cc6c4af748e2c416257faa2e6a1d9d030611acf04e43de43510e084921a8e515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->