### PR TITLE
fix(frontend): keep sent drafts resolved across reconnect

### DIFF
--- a/apps/frontend/src/hooks/use-draft-message-sync.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message-sync.test.ts
@@ -56,13 +56,13 @@ describe("draft write helpers — Stage 3 sync wiring", () => {
     expect((await db.composerLoaded.get(scope))?.draftId).toBe(row.id)
   })
 
-  it("clearLoadedDraft cancels the push for a never-synced draft (no server delete)", async () => {
+  it("clearLoadedDraft queues an idempotent cleanup delete for a never-confirmed draft", async () => {
     const row = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("hi"), attachments: [] })
 
     await clearLoadedDraft(workspaceId, scope)
 
     expect(await hasPendingDraftUpsert(row.id)).toBe(false)
-    expect(await pendingDeletes(row.id)).toBe(0)
+    expect(await pendingDeletes(row.id)).toBe(1)
   })
 
   it("clearLoadedDraft enqueues a server delete for a confirmed draft", async () => {
@@ -76,7 +76,7 @@ describe("draft write helpers — Stage 3 sync wiring", () => {
     expect(await db.drafts.get(row.id)).toBeUndefined()
   })
 
-  it("purgeScopeDrafts deletes server copies for confirmed rows and cancels pushes for unsynced ones", async () => {
+  it("purgeScopeDrafts queues cleanup deletes for confirmed and never-confirmed rows", async () => {
     const confirmed = await upsertLoadedDraft(workspaceId, scope, { contentJson: makeDoc("a"), attachments: [] })
     await db.drafts.put({ ...confirmed, baseVersion: 2 })
     const unsyncedRow: CachedDraft = {
@@ -92,7 +92,7 @@ describe("draft write helpers — Stage 3 sync wiring", () => {
     await purgeScopeDrafts(workspaceId, scope)
 
     expect(await pendingDeletes(confirmed.id)).toBe(1)
-    expect(await pendingDeletes(unsyncedRow.id)).toBe(0)
+    expect(await pendingDeletes(unsyncedRow.id)).toBe(1)
     expect(await db.drafts.count()).toBe(0)
   })
 

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -401,7 +401,7 @@ describe("useDraftMessage", () => {
       expect(resolves[0]?.payload).toMatchObject({ draftId: "draft_confirmed", expectedVersion: 2 })
     })
 
-    it("does not enqueue a server resolve for a never-synced draft (nothing to resolve)", async () => {
+    it("uses an idempotent delete cleanup for a never-confirmed draft instead of a CAS resolve", async () => {
       await db.pendingOperations.clear()
       await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("x"), attachments: [] })
 
@@ -412,6 +412,9 @@ describe("useDraftMessage", () => {
 
       expect(await loadedDraft(draftKey)).toBeUndefined()
       expect(await db.pendingOperations.where("type").equals("resolve_draft").count()).toBe(0)
+      const deletes = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+      expect(deletes).toHaveLength(1)
+      expect(typeof deletes[0]?.payload.draftId).toBe("string")
     })
 
     it("a stale debounced save (started before resolve-on-send) does NOT resurrect the draft", async () => {

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -357,12 +357,14 @@ describe("syncDraftResolution", () => {
     expect(resolves.filter((o) => o.payload.draftId === "draft_x" && o.payload.expectedVersion === 4)).toHaveLength(1)
   })
 
-  it("only drops the pending push for a never-synced draft (nothing to resolve server-side)", async () => {
+  it("queues a cleanup delete for a never-confirmed draft in case its upsert is already in flight", async () => {
     await enqueueDraftUpsert(workspaceId, "draft_x")
     await syncDraftResolution(workspaceId, "draft_x", 0)
 
     expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
     expect(await db.pendingOperations.where("type").equals("resolve_draft").count()).toBe(0)
+    const deletes = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+    expect(deletes.filter((op) => op.payload.draftId === "draft_x")).toHaveLength(1)
   })
 })
 
@@ -577,6 +579,25 @@ describe("resolve-on-send is authoritative against inbound echoes (no resurrecti
     expect(await db.drafts.get("draft_server1")).toBeUndefined()
   })
 
+  it("applyDraftUpserted drops an echo when the persisted resolve op is still queued", async () => {
+    // Same scenario after a reload/resume: the in-memory tombstone is gone, but
+    // the durable resolve_draft op remains. The server row still exists until the
+    // queue drains, and must not be re-seeded as a sent-message draft.
+    await enqueueDraftResolve(workspaceId, "draft_server1", 1)
+
+    await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wireDraft({ version: 1 }) }, workspaceId)
+
+    expect(await db.drafts.get("draft_server1")).toBeUndefined()
+  })
+
+  it("applyDraftsBootstrap does not resurrect a draft whose resolve is still queued", async () => {
+    await enqueueDraftResolve(workspaceId, "draft_server1", 1)
+
+    await applyDraftsBootstrap(workspaceId, [wireDraft({ version: 1 })])
+
+    expect(await db.drafts.get("draft_server1")).toBeUndefined()
+  })
+
   it("still applies a STRICTLY NEWER version from another device (no-loss)", async () => {
     // A genuine edit elsewhere bumped the version past what we resolved at — that
     // is real new work and survives (as a stash entry), never silently dropped.
@@ -585,6 +606,14 @@ describe("resolve-on-send is authoritative against inbound echoes (no resurrecti
     await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wireDraft({ version: 2 }) }, workspaceId)
 
     expect(await db.drafts.get("draft_server1")).toBeDefined()
+  })
+
+  it("still applies a strictly newer version when a persisted resolve is queued", async () => {
+    await enqueueDraftResolve(workspaceId, "draft_server1", 1)
+
+    await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wireDraft({ version: 2 }) }, workspaceId)
+
+    expect((await db.drafts.get("draft_server1"))?.baseVersion).toBe(2)
   })
 })
 
@@ -626,14 +655,15 @@ describe("deleteDraftById — the single user-initiated delete path", () => {
     expect(await db.composerLoaded.get(scope)).toBeUndefined()
   })
 
-  it("cancels a never-synced draft's push instead of queuing a server delete", async () => {
+  it("queues an idempotent server delete for a never-confirmed draft to clean up in-flight upsert ghosts", async () => {
     await db.drafts.put(localDraft({ id: "draft_x" })) // never confirmed → no baseVersion
     await enqueueDraftUpsert(workspaceId, "draft_x")
 
     await deleteDraftById(workspaceId, "draft_x")
 
     expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
-    expect(await db.pendingOperations.where("type").equals("delete_draft").toArray()).toHaveLength(0)
+    const deletes = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+    expect(deletes.filter((op) => op.payload.draftId === "draft_x")).toHaveLength(1)
   })
 
   it("no-ops on an already-gone row", async () => {

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -233,6 +233,24 @@ export async function hasPendingDraftDelete(draftId: string): Promise<boolean> {
 }
 
 /**
+ * Last server-confirmed version this device is trying to resolve-on-send for the
+ * draft, if that resolve is queued but has not drained yet. While this persisted
+ * op exists, inbound/bootstrap rows at or below the expected version are stale
+ * echoes of an already-sent draft and must not be re-created. Strictly newer
+ * rows still apply so another device's drifted edit survives (no-loss).
+ */
+export async function pendingDraftResolveVersion(draftId: string): Promise<number | undefined> {
+  const ops = await pendingDraftOps("resolve_draft", draftId)
+  let version: number | undefined
+  for (const op of ops) {
+    const expected = Number(op.payload.expectedVersion)
+    if (!Number.isFinite(expected)) continue
+    version = version === undefined ? expected : Math.max(version, expected)
+  }
+  return version
+}
+
+/**
  * Enqueue a debounced background push for a draft. Coalesces to at most one
  * queued `upsert_draft` op per id: the op reads the draft's current content
  * fresh at drain time, so a superseded op would only re-push identical state.
@@ -256,9 +274,10 @@ export async function enqueueDraftUpsert(workspaceId: string, draftId: string): 
 
 /**
  * Enqueue an unconditional server delete for a draft and drop any queued push
- * for it (no point mirroring content we're discarding). Use only when the draft
- * may exist server-side (`baseVersion > 0`); for a never-synced draft call
- * `cancelPendingDraftUpsert` instead — there is nothing to delete.
+ * for it (no point mirroring content we're discarding). This is also used for
+ * never-confirmed local drafts: their queued upsert may already be in-flight, so
+ * an idempotent delete is the durable cleanup/suppression marker that prevents a
+ * late server insert from reappearing on the next socket/bootstrap pass.
  */
 export async function enqueueDraftDelete(workspaceId: string, draftId: string): Promise<void> {
   await db.transaction("rw", db.pendingOperations, async () => {
@@ -316,30 +335,28 @@ export async function cancelPendingDraftUpsert(draftId: string): Promise<void> {
 }
 
 /**
- * Mirror a locally-removed draft to the backend: a confirmed draft
- * (`baseVersion > 0`) has a server row to delete; a never-synced one only needs
- * its queued push dropped (nothing exists server-side). Shared by every local
- * delete path (composer clear, scope purge, stash discard).
+ * Mirror a locally-removed draft to the backend. A confirmed draft
+ * (`baseVersion > 0`) has a server row to delete. A never-confirmed draft may
+ * still have an in-flight upsert creating a ghost server row after the local
+ * delete, so we also enqueue an idempotent delete instead of only canceling the
+ * queued upsert. Shared by every local delete path (composer clear, scope purge,
+ * stash discard).
  */
 export async function syncDraftRemoval(
   workspaceId: string,
   id: string,
-  baseVersion: number | undefined
+  _baseVersion: number | undefined
 ): Promise<void> {
-  if ((baseVersion ?? 0) > 0) {
-    await enqueueDraftDelete(workspaceId, id)
-  } else {
-    await cancelPendingDraftUpsert(id)
-  }
+  await enqueueDraftDelete(workspaceId, id)
 }
 
 /**
  * Mirror a sent draft's removal to the backend CAS-safely (resolve-on-send): a
  * confirmed draft (`baseVersion > 0`) is resolved on the version it was last
  * confirmed at, so a copy that drifted on another device survives as a stash
- * entry; a never-synced one only needs its queued push dropped (nothing exists
- * server-side). The counterpart to `syncDraftRemoval` for the send path — the
- * local row is already gone by the time this runs.
+ * entry. A never-confirmed draft cannot be CAS-resolved yet, but its upsert may
+ * already be in-flight; enqueue an idempotent delete so a ghost row from that
+ * late upsert is cleaned up and suppressed on bootstrap/socket echoes.
  */
 export async function syncDraftResolution(
   workspaceId: string,
@@ -349,7 +366,7 @@ export async function syncDraftResolution(
   if ((baseVersion ?? 0) > 0) {
     await enqueueDraftResolve(workspaceId, id, baseVersion as number)
   } else {
-    await cancelPendingDraftUpsert(id)
+    await enqueueDraftDelete(workspaceId, id)
   }
 }
 
@@ -379,7 +396,8 @@ export async function applyDraftUpserted(
   payload: DraftUpsertedPayload,
   expectedWorkspaceId: string,
   pendingUpsertIds?: ReadonlySet<string>,
-  pendingDeleteIds?: ReadonlySet<string>
+  pendingDeleteIds?: ReadonlySet<string>,
+  pendingResolveVersions?: ReadonlyMap<string, number>
 ): Promise<void> {
   const { draft } = payload
   if (draft.workspaceId !== expectedWorkspaceId) return
@@ -391,6 +409,13 @@ export async function applyDraftUpserted(
   // composer). Drop the echo at or below the resolved version; a strictly newer
   // version is a genuine edit from another device and still applies (no-loss).
   if (isResolvedDraftEcho(draft.id, draft.version)) return
+
+  // Same guard, but durable across reload/reconnect: if the resolve op is still
+  // queued, a bootstrap can see the not-yet-tombstoned server row before the op
+  // drains. Drop rows at or below the CAS version being resolved; accept a
+  // strictly newer version as real drift from another device.
+  const pendingResolveVersion = pendingResolveVersions?.get(draft.id) ?? (await pendingDraftResolveVersion(draft.id))
+  if (pendingResolveVersion !== undefined && draft.version <= pendingResolveVersion) return
 
   // A queued local delete wins: the user discarded this draft here and its
   // `delete_draft` op (not yet drained) will remove the server row. Until then,
@@ -469,18 +494,27 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
   // parallel) and reuse the sets across the loops, rather than scanning the op
   // table per draft. A queued delete means the user discarded that draft here;
   // the re-seed must not resurrect it before the delete drains.
-  const [upsertOps, deleteOps] = await Promise.all([
+  const [upsertOps, deleteOps, resolveOps] = await Promise.all([
     db.pendingOperations.where("type").equals("upsert_draft").toArray(),
     db.pendingOperations.where("type").equals("delete_draft").toArray(),
+    db.pendingOperations.where("type").equals("resolve_draft").toArray(),
   ])
   const pendingUpsertIds = new Set(upsertOps.map((op) => op.payload.draftId as string))
   const pendingDeleteIds = new Set(deleteOps.map((op) => op.payload.draftId as string))
+  const pendingResolveVersions = new Map<string, number>()
+  for (const op of resolveOps) {
+    const draftId = op.payload.draftId as string
+    const expectedVersion = Number(op.payload.expectedVersion)
+    if (!Number.isFinite(expectedVersion)) continue
+    pendingResolveVersions.set(draftId, Math.max(pendingResolveVersions.get(draftId) ?? 0, expectedVersion))
+  }
   for (const draft of drafts) {
     await applyDraftUpserted(
       { workspaceId: draft.workspaceId, targetUserId: draft.userId, draft },
       workspaceId,
       pendingUpsertIds,
-      pendingDeleteIds
+      pendingDeleteIds,
+      pendingResolveVersions
     )
   }
 


### PR DESCRIPTION
## Problem

The centralized draft design says a successful send **resolves** the exact checked-out draft by `draftId + version`: the local row is removed immediately, and the backend delete is CAS-guarded so a drifted edit from another device survives instead of being overwritten/deleted. That model had two frontend gaps:

1. `markDraftResolved(...)` protected same-session inbound echoes, but it is intentionally in-memory. After reload/resume/reconnect, the durable `resolve_draft` operation could still be queued while the server row still existed, and `GET /drafts` could re-seed the not-yet-tombstoned row as a stash entry.
2. For never-confirmed local drafts (`baseVersion` missing), `syncDraftResolution` / `syncDraftRemoval` assumed “nothing exists server-side” and only canceled a queued upsert. That misses the case where the upsert request is already in-flight: the server can create a version-1 ghost row after local send/discard, and that row can later bootstrap back as a draft.

Both bugs violate the intended system in `docs/plans/centralized-draft-system.md`: sent drafts should resolve, local user changes should not be overwritten, and drifted newer copies should survive instead of being blindly deleted.

## Solution

Make draft removal/resolution durable across reconnects and in-flight upserts, without weakening the no-loss rule.

### How it works

1. `pendingDraftResolveVersion(draftId)` reads queued `resolve_draft` operations and returns the highest `expectedVersion` being resolved for that draft.
2. `applyDraftUpserted(...)` now drops inbound/socket/bootstrap rows when `draft.version <= pendingResolveVersion`, because those rows are echoes of content this device already sent.
3. `applyDraftsBootstrap(...)` reads queued `resolve_draft` operations once, builds a `Map<draftId, expectedVersion>`, and passes it through the per-row apply loop alongside the existing pending-upsert/delete sets.
4. Never-confirmed local removals now enqueue an idempotent `delete_draft` cleanup instead of only canceling `upsert_draft`. `enqueueDraftDelete` still drops any queued push, but the persisted delete op also suppresses/cleans a ghost row created by an already-in-flight upsert.
5. The no-loss rule is preserved for confirmed drafts: `draft.version > pendingResolveVersion` still applies as a real newer edit from another device, so a drifted copy survives as the design requires.

### Key design decisions

**1. Use existing queue state as durable tombstones.** A queued `resolve_draft` already means “this device sent draft X at version N”; a queued `delete_draft` already means “this device discarded draft X.” Teaching inbound/bootstrap apply to respect those persisted facts avoids a second tombstone store.

**2. Version-gated suppression for resolves.** Dropping every inbound row for a pending resolve would violate the distributed-draft invariant: another device could have edited the draft after this device started sending. Suppressing only `<= expectedVersion` matches the existing `isResolvedDraftEcho` semantics and preserves strictly-newer rows.

**3. Idempotent cleanup delete for never-confirmed rows.** A CAS resolve cannot target a row that may not exist yet, but an unconditional delete is already the explicit-discard primitive and is idempotent on missing rows. Using it for never-confirmed send/discard closes the in-flight-upsert ghost path.

**4. Keep the backend/API unchanged.** The backend CAS behavior in `DraftsService.resolve` / `DraftsRepository.softDeleteCas` was already correct. This is a frontend sync/reconnect reconciliation fix only; no schema or API changes.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/draft-sync.ts` | Adds persisted pending-resolve awareness to inbound draft apply/bootstrap; turns never-confirmed removals into idempotent cleanup deletes. |
| `apps/frontend/src/sync/draft-sync.test.ts` | Adds regressions for socket/bootstrap resurrection with queued resolves, strictly-newer no-loss behavior, and never-confirmed cleanup deletes. |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | Updates resolve-on-send expectations for never-confirmed drafts to assert cleanup delete rather than no server op. |
| `apps/frontend/src/hooks/use-draft-message-sync.test.ts` | Updates clear/purge sync wiring expectations for never-confirmed cleanup deletes. |

## Deleted files

None.

## Out of scope (deliberate)

- No change to unpromoted scratchpad draft centralization; the design doc explicitly treats that as a separate problem.
- No backend migration/API change; server-side CAS resolve already matches the design.
- No merge/conflict UI; strictly-newer drift still lands as an ordinary draft entry, per the centralized draft design.

## Test plan

- [x] `bunx vitest run src/sync/draft-sync.test.ts` from `apps/frontend` — 47 passed
- [x] `bunx vitest run src/hooks/use-draft-message-sync.test.ts src/sync/draft-sync.test.ts src/hooks/use-draft-message.test.ts` from `apps/frontend` — 90 passed
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] Commit hook — lint across apps, Dockerfile workspace check, migration check, full workspace typecheck, OpenAPI check all clean

<details>
<summary>📋 Full implementation plan</summary>

Goal: fix sent/discarded message drafts being resurrected by remote draft sync without weakening the core distributed-draft invariant that user edits are never overwritten or deleted accidentally.

What was built:
1. Created a fresh worktree `threa.fix-remote-drafts` from fetched `origin/main`.
2. Reviewed recent draft-related context and the source-of-truth plan: #286 (offline draft promotion), #791 (draft write-after-purge race), and `docs/plans/centralized-draft-system.md` (resolve-on-send, CAS, split/no-overwrite model).
3. Traced the current send/resolve path: `useDraftMessage.resolveDraft` removes the local row, queues `resolve_draft` for confirmed drafts, and marks an in-memory `(draftId, version)` echo guard.
4. Found durable gap 1: `applyDraftsBootstrap` knew about pending `upsert_draft` and `delete_draft`, but not pending `resolve_draft`, so reconnect/bootstrap after reload could reaccept the server row before the resolve op drained.
5. Found durable gap 2 during self-review: never-confirmed draft removal only canceled queued upserts, but an upsert could already be in-flight and create a ghost server row. Never-confirmed removals now enqueue an idempotent cleanup delete.
6. Added regression tests for durable pending-resolve suppression, strictly-newer drift preservation, and never-confirmed cleanup deletes.

Design decisions: use existing pending operations as durable tombstones; suppress resolve echoes by version (`<= expectedVersion`) rather than by id; use idempotent delete for never-confirmed ghost cleanup; leave backend CAS and draft conflict semantics unchanged.

Schema changes: none.

What's NOT included: scratchpad draft roaming, backend API changes, merge/conflict UI, or broader composer refactors.

Status: implemented, rebased onto `origin/main`, pushed, and verified with targeted frontend draft suites plus commit-hook checks.

</details>

---

🤖 _PR by Pi Remote_
