### PR TITLE
refactor(frontend): name useDraftScratchpads returns by the scratchpad concept

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.test.tsx
@@ -13,7 +13,7 @@ import * as sidebarActionsModule from "./sidebar-actions"
 
 const collapseOnMobile = vi.fn()
 const archiveStream = vi.fn(async () => {})
-const deleteDraft = vi.fn(async () => {})
+const deleteScratchpad = vi.fn(async () => {})
 const openStreamSettings = vi.fn()
 
 function LocationEcho() {
@@ -69,7 +69,7 @@ describe("ScratchpadItem", () => {
     vi.restoreAllMocks()
     collapseOnMobile.mockReset()
     archiveStream.mockReset()
-    deleteDraft.mockReset()
+    deleteScratchpad.mockReset()
     openStreamSettings.mockReset()
 
     vi.spyOn(contextsModule, "useSidebar").mockReturnValue({
@@ -89,7 +89,7 @@ describe("ScratchpadItem", () => {
       mutateAsync: archiveStream,
     } as unknown as ReturnType<typeof hooksModule.useArchiveStream>)
     vi.spyOn(hooksModule, "useDraftScratchpads").mockReturnValue({
-      deleteDraft,
+      deleteScratchpad,
     } as unknown as ReturnType<typeof hooksModule.useDraftScratchpads>)
     vi.spyOn(hooksModule, "useStreamOrDraft").mockImplementation(() => {
       throw new Error("ScratchpadItem should not call useStreamOrDraft")
@@ -276,7 +276,7 @@ describe("ScratchpadItem", () => {
     fireEvent.click(screen.getByText("Delete"))
 
     await waitFor(() => {
-      expect(deleteDraft).toHaveBeenCalledWith("draft_scratchpad_1")
+      expect(deleteScratchpad).toHaveBeenCalledWith("draft_scratchpad_1")
       expect(screen.getByTestId("location").textContent).toBe("/w/workspace_1")
     })
     expect(archiveStream).not.toHaveBeenCalled()

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -51,7 +51,7 @@ export function ScratchpadItem({
 }: ScratchpadItemProps) {
   const navigate = useNavigate()
   const archiveStream = useArchiveStream(workspaceId)
-  const { deleteDraft } = useDraftScratchpads(workspaceId)
+  const { deleteScratchpad } = useDraftScratchpads(workspaceId)
   const { getActorName } = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const { collapseOnMobile } = useSidebar()
@@ -75,7 +75,7 @@ export function ScratchpadItem({
 
   const handleArchive = useCallback(async () => {
     if (isDraft) {
-      await deleteDraft(streamWithPreview.id)
+      await deleteScratchpad(streamWithPreview.id)
       // Drafts are fully deleted — navigate away if viewing
       if (isActive) {
         navigate(`/w/${workspaceId}`)
@@ -84,7 +84,7 @@ export function ScratchpadItem({
       // Real streams stay viewable as read-only after archival
       await archiveStream.mutateAsync(streamWithPreview.id)
     }
-  }, [archiveStream, deleteDraft, isActive, isDraft, navigate, streamWithPreview.id, workspaceId])
+  }, [archiveStream, deleteScratchpad, isActive, isDraft, navigate, streamWithPreview.id, workspaceId])
 
   const actions = useMemo<SidebarActionItem[]>(
     () => [

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -84,7 +84,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const idbDmPeers = useWorkspaceDmPeers(workspaceId)
   const labels = useWorkspaceLabels(workspaceId)
   const labelAssignments = useWorkspaceLabelAssignments(workspaceId)
-  const { createDraft } = useDraftScratchpads(workspaceId)
+  const { createScratchpad } = useDraftScratchpads(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getMentionCount, getActivityCount, unreadActivityCount } = useActivityCounts(workspaceId)
   const { drafts: allDrafts } = useAllDrafts(workspaceId)
@@ -302,7 +302,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
 
   const handleCreateScratchpad = async () => {
     try {
-      const draftId = await createDraft("on")
+      const draftId = await createScratchpad("on")
       collapseOnMobile()
       navigate(`/w/${workspaceId}/s/${draftId}`)
     } catch {
@@ -359,7 +359,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   }
 
   const handleCreateQuickNote = async () => {
-    const draftId = await createDraft("off")
+    const draftId = await createScratchpad("off")
     collapseOnMobile()
     navigate(`/w/${workspaceId}/s/${draftId}`)
   }

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.integration.test.tsx
@@ -163,8 +163,8 @@ function installSpies() {
     isLoading: false,
   } as unknown as ReturnType<typeof hooksModule.useWorkspaceBootstrap>)
   vi.spyOn(hooksModule, "useDraftScratchpads").mockReturnValue({
-    createDraft: vi.fn(),
-    deleteDraft: mockDeleteDraft,
+    createScratchpad: vi.fn(),
+    deleteScratchpad: mockDeleteDraft,
   } as unknown as ReturnType<typeof hooksModule.useDraftScratchpads>)
   vi.spyOn(hooksModule, "useArchiveStream").mockReturnValue({
     mutateAsync: mockArchiveMutateAsync,

--- a/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
+++ b/apps/frontend/src/components/quick-switcher/quick-switcher.tsx
@@ -84,7 +84,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
   const navigate = useNavigate()
   const [, setSearchParams] = useSearchParams()
   const user = useUser()
-  const { createDraft, deleteDraft } = useDraftScratchpads(workspaceId)
+  const { createScratchpad, deleteScratchpad } = useDraftScratchpads(workspaceId)
   const { openSettings } = useSettings()
   const { openCreateChannel } = useCreateChannel()
   const { open: openExplorer } = useExplorerUrlState()
@@ -262,7 +262,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       workspaceId,
       navigate,
       closeDialog: handleClose,
-      createDraftScratchpad: createDraft,
+      createDraftScratchpad: createScratchpad,
       createEncryptedScratchpad,
       openCreateChannel,
       setMode,
@@ -282,7 +282,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
       workspaceId,
       navigate,
       handleClose,
-      createDraft,
+      createScratchpad,
       createEncryptedScratchpad,
       openCreateChannel,
       setMode,
@@ -414,7 +414,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
     const { streamId, isDraft } = pendingArchive
     try {
       if (isDraft) {
-        await deleteDraft(streamId)
+        await deleteScratchpad(streamId)
         // Drafts are fully deleted — leave the (now-gone) stream if viewing it.
         if (currentStreamId === streamId) navigate(`/w/${workspaceId}`)
       } else {
@@ -425,7 +425,7 @@ export function QuickSwitcher({ workspaceId, open, onOpenChange, initialMode, cu
     } finally {
       setPendingArchive(null)
     }
-  }, [pendingArchive, deleteDraft, navigate, workspaceId, currentStreamId, archiveStream])
+  }, [pendingArchive, deleteScratchpad, navigate, workspaceId, currentStreamId, archiveStream])
 
   const archiveIsDraft = pendingArchive?.isDraft ?? false
   const archiveStreamLabel = pendingArchive?.name ?? "this stream"

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.test.tsx
@@ -6,16 +6,16 @@ import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import * as draftHook from "@/hooks/use-draft-scratchpads"
 import { DraftAgentSettings } from "./draft-agent-settings"
 
-const updateDraft = vi.fn()
+const updateScratchpad = vi.fn()
 
 beforeEach(() => {
-  updateDraft.mockReset()
+  updateScratchpad.mockReset()
   vi.spyOn(draftHook, "useDraftScratchpads").mockReturnValue({
-    drafts: [],
-    createDraft: vi.fn(),
-    updateDraft,
-    deleteDraft: vi.fn(),
-    getDraft: vi.fn(),
+    scratchpads: [],
+    createScratchpad: vi.fn(),
+    updateScratchpad,
+    deleteScratchpad: vi.fn(),
+    getScratchpad: vi.fn(),
   } as unknown as ReturnType<typeof draftHook.useDraftScratchpads>)
 })
 
@@ -43,7 +43,7 @@ describe("DraftAgentSettings", () => {
 
     await userEvent.click(screen.getByRole("radio", { name: /quiet/i }))
 
-    expect(updateDraft).toHaveBeenCalledWith("draft_1", { companionMode: "off" })
+    expect(updateScratchpad).toHaveBeenCalledWith("draft_1", { companionMode: "off" })
   })
 
   it("writes a restricted (empty) policy to the draft when restriction is turned on", async () => {
@@ -51,7 +51,7 @@ describe("DraftAgentSettings", () => {
 
     await userEvent.click(screen.getByRole("switch", { name: /restrict tool access/i }))
 
-    expect(updateDraft).toHaveBeenCalledWith("draft_1", { allowedToolCategories: [] })
+    expect(updateScratchpad).toHaveBeenCalledWith("draft_1", { allowedToolCategories: [] })
   })
 
   it("only offers the categories the workspace has configured", () => {

--- a/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/draft-agent-settings.tsx
@@ -24,15 +24,15 @@ export function DraftAgentSettings({
   allowedToolCategories,
   configuredCategories,
 }: DraftAgentSettingsProps) {
-  const { updateDraft } = useDraftScratchpads(workspaceId)
+  const { updateScratchpad } = useDraftScratchpads(workspaceId)
 
   return (
     <AgentSettingsPanel
       companionMode={companionMode}
-      onCompanionModeChange={(mode) => updateDraft(draftId, { companionMode: mode })}
+      onCompanionModeChange={(mode) => updateScratchpad(draftId, { companionMode: mode })}
       toolPolicy={{
         value: allowedToolCategories,
-        onChange: (next) => updateDraft(draftId, { allowedToolCategories: next }),
+        onChange: (next) => updateScratchpad(draftId, { allowedToolCategories: next }),
         configuredCategories,
         e2e: false,
       }}

--- a/apps/frontend/src/hooks/use-draft-scratchpads.ts
+++ b/apps/frontend/src/hooks/use-draft-scratchpads.ts
@@ -19,40 +19,40 @@ export function isDraftId(id: string): boolean {
 }
 
 export function useDraftScratchpads(workspaceId: string) {
-  const drafts = useDraftScratchpadsFromStore(workspaceId)
+  const scratchpads = useDraftScratchpadsFromStore(workspaceId)
 
-  const createDraft = useCallback(
+  const createScratchpad = useCallback(
     async (companionMode: CompanionMode = "on"): Promise<string> => {
       const id = generateDraftId()
-      const draft: DraftScratchpad = {
+      const scratchpad: DraftScratchpad = {
         id,
         workspaceId,
         displayName: null,
         companionMode,
         createdAt: Date.now(),
       }
-      await db.draftScratchpads.add(draft)
-      upsertDraftScratchpadInCache(workspaceId, draft)
+      await db.draftScratchpads.add(scratchpad)
+      upsertDraftScratchpadInCache(workspaceId, scratchpad)
       return id
     },
     [workspaceId]
   )
 
-  const updateDraft = useCallback(
+  const updateScratchpad = useCallback(
     async (
       id: string,
       data: Partial<Pick<DraftScratchpad, "displayName" | "companionMode" | "allowedToolCategories">>
     ) => {
       await db.draftScratchpads.update(id, data)
-      const existingDraft = drafts.find((draft) => draft.id === id)
-      if (existingDraft) {
-        upsertDraftScratchpadInCache(workspaceId, { ...existingDraft, ...data })
+      const existing = scratchpads.find((scratchpad) => scratchpad.id === id)
+      if (existing) {
+        upsertDraftScratchpadInCache(workspaceId, { ...existing, ...data })
       }
     },
-    [drafts, workspaceId]
+    [scratchpads, workspaceId]
   )
 
-  const deleteDraft = useCallback(
+  const deleteScratchpad = useCallback(
     async (id: string) => {
       await db.draftScratchpads.delete(id)
       deleteDraftScratchpadFromCache(workspaceId, id)
@@ -62,18 +62,18 @@ export function useDraftScratchpads(workspaceId: string) {
     [workspaceId]
   )
 
-  const getDraft = useCallback(
+  const getScratchpad = useCallback(
     (id: string): DraftScratchpad | undefined => {
-      return drafts?.find((d) => d.id === id)
+      return scratchpads?.find((s) => s.id === id)
     },
-    [drafts]
+    [scratchpads]
   )
 
   return {
-    drafts,
-    createDraft,
-    updateDraft,
-    deleteDraft,
-    getDraft,
+    scratchpads,
+    createScratchpad,
+    updateScratchpad,
+    deleteScratchpad,
+    getScratchpad,
   }
 }

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -158,8 +158,8 @@ export interface UseStreamOrDraftReturn {
 function useDraftStream(workspaceId: string, streamId: string, enabled: boolean): UseStreamOrDraftReturn {
   const navigate = useNavigate()
   const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
-  const { getDraft, updateDraft, deleteDraft } = useDraftScratchpads(workspaceId)
-  const draft = enabled ? getDraft(streamId) : undefined
+  const { getScratchpad, updateScratchpad, deleteScratchpad } = useDraftScratchpads(workspaceId)
+  const draft = enabled ? getScratchpad(streamId) : undefined
 
   const stream: VirtualStream | undefined = draft
     ? {
@@ -179,15 +179,15 @@ function useDraftStream(workspaceId: string, streamId: string, enabled: boolean)
 
   const rename = useCallback(
     async (newName: string) => {
-      await updateDraft(streamId, { displayName: newName })
+      await updateScratchpad(streamId, { displayName: newName })
     },
-    [streamId, updateDraft]
+    [streamId, updateScratchpad]
   )
 
   const archive = useCallback(async () => {
-    await deleteDraft(streamId)
+    await deleteScratchpad(streamId)
     navigate(`/w/${workspaceId}`)
-  }, [deleteDraft, streamId, workspaceId, navigate])
+  }, [deleteScratchpad, streamId, workspaceId, navigate])
 
   useEffect(() => {
     return onDraftPromoted((promotion) => {


### PR DESCRIPTION
## Problem

Two distinct concepts in the frontend both call themselves "draft":

- A **draft message** — the composer payload (`CachedDraft` / `db.drafts` / `useDraftMessage` / `lib/drafts/`). Per `docs/plans/centralized-draft-system.md`, this is the canonical meaning: _"Replaces both the old 'active draft' and 'stashed draft' notions — there is only one kind now."_
- An **unpromoted scratchpad stream** — a scratchpad that lives only in IndexedDB (`DraftScratchpad` / `db.draftScratchpads`) until its first message promotes it to a real server stream.

The `useDraftScratchpads` hook returned the second concept under bare-"draft" names (`drafts`, `createDraft`, `updateDraft`, `deleteDraft`, `getDraft`), colliding with the first at every call site — e.g. `sidebar.tsx` destructures `{ createDraft }` (a scratchpad) two lines above `{ drafts: allDrafts } = useAllDrafts(...)` (messages).

## Solution

Rename the `useDraftScratchpads` return shape to spell the scratchpad-stream concept, so "draft" in the codebase reads unambiguously as the message payload:

| Before | After |
| ------ | ----- |
| `drafts` | `scratchpads` |
| `createDraft` | `createScratchpad` |
| `updateDraft` | `updateScratchpad` |
| `deleteDraft` | `deleteScratchpad` |
| `getDraft` | `getScratchpad` |

The internal callbacks and the hook's local list variable are renamed to match; the loop bodies are otherwise unchanged.

### Key design decisions

**1. The message concept keeps "draft"; the scratchpad concept gives way.** The centralized-draft-system doc makes "Draft" canonically the composer payload, so `CachedDraft` / `db.drafts` / `useDraftMessage` / the `/drafts` page are left alone and the scratchpad-stream symbols move off bare "draft". This was the user's call after I laid out the options.

**2. Scoped to the hook's return shape only** (the user picked the minimal of three options). Deliberately **not** renamed, to keep the churn small and avoid a migration: the `DraftScratchpad` type, the `db.draftScratchpads` Dexie store (renaming it would need a v35 migration for zero added clarity — the store name already says "scratchpads"), `promoteDraft` / `DraftPromotion` / `onDraftPromoted`, `useDraftStream`, and the unified-stream `VirtualStream.isDraft` / `useStreamOrDraft` / `draft_dm_` naming (a coherent third sense — "a stream not yet on the server").

**3. The shared `draft_` id prefix is left intact.** It is persisted in IDB and in URLs and also matches the backend draft-message ULID prefix, so changing it would need a migration plus server coordination — out of scope. Known residual: `isDraftId()` still keys on `draft_`.

## Modified files

| File | Change |
| ---- | ------ |
| `hooks/use-draft-scratchpads.ts` | Rename return fields + backing callbacks + local list var |
| `hooks/use-stream-or-draft.ts` | `useDraftStream` destructure + `rename`/`archive` callbacks use the new names |
| `components/stream-settings/draft-agent-settings.tsx` | `updateDraft` → `updateScratchpad` |
| `components/quick-switcher/quick-switcher.tsx` | Destructure + command-context mapping + archive handler + deps |
| `components/layout/sidebar/sidebar.tsx` | `createDraft` → `createScratchpad` (both create handlers) |
| `components/layout/sidebar/scratchpad-item.tsx` | `deleteDraft` → `deleteScratchpad` + deps |
| `components/stream-settings/draft-agent-settings.test.tsx` | Mock return shape + assertion var |
| `components/quick-switcher/quick-switcher.integration.test.tsx` | Mock return shape keys |
| `components/layout/sidebar/scratchpad-item.test.tsx` | Mock var/field rename |

## Out of scope (deliberate)

See design decision 2 and 3 above — the `DraftScratchpad` type, the Dexie store, the promotion/virtual-stream symbols, and the `draft_` id prefix are intentionally untouched. `useAllDrafts().deleteDraft` (the message-draft hook) is a different hook and correctly keeps "draft".

## Test plan

- [x] `bun run typecheck` (tsc --noEmit across the monorepo + astro check) — clean. This is the authoritative completeness guard for a field rename: a missed accessor would not compile.
- [x] `bunx vitest run` over the 4 affected suites (`draft-agent-settings`, `quick-switcher.integration`, `scratchpad-item`, `use-stream-or-draft`) — 61 pass.
- [x] Pre-commit hook (full monorepo lint + typecheck + prettier + API-docs check) — passed on commit `19cd7e9`.
- [ ] No standalone `use-draft-scratchpads` unit suite exists; the hook is covered transitively through the four suites above and `tsc`.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfSeJninfWCwoeZBD6FV2f)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784317930&installation_id=129946197&pr_number=994&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F994&signature=faae615de5473346c421611074a18a1805771ea53d8782f35e41978570d67926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->