### PR TITLE
fix(db): retry transactions on deadlock/serialization failures

### DIFF
--- a/packages/backend-common/src/db/index.ts
+++ b/packages/backend-common/src/db/index.ts
@@ -142,6 +142,17 @@ function isRecoverableConnectionError(err: unknown): boolean {
   return error.code === "57P05" || error.code === "ECONNRESET"
 }
 
+// 40P01 = deadlock_detected, 40001 = serialization_failure. Postgres aborts one
+// transaction in a lock cycle; the documented remedy is to roll back and retry
+// the whole transaction (INV-20). The connection itself stays healthy, so unlike
+// a connection error we reuse it rather than destroying it.
+function isRetryableTransactionError(err: unknown): boolean {
+  const error = err as Error & { code?: string }
+  return error.code === "40P01" || error.code === "40001"
+}
+
+const MAX_TRANSACTION_ATTEMPTS = 3
+
 /**
  * Check if a querier is a PoolClient (already has connection, possibly in transaction).
  * PoolClient has a `release` method that Pool doesn't have.
@@ -181,8 +192,7 @@ export async function withTransaction<T>(
 
   let lastError: unknown
 
-  // Retry once on recoverable connection errors
-  for (let attempt = 0; attempt < 2; attempt++) {
+  for (let attempt = 0; attempt < MAX_TRANSACTION_ATTEMPTS; attempt++) {
     const client = await db.connect()
     let released = false
     try {
@@ -196,8 +206,9 @@ export async function withTransaction<T>(
       })
 
       lastError = error
+      const isLastAttempt = attempt === MAX_TRANSACTION_ATTEMPTS - 1
 
-      // Only retry on recoverable connection errors, and only on first attempt
+      // Recoverable connection errors: retry once with a fresh connection.
       if (attempt === 0 && isRecoverableConnectionError(error)) {
         logger.debug(
           { err: error, attempt: attempt + 1 },
@@ -205,6 +216,20 @@ export async function withTransaction<T>(
         )
         released = true
         client.release(true) // Destroy the bad connection
+        continue
+      }
+
+      // Deadlock / serialization failures are transient under concurrency. Return
+      // the healthy connection to the pool and retry after a little jittered
+      // backoff so the contending transactions don't immediately re-collide.
+      if (!isLastAttempt && isRetryableTransactionError(error)) {
+        logger.debug(
+          { err: error, attempt: attempt + 1 },
+          "Transaction failed with retryable serialization error, retrying..."
+        )
+        released = true
+        client.release()
+        await new Promise((resolve) => setTimeout(resolve, 5 + Math.random() * 20))
         continue
       }
 

--- a/packages/backend-common/src/db/transaction-retry.test.ts
+++ b/packages/backend-common/src/db/transaction-retry.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import type { Pool, PoolClient } from "pg"
+import { withTransaction } from "./index"
+
+class FakeClient {
+  queries: string[] = []
+  released = false
+  releasedDestroyed = false
+
+  async query(text: string): Promise<unknown> {
+    this.queries.push(text)
+    return { rows: [], rowCount: 0 }
+  }
+
+  release(destroy?: boolean): void {
+    this.released = true
+    if (destroy) this.releasedDestroyed = true
+  }
+}
+
+class FakePool {
+  clients: FakeClient[] = []
+
+  async connect(): Promise<PoolClient> {
+    const client = new FakeClient()
+    this.clients.push(client)
+    return client as unknown as PoolClient
+  }
+}
+
+function pgError(code: string): Error & { code: string } {
+  const err = new Error(`pg error ${code}`) as Error & { code: string }
+  err.code = code
+  return err
+}
+
+describe("withTransaction retry", () => {
+  test("retries the whole transaction on a deadlock and succeeds", async () => {
+    const pool = new FakePool()
+    let calls = 0
+
+    const result = await withTransaction(pool as unknown as Pool, async () => {
+      calls++
+      if (calls === 1) throw pgError("40P01") // deadlock_detected on first attempt
+      return "ok"
+    })
+
+    expect(result).toBe("ok")
+    expect(calls).toBe(2)
+    // Two attempts => two connections; the first is rolled back and returned to
+    // the pool intact (not destroyed), since a deadlocked connection stays healthy.
+    expect(pool.clients).toHaveLength(2)
+    expect(pool.clients[0].queries).toEqual(["BEGIN", "ROLLBACK"])
+    expect(pool.clients[0].releasedDestroyed).toBe(false)
+    expect(pool.clients[1].queries).toEqual(["BEGIN", "COMMIT"])
+  })
+
+  test("gives up after exhausting attempts and rethrows the deadlock", async () => {
+    const pool = new FakePool()
+    let calls = 0
+
+    await expect(
+      withTransaction(pool as unknown as Pool, async () => {
+        calls++
+        throw pgError("40P01")
+      })
+    ).rejects.toMatchObject({ code: "40P01" })
+
+    expect(calls).toBe(3)
+  })
+
+  test("does not retry on a non-retryable error", async () => {
+    const pool = new FakePool()
+    let calls = 0
+
+    await expect(
+      withTransaction(pool as unknown as Pool, async () => {
+        calls++
+        throw pgError("23505") // unique_violation - a real failure, not transient
+      })
+    ).rejects.toMatchObject({ code: "23505" })
+
+    expect(calls).toBe(1)
+  })
+})


### PR DESCRIPTION
## Problem

The `backend-integration` CI job is flaky. In [run 27709230498](https://github.com/threahq/threa/actions/runs/27709230498/job/81965676073) the failure was `BoundaryExtractionService > processMessage > creates new conversation when extractor returns null conversationId`, reported at **1038.90ms** — roughly Postgres's 1s `deadlock_timeout`, where this test normally runs in single-digit ms. It's not a logic bug; the test was a deadlock victim.

The Postgres container log for that run shows it directly:

```
ERROR:  deadlock detected
Process 525: DELETE FROM streams WHERE id != 'stream_...'
Process 426: SELECT id FROM messages WHERE id = ANY($1::text[]) FOR UPDATE
```

The mechanics:

- Integration tests share one `threa_test` database, and `tests/setup.ts` starts the **full backend with all background workers** (boundary extraction, naming, embeddings, link previews) that keep draining queued jobs across test files.
- `boundary-extraction-service.test.ts`'s `afterEach` (`apps/backend/tests/integration/boundary-extraction-service.test.ts:93`) issues global `DELETE FROM streams` / `DELETE FROM messages`.
- A background boundary-extraction worker still draining a job from an earlier file runs `BoundaryExtractionService.processMessage`, whose persist transaction locks `streams` (`boundary-extraction-service.ts:253`) then `messages` (`:322`, `SELECT ... FOR UPDATE`) — the opposite lock order to the cleanup's deletes. That's the deadlock cycle.
- bun folds `afterEach` hook time into the preceding test's duration, so the first test in the file gets blamed for the ~1s stall.

`withTransaction` (`packages/backend-common/src/db/index.ts`) retried only on connection errors (`57P05`, `ECONNRESET`), so the rolled-back transaction surfaced the deadlock as a hard failure instead of retrying.

## Solution

Treat deadlock (`40P01`) and serialization (`40001`) failures as transient and retry the whole transaction — the remedy Postgres documents for these codes. Both the boundary worker's persist phase and the test's `afterEach` cleanup go through `withTransaction(pool, …)`, so fixing it there removes the flake at the source and hardens the production write path (concurrent workers deadlock for real, not just under the test harness) rather than papering over one test's cleanup.

### How it works

- New predicate `isRetryableTransactionError` matches SQLSTATE `40P01` (deadlock_detected) and `40001` (serialization_failure), sitting beside the existing `isRecoverableConnectionError`.
- The `withTransaction` pool path now loops up to `MAX_TRANSACTION_ATTEMPTS = 3`. On a retryable transaction error that isn't the last attempt, it `ROLLBACK`s (already done in the shared catch), returns the connection to the pool with a plain `client.release()` — **not** `release(true)`, because a deadlocked connection is still healthy — waits a jittered `5 + random*20` ms so the contenders don't immediately re-collide, and retries.
- Existing connection-error behavior is unchanged: it still only retries on `attempt === 0` and still destroys the connection with `release(true)`.
- The nested-transaction (savepoint / `PoolClient`) branch is untouched: on deadlock Postgres aborts the entire enclosing transaction, so a savepoint retry would be incorrect — it still rethrows.

### Key design decisions

**1. Retry in `withTransaction`, not per-call-site or in the test.** The deadlock is inherent to a shared DB with live background workers plus global-delete cleanups, a pattern repeated across many integration files. A retry at the transaction boundary covers every `withTransaction(pool, …)` caller — workers and cleanups alike — and matches INV-20 ("write paths must be race-safe"). A test-only retry would hide a real production concurrency gap.

**2. Reuse the connection, don't destroy it.** Connection errors destroy the socket (`release(true)`) because it's dead; a deadlock leaves the connection fully usable after `ROLLBACK`, so it goes back to the pool intact. The jittered backoff (a few ms) is enough to desynchronize two transactions racing for the same rows without adding meaningful latency.

**3. 3 attempts.** One original try plus two retries. Deadlocks resolve as soon as one side wins, so a couple of retries is ample; an unbounded loop would mask genuine lock-contention pathologies instead of surfacing them.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/backend-common/src/db/index.ts` | Add `isRetryableTransactionError` (`40P01`/`40001`) and `MAX_TRANSACTION_ATTEMPTS`; `withTransaction` retries deadlock/serialization failures with a jittered backoff, reusing the connection. Connection-error and savepoint paths unchanged. |

## New files

| File | Purpose |
| ---- | ------- |
| `packages/backend-common/src/db/transaction-retry.test.ts` | Unit-tests the retry behavior with a fake pool/client: retry-then-succeed on deadlock (connection returned to pool, not destroyed; `BEGIN/ROLLBACK` then `BEGIN/COMMIT`), give-up-after-3-attempts rethrows `40P01`, and no retry on a non-transient `23505`. |

## Out of scope (deliberate)

- **`withClient` is not changed.** It runs a single statement, not a transaction; a deadlock there is rarer and has no rollback-and-retry semantics to mirror. Left as-is to keep the change minimal.
- **The test's `afterEach` delete ordering is not reworked.** Aligning every cleanup's lock order with every writer path across all integration files is fragile and broad; the transaction-level retry subsumes it.

## Test plan

- [x] `bun test ./src/db/` in `packages/backend-common` — 12 pass (3 new in `transaction-retry.test.ts`)
- [x] `bun test` full `packages/backend-common` suite — 34 pass across 7 files
- [x] `bun run typecheck` (monorepo, 23 projects) — 0 errors / 0 warnings / 0 hints
- [x] Pre-commit hook: eslint across all apps + full monorepo typecheck + migration/dockerfile/OpenAPI checks — clean
- [ ] The CI deadlock itself isn't reproduced by an integration test — it needs the shared-DB + live-worker harness and is inherently timing-dependent; the retry path is covered by the unit test above instead

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0141kq4eknttzkbMTSzFUUk2)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784317952&installation_id=129946197&pr_number=995&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F995&signature=3dc5fe51bc7bded232af0c33180ce242ffbae08c1d57b3c83deeaca63b8f8713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->