### PR TITLE
fix(pi-remote): keep intermediate narration out of the posted reply

### DIFF
--- a/extensions/pi-remote/bun.lock
+++ b/extensions/pi-remote/bun.lock
@@ -1,0 +1,31 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@threa/pi-remote-extension",
+      "dependencies": {
+        "socket.io-client": "^4.8.1",
+      },
+    },
+  },
+  "packages": {
+    "@socket.io/component-emitter": ["@socket.io/component-emitter@3.1.2", "", {}, "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "engine.io-client": ["engine.io-client@6.6.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.21.0", "xmlhttprequest-ssl": "~2.1.1" } }, "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q=="],
+
+    "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
+
+    "socket.io-parser": ["socket.io-parser@4.2.6", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
+  }
+}

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -222,6 +222,26 @@ describe("Pi remote trace safety", () => {
     ).toBe("here is the answer")
   })
 
+  test("uses only the last assistant message as the reply, not the concatenated narration", () => {
+    // During an agentic turn the model emits one assistant message per step
+    // ("I'll rebase…", "Running the suite…", …). Only the final summary is the
+    // user-facing answer; the intermediate narration must stay in the trace,
+    // not get joined into the posted reply.
+    expect(
+      __testing.resolveFinalText(
+        {},
+        {
+          assistantTexts: [
+            "I'll rebase the PR worktree onto fresh origin/main.",
+            "Rebase completed cleanly and force-pushed with lease.",
+            "Done.\n- Rebased onto b328a444\n- CI is green",
+          ],
+          otherTexts: [],
+        }
+      )
+    ).toBe("Done.\n- Rebased onto b328a444\n- CI is green")
+  })
+
   test("falls back to captured non-assistant message text when assistant produced nothing", () => {
     expect(
       __testing.resolveFinalText(
@@ -238,6 +258,16 @@ describe("Pi remote trace safety", () => {
         { assistantTexts: [], otherTexts: [] }
       )
     ).toBe("usage limit hit")
+  })
+
+  test("textFromAgentMessages keeps only the last assistant message from the fallback scan", () => {
+    expect(
+      __testing.textFromAgentMessages([
+        { role: "assistant", content: "I'll rebase onto origin/main." },
+        { role: "assistant", content: "Rebase completed cleanly." },
+        { role: "assistant", content: "Done. CI is green." },
+      ])
+    ).toBe("Done. CI is green.")
   })
 
   test("ignores user-role echoes when picking the final response", () => {

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -2003,8 +2003,10 @@ function textFromAgentMessages(messages: unknown): string {
   if (captured.length === 0) return "Done."
   const assistant = captured
     .filter((item) => item.role === "assistant")
-    .map((item) => item.text)
-    .join("\n\n")
+    // Same rationale as `resolveFinalText`: the final assistant message is the
+    // answer; earlier ones are per-step narration that belongs in the trace,
+    // not concatenated into the reply.
+    .at(-1)?.text
     .trim()
   if (assistant) return assistant
   return (
@@ -2101,6 +2103,17 @@ function extractAgentEndError(event: unknown): string | undefined {
   return undefined
 }
 
+/**
+ * Pick the text to post as the Threa reply.
+ *
+ * During an agentic turn Pi emits one assistant message per step — the model
+ * narrates each action ("Rebasing…", "Running the suite…") before producing
+ * its final summary. Only that final assistant message is the user-facing
+ * answer; the intermediate narration is shown in the scratchpad trace as
+ * `thinking` steps (see the `message_end` handler) and must NOT be concatenated
+ * into the reply, or the posted message balloons into a transcript of every
+ * "I'm doing this" aside followed by the summary.
+ */
 function resolveFinalText(
   event: unknown,
   state: {
@@ -2109,7 +2122,7 @@ function resolveFinalText(
     providerError?: string
   }
 ): string {
-  if (state.assistantTexts.length > 0) return state.assistantTexts.join("\n\n")
+  if (state.assistantTexts.length > 0) return state.assistantTexts[state.assistantTexts.length - 1]
   if (state.providerError) return state.providerError
   const eventError = extractAgentEndError(event)
   if (eventError) return eventError
@@ -2515,7 +2528,10 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("agent_start", async (_event, ctx) => {
     if (config && isEnabled(ctx)) await heartbeatBusyIfStale("Thinking…", ctx).catch(() => undefined)
-    await traceHeartbeat("Thinking…", ctx, "thinking")
+    // Just a live status heartbeat — no `thinking` trace step. The model's
+    // real narration lands as `thinking` trace steps from `message_end` below,
+    // so a placeholder "Thinking…" row here would only add noise to the trace.
+    await traceHeartbeat("Thinking…", ctx)
   })
 
   pi.on("tool_call", async (event) => {
@@ -2550,8 +2566,18 @@ export default function (pi: ExtensionAPI): void {
     if (!pending) return
     const captured = captureMessageText(event.message)
     if (!captured) return
-    if (captured.role === "assistant") pendingAssistantTexts.push(captured.text)
-    else pendingNonAssistantTexts.push(captured)
+    if (captured.role === "assistant") {
+      pendingAssistantTexts.push(captured.text)
+      // Surface the model's running narration as a `thinking` trace step so
+      // the scratchpad trace shows what the agent reasoned between tool
+      // calls — not just a placeholder "Thinking…". The final assistant
+      // message is reused as the posted reply (see `resolveFinalText`); we
+      // skip re-recording it as `message_sent` at `agent_end` to avoid a
+      // duplicate trace entry.
+      await recordTraceStep("thinking", sanitizeTraceText(captured.text), "Thinking…")
+    } else {
+      pendingNonAssistantTexts.push(captured)
+    }
   })
 
   pi.on("after_provider_response", async (event) => {
@@ -2587,8 +2613,15 @@ export default function (pi: ExtensionAPI): void {
         otherTexts: pendingNonAssistantTexts,
         providerError: pendingProviderError,
       })
-      const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
-      await recordTraceStep("message_sent", `Final response:\n\n${sanitizeTraceText(traceFinalText)}`, "Sent response")
+      // When the reply is the model's final assistant message, it was already
+      // recorded as the last `thinking` trace step in `message_end` — recording
+      // a `message_sent` step too would duplicate it in the trace dialog. Only
+      // record `message_sent` for the fallback paths (provider error, event
+      // error, non-assistant text) where there is no preceding thinking step.
+      if (pendingAssistantTexts.length === 0) {
+        const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
+        await recordTraceStep("message_sent", `Final response:\n\n${sanitizeTraceText(traceFinalText)}`, "Sent response")
+      }
       await completePending(finalText, ctx)
       setRemoteStatus(ctx, "Threa remote: linked")
     } catch (error) {


### PR DESCRIPTION
## What

The Threa Pi remote posted the model's **entire turn narration** as the reply. On a multi-step agent turn Pi emits one assistant message per step (the model says "I'll rebase…", "Running the suite…", … before its final summary), and `resolveFinalText` joined every assistant message with `\n\n` — so the posted message ballooned into a full transcript of "I'm doing this" asides followed by the summary.

At the same time the scratchpad trace only ever recorded a placeholder `Thinking…` heartbeat, so the real reasoning was invisible.

## Change

In `extensions/pi-remote/src/threa-remote.ts`:

- **Reply = final assistant message only.** `resolveFinalText` (and the `textFromAgentMessages` last-resort fallback) now keep only the last assistant message — the actual answer. Earlier narration stays out of the reply.
- **Real thinking traces.** The `message_end` handler records each assistant message as a `thinking` trace step with its real content (sanitized, capped at 9.5K chars/step), so the trace shows what the agent reasoned between tool calls instead of a bare `Thinking…`. The backend already maps `thinking` frames to thinking blocks (`AgentStepTypes.THINKING`).
- **Less noise.** `agent_start` no longer writes a placeholder `thinking` trace row (the real narration now flows from `message_end`); the busy heartbeat still drives the live "Thinking…" indicator.
- **No duplicate trace entry.** `agent_end` skips the redundant `message_sent` trace step when the reply is the final assistant message (already recorded as the last `thinking` step); the fallback paths (provider error / event error / non-assistant text) still record it.

Deterministic rule rather than trying to classify "important vs. filler" narration: the final message is the reply, everything else is a thinking trace. Gives a clean reply **and** the full thinking trace.

## Before / after

Before, a multi-step turn posted something like:

```
I'll rebase the PR worktree onto fresh origin/main, then inspect PR #993's CI failures…
Using the repo's rebase skill: fetch origin/main, rebase the feature branch onto it…
origin/main advanced to b328a444…
Rebase completed cleanly and force-pushed with lease…
…(15 more narration paragraphs)…
Done.
- Rebased fix-remote-drafts onto fresh origin/main (b328a444).
- Force-pushed safely with --force-with-lease.
- …
Fresh CI is green: …
```

After, the same turn posts only:

```
Done.
- Rebased fix-remote-drafts onto fresh origin/main (b328a444).
- Force-pushed safely with --force-with-lease.
- …
Fresh CI is green: …
```

…and the scratchpad activity card shows the intermediate narration as thinking steps with real content.

## Tests

- `extensions/pi-remote`: 85 pass (added 2 cases — last-message selection in `resolveFinalText`, and the `textFromAgentMessages` fallback scan keeping only the last assistant message).
- Bundles cleanly with `bun build`.

## Risk / rollout

Pi-runtime-only change (the extension is a runtime-loaded package, not part of the backend/frontend typecheck). No DB migration, no API contract change — the `thinking` stepType was already a valid `AgentStepType`. Verified live by reloading the local Pi install.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784323153&installation_id=129946197&pr_number=996&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F996&signature=434d39deebf3a84b752cec98297247db17a3a951cf60662195020acb11410af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->