### PR TITLE
fix(frontend): avoid body :has for mobile composer hiding

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -8,8 +8,11 @@ import {
 } from "./contexts"
 import { router } from "./routes"
 import { TooltipProvider } from "./components/ui/tooltip"
+import { useInlineEditPresenceAttribute } from "./hooks/use-inline-edit-presence-attribute"
 
 export function App() {
+  useInlineEditPresenceAttribute()
+
   return (
     <AuthProvider>
       <AccountScopeProvider>

--- a/apps/frontend/src/components/timeline/message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/message-edit-form.tsx
@@ -45,10 +45,8 @@ export function MessageEditForm({
   const queryClient = useQueryClient()
   const messageService = useMessageService()
   const isMobile = useIsMobile()
-  // While this form is mounted, the `data-inline-edit` wrapper below is visible
-  // in the DOM; the mobile stream composer hides itself via a CSS `:has()` rule
-  // (see apps/frontend/src/index.css). That makes composer visibility purely
-  // DOM-derived — it cannot desynchronise from the actual edit-surface lifecycle.
+  // The `data-inline-edit` wrapper below drives the mobile composer visibility
+  // through the body-level inline-edit presence attribute.
   const [contentJson, setContentJson] = useState<JSONContent>(initialContentJson ?? EMPTY_DOC)
   const [isSaving, setIsSaving] = useState(false)
   const [docEditorOpen, setDocEditorOpen] = useState(false)

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -907,9 +907,8 @@ function SentMessageEvent({
   }, [])
 
   // Restore focus to the zone's editor after exiting inline edit mode.
-  // On mobile the stream composer is hidden purely via CSS while MessageEditForm
-  // keeps a `[data-inline-edit]` element mounted, so there is no extra flag to
-  // reset here.
+  // On mobile the body-level inline-edit presence attribute hides the stream
+  // composer, so there is no extra flag to reset here.
   const stopEditing = useCallback(() => {
     const zone = containerRef.current?.closest<HTMLElement>("[data-editor-zone]") ?? null
     setIsEditing(false)

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -781,12 +781,8 @@ function MessageInputComponent({
           portalTargetRef.current
         )}
 
-      {/* Inline composer — hidden while expanded. Mobile inline editing is handled
-          via CSS: `body:has([data-inline-edit])` matches whenever a MessageEditForm or
-          UnsentMessageEditForm is mounted (including vaul drawer portals, which live
-          under document.body), so the composer is hidden purely from DOM presence.
-          This replaces a previous ref-counted React state mechanism that was prone to
-          leaks across hydration races and virtualization cycles. */}
+      {/* Inline composer — hidden while expanded. Mobile inline editing hides the
+          composer via the body-level inline-edit presence attribute. */}
       <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
         <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={e2eEnabled} streamId={e2eRootStreamId} />
         {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}

--- a/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
+++ b/apps/frontend/src/components/timeline/unsent-message-edit-form.tsx
@@ -32,11 +32,8 @@ export function UnsentMessageEditForm({
 }: UnsentMessageEditFormProps) {
   const { saveEditedMessage, cancelEditing, deleteMessage } = usePendingMessages()
   const isMobile = useIsMobile()
-  // The mobile stream composer hides itself via a CSS `:has()` rule whenever a
-  // `[data-inline-edit]` element (rendered below) is present in the DOM — see
-  // apps/frontend/src/index.css. This keeps composer visibility purely
-  // DOM-derived instead of carrying a ref-counted React state that could leak
-  // across hydration races or virtualisation cycles.
+  // The `data-inline-edit` wrapper below drives the mobile composer visibility
+  // through the body-level inline-edit presence attribute.
 
   const [contentJson, setContentJson] = useState<JSONContent>(initialContentJson ?? EMPTY_DOC)
   const [isSaving, setIsSaving] = useState(false)

--- a/apps/frontend/src/hooks/use-inline-edit-presence-attribute.test.tsx
+++ b/apps/frontend/src/hooks/use-inline-edit-presence-attribute.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, waitFor } from "@testing-library/react"
+import { useInlineEditPresenceAttribute } from "./use-inline-edit-presence-attribute"
+
+function Harness() {
+  useInlineEditPresenceAttribute()
+  return null
+}
+
+describe("useInlineEditPresenceAttribute", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+    document.body.removeAttribute("data-inline-edit-active")
+  })
+
+  it("mirrors inline edit presence onto the body", async () => {
+    const { unmount } = render(<Harness />)
+
+    expect(document.body).not.toHaveAttribute("data-inline-edit-active")
+
+    const edit = document.createElement("div")
+    edit.setAttribute("data-inline-edit", "")
+    document.body.append(edit)
+
+    await waitFor(() => expect(document.body).toHaveAttribute("data-inline-edit-active"))
+
+    edit.remove()
+
+    await waitFor(() => expect(document.body).not.toHaveAttribute("data-inline-edit-active"))
+
+    unmount()
+    expect(document.body).not.toHaveAttribute("data-inline-edit-active")
+  })
+
+  it("tracks nested and attribute-created edit surfaces", async () => {
+    render(<Harness />)
+
+    const wrapper = document.createElement("div")
+    wrapper.innerHTML = `<section><div data-inline-edit></div></section>`
+    document.body.append(wrapper)
+
+    await waitFor(() => expect(document.body).toHaveAttribute("data-inline-edit-active"))
+
+    wrapper.innerHTML = ""
+
+    await waitFor(() => expect(document.body).not.toHaveAttribute("data-inline-edit-active"))
+
+    const late = document.createElement("div")
+    document.body.append(late)
+    late.setAttribute("data-inline-edit", "")
+
+    await waitFor(() => expect(document.body).toHaveAttribute("data-inline-edit-active"))
+
+    late.removeAttribute("data-inline-edit")
+
+    await waitFor(() => expect(document.body).not.toHaveAttribute("data-inline-edit-active"))
+  })
+
+  it("keeps the body active when an attribute-created edit replaces an existing edit in one batch", async () => {
+    render(<Harness />)
+
+    const existing = document.createElement("div")
+    existing.setAttribute("data-inline-edit", "")
+    document.body.append(existing)
+
+    await waitFor(() => expect(document.body).toHaveAttribute("data-inline-edit-active"))
+
+    const replacement = document.createElement("div")
+    document.body.append(replacement)
+    replacement.setAttribute("data-inline-edit", "")
+    existing.remove()
+
+    await waitFor(() => expect(document.body).toHaveAttribute("data-inline-edit-active"))
+  })
+})

--- a/apps/frontend/src/hooks/use-inline-edit-presence-attribute.ts
+++ b/apps/frontend/src/hooks/use-inline-edit-presence-attribute.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react"
+
+const INLINE_EDIT_ATTR = "data-inline-edit"
+const INLINE_EDIT_SELECTOR = `[${INLINE_EDIT_ATTR}]`
+const BODY_ACTIVE_ATTR = "data-inline-edit-active"
+
+function countInlineEditElements(node: Node): number {
+  if (!(node instanceof Element)) return 0
+  return (node.hasAttribute(INLINE_EDIT_ATTR) ? 1 : 0) + node.querySelectorAll(INLINE_EDIT_SELECTOR).length
+}
+
+function setBodyActive(active: boolean): void {
+  document.body.toggleAttribute(BODY_ACTIVE_ATTR, active)
+}
+
+export function useInlineEditPresenceAttribute(): void {
+  useEffect(() => {
+    let inlineEditCount = document.body.querySelectorAll(INLINE_EDIT_SELECTOR).length
+    setBodyActive(inlineEditCount > 0)
+
+    const observer = new MutationObserver((mutations) => {
+      let nextCount = inlineEditCount
+
+      if (mutations.some((mutation) => mutation.type === "attributes")) {
+        nextCount = document.body.querySelectorAll(INLINE_EDIT_SELECTOR).length
+      } else {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) nextCount += countInlineEditElements(node)
+          for (const node of mutation.removedNodes) nextCount -= countInlineEditElements(node)
+        }
+
+        if (nextCount < 0) {
+          nextCount = document.body.querySelectorAll(INLINE_EDIT_SELECTOR).length
+        }
+      }
+
+      if (nextCount === inlineEditCount) return
+      inlineEditCount = nextCount
+      setBodyActive(inlineEditCount > 0)
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: [INLINE_EDIT_ATTR],
+    })
+
+    return () => {
+      observer.disconnect()
+      document.body.removeAttribute(BODY_ACTIVE_ATTR)
+    }
+  }, [])
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -198,17 +198,9 @@
      Applied to main content rather than #root to avoid double-counting
      with visualViewport height adjustments. */
 
-  /* Hide the mobile stream composer while any inline edit surface is mounted.
-     `body:has()` descends into portals (vaul renders its Drawer under
-     document.body), so this matches whenever a MessageEditForm or
-     UnsentMessageEditForm is in the DOM — on mobile only, gated by the
-     breakpoint. Visibility is therefore DOM-derived (impossible to leak) and
-     automatically reverses the instant the edit surface unmounts, regardless
-     of how or why (cancel, save, virtualization, navigation, crash). Previous
-     approaches used a ref-counted React context that drifted across hydration
-     races and left the composer stuck hidden. */
+  /* Hide the mobile stream composer while an inline edit surface is mounted. */
   @media (max-width: 639px) {
-    body:has([data-inline-edit]) [data-message-composer-root] {
+    body[data-inline-edit-active] [data-message-composer-root] {
       display: none;
     }
   }

--- a/apps/frontend/src/index.css.test.ts
+++ b/apps/frontend/src/index.css.test.ts
@@ -19,13 +19,10 @@ describe("index.css accessibility font families", () => {
 })
 
 describe("index.css mobile inline-edit composer hiding", () => {
-  // This CSS rule replaces a ref-counted React context that was prone to leaks
-  // (PRs #299 and #306 patched specific paths, but leakage kept recurring on
-  // refresh). Keep it — deleting the rule re-opens the class of bugs where the
-  // mobile stream composer stays invisible after the edit surface is gone.
-  it("hides the mobile stream composer while any inline edit surface is in the DOM", () => {
+  it("hides the mobile stream composer while an inline edit surface is active", () => {
     expect(css).toMatch(
-      /@media\s*\(max-width:\s*639px\)\s*{[\s\S]*body:has\(\[data-inline-edit\]\)\s*\[data-message-composer-root\]\s*{[\s\S]*display:\s*none/
+      /@media\s*\(max-width:\s*639px\)\s*{[\s\S]*body\[data-inline-edit-active\]\s*\[data-message-composer-root\]\s*{[\s\S]*display:\s*none/
     )
+    expect(css).not.toContain("body:has(")
   })
 })


### PR DESCRIPTION
## Problem

Typing into the mobile message composer felt sluggish in very large chats. The likely hot path was the mobile inline-edit hiding rule in `apps/frontend/src/index.css`:

```css
body:has([data-inline-edit]) [data-message-composer-root]
```

Composer typing mutates ProseMirror's contenteditable DOM. On mobile, that selector makes the browser keep re-evaluating a document-wide `:has(...)` predicate against a large timeline DOM even though inline-edit visibility is unrelated to normal composer input.

## Solution

Move inline-edit presence tracking out of CSS selector matching and into one body attribute maintained by React.

### How it works

1. `useInlineEditPresenceAttribute` installs a single `MutationObserver` from `App`.
2. The hook mirrors whether any `[data-inline-edit]` node exists under `document.body` into `body[data-inline-edit-active]`.
3. Child-list mutations are counted incrementally; attribute-created/removed edit surfaces recompute from the DOM to avoid drift.
4. `index.css` now hides the mobile composer with `body[data-inline-edit-active] [data-message-composer-root]`, and the CSS test asserts the old `body:has(` selector stays gone.

### Key design decisions

**1. Preserve DOM-derived visibility, avoid `:has`.** The previous rule had the right lifecycle semantics for edit surfaces rendered through portals, but the selector itself is expensive in the mobile long-chat case. A body attribute keeps the same DOM-derived behavior without asking style recalculation to search the full document on each input mutation.

**2. Use a global hook instead of per-edit ref counting.** `App` owns one observer for all inline edit surfaces, so `MessageEditForm` and `UnsentMessageEditForm` keep their existing `[data-inline-edit]` markers. That avoids reintroducing the older leak-prone ref-counting shape.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-inline-edit-presence-attribute.ts` | Mirrors `[data-inline-edit]` presence to `body[data-inline-edit-active]`. |
| `apps/frontend/src/hooks/use-inline-edit-presence-attribute.test.tsx` | Covers add/remove, nested edit nodes, attribute-created edit nodes, and cleanup. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/App.tsx` | Installs the inline-edit presence hook once at app root. |
| `apps/frontend/src/index.css` | Replaces `body:has([data-inline-edit])` with `body[data-inline-edit-active]`. |
| `apps/frontend/src/index.css.test.ts` | Updates the selector assertion and guards against reintroducing `body:has(`. |
| `apps/frontend/src/components/timeline/message-input.tsx` | Updates the comment describing mobile composer hiding. |
| `apps/frontend/src/components/timeline/message-edit-form.tsx` | Updates the `[data-inline-edit]` lifecycle comment. |
| `apps/frontend/src/components/timeline/unsent-message-edit-form.tsx` | Updates the `[data-inline-edit]` lifecycle comment. |
| `apps/frontend/src/components/timeline/message-event.tsx` | Updates the stop-editing comment to reference the body attribute. |

## Out of scope (deliberate)

- Real-device performance profiling is not included here; this removes the clearest long-DOM/mobile selector hotspot and should still be validated on a massive chat on phone.
- No composer state or draft persistence behavior changed.

## Test plan

- [x] `bun run --cwd apps/frontend test -- use-inline-edit-presence-attribute index.css.test.ts` — 6 pass
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] Commit hook: `bun run lint`, monorepo `bun run typecheck`, `bun apps/backend/scripts/generate-api-docs.ts --check` — clean
- [ ] Real mobile long-chat profiling — not run in this environment

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784374918&installation_id=129946197&pr_number=1001&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1001&signature=f19052698ce40115687e8e5da47161d4a79c5c142b72414819b6ca27790ce532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
