### PR TITLE
test(frontend): stabilize search filter menu tests

### DIFF
--- a/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
+++ b/apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx
@@ -449,6 +449,9 @@ describe("SidebarSearchPanel Integration Tests", () => {
 
   describe("add-filter menu", () => {
     async function openFilterMenu(user: ReturnType<typeof userEvent.setup>) {
+      await waitFor(() => {
+        expect(screen.getByLabelText("Search messages")).toHaveFocus()
+      })
       await user.click(screen.getByRole("button", { name: /add search filter/i }))
       await waitFor(() => {
         expect(screen.getByText("From user")).toBeInTheDocument()


### PR DESCRIPTION
## Problem

`apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx` could fail before the Add filter popover opened. The helper clicked the trigger immediately after `renderPanel()`, while the search editor's `autoFocus` path was still settling; in failed runs the trigger stayed `aria-expanded="false"` and the test timed out waiting for `From user`.

## Solution

Make the shared `openFilterMenu()` helper wait for the search editor to hold focus before clicking the Add filter trigger. That keeps the tests aligned with the panel's startup state and removes the race between initial editor focus and the popover trigger click.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/search/sidebar-search-panel.integration.test.tsx` | Waits for `Search messages` to have focus before opening the filter menu in add-filter tests. |

## Out of scope

- No runtime search UI changes.
- No change to Radix Popover/Drawer behavior.

## Test plan

- [x] `bun run --cwd apps/frontend test -- sidebar-search-panel.integration.test.tsx` — 27 pass
- [x] Repeated focused suite before committing: 5 consecutive passes of `sidebar-search-panel.integration.test.tsx`
- [x] Commit hook — lint, monorepo typecheck, migration checks, Dockerfile workspace checks, OpenAPI check all passed

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784379513&installation_id=129946197&pr_number=1002&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1002&signature=967cd0dd092dab8bbd8b043d0915e914cd18a447c67142db418866ca3153b489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->