### PR TITLE
fix(timeline): make the mobile message action drawer scrollable for long messages

### DIFF
--- a/apps/frontend/src/components/timeline/message-action-drawer.tsx
+++ b/apps/frontend/src/components/timeline/message-action-drawer.tsx
@@ -184,7 +184,7 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
                     <span className="truncate font-normal text-muted-foreground/70">{authorStatus.text}</span>
                   )}
                 </div>
-                <div className="text-sm text-foreground/80 line-clamp-2 leading-snug pr-6">
+                <div className="text-sm text-foreground/80 line-clamp-2 leading-snug pr-6 max-h-[2.75rem] overflow-hidden">
                   <MarkdownContent content={context.contentMarkdown} />
                 </div>
                 {context.onQuoteReplyWithSnippet && (
@@ -218,7 +218,10 @@ export function MessageActionDrawer({ open, onOpenChange, context, authorName }:
               </div>
             )}
 
-            <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
+            <div
+              data-vaul-no-drag
+              className="flex-1 min-h-0 overflow-y-auto px-2 pb-[max(12px,env(safe-area-inset-bottom))]"
+            >
               {groupedActions.map((item) => (
                 <DrawerActionItem
                   key={item.kind === "single" ? item.action.id : item.members[0].id}


### PR DESCRIPTION
## Problem

On mobile, opening the message context menu (`MessageActionDrawer`) on a long message made the lower actions unreachable — you couldn't scroll to "Copy link to message" or "Delete".

The non-expanded drawer stacks three things as plain flex children of `DrawerContent` (which is `flex flex-col` capped at `max-h-[85dvh]`): the message preview, the emoji quick-bar, and the action list. None of them was a scroll region. The preview renders full `MarkdownContent`, which emits block-level elements (`<p>`, `<h1>`, `<pre>`, `<ul>`); `line-clamp-2` only reliably clamps inline text, so a long handover message expanded the preview to its natural height. That pushed the action list past the 85dvh cap, where it was clipped with no way to scroll to it.

## Solution

Bound the preview so block markdown can't dominate, and turn the action list into a real scroll region — reusing the exact pattern the drawer's own expanded quote view already uses (`data-vaul-no-drag flex-1 min-h-0 overflow-y-auto`).

- **Preview cap** (`apps/frontend/src/components/timeline/message-action-drawer.tsx:187`): added `max-h-[2.75rem] overflow-hidden` alongside the existing `line-clamp-2`, so block-level markdown is hard-capped at ~2 lines instead of expanding freely.
- **Scrollable action list** (`message-action-drawer.tsx:221`): wrapped the action list in `flex-1 min-h-0 overflow-y-auto` with `data-vaul-no-drag`. Because `DrawerContent` is a height-capped flex column, the list now absorbs the overflow and scrolls when the full set of actions exceeds the cap; the preview and emoji bar keep their natural height (no `min-h-0`, so they don't shrink). The `data-vaul-no-drag` stops vaul from interpreting the scroll gesture as drag-to-dismiss — same reasoning as the expanded view.

In the common short case the drawer is still auto-height, so `flex-1` distributes no extra space and nothing visually changes.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-action-drawer.tsx` | Cap preview height (`max-h-[2.75rem] overflow-hidden`); make the action list a `flex-1 min-h-0 overflow-y-auto` scroll region with `data-vaul-no-drag` |

## Test plan

- [x] `bun run --filter @threa/frontend test src/components/timeline/message-context-menu.test.tsx` — 7 pass (shared action model)
- [x] `bun run --filter @threa/frontend typecheck` — exit 0
- [x] Pre-commit hook: full monorepo lint + typecheck clean
- [ ] No automated test for the scroll behavior itself — it's layout-dependent and jsdom has no layout engine, so the fix can't be exercised in a unit test. Worth a manual check on a real device with a long message.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FixH8CQwV1dc11uTsHKbqR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784379573&installation_id=129946197&pr_number=1003&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1003&signature=3cf10ac72a48b4fe07532d8f3f9c51d86f1129f7ba4c2b94aa64ecf379c50f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->