### PR TITLE
fix(backend): keep pi remote presence live after socket blips

### DIFF
--- a/apps/backend/src/features/bot-runtimes/bot-socket-registry.test.ts
+++ b/apps/backend/src/features/bot-runtimes/bot-socket-registry.test.ts
@@ -74,7 +74,9 @@ describe("BotSocketRegistry", () => {
     expect(onInstanceOffline).not.toHaveBeenCalled()
     await new Promise((r) => setTimeout(r, 60))
     expect(onInstanceOffline).toHaveBeenCalledTimes(1)
-    expect(onInstanceOffline).toHaveBeenCalledWith(key)
+    const calls = onInstanceOffline.mock.calls as unknown as Array<[typeof key, Date]>
+    expect(calls[0]?.[0]).toEqual(key)
+    expect(calls[0]?.[1]).toBeInstanceOf(Date)
     reg.dispose()
   })
 

--- a/apps/backend/src/features/bot-runtimes/bot-socket-registry.ts
+++ b/apps/backend/src/features/bot-runtimes/bot-socket-registry.ts
@@ -23,7 +23,7 @@ export interface BotSocketRegistryOptions {
    * (the row must persist so `target_instance_id`-pinned invocations remain
    * routable on reconnect — see the plan doc for the rationale).
    */
-  onInstanceOffline?: (key: BotSocketKey) => void | Promise<void>
+  onInstanceOffline?: (key: BotSocketKey, disconnectedAt: Date) => void | Promise<void>
 }
 
 /**
@@ -37,7 +37,7 @@ export class BotSocketRegistry {
   private byInstance = new Map<string, Set<Socket>>()
   private graceTimers = new Map<string, ReturnType<typeof setTimeout>>()
   private graceMs: number
-  private onInstanceOffline?: (key: BotSocketKey) => void | Promise<void>
+  private onInstanceOffline?: (key: BotSocketKey, disconnectedAt: Date) => void | Promise<void>
 
   constructor(options: BotSocketRegistryOptions = {}) {
     this.graceMs = options.graceMs ?? 30_000
@@ -80,13 +80,14 @@ export class BotSocketRegistry {
     const k = this.keyOf(key)
     const existing = this.graceTimers.get(k)
     if (existing) clearTimeout(existing)
+    const disconnectedAt = new Date()
     const timer = setTimeout(() => {
       this.graceTimers.delete(k)
       // Double-check inside the timer fire: a reconnect race could have put
       // sockets back without us seeing it (e.g. if graceMs is 0 in tests).
       if (this.byInstance.has(k)) return
       Promise.resolve()
-        .then(() => this.onInstanceOffline?.(key))
+        .then(() => this.onInstanceOffline?.(key, disconnectedAt))
         .catch((err: unknown) => {
           logger.error({ err, ...key }, "bot-socket-registry: onInstanceOffline callback failed")
         })

--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -141,6 +141,26 @@ describe("BotRuntimeInstanceRepository.upsertPresence", () => {
   })
 })
 
+describe("BotRuntimeInstanceRepository.markOffline", () => {
+  afterEach(() => mock.restore())
+
+  it("does not overwrite a newer heartbeat after the socket disconnect", async () => {
+    const captured: Captured = { text: null, values: null }
+    const disconnectedAt = new Date("2026-06-18T12:00:00.000Z")
+    const db = createQuerier(captured, [])
+
+    await BotRuntimeInstanceRepository.markOffline(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      instanceId: "inst_42",
+      disconnectedAt,
+    })
+
+    expect(captured.text).toContain("last_seen_at <=")
+    expect(captured.values).toContain(disconnectedAt)
+  })
+})
+
 describe("BotRuntimeInstanceRepository.findLiveWithKeyForBot", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -437,17 +437,21 @@ export const BotRuntimeInstanceRepository = {
   },
 
   /**
-   * Mark an instance offline after its grace window expires with no
-   * reconnect. Does NOT delete the row — `BotInvocationRepository.claimOne`
-   * has an `EXISTS … FROM bot_runtime_instances` check for
-   * `target_instance_id`-pinned invocations and would refuse to hand them
-   * back when the instance reconnects later if we deleted the row.
+   * Mark an instance offline after its socket grace window expires with no
+   * reconnect and no newer heartbeat. Does NOT delete the row —
+   * `BotInvocationRepository.claimOne` has an `EXISTS … FROM
+   * bot_runtime_instances` check for `target_instance_id`-pinned invocations
+   * and would refuse to hand them back when the instance reconnects later if
+   * we deleted the row.
    */
-  async markOffline(db: Querier, params: { workspaceId: string; botId: string; instanceId: string }): Promise<void> {
+  async markOffline(
+    db: Querier,
+    params: { workspaceId: string; botId: string; instanceId: string; disconnectedAt: Date }
+  ): Promise<void> {
     await db.query(
       sql`UPDATE bot_runtime_instances
         SET status = 'offline', accepting_invocations = FALSE, last_seen_at = NOW(), updated_at = NOW()
-        WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND instance_id = ${params.instanceId}`
+        WHERE workspace_id = ${params.workspaceId} AND bot_id = ${params.botId} AND instance_id = ${params.instanceId} AND last_seen_at <= ${params.disconnectedAt}`
     )
   },
 }

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -668,9 +668,9 @@ export async function startServer(): Promise<ServerInstance> {
     // row offline so `target_instance_id`-pinned invocations stop being
     // routed to a dead runtime.
     graceMs: 30_000,
-    onInstanceOffline: async (key) => {
+    onInstanceOffline: async (key, disconnectedAt) => {
       try {
-        await BotRuntimeInstanceRepository.markOffline(pools.main, key)
+        await BotRuntimeInstanceRepository.markOffline(pools.main, { ...key, disconnectedAt })
       } catch (err) {
         logger.error({ err, ...key }, "markOffline failed after grace window")
       }


### PR DESCRIPTION
## Problem

Pi Remote can still be alive over HTTP polling/heartbeats while its `/bot` WebSocket has temporarily disconnected. The backend socket registry starts a 30s offline timer when the last socket for `(workspaceId, botId, instanceId)` leaves. Before this change, that timer unconditionally called `BotRuntimeInstanceRepository.markOffline()`, so a newer HTTP heartbeat from the same runtime could be overwritten by the stale socket timer. The scratchpad presence pill could then briefly show "not connected" even though Pi was still running and sending heartbeats.

## Solution

Make socket-driven offline marking conditional on the disconnect that scheduled it.

### How it works

- `BotSocketRegistry.scheduleOffline()` captures `disconnectedAt` when the last socket leaves.
- The `onInstanceOffline` callback now receives `(key, disconnectedAt)`.
- `BotRuntimeInstanceRepository.markOffline()` only updates the row when `last_seen_at <= disconnectedAt`.
- A heartbeat that lands after the socket disconnect advances `last_seen_at`, so the old offline timer no-ops instead of clobbering the live presence row.

### Key design decision

**Keep the socket grace timer, but make it stale-aware.** The timer is still useful for genuinely dead runtimes and `target_instance_id` routing. The bug was not the timer itself; it was treating a socket disconnect as authoritative even after a newer heartbeat proved the runtime was alive.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/bot-runtimes/bot-socket-registry.ts` | Passes the socket disconnect timestamp to the offline callback. |
| `apps/backend/src/features/bot-runtimes/repository.ts` | Guards `markOffline()` with `last_seen_at <= disconnectedAt`. |
| `apps/backend/src/server.ts` | Forwards the disconnect timestamp into `markOffline()`. |
| `apps/backend/src/features/bot-runtimes/bot-socket-registry.test.ts` | Verifies the offline callback receives the disconnect timestamp. |
| `apps/backend/src/features/bot-runtimes/repository.test.ts` | Verifies the offline SQL is guarded by the disconnect timestamp. |

## Out of scope

- No changes to the Pi extension client.
- No changes to the frontend presence pill rendering.
- No schema changes.

## Test plan

- [x] `bun test apps/backend/src/features/bot-runtimes/bot-socket-registry.test.ts apps/backend/src/features/bot-runtimes/repository.test.ts` — 20 pass
- [x] `bun run --cwd apps/backend typecheck` — clean
- [x] Commit hook — lint, monorepo typecheck, migration checks, Dockerfile workspace checks, OpenAPI check all passed

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784380795&installation_id=129946197&pr_number=1004&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1004&signature=67c37b8558607809c91f8a1e1b84ee8a88a3accc343aadcc9f1abbc3b9417e16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->