### PR TITLE
fix(drafts): suppress sent draft resurrection races

### DIFF
--- a/apps/backend/src/features/drafts/handlers.ts
+++ b/apps/backend/src/features/drafts/handlers.ts
@@ -39,6 +39,7 @@ const upsertSchema = z
 
 const resolveSchema = z.object({
   expectedVersion: z.number().int().min(1),
+  supersededWriteIds: z.array(z.string().min(1)).optional(),
 })
 
 interface Dependencies {
@@ -106,6 +107,7 @@ export function createDraftsHandlers({ draftsService }: Dependencies) {
         userId,
         id,
         expectedVersion: parsed.data.expectedVersion,
+        supersededWriteIds: parsed.data.supersededWriteIds ?? [],
       })
       res.json(result)
     },

--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -167,7 +167,7 @@ describe("DraftsRepository.casUpdate", () => {
 describe("DraftsRepository.softDeleteCas", () => {
   afterEach(() => mock.restore())
 
-  it("tombstones only when the version matches so a drifted copy survives", async () => {
+  it("tombstones on a matching version or superseded write id so unrelated drift survives", async () => {
     const captured: Captured = { text: null, values: null }
     const db = createQuerier(captured)
 
@@ -176,12 +176,15 @@ describe("DraftsRepository.softDeleteCas", () => {
       userId: "usr_1",
       id: "draft_01",
       expectedVersion: 2,
+      supersededWriteIds: ["write_sent"],
     })
 
     expect(captured.text).toContain("deleted_at = NOW()")
     expect(captured.text).toContain("deleted_at IS NULL")
     expect(captured.text).toContain("version =")
+    expect(captured.text).toContain("last_client_write_id = ANY")
     expect(captured.values).toContain(2)
+    expect(captured.values).toContainEqual(["write_sent"])
   })
 })
 

--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -191,15 +191,20 @@ describe("DraftsRepository.softDeleteCas", () => {
 describe("DraftsRepository.softDelete", () => {
   afterEach(() => mock.restore())
 
-  it("tombstones unconditionally (explicit discard) without a version guard", async () => {
+  it("plants a negative tombstone so a delete that wins the race against first insert still sticks", async () => {
     const captured: Captured = { text: null, values: null }
     const db = createQuerier(captured)
 
     await DraftsRepository.softDelete(db, "ws_1", "usr_1", "draft_01")
 
+    expect(captured.text).toContain("INSERT INTO drafts")
+    expect(captured.text).toContain("ON CONFLICT (id) DO UPDATE")
     expect(captured.text).toContain("deleted_at = NOW()")
     expect(captured.text).toContain("deleted_at IS NULL")
     expect(captured.text).not.toContain("AND version =")
+    expect(captured.values).toContain("draft_01")
+    expect(captured.values).toContain("ws_1")
+    expect(captured.values).toContain("usr_1")
   })
 })
 

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -292,20 +292,24 @@ export const DraftsRepository = {
   },
 
   /**
-   * Unconditional soft-delete for explicit discard (no CAS) — the user threw
-   * the draft away, so drift doesn't matter. Idempotent on an already-deleted
-   * row. Returns the row when it tombstoned, `null` when it was missing.
+   * Unconditional soft-delete for explicit discard and resolve-on-send of a
+   * never-confirmed draft (no CAS). Plants a negative tombstone when the id has
+   * not been seen yet, so a delete that reaches the server before the draft's
+   * first insert still wins the race. Returns the row when this call tombstoned
+   * it (live row transitioned, or negative marker inserted) and `null` when the
+   * row was already tombstoned.
    */
   async softDelete(db: Querier, workspaceId: string, userId: string, id: string): Promise<Draft | null> {
     const result = await db.query<DraftRow>(sql`
-      UPDATE drafts SET
+      INSERT INTO drafts (id, workspace_id, user_id, scope, client_updated_at, deleted_at)
+      VALUES (${id}, ${workspaceId}, ${userId}, '', NOW(), NOW())
+      ON CONFLICT (id) DO UPDATE SET
         deleted_at = NOW(),
         updated_at = NOW(),
-        version = version + 1
-      WHERE id = ${id}
-        AND workspace_id = ${workspaceId}
-        AND user_id = ${userId}
-        AND deleted_at IS NULL
+        version = drafts.version + 1
+      WHERE drafts.workspace_id = ${workspaceId}
+        AND drafts.user_id = ${userId}
+        AND drafts.deleted_at IS NULL
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -223,15 +223,23 @@ export const DraftsRepository = {
   },
 
   /**
-   * CAS soft-delete for resolve-on-send and explicit discard. Tombstones the
-   * row only when `version` still matches, so a copy that drifted since the
-   * send started survives as a stash entry instead of being collaterally
-   * destroyed. Returns the tombstoned row on success, `null` on version drift.
+   * CAS soft-delete for resolve-on-send. Tombstones the row when `version` still
+   * matches, or when its last write id is one this device already superseded by
+   * sending the message. Unrelated drift survives as a stash entry instead of
+   * being collaterally destroyed. Returns the tombstoned row on success, `null`
+   * on version drift.
    */
   async softDeleteCas(
     db: Querier,
-    params: { workspaceId: string; userId: string; id: string; expectedVersion: number }
+    params: {
+      workspaceId: string
+      userId: string
+      id: string
+      expectedVersion: number
+      supersededWriteIds?: string[]
+    }
   ): Promise<Draft | null> {
+    const supersededWriteIds = params.supersededWriteIds ?? []
     const result = await db.query<DraftRow>(sql`
       UPDATE drafts SET
         deleted_at = NOW(),
@@ -241,7 +249,8 @@ export const DraftsRepository = {
         AND workspace_id = ${params.workspaceId}
         AND user_id = ${params.userId}
         AND deleted_at IS NULL
-        AND version = ${params.expectedVersion}
+        AND (version = ${params.expectedVersion}
+          OR (${supersededWriteIds.length > 0} AND last_client_write_id = ANY(${supersededWriteIds})))
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -302,6 +302,7 @@ export const DraftsRepository = {
   async softDelete(db: Querier, workspaceId: string, userId: string, id: string): Promise<Draft | null> {
     const result = await db.query<DraftRow>(sql`
       INSERT INTO drafts (id, workspace_id, user_id, scope, client_updated_at, deleted_at)
+      -- Empty scope is a tombstone-only sentinel; real draft scopes are never blank.
       VALUES (${id}, ${workspaceId}, ${userId}, '', NOW(), NOW())
       ON CONFLICT (id) DO UPDATE SET
         deleted_at = NOW(),

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -128,6 +128,25 @@ describe("DraftsService.upsert", () => {
     expect(result.draft.id).toBe("draft_split")
   })
 
+  it("drops a fresh insert landing on a tombstone without splitting", async () => {
+    const service = setupService()
+    const insertIfAbsent = spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 1, lastClientWriteId: null, deletedAt: NOW })
+    )
+    const casUpdate = spyOn(DraftsRepository, "casUpdate")
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_late", expectedVersion: 0 })
+
+    expect(result.split).toBe(false)
+    expect(result.originalId).toBeUndefined()
+    expect(result.draft.id).toBe(DRAFT_ID)
+    expect(insertIfAbsent).toHaveBeenCalledTimes(1)
+    expect(casUpdate).not.toHaveBeenCalled()
+    expect(outbox).not.toHaveBeenCalled()
+  })
+
   it("does NOT return a tombstoned row as live on a writeId match — splits instead", async () => {
     // A resolve raced in after the original write landed: the writeId still
     // matches, but the row is soft-deleted. Branch (b) must not hand it back as
@@ -193,6 +212,34 @@ describe("DraftsService.resolve", () => {
     })
 
     expect(result.resolved).toBe(false)
+    expect(outbox).not.toHaveBeenCalled()
+  })
+})
+
+describe("DraftsService.delete", () => {
+  afterEach(() => mock.restore())
+
+  it("publishes draft:deleted when softDelete tombstones or plants a negative marker", async () => {
+    const service = setupService()
+    spyOn(DraftsRepository, "softDelete").mockResolvedValue(fakeDraft({ deletedAt: NOW }))
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.delete({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: DRAFT_ID })
+
+    expect(outbox).toHaveBeenCalledWith(
+      expect.anything(),
+      "draft:deleted",
+      expect.objectContaining({ targetUserId: USER_ID, draftId: DRAFT_ID })
+    )
+  })
+
+  it("does not publish when the row was already tombstoned", async () => {
+    const service = setupService()
+    spyOn(DraftsRepository, "softDelete").mockResolvedValue(null)
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.delete({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: DRAFT_ID })
+
     expect(outbox).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -157,7 +157,7 @@ describe("DraftsService.resolve", () => {
 
   it("soft-deletes on a version match and publishes draft:deleted", async () => {
     const service = setupService()
-    spyOn(DraftsRepository, "softDeleteCas").mockResolvedValue(fakeDraft({ deletedAt: NOW }))
+    const softDelete = spyOn(DraftsRepository, "softDeleteCas").mockResolvedValue(fakeDraft({ deletedAt: NOW }))
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const result = await service.resolve({
@@ -165,9 +165,14 @@ describe("DraftsService.resolve", () => {
       userId: USER_ID,
       id: DRAFT_ID,
       expectedVersion: 1,
+      supersededWriteIds: ["write_sent"],
     })
 
     expect(result.resolved).toBe(true)
+    expect(softDelete).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ expectedVersion: 1, supersededWriteIds: ["write_sent"] })
+    )
     expect(outbox).toHaveBeenCalledWith(
       expect.anything(),
       "draft:deleted",

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -113,6 +113,14 @@ export class DraftsService {
       // The id already exists — lock it and decide update vs split.
       const existing = await DraftsRepository.findByIdForUpdate(client, params.workspaceId, params.userId, params.id)
 
+      // (a2) A never-confirmed draft's first push can land after resolve/discard
+      // planted a negative tombstone for the id. The content was already sent or
+      // thrown away, so drop the late insert rather than splitting it into a live
+      // zombie. Confirmed drift (expectedVersion > 0) still splits below.
+      if (existing && existing.deletedAt && params.expectedVersion === 0) {
+        return { draft: toDraftView(existing), split: false }
+      }
+
       // (b) Lost-ack retry of a write we already accepted — return as-is. Gated
       // on a LIVE row: if the draft was resolved (tombstoned) after this write
       // landed, the writeId still matches but the row is gone, so we must not

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -40,6 +40,7 @@ export interface ResolveDraftParams {
   userId: string
   id: string
   expectedVersion: number
+  supersededWriteIds?: string[]
 }
 
 export interface DeleteDraftParams {
@@ -161,10 +162,10 @@ export class DraftsService {
 
   /**
    * Clear a draft on successful send (resolve-on-send). CAS-guarded by
-   * `expectedVersion` so a copy that drifted since the send started survives as
-   * a stash entry instead of being collaterally deleted. On a match, soft-delete
-   * and emit `draft:deleted`; on drift, leave the row and report `resolved:
-   * false`.
+   * `expectedVersion`, with this device's superseded write ids as a lost-ack
+   * escape hatch, so unrelated drift survives as a stash entry instead of being
+   * collaterally deleted. On a match, soft-delete and emit `draft:deleted`; on
+   * drift, leave the row and report `resolved: false`.
    */
   async resolve(params: ResolveDraftParams): Promise<{ resolved: boolean }> {
     return withTransaction(this.pool, async (client) => {
@@ -173,6 +174,7 @@ export class DraftsService {
         userId: params.userId,
         id: params.id,
         expectedVersion: params.expectedVersion,
+        supersededWriteIds: params.supersededWriteIds ?? [],
       })
       if (!deleted) {
         // Either drifted (version moved on) or already gone — keep the row.

--- a/apps/backend/src/features/drafts/view.ts
+++ b/apps/backend/src/features/drafts/view.ts
@@ -3,9 +3,10 @@ import type { Draft } from "./repository"
 
 /**
  * Wire shape for a draft row. `version` is the optimistic-lock value the client
- * sends back as `expectedVersion` on the next push. The internal-only fields
- * (`lastClientWriteId`, `deletedAt`) never cross the boundary — idempotency and
- * tombstones are server bookkeeping. Drafts are rendered directly from
+ * sends back as `expectedVersion` on the next push. Tombstones remain server
+ * bookkeeping; `lastClientWriteId` crosses the boundary only so a device that
+ * just sent the draft can suppress/delete its own lost-ack echoes without
+ * mistaking them for another device's drift. Drafts are rendered directly from
  * `contentJson` (or decrypted `ciphertext` for E2E), so the row IS the draft.
  */
 export function toDraftView(row: Draft): DraftView {
@@ -25,6 +26,7 @@ export function toDraftView(row: Draft): DraftView {
     e2eVersion: row.e2eVersion,
     version: row.version,
     clientUpdatedAt: row.clientUpdatedAt.toISOString(),
+    lastClientWriteId: row.lastClientWriteId,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   }

--- a/apps/frontend/src/api/drafts.ts
+++ b/apps/frontend/src/api/drafts.ts
@@ -35,10 +35,10 @@ export const draftsApi = {
   },
 
   /**
-   * Resolve-on-send: CAS soft-delete guarded by `expectedVersion`. The server
-   * removes the draft only if its version still matches, so a copy that drifted
-   * since the send started survives as a stash entry instead of being
-   * collaterally destroyed (`response.resolved` is false in that case).
+   * Resolve-on-send: CAS soft-delete guarded by `expectedVersion` plus this
+   * device's superseded write ids. Unrelated drift survives as a stash entry
+   * instead of being collaterally destroyed (`response.resolved` is false in
+   * that case).
    */
   async resolve(workspaceId: string, id: string, input: ResolveDraftInput): Promise<ResolveDraftResponse> {
     return api.post<ResolveDraftResponse>(`/api/workspaces/${workspaceId}/drafts/${id}/resolve`, input)

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -451,6 +451,43 @@ describe("useDraftMessage", () => {
       expect(scoped).toHaveLength(0)
     })
 
+    it("a stale debounced save that already read the loaded row does NOT restash it after send", async () => {
+      await db.drafts.put({
+        id: "draft_confirmed",
+        workspaceId,
+        scope: draftKey,
+        contentJson: makeDoc("sent message"),
+        attachments: [],
+        baseVersion: 2,
+        clientUpdatedAt: Date.now(),
+      })
+      await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_confirmed" })
+
+      const observedResolveSeq = getScopeResolveSeq(draftKey)
+      const realGet = db.drafts.get.bind(db.drafts)
+      let injectedResolve = false
+      vi.spyOn(db.drafts, "get").mockImplementation((async (key: string) => {
+        const row = await realGet(key)
+        if (key === "draft_confirmed" && !injectedResolve) {
+          injectedResolve = true
+          await resolveLoadedDraft(workspaceId, draftKey)
+        }
+        return row
+      }) as never)
+
+      await upsertLoadedDraft(
+        workspaceId,
+        draftKey,
+        { contentJson: makeDoc("sent message"), attachments: [] },
+        undefined,
+        { observedResolveSeq }
+      )
+
+      expect(await db.composerLoaded.get(draftKey)).toBeUndefined()
+      const scoped = (await db.drafts.toArray()).filter((d) => d.scope === draftKey)
+      expect(scoped).toHaveLength(0)
+    })
+
     it("allows a fresh save started AFTER the send to create a new draft", async () => {
       await db.drafts.put({
         id: "draft_confirmed",

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -37,6 +37,10 @@ export function getDraftMessageKey(
 
 const DEBOUNCE_MS = import.meta.env.VITE_DRAFT_DEBOUNCE_MS ? Number(import.meta.env.VITE_DRAFT_DEBOUNCE_MS) : 500
 
+function isStaleObservedResolve(scope: string, observedResolveSeq: number | undefined): boolean {
+  return observedResolveSeq !== undefined && getScopeResolveSeq(scope) > observedResolveSeq
+}
+
 /** Resolve the draft id currently checked out into the composer for a scope. */
 async function getLoadedDraftId(scope: string): Promise<string | null> {
   const row = await db.composerLoaded.get(scope)
@@ -150,8 +154,14 @@ export async function upsertLoadedDraft(
     }
   }
 
+  let persisted = false
   if (existing) {
-    await db.drafts.put(row)
+    await db.transaction("rw", db.drafts, async () => {
+      if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return
+      await db.drafts.put(row)
+      persisted = true
+    })
+    if (!persisted || isStaleObservedResolve(scope, opts?.observedResolveSeq)) return row
     upsertDraftInCache(workspaceId, row)
   } else {
     // No loaded draft for this scope → this save would CREATE one and check it
@@ -163,17 +173,16 @@ export async function upsertLoadedDraft(
     // by the time the cleared pointer routes us here the bumped seq is visible.
     // Only the debounced save passes `observedResolveSeq`; every other create
     // path (share-target, attachments, fresh first keystroke) is unaffected.
-    if (opts?.observedResolveSeq !== undefined && getScopeResolveSeq(scope) > opts.observedResolveSeq) {
-      return row
-    }
-    // A brand-new loaded draft: write the row and its loaded pointer together so
-    // a live reader never observes the draft before the pointer lands — otherwise
-    // the just-created draft flashes into its own stash list for a tick (it isn't
-    // filtered out as "loaded" until the pointer exists).
+    // Check inside the write transaction too: a stale save may have already read
+    // the old loaded row before resolve-on-send deleted it, and writing that row
+    // afterward would stash an identical copy of the sent message.
     await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+      if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return
       await db.drafts.put(row)
       await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+      persisted = true
     })
+    if (!persisted || isStaleObservedResolve(scope, opts?.observedResolveSeq)) return row
     upsertLoadedDraftInCache(workspaceId, row, scope)
   }
 

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -337,15 +337,18 @@ describe("enqueueDraftUpsert / enqueueDraftDelete", () => {
     expect(dels.filter((o) => o.payload.draftId === "draft_x")).toHaveLength(1)
   })
 
-  it("enqueueDraftResolve drops a queued push and adds a CAS resolve carrying expectedVersion", async () => {
+  it("enqueueDraftResolve keeps a queued push as the in-flight echo marker", async () => {
     await enqueueDraftUpsert(workspaceId, "draft_x")
+    const upserts = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    const writeId = upserts.find((o) => o.payload.draftId === "draft_x")?.payload.writeId
     await enqueueDraftResolve(workspaceId, "draft_x", 3)
 
-    expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
+    expect(await hasPendingDraftUpsert("draft_x")).toBe(true)
     const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
     const forDraft = resolves.filter((o) => o.payload.draftId === "draft_x")
     expect(forDraft).toHaveLength(1)
     expect(forDraft[0]?.payload.expectedVersion).toBe(3)
+    expect(forDraft[0]?.payload.supersededWriteIds).toEqual([writeId])
   })
 })
 
@@ -483,6 +486,22 @@ describe("executeDraftUpsert", () => {
     expect(dels.filter((o) => o.payload.draftId === "draft_x")).toHaveLength(1)
   })
 
+  it("CAS-resolves the ghost server row when the draft was sent mid-push", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 2 }))
+    await enqueueDraftResolve(workspaceId, "draft_x", 2)
+    const upsert = vi.fn(async (): Promise<UpsertDraftResponse> => {
+      await db.drafts.delete("draft_x")
+      return { draft: wireDraft({ id: "draft_x", version: 3 }), split: false }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    expect(await db.drafts.get("draft_x")).toBeUndefined()
+    expect(await db.pendingOperations.where("type").equals("delete_draft").count()).toBe(0)
+    const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+    expect(resolves.filter((o) => o.payload.draftId === "draft_x" && o.payload.expectedVersion === 3)).toHaveLength(1)
+  })
+
   it("deletes the split server row when the original was discarded mid-push", async () => {
     await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1 }))
     const upsert = vi.fn(async (): Promise<UpsertDraftResponse> => {
@@ -494,6 +513,38 @@ describe("executeDraftUpsert", () => {
 
     const dels = await db.pendingOperations.where("type").equals("delete_draft").toArray()
     expect(dels.filter((o) => o.payload.draftId === "draft_new")).toHaveLength(1)
+  })
+
+  it("removes a split ghost locally when its socket echo won the race", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1 }))
+    const upsert = vi.fn(async (): Promise<UpsertDraftResponse> => {
+      await db.drafts.delete("draft_x")
+      await db.drafts.put(localDraft({ id: "draft_new", baseVersion: 1 }))
+      return { draft: wireDraft({ id: "draft_new", version: 1 }), split: true, originalId: "draft_x" }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    expect(await db.drafts.get("draft_new")).toBeUndefined()
+    const dels = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+    expect(dels.filter((o) => o.payload.draftId === "draft_new")).toHaveLength(1)
+  })
+
+  it("CAS-resolves a split ghost when the original was sent mid-push", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1 }))
+    await enqueueDraftResolve(workspaceId, "draft_x", 1)
+    const upsert = vi.fn(async (): Promise<UpsertDraftResponse> => {
+      await db.drafts.delete("draft_x")
+      await db.drafts.put(localDraft({ id: "draft_new", baseVersion: 1 }))
+      return { draft: wireDraft({ id: "draft_new", version: 1 }), split: true, originalId: "draft_x" }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    expect(await db.drafts.get("draft_new")).toBeUndefined()
+    expect(await db.pendingOperations.where("type").equals("delete_draft").count()).toBe(0)
+    const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+    expect(resolves.filter((o) => o.payload.draftId === "draft_new" && o.payload.expectedVersion === 1)).toHaveLength(1)
   })
 })
 
@@ -508,12 +559,21 @@ describe("executeDraftDelete", () => {
 describe("executeDraftResolve", () => {
   it("delegates a CAS resolve carrying expectedVersion to the service", async () => {
     const resolve = vi.fn(async () => ({ resolved: true }))
-    await executeDraftResolve(workspaceId, "draft_x", 5, {
-      upsert: vi.fn(),
-      resolve,
-      delete: vi.fn(),
-    } as unknown as DraftsServiceLike)
-    expect(resolve).toHaveBeenCalledWith(workspaceId, "draft_x", { expectedVersion: 5 })
+    await executeDraftResolve(
+      workspaceId,
+      "draft_x",
+      5,
+      {
+        upsert: vi.fn(),
+        resolve,
+        delete: vi.fn(),
+      } as unknown as DraftsServiceLike,
+      ["write_sent"]
+    )
+    expect(resolve).toHaveBeenCalledWith(workspaceId, "draft_x", {
+      expectedVersion: 5,
+      supersededWriteIds: ["write_sent"],
+    })
   })
 
   it("propagates a declined resolve (drift) without throwing — the drifted copy survives", async () => {
@@ -614,6 +674,37 @@ describe("resolve-on-send is authoritative against inbound echoes (no resurrecti
     await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wireDraft({ version: 2 }) }, workspaceId)
 
     expect((await db.drafts.get("draft_server1"))?.baseVersion).toBe(2)
+  })
+
+  it("does not apply a newer echo while this device still has the sent upsert in flight", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_server1")
+    await enqueueDraftResolve(workspaceId, "draft_server1", 1)
+
+    await applyDraftUpserted({ workspaceId, targetUserId: userId, draft: wireDraft({ version: 2 }) }, workspaceId)
+
+    expect(await db.drafts.get("draft_server1")).toBeUndefined()
+  })
+
+  it("CAS-resolves a split echo whose write id belongs to a sent draft", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_server1")
+    const upserts = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    const writeId = upserts.find((o) => o.payload.draftId === "draft_server1")?.payload.writeId as string
+    await enqueueDraftResolve(workspaceId, "draft_server1", 1)
+
+    await applyDraftUpserted(
+      {
+        workspaceId,
+        targetUserId: userId,
+        draft: wireDraft({ id: "draft_split", version: 1, lastClientWriteId: writeId }),
+      },
+      workspaceId
+    )
+
+    expect(await db.drafts.get("draft_split")).toBeUndefined()
+    const resolves = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+    expect(
+      resolves.filter((op) => op.payload.draftId === "draft_split" && op.payload.expectedVersion === 1)
+    ).toHaveLength(1)
   })
 })
 

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -237,7 +237,8 @@ export async function hasPendingDraftDelete(draftId: string): Promise<boolean> {
  * draft, if that resolve is queued but has not drained yet. While this persisted
  * op exists, inbound/bootstrap rows at or below the expected version are stale
  * echoes of an already-sent draft and must not be re-created. Strictly newer
- * rows still apply so another device's drifted edit survives (no-loss).
+ * rows apply unless their write id is one this resolve superseded, so another
+ * device's drifted edit survives (no-loss).
  */
 export async function pendingDraftResolveVersion(draftId: string): Promise<number | undefined> {
   const ops = await pendingDraftOps("resolve_draft", draftId)
@@ -248,6 +249,14 @@ export async function pendingDraftResolveVersion(draftId: string): Promise<numbe
     version = version === undefined ? expected : Math.max(version, expected)
   }
   return version
+}
+
+async function hasPendingSupersededWriteId(writeId: string): Promise<boolean> {
+  const ops = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
+  return ops.some(
+    (op) =>
+      Array.isArray(op.payload.supersededWriteIds) && op.payload.supersededWriteIds.some((value) => value === writeId)
+  )
 }
 
 /**
@@ -298,12 +307,17 @@ export async function enqueueDraftDelete(workspaceId: string, draftId: string): 
 }
 
 /**
- * Enqueue a CAS clear-on-send for a draft (resolve-on-send) and drop any queued
- * push or delete for it. `expectedVersion` is the last server-confirmed version
- * (`baseVersion`); the server removes the row only if it still matches, so a
- * copy that drifted on another device survives as a stash entry. Use only when
- * the draft reached the server (`baseVersion > 0`); for a never-synced draft
- * call `cancelPendingDraftUpsert` — there is nothing on the server to resolve.
+ * Enqueue a CAS clear-on-send for a draft (resolve-on-send). `expectedVersion`
+ * is the last server-confirmed version (`baseVersion`); the server removes the
+ * row only if it still matches, so a copy that drifted on another device
+ * survives as a stash entry. Any queued upsert is deliberately kept as an
+ * in-flight-write marker: its socket echo may be version-newer than the resolve
+ * CAS, but it is still this device's just-sent content and must not re-seed a
+ * stash entry before the cleanup path runs. Its write id is also copied onto the
+ * resolve op so a lost-ack write that reached the server can be tombstoned
+ * without deleting unrelated drift. Use only when the draft reached the server
+ * (`baseVersion > 0`); never-confirmed sends go through `enqueueDraftDelete` so
+ * a late first upsert is cleaned up.
  */
 export async function enqueueDraftResolve(
   workspaceId: string,
@@ -311,8 +325,11 @@ export async function enqueueDraftResolve(
   expectedVersion: number
 ): Promise<void> {
   await db.transaction("rw", db.pendingOperations, async () => {
+    const pendingUpserts = await pendingDraftOps("upsert_draft", draftId)
+    const supersededWriteIds = pendingUpserts
+      .map((op) => op.payload.writeId)
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
     const stale = [
-      ...(await pendingDraftOps("upsert_draft", draftId)),
       ...(await pendingDraftOps("resolve_draft", draftId)),
       ...(await pendingDraftOps("delete_draft", draftId)),
     ]
@@ -321,7 +338,7 @@ export async function enqueueDraftResolve(
       id: operationId(),
       workspaceId,
       type: "resolve_draft",
-      payload: { draftId, expectedVersion },
+      payload: { draftId, expectedVersion, supersededWriteIds },
       createdAt: Date.now(),
       retryCount: 0,
     })
@@ -378,15 +395,15 @@ export async function syncDraftResolution(
  * Apply an inbound `draft:upserted` (another device's edit, or an echo of our
  * own confirmed write):
  *
- *  - No local row → accept the server row.
+ *  - No local row and no pending local op → accept the server row.
  *  - `version <= baseVersion` → stale echo (usually our own write returning);
  *    ignore.
- *  - Newer server version, unpushed local edits exist → IGNORE. The server is
- *    the single authority on drift: our queued push will reach it and it splits
- *    CAS-safely (executeDraftUpsert then migrates our local id). Resolving the
- *    drift here too would fork our OWN in-flight write — its echo can arrive
- *    before the push's HTTP ack records `baseVersion`, and a local split would
- *    then mint a duplicate of the draft we are editing.
+ *  - Pending local edits (even if the row was just removed by send) → IGNORE.
+ *    The server is the single authority on drift: our queued push reaches it and
+ *    splits CAS-safely (`executeDraftUpsert` then migrates our local id).
+ *    Resolving the drift here too would fork our OWN in-flight write — its echo
+ *    can arrive before the push's HTTP ack records `baseVersion`; a local split
+ *    would then mint a duplicate of the draft we are editing.
  *  - Newer server version, no unpushed edits → accept (preserving local
  *    attachment metadata the wire row lacks). When the scope also changed
  *    (thread re-pointing — the target message became a thread), the draft moves
@@ -397,7 +414,8 @@ export async function applyDraftUpserted(
   expectedWorkspaceId: string,
   pendingUpsertIds?: ReadonlySet<string>,
   pendingDeleteIds?: ReadonlySet<string>,
-  pendingResolveVersions?: ReadonlyMap<string, number>
+  pendingResolveVersions?: ReadonlyMap<string, number>,
+  pendingSupersededWriteIds?: ReadonlySet<string>
 ): Promise<void> {
   const { draft } = payload
   if (draft.workspaceId !== expectedWorkspaceId) return
@@ -417,6 +435,18 @@ export async function applyDraftUpserted(
   const pendingResolveVersion = pendingResolveVersions?.get(draft.id) ?? (await pendingDraftResolveVersion(draft.id))
   if (pendingResolveVersion !== undefined && draft.version <= pendingResolveVersion) return
 
+  // A version-newer row with one of our superseded write ids is not another
+  // device's drift; it is this device's sent draft write landing late (possibly
+  // under a split id). CAS-resolve it at the version we observed.
+  const lastWriteId = draft.lastClientWriteId ?? null
+  const ownSentWrite = lastWriteId
+    ? (pendingSupersededWriteIds?.has(lastWriteId) ?? (await hasPendingSupersededWriteId(lastWriteId)))
+    : false
+  if (ownSentWrite) {
+    await enqueueDraftResolve(expectedWorkspaceId, draft.id, draft.version)
+    return
+  }
+
   // A queued local delete wins: the user discarded this draft here and its
   // `delete_draft` op (not yet drained) will remove the server row. Until then,
   // accepting an echo or a bootstrap re-seed would resurrect the row the user
@@ -425,6 +455,14 @@ export async function applyDraftUpserted(
   const deleting = pendingDeleteIds ? pendingDeleteIds.has(draft.id) : await hasPendingDraftDelete(draft.id)
   if (deleting) return
 
+  // Unpushed local edits → leave them; the pending push lets the server arbitrate
+  // (the pending set, passed by bootstrap, avoids a per-draft op-table scan). The
+  // row may already be gone locally when the pending write belongs to a draft we
+  // just sent; in that case the op is still an in-flight echo marker and must
+  // suppress a server re-seed until the queue observes the missing row.
+  const dirty = pendingUpsertIds ? pendingUpsertIds.has(draft.id) : await hasPendingDraftUpsert(draft.id)
+  if (dirty) return
+
   const local = await db.drafts.get(draft.id)
   if (!local) {
     await putLocalDraft(cachedDraftFromWire(draft))
@@ -432,11 +470,6 @@ export async function applyDraftUpserted(
   }
 
   if (draft.version <= (local.baseVersion ?? 0)) return
-
-  // Unpushed local edits → leave them; the pending push lets the server arbitrate
-  // (the pending set, passed by bootstrap, avoids a per-draft op-table scan).
-  const dirty = pendingUpsertIds ? pendingUpsertIds.has(draft.id) : await hasPendingDraftUpsert(draft.id)
-  if (dirty) return
 
   // Clean locally — accept the server row, keeping any local attachment metadata
   // (an echo of our own confirmed push matches it). A changed scope (thread
@@ -502,11 +535,18 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
   const pendingUpsertIds = new Set(upsertOps.map((op) => op.payload.draftId as string))
   const pendingDeleteIds = new Set(deleteOps.map((op) => op.payload.draftId as string))
   const pendingResolveVersions = new Map<string, number>()
+  const pendingSupersededWriteIds = new Set<string>()
   for (const op of resolveOps) {
     const draftId = op.payload.draftId as string
     const expectedVersion = Number(op.payload.expectedVersion)
-    if (!Number.isFinite(expectedVersion)) continue
-    pendingResolveVersions.set(draftId, Math.max(pendingResolveVersions.get(draftId) ?? 0, expectedVersion))
+    if (Number.isFinite(expectedVersion)) {
+      pendingResolveVersions.set(draftId, Math.max(pendingResolveVersions.get(draftId) ?? 0, expectedVersion))
+    }
+    if (Array.isArray(op.payload.supersededWriteIds)) {
+      for (const value of op.payload.supersededWriteIds) {
+        if (typeof value === "string") pendingSupersededWriteIds.add(value)
+      }
+    }
   }
   for (const draft of drafts) {
     await applyDraftUpserted(
@@ -514,7 +554,8 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
       workspaceId,
       pendingUpsertIds,
       pendingDeleteIds,
-      pendingResolveVersions
+      pendingResolveVersions,
+      pendingSupersededWriteIds
     )
   }
 
@@ -590,9 +631,15 @@ export async function executeDraftUpsert(
     // The original id's divergent server row arrives via its own socket event.
     const current = await db.drafts.get(draftId)
     if (!current) {
-      // Discarded locally while the push was in flight — the server still minted
-      // a fresh row for our (now-gone) content; delete it so it can't resurrect.
-      await enqueueDraftDelete(workspaceId, res.draft.id)
+      // Removed locally while the push was in flight. A sent draft gets a CAS
+      // cleanup at the version this push created; an explicit discard keeps the
+      // unconditional delete semantics.
+      await deleteLocalDraft(workspaceId, res.draft.id)
+      if ((await pendingDraftResolveVersion(draftId)) !== undefined) {
+        await enqueueDraftResolve(workspaceId, res.draft.id, res.draft.version)
+      } else {
+        await enqueueDraftDelete(workspaceId, res.draft.id)
+      }
       return
     }
     await migrateLocalDraftId(workspaceId, draftId, {
@@ -611,10 +658,10 @@ export async function executeDraftUpsert(
   // Happy path — confirm our row at the returned version without clobbering any
   // content typed since the push (only the version basis advances). The
   // existence check and the write share one transaction so a concurrent local
-  // discard can't slip between them and have us re-create a row the user just
-  // deleted; if the row is gone, the server now holds a draft the user threw
-  // away, so we delete it (otherwise it resurrects on the next pull — the
-  // "ghost draft" race).
+  // removal can't slip between them and have us re-create a row the user just
+  // cleared; if the row is gone, the server now holds stale content and we queue
+  // the matching cleanup (CAS resolve for sends, unconditional delete for
+  // discards) so it cannot resurrect on the next pull.
   let confirmed: CachedDraft | undefined
   await db.transaction("rw", db.drafts, async () => {
     const current = await db.drafts.get(draftId)
@@ -623,7 +670,11 @@ export async function executeDraftUpsert(
     await db.drafts.put(confirmed)
   })
   if (!confirmed) {
-    await enqueueDraftDelete(workspaceId, draftId)
+    if ((await pendingDraftResolveVersion(draftId)) !== undefined) {
+      await enqueueDraftResolve(workspaceId, draftId, res.draft.version)
+    } else {
+      await enqueueDraftDelete(workspaceId, draftId)
+    }
     return
   }
   if (hasSeededDraftCache(workspaceId)) upsertDraftInCache(workspaceId, confirmed)
@@ -631,21 +682,22 @@ export async function executeDraftUpsert(
 
 /**
  * Resolve a draft on the backend after its message sent (operation-queue replay
- * of `resolve_draft`). CAS-guarded by `expectedVersion`: the server keeps a
- * drifted copy (`resolved: false`) rather than deleting it, and that copy
- * re-syncs as a stash entry on the next bootstrap. Either outcome is terminal
- * for this op — the local row is already gone — so the response is informational
- * and nothing more runs locally. Throws (network) so the queue retries; resolve
- * is idempotent (a re-run hits an already-tombstoned row and returns
- * `resolved: false`), so no idempotency key is needed.
+ * of `resolve_draft`). CAS-guarded by `expectedVersion` plus superseded write
+ * ids: the server keeps unrelated drift (`resolved: false`) rather than deleting
+ * it, and that copy re-syncs as a stash entry on the next bootstrap. Either
+ * outcome is terminal for this op — the local row is already gone — so the
+ * response is informational and nothing more runs locally. Throws (network) so
+ * the queue retries; resolve is idempotent (a re-run hits an already-tombstoned
+ * row and returns `resolved: false`), so no idempotency key is needed.
  */
 export async function executeDraftResolve(
   workspaceId: string,
   draftId: string,
   expectedVersion: number,
-  service: DraftsServiceLike
+  service: DraftsServiceLike,
+  supersededWriteIds: string[] = []
 ): Promise<void> {
-  await service.resolve(workspaceId, draftId, { expectedVersion })
+  await service.resolve(workspaceId, draftId, { expectedVersion, supersededWriteIds })
 }
 
 /** Push a draft deletion to the backend (operation-queue replay of `delete_draft`). */

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -252,6 +252,9 @@ export async function pendingDraftResolveVersion(draftId: string): Promise<numbe
 }
 
 async function hasPendingSupersededWriteId(writeId: string): Promise<boolean> {
+  // Intentionally scan all pending resolves, not only the inbound draft id: a
+  // server-side split echo arrives under a fresh draft id, but carries the
+  // original resolve op's superseded write id.
   const ops = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
   return ops.some(
     (op) =>

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -234,11 +234,15 @@ async function executeOperation(
       // a drafts service this context is local-only — drop the op (a throw would
       // retry forever, never reaching a service).
       if (!draftsService) break
+      const supersededWriteIds = Array.isArray(payload.supersededWriteIds)
+        ? payload.supersededWriteIds.filter((id): id is string => typeof id === "string")
+        : []
       await executeDraftResolve(
         workspaceId,
         payload.draftId as string,
         payload.expectedVersion as number,
-        draftsService
+        draftsService,
+        supersededWriteIds
       )
       break
     }

--- a/docs/features/architecture/drafts.md
+++ b/docs/features/architecture/drafts.md
@@ -70,7 +70,8 @@ Content takes one of two shapes. A plaintext draft carries `content_json` and a 
 triple with the plaintext columns null, sealed to the stream key before it ever leaves
 the device (E2EE-4, "no plaintext at rest"). `deleted_at` is a soft-delete tombstone so
 a removal on one device propagates to the others, and `last_client_write_id` is a
-per-push idempotency key (see below).
+per-push idempotency key (see below). That write id is exposed back to the owner only so
+the device that just sent a draft can recognize its own late echo.
 
 ### The split-on-drift upsert
 
@@ -144,10 +145,11 @@ Sending a message clears its draft, but a send is not a discard. If another devi
 edited the draft after this send started, an unconditional delete would destroy that
 work. So the send path calls `resolve`, not `delete`:
 `POST /drafts/:id/resolve` soft-deletes **only if** `version` still matches
-`expectedVersion` (`DraftsService.resolve`, `service.ts:169`). On drift the server keeps
-the row and reports `resolved: false`, and the drifted copy survives as a stash entry.
-Explicit discard (stashing away, emptying the composer, deleting from the Drafts view)
-keeps the unconditional `delete`, which is idempotent on an already-gone row.
+`expectedVersion`, or if the row's `last_client_write_id` is one this send already
+superseded (`DraftsService.resolve`, `service.ts:169`). On unrelated drift the server
+keeps the row and reports `resolved: false`, and the drifted copy survives as a stash
+entry. Explicit discard (stashing away, emptying the composer, deleting from the Drafts
+view) keeps the unconditional `delete`, which is idempotent on an already-gone row.
 
 ### The resolution guard stops a sent draft from coming back
 
@@ -159,15 +161,20 @@ two ways to close both. `markScopeResolved(scope)` runs as the first statement o
 resolve, before the async teardown, so the create branch of `upsertLoadedDraft` refuses a
 just-resolved scope regardless of how Dexie interleaves the reads. `markDraftResolved(id,
 version)` lets inbound apply drop an echo at or below the resolved version, while a
-strictly newer version still applies as a real edit from another device (no loss). The
-guard lifts the instant the user re-engages (a keystroke or an attachment), so the next
-message starts a fresh draft.
+strictly newer version still applies as a real edit from another device unless its
+`last_client_write_id` is one this send already superseded (no loss). The guard lifts
+the instant the user re-engages (a keystroke or an attachment), so the next message
+starts a fresh draft.
 
 Because the guard is in-memory, it does not survive a page reload. PR #993 made the
 suppression durable by reading the queued `resolve_draft` ops directly
 (`pendingDraftResolveVersion`): a bootstrap after reload drops rows at or below the
 version still queued for resolve, so a sent draft cannot bootstrap back as a stash entry
-across a reconnect.
+across a reconnect. A resolve also keeps any queued `upsert_draft` op as an in-flight
+write marker until the queue observes the locally deleted row, and copies its `writeId`
+onto the resolve op so a lost-ack write can still be tombstoned if it reached the
+server. Otherwise that write's version-newer socket echo can look like real drift and
+re-seed the just-sent content.
 
 ### Thread re-pointing: drafts follow their message
 

--- a/docs/features/architecture/drafts.md
+++ b/docs/features/architecture/drafts.md
@@ -150,6 +150,11 @@ superseded (`DraftsService.resolve`, `service.ts:169`). On unrelated drift the s
 keeps the row and reports `resolved: false`, and the drifted copy survives as a stash
 entry. Explicit discard (stashing away, emptying the composer, deleting from the Drafts
 view) keeps the unconditional `delete`, which is idempotent on an already-gone row.
+Never-confirmed drafts (`baseVersion = 0`) also use `delete`: there is no server version
+to CAS against. To make delete-before-insert ordering safe, `DraftsRepository.softDelete`
+plants a negative tombstone even when the row is absent; a late first upsert
+(`expectedVersion = 0`) that collides with that tombstone is dropped rather than split
+into a live zombie.
 
 ### The resolution guard stops a sent draft from coming back
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1890,6 +1890,8 @@ export interface Draft {
   version: number
   /** Authoring device's wall clock for the last edit; drives recency ordering. */
   clientUpdatedAt: string
+  /** Last accepted write id; lets the authoring device suppress its own sent-write echoes. */
+  lastClientWriteId?: string | null
   createdAt: string
   updatedAt: string
 }
@@ -1935,12 +1937,16 @@ export interface UpsertDraftResponse {
  * Wire body for `POST /drafts/:id/resolve` (clear-on-send). CAS-guarded by
  * `expectedVersion`: the draft is removed only if it still matches, so a copy
  * that drifted since the send started survives as a stash entry instead of
- * being collaterally deleted. A lost-ack retry re-runs the same version CAS:
- * the row is already tombstoned, so it returns `resolved: false` with the draft
- * gone either way — no idempotency key is needed on this path.
+ * being collaterally deleted. `supersededWriteIds` lets the server also remove
+ * this device's own lost-ack upsert if it landed after send began, without
+ * deleting unrelated drift. A lost-ack retry re-runs the same resolve: the row
+ * is already tombstoned, so it returns `resolved: false` with the draft gone
+ * either way.
  */
 export interface ResolveDraftInput {
   expectedVersion: number
+  /** Write ids from this device's sent draft upserts that may have landed after send began. */
+  supersededWriteIds?: string[]
 }
 
 export interface ResolveDraftResponse {


### PR DESCRIPTION
## Problem

Draft resolve-on-send still had race windows that could leave an identical stash entry after the user sent a message:

1. `upsertLoadedDraft` only guarded the no-existing-row create path. A debounced save that had already read the loaded draft before `resolveLoadedDraft()` deleted it could still write that same row back afterward, turning the sent message into a stash entry.
2. `enqueueDraftResolve` deleted the queued `upsert_draft` op. If that op was already in flight, its socket/bootstrap echo could arrive with a version newer than the resolve CAS. With no local row and no dirty marker left, `applyDraftUpserted` treated the echo as another device's drift and accepted it.
3. Never-confirmed drafts (`baseVersion = 0`) used the unconditional delete path. If that delete reached the server before the first draft insert, the old `softDelete` matched zero rows and vanished; the late insert then created a live `version = 1` zombie draft.

The second race also has a split variant: a stale in-flight write can be accepted by the server under a fresh split id, so the client needs a way to recognize that split row as this device's own sent write rather than unrelated drift.

## Solution

Keep resolve-on-send as a no-loss CAS path, but teach both sides to distinguish unrelated drift from this device's own superseded sent-write echoes, and make delete-before-insert ordering durable for never-confirmed drafts.

### How it works

1. `upsertLoadedDraft` now checks the scope resolve sequence inside the IndexedDB write transaction before writing either an existing row or a new loaded row. If `resolveLoadedDraft` advanced the sequence while a debounced save was in flight, the stale save returns without touching IDB, cache, decrypt state, or the operation queue.
2. `enqueueDraftResolve` no longer removes a pending `upsert_draft`. It keeps the op as an in-flight echo marker and copies its `writeId` into the resolve payload as `supersededWriteIds`.
3. `applyDraftUpserted` now suppresses no-local-row echoes while a pending upsert exists, and CAS-resolves inbound rows whose `lastClientWriteId` is in the pending resolve's `supersededWriteIds` set. Bootstrap builds the same pending-id and pending-write-id sets once and passes them through the apply path.
4. The backend resolve endpoint accepts `supersededWriteIds`. `DraftsRepository.softDeleteCas` remains one workspace/user/id-scoped `UPDATE`, but its guard is now `(version = expectedVersion OR last_client_write_id = ANY(supersededWriteIds))`, so this device's lost-ack write can be tombstoned without deleting unrelated drift.
5. `DraftsRepository.softDelete` is now an `INSERT ... ON CONFLICT DO UPDATE` tombstone write. If delete wins before a never-confirmed draft's first insert, it plants a negative tombstone; when the late `expectedVersion = 0` upsert collides with that tombstone, `DraftsService.upsert` drops it without splitting.
6. If `executeDraftUpsert` receives an ack after the local draft was removed, it queues the matching cleanup: CAS resolve for sends, unconditional delete for explicit discards. Split rows are locally removed before queuing their cleanup so a socket echo that won the race cannot linger in IDB.

### Key design decisions

**1. Keep the queued upsert as the dirty marker** — deleting the op made the client unable to tell “my write is still in flight” from “there is no local work.” The queue still no-ops the upsert if the row is gone; keeping it only extends the dirty marker through the dangerous echo window.

**2. Match sent-write echoes by `lastClientWriteId`, not content** — content equality would be brittle across markdown/ProseMirror serialization and attachments. `lastClientWriteId` already exists as the server-side idempotency key, so exposing it on the owner-scoped draft wire row gives the authoring device a precise identifier for its own late write.

**3. Preserve resolve-vs-discard semantics** — confirmed send cleanup remains CAS-guarded and only removes matching versions or superseded write ids. Explicit discard still uses the unconditional delete path. Never-confirmed send cleanup also uses the unconditional path, but that path now plants a tombstone instead of disappearing when the row is absent.

## New files

None.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | Adds the transactional stale-resolve check for debounced saves that already read the loaded draft. |
| `apps/frontend/src/sync/draft-sync.ts` | Carries superseded write ids through resolve ops, suppresses own in-flight echoes, resolves split ghosts, and preserves discard cleanup semantics. |
| `apps/frontend/src/sync/operation-queue.ts` | Replays `resolve_draft` with `supersededWriteIds`. |
| `apps/frontend/src/api/drafts.ts` | Documents the resolve wire contract. |
| `apps/backend/src/features/drafts/handlers.ts` | Validates optional `supersededWriteIds` on resolve. |
| `apps/backend/src/features/drafts/service.ts` | Passes superseded write ids into resolve and drops fresh upserts that collide with tombstones. |
| `apps/backend/src/features/drafts/repository.ts` | Extends the CAS soft-delete predicate and changes unconditional delete to plant negative tombstones. |
| `apps/backend/src/features/drafts/view.ts` | Includes `lastClientWriteId` on owner-scoped draft wire rows. |
| `packages/types/src/api.ts` | Adds `Draft.lastClientWriteId` and `ResolveDraftInput.supersededWriteIds`. |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | Covers the stale save that already read the old loaded row. |
| `apps/frontend/src/sync/draft-sync.test.ts` | Covers pending-upsert echo suppression, split echo cleanup, CAS-vs-delete cleanup, and resolve payload write ids. |
| `apps/backend/src/features/drafts/repository.test.ts` | Covers the extended CAS predicate and negative tombstone write. |
| `apps/backend/src/features/drafts/service.test.ts` | Verifies resolve forwards superseded write ids, tombstoned fresh upserts are dropped, and delete publish/no-op behavior. |
| `docs/features/architecture/drafts.md` | Updates the draft architecture doc with the lost-ack, superseded-write-id, and negative-tombstone edges. |

## Deleted files

None.

## Out of scope (deliberate)

- No database migration: `last_client_write_id` and `deleted_at` already exist; the negative tombstone uses the existing `drafts` table.
- No prod data cleanup/backfill for already-created ghost drafts. Existing identical stashes still need manual discard or a separate forensic cleanup.
- No content-based dedupe. It risks deleting real user drafts that happen to match the sent message.

## Self-review

Manual pre-PR review focused on the resolve/send lifecycle and own-echo interleavings. The first pass fixed the pending-upsert marker race; the review pass then found the split-id variant, which is why the patch exposes `lastClientWriteId` and queues CAS cleanup for split echoes. Claude Code review later found the never-confirmed delete-before-insert variant with production evidence; that was accepted and fixed by the negative tombstone path in commit `a5152478`.

## Test plan

- [x] `bun scripts/test-silent.ts frontend src/sync/draft-sync.test.ts src/hooks/use-draft-message.test.ts --run` — 90 pass
- [x] `bun scripts/test-silent.ts backend-unit src/features/drafts/repository.test.ts src/features/drafts/service.test.ts` — 19 pass
- [x] `bun run typecheck` — all workspaces clean
- [x] Pre-commit hooks — `bun run lint`, `bun run typecheck`, `bun apps/backend/scripts/generate-api-docs.ts --check`, Dockerfile workspace check, migration check all clean

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Stop sent message drafts from reappearing as identical stash entries without weakening the draft system's no-loss split-on-drift rule.

## What was built

- A transactional stale-save guard in `upsertLoadedDraft` for debounced saves that began before send teardown.
- Resolve-op preservation of in-flight upsert markers plus copied `writeId`s.
- Client reconciliation that suppresses/cleans up this device's own sent-write echoes, including rows that arrive under a server split id.
- Backend CAS resolve support for `supersededWriteIds` via the existing `last_client_write_id` column.
- Backend negative tombstones for never-confirmed deletes, plus fresh-upsert dropping when `expectedVersion = 0` collides with such a tombstone.
- Unit coverage for frontend reconciliation and backend resolve/delete predicates.

## Design decisions

- Use `last_client_write_id` as the identity for own sent-write echoes.
- Keep explicit discard as unconditional delete; keep confirmed send cleanup as CAS resolve.
- Make unconditional delete durable on absent rows so mobile request ordering cannot create `version = 1` zombies.
- Keep the solution local to draft reconciliation; no schema change or content dedupe.

## Design evolution

The initial investigation found two races: stale debounced saves and pending-upsert echoes. Self-review found a third form of the second race: the server can split a stale in-flight write under a fresh id, so pending draft id alone is insufficient. Claude Code review then found the never-confirmed delete-before-insert variant that matched production `version = 1` rows. The final version carries write ids through resolve, exposes `lastClientWriteId` on owner-scoped draft wire rows, and plants negative tombstones for delete-before-insert ordering.

## Schema changes

None.

## Not included

- Cleanup of already-created production ghost drafts.
- A merge/dedupe UI for duplicate drafts.
- Garbage collection of draft tombstones.

## Status

Implemented, committed, pushed, and covered by targeted frontend/backend tests plus full typecheck and pre-commit checks.

</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_
