### PR TITLE
fix(pwa): retain recent build assets across deploys to prevent stale-chunk crashes

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -33,8 +33,34 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Carry recent builds' content-hashed chunks across deploys so a tab still
+      # running the previous build can keep lazy-loading its own /assets/*.js
+      # instead of hitting "Failed to fetch dynamically imported module" the
+      # moment a new build ships (see apps/frontend/scripts/retain-assets.ts).
+      # Best-effort: a cache miss/hiccup must never block a deploy.
+      - name: Restore retained assets
+        id: restore-retained-assets
+        uses: actions/cache/restore@v4
+        continue-on-error: true
+        with:
+          path: apps/frontend/.retained-assets
+          key: frontend-retained-assets-prod-${{ github.run_id }}
+          restore-keys: |
+            frontend-retained-assets-prod-
+
       - name: Build frontend
         run: bun run --cwd apps/frontend build
+
+      - name: Fold retained assets into dist
+        continue-on-error: true
+        run: bun apps/frontend/scripts/retain-assets.ts
+
+      - name: Save retained assets
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: apps/frontend/.retained-assets
+          key: frontend-retained-assets-prod-${{ github.run_id }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
@@ -290,8 +316,31 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # Retain recent builds' chunks across deploys (see the prod job and
+      # apps/frontend/scripts/retain-assets.ts). Separate cache key so staging
+      # and prod never cross-pollinate their asset stores. Best-effort.
+      - name: Restore retained assets
+        uses: actions/cache/restore@v4
+        continue-on-error: true
+        with:
+          path: apps/frontend/.retained-assets
+          key: frontend-retained-assets-staging-${{ github.run_id }}
+          restore-keys: |
+            frontend-retained-assets-staging-
+
       - name: Build frontend
         run: bun run --cwd apps/frontend build
+
+      - name: Fold retained assets into dist
+        continue-on-error: true
+        run: bun apps/frontend/scripts/retain-assets.ts
+
+      - name: Save retained assets
+        uses: actions/cache/save@v4
+        continue-on-error: true
+        with:
+          path: apps/frontend/.retained-assets
+          key: frontend-retained-assets-staging-${{ github.run_id }}
 
       # Pushes to the `main` branch of the `threa-staging` Pages project, which
       # the workspace-router-staging worker resolves for `staging.threa.io`. The

--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -1,0 +1,1 @@
+.retained-assets/

--- a/apps/frontend/scripts/retain-assets.test.ts
+++ b/apps/frontend/scripts/retain-assets.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { mkdtemp, mkdir, writeFile, rm, readFile, utimes, readdir } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { retainAssets } from "./retain-assets"
+
+const DAY = 24 * 60 * 60 * 1000
+
+describe("retainAssets", () => {
+  let root: string
+  let distAssetsDir: string
+  let retainDir: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "retain-assets-"))
+    distAssetsDir = path.join(root, "dist", "assets")
+    retainDir = path.join(root, ".retained-assets")
+    await mkdir(distAssetsDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  async function writeAsset(dir: string, name: string, content: string, mtimeMs?: number) {
+    const filePath = path.join(dir, name)
+    await mkdir(dir, { recursive: true })
+    await writeFile(filePath, content)
+    if (mtimeMs !== undefined) await utimes(filePath, new Date(mtimeMs), new Date(mtimeMs))
+  }
+
+  it("revives a chunk that dropped out of the new build", async () => {
+    // Previous build retained an old chunk; the new build no longer ships it.
+    await writeAsset(retainDir, "old-AAA.js", "old-chunk")
+    await writeAsset(distAssetsDir, "index-BBB.js", "new-entry")
+
+    const result = await retainAssets({ distAssetsDir, retainDir })
+
+    expect(result).toMatchObject({ revived: 1, pruned: 0 })
+    expect(existsSync(path.join(distAssetsDir, "old-AAA.js"))).toBe(true)
+    expect(await readFile(path.join(distAssetsDir, "old-AAA.js"), "utf8")).toBe("old-chunk")
+  })
+
+  it("never overwrites a current-build file with a retained copy", async () => {
+    await writeAsset(retainDir, "index-BBB.js", "stale-bytes")
+    await writeAsset(distAssetsDir, "index-BBB.js", "fresh-bytes")
+
+    const result = await retainAssets({ distAssetsDir, retainDir })
+
+    expect(result.revived).toBe(0)
+    expect(await readFile(path.join(distAssetsDir, "index-BBB.js"), "utf8")).toBe("fresh-bytes")
+  })
+
+  it("prunes a chunk that has been absent past the retention window", async () => {
+    const now = Date.now()
+    await writeAsset(retainDir, "ancient-CCC.js", "ancient", now - 20 * DAY)
+    await writeAsset(distAssetsDir, "index-BBB.js", "new-entry")
+
+    const result = await retainAssets({ distAssetsDir, retainDir, now, retentionMs: 14 * DAY })
+
+    expect(result).toMatchObject({ revived: 0, pruned: 1 })
+    expect(existsSync(path.join(retainDir, "ancient-CCC.js"))).toBe(false)
+    expect(existsSync(path.join(distAssetsDir, "ancient-CCC.js"))).toBe(false)
+  })
+
+  it("keeps a chunk alive indefinitely while it stays in the build", async () => {
+    const start = Date.now()
+    // The chunk has been in the retain store since well past the window, but it
+    // is still part of the current build, so it must not be pruned.
+    await writeAsset(retainDir, "stable-DDD.js", "stable", start - 30 * DAY)
+    await writeAsset(distAssetsDir, "stable-DDD.js", "stable")
+
+    const result = await retainAssets({ distAssetsDir, retainDir, now: start, retentionMs: 14 * DAY })
+
+    expect(result.pruned).toBe(0)
+    expect(existsSync(path.join(retainDir, "stable-DDD.js"))).toBe(true)
+
+    // A later deploy where the chunk has finally dropped out now ages it from
+    // the freshly-stamped mtime, not its original 30-day-old one.
+    await rm(path.join(distAssetsDir, "stable-DDD.js"))
+    await writeAsset(distAssetsDir, "index-EEE.js", "newer-entry")
+    const later = await retainAssets({
+      distAssetsDir,
+      retainDir,
+      now: start + 10 * DAY,
+      retentionMs: 14 * DAY,
+    })
+    expect(later).toMatchObject({ revived: 1, pruned: 0 })
+  })
+
+  it("creates the retain store on first run and folds the build into it", async () => {
+    await writeAsset(distAssetsDir, "index-BBB.js", "new-entry")
+    await writeAsset(distAssetsDir, "vendor-FFF.js", "vendor")
+
+    const result = await retainAssets({ distAssetsDir, retainDir })
+
+    expect(result).toMatchObject({ revived: 0, pruned: 0, retained: 2 })
+    expect((await readdir(retainDir)).sort()).toEqual(["index-BBB.js", "vendor-FFF.js"])
+  })
+
+  it("throws when the dist assets dir is missing", async () => {
+    await rm(distAssetsDir, { recursive: true, force: true })
+    await expect(retainAssets({ distAssetsDir, retainDir })).rejects.toThrow(/dist assets dir not found/)
+  })
+})

--- a/apps/frontend/scripts/retain-assets.ts
+++ b/apps/frontend/scripts/retain-assets.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env bun
+/**
+ * Cross-deploy asset retention for the SPA.
+ *
+ * CF Pages serves only the latest deployment's files at app.threa.io, so the
+ * moment a new build ships every previous build's content-hashed
+ * /assets/*.js chunk 404s. A tab still running the old build then fails any
+ * lazy `import()` it hasn't loaded yet ("Failed to fetch dynamically imported
+ * module") — and because the SPA `_redirects` fallback answers that 404 with
+ * index.html (200) under the immutable `/assets/*` cache header, the bad
+ * response sticks until the SW lifecycle swaps builds. That is the stale-deploy
+ * crash lib/sw-recovery.ts exists to clean up after.
+ *
+ * This keeps a rolling window of recent builds' assets and folds them back into
+ * the new `dist/` before deploy, so an old tab can keep loading its own chunks
+ * until it picks up the new build via the in-app update toast. The crash stops
+ * happening rather than being recovered from.
+ *
+ * Folding happens AFTER `vite build`, so revived chunks are not in the SW
+ * precache manifest: the new SW precaches only the current build, and the old
+ * chunks are plain network-served fallbacks for tabs still on the old build.
+ */
+import { mkdir, readdir, copyFile, stat, utimes, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+export interface RetainAssetsOptions {
+  /** The just-built `dist/assets` directory to deploy. */
+  distAssetsDir: string
+  /** Persistent store of recent builds' assets, carried across CI runs via cache. */
+  retainDir: string
+  /** Injected for tests; defaults to now. */
+  now?: number
+  /** How long a chunk that has dropped out of the build stays revivable. */
+  retentionMs?: number
+}
+
+export interface RetainAssetsResult {
+  /** Old chunks copied back into the build so old tabs can still load them. */
+  revived: number
+  /** Files in the retain store after this run. */
+  retained: number
+  /** Files dropped for exceeding the retention window. */
+  pruned: number
+}
+
+const DEFAULT_RETENTION_MS = 14 * 24 * 60 * 60 * 1000 // 14 days
+
+export async function retainAssets(options: RetainAssetsOptions): Promise<RetainAssetsResult> {
+  const now = options.now ?? Date.now()
+  const retentionMs = options.retentionMs ?? DEFAULT_RETENTION_MS
+  const { distAssetsDir, retainDir } = options
+
+  // A missing dist means the build never produced assets — fail loudly rather
+  // than deploy a frontend with no chunks (INV-11).
+  if (!existsSync(distAssetsDir)) {
+    throw new Error(`dist assets dir not found: ${distAssetsDir} (did 'vite build' run first?)`)
+  }
+  await mkdir(retainDir, { recursive: true })
+
+  // 1) Fold the current build into the retain store first, stamping mtime=now.
+  //    Doing this before the prune is what keeps a chunk that is still part of
+  //    the live build from ever aging out, however old its retained copy was.
+  const currentNames = new Set<string>()
+  for (const name of await readdir(distAssetsDir)) {
+    const src = path.join(distAssetsDir, name)
+    const info = await stat(src)
+    if (!info.isFile()) continue
+    currentNames.add(name)
+    const dest = path.join(retainDir, name)
+    await copyFile(src, dest)
+    await utimes(dest, new Date(now), new Date(now))
+  }
+
+  // 2) Prune retained chunks past the window. mtime is the age signal; because
+  //    step 1 re-stamped every live chunk to `now`, only chunks that have been
+  //    absent from the build for the whole window age out here.
+  let pruned = 0
+  for (const name of await readdir(retainDir)) {
+    const filePath = path.join(retainDir, name)
+    const info = await stat(filePath)
+    if (!info.isFile()) continue
+    if (now - info.mtimeMs > retentionMs) {
+      await rm(filePath)
+      pruned++
+    }
+  }
+
+  // 3) Revive retained chunks that dropped out of the current build. Never
+  //    overwrite a current-build file — content-hashed names collide only when
+  //    the bytes are identical, but a live file is the source of truth.
+  let revived = 0
+  for (const name of await readdir(retainDir)) {
+    if (currentNames.has(name)) continue
+    const src = path.join(retainDir, name)
+    const info = await stat(src)
+    if (!info.isFile()) continue
+    await copyFile(src, path.join(distAssetsDir, name))
+    revived++
+  }
+
+  const retained = (await readdir(retainDir)).length
+  return { revived, retained, pruned }
+}
+
+if (import.meta.main) {
+  const distAssetsDir = path.resolve(import.meta.dir, "../dist/assets")
+  const retainDir = path.resolve(import.meta.dir, "../.retained-assets")
+  const result = await retainAssets({ distAssetsDir, retainDir })
+  console.log(
+    `[retain-assets] revived ${result.revived} old chunk(s), pruned ${result.pruned}, ${result.retained} retained`
+  )
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -135,7 +135,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.ts"],
   },
   server: {
     host: "0.0.0.0",

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -132,10 +132,30 @@ export default defineConfig({
     },
   },
   test: {
-    globals: true,
-    environment: "jsdom",
-    setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.ts"],
+    // Two projects so the Node build-script tests under scripts/ don't drag in
+    // the jsdom UI bootstrap (./src/test/setup.ts → @/db, localStorage, DOM
+    // polyfills) that has nothing to do with a filesystem script.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "frontend",
+          globals: true,
+          environment: "jsdom",
+          setupFiles: ["./src/test/setup.ts"],
+          include: ["src/**/*.test.{ts,tsx}"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "scripts",
+          globals: true,
+          environment: "node",
+          include: ["scripts/**/*.test.ts"],
+        },
+      },
+    ],
   },
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Problem

After a frontend deploy, users on an already-open tab hit a hard crash:

> TypeError: Failed to fetch dynamically imported module: https://app.threa.io/assets/workspace-layout-DO0oQwkQ.js

CF Pages (`threa-frontend`, bound directly to `app.threa.io`) serves only the **latest** deployment's files at the production alias. The moment a new build ships, every previous build's content-hashed `/assets/*.js` chunk 404s. A tab still running the old build then fails any lazy `import()` it hadn't loaded yet — opening a route whose chunk is now gone.

It gets worse than a transient 404. `apps/frontend/public/_redirects` is `/* /index.html 200`, so the missing chunk is answered with `index.html` (200, `text/html`); `apps/frontend/public/_headers` stamps `/assets/*` with `Cache-Control: public, max-age=31536000, immutable`, matched by request path. The bad HTML-as-JS response is then pinned for a year in the browser HTTP cache (and can sit at the CF edge), so the tab stays wedged until the service-worker lifecycle swaps builds. This is the exact failure `apps/frontend/src/lib/sw-recovery.ts` + `crash-recovery.ts` + the `index.html` watchdog + `/recover` all exist to clean up after.

The config-only fix considered first — make `/assets/*` return a real 404 — is **not expressible on CF Pages**: `_redirects` supports only 200 rewrites and 301/302/303/307/308 redirects (the `/path/* /x 404` form is documented as unsupported), and `_headers` can't tell a real asset from the SPA fallback (both match `/assets/*` by path). So the durable fix is to stop the missing chunk from happening at all.

## Solution

Keep a rolling window of recent builds' `/assets/*` files and fold them back into the new `dist/` before `wrangler pages deploy`. An old tab can then keep loading **its own** chunks until it picks up the new build through the existing in-app update toast (`useAppUpdate` / `version.json`). The crash stops happening rather than being recovered from after the fact.

### How it works

1. `apps/frontend/scripts/retain-assets.ts` exports `retainAssets({ distAssetsDir, retainDir, now?, retentionMs? })`, run after `vite build`:
   - **Fold** every file in `dist/assets` into a persistent `retainDir`, stamping `mtime = now`.
   - **Prune** `retainDir` entries whose `mtime` is older than the window (default `DEFAULT_RETENTION_MS` = 14 days). Folding *before* pruning is load-bearing: a chunk still in the live build is re-stamped to `now` each deploy, so it never ages out while it's current — only chunks absent from the build for the whole window are dropped.
   - **Revive** `retainDir` entries not present in the current build by copying them into `dist/assets`. A current-build file is never overwritten (content-hashed names collide only on identical bytes, but the live file is the source of truth).
2. The deploy jobs cache `retainDir` across runs with `actions/cache` (restore → build → fold → save), keyed `frontend-retained-assets-{prod,staging}-${{ github.run_id }}` with a prefix `restore-keys` so each run restores the most recent store and writes a fresh one. Prod and staging use separate keys so their stores never cross-pollinate.
3. Folding happens **after** the build, so revived chunks are not in the SW precache manifest (`self.__WB_MANIFEST`): the new SW precaches only the current build, and the old chunks are plain network-served fallbacks for tabs still on the old build.

### Key design decisions

**1. Retention in CI over a Pages Function or R2.** A Pages Function that 404s missing `/assets/*` would only convert the poison into a *clean* failure (the tab still crashes and leans on recovery); it also puts a Function on the asset-serving critical path with CF runtime semantics (`next()` vs `_redirects`) I couldn't verify offline. R2-backed immutable asset hosting is the heavyweight version of the same idea. Folding old chunks into `dist/` prevents the failure with no change to the request path and reuses the update toast the app already has.

**2. Time-windowed prune, fold-before-prune.** A pure count cap would shrink the healing window for a firehose of deploys; a pure time window with no re-stamp would age out chunks that are still live. Re-stamping live chunks to `now` on every deploy and pruning by `mtime` keeps any still-current chunk indefinitely and ages out only genuinely-dropped ones 14 days after they leave the build.

**3. Best-effort, never a deploy gate.** Restore, fold, and save all carry `continue-on-error: true`. Retention is a resilience enhancement; a cache miss or script hiccup must never block shipping the frontend. The one hard failure is a missing `dist/assets` (build never produced assets), which throws (INV-11) rather than deploying an empty frontend.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/scripts/retain-assets.ts` | Fold/prune/revive logic + CLI entry (`import.meta.main`) |
| `apps/frontend/scripts/retain-assets.test.ts` | 6 vitest cases over the fold/prune/revive behavior |
| `apps/frontend/.gitignore` | Ignore the local `.retained-assets/` store |

## Modified files

| File | Change |
| ---- | ------ |
| `.github/workflows/deploy-cloudflare.yml` | Restore/fold/save steps in the frontend **prod** and **staging** deploy jobs |
| `apps/frontend/vite.config.ts` | Broaden vitest `include` to `scripts/**/*.test.ts` so the new test runs in CI |

## Out of scope (deliberate)

- **Hardening the client recovery / `/recover` "nuke" path** (delete caches before navigating to a cache-busted URL; route stuck states there instead of capping at 2 auto-retries). Retention makes the common case never reach recovery; the nuke path is a separate follow-up.
- **`apps/backoffice`** has the same `_redirects`/`_headers` shape but is a low-traffic internal admin SPA; left out to keep this scoped to the user-facing app.
- **CF edge cache** (layer outside the browser) is untouched — retention sidesteps it by keeping the real chunk available, so the edge never has a poisoned entry to serve.

## Test plan

- [x] `bunx vitest run scripts/retain-assets.test.ts` — 6 pass (revive dropped chunk; never overwrite current; prune past window; keep-alive while live across two deploys; first-run fold + store creation; throw on missing dist)
- [x] CLI smoke run of `retainAssets` against a temp `dist/assets` — folds + returns `{revived:0, retained:1, pruned:0}`
- [x] Pre-commit hook: full monorepo lint + `tsc --noEmit` (all apps, incl. frontend `tsconfig.app`/`tsconfig.test`) + dockerfile/migration checks — clean
- [ ] **End-to-end deploy not exercised** — no way to run `actions/cache` + `wrangler pages deploy` from here. The fold/prune/revive logic is unit-covered; the GitHub Actions wiring is reviewed by reading the YAML, not executed.

### Honest limitations

- GitHub Actions caches are evicted after ~7 days of no access (and under the 10 GB repo LRU). With frequent merges to `main` the store stays warm, but a >7-day deploy gap resets the window — degrading to today's behavior, never worse.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeKiRFBN6SWYHNq3S1zc1q)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784397090&installation_id=129946197&pr_number=1007&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1007&signature=9e09f6f29181151db02d8612748fb4ec814cecf7ab9276d4c98fb3cc6057f59f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->