### PR TITLE
fix: land date jumps on resolved timeline anchors

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1218,12 +1218,15 @@ export function StreamContent({
     }
   }, [])
 
-  // Set when a jump (deep-link `?m=` or out-of-window search) has loaded a new
-  // event window and the target still needs to be scrolled into view. Stays
-  // set until scrollToMessage actually engages its own resilient refine loop
+  // Set when a jump (deep-link `?m=`, out-of-window search, or date picker) has
+  // loaded a new event window and the target still needs to be scrolled into
+  // view. Stays set until scrollToMessage engages its own resilient refine loop
   // — see the convergent driver below for why a one-shot attempt isn't enough.
   const pendingScrollTarget = useRef<string | null>(null)
   const pendingScrollRafRef = useRef(0)
+  // Date jumps learn the anchor after the window fetch has already scheduled
+  // state updates, so a ref write alone can miss the effect's dependency tick.
+  const [pendingScrollRequestVersion, setPendingScrollRequestVersion] = useState(0)
 
   // When a search result is selected, navigate to that message.
   // If the message is already in the loaded events, just scroll to it in the DOM —
@@ -1274,14 +1277,17 @@ export function StreamContent({
           return
         }
       }
+      resetShiftBaseline()
       const anchorId = await jumpToEventByDate(new Date(targetDayMs).toISOString())
       if (anchorId) {
         pendingScrollTarget.current = anchorId
+        setPendingScrollRequestVersion((version) => version + 1)
       } else {
+        pendingScrollTarget.current = null
         toast.info("No messages on or after that date")
       }
     },
-    [events, disableAutoScroll, scrollToMessage, jumpToEventByDate]
+    [events, disableAutoScroll, scrollToMessage, jumpToEventByDate, resetShiftBaseline]
   )
 
   // Highlight search matches in the DOM via CSS Custom Highlight API
@@ -1293,10 +1299,10 @@ export function StreamContent({
   )
   // Convergent post-jump scroll driver.
   //
-  // A deep-link/search jump is not a single observable React transition: the
-  // window swap updates `events`, then the `holdForDeepLink` skeleton
-  // releases, then <Virtuoso> (re)mounts and only *then* attaches its
-  // scroller — and the target row may be virtualized out or transiently
+  // A post-jump scroll is not a single observable React transition: the window
+  // swap updates `events`; deep links may then wait for `holdForDeepLink`; then
+  // <Virtuoso> (re)mounts and only *then* attaches its scroller — and the
+  // target row may be virtualized out or transiently
   // grouped for the first few frames. The previous one-shot
   // `requestAnimationFrame(scrollToMessage)` + unconditional
   // `pendingScrollTarget = null` frequently fired into a not-yet-mounted
@@ -1374,7 +1380,7 @@ export function StreamContent({
         pendingScrollRafRef.current = 0
       }
     }
-  }, [events, isLoading, scrollToMessage, useVirtualized, setDeepLinkGaveUp])
+  }, [events, isLoading, scrollToMessage, useVirtualized, setDeepLinkGaveUp, pendingScrollRequestVersion])
 
   // Jump to highlighted message if it's not in the current event window.
   // The guard uses location.key so repeat clicks on the same message link


### PR DESCRIPTION
## Problem

The floating date header's date picker could load the right historical event window without reliably landing on the server-resolved message. In `StreamContent.handleJumpToDate`, `jumpToEventByDate(...)` swaps the timeline window from inside the hook, then returns `anchorMessageId` to the caller. The existing post-jump scroll driver only re-ran when React-visible dependencies such as `events` changed; if the window update rendered before `pendingScrollTarget.current` was populated, the driver observed no target and had no later dependency tick to wake it. The result matched the reported behavior: selecting a date could leave the viewport at the top of the loaded window rather than on the first message for that day.

## Solution

Reuse the existing convergent post-jump scroll driver, but make date jumps explicitly wake it after the backend-resolved anchor is known.

### How it works

1. `StreamContent` now tracks `pendingScrollRequestVersion` next to `pendingScrollTarget`. Date jumps still store the target in the ref, but increment the version after `jumpToEventByDate(...)` returns an `anchorMessageId`.
2. The post-jump `useEffect` depends on `pendingScrollRequestVersion`, so the same retry loop used for deep links and search jumps starts even when the event-window render already happened before the ref was written.
3. `handleJumpToDate` calls `resetShiftBaseline()` before replacing the loaded event window, so the virtualizer does not treat a wholesale date-window swap like an older-page prepend.
4. If the selected date has no message on or after it, the handler clears any stale pending target before keeping the existing `toast.info("No messages on or after that date")` feedback.

### Key design decisions

**1. Reuse the post-jump scroll driver** — The existing driver already handles delayed scroller attachment, virtualized-out rows, transient grouping, user aborts, and a hard deadline. A date-specific `requestAnimationFrame` path would duplicate the fragile part of deep-link/search scrolling.

**2. Wake with a version instead of guessing the target early** — The date target is not known until the backend resolves the first message on or after the local day. The version state is only a wake signal; the target remains in the existing ref used by the scroll driver.

**3. Reset only the virtualizer baseline for the date window swap** — Date jumps replace the event window. Resetting the shift baseline keeps the existing prepend compensation for real older-page loads while avoiding false prepend handling for this navigation.

## New files

None.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Wakes the post-jump scroll driver after date-anchor resolution, resets the virtualizer shift baseline before date-window replacement, and clears stale pending targets when no date anchor exists. |

## Deleted files

None.

## Out of scope (deliberate)

- Backend date-anchor resolution is unchanged; `jumpToEventByDate` already returns the message id this fix needs.
- The date picker UI and preset list are unchanged.
- No new browser-level E2E was added for this small scroll-driver coordination bug.

## Test plan

- [x] `bun run --cwd apps/frontend test stream-date-header.test.tsx stream-content.test.ts` — 28 pass
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] Pre-PR local code review (`/skill:code-review`) — confidence 7/7, no issues found
- [x] Commit hook — root lint, monorepo typecheck, Dockerfile/migration checks, and API docs check passed
- [ ] Manual browser reproduction — not run in this remote invocation

<details>
<summary>📋 Full implementation plan</summary>

## Goal

Fix the date scroll-back flow so selecting a date loads the surrounding messages and lands on the backend-resolved anchor instead of leaving the viewport at the top of the loaded window.

## What Was Built

- Added an explicit `pendingScrollRequestVersion` wake signal for date jumps in `StreamContent`.
- Incremented that signal after `jumpToEventByDate(...)` returns an `anchorMessageId`, ensuring the existing post-jump scroll effect runs after the ref target is set.
- Reset the virtualizer shift baseline before date-window replacement.
- Cleared stale pending scroll targets when the backend reports no message on or after the selected date.

## Design Decisions

- Reuse the shared post-jump scroll driver for deep links, search jumps, and date jumps rather than adding a parallel date-only scroll path.
- Keep the target in `pendingScrollTarget.current`; use state only as a wake/version dependency because the date anchor is only known after the async backend call resolves.
- Limit the change to frontend scroll coordination; no API or backend query changes are required.

## Design Evolution

Initial investigation showed the date path differed from search/deep-link jumps: date jumps only learn the final anchor after the event-window state update has already been scheduled. The fix therefore adds an explicit wake after anchor resolution and resets the virtualizer baseline before the window swap.

## Schema Changes

None.

## What's NOT Included

- No changes to `getEventsAroundDate` or `/events/around?date=`.
- No date picker redesign.
- No new E2E/browser test.

## Status

Implemented, committed, pushed, typechecked, unit-tested, and reviewed locally.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784410426&installation_id=129946197&pr_number=1008&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1008&signature=f3e77d91d255ca92f8618104feff27e34e4a42df66398077ec55079c50c4c9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->