### PR TITLE
fix(timeline): fetch and re-anchor when date jump target is out of window

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -5,7 +5,9 @@ import {
   computeScrollEdges,
   shouldPrefetchOlderHistory,
   shouldShowOlderSkeletons,
+  resolveDateJumpAnchor,
 } from "./stream-content"
+import { localStartOfDayMs } from "@/lib/dates"
 
 const DEADLINE = 4000
 
@@ -296,5 +298,82 @@ describe("shouldShowOlderSkeletons", () => {
         appearDelayElapsed: true,
       })
     ).toBe(false)
+  })
+})
+
+describe("resolveDateJumpAnchor", () => {
+  // Build a message event whose local day is `daysFromTarget` away from a fixed
+  // reference day, using mid-day timestamps so timezone never straddles a day
+  // boundary. The target day is the reference day itself.
+  const REF = new Date(2026, 0, 15, 12, 0, 0) // Jan 15 2026, noon local
+  const targetDayMs = localStartOfDayMs(REF)
+  const dayMs = 24 * 60 * 60 * 1000
+  const msg = (id: string, daysFromTarget: number) => ({
+    eventType: "message_created" as const,
+    createdAt: new Date(targetDayMs + daysFromTarget * dayMs + 12 * 60 * 60 * 1000).toISOString(),
+    payload: { messageId: id },
+  })
+
+  it("scrolls directly when a loaded message sits strictly before the target day", () => {
+    // Window straddles the day: Jan 14 is before, Jan 15/16 are on-or-after, so
+    // the first on-or-after match is the genuine anchor.
+    const events = [msg("m_before", -1), msg("m_anchor", 0), msg("m_after", 1)]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBe("m_anchor")
+  })
+
+  it("fetches when every loaded message is newer than the target and older history exists", () => {
+    // The regression: parked at the live tail (all messages on/after the target),
+    // a find-first match would return the oldest loaded row. Must fetch instead.
+    const events = [msg("m_oldest_loaded", 5), msg("m_mid", 6), msg("m_newest", 7)]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBeNull()
+  })
+
+  it("scrolls to the first message when the window is the start of the stream (no older history)", () => {
+    // No older events to fetch — the first loaded message IS the earliest
+    // on-or-after the target, even though nothing precedes it in the window.
+    const events = [msg("m_first", 2), msg("m_next", 3)]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: false })).toBe("m_first")
+  })
+
+  it("fetches when no loaded message lands on or after the target day", () => {
+    // Jumping forward of everything loaded (e.g. scrolled up in old history,
+    // then picked today): no in-window match, so fetch a fresh window.
+    const events = [msg("m_a", -10), msg("m_b", -9)]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBeNull()
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: false })).toBeNull()
+  })
+
+  it("ignores non-message events when locating the anchor", () => {
+    const events = [
+      { eventType: "member_joined" as const, createdAt: new Date(targetDayMs - 5 * dayMs).toISOString(), payload: {} },
+      msg("m_before", -1),
+      {
+        eventType: "member_added" as const,
+        createdAt: new Date(targetDayMs + 12 * 60 * 60 * 1000).toISOString(),
+        payload: {},
+      },
+      msg("m_anchor", 0),
+    ]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBe("m_anchor")
+  })
+
+  it("treats companion responses as anchors", () => {
+    const events = [
+      msg("m_before", -1),
+      {
+        eventType: "companion_response" as const,
+        createdAt: new Date(targetDayMs + 12 * 60 * 60 * 1000).toISOString(),
+        payload: { messageId: "m_companion" },
+      },
+    ]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBe("m_companion")
+  })
+
+  it("fetches when the in-window match carries no messageId in its payload", () => {
+    const events = [
+      msg("m_before", -1),
+      { eventType: "message_created" as const, createdAt: REF.toISOString(), payload: {} },
+    ]
+    expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBeNull()
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -248,6 +248,43 @@ export function shouldShowOlderSkeletons(args: {
   return args.currentOldestEventId === args.trackedOldestEventId
 }
 
+/**
+ * Resolve a date jump against the currently loaded window: return the message
+ * id to scroll to directly, or `null` when the caller must fetch a fresh window
+ * around the date.
+ *
+ * The trap this guards is `events.find(day >= target)`: when the target day is
+ * older than everything loaded — the user is parked at the live tail and jumps
+ * weeks back — *every* loaded message satisfies `day >= target`, so the first
+ * match is the oldest loaded row, not the day's first message. The jump then
+ * looks like it just nudges the scroll up a little instead of relocating to the
+ * date, and no fetch ever happens.
+ *
+ * The in-window scroll is correct only when the loaded window straddles the
+ * target day: either a loaded message sits strictly before it (so the first
+ * on-or-after match is the true anchor with nothing earlier missing), or the
+ * stream has no older history left to fetch (the window already starts at the
+ * beginning). Otherwise the earliest on-or-after-target message may live below
+ * the loaded window, so we return `null` and the caller fetches.
+ */
+export function resolveDateJumpAnchor(args: {
+  events: Array<Pick<StreamEvent, "eventType" | "createdAt" | "payload">>
+  targetDayMs: number
+  hasOlderEvents: boolean
+}): string | null {
+  const { events, targetDayMs, hasOlderEvents } = args
+  let sawEarlierMessage = false
+  for (const event of events) {
+    if (event.eventType !== "message_created" && event.eventType !== "companion_response") continue
+    if (localStartOfDayMs(new Date(event.createdAt)) >= targetDayMs) {
+      if (!sawEarlierMessage && hasOlderEvents) return null
+      return (event.payload as { messageId?: string })?.messageId ?? null
+    }
+    sawEarlierMessage = true
+  }
+  return null
+}
+
 interface StreamContentProps {
   workspaceId: string
   streamId: string
@@ -1264,18 +1301,12 @@ export function StreamContent({
     async (date: Date) => {
       userInteractedAtRef.current = 0
       const targetDayMs = localStartOfDayMs(date)
-      const loaded = events.find((event) => {
-        if (event.eventType !== "message_created" && event.eventType !== "companion_response") return false
-        return localStartOfDayMs(new Date(event.createdAt)) >= targetDayMs
-      })
       disableAutoScroll()
-      if (loaded) {
-        const messageId = (loaded.payload as { messageId?: string })?.messageId
-        if (messageId) {
-          pendingScrollTarget.current = null
-          scrollToMessage(messageId)
-          return
-        }
+      const inWindowMessageId = resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents })
+      if (inWindowMessageId) {
+        pendingScrollTarget.current = null
+        scrollToMessage(inWindowMessageId)
+        return
       }
       resetShiftBaseline()
       const anchorId = await jumpToEventByDate(new Date(targetDayMs).toISOString())
@@ -1287,7 +1318,7 @@ export function StreamContent({
         toast.info("No messages on or after that date")
       }
     },
-    [events, disableAutoScroll, scrollToMessage, jumpToEventByDate, resetShiftBaseline]
+    [events, hasOlderEvents, disableAutoScroll, scrollToMessage, jumpToEventByDate, resetShiftBaseline]
   )
 
   // Highlight search matches in the DOM via CSS Custom Highlight API


### PR DESCRIPTION
## Problem

Jumping to a date in a stream timeline (the floating date pill → preset or calendar) usually did nothing useful: it relocated the scroll to the *oldest already-loaded* message instead of fetching and landing on the chosen day.

The fast path in `handleJumpToDate` (`apps/frontend/src/components/timeline/stream-content.tsx`) decided "is the target already loaded?" with:

```js
events.find(event => localStartOfDayMs(new Date(event.createdAt)) >= targetDayMs)
```

`find` returns the *first* event satisfying `day >= target`. When you're parked at the live tail and jump weeks back, **every** loaded message satisfies `day >= target`, so the match is `events[0]` — the oldest loaded row. The handler scrolled there and returned, so the out-of-window fetch path almost never ran. From the user's seat the jump "just nudges the scroll up a little" and never relocates.

`#1008` (already in `main`) wired up the post-jump scroll driver, the shift-baseline reset, and stale-target clearing — but left this false-positive in the guard, so all that machinery sat unused for the common case.

## Solution

Only take the in-window scroll when the loaded window genuinely **straddles** the target day; otherwise fall through to the existing fetch-and-re-anchor path.

### How it works

The decision moves into a pure, exported `resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents })` that returns the message id to scroll to, or `null` to mean "fetch". It walks events in ascending (chronological) order and returns the in-window anchor only when:

- a loaded message sits **strictly before** the target day (`sawEarlierMessage`) — so the first on-or-after match is the genuine anchor with nothing earlier missing; or
- there is **no older history left to fetch** (`hasOlderEvents === false`) — the window already starts at the beginning of the stream.

Otherwise it returns `null`, and `handleJumpToDate` calls `jumpToEventByDate` (`apps/frontend/src/hooks/use-events.ts`), which fetches a window of surrounding messages around the day's first message via `getEventsAroundDate`, enters jump mode (bidirectional pagination — `hasOlder`/`hasNewer`, separate older/newer infinite queries), and re-anchors the scroll on the server-resolved `anchorMessageId` through the existing `pendingScrollTarget` + `pendingScrollRequestVersion` driver. So after the jump, scrolling up *and* down keeps loading history.

### Key design decisions

**1. Gate on "window straddles the day", not "any loaded message is newer".** The straddle test is exactly the condition under which `find`'s first match is provably the earliest on-or-after-target message: the preceding loaded message is strictly before the day, and the window is contiguous, so nothing earlier can be missing. The two opposite failure modes the gate closes: a target older than the whole window (every row matches → wrong oldest-row anchor) versus a target genuinely inside the window (correct, no fetch). The `!hasOlderEvents` branch covers the start-of-stream case where the first row legitimately has no predecessor.

**2. Extract a pure helper rather than inline the logic.** Matches the sibling timeline predicates (`classifyDeepLinkScrollTick`, `shouldPrefetchOlderHistory`, `computeScrollEdges`) that already live as exported pure functions with unit coverage in `stream-content.test.ts`. The scroll/fetch wiring itself is untestable without a live virtualizer; the decision is not, so it's the part worth isolating.

**3. Reuse the existing fetch + re-anchor machinery untouched.** `jumpToEventByDate`, jump mode, and the post-jump driver are the same paths deep-links and search already use. The fix is purely making the guard fall through to them at the right time — no new fetch or scroll code.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Add pure `resolveDateJumpAnchor` helper; rewrite `handleJumpToDate` to use it (replaces the `events.find` false-positive); add `hasOlderEvents` to the callback deps |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | 7 unit tests for `resolveDateJumpAnchor`: straddle, live-tail (regression), start-of-stream, forward-jump, non-message events, companion-response anchor, missing-messageId |

## Out of scope (deliberate)

- The fetch/jump-mode/re-anchor machinery and the date pill UI (`stream-date-header.tsx`) are unchanged — the bug was the guard in front of them, not the machinery itself.
- No backend change. `getEventsAroundDate` / `findFirstMessageOnOrAfter` already resolve the correct anchor and surrounding window.

## Test plan

- [x] `bunx vitest run src/components/timeline/stream-content.test.ts` — 31 pass (7 new)
- [x] `bunx tsc --noEmit -p apps/frontend/tsconfig.json` — clean
- [ ] No live virtualizer harness, so the scroll/fetch wiring is exercised only through the pure `resolveDateJumpAnchor` helper (as with its sibling predicates) — the DOM-level jump is not integration-tested

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7uzs8qTSrmyUaojB5NHV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784423593&installation_id=129946197&pr_number=1009&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1009&signature=544e1727173eead5afdf425e06c7ea71cdfa308dbec3b77cdf41a8f0e2e17958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->