### PR TITLE
fix(public-api): render every spec tag (Labels) + scrollable mobile docs drawer

### DIFF
--- a/apps/backend/scripts/generate-api-docs.ts
+++ b/apps/backend/scripts/generate-api-docs.ts
@@ -50,6 +50,41 @@ function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
 // Build OpenAPI 3.0 document
 // ---------------------------------------------------------------------------
 
+// Tag order + descriptions for the reference. Every tag a route declares must
+// have an entry here. The spec emits the entries that are actually in use, so a
+// newly added group surfaces in the rendered reference without editing the docs
+// site; a route that introduces an undescribed tag fails the build loudly
+// (INV-11) instead of shipping a group with no heading.
+const TAG_DEFS: { name: string; description: string }[] = [
+  { name: "Identity", description: "Confirm who a key belongs to and list the bots you own." },
+  { name: "Streams", description: "List and inspect streams (channels, scratchpads, threads)" },
+  { name: "Messages", description: "Read, send, update, and delete messages" },
+  { name: "Memos", description: "Search preserved workspace knowledge and inspect memo provenance" },
+  { name: "Attachments", description: "Search attachments, inspect extracted content, and fetch download URLs" },
+  { name: "Users", description: "List workspace users" },
+  { name: "Labels", description: "List, create, edit, archive, join, and apply workspace labels" },
+  {
+    name: "Bot runtimes",
+    description: "Register a runtime and keep its presence alive so it can be assigned work.",
+  },
+  {
+    name: "Bot invocations",
+    description: "Claim, renew, step through, complete, or fail the work a bot is summoned to do.",
+  },
+]
+
+function buildTags() {
+  const used = new Set<string>()
+  for (const route of PUBLIC_API_ROUTES) for (const tag of route.tags ?? []) used.add(tag)
+  const undescribed = [...used].filter((tag) => !TAG_DEFS.some((d) => d.name === tag))
+  if (undescribed.length > 0) {
+    throw new Error(
+      `Public API routes declare tags with no description (add them to TAG_DEFS in generate-api-docs.ts): ${undescribed.join(", ")}`
+    )
+  }
+  return TAG_DEFS.filter((d) => used.has(d.name))
+}
+
 function buildSpec() {
   const paths: Record<string, Record<string, unknown>> = {}
 
@@ -229,13 +264,7 @@ function buildSpec() {
         },
       },
     },
-    tags: [
-      { name: "Streams", description: "List and inspect streams (channels, scratchpads, threads)" },
-      { name: "Messages", description: "Read, send, update, and delete messages" },
-      { name: "Memos", description: "Search preserved workspace knowledge and inspect memo provenance" },
-      { name: "Attachments", description: "Search attachments, inspect extracted content, and fetch download URLs" },
-      { name: "Users", description: "List workspace users" },
-    ],
+    tags: buildTags(),
   }
 }
 

--- a/apps/backend/tests/e2e/public-api-openapi.test.ts
+++ b/apps/backend/tests/e2e/public-api-openapi.test.ts
@@ -190,6 +190,21 @@ describe("Public API — OpenAPI Spec Validation", () => {
     }
   })
 
+  test("spec declares every tag its operations use", () => {
+    // The reference site renders groups from spec.tags; an operation tag missing
+    // from that array reads as an undescribed group and was silently dropped by
+    // the old hardcoded allowlist. Keep the declaration exhaustive.
+    const specPath = resolve(import.meta.dirname!, "../../../../docs/public-api/openapi.json")
+    const spec = JSON.parse(readFileSync(specPath, "utf-8"))
+
+    const declared = new Set<string>((spec.tags ?? []).map((t: { name: string }) => t.name))
+    const usedTags = new Set<string>()
+    for (const route of PUBLIC_API_ROUTES) for (const tag of route.tags ?? []) usedTags.add(tag)
+
+    const undeclared = [...usedTags].filter((tag) => !declared.has(tag))
+    expect(undeclared).toEqual([])
+  })
+
   describe("Response shape validation", () => {
     test("GET /streams returns data matching streamSchema", async () => {
       const res = await apiRequest("GET", `/api/v1/workspaces/${ctx.workspaceId}/streams`, ctx.allScopesKey)

--- a/apps/public-site/src/pages/developers/reference.astro
+++ b/apps/public-site/src/pages/developers/reference.astro
@@ -19,31 +19,16 @@ const WORKSPACE_PREFIX = "/api/v1/workspaces/{workspaceId}"
 // would fire a literal "/workspaces/{workspaceId}/…" request.
 const RUN_PREFIX = "/api/v1/workspaces/{{workspaceId}}"
 
-// Tag order and descriptions. The spec declares only the first five; the bot and
-// identity tags are described here so the reference reads in a sensible order.
-const TAG_ORDER = [
-  "Identity",
-  "Streams",
-  "Messages",
-  "Memos",
-  "Attachments",
-  "Users",
-  "Bot runtimes",
-  "Bot invocations",
-]
-const declared: Record<string, string> = Object.fromEntries(
-  (spec.tags ?? []).map((t: { name: string; description?: string }) => [t.name, t.description ?? ""]),
+// Group order and descriptions come straight from the spec's tag declaration —
+// the generator emits every tag it uses, in reading order — so a newly added
+// group (e.g. Labels) surfaces here without editing this page. The list below is
+// derived, not hardcoded; that is the whole point: nothing the spec describes can
+// be silently dropped from the reference.
+const declaredTags: { name: string; description?: string }[] = spec.tags ?? []
+const tagOrder = declaredTags.map((t) => t.name)
+const TAG_DESC: Record<string, string> = Object.fromEntries(
+  declaredTags.map((t) => [t.name, t.description ?? ""]),
 )
-const TAG_DESC: Record<string, string> = {
-  Identity: "Confirm who a key belongs to and list the bots you own.",
-  Streams: declared.Streams,
-  Messages: declared.Messages,
-  Memos: declared.Memos,
-  Attachments: declared.Attachments,
-  Users: declared.Users,
-  "Bot runtimes": "Register a runtime and keep its presence alive so it can be assigned work.",
-  "Bot invocations": "Claim, renew, step through, complete, or fail the work a bot is summoned to do.",
-}
 
 // Runnable, read-only endpoints that need only workspace scope (no real resource
 // id). Everything else shows a copyable curl without a Run button, so the docs
@@ -89,12 +74,22 @@ for (const [path, item] of Object.entries(spec.paths as Record<string, Record<st
   }
 }
 
-const groups = TAG_ORDER.map((tag) => ({
-  tag,
-  slug: tag.toLowerCase().replace(/\s+/g, "-"),
-  desc: TAG_DESC[tag],
-  ops: ops.filter((o) => o.tag === tag),
-})).filter((g) => g.ops.length > 0)
+// Render the spec's declared order first, then append any tag that appears on an
+// operation but isn't declared (sorted, so it's stable) — an undeclared tag is a
+// generator gap, not a reason to hide its endpoints.
+const usedTags = [...new Set(ops.map((o) => o.tag))]
+const orderedTags = [
+  ...tagOrder.filter((t) => usedTags.includes(t)),
+  ...usedTags.filter((t) => !tagOrder.includes(t)).sort(),
+]
+const groups = orderedTags
+  .map((tag) => ({
+    tag,
+    slug: tag.toLowerCase().replace(/\s+/g, "-"),
+    desc: TAG_DESC[tag],
+    ops: ops.filter((o) => o.tag === tag),
+  }))
+  .filter((g) => g.ops.length > 0)
 
 // Worked examples that use each group's endpoints. The reference describes
 // the wire; the recipe shows the task — link them so a reader who lands on
@@ -119,6 +114,7 @@ const TAG_HINT: Record<string, string> = {
   Memos: "memo",
   Attachments: "attachment",
   Users: "user",
+  Labels: "label",
   "Bot runtimes": "bot",
   "Bot invocations": "invocation",
 }

--- a/apps/public-site/src/styles/docs.css
+++ b/apps/public-site/src/styles/docs.css
@@ -1240,10 +1240,17 @@ a {
     position: fixed;
     top: 52px;
     left: 0;
-    bottom: 0;
     z-index: 35;
     width: min(82vw, 320px);
-    height: auto;
+    /* dvh, not bottom:0 — on mobile the dynamic browser toolbar sits over the
+       bottom of the layout viewport, so a `bottom: 0` box extends behind it and
+       its tail (a long group like Bot invocations) becomes unreachable. An
+       explicit dvh-based height bounds the drawer to what's actually visible and
+       makes it its own scroll container. */
+    height: calc(100dvh - 52px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
     padding: 26px 22px 40px;
     background: hsl(var(--paper));
     border-right: 1px solid hsl(var(--line));

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -4550,10 +4550,20 @@
     }
   },
   "tags": [
+    { "name": "Identity", "description": "Confirm who a key belongs to and list the bots you own." },
     { "name": "Streams", "description": "List and inspect streams (channels, scratchpads, threads)" },
     { "name": "Messages", "description": "Read, send, update, and delete messages" },
     { "name": "Memos", "description": "Search preserved workspace knowledge and inspect memo provenance" },
     { "name": "Attachments", "description": "Search attachments, inspect extracted content, and fetch download URLs" },
-    { "name": "Users", "description": "List workspace users" }
+    { "name": "Users", "description": "List workspace users" },
+    { "name": "Labels", "description": "List, create, edit, archive, join, and apply workspace labels" },
+    {
+      "name": "Bot runtimes",
+      "description": "Register a runtime and keep its presence alive so it can be assigned work."
+    },
+    {
+      "name": "Bot invocations",
+      "description": "Claim, renew, step through, complete, or fail the work a bot is summoned to do."
+    }
   ]
 }


### PR DESCRIPTION
## Problem

Two defects on the public developer docs (`threa.io/developers/reference`), both reported from mobile:

1. **The new Labels endpoints don't appear in the reference.** `bcb7230` (feat(public-api): label endpoints, #1006) added 9 `Labels` routes to the registry, but they were nowhere on the reference page. The instinct was "does the spec not auto-update?" — but the spec was never the problem: `docs/public-api/openapi.json` already carried all 9 endpoints under `tags: ["Labels"]`. The endpoints were dropped by **two hardcoded allowlists downstream** of the spec:
   - `apps/backend/scripts/generate-api-docs.ts` emitted a fixed 5-entry `tags` array (`Streams, Messages, Memos, Attachments, Users`), so `spec.tags` never described `Labels`, `Identity`, `Bot runtimes`, or `Bot invocations`.
   - `apps/public-site/src/pages/developers/reference.astro` built its render list from a hardcoded `TAG_ORDER` and then `.filter((g) => g.ops.length > 0)`. `TAG_ORDER` listed `Identity`/`Bot runtimes`/`Bot invocations` but **not** `Labels`, so the entire Labels group — heading, sidebar entries, all 9 endpoints — was silently discarded.

2. **The mobile nav drawer doesn't scroll when its content overflows.** On the reference page the drawer lists every endpoint grouped by tag; with a long group expanded (e.g. Bot invocations) the list exceeds the viewport. The drawer was `position: fixed; top: 52px; bottom: 0; height: auto` — on mobile the dynamic browser toolbar overlays the bottom of the layout viewport, so a `bottom: 0` box extends *behind* the toolbar and its tail is unreachable, with no inner scroll.

## Solution

Make the rendered reference derive entirely from the spec, and the generator emit a spec that fully describes itself — so a newly added tag surfaces with no edit to the docs site. Separately, bound the mobile drawer to the dynamic viewport so it becomes its own scroll container.

### How it works

**Labels (and any future group):**
- `generate-api-docs.ts` now keeps a single ordered `TAG_DEFS` list (name + description) and a `buildTags()` that emits only the tags actually used by a route, in that order. If a route declares a tag with no `TAG_DEFS` entry, `buildTags()` **throws** — the spec build fails loudly (INV-11) rather than shipping a group with no heading. Regenerating produced a `spec.tags` with all 9 tags: `Identity, Streams, Messages, Memos, Attachments, Users, Labels, Bot runtimes, Bot invocations`.
- `reference.astro` drops `TAG_ORDER` entirely. `tagOrder` and `TAG_DESC` are now read from `spec.tags`. Group order = spec's declared order, then any tag that appears on an operation but isn't declared is **appended** (sorted) instead of dropped — an undeclared tag is a generator gap, never a reason to hide endpoints. Added a `Labels: "label"` entry to `TAG_HINT` so example-response ids render as `label_…`.
- New guard test in `public-api-openapi.test.ts` asserts every tag used by a route is declared in `spec.tags`, so this can't silently regress.

**Mobile drawer scroll:** in the `max-width: 880px` block, `.docs-side` swaps `bottom: 0; height: auto` for `height: calc(100dvh - 52px)` plus `overflow-y: auto`, `overscroll-behavior: contain`, and `-webkit-overflow-scrolling: touch`. `dvh` tracks the *visible* viewport as the mobile toolbar shows/hides, so the drawer is bounded to what's on screen and scrolls internally.

### Key design decisions

**1. Fix the allowlists, don't special-case Labels.** Adding `"Labels"` to the two hardcoded lists would have fixed the symptom and left the next tag to rot the same way. Deriving order/descriptions from the spec, and emitting every used tag from the generator, removes the class of bug. The reporter's framing ("we sure should auto-update") is exactly this.

**2. Throw on an undescribed tag rather than synthesize a heading.** `buildTags()` could have fallen back to the bare tag name as its own description. A loud build failure (INV-11) forces the author to write a real one-line group description, which is what the reference reads from — a silent fallback would ship an empty-looking group.

**3. Append undeclared tags on the render side too.** Even though the generator now guarantees coverage, `reference.astro` still appends any used-but-undeclared tag instead of filtering it out. The two layers are built/served independently (the page reads the committed JSON at build time); defense on the render side means a hand-edited or stale spec degrades to "group shown, unsorted" rather than "endpoints vanish".

**4. `dvh`, not `bottom: 0` or `vh`.** `bottom: 0` extends behind the mobile toolbar (the original bug); `100vh` is the *large* viewport and has the same overshoot. `100dvh` is the dynamic viewport — the only one that matches what the user can actually see and reach.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/scripts/generate-api-docs.ts` | Replace the fixed 5-tag array with ordered `TAG_DEFS` + `buildTags()`; emit every used tag, throw on an undescribed one (INV-11). |
| `docs/public-api/openapi.json` | Regenerated — `tags` now declares all 9 groups (added `Identity`, `Labels`, `Bot runtimes`, `Bot invocations`). |
| `apps/public-site/src/pages/developers/reference.astro` | Derive `tagOrder`/`TAG_DESC` from `spec.tags`; render declared order then append undeclared used tags; add `Labels` to `TAG_HINT`. |
| `apps/public-site/src/styles/docs.css` | Mobile `.docs-side`: `dvh`-bounded height + `overflow-y: auto` so the drawer scrolls instead of clipping behind the toolbar. |
| `apps/backend/tests/e2e/public-api-openapi.test.ts` | Guard test: every route tag must be declared in `spec.tags`. |

## Out of scope (deliberate)

- The Labels routes themselves (#1006) and their schemas are unchanged — this only fixes how the already-correct spec is described and rendered.
- No new tag *descriptions* on the route definitions in `routes.ts`; descriptions live in the generator's `TAG_DEFS` next to the order, matching how the prior 5 were defined.

## Test plan

- [x] `bun apps/backend/scripts/generate-api-docs.ts --check` — spec up to date after regeneration
- [x] `bunx astro build` (public-site) — builds; rendered `dist/developers/reference/index.html` shows all 9 `<h2>` group headings including `Labels`, and `listLabels`/`createLabel`/`joinLabel`/`promoteLabel` endpoints present
- [x] `bunx astro check` (public-site) — 0 errors / 0 warnings / 0 hints
- [x] Pre-commit hook: full monorepo `tsc --noEmit`, all app `eslint`, `astro check`, dockerfile/migration checks, and openapi `--check` — all green
- [x] New guard-test logic verified standalone against the committed spec — `undeclared: [] PASS`
- [ ] `public-api-openapi.test.ts` not run in-harness — the e2e suite's `beforeAll` needs a live DB, which this environment lacks. The new test is a pure spec/registry read (no DB), verified standalone as above and sits with the other spec-validation tests in the same describe.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzUui8RtunSTR8sfMFwPCp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784423602&installation_id=129946197&pr_number=1010&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1010&signature=cb4ccddeb44ec1fa381e3157e1e8cc4f4640be7958b72dae609c13337ac680c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->