### PR TITLE
feat(pi-remote): label scratchpads by name

### DIFF
--- a/apps/backend/src/features/bot-runtimes/service.test.ts
+++ b/apps/backend/src/features/bot-runtimes/service.test.ts
@@ -466,6 +466,100 @@ describe("BotRuntimeService outbox emission", () => {
     })
   })
 
+  describe("createLinkedScratchpadSession", () => {
+    it("creates the scratchpad, bot grant, label, and session link in one transaction", async () => {
+      patchWithTransaction()
+      const streamService = {
+        createScratchpadInTransaction: mock(() => Promise.resolve({ id: "stream_1" })),
+        addBotToStreamOn: mock(() => Promise.resolve()),
+      }
+      const labelAssignmentService = {
+        assignByNameInTransaction: mock(() => Promise.resolve({})),
+      }
+      spyOn(BotRuntimeService.prototype, "repairBotTraitsInTransaction").mockResolvedValue(undefined)
+      const createLinkSpy = spyOn(
+        BotRuntimeService.prototype,
+        "createOrLinkPiRemoteSessionInTransaction"
+      ).mockResolvedValue({
+        id: "brsl_1",
+        rootStreamId: "stream_1",
+        activeStreamId: "stream_1",
+        runtimeSessionId: "sess_1",
+      } as never)
+      const service = new BotRuntimeService({
+        pool: fakePool,
+        streamService: streamService as never,
+        labelAssignmentService: labelAssignmentService as never,
+      })
+
+      const result = await service.createLinkedScratchpadSession({
+        workspaceId: "ws_1",
+        botId: "bot_1",
+        ownerUserId: "usr_owner",
+        runtimeKind: "pi-local",
+        instanceId: "inst_1",
+        runtimeSessionId: "sess_1",
+        displayName: "Pi remote - threa",
+        localCwd: "/repo/threa",
+        labelName: "Pi remote",
+        traits: ["active-scratchpad"],
+      })
+
+      expect(streamService.createScratchpadInTransaction).toHaveBeenCalledWith(
+        fakeQuerier,
+        expect.objectContaining({ workspaceId: "ws_1", displayName: "Pi remote - threa", createdBy: "usr_owner" })
+      )
+      expect(streamService.addBotToStreamOn).toHaveBeenCalledWith(fakeQuerier, "stream_1", "bot_1", "ws_1", "usr_owner")
+      expect(labelAssignmentService.assignByNameInTransaction).toHaveBeenCalledWith(
+        fakeQuerier,
+        expect.objectContaining({ name: "Pi remote", resourceId: "stream_1" })
+      )
+      expect(createLinkSpy).toHaveBeenCalledWith(
+        fakeQuerier,
+        expect.objectContaining({
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+          linkedBy: "usr_owner",
+          metadata: { displayName: "Pi remote - threa", localCwd: "/repo/threa" },
+        })
+      )
+      expect(result.link.id).toBe("brsl_1")
+      expect(result.stream.id).toBe("stream_1")
+    })
+
+    it("rejects and lets the transaction roll back when label assignment fails", async () => {
+      patchWithTransaction()
+      const streamService = {
+        createScratchpadInTransaction: mock(() => Promise.resolve({ id: "stream_1" })),
+        addBotToStreamOn: mock(() => Promise.resolve()),
+      }
+      const labelAssignmentService = {
+        assignByNameInTransaction: mock(() => Promise.reject(new Error("boom"))),
+      }
+      const createLinkSpy = spyOn(BotRuntimeService.prototype, "createOrLinkPiRemoteSessionInTransaction")
+      const service = new BotRuntimeService({
+        pool: fakePool,
+        streamService: streamService as never,
+        labelAssignmentService: labelAssignmentService as never,
+      })
+
+      await expect(
+        service.createLinkedScratchpadSession({
+          workspaceId: "ws_1",
+          botId: "bot_1",
+          ownerUserId: "usr_owner",
+          runtimeKind: "pi-local",
+          instanceId: "inst_1",
+          runtimeSessionId: "sess_1",
+          displayName: "Pi remote - threa",
+          labelName: "Pi remote",
+          traits: ["active-scratchpad"],
+        })
+      ).rejects.toThrow("boom")
+
+      expect(createLinkSpy).not.toHaveBeenCalled()
+    })
+  })
   describe("requestResyncInTransaction", () => {
     it("rejects instanceId without botId", async () => {
       const service = new BotRuntimeService({ pool: fakePool })

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -1,5 +1,6 @@
 import type { Pool } from "pg"
 import type { Querier } from "../../db"
+import { LabelActorTypes, LabelableResourceTypes, MemoryModes, type MemoryMode } from "@threa/types"
 import type {
   BotInvocationCapability,
   BotInvocationTrigger,
@@ -24,9 +25,13 @@ import {
   type BotRuntimeSessionLink,
   type StreamActiveActor,
 } from "./repository"
+import type { LabelAssignmentService } from "../labels"
+import type { Stream, StreamService } from "../streams"
 
 interface BotRuntimeServiceDeps {
   pool: Pool
+  streamService?: Pick<StreamService, "createScratchpadInTransaction" | "addBotToStreamOn">
+  labelAssignmentService?: Pick<LabelAssignmentService, "assignByNameInTransaction">
 }
 
 function serializeBotForOutbox(bot: Bot) {
@@ -49,9 +54,13 @@ function serializeBotForOutbox(bot: Bot) {
 
 export class BotRuntimeService {
   private readonly pool: Pool
+  private readonly streamService?: Pick<StreamService, "createScratchpadInTransaction" | "addBotToStreamOn">
+  private readonly labelAssignmentService?: Pick<LabelAssignmentService, "assignByNameInTransaction">
 
   constructor(deps: BotRuntimeServiceDeps) {
     this.pool = deps.pool
+    this.streamService = deps.streamService
+    this.labelAssignmentService = deps.labelAssignmentService
   }
 
   async findLatestPresence(params: { workspaceId: string; botId: string }): Promise<BotRuntimeInstance | null> {
@@ -232,6 +241,63 @@ export class BotRuntimeService {
     metadata?: Record<string, unknown>
   }): Promise<BotRuntimeSessionLink> {
     return withTransaction(this.pool, (client) => this.createOrLinkPiRemoteSessionInTransaction(client, params))
+  }
+
+  async createLinkedScratchpadSession(params: {
+    workspaceId: string
+    botId: string
+    ownerUserId: string
+    runtimeKind: BotRuntimeKind
+    instanceId: string
+    runtimeSessionId: string
+    displayName: string
+    localCwd?: string
+    memoryMode?: MemoryMode
+    labelName?: string
+    traits: readonly BotTrait[]
+  }): Promise<{ link: BotRuntimeSessionLink; stream: Stream }> {
+    const { streamService, labelAssignmentService } = this
+    if (!streamService || !labelAssignmentService) {
+      throw new Error("BotRuntimeService missing scratchpad session dependencies")
+    }
+
+    return withTransaction(this.pool, async (client) => {
+      const stream = await streamService.createScratchpadInTransaction(client, {
+        workspaceId: params.workspaceId,
+        displayName: params.displayName,
+        memoryMode: params.memoryMode ?? MemoryModes.OFF,
+        createdBy: params.ownerUserId,
+      })
+      await streamService.addBotToStreamOn(client, stream.id, params.botId, params.workspaceId, params.ownerUserId)
+
+      if (params.labelName) {
+        await labelAssignmentService.assignByNameInTransaction(client, {
+          workspaceId: params.workspaceId,
+          actor: { type: LabelActorTypes.USER, id: params.ownerUserId },
+          name: params.labelName,
+          resourceType: LabelableResourceTypes.STREAM,
+          resourceId: stream.id,
+        })
+      }
+
+      await this.repairBotTraitsInTransaction(client, {
+        workspaceId: params.workspaceId,
+        botId: params.botId,
+        traits: params.traits,
+      })
+      const link = await this.createOrLinkPiRemoteSessionInTransaction(client, {
+        workspaceId: params.workspaceId,
+        botId: params.botId,
+        runtimeKind: params.runtimeKind,
+        instanceId: params.instanceId,
+        runtimeSessionId: params.runtimeSessionId,
+        rootStreamId: stream.id,
+        activeStreamId: stream.id,
+        linkedBy: params.ownerUserId,
+        metadata: { displayName: params.displayName, localCwd: params.localCwd ?? null },
+      })
+      return { link, stream }
+    })
   }
 
   async createOrLinkPiRemoteSessionInTransaction(

--- a/apps/backend/src/features/labels/assignment-service.ts
+++ b/apps/backend/src/features/labels/assignment-service.ts
@@ -97,19 +97,24 @@ export class LabelAssignmentService {
    * commit together. Returns the resolved label alongside the assignment.
    */
   async assignByName(params: AssignLabelByNameParams): Promise<{ label: Label; assignment: LabelAssignment }> {
-    return withTransaction(this.pool, async (client) => {
-      await this.assertResourceAccess(client, params.actor, params.workspaceId, params.resourceType, params.resourceId)
+    return withTransaction(this.pool, (client) => this.assignByNameInTransaction(client, params))
+  }
 
-      const { label } = await this.labelService.upsertByNameWithin(client, params)
-      const assignment = await this.assignWithin(client, label, {
-        workspaceId: params.workspaceId,
-        actor: params.actor,
-        labelId: label.id,
-        resourceType: params.resourceType,
-        resourceId: params.resourceId,
-      })
-      return { label, assignment }
+  async assignByNameInTransaction(
+    client: PoolClient,
+    params: AssignLabelByNameParams
+  ): Promise<{ label: Label; assignment: LabelAssignment }> {
+    await this.assertResourceAccess(client, params.actor, params.workspaceId, params.resourceType, params.resourceId)
+
+    const { label } = await this.labelService.upsertByNameWithin(client, params)
+    const assignment = await this.assignWithin(client, label, {
+      workspaceId: params.workspaceId,
+      actor: params.actor,
+      labelId: label.id,
+      resourceType: params.resourceType,
+      resourceId: params.resourceId,
     })
+    return { label, assignment }
   }
 
   private async assignWithin(client: PoolClient, label: Label, params: AssignLabelParams): Promise<LabelAssignment> {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -43,7 +43,6 @@ import {
   AttachmentSafetyStatuses,
   AuthorTypes,
   LabelActorTypes,
-  LabelableResourceTypes,
   type Label,
   type LabelActor,
   type LabelAssignment,
@@ -1100,46 +1099,18 @@ export function createPublicApiHandlers({
         })
       }
 
-      const { link, stream } = await withTransaction(pool, async (client) => {
-        const stream = await streamService.createScratchpadInTransaction(client, {
-          workspaceId: req.workspaceId!,
-          displayName: data.displayName,
-          // Coding-agent build sessions (pi-local / claude-code-channel) default
-          // to memory off — their turns are implementation churn, not durable
-          // knowledge, so GAM extraction there is noise. Callers can opt in with
-          // `memoryMode: "auto"`.
-          memoryMode: data.memoryMode ?? MemoryModes.OFF,
-          createdBy: bot.ownerUserId,
-        })
-        await streamService.addBotToStreamOn(client, stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
-
-        if (data.labelName) {
-          await labelAssignmentService.assignByNameInTransaction(client, {
-            workspaceId: req.workspaceId!,
-            actor: { type: LabelActorTypes.USER, id: bot.ownerUserId },
-            name: data.labelName,
-            resourceType: LabelableResourceTypes.STREAM,
-            resourceId: stream.id,
-          })
-        }
-
-        await botRuntimeService.repairBotTraitsInTransaction(client, {
-          workspaceId: req.workspaceId!,
-          botId: bot.id,
-          traits: requiredRuntimeTraits,
-        })
-        const link = await botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
-          workspaceId: req.workspaceId!,
-          botId: bot.id,
-          runtimeKind: data.runtimeKind,
-          instanceId: data.instanceId,
-          runtimeSessionId: data.runtimeSessionId,
-          rootStreamId: stream.id,
-          activeStreamId: stream.id,
-          linkedBy: bot.ownerUserId,
-          metadata: { displayName: data.displayName, localCwd: data.localCwd ?? null },
-        })
-        return { link, stream }
+      const { link, stream } = await botRuntimeService.createLinkedScratchpadSession({
+        workspaceId: req.workspaceId!,
+        botId: bot.id,
+        ownerUserId: bot.ownerUserId,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
+        displayName: data.displayName,
+        localCwd: data.localCwd,
+        memoryMode: data.memoryMode,
+        labelName: data.labelName,
+        traits: requiredRuntimeTraits,
       })
 
       res.json({

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -43,6 +43,7 @@ import {
   AttachmentSafetyStatuses,
   AuthorTypes,
   LabelActorTypes,
+  LabelableResourceTypes,
   type Label,
   type LabelActor,
   type LabelAssignment,
@@ -1110,6 +1111,24 @@ export function createPublicApiHandlers({
         createdBy: bot.ownerUserId,
       })
       await streamService.addBotToStream(stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
+
+      if (data.labelName) {
+        try {
+          await labelAssignmentService.assignByName({
+            workspaceId: req.workspaceId!,
+            actor: { type: LabelActorTypes.USER, id: bot.ownerUserId },
+            name: data.labelName,
+            resourceType: LabelableResourceTypes.STREAM,
+            resourceId: stream.id,
+          })
+        } catch (err) {
+          logger.warn(
+            { err, workspaceId: req.workspaceId!, streamId: stream.id, labelName: data.labelName },
+            "Failed to assign optional runtime session label"
+          )
+        }
+      }
+
       const link = await withTransaction(pool, async (client) => {
         await botRuntimeService.repairBotTraitsInTransaction(client, {
           workspaceId: req.workspaceId!,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1100,42 +1100,35 @@ export function createPublicApiHandlers({
         })
       }
 
-      const stream = await streamService.createScratchpad({
-        workspaceId: req.workspaceId!,
-        displayName: data.displayName,
-        // Coding-agent build sessions (pi-local / claude-code-channel) default
-        // to memory off — their turns are implementation churn, not durable
-        // knowledge, so GAM extraction there is noise. Callers can opt in with
-        // `memoryMode: "auto"`.
-        memoryMode: data.memoryMode ?? MemoryModes.OFF,
-        createdBy: bot.ownerUserId,
-      })
-      await streamService.addBotToStream(stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
+      const { link, stream } = await withTransaction(pool, async (client) => {
+        const stream = await streamService.createScratchpadInTransaction(client, {
+          workspaceId: req.workspaceId!,
+          displayName: data.displayName,
+          // Coding-agent build sessions (pi-local / claude-code-channel) default
+          // to memory off — their turns are implementation churn, not durable
+          // knowledge, so GAM extraction there is noise. Callers can opt in with
+          // `memoryMode: "auto"`.
+          memoryMode: data.memoryMode ?? MemoryModes.OFF,
+          createdBy: bot.ownerUserId,
+        })
+        await streamService.addBotToStreamOn(client, stream.id, bot.id, req.workspaceId!, bot.ownerUserId)
 
-      if (data.labelName) {
-        try {
-          await labelAssignmentService.assignByName({
+        if (data.labelName) {
+          await labelAssignmentService.assignByNameInTransaction(client, {
             workspaceId: req.workspaceId!,
             actor: { type: LabelActorTypes.USER, id: bot.ownerUserId },
             name: data.labelName,
             resourceType: LabelableResourceTypes.STREAM,
             resourceId: stream.id,
           })
-        } catch (err) {
-          logger.warn(
-            { err, workspaceId: req.workspaceId!, streamId: stream.id, labelName: data.labelName },
-            "Failed to assign optional runtime session label"
-          )
         }
-      }
 
-      const link = await withTransaction(pool, async (client) => {
         await botRuntimeService.repairBotTraitsInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: bot.id,
           traits: requiredRuntimeTraits,
         })
-        return botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
+        const link = await botRuntimeService.createOrLinkPiRemoteSessionInTransaction(client, {
           workspaceId: req.workspaceId!,
           botId: bot.id,
           runtimeKind: data.runtimeKind,
@@ -1146,6 +1139,7 @@ export function createPublicApiHandlers({
           linkedBy: bot.ownerUserId,
           metadata: { displayName: data.displayName, localCwd: data.localCwd ?? null },
         })
+        return { link, stream }
       })
 
       res.json({

--- a/apps/backend/src/features/public-api/runtime-session-label.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-label.test.ts
@@ -33,12 +33,12 @@ function createPool() {
 }
 
 function createHandlers(overrides: Partial<PublicApiDeps> = {}) {
-  const { pool } = createPool()
+  const { pool, client } = createPool()
   const deps: PublicApiDeps = {
     eventService: {} as PublicApiDeps["eventService"],
     streamService: {
-      createScratchpad: mock(() => Promise.resolve({ id: "stream_1" })),
-      addBotToStream: mock(() => Promise.resolve()),
+      createScratchpadInTransaction: mock(() => Promise.resolve({ id: "stream_1" })),
+      addBotToStreamOn: mock(() => Promise.resolve()),
     } as unknown as PublicApiDeps["streamService"],
     searchService: {} as PublicApiDeps["searchService"],
     memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
@@ -58,13 +58,13 @@ function createHandlers(overrides: Partial<PublicApiDeps> = {}) {
     } as unknown as PublicApiDeps["botRuntimeService"],
     labelService: {} as PublicApiDeps["labelService"],
     labelAssignmentService: {
-      assignByName: mock(() => Promise.resolve({})),
+      assignByNameInTransaction: mock(() => Promise.resolve({})),
     } as unknown as PublicApiDeps["labelAssignmentService"],
     pool,
     io: {} as PublicApiDeps["io"],
     ...overrides,
   }
-  return { handlers: createPublicApiHandlers(deps), deps }
+  return { handlers: createPublicApiHandlers(deps), deps, client }
 }
 
 function botRequest(body: unknown): Request {
@@ -82,9 +82,9 @@ describe("bot runtime session labels", () => {
 
   it("assigns an optional label by name for the personal bot owner", async () => {
     spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
-    const assignByName = mock(() => Promise.resolve({}))
+    const assignByNameInTransaction = mock(() => Promise.resolve({}))
     const { handlers, deps } = createHandlers({
-      labelAssignmentService: { assignByName } as unknown as PublicApiDeps["labelAssignmentService"],
+      labelAssignmentService: { assignByNameInTransaction } as unknown as PublicApiDeps["labelAssignmentService"],
     })
     const cap = createResponse()
 
@@ -99,10 +99,12 @@ describe("bot runtime session labels", () => {
       cap.res
     )
 
-    expect(deps.streamService.createScratchpad).toHaveBeenCalledWith(
+    expect(deps.streamService.createScratchpadInTransaction).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({ createdBy: "usr_owner" })
     )
-    expect(assignByName).toHaveBeenCalledWith(
+    expect(assignByNameInTransaction).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         actor: { type: LabelActorTypes.USER, id: "usr_owner" },
         name: "Pi remote",
@@ -118,5 +120,30 @@ describe("bot runtime session labels", () => {
         runtimeSessionId: "sess_1",
       },
     })
+  })
+
+  it("rejects the session creation when label assignment fails", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const assignByNameInTransaction = mock(() => Promise.reject(new Error("boom")))
+    const { handlers, deps, client } = createHandlers({
+      labelAssignmentService: { assignByNameInTransaction } as unknown as PublicApiDeps["labelAssignmentService"],
+    })
+    const cap = createResponse()
+
+    await expect(
+      handlers.createBotRuntimeSession(
+        botRequest({
+          runtimeKind: "pi-local",
+          instanceId: "inst_1",
+          runtimeSessionId: "sess_1",
+          displayName: "Pi remote - threa",
+          labelName: "Pi remote",
+        }),
+        cap.res
+      )
+    ).rejects.toThrow("boom")
+
+    expect(deps.botRuntimeService.createOrLinkPiRemoteSessionInTransaction).not.toHaveBeenCalled()
+    expect(client.query).toHaveBeenCalledWith("ROLLBACK")
   })
 })

--- a/apps/backend/src/features/public-api/runtime-session-label.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-label.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
 import type { Request, Response } from "express"
-import { LabelActorTypes, LabelableResourceTypes } from "@threa/types"
 import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
 import { BotRepository } from "./bot-repository"
 
@@ -9,62 +8,46 @@ function personalBot(ownerUserId: string) {
 }
 
 function createResponse() {
-  let statusCode = 200
   let body: unknown
   const res = {} as Response
-  res.status = mock((code: number) => {
-    statusCode = code
-    return res
-  }) as unknown as Response["status"]
+  res.status = mock(() => res) as unknown as Response["status"]
   res.json = mock((payload: unknown) => {
     body = payload
     return res
   }) as unknown as Response["json"]
   res.end = mock(() => res) as unknown as Response["end"]
-  return { res, status: () => statusCode, body: () => body }
-}
-
-function createPool() {
-  const client = {
-    query: mock(() => Promise.resolve({ rows: [] })),
-    release: mock(() => undefined),
-  }
-  return { pool: { connect: mock(() => Promise.resolve(client)) } as never, client }
+  return { res, body: () => body }
 }
 
 function createHandlers(overrides: Partial<PublicApiDeps> = {}) {
-  const { pool, client } = createPool()
   const deps: PublicApiDeps = {
     eventService: {} as PublicApiDeps["eventService"],
-    streamService: {
-      createScratchpadInTransaction: mock(() => Promise.resolve({ id: "stream_1" })),
-      addBotToStreamOn: mock(() => Promise.resolve()),
-    } as unknown as PublicApiDeps["streamService"],
+    streamService: {} as PublicApiDeps["streamService"],
     searchService: {} as PublicApiDeps["searchService"],
     memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
     attachmentService: {} as PublicApiDeps["attachmentService"],
     botChannelService: {} as PublicApiDeps["botChannelService"],
     botRuntimeService: {
       findActivePiRemoteSession: mock(() => Promise.resolve(null)),
-      repairBotTraitsInTransaction: mock(() => Promise.resolve()),
-      createOrLinkPiRemoteSessionInTransaction: mock(() =>
+      createLinkedScratchpadSession: mock(() =>
         Promise.resolve({
-          id: "brsl_1",
-          rootStreamId: "stream_1",
-          activeStreamId: "stream_1",
-          runtimeSessionId: "sess_1",
+          link: {
+            id: "brsl_1",
+            rootStreamId: "stream_1",
+            activeStreamId: "stream_1",
+            runtimeSessionId: "sess_1",
+          },
+          stream: { id: "stream_1" },
         })
       ),
     } as unknown as PublicApiDeps["botRuntimeService"],
     labelService: {} as PublicApiDeps["labelService"],
-    labelAssignmentService: {
-      assignByNameInTransaction: mock(() => Promise.resolve({})),
-    } as unknown as PublicApiDeps["labelAssignmentService"],
-    pool,
+    labelAssignmentService: {} as PublicApiDeps["labelAssignmentService"],
+    pool: {} as PublicApiDeps["pool"],
     io: {} as PublicApiDeps["io"],
     ...overrides,
   }
-  return { handlers: createPublicApiHandlers(deps), deps, client }
+  return { handlers: createPublicApiHandlers(deps), deps }
 }
 
 function botRequest(body: unknown): Request {
@@ -80,11 +63,24 @@ function botRequest(body: unknown): Request {
 describe("bot runtime session labels", () => {
   afterEach(() => mock.restore())
 
-  it("assigns an optional label by name for the personal bot owner", async () => {
+  it("delegates label creation to the runtime session service for the personal bot owner", async () => {
     spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
-    const assignByNameInTransaction = mock(() => Promise.resolve({}))
-    const { handlers, deps } = createHandlers({
-      labelAssignmentService: { assignByNameInTransaction } as unknown as PublicApiDeps["labelAssignmentService"],
+    const createLinkedScratchpadSession = mock(() =>
+      Promise.resolve({
+        link: {
+          id: "brsl_1",
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+          runtimeSessionId: "sess_1",
+        },
+        stream: { id: "stream_1" },
+      })
+    )
+    const { handlers } = createHandlers({
+      botRuntimeService: {
+        findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+        createLinkedScratchpadSession,
+      } as unknown as PublicApiDeps["botRuntimeService"],
     })
     const cap = createResponse()
 
@@ -99,17 +95,16 @@ describe("bot runtime session labels", () => {
       cap.res
     )
 
-    expect(deps.streamService.createScratchpadInTransaction).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ createdBy: "usr_owner" })
-    )
-    expect(assignByNameInTransaction).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(createLinkedScratchpadSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        actor: { type: LabelActorTypes.USER, id: "usr_owner" },
-        name: "Pi remote",
-        resourceType: LabelableResourceTypes.STREAM,
-        resourceId: "stream_1",
+        workspaceId: "ws_1",
+        botId: "bot_1",
+        ownerUserId: "usr_owner",
+        runtimeKind: "pi-local",
+        instanceId: "inst_1",
+        runtimeSessionId: "sess_1",
+        displayName: "Pi remote - threa",
+        labelName: "Pi remote",
       })
     )
     expect(cap.body()).toMatchObject({
@@ -122,13 +117,15 @@ describe("bot runtime session labels", () => {
     })
   })
 
-  it("rejects the session creation when label assignment fails", async () => {
+  it("rejects the handler when the runtime session service rejects", async () => {
     spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
-    const assignByNameInTransaction = mock(() => Promise.reject(new Error("boom")))
-    const { handlers, deps, client } = createHandlers({
-      labelAssignmentService: { assignByNameInTransaction } as unknown as PublicApiDeps["labelAssignmentService"],
+    const createLinkedScratchpadSession = mock(() => Promise.reject(new Error("boom")))
+    const { handlers } = createHandlers({
+      botRuntimeService: {
+        findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+        createLinkedScratchpadSession,
+      } as unknown as PublicApiDeps["botRuntimeService"],
     })
-    const cap = createResponse()
 
     await expect(
       handlers.createBotRuntimeSession(
@@ -139,11 +136,8 @@ describe("bot runtime session labels", () => {
           displayName: "Pi remote - threa",
           labelName: "Pi remote",
         }),
-        cap.res
+        createResponse().res
       )
     ).rejects.toThrow("boom")
-
-    expect(deps.botRuntimeService.createOrLinkPiRemoteSessionInTransaction).not.toHaveBeenCalled()
-    expect(client.query).toHaveBeenCalledWith("ROLLBACK")
   })
 })

--- a/apps/backend/src/features/public-api/runtime-session-label.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-label.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { LabelActorTypes, LabelableResourceTypes } from "@threa/types"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { BotRepository } from "./bot-repository"
+
+function personalBot(ownerUserId: string) {
+  return { id: "bot_1", workspaceId: "ws_1", type: "personal", ownerUserId, archivedAt: null } as never
+}
+
+function createResponse() {
+  let statusCode = 200
+  let body: unknown
+  const res = {} as Response
+  res.status = mock((code: number) => {
+    statusCode = code
+    return res
+  }) as unknown as Response["status"]
+  res.json = mock((payload: unknown) => {
+    body = payload
+    return res
+  }) as unknown as Response["json"]
+  res.end = mock(() => res) as unknown as Response["end"]
+  return { res, status: () => statusCode, body: () => body }
+}
+
+function createPool() {
+  const client = {
+    query: mock(() => Promise.resolve({ rows: [] })),
+    release: mock(() => undefined),
+  }
+  return { pool: { connect: mock(() => Promise.resolve(client)) } as never, client }
+}
+
+function createHandlers(overrides: Partial<PublicApiDeps> = {}) {
+  const { pool } = createPool()
+  const deps: PublicApiDeps = {
+    eventService: {} as PublicApiDeps["eventService"],
+    streamService: {
+      createScratchpad: mock(() => Promise.resolve({ id: "stream_1" })),
+      addBotToStream: mock(() => Promise.resolve()),
+    } as unknown as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService: {
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      repairBotTraitsInTransaction: mock(() => Promise.resolve()),
+      createOrLinkPiRemoteSessionInTransaction: mock(() =>
+        Promise.resolve({
+          id: "brsl_1",
+          rootStreamId: "stream_1",
+          activeStreamId: "stream_1",
+          runtimeSessionId: "sess_1",
+        })
+      ),
+    } as unknown as PublicApiDeps["botRuntimeService"],
+    labelService: {} as PublicApiDeps["labelService"],
+    labelAssignmentService: {
+      assignByName: mock(() => Promise.resolve({})),
+    } as unknown as PublicApiDeps["labelAssignmentService"],
+    pool,
+    io: {} as PublicApiDeps["io"],
+    ...overrides,
+  }
+  return { handlers: createPublicApiHandlers(deps), deps }
+}
+
+function botRequest(body: unknown): Request {
+  return {
+    workspaceId: "ws_1",
+    body,
+    params: {},
+    query: {},
+    botApiKey: { id: "bkey_1", botId: "bot_1" },
+  } as unknown as Request
+}
+
+describe("bot runtime session labels", () => {
+  afterEach(() => mock.restore())
+
+  it("assigns an optional label by name for the personal bot owner", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const assignByName = mock(() => Promise.resolve({}))
+    const { handlers, deps } = createHandlers({
+      labelAssignmentService: { assignByName } as unknown as PublicApiDeps["labelAssignmentService"],
+    })
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(
+      botRequest({
+        runtimeKind: "pi-local",
+        instanceId: "inst_1",
+        runtimeSessionId: "sess_1",
+        displayName: "Pi remote - threa",
+        labelName: "Pi remote",
+      }),
+      cap.res
+    )
+
+    expect(deps.streamService.createScratchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ createdBy: "usr_owner" })
+    )
+    expect(assignByName).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { type: LabelActorTypes.USER, id: "usr_owner" },
+        name: "Pi remote",
+        resourceType: LabelableResourceTypes.STREAM,
+        resourceId: "stream_1",
+      })
+    )
+    expect(cap.body()).toMatchObject({
+      data: {
+        linkId: "brsl_1",
+        rootStreamId: "stream_1",
+        activeStreamId: "stream_1",
+        runtimeSessionId: "sess_1",
+      },
+    })
+  })
+})

--- a/apps/backend/src/features/public-api/schemas.test.ts
+++ b/apps/backend/src/features/public-api/schemas.test.ts
@@ -70,4 +70,12 @@ describe("createRuntimeSessionSchema runtimeKind", () => {
       createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "pi-local", memoryMode: "disabled" }).success
     ).toBe(false)
   })
+
+  it("accepts an optional label name", () => {
+    const parsed = createRuntimeSessionSchema.parse({ ...base, runtimeKind: "pi-local", labelName: " Pi remote " })
+    expect(parsed.labelName).toBe("Pi remote")
+    expect(createRuntimeSessionSchema.safeParse({ ...base, runtimeKind: "pi-local", labelName: "   " }).success).toBe(
+      false
+    )
+  })
 })

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -149,7 +149,7 @@ export const createRuntimeSessionSchema = z.object({
   // 'auto' to opt the session's scratchpad into GAM memory extraction.
   memoryMode: z.enum(MEMORY_MODES).optional(),
   // Optional owner-scoped label name to assign to the created scratchpad stream.
-  labelName: z.string().trim().min(1).max(100).optional(),
+  labelName: z.string().trim().min(1).max(100).regex(/\S/).optional(),
 })
 
 export const renameRuntimeSessionSchema = z.object({

--- a/apps/backend/src/features/public-api/schemas.ts
+++ b/apps/backend/src/features/public-api/schemas.ts
@@ -148,6 +148,8 @@ export const createRuntimeSessionSchema = z.object({
   // Defaults to 'off' server-side for these coding-agent scratchpads; send
   // 'auto' to opt the session's scratchpad into GAM memory extraction.
   memoryMode: z.enum(MEMORY_MODES).optional(),
+  // Optional owner-scoped label name to assign to the created scratchpad stream.
+  labelName: z.string().trim().min(1).max(100).optional(),
 })
 
 export const renameRuntimeSessionSchema = z.object({

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -406,75 +406,72 @@ export class StreamService {
   }
 
   async createScratchpad(params: CreateScratchpadParams): Promise<Stream> {
-    return withTransaction(this.pool, async (client) => {
-      const id = streamId()
+    return withTransaction(this.pool, (client) => this.createScratchpadInTransaction(client, params))
+  }
 
-      const stream = await StreamRepository.insert(client, {
-        id,
-        workspaceId: params.workspaceId,
-        type: StreamTypes.SCRATCHPAD,
-        displayName: params.displayName,
-        description: params.description,
-        visibility: Visibilities.PRIVATE,
-        companionMode: params.companionMode ?? CompanionModes.OFF,
-        companionPersonaId: params.companionPersonaId,
-        memoryMode: params.memoryMode,
-        createdBy: params.createdBy,
-      })
+  async createScratchpadInTransaction(db: Querier, params: CreateScratchpadParams): Promise<Stream> {
+    const id = streamId()
 
-      await StreamMemberRepository.insert(client, id, params.createdBy)
+    const stream = await StreamRepository.insert(db, {
+      id,
+      workspaceId: params.workspaceId,
+      type: StreamTypes.SCRATCHPAD,
+      displayName: params.displayName,
+      description: params.description,
+      visibility: Visibilities.PRIVATE,
+      companionMode: params.companionMode ?? CompanionModes.OFF,
+      companionPersonaId: params.companionPersonaId,
+      memoryMode: params.memoryMode,
+      createdBy: params.createdBy,
+    })
 
-      // Attach optional context bag in the same transaction as the stream +
-      // outbox event so the pre-compute handler (which fires on stream:created)
-      // always sees a fully-wired bag by the time it processes the event. INV-7.
-      if (params.contextBag) {
-        await ContextBagRepository.insert(client, {
-          workspaceId: params.workspaceId,
-          streamId: stream.id,
-          intent: params.contextBag.intent,
-          refs: params.contextBag.refs,
-          createdBy: params.createdBy,
-        })
-      }
+    await StreamMemberRepository.insert(db, id, params.createdBy)
 
-      // INV-E1: the E2E flag must be visible the instant the stream is, or
-      // a plaintext writer could squeeze a message in between the stream
-      // insert and the flag insert. Same transaction guarantees there is no
-      // such window. We annotate the returned stream so the create handler
-      // can hand the encryption metadata back to the client without a
-      // second round-trip.
-      if (params.e2e) {
-        await E2eStreamsRepository.markStreamE2e(client, {
-          streamId: stream.id,
-          workspaceId: params.workspaceId,
-          ownerUserId: params.createdBy,
-          ownerUserKeyId: params.e2e.ownerKeyId,
-        })
-        stream.e2eEnabled = true
-        stream.e2eOwnerKeyId = params.e2e.ownerKeyId
-        stream.e2eActors = []
-      }
-
-      // Persist an at-creation tool policy in the same transaction, so the
-      // very first turn already respects it. `undefined` = unrestricted (no
-      // row); a policy (incl. `[]`) is written via the shared upsert.
-      if (params.allowedToolCategories !== undefined) {
-        await StreamPoliciesRepository.setToolPolicy(
-          client,
-          params.workspaceId,
-          stream.id,
-          params.allowedToolCategories
-        )
-      }
-
-      await OutboxRepository.insert(client, "stream:created", {
+    // Attach optional context bag in the same transaction as the stream +
+    // outbox event so the pre-compute handler (which fires on stream:created)
+    // always sees a fully-wired bag by the time it processes the event. INV-7.
+    if (params.contextBag) {
+      await ContextBagRepository.insert(db, {
         workspaceId: params.workspaceId,
         streamId: stream.id,
-        stream,
+        intent: params.contextBag.intent,
+        refs: params.contextBag.refs,
+        createdBy: params.createdBy,
       })
+    }
 
-      return stream
+    // INV-E1: the E2E flag must be visible the instant the stream is, or
+    // a plaintext writer could squeeze a message in between the stream
+    // insert and the flag insert. Same transaction guarantees there is no
+    // such window. We annotate the returned stream so the create handler
+    // can hand the encryption metadata back to the client without a
+    // second round-trip.
+    if (params.e2e) {
+      await E2eStreamsRepository.markStreamE2e(db, {
+        streamId: stream.id,
+        workspaceId: params.workspaceId,
+        ownerUserId: params.createdBy,
+        ownerUserKeyId: params.e2e.ownerKeyId,
+      })
+      stream.e2eEnabled = true
+      stream.e2eOwnerKeyId = params.e2e.ownerKeyId
+      stream.e2eActors = []
+    }
+
+    // Persist an at-creation tool policy in the same transaction, so the
+    // very first turn already respects it. `undefined` = unrestricted (no
+    // row); a policy (incl. `[]`) is written via the shared upsert.
+    if (params.allowedToolCategories !== undefined) {
+      await StreamPoliciesRepository.setToolPolicy(db, params.workspaceId, stream.id, params.allowedToolCategories)
+    }
+
+    await OutboxRepository.insert(db, "stream:created", {
+      workspaceId: params.workspaceId,
+      streamId: stream.id,
+      stream,
     })
+
+    return stream
   }
 
   async createChannel(params: CreateChannelParams): Promise<Stream> {

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -578,7 +578,7 @@ export async function startServer(): Promise<ServerInstance> {
   // Bot runtime service — owns the outbox-emitting writes that drive the `/bot`
   // namespace. One instance shared between HTTP routes (claim/complete/fail)
   // and the WebSocket namespace handler (presence + bootstrap).
-  const botRuntimeService = new BotRuntimeService({ pool })
+  const botRuntimeService = new BotRuntimeService({ pool, streamService, labelAssignmentService })
 
   // Workspace authz mirror service — shared by routes (middleware + handlers,
   // public API auth) and feature services that need to gate on workspace

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1044,7 +1044,7 @@
                   "displayName": { "type": "string", "minLength": 1, "maxLength": 100 },
                   "localCwd": { "type": "string", "maxLength": 1000 },
                   "memoryMode": { "type": "string", "enum": ["auto", "off"] },
-                  "labelName": { "type": "string", "minLength": 1, "maxLength": 100 }
+                  "labelName": { "type": "string", "minLength": 1, "maxLength": 100, "pattern": "\\S" }
                 },
                 "required": ["runtimeKind", "instanceId", "runtimeSessionId", "displayName"],
                 "additionalProperties": false

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -1043,7 +1043,8 @@
                   "runtimeSessionId": { "type": "string", "minLength": 1, "maxLength": 256 },
                   "displayName": { "type": "string", "minLength": 1, "maxLength": 100 },
                   "localCwd": { "type": "string", "maxLength": 1000 },
-                  "memoryMode": { "type": "string", "enum": ["auto", "off"] }
+                  "memoryMode": { "type": "string", "enum": ["auto", "off"] },
+                  "labelName": { "type": "string", "minLength": 1, "maxLength": 100 }
                 },
                 "required": ["runtimeKind", "instanceId", "runtimeSessionId", "displayName"],
                 "additionalProperties": false

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -356,7 +356,8 @@ describe("Pi remote trace safety", () => {
         "workspaceId": " ws_123 ",
         "apiKey": " threa_bk_test ",
         "pollMs": 1500,
-        "defaultDisplayName": " Local Pi "
+        "defaultDisplayName": " Local Pi ",
+        "defaultLabel": " Pi remote "
       }`)
     ).toEqual({
       baseUrl: "https://app.threa.io/",
@@ -364,6 +365,7 @@ describe("Pi remote trace safety", () => {
       apiKey: "threa_bk_test",
       pollMs: 1500,
       defaultDisplayName: "Local Pi",
+      defaultLabel: "Pi remote",
     })
   })
 

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -1,6 +1,16 @@
 import { execFile, spawn } from "node:child_process"
 import { promisify } from "node:util"
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs"
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
 import { homedir, hostname, platform } from "node:os"
 import { basename, dirname, join, resolve } from "node:path"
 import { io as openSocket, type Socket } from "socket.io-client"
@@ -68,6 +78,8 @@ type Config = {
   defaultDisplayName?: string
   /** Pinned model identifiers (`provider/id`) rendered first by /model. */
   preferredModels?: string[]
+  /** Label name to assign to scratchpads created by this Pi instance. */
+  defaultLabel?: string
   /** Legacy global flag; migrated to per-session link state on write. */
   enabled?: boolean
   linkedSessions?: Record<string, RuntimeSessionLink>
@@ -105,7 +117,7 @@ type WorkspaceConfigResponse = {
 
 type ConfigPatch = Pick<
   Config,
-  "baseUrl" | "workspaceId" | "apiKey" | "pollMs" | "defaultDisplayName" | "preferredModels"
+  "baseUrl" | "workspaceId" | "apiKey" | "pollMs" | "defaultDisplayName" | "preferredModels" | "defaultLabel"
 >
 
 type ClaimedInvocation = {
@@ -195,6 +207,13 @@ function validateConfig(value: unknown): Config | undefined {
     console.error(`Invalid ${CONFIG_PATH}: missing or invalid ${invalidFields.join(", ")}`)
     return undefined
   }
+  if (candidate.defaultLabel !== undefined) {
+    if (typeof candidate.defaultLabel !== "string") {
+      console.error(`Invalid ${CONFIG_PATH}: defaultLabel must be a string`)
+      return undefined
+    }
+    candidate.defaultLabel = candidate.defaultLabel.trim() || undefined
+  }
   return migrateSessionState(candidate as Config)
 }
 
@@ -247,7 +266,7 @@ function acquireConfigLockSync(): (() => void) | undefined {
     let fd: number | undefined
     try {
       // O_EXCL + O_CREAT: the open succeeds only for the creator of the file,
-// giving us an exclusive cross-process lock. `wx` flag = O_EXCL|O_CREAT|O_WRONLY.
+      // giving us an exclusive cross-process lock. `wx` flag = O_EXCL|O_CREAT|O_WRONLY.
       fd = openSync(CONFIG_LOCK_PATH, "wx")
       const release = (): void => {
         try {
@@ -259,7 +278,10 @@ function acquireConfigLockSync(): (() => void) | undefined {
       }
       return release
     } catch (error) {
-      const code = typeof error === "object" && error !== null && "code" in error ? String((error as { code: unknown }).code) : undefined
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String((error as { code: unknown }).code)
+          : undefined
       if (code !== "EEXIST") {
         // Unexpected error (permissions, disk full, …) — skip this save
         // rather than perform an unlocked RMW (INV-20).
@@ -551,9 +573,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       }
     }
     detail = detail.slice(0, 500)
-    throw new Error(
-      `Threa API ${response.status}: ${response.statusText}${detail ? ` — ${detail}` : ""}`
-    )
+    throw new Error(`Threa API ${response.status}: ${response.statusText}${detail ? ` — ${detail}` : ""}`)
   }
   return (await response.json()) as T
 }
@@ -1101,6 +1121,7 @@ async function createRemoteSession(ctx: ExtensionCommandContext, args: string): 
         runtimeSessionId,
         displayName,
         localCwd: ctx.cwd,
+        ...(config.defaultLabel && { labelName: config.defaultLabel }),
       }),
     }
   )
@@ -1247,6 +1268,7 @@ function configTemplate(existing: Partial<Config> | undefined): string {
       // a custom prefix (e.g. "Work Pi") can set it here and the dirname will
       // still be appended.
       defaultDisplayName: existing?.defaultDisplayName ?? "",
+      defaultLabel: existing?.defaultLabel ?? "",
       preferredModels: existing?.preferredModels ?? [],
     },
     null,
@@ -1271,6 +1293,9 @@ function parseConfigPatch(text: string): ConfigPatch {
   if (candidate.defaultDisplayName !== undefined && typeof candidate.defaultDisplayName !== "string") {
     throw new Error("defaultDisplayName must be a string")
   }
+  if (candidate.defaultLabel !== undefined && typeof candidate.defaultLabel !== "string") {
+    throw new Error("defaultLabel must be a string")
+  }
   if (
     candidate.preferredModels !== undefined &&
     (!Array.isArray(candidate.preferredModels) || candidate.preferredModels.some((value) => typeof value !== "string"))
@@ -1284,6 +1309,7 @@ function parseConfigPatch(text: string): ConfigPatch {
     apiKey: apiKey.trim(),
     pollMs: candidate.pollMs,
     defaultDisplayName: candidate.defaultDisplayName?.trim() || undefined,
+    defaultLabel: candidate.defaultLabel?.trim() || undefined,
     preferredModels: candidate.preferredModels?.map((value) => value.trim()).filter((value) => value.length > 0),
   }
 }
@@ -2135,8 +2161,8 @@ function textFromAgentMessages(messages: unknown): string {
     // Same rationale as `resolveFinalText`: the final assistant message is the
     // answer; earlier ones are per-step narration that belongs in the trace,
     // not concatenated into the reply.
-    .at(-1)?.text
-    .trim()
+    .at(-1)
+    ?.text.trim()
   if (assistant) return assistant
   return (
     captured
@@ -2749,7 +2775,11 @@ export default function (pi: ExtensionAPI): void {
       // error, non-assistant text) where there is no preceding thinking step.
       if (pendingAssistantTexts.length === 0) {
         const traceFinalText = extractAttachmentDirectives(finalText).markdown || NO_RESPONSE_MARKER
-        await recordTraceStep("message_sent", `Final response:\n\n${sanitizeTraceText(traceFinalText)}`, "Sent response")
+        await recordTraceStep(
+          "message_sent",
+          `Final response:\n\n${sanitizeTraceText(traceFinalText)}`,
+          "Sent response"
+        )
       }
       await completePending(finalText, ctx)
       setRemoteStatus(ctx, "Threa remote: linked")


### PR DESCRIPTION
## Problem

The PR still used the pre-merge label contract: runtime sessions accepted a `labelId`, and the Pi remote config stored `defaultLabelId`. `origin/main` now exposes labels to the public API by owner-scoped name, and a personal bot key applies labels on behalf of its owner user.

## Solution

- Rebased `fix/pi-remote-label` onto fresh `origin/main`.
- Replaced runtime-session `labelId` with `labelName`.
- Renamed the Pi remote config field to `defaultLabel` and send it as `labelName` when creating a scratchpad.
- Made scratchpad labeling atomic in `BotRuntimeService`: scratchpad creation, bot grant, label assignment, and runtime session link all commit together or fail together.
- Kept the public API handler thin by delegating session creation to the service.

## Files changed

| File | Change |
| --- | --- |
| `apps/backend/src/features/public-api/schemas.ts` | Adds optional `labelName` to runtime session creation with non-whitespace validation. |
| `apps/backend/src/features/public-api/handlers.ts` | Delegates scratchpad runtime session creation to `BotRuntimeService`. |
| `apps/backend/src/features/bot-runtimes/service.ts` | Owns the atomic scratchpad/session transaction. |
| `apps/backend/src/features/streams/service.ts` | Exposes scratchpad creation for caller-owned transactions. |
| `apps/backend/src/features/labels/assignment-service.ts` | Exposes label assignment by name for caller-owned transactions. |
| `extensions/pi-remote/src/threa-remote.ts` | Adds `defaultLabel` config and sends `labelName`. |
| `docs/public-api/openapi.json` | Regenerates the public API spec. |
| `*.test.ts` | Covers schema parsing, config parsing, owner-attributed delegation, and label-assignment failure rollback. |

## Test plan

- [x] `bun test ./apps/backend/src/features/bot-runtimes/service.test.ts ./apps/backend/src/features/public-api/runtime-session-label.test.ts ./apps/backend/src/features/public-api/schemas.test.ts ./extensions/pi-remote/src/threa-remote.test.ts`
- [x] `bun run --cwd apps/backend typecheck`
- [x] pre-commit hook: full lint, root typecheck, migration/Dockerfile checks, API docs check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784446727&installation_id=129946197&pr_number=1012&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1012&signature=b603d867f1420c1e255d4fe15ca125509dadda0e45edc6e107f891bd412a1489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->