### PR TITLE
fix(backend): bound graceful shutdown so a wedged DB can't pin the process

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -13,7 +13,9 @@ const { server, stop, fastShutdown } = await startServer()
 // blocks on an unreachable Postgres — that wedged the process half-dead for ~24
 // min in the 2026-06-19 disk-full incident (no exit, no logs, no supervisor
 // restart). Past this deadline we force-exit so the supervisor restarts us.
-const SHUTDOWN_TIMEOUT_MS = Number(process.env.SHUTDOWN_TIMEOUT_MS) || 15_000
+const configuredShutdownTimeoutMs = Number(process.env.SHUTDOWN_TIMEOUT_MS)
+const SHUTDOWN_TIMEOUT_MS =
+  Number.isFinite(configuredShutdownTimeoutMs) && configuredShutdownTimeoutMs > 0 ? configuredShutdownTimeoutMs : 15_000
 
 if (fastShutdown) {
   logger.info("Fast shutdown enabled - graceful shutdown disabled")

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -5,8 +5,15 @@ initLangfuse()
 import { startServer } from "./server"
 import { logger } from "./lib/logger"
 import { classifyGlobalCrash, serializeCrashReason } from "./lib/crash-policy"
+import { runWithShutdownWatchdog } from "./lib/graceful-shutdown"
 
 const { server, stop, fastShutdown } = await startServer()
+
+// Hard ceiling on graceful shutdown. `stop()` drains the pools, and `pool.end()`
+// blocks on an unreachable Postgres — that wedged the process half-dead for ~24
+// min in the 2026-06-19 disk-full incident (no exit, no logs, no supervisor
+// restart). Past this deadline we force-exit so the supervisor restarts us.
+const SHUTDOWN_TIMEOUT_MS = Number(process.env.SHUTDOWN_TIMEOUT_MS) || 15_000
 
 if (fastShutdown) {
   logger.info("Fast shutdown enabled - graceful shutdown disabled")
@@ -22,9 +29,22 @@ async function shutdown(code: number) {
     process.exit(code)
   }
 
-  await stop()
-  await shutdownLangfuse()
-  process.exit(code)
+  await runWithShutdownWatchdog({
+    timeoutMs: SHUTDOWN_TIMEOUT_MS,
+    shutdown: async () => {
+      try {
+        await stop()
+        await shutdownLangfuse()
+      } catch (err) {
+        logger.error({ err }, "Error during graceful shutdown")
+      }
+    },
+    onComplete: () => process.exit(code),
+    onTimeout: () => {
+      logger.fatal({ timeoutMs: SHUTDOWN_TIMEOUT_MS }, "Graceful shutdown timed out — forcing exit")
+      process.exit(code)
+    },
+  })
 }
 
 process.on("SIGTERM", () => shutdown(0))

--- a/apps/backend/src/lib/graceful-shutdown.test.ts
+++ b/apps/backend/src/lib/graceful-shutdown.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, mock, test } from "bun:test"
+import { runWithShutdownWatchdog } from "./graceful-shutdown"
+
+function makeFakeTimers() {
+  let fire: (() => void) | null = null
+  let cleared = false
+  return {
+    trigger: () => fire?.(),
+    wasCleared: () => cleared,
+    timers: {
+      setTimeout: (callback: () => void) => {
+        fire = callback
+        return { unref: () => {} }
+      },
+      clearTimeout: () => {
+        cleared = true
+      },
+    },
+  }
+}
+
+describe("runWithShutdownWatchdog", () => {
+  test("completes via onComplete and clears the timer when shutdown settles in time", async () => {
+    const fake = makeFakeTimers()
+    const onComplete = mock(() => {})
+    const onTimeout = mock(() => {})
+
+    await runWithShutdownWatchdog({
+      shutdown: async () => {},
+      timeoutMs: 100,
+      onComplete,
+      onTimeout,
+      timers: fake.timers,
+    })
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(fake.wasCleared()).toBe(true)
+  })
+
+  test("fires onTimeout when shutdown overruns the deadline, and ignores a late completion", async () => {
+    const fake = makeFakeTimers()
+    const onComplete = mock(() => {})
+    const onTimeout = mock(() => {})
+
+    let resolveShutdown: () => void = () => {}
+    const shutdownPromise = new Promise<void>((resolve) => {
+      resolveShutdown = resolve
+    })
+
+    void runWithShutdownWatchdog({
+      shutdown: () => shutdownPromise,
+      timeoutMs: 100,
+      onComplete,
+      onTimeout,
+      timers: fake.timers,
+    })
+
+    fake.trigger()
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    expect(onComplete).not.toHaveBeenCalled()
+
+    // A shutdown that finally settles after the deadline must not double-fire.
+    resolveShutdown()
+    await Promise.resolve()
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/backend/src/lib/graceful-shutdown.test.ts
+++ b/apps/backend/src/lib/graceful-shutdown.test.ts
@@ -48,7 +48,7 @@ describe("runWithShutdownWatchdog", () => {
       resolveShutdown = resolve
     })
 
-    void runWithShutdownWatchdog({
+    const watchdog = runWithShutdownWatchdog({
       shutdown: () => shutdownPromise,
       timeoutMs: 100,
       onComplete,
@@ -62,7 +62,7 @@ describe("runWithShutdownWatchdog", () => {
 
     // A shutdown that finally settles after the deadline must not double-fire.
     resolveShutdown()
-    await Promise.resolve()
+    await watchdog
     expect(onComplete).not.toHaveBeenCalled()
     expect(onTimeout).toHaveBeenCalledTimes(1)
   })

--- a/apps/backend/src/lib/graceful-shutdown.ts
+++ b/apps/backend/src/lib/graceful-shutdown.ts
@@ -1,0 +1,55 @@
+interface ShutdownTimers {
+  setTimeout: (callback: () => void, ms: number) => { unref?: () => void }
+  clearTimeout: (handle: unknown) => void
+}
+
+export interface ShutdownWatchdogOptions {
+  /** The graceful-shutdown routine to run. Must not reject — wrap logging inside it. */
+  shutdown: () => Promise<void>
+  /** Hard deadline; if `shutdown` overruns it, `onTimeout` fires instead of `onComplete`. */
+  timeoutMs: number
+  /** Fired once when `shutdown` settles within the deadline. */
+  onComplete: () => void
+  /** Fired once when the deadline elapses before `shutdown` settles. */
+  onTimeout: () => void
+  /** Injectable timers for tests; defaults to the globals. */
+  timers?: ShutdownTimers
+}
+
+/**
+ * Runs a graceful-shutdown routine under a hard deadline, firing exactly one of
+ * `onComplete` / `onTimeout`.
+ *
+ * Without this, a wedged shutdown — `pool.end()` blocking on an unreachable
+ * Postgres is the live example — leaves the process half-dead: it never exits,
+ * emits no logs, and the supervisor (Railway) never restarts it, so a transient
+ * DB outage becomes a prolonged one. The watchdog forces termination past the
+ * deadline so the supervisor can restart us, which auto-recovers the moment the
+ * DB is reachable again.
+ */
+export async function runWithShutdownWatchdog(options: ShutdownWatchdogOptions): Promise<void> {
+  const { shutdown, timeoutMs, onComplete, onTimeout } = options
+  const timers: ShutdownTimers = options.timers ?? {
+    setTimeout: (callback, ms) => setTimeout(callback, ms),
+    clearTimeout: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  }
+
+  let settled = false
+  const handle = timers.setTimeout(() => {
+    if (settled) return
+    settled = true
+    onTimeout()
+  }, timeoutMs)
+  // Don't let the watchdog timer itself hold the event loop open.
+  handle.unref?.()
+
+  try {
+    await shutdown()
+  } finally {
+    timers.clearTimeout(handle)
+    if (!settled) {
+      settled = true
+      onComplete()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up hardening from the **2026-06-19 prod outage**. The production Postgres data volume (a 500 MB volume mounted at `/var/lib/postgresql/data`) filled up. At 06:54 UTC every backend DB connection failed in the same millisecond (`Unexpected database pool error` ×30, then `Failed to setup LISTEN connection`), the backend hit a fatal unhandled rejection, and began a graceful shutdown.

`stop()` then reached `pools.*.end()`, which **blocked on the unreachable Postgres**. The process hung half-dead: its last log line was `Closing database pools…` at 06:54:33 and it emitted nothing for the next ~24 minutes — no exit, so Railway's supervisor never restarted it. A few-second disk event became a ~24-minute outage that only cleared on a manual restart. Clients sat on the "Reconnecting" pill the whole time (the socket.io Postgres adapter rides the dead LISTEN connection).

This PR addresses the *prolonged* part of the outage: a transient DB problem should not be able to pin the process indefinitely.

## What changed

- **`lib/graceful-shutdown.ts`** — `runWithShutdownWatchdog`: runs the shutdown routine under a hard deadline and fires exactly one of `onComplete` / `onTimeout`. Past the deadline it force-terminates so the supervisor restarts us, and we auto-recover the moment the DB is reachable again.
- **`index.ts`** — `shutdown()` now runs `stop()` + Langfuse flush through the watchdog with a `SHUTDOWN_TIMEOUT_MS` (default **15s**, env-overridable). Shutdown errors are caught and logged instead of escaping as a second unhandled rejection.
- **`lib/graceful-shutdown.test.ts`** — covers the in-time completion path (timer cleared, `onComplete` once) and the overrun path (`onTimeout` fires, a late completion does not double-fire).

## Design decisions

- **Watchdog over reclassifying DB errors as non-fatal.** I deliberately did *not* broaden `crash-policy.ts` to swallow DB-connectivity errors. The actual damage here was the process *staying down*, not that it decided to go down — and marking availability errors non-fatal risks a server limping along in a broken state. Forcing a clean exit + supervisor restart is the lower-risk fix and it's what ultimately recovered prod. (Reclassification can be revisited separately if we see fatal-loop churn.)
- **Extracted helper, not inline.** `index.ts` runs `await startServer()` at import time and calls `process.exit`, so it isn't unit-testable. This mirrors how `crash-policy.ts` is factored out of the same file for exactly that reason.
- **15s default** sits comfortably above the existing internal 5s `io.close()` timeout while staying well under typical platform SIGKILL grace.

## Not in this PR (the actual incident fix)

The root cause was infra capacity — the 500 MB Postgres volume — which was remediated operationally (volume grown, services restarted; backend healthy as of 07:18 UTC). A disk-usage alert on the Postgres volume is a separate follow-up (tracked in Linear).

## Testing

- `bun test apps/backend/src/lib/graceful-shutdown.test.ts apps/backend/src/lib/crash-policy.test.ts` → 7 pass
- `bunx tsc --noEmit -p apps/backend/tsconfig.json` → clean
- Pre-commit hooks (full monorepo typecheck + api-docs check) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYPXQvYqZgGiTBiHiSQV8d)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784447379&installation_id=129946197&pr_number=1013&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1013&signature=5a3f4d64c3c5b7a398d687ebe3aaec055de9cb49755f11adf868213b9bed5963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->