### PR TITLE
fix(conversations): use quote-replies and back-and-forth continuity in boundary classification

### DIFF
--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -464,4 +464,98 @@ Any ideas what's causing this?`,
       minConfidence: 0.7,
     },
   },
+
+  // Quote-reply: explicit reply continues the quoted message's conversation,
+  // even when a different conversation is the most recent one in the stream.
+  {
+    id: "reply-quote-continues-quoted-conv-001",
+    name: "Reply: quote-reply joins quoted message's conversation, not the most recent",
+    input: {
+      newMessage: {
+        authorId: "user_def456",
+        authorType: "user",
+        contentMarkdown: "samma här, kör på det",
+      },
+      activeConversations: [
+        {
+          id: "conv_buss",
+          topicSummary: "Buss nio imorgon",
+          messageCount: 8,
+          lastMessagePreview: "samma här",
+          participantIds: ["user_abc123", "user_def456"],
+          completenessScore: 3,
+        },
+        {
+          id: "conv_gpt",
+          topicSummary: "gpt down?",
+          messageCount: 2,
+          lastMessagePreview: "nvm, fungerar nu",
+          participantIds: ["user_abc123", "user_def456"],
+          completenessScore: 5,
+        },
+      ],
+      recentMessages: [
+        { authorId: "user_abc123", authorType: "user", contentMarkdown: "wtf. gpt down?" },
+        { authorId: "user_def456", authorType: "user", contentMarkdown: "nvm, fungerar nu" },
+      ],
+      replyTargets: [
+        {
+          quotedMessageId: "msg_buss_last",
+          conversationId: "conv_buss",
+          topicSummary: "Buss nio imorgon",
+          snippet: "Kan kika lite på vilka uteserveringar som kan verka rimliga",
+        },
+      ],
+      streamType: "dm",
+      category: "reply",
+    },
+    expectedOutput: {
+      // The quote-reply targets conv_buss; it must win over the more recent conv_gpt.
+      expectConversationId: "conv_buss",
+      minConfidence: 0.7,
+    },
+  },
+
+  // Continuity: a short acknowledgement from the OTHER participant continues the
+  // active exchange rather than spawning its own singleton conversation.
+  {
+    id: "continuity-short-ack-001",
+    name: "Continuity: short reply continues active back-and-forth",
+    input: {
+      newMessage: {
+        authorId: "user_def456",
+        authorType: "user",
+        contentMarkdown: ":fire: tokens",
+      },
+      activeConversations: [
+        {
+          id: "conv_exsules",
+          topicSummary: "exsules API/GraphQL",
+          messageCount: 6,
+          lastMessagePreview: "mer att AI blir förvirrad och slösar tokens lol",
+          participantIds: ["user_abc123", "user_def456"],
+          completenessScore: 3,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_abc123",
+          authorType: "user",
+          contentMarkdown: "finns bara en remote, just nu dock",
+        },
+        {
+          authorId: "user_abc123",
+          authorType: "user",
+          contentMarkdown: "mer att AI blir förvirrad och slösar tokens lol",
+        },
+      ],
+      streamType: "dm",
+      category: "continuity",
+    },
+    expectedOutput: {
+      // ":fire: tokens" reacts to the "slösar tokens" line — stays in the exchange.
+      expectConversationId: "conv_exsules",
+      minConfidence: 0.6,
+    },
+  },
 ]

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -93,6 +93,7 @@ function buildExtractionContext(input: BoundaryExtractionInput, workspaceId: str
       status: c.status ?? "active",
       contextMessageIds: [],
     })),
+    replyTargets: input.replyTargets,
     streamType: input.streamType || "scratchpad",
     workspaceId,
   }

--- a/apps/backend/evals/suites/boundary-extraction/types.ts
+++ b/apps/backend/evals/suites/boundary-extraction/types.ts
@@ -28,6 +28,18 @@ export interface EvalMessage {
 }
 
 /**
+ * One explicit quote-reply the new message makes, already resolved to the
+ * conversation that owns the quoted message (the production service does this
+ * resolution from `content_json`; evals provide it directly).
+ */
+export interface EvalReplyTarget {
+  quotedMessageId: string
+  conversationId: string
+  topicSummary: string | null
+  snippet: string
+}
+
+/**
  * Input for boundary extraction evaluation.
  */
 export interface BoundaryExtractionInput {
@@ -37,10 +49,12 @@ export interface BoundaryExtractionInput {
   recentMessages?: EvalMessage[]
   /** Active conversations in the stream */
   activeConversations?: EvalConversationSummary[]
+  /** Conversations the new message explicitly quote-replies (strong continuity signal) */
+  replyTargets?: EvalReplyTarget[]
   /** Stream type (channel, scratchpad, thread, dm) */
   streamType?: string
   /** Category for organizing test cases */
-  category?: "new-topic" | "continue-existing" | "topic-shift" | "resolution" | "ambiguous"
+  category?: "new-topic" | "continue-existing" | "topic-shift" | "resolution" | "ambiguous" | "reply" | "continuity"
 }
 
 /**

--- a/apps/backend/src/features/agents/quote-resolver.test.ts
+++ b/apps/backend/src/features/agents/quote-resolver.test.ts
@@ -54,7 +54,7 @@ function createMessage(overrides: Partial<Message> & { id: string }): Message {
   return { ...base, ...overrides }
 }
 
-const mockFindByIdsInStreams = mock((_db: Querier, _ids: string[], _streamIds: string[]) =>
+const mockFindByIdsInStreams = mock((_db: Querier, _workspaceId: string, _ids: string[], _streamIds: string[]) =>
   Promise.resolve(new Map<string, Message>())
 )
 const mockFindUsersByIds = mock(() => Promise.resolve([] as { id: string; name: string }[]))
@@ -95,7 +95,7 @@ describe("resolveQuoteReplies", () => {
     expect(resolved.size).toBe(1)
     expect(resolved.get("msg_B")?.id).toBe("msg_B")
     expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
-    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B"])
+    expect(mockFindByIdsInStreams.mock.calls[0][2]).toEqual(["msg_B"])
   })
 
   test("follows a depth chain up to maxDepth=5", async () => {
@@ -180,7 +180,7 @@ describe("resolveQuoteReplies", () => {
 
     expect([...resolved.keys()]).toEqual(["msg_B"])
     expect(mockFindByIdsInStreams).toHaveBeenCalledTimes(1)
-    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B"])
+    expect(mockFindByIdsInStreams.mock.calls[0][2]).toEqual(["msg_B"])
   })
 
   test("multiple distinct precursors in one message are all resolved", async () => {
@@ -203,7 +203,7 @@ describe("resolveQuoteReplies", () => {
     })
 
     expect([...resolved.keys()].sort()).toEqual(["msg_B", "msg_C"])
-    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B", "msg_C"])
+    expect(mockFindByIdsInStreams.mock.calls[0][2]).toEqual(["msg_B", "msg_C"])
   })
 
   test("access-denied or soft-deleted precursors are filtered at the SQL layer", async () => {
@@ -229,7 +229,7 @@ describe("resolveQuoteReplies", () => {
       accessibleStreamIds: new Set(["stream_main", "stream_other"]),
     })
 
-    const streamIdsArg = mockFindByIdsInStreams.mock.calls[0][2]
+    const streamIdsArg = mockFindByIdsInStreams.mock.calls[0][3]
     expect(new Set(streamIdsArg)).toEqual(new Set(["stream_main", "stream_other"]))
   })
 
@@ -238,7 +238,7 @@ describe("resolveQuoteReplies", () => {
     const manyQuotes = Array.from({ length: 10 }, (_, i) => quoteReplyNode(`msg_B${i}`))
     const seed = createMessage({ id: "msg_A", contentJson: doc(...manyQuotes) })
     // Only return the first 3 (simulating the cap)
-    mockFindByIdsInStreams.mockImplementation((_db, ids) => {
+    mockFindByIdsInStreams.mockImplementation((_db, _workspaceId, ids) => {
       const result = new Map<string, Message>()
       for (const id of ids) {
         result.set(id, createMessage({ id, contentMarkdown: `body ${id}` }))
@@ -254,7 +254,7 @@ describe("resolveQuoteReplies", () => {
 
     expect(resolved.size).toBe(3)
     // Only the first 3 IDs should have been fetched
-    expect(mockFindByIdsInStreams.mock.calls[0][1]).toEqual(["msg_B0", "msg_B1", "msg_B2"])
+    expect(mockFindByIdsInStreams.mock.calls[0][2]).toEqual(["msg_B0", "msg_B1", "msg_B2"])
   })
 
   test("batch resolves author names for all precursors", async () => {

--- a/apps/backend/src/features/agents/quote-resolver.ts
+++ b/apps/backend/src/features/agents/quote-resolver.ts
@@ -1,5 +1,5 @@
 import type { Querier } from "../../db"
-import type { JSONContent } from "@threa/types"
+import { collectQuoteReplyMessageIds } from "@threa/prosemirror"
 import { MessageRepository, type Message } from "../messaging"
 import { UserRepository } from "../workspaces"
 import { PersonaRepository } from "./persona-repository"
@@ -82,7 +82,7 @@ export async function resolveQuoteReplies(
   // Walk seeds to get depth-0 frontier (= depth-1 precursors, since the seed is 0 hops).
   let frontier: string[] = []
   for (const seed of input.seedMessages) {
-    const quotedIds = extractQuoteReplyMessageIds(seed.contentJson)
+    const quotedIds = collectQuoteReplyMessageIds(seed.contentJson)
     for (const quotedId of quotedIds) {
       if (visited.has(quotedId)) {
         logger.debug({ messageId: seed.id, quotedId, reason: "cycle" }, "Quote resolution skipped reference")
@@ -117,7 +117,7 @@ export async function resolveQuoteReplies(
     const nextFrontier: string[] = []
     for (const [id, message] of fetched) {
       resolved.set(id, message)
-      const quotedIds = extractQuoteReplyMessageIds(message.contentJson)
+      const quotedIds = collectQuoteReplyMessageIds(message.contentJson)
       for (const quotedId of quotedIds) {
         if (visited.has(quotedId)) {
           logger.debug({ messageId: id, quotedId, reason: "cycle" }, "Quote resolution skipped reference")
@@ -170,7 +170,7 @@ export function renderMessageWithQuoteContext(
   const base = message.contentMarkdown
   if (depth >= maxDepth) return base
 
-  const quotedIds = extractQuoteReplyMessageIds(message.contentJson)
+  const quotedIds = collectQuoteReplyMessageIds(message.contentJson)
   if (quotedIds.length === 0) return base
 
   const blocks: string[] = [base]
@@ -212,27 +212,6 @@ export function extractAppendedQuoteContext(rendered: string, base: string): str
   // Strip the base prefix and the "\n\n" separator we inserted in the renderer
   const tail = rendered.slice(base.length)
   return tail.startsWith("\n\n") ? tail.slice(2) : tail
-}
-
-function extractQuoteReplyMessageIds(content: JSONContent): string[] {
-  const ids: string[] = []
-  walkJsonNodes(content, (node) => {
-    if (node.type === "quoteReply") {
-      const messageId = node.attrs?.messageId
-      if (typeof messageId === "string" && messageId.length > 0) {
-        ids.push(messageId)
-      }
-    }
-  })
-  return ids
-}
-
-function walkJsonNodes(node: JSONContent, visit: (node: JSONContent) => void): void {
-  visit(node)
-  if (!node.content) return
-  for (const child of node.content) {
-    walkJsonNodes(child, visit)
-  }
 }
 
 async function resolveAuthorNamesForMessages(

--- a/apps/backend/src/features/agents/quote-resolver.ts
+++ b/apps/backend/src/features/agents/quote-resolver.ts
@@ -103,7 +103,7 @@ export async function resolveQuoteReplies(
       }
     }
 
-    const fetched = await MessageRepository.findByIdsInStreams(db, toFetch, streamIdsArray)
+    const fetched = await MessageRepository.findByIdsInStreams(db, workspaceId, toFetch, streamIdsArray)
 
     for (const requestedId of toFetch) {
       if (!fetched.has(requestedId)) {

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -1244,6 +1244,7 @@ Each query must have:
         if (enriched.length > 0) {
           const seedMessageMap = await MessageRepository.findByIdsInStreams(
             client,
+            workspaceId,
             enriched.map((e) => e.id),
             accessibleStreamIds
           )

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -13,7 +13,9 @@ import type {
   CompletenessUpdate,
   MessageAssignment,
   Reassignment,
+  ReplyTarget,
 } from "./boundary-extraction/types"
+import { collectQuoteReplyMessageIds } from "@threa/prosemirror"
 import { addStalenessFields } from "./staleness"
 import { conversationId } from "../../lib/id"
 import { ConversationStatuses, StreamTypes } from "@threa/types"
@@ -95,6 +97,21 @@ export class BoundaryExtractionService {
         allContextMessageIds
       )
 
+      // Resolve explicit quote-replies to a strong continuity signal (INV-54:
+      // structural attrs, not markdown heuristics). A quote-reply is a
+      // deliberate user action, so the conversation that owns the quoted message
+      // must be a candidate even when it scrolled out of the surrounding-message
+      // window — otherwise the model can't assign to it. Scoped to this stream:
+      // conversations are per-stream, so a quote into another stream has no valid
+      // target here and is dropped.
+      const { replyTargets, quotedConversations } = await this.resolveReplyTargets(
+        client,
+        workspaceId,
+        stream.id,
+        message
+      )
+      const candidateConversations = mergeConversationsById(relevantConversations, quotedConversations)
+
       let parentMessageConversations: Conversation[] = []
       if (stream.type === StreamTypes.THREAD && stream.parentMessageId) {
         parentMessageConversations = await ConversationRepository.findByMessageId(
@@ -106,7 +123,7 @@ export class BoundaryExtractionService {
 
       const contextMessageIdSet = new Set(allContextMessageIds)
       const activeConversations = this.buildConversationSummaries(
-        relevantConversations,
+        candidateConversations,
         allContextMessages,
         contextMessageIdSet
       )
@@ -127,11 +144,12 @@ export class BoundaryExtractionService {
         activeConversations,
         streamType: stream.type,
         parentMessageConversations: parentConversations,
+        replyTargets: replyTargets.length > 0 ? replyTargets : undefined,
         workspaceId: stream.workspaceId,
       }
 
       const validUpdateTargets = new Set<string>([
-        ...relevantConversations.map((c) => c.id),
+        ...candidateConversations.map((c) => c.id),
         ...parentMessageConversations.map((c) => c.id),
       ])
 
@@ -525,6 +543,50 @@ export class BoundaryExtractionService {
       }
     })
   }
+
+  private async resolveReplyTargets(
+    client: PoolClient,
+    workspaceId: string,
+    streamId: string,
+    message: Message
+  ): Promise<{ replyTargets: ReplyTarget[]; quotedConversations: Conversation[] }> {
+    const quotedMessageIds = collectQuoteReplyMessageIds(message.contentJson)
+    if (quotedMessageIds.length === 0) return { replyTargets: [], quotedConversations: [] }
+
+    const quotedMessages = await MessageRepository.findByIdsInStreams(client, quotedMessageIds, [streamId])
+    if (quotedMessages.size === 0) return { replyTargets: [], quotedConversations: [] }
+
+    const primariesByMessageId = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, [
+      ...quotedMessages.keys(),
+    ])
+
+    const replyTargets: ReplyTarget[] = []
+    const quotedConversations: Conversation[] = []
+    for (const quotedMessageId of quotedMessageIds) {
+      const quotedMessage = quotedMessages.get(quotedMessageId)
+      if (!quotedMessage) continue
+      const conv = primariesByMessageId.get(quotedMessageId)
+      if (!conv) continue
+      replyTargets.push({
+        quotedMessageId,
+        conversationId: conv.id,
+        topicSummary: conv.topicSummary,
+        snippet: quotedMessage.contentMarkdown.slice(0, 100),
+      })
+      quotedConversations.push(conv)
+    }
+    return { replyTargets, quotedConversations }
+  }
+}
+
+/** Append `extra` conversations not already present in `primary`, deduped by id. */
+function mergeConversationsById(primary: Conversation[], extra: Conversation[]): Conversation[] {
+  if (extra.length === 0) return primary
+  const byId = new Map<string, Conversation>(primary.map((c) => [c.id, c]))
+  for (const c of extra) {
+    if (!byId.has(c.id)) byId.set(c.id, c)
+  }
+  return [...byId.values()]
 }
 
 /**

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -553,7 +553,7 @@ export class BoundaryExtractionService {
     const quotedMessageIds = collectQuoteReplyMessageIds(message.contentJson)
     if (quotedMessageIds.length === 0) return { replyTargets: [], quotedConversations: [] }
 
-    const quotedMessages = await MessageRepository.findByIdsInStreams(client, quotedMessageIds, [streamId])
+    const quotedMessages = await MessageRepository.findByIdsInStreams(client, workspaceId, quotedMessageIds, [streamId])
     if (quotedMessages.size === 0) return { replyTargets: [], quotedConversations: [] }
 
     const primariesByMessageId = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, [

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -34,13 +34,22 @@ Content: {{CONTENT}}
 ## Attachments
 Some messages above may include an indented \`[attachment <filename> (<kind>)]:\` block beneath them. That block is the extracted text of the attachment — the transcript for audio/video, OCR text for an image, the parsed body for a PDF/Word/Excel, etc. Treat that extracted text as **part of the message's content** when judging topic continuity: a voice memo whose transcript is about onboarding is an onboarding message even if its written content is empty. Pay particular attention to the new message's attachments, since a short or empty written body is often a wrapper around the real payload that lives in the attachment.
 
+## Explicit reply
+{{REPLY_CONTEXT}}
+
+When the new message explicitly quote-replies an earlier message, that is a deliberate user action and the STRONGEST available signal of continuity: default to assigning the new message (as primary) to the conversation the quoted message belongs to. Override this only when the new message's own content clearly opens a different topic — quoting a message while explicitly changing the subject ("unrelated, but…"). A reply that merely reacts, agrees, asks a follow-up, or builds on the quoted message stays in the quoted message's conversation. The quoted message's conversation is listed in Active Conversations above, so you can always assign to it.
+
 ## Choosing a conversation
-First decide whether this message continues an existing conversation or starts a new one. Assign it to an existing conversation (as primary) only when it genuinely continues that topic — judge by:
+First decide whether this message continues an existing conversation or starts a new one. Judge by:
+- Explicit references: does it quote, reply to, or build on something in a conversation? (See "Explicit reply" above — a quote-reply is decisive.)
 - Topic continuity: does it advance the same subject the conversation is about? Use the attachment-extracted text as content here too.
-- Explicit references: does it reply to, quote, or build on something in that conversation?
 - Recency and flow: does it read as the next turn of an active back-and-forth?
 
-Start a NEW conversation (primary assignment with conversationId=null) when the message opens a topic that no active conversation covers — a new question, a new subject, or an unrelated aside. A short or ambiguous message that doesn't clearly continue any listed conversation is a new conversation, not a default into the most recent one. Do not attach a message to a conversation whose status is "resolved" unless it directly reopens that exact topic; a new topic after a resolved conversation is a new conversation. When in doubt between extending a stale/resolved conversation and starting fresh, start fresh.
+Prefer continuing the active exchange. Conversation is a back-and-forth between participants: a short reply, agreement, reaction, joke, or follow-up from EITHER participant ("samma här", "haha", "100%", ":fire:", "what?", "nice") continues the current exchange — it does not start its own conversation, and which participant sent it is irrelevant. Both sides of one live exchange belong in the SAME conversation; never split an exchange so one participant's turns sit in a different conversation than the other's.
+
+Start a NEW conversation (primary assignment with conversationId=null) only when the message clearly opens a topic no active conversation covers — a distinct new question, subject, or unrelated aside that does not read as the next turn of any listed exchange. Do not attach a message to a conversation whose status is "resolved" unless it directly reopens that exact topic.
+
+You don't need full certainty up front. When a short or ambiguous message plausibly continues the active exchange, keep it there rather than spawning a singleton — if a later message reveals it actually began a new topic, the reassignment mechanism below will split it out then. Early continuity that settles is better than fragmentation that never recovers.
 
 ## Multi-membership
 A message can belong to more than one conversation. If this new message clearly continues two different ongoing threads (e.g. a single ping that references two topics), assign it to both. Pick the conversation it MOST continues as primary; the others are secondaries. Most messages have only a primary assignment — only return secondaries when the message genuinely advances two distinct conversations.
@@ -51,7 +60,11 @@ If this new message reveals that one or more of the *Recent Messages* or message
 - The new message reopens a conversation that was prematurely marked resolved.
 - The new message shows two adjacent conversations are actually the same topic — move the smaller one into the larger.
 
-Reassignment is *the* mechanism for fixing classification mistakes. Use it whenever the new message gives you evidence the prior placement was wrong. Do not be conservative — moving a message to where it now clearly belongs is better than leaving it stranded.
+Reassignment is *the* mechanism for fixing classification mistakes, and it works in both directions — it is how conversations settle as more context arrives:
+- MERGE: the new message shows two threads are really one topic, or that an earlier message belongs with the current exchange — move it in.
+- SPLIT: the new message reveals that recent messages lumped into the current conversation were actually the start of a separate topic — move them into a different (or brand-new) conversation. This is the correction for having earlier leaned toward continuity: if you kept a short message in an exchange and now see it opened its own topic, split it out here.
+
+Use it whenever the new message gives you evidence the prior placement was wrong. Do not be conservative — moving a message to where it now clearly belongs is better than leaving it stranded.
 
 ## Output Requirements
 - assignments: Array of {conversationId, isPrimary}. At least one entry with isPrimary=true. conversationId=null means "create a new conversation" (set newConversationTopic).

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -127,10 +127,22 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
     const newMessageAttachmentSection =
       newMessageAtts.length > 0 ? `\n${this.renderAttachments(newMessageAtts, NEW_MESSAGE_ATTACHMENT_CHARS)}` : ""
 
+    const replyTargets = context.replyTargets ?? []
+    const replySection =
+      replyTargets.length > 0
+        ? replyTargets
+            .map(
+              (t) =>
+                `- Quote-replies message [${t.quotedMessageId}], which is PRIMARY in conversation ${t.conversationId} ("${t.topicSummary ?? "No topic yet"}"). Quoted text: "${t.snippet}"`
+            )
+            .join("\n")
+        : "None — this message does not quote-reply anything."
+
     return BOUNDARY_EXTRACTION_PROMPT.replace("{{CONVERSATIONS}}", convSection)
       .replace("{{RECENT_MESSAGES}}", recentSection || "No recent messages.")
       .replace("{{AUTHOR}}", `${context.newMessage.authorType}:${context.newMessage.authorId.slice(-8)}`)
       .replace("{{CONTENT}}", context.newMessage.contentMarkdown + newMessageAttachmentSection)
+      .replace("{{REPLY_CONTEXT}}", replySection)
   }
 
   private renderAttachments(attachments: AttachmentExtractContext[], maxChars: number): string {

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -103,6 +103,21 @@ export interface AttachmentExtractContext {
   fullText: string | null
 }
 
+/**
+ * An explicit quote-reply the new message makes, resolved to the conversation
+ * that owns the quoted message as primary. This is a deliberate user action, so
+ * the prompt treats it as strong (overridable) evidence the new message
+ * continues `conversationId`. Only quotes whose target has a primary
+ * conversation appear here; the quoted conversation is guaranteed to be in
+ * `activeConversations` so the model can actually assign to it.
+ */
+export interface ReplyTarget {
+  quotedMessageId: string
+  conversationId: string
+  topicSummary: string | null
+  snippet: string
+}
+
 export interface ExtractionContext {
   newMessage: Message
   recentMessages: Message[]
@@ -110,6 +125,8 @@ export interface ExtractionContext {
   streamType: string
   /** For threads: conversations containing the parent message (in the parent channel) */
   parentMessageConversations?: ConversationSummary[]
+  /** Conversations the new message explicitly quote-replies into (strong continuity signal). */
+  replyTargets?: ReplyTarget[]
   /**
    * Extracted text from attachments, keyed by message id. Includes the new
    * message and any recent/context messages whose attachments produced a

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -15,6 +15,7 @@ export type {
   CompletenessUpdate,
   MessageAssignment,
   Reassignment,
+  ReplyTarget,
 } from "./boundary-extraction/types"
 export {
   BOUNDARY_EXTRACTION_MODEL_ID,

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -265,18 +265,26 @@ export const MessageRepository = {
   },
 
   /**
-   * Fetch messages by ID, restricted to a set of accessible streams and excluding
-   * soft-deleted rows. Used by quote-reply resolution where the quoted message ID
-   * comes from untrusted client content (`content_json.attrs.messageId`) and must
-   * be filtered against the caller's access scope.
+   * Fetch messages by ID, scoped to a workspace AND a set of accessible streams,
+   * excluding soft-deleted rows. Used by quote-reply resolution where the quoted
+   * message ID comes from untrusted client content (`content_json.attrs.messageId`)
+   * and must be filtered against the caller's access scope. The explicit
+   * `workspace_id` predicate (joined through `streams`) satisfies INV-8 even if a
+   * caller passes a stream id outside the workspace.
    */
-  async findByIdsInStreams(db: Querier, ids: string[], streamIds: string[]): Promise<Map<string, Message>> {
+  async findByIdsInStreams(
+    db: Querier,
+    workspaceId: string,
+    ids: string[],
+    streamIds: string[]
+  ): Promise<Map<string, Message>> {
     if (ids.length === 0 || streamIds.length === 0) return new Map()
 
     const result = await db.query<MessageRow>(sql`
       SELECT ${sql.raw(SELECT_FIELDS)} FROM messages
       WHERE id = ANY(${ids})
         AND stream_id = ANY(${streamIds})
+        AND stream_id IN (SELECT id FROM streams WHERE workspace_id = ${workspaceId})
         AND deleted_at IS NULL
     `)
 

--- a/packages/prosemirror/src/extractors.test.ts
+++ b/packages/prosemirror/src/extractors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import type { JSONContent } from "@threa/types"
-import { collectAttachmentReferenceIds, collectMentionSlugs } from "./extractors"
+import { collectAttachmentReferenceIds, collectMentionSlugs, collectQuoteReplyMessageIds } from "./extractors"
+
+const quoteReply = (messageId: string): JSONContent => ({
+  type: "quoteReply",
+  attrs: { messageId, snippet: "quoted text", authorId: "usr_x", streamId: "stream_x", actorType: "user" },
+})
 
 const mention = (slug: string): JSONContent => ({
   type: "mention",
@@ -106,6 +111,55 @@ describe("collectAttachmentReferenceIds", () => {
     }
 
     expect(collectAttachmentReferenceIds(doc)).toEqual(["attach_real"])
+  })
+})
+
+describe("collectQuoteReplyMessageIds", () => {
+  it("returns quoted message ids in document order across nested blocks", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        quoteReply("msg_a"),
+        { type: "paragraph", content: [{ type: "text", text: "håller med" }] },
+        {
+          type: "blockquote",
+          content: [{ type: "paragraph", content: [quoteReply("msg_b")] }],
+        },
+      ],
+    }
+
+    expect(collectQuoteReplyMessageIds(doc)).toEqual(["msg_a", "msg_b"])
+  })
+
+  it("dedupes repeats while preserving first-seen order", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [quoteReply("msg_a"), quoteReply("msg_b"), quoteReply("msg_a")],
+    }
+
+    expect(collectQuoteReplyMessageIds(doc)).toEqual(["msg_a", "msg_b"])
+  })
+
+  it("ignores quoteReply nodes with missing or empty messageId", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        { type: "quoteReply", attrs: { snippet: "no id" } },
+        { type: "quoteReply", attrs: { messageId: "" } },
+        quoteReply("msg_real"),
+      ],
+    }
+
+    expect(collectQuoteReplyMessageIds(doc)).toEqual(["msg_real"])
+  })
+
+  it("returns empty array for documents without quote replies", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+    }
+
+    expect(collectQuoteReplyMessageIds(doc)).toEqual([])
   })
 })
 

--- a/packages/prosemirror/src/extractors.ts
+++ b/packages/prosemirror/src/extractors.ts
@@ -33,6 +33,34 @@ export function collectMentionSlugs(content: JSONContent): string[] {
 }
 
 /**
+ * Message IDs this document explicitly quote-replies to, read from the
+ * `quoteReply` node attrs (so it works for any language/script — no markdown
+ * pattern matching, INV-54). Dedupes preserving first-seen order.
+ */
+export function collectQuoteReplyMessageIds(content: JSONContent): string[] {
+  const seen = new Set<string>()
+  const ordered: string[] = []
+
+  const walk = (node: JSONContent): void => {
+    if (node.type === "quoteReply") {
+      const messageId = node.attrs?.messageId
+      if (typeof messageId === "string" && messageId.length > 0 && !seen.has(messageId)) {
+        seen.add(messageId)
+        ordered.push(messageId)
+      }
+    }
+    if (node.content) {
+      for (const child of node.content) {
+        walk(child)
+      }
+    }
+  }
+
+  walk(content)
+  return ordered
+}
+
+/**
  * Skips `uploading`/`error` nodes to mirror the markdown serializer's omission
  * rule (markdown.ts), and dedupes preserving first-seen order.
  */

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -38,6 +38,6 @@ export {
   type MemoHref,
   type GiphyHref,
 } from "./pointer-urls"
-export { collectAttachmentReferenceIds, collectMentionSlugs } from "./extractors"
+export { collectAttachmentReferenceIds, collectMentionSlugs, collectQuoteReplyMessageIds } from "./extractors"
 
 export type { JSONContent, JSONContentMark, ThreaDocument } from "@threa/types"


### PR DESCRIPTION
## Problem

The conversation boundary classifier (`apps/backend/src/features/conversations/boundary-extraction/`) was over-fragmenting long DM threads. Forensics on one production DM (read-only prod query): **3,597 messages split across 452 conversations** — 52 singletons, 20 empty. Two root causes in the classifier, which is a single per-message LLM call (`gpt-5.4-nano`, temp 0.2) fed only rendered markdown:

1. **Explicit quote-replies carried no weight.** A `quoteReply` node in `content_json` records `attrs.messageId` — the exact message the user chose to reply to — but the service never resolved it, and the quoted message's conversation wasn't guaranteed to be a candidate the model could pick. Measured on that DM: **19 of 90 quote-replies (21%) were filed in a different conversation than the message they quote**, despite the reply being an explicit user action.

2. **The prompt biased toward fragmentation.** `config.ts` said *"When in doubt … start fresh"* and *"A short or ambiguous message … is a new conversation"*. In a rapid back-and-forth this split a single exchange: short acks ("samma här", ":fire:") became their own singletons, and each participant's turns drifted into different conversations (e.g. one side's messages in "Kimi k2.7-code i Pi", the other's in "exsules API/GraphQL" — one conversation, torn in two).

## Solution

Give the classifier the one structural signal it was ignoring (the quote-reply edge) and rebalance the prompt toward continuing the live exchange — while leaning on the existing reassignment mechanism to split or merge as broader context arrives, rather than trying to be right on the first message.

### How it works

1. **Resolve quote-replies to a conversation.** `BoundaryExtractionService.resolveReplyTargets` reads the new message's `quoteReply.attrs.messageId` via the new `collectQuoteReplyMessageIds` (`@threa/prosemirror`), fetches those messages **scoped to the current stream** (`MessageRepository.findByIdsInStreams(client, ids, [streamId])` — conversations are per-stream, so a quote into another stream has no valid target here), and looks up their primary conversation with `ConversationRepository.findPrimariesByMessageIds`.
2. **Force the quoted conversation into the candidate set.** `mergeConversationsById` folds those conversations into `candidateConversations`, which feeds both `activeConversations` (so the model can assign to it even when it scrolled out of the surrounding-message window) and `validUpdateTargets`. The resolved edges are passed as `ExtractionContext.replyTargets`.
3. **Surface it in the prompt.** `LLMBoundaryExtractor.buildPrompt` renders an `## Explicit reply` block listing each quoted message, its conversation, topic, and a 100-char snippet. The prompt instructs the model to treat a quote-reply as the strongest continuity signal — default the reply into the quoted conversation, overridable only when the content clearly opens a new topic.
4. **Rebalance continuity.** The "start fresh when in doubt" guidance is replaced with: prefer continuing the active exchange; a short reply/reaction/follow-up from *either* participant continues it (author is irrelevant); never split one exchange across authors. The reassignment section now explicitly covers **both** directions — merge two threads that are one topic, and split out messages a continuity guess lumped together once a later message reveals a distinct topic.

### Key design decisions

**1. Strong signal, not a hard override.** A quote-reply biases the decision but the model can still start a new conversation when the content plainly changes subject. This matches the user's framing: *"a reply may not necessarily be of the same conversation … but at the very least it should be a strong signal."* Hard-forcing would misfile the "quoting you, but new topic" case.

**2. Same-stream scoping over cross-stream resolution.** The agents quote-resolver walks cross-stream with access checks; here the target must be a conversation in *this* stream (conversations carry a `streamId`), so resolving cross-stream quotes would only produce unusable candidates. Scoping the fetch to `[streamId]` is both correct and cheaper.

**3. Lean into early continuity, let reassignment settle it.** Per the user's ruling, it's fine for classification to be jumpy early and settle later — conversations can be split or merged retroactively. So the prompt prefers continuity up front and the reassignment guidance is strengthened to split out mistakes, rather than trying to avoid every premature merge. Moderate (not maximal) continuity: still starts a new conversation on a clear topic change.

**4. Reuse the extractor, don't duplicate it (INV-35).** `collectQuoteReplyMessageIds` lands in `@threa/prosemirror` next to `collectMentionSlugs`/`collectAttachmentReferenceIds`, reading node attrs rather than markdown (INV-54). The agents `quote-resolver.ts` now imports it and its private `extractQuoteReplyMessageIds`/`walkJsonNodes` duplicate is deleted (INV-38).

## New files

None.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/extractors.ts` | Add `collectQuoteReplyMessageIds` (reads `quoteReply.attrs.messageId`, deduped, first-seen order) |
| `packages/prosemirror/src/index.ts` | Export `collectQuoteReplyMessageIds` |
| `packages/prosemirror/src/extractors.test.ts` | Tests: document order, dedupe, missing/empty id, no-quote |
| `apps/backend/src/features/agents/quote-resolver.ts` | Use the shared helper; delete the private `extractQuoteReplyMessageIds`/`walkJsonNodes` |
| `apps/backend/src/features/conversations/boundary-extraction-service.ts` | `resolveReplyTargets` + `mergeConversationsById`; thread `replyTargets` and the merged candidate set through phase 1 |
| `apps/backend/src/features/conversations/boundary-extraction/types.ts` | `ReplyTarget` type; `ExtractionContext.replyTargets` |
| `apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts` | Render the `## Explicit reply` block; fill `{{REPLY_CONTEXT}}` |
| `apps/backend/src/features/conversations/boundary-extraction/config.ts` | `{{REPLY_CONTEXT}}` section; quote-reply + continuity guidance; bidirectional reassignment |
| `apps/backend/src/features/conversations/index.ts` | Export `ReplyTarget` |
| `apps/backend/evals/suites/boundary-extraction/types.ts` | `EvalReplyTarget`; `replyTargets` on input; `reply`/`continuity` categories |
| `apps/backend/evals/suites/boundary-extraction/suite.ts` | Pass `replyTargets` into the production `ExtractionContext` |
| `apps/backend/evals/suites/boundary-extraction/cases.ts` | Two cases: quote-reply beats the more-recent conversation; short ack stays in the exchange |

## Out of scope (deliberate)

- **No backfill / reclassification of existing data.** Per the user's call, this is forward-only — the 452 existing conversations are left as-is. A reclassification job would be a separate, costed write operation (and this branch only had read-only DB access).
- **No structural use of *sequential* (non-quote) replies.** Only explicit quote-replies are resolved structurally; plain back-and-forth continuity is handled by the prompt, not a metadata edge.
- **No model or temperature change.** Same `gpt-5.4-nano` @ 0.2.

## Test plan

- [x] `bunx tsc -p apps/backend/tsconfig.json --noEmit` — clean (covers `evals/**` too)
- [x] `bunx tsc -p packages/prosemirror/tsconfig.json --noEmit` — clean
- [x] `bun test ./packages/prosemirror/src/extractors.test.ts` — 14 pass
- [x] `bun test apps/backend/src/features/agents/ apps/backend/src/features/conversations/` — 327 pass (one logged ERROR is a deliberate error-path test)
- [ ] `bun run eval -- -s boundary-extraction` — **not run**: hits OpenRouter (live API/cost), so the new eval cases are committed but unscored here. Worth running before merge to confirm the prompt changes score as intended.
- [x] Self-review (inline): correctness + claim-verification pass over the diff. Confirmed no stale `relevantConversations` read after the merge, and `validConvIds` (in `validateResult`) derives from `activeConversations`, so quoted conversations are assignable.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qw9PhTCx9VGzvUJapN15Xy)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784452170&installation_id=129946197&pr_number=1015&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1015&signature=555404dd43b91ee3166620efb75fa833cbbcfd6cfd7980bfa47cac7a6bb69797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->