### PR TITLE
feat(timeline): open at bottom with a jump-to-unread bar + progressive read + Escape

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -5,6 +5,7 @@ import {
   filterVisibleItems,
   findFirstMessageId,
   findMessageItemIndex,
+  findEventItemIndex,
   getTimelineItemKey,
   groupTimelineItems,
   injectGapItems,
@@ -395,6 +396,34 @@ describe("findMessageItemIndex", () => {
       eventItem("evt_2", "msg_real"),
     ]
     expect(findMessageItemIndex(items, "msg_real")).toBe(1)
+  })
+})
+
+describe("findEventItemIndex", () => {
+  function eventItem(id: string): TimelineItem {
+    return { type: "event", event: createEvent({ id, sequence: id, eventType: "message_created", payload: {} }) }
+  }
+
+  it("returns the index of the item carrying the event id (the unread-divider anchor)", () => {
+    const items: TimelineItem[] = [eventItem("evt_1"), eventItem("evt_2"), eventItem("evt_3")]
+    expect(findEventItemIndex(items, "evt_2")).toBe(1)
+  })
+
+  it("matches a group on its first event, like the divider does", () => {
+    const items: TimelineItem[] = [
+      eventItem("evt_1"),
+      {
+        type: "session_group",
+        sessionId: "sess_1",
+        sessionVersion: 1,
+        events: [createEvent({ id: "evt_2", sequence: "2", eventType: "message_created", payload: {} })],
+      },
+    ]
+    expect(findEventItemIndex(items, "evt_2")).toBe(1)
+  })
+
+  it("returns -1 when the event is not in the window so the cold-load scroll falls back to the bottom", () => {
+    expect(findEventItemIndex([eventItem("evt_1")], "evt_gone")).toBe(-1)
   })
 })
 

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -662,11 +662,12 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
   return (
     <>
       {showUnreadDivider && <UnreadDivider isDimmed={ctx.isDividerDimmed} />}
-      {/* The first-unread row gets extra top padding so the absolutely-positioned
-          divider has room to breathe above the message instead of crowding it.
-          Only wrap when the divider shows so every other row keeps its spacing
-          and DOM shape. */}
-      {showUnreadDivider ? <div className="pt-3">{rowContent}</div> : rowContent}
+      {/* The first-unread row reserves `pt-6` (24px) of top padding so the
+          absolutely-positioned divider, centered at 12px (`top-3`), gets equal
+          12px breathing room above and below the line — `pt-3` left the line
+          flush against the message top. Only wrap when the divider shows so
+          every other row keeps its spacing and DOM shape. */}
+      {showUnreadDivider ? <div className="pt-6">{rowContent}</div> : rowContent}
     </>
   )
 }

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -286,6 +286,19 @@ export function findMessageItemIndex(items: TimelineItem[], messageId: string): 
   )
 }
 
+/**
+ * Index of the timeline item carrying `eventId` (the row, command group, or
+ * session group whose first event matches). Mirrors `isFirstUnread` so the
+ * scroll target resolves to the same item that renders the unread divider.
+ */
+export function findEventItemIndex(items: TimelineItem[], eventId: string): number {
+  return items.findIndex((item) => {
+    if (item.type === "event") return item.event.id === eventId
+    if (item.type === "command_group" || item.type === "session_group") return item.events[0]?.id === eventId
+    return false
+  })
+}
+
 /** Returns a stable key string for a timeline item */
 export function getTimelineItemKey(item: TimelineItem): string {
   switch (item.type) {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -12,7 +12,10 @@ import {
   useStreamBootstrap,
   useWorkspaceUserId,
   useAutoMarkAsRead,
+  useLastSeenEvent,
+  useUnreadCounts,
   useUnreadDivider,
+  useIsMobile,
   useNewMessageIndicator,
   useAgentActivity,
   useAbortResearch,
@@ -61,6 +64,7 @@ import {
   itemDayStartMs,
   findFirstMessageId,
   findMessageItemIndex,
+  findEventItemIndex,
   getTimelineItemKey,
   filterVisibleItems,
   OLDER_SKELETON_ITEMS,
@@ -970,6 +974,25 @@ export function StreamContent({
   // (new message, link preview, virtua measuring) must not disarm follow.
   const userInteractedAtRef = useRef(0)
 
+  // Initial scroll target for the land-at-first-unread path. Updated each render
+  // once the unread divider has computed (below), read lazily by
+  // useTimelineScroll's cold-load layout effect. A ref because the divider is
+  // computed after this call; the getter is stable so it doesn't churn the
+  // effect.
+  const initialUnreadIndexRef = useRef<number | null>(null)
+  const getInitialScrollIndex = useCallback(() => initialUnreadIndexRef.current, [])
+
+  // The cold-load scroll waits for the read position so it lands on first-unread
+  // vs the bottom only once. This timeout is the floor: if the read position
+  // never resolves (e.g. a non-member preview with no membership row), land at
+  // the bottom anyway rather than hold the skeleton mask up forever.
+  const [readGateTimedOut, setReadGateTimedOut] = useState(false)
+  useEffect(() => {
+    setReadGateTimedOut(false)
+    const timer = setTimeout(() => setReadGateTimedOut(true), 1000)
+    return () => clearTimeout(timer)
+  }, [streamId])
+
   const {
     listRef,
     scrollerRef: virtualScrollerRef,
@@ -990,6 +1013,10 @@ export function StreamContent({
     skipInitialScroll,
     isJumpMode,
     userInteractedAtRef,
+    // Wait for the read position before the cold-load scroll decides
+    // unread-vs-bottom; only the virtualized timeline lands on first unread.
+    readStateResolved: !useVirtualized || lastReadEventId !== undefined || readGateTimedOut,
+    getInitialScrollIndex: useVirtualized ? getInitialScrollIndex : undefined,
   })
 
   // Scroll container element, owned by useTimelineScroll. Attached to the
@@ -1471,9 +1498,22 @@ export function StreamContent({
     clearSearch()
   }, [streamId, exitJumpMode, clearSearch])
 
-  // Auto-mark stream as read when viewing
-  const lastEventId = events.length > 0 ? events[events.length - 1].id : undefined
-  useAutoMarkAsRead(workspaceId, streamId, lastEventId, { enabled: !isDraft && !isLoading && !isJumpMode })
+  // Auto-mark stream as read when viewing. Read state never runs ahead of what
+  // the viewer has actually scrolled into view: mark up to the bottom-most seen
+  // row (Slack-style progressive read), not the tail of the loaded window. When
+  // the viewer is not at the live tail the mark is partial — the badge keeps the
+  // unread still below the fold (see useAutoMarkAsRead / markAsRead partial).
+  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
+  const { lastSeenEventId, atLastRow } = useLastSeenEvent({
+    scrollContainerRef,
+    events: displayEvents,
+    streamId,
+    enabled: autoMarkEnabled,
+  })
+  useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
+
+  const isMobile = useIsMobile()
+  const { markAsRead } = useUnreadCounts(workspaceId)
 
   // Track live-arriving messages from other users for brief "new" indicator.
   const newMessageIds = useNewMessageIndicator(events, currentWorkspaceUserId ?? undefined, streamId, lastReadEventId)
@@ -1483,13 +1523,22 @@ export function StreamContent({
   // hide from this stream's render (e.g. thread membership rows) — otherwise
   // the divider can target an event id that never matches a rendered row and
   // silently fails to show.
-  const { dividerEventId, isDimmed: isDividerDimmed } = useUnreadDivider({
+  const {
+    firstUnreadEventId,
+    dividerEventId,
+    isDimmed: isDividerDimmed,
+    dismiss: dismissUnreadDivider,
+  } = useUnreadDivider({
     events: displayEvents,
     lastReadEventId,
     currentUserId: currentWorkspaceUserId ?? undefined,
     streamId,
     isLoading,
     highlightMessageId,
+    // The virtualized timeline lands on first unread through useTimelineScroll's
+    // cold-load settle (precise on an unmeasured list); only the plain thread
+    // scroller still needs the divider's own scrollIntoView.
+    scrollToUnread: !useVirtualized,
     // `lastReadEventId` is `string | null` once resolved; it is only `undefined`
     // while the read sources (stream row / membership) are still hydrating. Gate
     // on that so a not-yet-known read position can't be read as "all unread" and
@@ -1498,6 +1547,54 @@ export function StreamContent({
     // stale null while the authoritative membership value is still loading.
     readStateResolved: lastReadEventId !== undefined,
   })
+
+  // Feed the cold-load landing target: the item index of the first unread row,
+  // or null to land at the bottom. Read lazily by useTimelineScroll's layout
+  // effect once read state resolves. A deep-link (?m=) drives its own scroll, so
+  // never override it with the unread target.
+  initialUnreadIndexRef.current =
+    firstUnreadEventId && !highlightMessageId ? findEventItemIndex(visibleItems, firstUnreadEventId) : null
+
+  // Escape "escapes the unread block" (desktop, Slack's Esc-marks-channel-read):
+  // mark the stream fully read, dismiss the persistent unread divider, and
+  // resume tailing the live bottom. Scoped to when the divider is actually shown
+  // so it never swallows Escape elsewhere; the composer/editor keep their own
+  // Escape via the isInput guard, and search owns Escape while open.
+  useEffect(() => {
+    if (isMobile || isDraft || !dividerEventId || isSearchOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return
+      const target = event.target as HTMLElement | null
+      const isInput = target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable
+      if (isInput) return
+      // An open Radix overlay (move dialog, dropdown, popover) consumes Escape to
+      // dismiss itself; it listens in the capture phase and does not stop
+      // propagation, so without this our bubble-phase handler would ALSO mark the
+      // stream read and jump to the tail on the same keypress.
+      if (
+        document.querySelector(
+          '[role="dialog"][data-state="open"],[role="alertdialog"][data-state="open"],[role="menu"][data-state="open"],[data-radix-popper-content-wrapper]'
+        )
+      )
+        return
+      const lastLoadedEventId = events.length > 0 ? events[events.length - 1].id : undefined
+      if (lastLoadedEventId) markAsRead(streamId, lastLoadedEventId)
+      dismissUnreadDivider()
+      scrollToBottom({ force: true })
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [
+    isMobile,
+    isDraft,
+    dividerEventId,
+    isSearchOpen,
+    events,
+    markAsRead,
+    streamId,
+    dismissUnreadDivider,
+    scrollToBottom,
+  ])
 
   const queryClient = useQueryClient()
   const isPublicChannel = stream?.type === StreamTypes.CHANNEL && stream?.visibility === Visibilities.PUBLIC

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1556,6 +1556,12 @@ export function StreamContent({
     firstUnreadEventId && !highlightMessageId ? findEventItemIndex(visibleItems, firstUnreadEventId) : -1
   initialUnreadIndexRef.current = firstUnreadItemIndex >= 0 ? firstUnreadItemIndex : null
 
+  // Read the last loaded event from a ref so the Escape listener below doesn't
+  // re-attach on every live message (the events array is a fresh reference each
+  // append).
+  const lastLoadedEventIdRef = useRef<string | undefined>(undefined)
+  lastLoadedEventIdRef.current = events.length > 0 ? events[events.length - 1].id : undefined
+
   // Escape "escapes the unread block" (desktop, Slack's Esc-marks-channel-read):
   // mark the stream fully read, dismiss the persistent unread divider, and
   // resume tailing the live bottom. Scoped to when the divider is actually shown
@@ -1571,31 +1577,23 @@ export function StreamContent({
       // An open Radix overlay (move dialog, dropdown, popover) consumes Escape to
       // dismiss itself; it listens in the capture phase and does not stop
       // propagation, so without this our bubble-phase handler would ALSO mark the
-      // stream read and jump to the tail on the same keypress.
+      // stream read and jump to the tail on the same keypress. The popper wrapper
+      // is only in the DOM while an overlay is open (no forceMount), so this never
+      // suppresses Escape spuriously.
       if (
         document.querySelector(
           '[role="dialog"][data-state="open"],[role="alertdialog"][data-state="open"],[role="menu"][data-state="open"],[data-radix-popper-content-wrapper]'
         )
       )
         return
-      const lastLoadedEventId = events.length > 0 ? events[events.length - 1].id : undefined
+      const lastLoadedEventId = lastLoadedEventIdRef.current
       if (lastLoadedEventId) markAsRead(streamId, lastLoadedEventId)
       dismissUnreadDivider()
       scrollToBottom({ force: true })
     }
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [
-    isMobile,
-    isDraft,
-    dividerEventId,
-    isSearchOpen,
-    events,
-    markAsRead,
-    streamId,
-    dismissUnreadDivider,
-    scrollToBottom,
-  ])
+  }, [isMobile, isDraft, dividerEventId, isSearchOpen, markAsRead, streamId, dismissUnreadDivider, scrollToBottom])
 
   const queryClient = useQueryClient()
   const isPublicChannel = stream?.type === StreamTypes.CHANNEL && stream?.visibility === Visibilities.PUBLIC

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1900,12 +1900,11 @@ export function StreamContent({
               Jumps up to the "New" divider so the viewer can read from there. */}
             {unreadAboveViewport && unreadCount > 0 && !batchMode && (
               <div
-                // Sits below the floating date pill (top-2, ~z-20) so the two
-                // top-center affordances stack instead of overlapping. When
-                // search is open the date pill is hidden but the search bar
-                // takes the top, so drop a little further.
+                // Sits clearly below the floating date pill (top-2, ~30px tall)
+                // and the search bar (when open) so the top-center affordances
+                // never overlap.
                 className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
-                style={{ top: isSearchOpen ? "3.5rem" : "2.75rem" }}
+                style={{ top: "3.5rem" }}
               >
                 <Button
                   variant="secondary"

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1577,18 +1577,23 @@ export function StreamContent({
       const target = event.target as HTMLElement | null
       const isInput = target?.tagName === "INPUT" || target?.tagName === "TEXTAREA" || target?.isContentEditable
       if (isInput) return
-      // An open Radix overlay (move dialog, dropdown, popover) consumes Escape to
-      // dismiss itself; it listens in the capture phase and does not stop
-      // propagation, so without this our bubble-phase handler would ALSO mark the
-      // stream read and jump to the tail on the same keypress. The popper wrapper
-      // is only in the DOM while an overlay is open (no forceMount), so this never
-      // suppresses Escape spuriously.
-      if (
+      // An open Radix overlay that owns Escape (move dialog, dropdown, the
+      // reaction popover) listens in the capture phase and does not stop
+      // propagation, so without this our bubble-phase handler would ALSO mark
+      // the stream read and jump to the tail on the same keypress. Dialogs and
+      // menus match by role; other popovers match the popper wrapper (only in
+      // the DOM while open — no forceMount). Hover-only tooltips render in a
+      // popper wrapper too but never own Escape, so a tooltip showing on a
+      // hovered message must not block the shortcut — skip wrappers whose
+      // content is a tooltip.
+      const overlayOwnsEscape =
         document.querySelector(
-          '[role="dialog"][data-state="open"],[role="alertdialog"][data-state="open"],[role="menu"][data-state="open"],[data-radix-popper-content-wrapper]'
+          '[role="dialog"][data-state="open"],[role="alertdialog"][data-state="open"],[role="menu"][data-state="open"]'
+        ) != null ||
+        Array.from(document.querySelectorAll("[data-radix-popper-content-wrapper]")).some(
+          (wrapper) => wrapper.querySelector('[role="tooltip"]') == null
         )
-      )
-        return
+      if (overlayOwnsEscape) return
       const lastLoadedEventId = lastLoadedEventIdRef.current
       if (lastLoadedEventId) markAsRead(streamId, lastLoadedEventId)
       dismissUnreadDivider()

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1552,8 +1552,9 @@ export function StreamContent({
   // or null to land at the bottom. Read lazily by useTimelineScroll's layout
   // effect once read state resolves. A deep-link (?m=) drives its own scroll, so
   // never override it with the unread target.
-  initialUnreadIndexRef.current =
-    firstUnreadEventId && !highlightMessageId ? findEventItemIndex(visibleItems, firstUnreadEventId) : null
+  const firstUnreadItemIndex =
+    firstUnreadEventId && !highlightMessageId ? findEventItemIndex(visibleItems, firstUnreadEventId) : -1
+  initialUnreadIndexRef.current = firstUnreadItemIndex >= 0 ? firstUnreadItemIndex : null
 
   // Escape "escapes the unread block" (desktop, Slack's Esc-marks-channel-read):
   // mark the stream fully read, dismiss the persistent unread divider, and

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useLayoutEffect, useCallback, useRef, useState } from "react"
 import { useLocation, useSearchParams } from "react-router-dom"
 import { Virtualizer, type VirtualizerHandle } from "virtua"
-import { MessageSquare, ArrowDown, X, Move, Loader2, Check } from "lucide-react"
+import { MessageSquare, ArrowDown, ArrowUp, X, Move, Loader2, Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useQueryClient } from "@tanstack/react-query"
 import {
@@ -974,25 +974,6 @@ export function StreamContent({
   // (new message, link preview, virtua measuring) must not disarm follow.
   const userInteractedAtRef = useRef(0)
 
-  // Initial scroll target for the land-at-first-unread path. Updated each render
-  // once the unread divider has computed (below), read lazily by
-  // useTimelineScroll's cold-load layout effect. A ref because the divider is
-  // computed after this call; the getter is stable so it doesn't churn the
-  // effect.
-  const initialUnreadIndexRef = useRef<number | null>(null)
-  const getInitialScrollIndex = useCallback(() => initialUnreadIndexRef.current, [])
-
-  // The cold-load scroll waits for the read position so it lands on first-unread
-  // vs the bottom only once. This timeout is the floor: if the read position
-  // never resolves (e.g. a non-member preview with no membership row), land at
-  // the bottom anyway rather than hold the skeleton mask up forever.
-  const [readGateTimedOut, setReadGateTimedOut] = useState(false)
-  useEffect(() => {
-    setReadGateTimedOut(false)
-    const timer = setTimeout(() => setReadGateTimedOut(true), 1000)
-    return () => clearTimeout(timer)
-  }, [streamId])
-
   const {
     listRef,
     scrollerRef: virtualScrollerRef,
@@ -1013,10 +994,6 @@ export function StreamContent({
     skipInitialScroll,
     isJumpMode,
     userInteractedAtRef,
-    // Wait for the read position before the cold-load scroll decides
-    // unread-vs-bottom; only the virtualized timeline lands on first unread.
-    readStateResolved: !useVirtualized || lastReadEventId !== undefined || readGateTimedOut,
-    getInitialScrollIndex: useVirtualized ? getInitialScrollIndex : undefined,
   })
 
   // Scroll container element, owned by useTimelineScroll. Attached to the
@@ -1506,28 +1483,32 @@ export function StreamContent({
   // Held off until the cold-load settle reveals the rows: the timeline DOM is
   // populated behind the skeleton mask during the settle, so scanning it then
   // would mark rows read the viewer hasn't actually seen yet.
-  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && !(useVirtualized && virtualIsInitialSettling)
-  const { lastSeenEventId, atLastRow } = useLastSeenEvent({
+  // Auto-mark stream as read when viewing. The stream opens at the live bottom;
+  // read state advances only through the contiguous run the viewer scrolls
+  // through from where they left off (see useLastSeenEvent), so the unread above
+  // the fold stays unread until they go up to it (or press Escape). A not-at-tail
+  // mark is partial — the badge keeps the remaining unread (markAsRead partial).
+  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
+  const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     events: displayEvents,
     streamId,
+    lastReadEventId,
     enabled: autoMarkEnabled,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
 
   const isMobile = useIsMobile()
-  const { markAsRead } = useUnreadCounts(workspaceId)
+  const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
+  const unreadCount = getUnreadCount(streamId)
 
   // Track live-arriving messages from other users for brief "new" indicator.
   const newMessageIds = useNewMessageIndicator(events, currentWorkspaceUserId ?? undefined, streamId, lastReadEventId)
 
-  // Unread divider state management (also handles scroll-to-first-unread).
-  // Pass `displayEvents` so the divider's first-unread search skips events we
-  // hide from this stream's render (e.g. thread membership rows) — otherwise
-  // the divider can target an event id that never matches a rendered row and
-  // silently fails to show.
+  // Unread divider state — a bookmark line at the first unread message. The
+  // stream opens at the bottom (no auto-scroll to unread); the viewer reaches
+  // the divider via the "N new" jump button or by scrolling up.
   const {
-    firstUnreadEventId,
     dividerEventId,
     isDimmed: isDividerDimmed,
     dismiss: dismissUnreadDivider,
@@ -1538,10 +1519,8 @@ export function StreamContent({
     streamId,
     isLoading,
     highlightMessageId,
-    // The virtualized timeline lands on first unread through useTimelineScroll's
-    // cold-load settle (precise on an unmeasured list); only the plain thread
-    // scroller still needs the divider's own scrollIntoView.
-    scrollToUnread: !useVirtualized,
+    // Never auto-scroll to the unread line — opening lands at the live bottom.
+    scrollToUnread: false,
     // `lastReadEventId` is `string | null` once resolved; it is only `undefined`
     // while the read sources (stream row / membership) are still hydrating. Gate
     // on that so a not-yet-known read position can't be read as "all unread" and
@@ -1550,14 +1529,6 @@ export function StreamContent({
     // stale null while the authoritative membership value is still loading.
     readStateResolved: lastReadEventId !== undefined,
   })
-
-  // Feed the cold-load landing target: the item index of the first unread row,
-  // or null to land at the bottom. Read lazily by useTimelineScroll's layout
-  // effect once read state resolves. A deep-link (?m=) drives its own scroll, so
-  // never override it with the unread target.
-  const firstUnreadItemIndex =
-    firstUnreadEventId && !highlightMessageId ? findEventItemIndex(visibleItems, firstUnreadEventId) : -1
-  initialUnreadIndexRef.current = firstUnreadItemIndex >= 0 ? firstUnreadItemIndex : null
 
   // Read the last loaded event from a ref so the Escape listener below doesn't
   // re-attach on every live message (the events array is a fresh reference each
@@ -1597,7 +1568,7 @@ export function StreamContent({
       const lastLoadedEventId = lastLoadedEventIdRef.current
       if (lastLoadedEventId) markAsRead(streamId, lastLoadedEventId)
       dismissUnreadDivider()
-      scrollToBottom({ force: true, resumeTail: true })
+      scrollToBottom({ force: true })
     }
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
@@ -1640,12 +1611,34 @@ export function StreamContent({
       // mis-detected as a real prepend.
       resetShiftBaseline()
       requestAnimationFrame(() => {
-        scrollToBottom({ force: true, resumeTail: true })
+        scrollToBottom({ force: true })
       })
     } else {
-      scrollToBottom({ force: true, resumeTail: true })
+      scrollToBottom({ force: true })
     }
   }, [isJumpMode, exitJumpMode, resetShiftBaseline, scrollToBottom])
+
+  // Jump up to the first unread (the "New" divider) and stop following the tail
+  // so a live message doesn't yank the reader back down. Lands the divider near
+  // the top with a little context above so the run reads from the top.
+  const scrollToFirstUnread = useCallback(() => {
+    if (!dividerEventId) return
+    disableAutoScroll()
+    if (useVirtualized) {
+      const idx = findEventItemIndex(visibleItems, dividerEventId)
+      if (idx < 0) return
+      try {
+        listRef.current?.scrollToIndex(idx, { align: "start", offset: -56 })
+      } catch {
+        // A not-yet-measured virtua list can throw; the row is already rendered
+        // by the time this button is clickable, so this is best-effort.
+      }
+    } else {
+      scrollContainerRef.current
+        ?.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(dividerEventId)}"]`)
+        ?.scrollIntoView({ block: "start" })
+    }
+  }, [dividerEventId, useVirtualized, visibleItems, listRef, disableAutoScroll, scrollContainerRef])
 
   const editLastMessageCtxWithScroll = useMemo(
     () => ({ ...editLastMessageCtx, scrollToMessage }),
@@ -1899,6 +1892,24 @@ export function StreamContent({
                 >
                   <ArrowDown className="h-3.5 w-3.5" />
                   Jump to latest
+                </Button>
+              </div>
+            )}
+            {/* "N new messages" jump — shown when unread sits above the viewport.
+              Jumps up to the "New" divider so the viewer can read from there. */}
+            {unreadAboveViewport && unreadCount > 0 && !batchMode && (
+              <div
+                className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
+                style={{ top: isSearchOpen ? "3.5rem" : "0.5rem" }}
+              >
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="pointer-events-auto shadow-lg gap-1.5"
+                  onClick={scrollToFirstUnread}
+                >
+                  <ArrowUp className="h-3.5 w-3.5" />
+                  {unreadCount} new message{unreadCount === 1 ? "" : "s"}
                 </Button>
               </div>
             )}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1476,14 +1476,6 @@ export function StreamContent({
     clearSearch()
   }, [streamId, exitJumpMode, clearSearch])
 
-  // Auto-mark stream as read when viewing. Read state never runs ahead of what
-  // the viewer has actually scrolled into view: mark up to the bottom-most seen
-  // row (Slack-style progressive read), not the tail of the loaded window. When
-  // the viewer is not at the live tail the mark is partial — the badge keeps the
-  // unread still below the fold (see useAutoMarkAsRead / markAsRead partial).
-  // Held off until the cold-load settle reveals the rows: the timeline DOM is
-  // populated behind the skeleton mask during the settle, so scanning it then
-  // would mark rows read the viewer hasn't actually seen yet.
   // Auto-mark stream as read when viewing. The stream opens at the live bottom;
   // read state advances only through the contiguous run the viewer scrolls
   // through from where they left off (see useLastSeenEvent), so the unread above
@@ -1897,12 +1889,14 @@ export function StreamContent({
               </div>
             )}
             {/* "N new messages" jump — shown when unread sits above the viewport.
-              Jumps up to the "New" divider so the viewer can read from there. */}
-            {unreadAboveViewport && unreadCount > 0 && !batchMode && (
+              Jumps up to the "New" divider so the viewer can read from there.
+              Hidden while search is open: jumping the timeline would yank it out
+              from under the active search-result navigation, and the Escape
+              mark-read shortcut is gated on `!isSearchOpen` too. */}
+            {unreadAboveViewport && unreadCount > 0 && !batchMode && !isSearchOpen && (
               <div
                 // Sits clearly below the floating date pill (top-2, ~30px tall)
-                // and the search bar (when open) so the top-center affordances
-                // never overlap.
+                // so the top-center affordances never overlap.
                 className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
                 style={{ top: "3.5rem" }}
               >

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1503,7 +1503,10 @@ export function StreamContent({
   // row (Slack-style progressive read), not the tail of the loaded window. When
   // the viewer is not at the live tail the mark is partial — the badge keeps the
   // unread still below the fold (see useAutoMarkAsRead / markAsRead partial).
-  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
+  // Held off until the cold-load settle reveals the rows: the timeline DOM is
+  // populated behind the skeleton mask during the settle, so scanning it then
+  // would mark rows read the viewer hasn't actually seen yet.
+  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && !(useVirtualized && virtualIsInitialSettling)
   const { lastSeenEventId, atLastRow } = useLastSeenEvent({
     scrollContainerRef,
     events: displayEvents,
@@ -1589,7 +1592,7 @@ export function StreamContent({
       const lastLoadedEventId = lastLoadedEventIdRef.current
       if (lastLoadedEventId) markAsRead(streamId, lastLoadedEventId)
       dismissUnreadDivider()
-      scrollToBottom({ force: true })
+      scrollToBottom({ force: true, resumeTail: true })
     }
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
@@ -1632,10 +1635,10 @@ export function StreamContent({
       // mis-detected as a real prepend.
       resetShiftBaseline()
       requestAnimationFrame(() => {
-        scrollToBottom({ force: true })
+        scrollToBottom({ force: true, resumeTail: true })
       })
     } else {
-      scrollToBottom({ force: true })
+      scrollToBottom({ force: true, resumeTail: true })
     }
   }, [isJumpMode, exitJumpMode, resetShiftBaseline, scrollToBottom])
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -15,6 +15,7 @@ import {
   useLastSeenEvent,
   useUnreadCounts,
   useUnreadDivider,
+  useDividerDim,
   useIsMobile,
   useNewMessageIndicator,
   useAgentActivity,
@@ -1508,11 +1509,7 @@ export function StreamContent({
   // Unread divider state — a bookmark line at the first unread message. The
   // stream opens at the bottom (no auto-scroll to unread); the viewer reaches
   // the divider via the "N new" jump button or by scrolling up.
-  const {
-    dividerEventId,
-    isDimmed: isDividerDimmed,
-    dismiss: dismissUnreadDivider,
-  } = useUnreadDivider({
+  const { dividerEventId, dismiss: dismissUnreadDivider } = useUnreadDivider({
     events: displayEvents,
     lastReadEventId,
     currentUserId: currentWorkspaceUserId ?? undefined,
@@ -1529,6 +1526,10 @@ export function StreamContent({
     // stale null while the authoritative membership value is still loading.
     readStateResolved: lastReadEventId !== undefined,
   })
+
+  // The divider's red → gray fade waits until the row is actually on screen —
+  // it usually starts off-screen above (the stream opens at the bottom).
+  const isDividerDimmed = useDividerDim(scrollContainerRef, dividerEventId, streamId)
 
   // Read the last loaded event from a ref so the Escape listener below doesn't
   // re-attach on every live message (the events array is a fresh reference each
@@ -1899,8 +1900,12 @@ export function StreamContent({
               Jumps up to the "New" divider so the viewer can read from there. */}
             {unreadAboveViewport && unreadCount > 0 && !batchMode && (
               <div
+                // Sits below the floating date pill (top-2, ~z-20) so the two
+                // top-center affordances stack instead of overlapping. When
+                // search is open the date pill is hidden but the search bar
+                // takes the top, so drop a little further.
                 className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
-                style={{ top: isSearchOpen ? "3.5rem" : "0.5rem" }}
+                style={{ top: isSearchOpen ? "3.5rem" : "2.75rem" }}
               >
                 <Button
                   variant="secondary"

--- a/apps/frontend/src/components/timeline/unread-divider.tsx
+++ b/apps/frontend/src/components/timeline/unread-divider.tsx
@@ -7,10 +7,11 @@ export function UnreadDivider({ isDimmed }: UnreadDividerProps) {
   return (
     <div
       // The line sits in the gap *above* the first-unread item, centered in the
-      // extra `pt-3` that row gets while the divider shows (see TimelineItemContent).
-      // `top-3` + `-translate-y-1/2` lands the line's center ~12px below the row
-      // top, leaving even breathing room above (to the previous row) and below
-      // (the message's own `pt-3`) so it doesn't crowd either.
+      // extra `pt-6` (24px) that row gets while the divider shows (see
+      // TimelineItemContent). `top-3` + `-translate-y-1/2` lands the line's
+      // center 12px below the row top — exactly half the reserved padding — so
+      // the breathing room above (to the previous row) and below (to the
+      // message) is symmetric.
       //
       // Color, not opacity: the line keeps reserving its row as it settles, so
       // nothing shifts when it dims (INV-21).

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -109,7 +109,7 @@ export { useAutoMarkAsRead } from "./use-auto-mark-as-read"
 
 export { useLastSeenEvent } from "./use-last-seen-event"
 
-export { useUnreadDivider } from "./use-unread-divider"
+export { useUnreadDivider, useDividerDim } from "./use-unread-divider"
 
 export { useNewMessageIndicator } from "./use-new-message-indicator"
 

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -107,6 +107,8 @@ export { useActivityFeed, useMarkActivityRead, useMarkAllActivityRead, activityK
 
 export { useAutoMarkAsRead } from "./use-auto-mark-as-read"
 
+export { useLastSeenEvent } from "./use-last-seen-event"
+
 export { useUnreadDivider } from "./use-unread-divider"
 
 export { useNewMessageIndicator } from "./use-new-message-indicator"

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -84,7 +84,7 @@ describe("useAutoMarkAsRead", () => {
       vi.advanceTimersByTime(500)
     })
 
-    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123")
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: SW_MSG_CLEAR_NOTIFICATIONS,
       streamId: "stream_123",
@@ -155,10 +155,44 @@ describe("useAutoMarkAsRead", () => {
       vi.advanceTimersByTime(500)
     })
 
-    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123")
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
     expect(mockPostMessage).toHaveBeenCalledWith({
       type: SW_MSG_CLEAR_NOTIFICATIONS,
       streamId: "stream_123",
     })
+  })
+
+  it("passes partial through so a mid-window read does not zero the badge", () => {
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123", { partial: true }))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: true })
+  })
+
+  it("re-fires a full mark when partial flips to false at the same event (scrolled on to the tail)", () => {
+    const { rerender } = renderHook(
+      ({ partial }) => useAutoMarkAsRead("ws_123", "stream_123", "event_123", { partial }),
+      {
+        initialProps: { partial: true },
+      }
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_123", "event_123", { partial: true })
+
+    rerender({ partial: false })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Same event, now full — must re-fire so the badge clears optimistically
+    // rather than waiting on the server round-trip.
+    expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_123", "event_123", { partial: false })
+    expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -7,6 +7,14 @@ import { SW_MSG_CLEAR_NOTIFICATIONS } from "../lib/sw-messages"
 interface UseAutoMarkAsReadOptions {
   enabled?: boolean
   debounceMs?: number
+  /**
+   * When true, `lastEventId` is the bottom of what the viewer has seen, not the
+   * tail of the loaded window — unread messages remain below the fold. The read
+   * pointer advances to `lastEventId`, but the unread badge is NOT optimistically
+   * zeroed; the server `stream:read` round-trip sets the true remaining count
+   * (Slack-style progressive read). Defaults false: mark fully read as before.
+   */
+  partial?: boolean
 }
 
 /**
@@ -16,6 +24,10 @@ interface UseAutoMarkAsReadOptions {
  * Checks unread counts, mention counts, AND activity counts — the mark-as-read API
  * clears all of these, so this must fire when any is elevated (e.g., activity arrives
  * via the outbox handler while viewing the stream).
+ *
+ * `lastEventId` is the furthest event the viewer has actually scrolled into
+ * view (see `useLastSeenEvent`), not the last loaded event — read state never
+ * runs ahead of what the user has seen.
  */
 export function useAutoMarkAsRead(
   workspaceId: string,
@@ -23,18 +35,24 @@ export function useAutoMarkAsRead(
   lastEventId: string | undefined,
   options: UseAutoMarkAsReadOptions = {}
 ) {
-  const { enabled = true, debounceMs = 500 } = options
+  const { enabled = true, debounceMs = 500, partial = false } = options
   const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
   const { isActive } = usePageActivity()
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
+  // Track the partial-ness of the last mark so a partial→full transition at the
+  // SAME event (viewer scrolled partway, then on to the tail) re-fires to clear
+  // the badge optimistically instead of waiting on the server round-trip.
+  const lastMarkedPartialRef = useRef<boolean | null>(null)
 
   // Use refs to avoid stale closure in setTimeout callback
   const streamIdRef = useRef(streamId)
   const lastEventIdRef = useRef(lastEventId)
+  const partialRef = useRef(partial)
   streamIdRef.current = streamId
   lastEventIdRef.current = lastEventId
+  partialRef.current = partial
 
   useEffect(() => {
     if (!enabled || !lastEventId || !isActive) return
@@ -44,11 +62,12 @@ export function useAutoMarkAsRead(
 
     if (unreadCount === 0 && activityCount === 0) return
 
-    // Skip if already marked this event AND no pending activities to clear.
-    // Activities can arrive via activity:created while we're viewing the stream
-    // (the outbox handler is async), so we must re-fire markAsRead to clear
-    // them even if lastEventId hasn't changed.
-    if (lastMarkedRef.current === lastEventId && activityCount === 0) return
+    // Skip if already marked this event at the same partial-ness AND no pending
+    // activities to clear. Activities can arrive via activity:created while we're
+    // viewing the stream (the outbox handler is async), so we must re-fire to
+    // clear them even if lastEventId hasn't changed; likewise a partial→full
+    // transition at the same event must re-fire to clear the badge.
+    if (lastMarkedRef.current === lastEventId && lastMarkedPartialRef.current === partial && activityCount === 0) return
 
     if (timerRef.current) {
       clearTimeout(timerRef.current)
@@ -60,8 +79,9 @@ export function useAutoMarkAsRead(
       const currentStreamId = streamIdRef.current
       const currentLastEventId = lastEventIdRef.current
       if (currentLastEventId) {
-        markAsRead(currentStreamId, currentLastEventId)
+        markAsRead(currentStreamId, currentLastEventId, { partial: partialRef.current })
         lastMarkedRef.current = currentLastEventId
+        lastMarkedPartialRef.current = partialRef.current
         // Dismiss any push notification for this stream — the user is reading it
         navigator.serviceWorker?.controller?.postMessage({
           type: SW_MSG_CLEAR_NOTIFICATIONS,
@@ -75,5 +95,5 @@ export function useAutoMarkAsRead(
         clearTimeout(timerRef.current)
       }
     }
-  }, [enabled, streamId, lastEventId, debounceMs, markAsRead, getUnreadCount, getActivityCount, isActive])
+  }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, isActive])
 }

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -1,48 +1,45 @@
 import { describe, it, expect } from "vitest"
-import { pickBottomSeenId, type VisibleRow } from "./use-last-seen-event"
+import { pickVisibleRange, advanceFrontier, type VisibleRow } from "./use-last-seen-event"
 
 // Viewport spans y=0..100. Rows are in chronological (DOM) order.
 const VIEWPORT_TOP = 0
 const VIEWPORT_BOTTOM = 100
 
-function pick(rows: VisibleRow[]): string | null {
-  return pickBottomSeenId(rows, VIEWPORT_TOP, VIEWPORT_BOTTOM)
+function pick(rows: VisibleRow[]): ReturnType<typeof pickVisibleRange> {
+  return pickVisibleRange(rows, VIEWPORT_TOP, VIEWPORT_BOTTOM)
 }
 
-describe("pickBottomSeenId", () => {
-  it("returns the bottom-most row whose top has entered the viewport", () => {
+describe("pickVisibleRange", () => {
+  it("returns the first and last rows intersecting the viewport", () => {
     const rows: VisibleRow[] = [
       { id: "a", top: 10, bottom: 40 },
       { id: "b", top: 40, bottom: 70 },
       { id: "c", top: 70, bottom: 95 },
     ]
-    expect(pick(rows)).toBe("c")
+    expect(pick(rows)).toEqual({ topId: "a", bottomId: "c" })
   })
 
-  it("ignores rows entirely below the viewport (not yet seen)", () => {
-    const rows: VisibleRow[] = [
-      { id: "a", top: 10, bottom: 60 },
-      { id: "b", top: 60, bottom: 99 },
-      // Below the fold — top has not crossed the viewport bottom.
-      { id: "c", top: 120, bottom: 180 },
-      { id: "d", top: 180, bottom: 240 },
-    ]
-    expect(pick(rows)).toBe("b")
-  })
-
-  it("counts a row taller than the viewport as seen once its top scrolls past", () => {
-    const rows: VisibleRow[] = [
-      { id: "a", top: -50, bottom: 200 }, // top above viewport, spans whole screen
-    ]
-    expect(pick(rows)).toBe("a")
-  })
-
-  it("ignores rows scrolled entirely above the viewport top", () => {
+  it("excludes rows scrolled entirely above the viewport top", () => {
     const rows: VisibleRow[] = [
       { id: "a", top: -80, bottom: -10 }, // fully above
       { id: "b", top: 5, bottom: 50 },
+      { id: "c", top: 50, bottom: 95 },
     ]
-    expect(pick(rows)).toBe("b")
+    expect(pick(rows)).toEqual({ topId: "b", bottomId: "c" })
+  })
+
+  it("excludes rows entirely below the viewport (not yet seen)", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: 10, bottom: 60 },
+      { id: "b", top: 60, bottom: 99 },
+      { id: "c", top: 120, bottom: 180 }, // below the fold
+    ]
+    expect(pick(rows)).toEqual({ topId: "a", bottomId: "b" })
+  })
+
+  it("counts a row taller than the viewport as both top and bottom", () => {
+    const rows: VisibleRow[] = [{ id: "a", top: -50, bottom: 200 }]
+    expect(pick(rows)).toEqual({ topId: "a", bottomId: "a" })
   })
 
   it("returns null when no rows intersect the viewport", () => {
@@ -57,12 +54,45 @@ describe("pickBottomSeenId", () => {
     expect(pick([])).toBeNull()
   })
 
-  it("picks the last row when the whole window fits in the viewport", () => {
+  it("returns a single-row range when only one row is visible", () => {
     const rows: VisibleRow[] = [
-      { id: "a", top: 0, bottom: 20 },
-      { id: "b", top: 20, bottom: 40 },
-      { id: "c", top: 40, bottom: 60 },
+      { id: "a", top: -80, bottom: -10 },
+      { id: "b", top: 5, bottom: 50 },
+      { id: "c", top: 200, bottom: 260 },
     ]
-    expect(pick(rows)).toBe("c")
+    expect(pick(rows)).toEqual({ topId: "b", bottomId: "b" })
+  })
+})
+
+describe("advanceFrontier", () => {
+  it("does NOT advance when landing at the live bottom with a gap above", () => {
+    // Read up to row 4; viewport shows rows 27..30 (the tail). The gap 5..26 is
+    // unseen, so the frontier must stay at 4 — opening at the bottom keeps the
+    // unread above unread.
+    expect(advanceFrontier(4, 27, 30)).toBe(4)
+  })
+
+  it("advances to the bottom of the viewport when contiguous with the frontier", () => {
+    // Jumped to the first unread (row 5, frontier+1) and it's at the top; advance
+    // through what's on screen.
+    expect(advanceFrontier(4, 5, 8)).toBe(8)
+  })
+
+  it("advances when the viewport top sits above the frontier (overlap)", () => {
+    expect(advanceFrontier(7, 5, 12)).toBe(12)
+  })
+
+  it("does not advance when flinging past leaves a gap above the viewport", () => {
+    // Frontier at 7, but a fast scroll put rows 20..25 on screen without 8..19
+    // ever being visible — they stay unseen.
+    expect(advanceFrontier(7, 20, 25)).toBe(7)
+  })
+
+  it("does not retract when scrolling back up (bottom below the frontier)", () => {
+    expect(advanceFrontier(20, 10, 15)).toBe(20)
+  })
+
+  it("treats an exactly-contiguous top (frontier + 1) as no gap", () => {
+    expect(advanceFrontier(9, 10, 14)).toBe(14)
   })
 })

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import { pickBottomSeenId, type VisibleRow } from "./use-last-seen-event"
+
+// Viewport spans y=0..100. Rows are in chronological (DOM) order.
+const VIEWPORT_TOP = 0
+const VIEWPORT_BOTTOM = 100
+
+function pick(rows: VisibleRow[]): string | null {
+  return pickBottomSeenId(rows, VIEWPORT_TOP, VIEWPORT_BOTTOM)
+}
+
+describe("pickBottomSeenId", () => {
+  it("returns the bottom-most row whose top has entered the viewport", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: 10, bottom: 40 },
+      { id: "b", top: 40, bottom: 70 },
+      { id: "c", top: 70, bottom: 95 },
+    ]
+    expect(pick(rows)).toBe("c")
+  })
+
+  it("ignores rows entirely below the viewport (not yet seen)", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: 10, bottom: 60 },
+      { id: "b", top: 60, bottom: 99 },
+      // Below the fold — top has not crossed the viewport bottom.
+      { id: "c", top: 120, bottom: 180 },
+      { id: "d", top: 180, bottom: 240 },
+    ]
+    expect(pick(rows)).toBe("b")
+  })
+
+  it("counts a row taller than the viewport as seen once its top scrolls past", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: -50, bottom: 200 }, // top above viewport, spans whole screen
+    ]
+    expect(pick(rows)).toBe("a")
+  })
+
+  it("ignores rows scrolled entirely above the viewport top", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: -80, bottom: -10 }, // fully above
+      { id: "b", top: 5, bottom: 50 },
+    ]
+    expect(pick(rows)).toBe("b")
+  })
+
+  it("returns null when no rows intersect the viewport", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: -80, bottom: -10 },
+      { id: "b", top: 200, bottom: 260 },
+    ]
+    expect(pick(rows)).toBeNull()
+  })
+
+  it("returns null for an empty list", () => {
+    expect(pick([])).toBeNull()
+  })
+
+  it("picks the last row when the whole window fits in the viewport", () => {
+    const rows: VisibleRow[] = [
+      { id: "a", top: 0, bottom: 20 },
+      { id: "b", top: 20, bottom: 40 },
+      { id: "c", top: 40, bottom: 60 },
+    ]
+    expect(pick(rows)).toBe("c")
+  })
+})

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -7,75 +7,117 @@ export interface VisibleRow {
   bottom: number
 }
 
+export interface VisibleRange {
+  /** First row (chronological DOM order) intersecting the viewport. */
+  topId: string
+  /** Last row intersecting the viewport. */
+  bottomId: string
+}
+
 /**
- * Bottom-most row the viewer has seen: the last row (chronological DOM order)
- * whose top edge has crossed above the viewport bottom while any part of it is
- * still below the viewport top. A row taller than the viewport counts as seen
- * once its top scrolls past — the viewer has reached its start.
+ * The contiguous run of rows intersecting the viewport — first and last. A row
+ * counts as visible when any part of it is between the viewport top and bottom;
+ * a row taller than the viewport still counts (the viewer has reached it).
  */
-export function pickBottomSeenId(rows: VisibleRow[], viewportTop: number, viewportBottom: number): string | null {
-  let seen: string | null = null
+export function pickVisibleRange(rows: VisibleRow[], viewportTop: number, viewportBottom: number): VisibleRange | null {
+  let topId: string | null = null
+  let bottomId: string | null = null
   for (const row of rows) {
-    if (row.top < viewportBottom && row.bottom > viewportTop) seen = row.id
+    if (row.top < viewportBottom && row.bottom > viewportTop) {
+      if (topId === null) topId = row.id
+      bottomId = row.id
+    }
   }
-  return seen
+  return topId !== null && bottomId !== null ? { topId, bottomId } : null
+}
+
+/**
+ * Advance the read frontier through a contiguous run only. The frontier moves to
+ * the bottom of the viewport when the viewport's top is at or above the first
+ * unread row (`frontier + 1`) — i.e. there is no gap of unseen rows between the
+ * read frontier and what's on screen. Landing at the live bottom leaves such a
+ * gap, so the frontier (and the read pointer) stays put; flinging past a block
+ * of rows without them entering the viewport likewise stops the advance.
+ */
+export function advanceFrontier(frontier: number, topIdx: number, botIdx: number): number {
+  if (topIdx <= frontier + 1 && botIdx > frontier) return botIdx
+  return frontier
 }
 
 interface UseLastSeenEventOptions {
   /** The owned scroll container (virtualized timeline or plain thread scroller). */
   scrollContainerRef: React.RefObject<HTMLElement | null>
-  /** The loaded event window, used to map a seen row back to its position. */
+  /** The loaded event window, used to map a visible row back to its position. */
   events: StreamEvent[]
   streamId: string
+  /**
+   * The viewer's persisted read pointer (the last event they've read up to), or
+   * `null`/`undefined` when nothing is read / still hydrating. Seeds the read
+   * frontier so marking resumes from where the viewer left off.
+   */
+  lastReadEventId: string | null | undefined
   /** Off while loading/jumping/draft — no scroller to read, nothing to track. */
   enabled: boolean
 }
 
 interface UseLastSeenEventResult {
   /**
-   * Highest event the viewer has scrolled into view this session, advanced
-   * monotonically and reset per stream. `undefined` until the first scan, so
-   * read state never runs ahead of what the user has actually reached.
+   * The event to mark read up to: the bottom of the contiguous run the viewer
+   * has scrolled through starting from their read pointer. `undefined` until the
+   * frontier advances past the pointer. Read state never jumps a gap — landing
+   * at the live bottom does NOT mark the unread above it read; the viewer must
+   * scroll down through it (or press Escape) for the pointer to advance.
    */
   lastSeenEventId: string | undefined
-  /**
-   * Whether the bottom-most visible row is the last rendered row — i.e. the
-   * viewer is at the live tail. Drives whether a mark-as-read is a full read
-   * (clear the badge) or a partial one (leave messages below the fold unread).
-   */
+  /** Whether the read frontier has reached the last rendered row (a full read). */
   atLastRow: boolean
+  /**
+   * Whether unread sits above the current viewport — i.e. the first unread row
+   * is scrolled off the top. Drives the "N new ↑" jump affordance.
+   */
+  unreadAboveViewport: boolean
 }
 
 /**
- * Track how far down a stream the viewer has actually read — the bottom-most
- * timeline row that has entered the viewport, advanced monotonically. Drives
- * progressive mark-as-read (Slack parity): opening a stream no longer marks
- * everything read after a debounce regardless of scroll; unread messages below
- * the fold stay unread until the viewer scrolls to them.
+ * Track how far the viewer has actually read, advancing the read pointer only
+ * through a CONTIGUOUS run from where they left off (Slack-style). Opening a
+ * stream lands at the live bottom; the unread above stays unread until the
+ * viewer scrolls up to the first unread and reads down through it — the pointer
+ * cannot skip a gap of messages the viewer never had on screen.
  */
 export function useLastSeenEvent({
   scrollContainerRef,
   events,
   streamId,
+  lastReadEventId,
   enabled,
 }: UseLastSeenEventOptions): UseLastSeenEventResult {
   const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
   const [atLastRow, setAtLastRow] = useState(false)
+  const [unreadAboveViewport, setUnreadAboveViewport] = useState(false)
 
-  // Index lookup + events kept in refs so the scroll listener closure stays
-  // stable across data ticks — re-attaching it on every new message would drop
-  // scroll events mid-gesture.
   const indexById = useMemo(() => {
     const m = new Map<string, number>()
     for (let i = 0; i < events.length; i++) m.set(events[i].id, i)
     return m
   }, [events])
+  // Refs keep the scroll-listener closure stable across data ticks — re-attaching
+  // it on every new message would drop scroll events mid-gesture.
   const indexByIdRef = useRef(indexById)
   indexByIdRef.current = indexById
+  const eventsRef = useRef(events)
+  eventsRef.current = events
 
-  // Highest seen index this session. Monotonic so a scroll back up never
-  // retracts the read pointer.
-  const maxSeenIndexRef = useRef(-1)
+  // The viewer's read pointer as an index into the loaded window. A read event
+  // older than the window (or unknown) is -1: everything loaded is unread.
+  const readIndex = lastReadEventId != null ? (indexById.get(lastReadEventId) ?? -1) : -1
+  const readIndexRef = useRef(readIndex)
+  readIndexRef.current = readIndex
+
+  // The read frontier: the bottom of the contiguous run read so far. Seeded from
+  // the read pointer and advanced only while the viewport stays contiguous with
+  // it. An external read (another device) bumps it forward via readIndexRef.
+  const frontierRef = useRef(readIndex)
 
   const recompute = useCallback(() => {
     const el = scrollContainerRef.current
@@ -97,30 +139,44 @@ export function useLastSeenEvent({
       rows.push({ id, top: r.top, bottom: r.bottom })
     }
 
-    const seenId = pickBottomSeenId(rows, viewportTop, viewportBottom)
-    if (!seenId) return
-    setAtLastRow(seenId === rows[rows.length - 1]?.id)
+    const range = pickVisibleRange(rows, viewportTop, viewportBottom)
+    if (!range) return
+    const map = indexByIdRef.current
+    const topIdx = map.get(range.topId)
+    const botIdx = map.get(range.bottomId)
+    if (topIdx === undefined || botIdx === undefined) return
+    const lastRenderedIdx = map.get(rows[rows.length - 1].id) ?? botIdx
 
-    const idx = indexByIdRef.current.get(seenId)
-    if (idx === undefined) return
-    if (idx > maxSeenIndexRef.current) {
-      maxSeenIndexRef.current = idx
-      setLastSeenEventId(seenId)
+    // External reads can only move the frontier forward.
+    if (readIndexRef.current > frontierRef.current) frontierRef.current = readIndexRef.current
+
+    frontierRef.current = advanceFrontier(frontierRef.current, topIdx, botIdx)
+
+    const frontier = frontierRef.current
+    setAtLastRow(frontier >= lastRenderedIdx)
+    // Unread sits above the viewport when the first unread row (frontier + 1)
+    // exists in the window and is scrolled off the top.
+    setUnreadAboveViewport(frontier + 1 <= lastRenderedIdx && frontier + 1 < topIdx)
+    // Only emit a mark target once the frontier has moved PAST the read pointer —
+    // marking up to where they already are is a wasted no-op round-trip.
+    if (frontier > readIndexRef.current && frontier >= 0) {
+      const id = eventsRef.current[frontier]?.id
+      if (id) setLastSeenEventId((prev) => (prev === id ? prev : id))
     }
   }, [scrollContainerRef])
 
-  // Reset on stream switch — a new stream's read position must not inherit the
-  // previous stream's seen pointer.
+  // Reset on stream switch — the new stream's frontier seeds from its own read
+  // pointer, never inheriting the previous stream's position.
   useEffect(() => {
-    maxSeenIndexRef.current = -1
+    frontierRef.current = readIndexRef.current
     setLastSeenEventId(undefined)
     setAtLastRow(false)
+    setUnreadAboveViewport(false)
   }, [streamId])
 
-  // Attach the scroll listener and seed an initial scan. The initial scan
-  // covers a window that fits the viewport with no scroll, where no scroll
-  // event would ever fire. `enabled` flips true exactly when the scroller is
-  // mounted (loading skeleton gone), so the container ref is live here.
+  // Attach the scroll listener and seed an initial scan. The initial scan covers
+  // a window that fits the viewport with no scroll (no scroll event would fire).
+  // `enabled` flips true exactly when the scroller is mounted, so the ref is live.
   useEffect(() => {
     if (!enabled) return
     const el = scrollContainerRef.current
@@ -140,13 +196,13 @@ export function useLastSeenEvent({
     }
   }, [enabled, streamId, recompute, scrollContainerRef])
 
-  // Re-scan when the loaded window grows (a live append at the tail moves the
-  // last row; a content-fits-viewport append fires no scroll event).
+  // Re-scan when the window grows (live append) or the read pointer moves under
+  // us (external read), so the frontier and the affordance stay current.
   useEffect(() => {
     if (!enabled) return
     const raf = requestAnimationFrame(recompute)
     return () => cancelAnimationFrame(raf)
-  }, [enabled, events.length, recompute])
+  }, [enabled, events.length, readIndex, recompute])
 
-  return { lastSeenEventId, atLastRow }
+  return { lastSeenEventId, atLastRow, unreadAboveViewport }
 }

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { StreamEvent } from "@threa/types"
+
+export interface VisibleRow {
+  id: string
+  top: number
+  bottom: number
+}
+
+/**
+ * Bottom-most row the viewer has seen: the last row (chronological DOM order)
+ * whose top edge has crossed above the viewport bottom while any part of it is
+ * still below the viewport top. A row taller than the viewport counts as seen
+ * once its top scrolls past — the viewer has reached its start.
+ */
+export function pickBottomSeenId(rows: VisibleRow[], viewportTop: number, viewportBottom: number): string | null {
+  let seen: string | null = null
+  for (const row of rows) {
+    if (row.top < viewportBottom && row.bottom > viewportTop) seen = row.id
+  }
+  return seen
+}
+
+interface UseLastSeenEventOptions {
+  /** The owned scroll container (virtualized timeline or plain thread scroller). */
+  scrollContainerRef: React.RefObject<HTMLElement | null>
+  /** The loaded event window, used to map a seen row back to its position. */
+  events: StreamEvent[]
+  streamId: string
+  /** Off while loading/jumping/draft — no scroller to read, nothing to track. */
+  enabled: boolean
+}
+
+interface UseLastSeenEventResult {
+  /**
+   * Highest event the viewer has scrolled into view this session, advanced
+   * monotonically and reset per stream. `undefined` until the first scan, so
+   * read state never runs ahead of what the user has actually reached.
+   */
+  lastSeenEventId: string | undefined
+  /**
+   * Whether the bottom-most visible row is the last rendered row — i.e. the
+   * viewer is at the live tail. Drives whether a mark-as-read is a full read
+   * (clear the badge) or a partial one (leave messages below the fold unread).
+   */
+  atLastRow: boolean
+}
+
+/**
+ * Track how far down a stream the viewer has actually read — the bottom-most
+ * timeline row that has entered the viewport, advanced monotonically. Drives
+ * progressive mark-as-read (Slack parity): opening a stream no longer marks
+ * everything read after a debounce regardless of scroll; unread messages below
+ * the fold stay unread until the viewer scrolls to them.
+ */
+export function useLastSeenEvent({
+  scrollContainerRef,
+  events,
+  streamId,
+  enabled,
+}: UseLastSeenEventOptions): UseLastSeenEventResult {
+  const [lastSeenEventId, setLastSeenEventId] = useState<string | undefined>(undefined)
+  const [atLastRow, setAtLastRow] = useState(false)
+
+  // Index lookup + events kept in refs so the scroll listener closure stays
+  // stable across data ticks — re-attaching it on every new message would drop
+  // scroll events mid-gesture.
+  const indexById = useMemo(() => {
+    const m = new Map<string, number>()
+    for (let i = 0; i < events.length; i++) m.set(events[i].id, i)
+    return m
+  }, [events])
+  const indexByIdRef = useRef(indexById)
+  indexByIdRef.current = indexById
+
+  // Highest seen index this session. Monotonic so a scroll back up never
+  // retracts the read pointer.
+  const maxSeenIndexRef = useRef(-1)
+
+  const recompute = useCallback(() => {
+    const el = scrollContainerRef.current
+    if (!el) return
+    const containerRect = el.getBoundingClientRect()
+    // The floating composer overlaps the scroller's bottom; a row hidden behind
+    // it has not been seen, so exclude that band from the viewport.
+    const composerH = Number.parseFloat(getComputedStyle(el).getPropertyValue("--composer-height")) || 0
+    const viewportTop = containerRect.top
+    const viewportBottom = containerRect.bottom - composerH
+
+    const rowEls = el.querySelectorAll<HTMLElement>("[data-event-id]")
+    if (rowEls.length === 0) return
+    const rows: VisibleRow[] = []
+    for (let i = 0; i < rowEls.length; i++) {
+      const id = rowEls[i].dataset.eventId
+      if (!id) continue
+      const r = rowEls[i].getBoundingClientRect()
+      rows.push({ id, top: r.top, bottom: r.bottom })
+    }
+
+    const seenId = pickBottomSeenId(rows, viewportTop, viewportBottom)
+    if (!seenId) return
+    setAtLastRow(seenId === rows[rows.length - 1]?.id)
+
+    const idx = indexByIdRef.current.get(seenId)
+    if (idx === undefined) return
+    if (idx > maxSeenIndexRef.current) {
+      maxSeenIndexRef.current = idx
+      setLastSeenEventId(seenId)
+    }
+  }, [scrollContainerRef])
+
+  // Reset on stream switch — a new stream's read position must not inherit the
+  // previous stream's seen pointer.
+  useEffect(() => {
+    maxSeenIndexRef.current = -1
+    setLastSeenEventId(undefined)
+    setAtLastRow(false)
+  }, [streamId])
+
+  // Attach the scroll listener and seed an initial scan. The initial scan
+  // covers a window that fits the viewport with no scroll, where no scroll
+  // event would ever fire. `enabled` flips true exactly when the scroller is
+  // mounted (loading skeleton gone), so the container ref is live here.
+  useEffect(() => {
+    if (!enabled) return
+    const el = scrollContainerRef.current
+    let raf = 0
+    const schedule = () => {
+      if (raf) return
+      raf = requestAnimationFrame(() => {
+        raf = 0
+        recompute()
+      })
+    }
+    schedule()
+    el?.addEventListener("scroll", schedule, { passive: true })
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      el?.removeEventListener("scroll", schedule)
+    }
+  }, [enabled, streamId, recompute, scrollContainerRef])
+
+  // Re-scan when the loaded window grows (a live append at the tail moves the
+  // last row; a content-fits-viewport append fires no scroll event).
+  useEffect(() => {
+    if (!enabled) return
+    const raf = requestAnimationFrame(recompute)
+    return () => cancelAnimationFrame(raf)
+  }, [enabled, events.length, recompute])
+
+  return { lastSeenEventId, atLastRow }
+}

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -293,6 +293,11 @@ export function useTimelineScroll({
     (options?: { force?: boolean; behavior?: ScrollBehavior }) => {
       if (!options?.force && !isFollowingTailRef.current) return
       isFollowingTailRef.current = true
+      // An explicit jump to the tail (Escape "resume tail", Jump-to-latest) ends
+      // the unread-landing follow-suppression; without this the scroll's own
+      // handleScroll would read landedOnUnread and re-disarm the follow we just
+      // armed, so new messages would stop pinning to the bottom.
+      landedOnUnreadRef.current = false
       setIsScrolledFarFromBottom(false)
       const el = scrollerRef.current
       if (!el) return

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -100,8 +100,10 @@ interface UseTimelineScrollReturn {
   isInitialSettling: boolean
   /** True while parked at the live tail (auto-following new output). */
   isFollowingTailRef: React.MutableRefObject<boolean>
-  /** Imperatively scroll to the very bottom (the composer-spacer edge). */
-  scrollToBottom: (options?: { force?: boolean; behavior?: ScrollBehavior }) => void
+  /** Imperatively scroll to the very bottom (the composer-spacer edge).
+   *  `resumeTail` additionally ends the cold-load first-unread follow-suppression
+   *  (Escape / Jump-to-latest); a plain `force` geometry re-pin must not. */
+  scrollToBottom: (options?: { force?: boolean; resumeTail?: boolean; behavior?: ScrollBehavior }) => void
   /** Disable auto-follow (e.g. when a deep-link jump takes over). */
   disableAutoScroll: () => void
   /** Attach to virtua's `onScroll` (and/or call after a native scroll). */
@@ -290,14 +292,16 @@ export function useTimelineScroll({
   }, [])
 
   const scrollToBottom = useCallback(
-    (options?: { force?: boolean; behavior?: ScrollBehavior }) => {
+    (options?: { force?: boolean; resumeTail?: boolean; behavior?: ScrollBehavior }) => {
       if (!options?.force && !isFollowingTailRef.current) return
       isFollowingTailRef.current = true
-      // An explicit jump to the tail (Escape "resume tail", Jump-to-latest) ends
+      // Only an explicit tail resume (Escape "resume tail", Jump-to-latest) ends
       // the unread-landing follow-suppression; without this the scroll's own
       // handleScroll would read landedOnUnread and re-disarm the follow we just
-      // armed, so new messages would stop pinning to the bottom.
-      landedOnUnreadRef.current = false
+      // armed, so new messages would stop pinning to the bottom. A plain forced
+      // geometry correction (e.g. the composer's first-measure re-pin) must NOT
+      // clear it, or it would cancel the cold-load first-unread landing.
+      if (options?.resumeTail) landedOnUnreadRef.current = false
       setIsScrolledFarFromBottom(false)
       const el = scrollerRef.current
       if (!el) return

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -11,10 +11,6 @@ const USER_SCROLL_GRACE_MS = 300
 /** Consecutive frames of unchanged scrollHeight that mark the cold-load settle
  *  as converged, so the content can be revealed without a visible bounce. */
 const SETTLE_STABLE_FRAMES = 3
-/** Context (px) revealed above the first-unread row when landing on it, so the
- *  unread divider and a sliver of the prior message show rather than the
- *  unread message sitting flush against the top edge. */
-const UNREAD_LANDING_TOP_GAP = 56
 
 /**
  * Height (px) of the floating composer, published as `--composer-height` on the
@@ -58,22 +54,6 @@ interface UseTimelineScrollOptions {
    * is the secondary signal for touch/wheel that hasn't yet moved scrollTop.
    */
   userInteractedAtRef?: React.MutableRefObject<number>
-  /**
-   * Whether the viewer's read position is known yet. The initial scroll waits
-   * for this so the land-at-first-unread vs land-at-bottom decision is made
-   * once, correctly: deciding before read state resolves would land at the
-   * bottom and then a late correction would fight the cold-load settle. The
-   * skeleton mask stays up during the (brief, IDB-backed) wait, so there is no
-   * flash. Defaults true so callers without unread semantics are unaffected.
-   */
-  readStateResolved?: boolean
-  /**
-   * Resolve the item index to land on at cold load instead of the bottom — the
-   * first unread row (Slack parity). Returns null to land at the bottom as
-   * usual. Evaluated lazily inside the initial-scroll layout effect, after the
-   * unread divider has computed for the same render.
-   */
-  getInitialScrollIndex?: () => number | null
 }
 
 interface UseTimelineScrollReturn {
@@ -100,10 +80,8 @@ interface UseTimelineScrollReturn {
   isInitialSettling: boolean
   /** True while parked at the live tail (auto-following new output). */
   isFollowingTailRef: React.MutableRefObject<boolean>
-  /** Imperatively scroll to the very bottom (the composer-spacer edge).
-   *  `resumeTail` additionally ends the cold-load first-unread follow-suppression
-   *  (Escape / Jump-to-latest); a plain `force` geometry re-pin must not. */
-  scrollToBottom: (options?: { force?: boolean; resumeTail?: boolean; behavior?: ScrollBehavior }) => void
+  /** Imperatively scroll to the very bottom (the composer-spacer edge). */
+  scrollToBottom: (options?: { force?: boolean; behavior?: ScrollBehavior }) => void
   /** Disable auto-follow (e.g. when a deep-link jump takes over). */
   disableAutoScroll: () => void
   /** Attach to virtua's `onScroll` (and/or call after a native scroll). */
@@ -149,8 +127,6 @@ export function useTimelineScroll({
   skipInitialScroll = false,
   isJumpMode = false,
   userInteractedAtRef,
-  readStateResolved = true,
-  getInitialScrollIndex,
 }: UseTimelineScrollOptions): UseTimelineScrollReturn {
   const listRef = useRef<VirtualizerHandle>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -190,13 +166,6 @@ export function useTimelineScroll({
   // snap to bottom before the jump positions on its target.
   const isFollowingTailRef = useRef(!skipInitialScroll)
 
-  // True while the cold-load settle is holding the first-unread row near the
-  // top. The settle's programmatic pins fire `scroll`, and if first-unread is
-  // within the at-bottom band (only a few unread), handleScroll would re-arm
-  // follow and the ResizeObserver would then fight the pin and snap to the
-  // bottom. Suppress the re-arm until a genuine user gesture clears this.
-  const landedOnUnreadRef = useRef(false)
-
   // Prepend detection. Comparing the first row's key across renders tells us an
   // older page landed (or the window trimmed from the start); virtua's `shift`
   // then holds the viewport from the end.
@@ -233,7 +202,6 @@ export function useTimelineScroll({
     prevScrollHeightRef.current = 0
     didInitialScrollRef.current = false
     isFollowingTailRef.current = !skipInitialScroll
-    landedOnUnreadRef.current = false
     // Re-mask for the new stream's cold-load settle (a no-op when it converges
     // instantly, e.g. revisiting an already-measured stream).
     setIsInitialSettling(!skipInitialScroll)
@@ -274,34 +242,10 @@ export function useTimelineScroll({
     prevScrollHeightRef.current = el.scrollHeight
   }, [])
 
-  // Pin the first-unread row near the top while virtua measures real heights —
-  // the cold-load analogue of pinToBottom for the land-at-unread path. Re-asks
-  // virtua to place the target each frame so the row doesn't drift as estimates
-  // resolve, and syncs the scroll-up baseline so this programmatic write is not
-  // mistaken for a user scroll.
-  const pinToIndex = useCallback((index: number) => {
-    const el = scrollerRef.current
-    if (!el) return
-    try {
-      listRef.current?.scrollToIndex(index, { align: "start", offset: -UNREAD_LANDING_TOP_GAP })
-    } catch {
-      // Not-yet-measured list can throw; the next frame retries.
-    }
-    prevScrollTopRef.current = el.scrollTop
-    prevScrollHeightRef.current = el.scrollHeight
-  }, [])
-
   const scrollToBottom = useCallback(
-    (options?: { force?: boolean; resumeTail?: boolean; behavior?: ScrollBehavior }) => {
+    (options?: { force?: boolean; behavior?: ScrollBehavior }) => {
       if (!options?.force && !isFollowingTailRef.current) return
       isFollowingTailRef.current = true
-      // Only an explicit tail resume (Escape "resume tail", Jump-to-latest) ends
-      // the unread-landing follow-suppression; without this the scroll's own
-      // handleScroll would read landedOnUnread and re-disarm the follow we just
-      // armed, so new messages would stop pinning to the bottom. A plain forced
-      // geometry correction (e.g. the composer's first-measure re-pin) must NOT
-      // clear it, or it would cancel the cold-load first-unread landing.
-      if (options?.resumeTail) landedOnUnreadRef.current = false
       setIsScrolledFarFromBottom(false)
       const el = scrollerRef.current
       if (!el) return
@@ -332,60 +276,63 @@ export function useTimelineScroll({
   // A real user gesture aborts immediately (reveal + stop) so we never trap a
   // user who wants to scroll during a slow settle. Pinning here is the same
   // idempotent pinToBottom the ResizeObserver uses, so the two never disagree.
-  const settle = useCallback((pin: () => void, maxMs: number) => {
-    initialSettleCleanupRef.current?.()
-    const el = scrollerRef.current
-    if (!el) {
-      setIsInitialSettling(false)
-      return
-    }
-    const start = performance.now()
-    let aborted = false
-    let revealed = false
-    let lastHeight = -1
-    let stableFrames = 0
-    const reveal = () => {
-      if (!revealed) {
-        revealed = true
+  const settleToBottom = useCallback(
+    (maxMs: number) => {
+      initialSettleCleanupRef.current?.()
+      const el = scrollerRef.current
+      if (!el) {
         setIsInitialSettling(false)
-      }
-    }
-    const cleanup = () => {
-      aborted = true
-      reveal()
-      if (initialSettleRafRef.current) cancelAnimationFrame(initialSettleRafRef.current)
-      initialSettleRafRef.current = 0
-      el.removeEventListener("wheel", cleanup)
-      el.removeEventListener("touchmove", cleanup)
-      el.removeEventListener("pointerdown", cleanup)
-      el.removeEventListener("keydown", cleanup)
-      initialSettleCleanupRef.current = null
-    }
-    initialSettleCleanupRef.current = cleanup
-    el.addEventListener("wheel", cleanup, { passive: true })
-    el.addEventListener("touchmove", cleanup, { passive: true })
-    el.addEventListener("pointerdown", cleanup, { passive: true })
-    el.addEventListener("keydown", cleanup)
-
-    const tick = () => {
-      if (aborted) return
-      pin()
-      const height = el.scrollHeight
-      if (height === lastHeight) stableFrames += 1
-      else {
-        stableFrames = 0
-        lastHeight = height
-      }
-      // Converged (height steady) or capped → reveal and hand off to the
-      // ResizeObserver, which keeps the tail pinned for any later growth.
-      if (stableFrames >= SETTLE_STABLE_FRAMES || performance.now() - start >= maxMs) {
-        cleanup()
         return
       }
+      const start = performance.now()
+      let aborted = false
+      let revealed = false
+      let lastHeight = -1
+      let stableFrames = 0
+      const reveal = () => {
+        if (!revealed) {
+          revealed = true
+          setIsInitialSettling(false)
+        }
+      }
+      const cleanup = () => {
+        aborted = true
+        reveal()
+        if (initialSettleRafRef.current) cancelAnimationFrame(initialSettleRafRef.current)
+        initialSettleRafRef.current = 0
+        el.removeEventListener("wheel", cleanup)
+        el.removeEventListener("touchmove", cleanup)
+        el.removeEventListener("pointerdown", cleanup)
+        el.removeEventListener("keydown", cleanup)
+        initialSettleCleanupRef.current = null
+      }
+      initialSettleCleanupRef.current = cleanup
+      el.addEventListener("wheel", cleanup, { passive: true })
+      el.addEventListener("touchmove", cleanup, { passive: true })
+      el.addEventListener("pointerdown", cleanup, { passive: true })
+      el.addEventListener("keydown", cleanup)
+
+      const tick = () => {
+        if (aborted) return
+        pinToBottom()
+        const height = el.scrollHeight
+        if (height === lastHeight) stableFrames += 1
+        else {
+          stableFrames = 0
+          lastHeight = height
+        }
+        // Converged (height steady) or capped → reveal and hand off to the
+        // ResizeObserver, which keeps the tail pinned for any later growth.
+        if (stableFrames >= SETTLE_STABLE_FRAMES || performance.now() - start >= maxMs) {
+          cleanup()
+          return
+        }
+        initialSettleRafRef.current = requestAnimationFrame(tick)
+      }
       initialSettleRafRef.current = requestAnimationFrame(tick)
-    }
-    initialSettleRafRef.current = requestAnimationFrame(tick)
-  }, [])
+    },
+    [pinToBottom]
+  )
 
   const handleScroll = useCallback(() => {
     const el = scrollerRef.current
@@ -431,16 +378,12 @@ export function useTimelineScroll({
     // stays armed through a keyboard open. Content growth never lowers scrollTop,
     // and our own pins sync prevTop, so neither reads as scrolledUp.
     const userScrolledUp = scrolledUp && userGestured
-    // A genuine gesture ends the unread-landing hold: the user has taken over,
-    // so reaching the tail may re-arm follow normally from here.
-    if (userGestured) landedOnUnreadRef.current = false
     if (atBottom && !userScrolledUp) {
       // Reaching the tail re-arms follow — except in jump mode, where the user
-      // is anchored on a deep-linked message, and during the unread landing,
-      // where a transient atBottom from the settle's pin must not yank a reader
-      // off a near-bottom unread row to the live tail. Sub-threshold jitter (no
+      // is anchored on a deep-linked message and a transient atBottom from
+      // reflow must never yank them to the live tail. Sub-threshold jitter (no
       // gesture) re-arms here too, so it never detaches.
-      isFollowingTailRef.current = !isJumpMode && !landedOnUnreadRef.current
+      isFollowingTailRef.current = !isJumpMode
     } else if (scrolledUp || userGestured) {
       // The user scrolled away from the bottom (past the band, or a deliberate
       // nudge inside it). Content growth (new message, link preview, virtua
@@ -463,48 +406,22 @@ export function useTimelineScroll({
   // bottom region. Passing offset = the composer footer-spacer height lands it
   // at the footer-INCLUSIVE bottom, so the last message sits above the composer.
   // virtua re-applies that target as items measure, and the cold-load settle
-  // re-pins each frame behind the skeleton mask until the height — composer
-  // spacer included — converges.
+  // (settleToBottom) re-pins each frame behind the skeleton mask until the
+  // height — composer spacer included — converges.
   useLayoutEffect(() => {
     if (skipInitialScroll || didInitialScrollRef.current || itemCount === 0) return
-    // Wait until the read position is known so land-at-unread vs land-at-bottom
-    // is decided once. The skeleton mask stays up during the brief wait.
-    if (!readStateResolved) return
     const el = scrollerRef.current
     if (!el) return
-    didInitialScrollRef.current = true
-
-    const unreadIndex = getInitialScrollIndex?.() ?? null
-    if (unreadIndex !== null && unreadIndex >= 0) {
-      // Land on the first unread row and do NOT follow the tail — new messages
-      // must not yank the reader off the unread boundary down to the bottom.
-      isFollowingTailRef.current = false
-      landedOnUnreadRef.current = true
-      setIsScrolledFarFromBottom(true)
-      pinToIndex(unreadIndex)
-      settle(() => pinToIndex(unreadIndex), 2000)
-      return
-    }
-
     isFollowingTailRef.current = true
-    landedOnUnreadRef.current = false
+    didInitialScrollRef.current = true
     try {
       listRef.current?.scrollToIndex(itemCount - 1, { align: "end", offset: readComposerHeight(el) })
     } catch {
       // Not-yet-measured list can throw; the pin + settle still converge.
     }
     pinToBottom()
-    settle(pinToBottom, 2000)
-  }, [
-    itemCount,
-    skipInitialScroll,
-    resetKey,
-    readStateResolved,
-    getInitialScrollIndex,
-    pinToBottom,
-    pinToIndex,
-    settle,
-  ])
+    settleToBottom(2000)
+  }, [itemCount, skipInitialScroll, resetKey, pinToBottom, settleToBottom])
 
   // The one observer that keeps the tail glued. Two observed targets:
   //  - content (contentRef): grows on a live append, on media decoding, as

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -11,6 +11,10 @@ const USER_SCROLL_GRACE_MS = 300
 /** Consecutive frames of unchanged scrollHeight that mark the cold-load settle
  *  as converged, so the content can be revealed without a visible bounce. */
 const SETTLE_STABLE_FRAMES = 3
+/** Context (px) revealed above the first-unread row when landing on it, so the
+ *  unread divider and a sliver of the prior message show rather than the
+ *  unread message sitting flush against the top edge. */
+const UNREAD_LANDING_TOP_GAP = 56
 
 /**
  * Height (px) of the floating composer, published as `--composer-height` on the
@@ -54,6 +58,22 @@ interface UseTimelineScrollOptions {
    * is the secondary signal for touch/wheel that hasn't yet moved scrollTop.
    */
   userInteractedAtRef?: React.MutableRefObject<number>
+  /**
+   * Whether the viewer's read position is known yet. The initial scroll waits
+   * for this so the land-at-first-unread vs land-at-bottom decision is made
+   * once, correctly: deciding before read state resolves would land at the
+   * bottom and then a late correction would fight the cold-load settle. The
+   * skeleton mask stays up during the (brief, IDB-backed) wait, so there is no
+   * flash. Defaults true so callers without unread semantics are unaffected.
+   */
+  readStateResolved?: boolean
+  /**
+   * Resolve the item index to land on at cold load instead of the bottom — the
+   * first unread row (Slack parity). Returns null to land at the bottom as
+   * usual. Evaluated lazily inside the initial-scroll layout effect, after the
+   * unread divider has computed for the same render.
+   */
+  getInitialScrollIndex?: () => number | null
 }
 
 interface UseTimelineScrollReturn {
@@ -127,6 +147,8 @@ export function useTimelineScroll({
   skipInitialScroll = false,
   isJumpMode = false,
   userInteractedAtRef,
+  readStateResolved = true,
+  getInitialScrollIndex,
 }: UseTimelineScrollOptions): UseTimelineScrollReturn {
   const listRef = useRef<VirtualizerHandle>(null)
   const scrollerRef = useRef<HTMLDivElement>(null)
@@ -166,6 +188,13 @@ export function useTimelineScroll({
   // snap to bottom before the jump positions on its target.
   const isFollowingTailRef = useRef(!skipInitialScroll)
 
+  // True while the cold-load settle is holding the first-unread row near the
+  // top. The settle's programmatic pins fire `scroll`, and if first-unread is
+  // within the at-bottom band (only a few unread), handleScroll would re-arm
+  // follow and the ResizeObserver would then fight the pin and snap to the
+  // bottom. Suppress the re-arm until a genuine user gesture clears this.
+  const landedOnUnreadRef = useRef(false)
+
   // Prepend detection. Comparing the first row's key across renders tells us an
   // older page landed (or the window trimmed from the start); virtua's `shift`
   // then holds the viewport from the end.
@@ -202,6 +231,7 @@ export function useTimelineScroll({
     prevScrollHeightRef.current = 0
     didInitialScrollRef.current = false
     isFollowingTailRef.current = !skipInitialScroll
+    landedOnUnreadRef.current = false
     // Re-mask for the new stream's cold-load settle (a no-op when it converges
     // instantly, e.g. revisiting an already-measured stream).
     setIsInitialSettling(!skipInitialScroll)
@@ -242,6 +272,23 @@ export function useTimelineScroll({
     prevScrollHeightRef.current = el.scrollHeight
   }, [])
 
+  // Pin the first-unread row near the top while virtua measures real heights —
+  // the cold-load analogue of pinToBottom for the land-at-unread path. Re-asks
+  // virtua to place the target each frame so the row doesn't drift as estimates
+  // resolve, and syncs the scroll-up baseline so this programmatic write is not
+  // mistaken for a user scroll.
+  const pinToIndex = useCallback((index: number) => {
+    const el = scrollerRef.current
+    if (!el) return
+    try {
+      listRef.current?.scrollToIndex(index, { align: "start", offset: -UNREAD_LANDING_TOP_GAP })
+    } catch {
+      // Not-yet-measured list can throw; the next frame retries.
+    }
+    prevScrollTopRef.current = el.scrollTop
+    prevScrollHeightRef.current = el.scrollHeight
+  }, [])
+
   const scrollToBottom = useCallback(
     (options?: { force?: boolean; behavior?: ScrollBehavior }) => {
       if (!options?.force && !isFollowingTailRef.current) return
@@ -276,63 +323,60 @@ export function useTimelineScroll({
   // A real user gesture aborts immediately (reveal + stop) so we never trap a
   // user who wants to scroll during a slow settle. Pinning here is the same
   // idempotent pinToBottom the ResizeObserver uses, so the two never disagree.
-  const settleToBottom = useCallback(
-    (maxMs: number) => {
-      initialSettleCleanupRef.current?.()
-      const el = scrollerRef.current
-      if (!el) {
+  const settle = useCallback((pin: () => void, maxMs: number) => {
+    initialSettleCleanupRef.current?.()
+    const el = scrollerRef.current
+    if (!el) {
+      setIsInitialSettling(false)
+      return
+    }
+    const start = performance.now()
+    let aborted = false
+    let revealed = false
+    let lastHeight = -1
+    let stableFrames = 0
+    const reveal = () => {
+      if (!revealed) {
+        revealed = true
         setIsInitialSettling(false)
+      }
+    }
+    const cleanup = () => {
+      aborted = true
+      reveal()
+      if (initialSettleRafRef.current) cancelAnimationFrame(initialSettleRafRef.current)
+      initialSettleRafRef.current = 0
+      el.removeEventListener("wheel", cleanup)
+      el.removeEventListener("touchmove", cleanup)
+      el.removeEventListener("pointerdown", cleanup)
+      el.removeEventListener("keydown", cleanup)
+      initialSettleCleanupRef.current = null
+    }
+    initialSettleCleanupRef.current = cleanup
+    el.addEventListener("wheel", cleanup, { passive: true })
+    el.addEventListener("touchmove", cleanup, { passive: true })
+    el.addEventListener("pointerdown", cleanup, { passive: true })
+    el.addEventListener("keydown", cleanup)
+
+    const tick = () => {
+      if (aborted) return
+      pin()
+      const height = el.scrollHeight
+      if (height === lastHeight) stableFrames += 1
+      else {
+        stableFrames = 0
+        lastHeight = height
+      }
+      // Converged (height steady) or capped → reveal and hand off to the
+      // ResizeObserver, which keeps the tail pinned for any later growth.
+      if (stableFrames >= SETTLE_STABLE_FRAMES || performance.now() - start >= maxMs) {
+        cleanup()
         return
       }
-      const start = performance.now()
-      let aborted = false
-      let revealed = false
-      let lastHeight = -1
-      let stableFrames = 0
-      const reveal = () => {
-        if (!revealed) {
-          revealed = true
-          setIsInitialSettling(false)
-        }
-      }
-      const cleanup = () => {
-        aborted = true
-        reveal()
-        if (initialSettleRafRef.current) cancelAnimationFrame(initialSettleRafRef.current)
-        initialSettleRafRef.current = 0
-        el.removeEventListener("wheel", cleanup)
-        el.removeEventListener("touchmove", cleanup)
-        el.removeEventListener("pointerdown", cleanup)
-        el.removeEventListener("keydown", cleanup)
-        initialSettleCleanupRef.current = null
-      }
-      initialSettleCleanupRef.current = cleanup
-      el.addEventListener("wheel", cleanup, { passive: true })
-      el.addEventListener("touchmove", cleanup, { passive: true })
-      el.addEventListener("pointerdown", cleanup, { passive: true })
-      el.addEventListener("keydown", cleanup)
-
-      const tick = () => {
-        if (aborted) return
-        pinToBottom()
-        const height = el.scrollHeight
-        if (height === lastHeight) stableFrames += 1
-        else {
-          stableFrames = 0
-          lastHeight = height
-        }
-        // Converged (height steady) or capped → reveal and hand off to the
-        // ResizeObserver, which keeps the tail pinned for any later growth.
-        if (stableFrames >= SETTLE_STABLE_FRAMES || performance.now() - start >= maxMs) {
-          cleanup()
-          return
-        }
-        initialSettleRafRef.current = requestAnimationFrame(tick)
-      }
       initialSettleRafRef.current = requestAnimationFrame(tick)
-    },
-    [pinToBottom]
-  )
+    }
+    initialSettleRafRef.current = requestAnimationFrame(tick)
+  }, [])
 
   const handleScroll = useCallback(() => {
     const el = scrollerRef.current
@@ -378,12 +422,16 @@ export function useTimelineScroll({
     // stays armed through a keyboard open. Content growth never lowers scrollTop,
     // and our own pins sync prevTop, so neither reads as scrolledUp.
     const userScrolledUp = scrolledUp && userGestured
+    // A genuine gesture ends the unread-landing hold: the user has taken over,
+    // so reaching the tail may re-arm follow normally from here.
+    if (userGestured) landedOnUnreadRef.current = false
     if (atBottom && !userScrolledUp) {
       // Reaching the tail re-arms follow — except in jump mode, where the user
-      // is anchored on a deep-linked message and a transient atBottom from
-      // reflow must never yank them to the live tail. Sub-threshold jitter (no
+      // is anchored on a deep-linked message, and during the unread landing,
+      // where a transient atBottom from the settle's pin must not yank a reader
+      // off a near-bottom unread row to the live tail. Sub-threshold jitter (no
       // gesture) re-arms here too, so it never detaches.
-      isFollowingTailRef.current = !isJumpMode
+      isFollowingTailRef.current = !isJumpMode && !landedOnUnreadRef.current
     } else if (scrolledUp || userGestured) {
       // The user scrolled away from the bottom (past the band, or a deliberate
       // nudge inside it). Content growth (new message, link preview, virtua
@@ -406,22 +454,48 @@ export function useTimelineScroll({
   // bottom region. Passing offset = the composer footer-spacer height lands it
   // at the footer-INCLUSIVE bottom, so the last message sits above the composer.
   // virtua re-applies that target as items measure, and the cold-load settle
-  // (settleToBottom) re-pins each frame behind the skeleton mask until the
-  // height — composer spacer included — converges.
+  // re-pins each frame behind the skeleton mask until the height — composer
+  // spacer included — converges.
   useLayoutEffect(() => {
     if (skipInitialScroll || didInitialScrollRef.current || itemCount === 0) return
+    // Wait until the read position is known so land-at-unread vs land-at-bottom
+    // is decided once. The skeleton mask stays up during the brief wait.
+    if (!readStateResolved) return
     const el = scrollerRef.current
     if (!el) return
-    isFollowingTailRef.current = true
     didInitialScrollRef.current = true
+
+    const unreadIndex = getInitialScrollIndex?.() ?? null
+    if (unreadIndex !== null && unreadIndex >= 0) {
+      // Land on the first unread row and do NOT follow the tail — new messages
+      // must not yank the reader off the unread boundary down to the bottom.
+      isFollowingTailRef.current = false
+      landedOnUnreadRef.current = true
+      setIsScrolledFarFromBottom(true)
+      pinToIndex(unreadIndex)
+      settle(() => pinToIndex(unreadIndex), 2000)
+      return
+    }
+
+    isFollowingTailRef.current = true
+    landedOnUnreadRef.current = false
     try {
       listRef.current?.scrollToIndex(itemCount - 1, { align: "end", offset: readComposerHeight(el) })
     } catch {
       // Not-yet-measured list can throw; the pin + settle still converge.
     }
     pinToBottom()
-    settleToBottom(2000)
-  }, [itemCount, skipInitialScroll, resetKey, pinToBottom, settleToBottom])
+    settle(pinToBottom, 2000)
+  }, [
+    itemCount,
+    skipInitialScroll,
+    resetKey,
+    readStateResolved,
+    getInitialScrollIndex,
+    pinToBottom,
+    pinToIndex,
+    settle,
+  ])
 
   // The one observer that keeps the tail glued. Two observed targets:
   //  - content (contentRef): grows on a live append, on media decoding, as

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -193,5 +193,52 @@ describe("useUnreadCounts", () => {
     expect(bootstrap?.streamMemberships.find((membership) => membership.streamId === "stream_1")?.lastReadEventId).toBe(
       "event_new"
     )
+    expect(bootstrap?.unreadCounts.stream_1).toBe(0)
+  })
+
+  it("advances the read pointer but keeps the unread badge on a partial read", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 2 },
+      mentionCounts: { stream_1: 0 },
+      activityCounts: { stream_1: 0 },
+      unreadActivityCount: 0,
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_mid",
+      lastReadAt: new Date().toISOString(),
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.markAsRead("stream_1", "event_mid", { partial: true })
+    })
+
+    await waitFor(() => {
+      const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+      expect(
+        bootstrap?.streamMemberships.find((membership) => membership.streamId === "stream_1")?.lastReadEventId
+      ).toBe("event_mid")
+    })
+
+    // Pointer advanced, but the badge is untouched — the server `stream:read`
+    // round-trip owns the true remaining count (no sticky optimistic zero).
+    const bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.unreadCounts.stream_1).toBe(2)
+    expect(await db.unreadState.get("ws_1")).toMatchObject({ unreadCounts: { stream_1: 2 } })
   })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -28,21 +28,34 @@ export function useUnreadCounts(workspaceId: string) {
   )
 
   const markAsReadMutation = useMutation({
-    mutationFn: ({ streamId, lastEventId }: { streamId: string; lastEventId: string }) =>
+    mutationFn: ({ streamId, lastEventId }: { streamId: string; lastEventId: string; partial?: boolean }) =>
       streamService.markAsRead(workspaceId, streamId, lastEventId),
-    onSuccess: async (membership, { streamId, lastEventId }) => {
+    onSuccess: async (membership, { streamId, lastEventId, partial }) => {
       const current = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))
       const hadActivity = (current?.activityCounts[streamId] ?? 0) > 0
 
+      // A partial read advances the read pointer to a mid-window event with
+      // unread still below it. Zeroing the counters optimistically would be
+      // wrong AND sticky: the ordinal read position MAX-merges (see
+      // `applyStreamReadOrdinal`), so once forced to "read = latest" the
+      // server's `stream:read` for the mid event can never restore the
+      // remaining count. So for a partial read only the read POINTER moves
+      // optimistically; the badge resolves to the true remainder on the
+      // `stream:read` round-trip.
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
         const clearedActivity = old.activityCounts[streamId] ?? 0
+        const counters = partial
+          ? {}
+          : {
+              unreadCounts: { ...old.unreadCounts, [streamId]: 0 },
+              mentionCounts: { ...old.mentionCounts, [streamId]: 0 },
+              activityCounts: { ...old.activityCounts, [streamId]: 0 },
+              unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - clearedActivity),
+            }
         return {
           ...old,
-          unreadCounts: { ...old.unreadCounts, [streamId]: 0 },
-          mentionCounts: { ...old.mentionCounts, [streamId]: 0 },
-          activityCounts: { ...old.activityCounts, [streamId]: 0 },
-          unreadActivityCount: Math.max(0, (old.unreadActivityCount ?? 0) - clearedActivity),
+          ...counters,
           streamMemberships: old.streamMemberships.map((existingMembership) =>
             existingMembership.streamId === streamId ? { ...existingMembership, ...membership } : existingMembership
           ),
@@ -62,7 +75,7 @@ export function useUnreadCounts(workspaceId: string) {
       await db.transaction("rw", [db.unreadState, db.streams, db.streamMemberships], async () => {
         const now = Date.now()
         const state = await db.unreadState.get(workspaceId)
-        if (state) {
+        if (state && !partial) {
           const clearedActivity = state.activityCounts[streamId] ?? 0
           await db.unreadState.put({
             ...state,
@@ -148,8 +161,8 @@ export function useUnreadCounts(workspaceId: string) {
   })
 
   const markAsRead = useCallback(
-    (streamId: string, lastEventId: string) => {
-      markAsReadMutation.mutate({ streamId, lastEventId })
+    (streamId: string, lastEventId: string, opts?: { partial?: boolean }) => {
+      markAsReadMutation.mutate({ streamId, lastEventId, partial: opts?.partial })
     },
     [markAsReadMutation]
   )

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -111,6 +111,25 @@ describe("useUnreadDivider", () => {
     expect(result.current.dividerEventId).toBe("event_9")
   })
 
+  it("hides the latched divider once dismissed, and re-shows it on a fresh stream", () => {
+    const { result, rerender } = renderHook(
+      ({ streamId, events }: { streamId: string; events: ReturnType<typeof makeMessageEvent>[] }) =>
+        useUnreadDivider({ events, lastReadEventId: null, currentUserId: "me", streamId, readStateResolved: true }),
+      { initialProps: { streamId: "stream_1", events: [makeMessageEvent("event_1", "other")] } }
+    )
+
+    expect(result.current.dividerEventId).toBe("event_1")
+
+    // Escape "escapes the unread block".
+    act(() => result.current.dismiss())
+    expect(result.current.dividerEventId).toBeUndefined()
+
+    // A different stream with unread shows its divider again (dismissal is
+    // scoped to the stream it happened in).
+    rerender({ streamId: "stream_2", events: [makeMessageEvent("event_9", "other")] })
+    expect(result.current.dividerEventId).toBe("event_9")
+  })
+
   it("shows no divider when switching to an already-read stream", () => {
     const { result, rerender } = renderHook(
       ({

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -49,45 +49,31 @@ describe("useUnreadDivider", () => {
     expect(result.current.dividerEventId).toBeUndefined()
   })
 
-  it("keeps the divider in place after the stream becomes read, then dims it", async () => {
-    vi.useFakeTimers()
-    try {
-      const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
+  it("keeps the divider in place after the stream becomes read", () => {
+    const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
 
-      const { result, rerender } = renderHook(
-        ({ lastReadEventId }: { lastReadEventId: string | null | undefined }) =>
-          useUnreadDivider({
-            events,
-            lastReadEventId,
-            currentUserId: "me",
-            streamId: "stream_1",
-            readStateResolved: true,
-          }),
-        {
-          initialProps: { lastReadEventId: null as string | null | undefined },
-        }
-      )
+    const { result, rerender } = renderHook(
+      ({ lastReadEventId }: { lastReadEventId: string | null | undefined }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId,
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+        }),
+      {
+        initialProps: { lastReadEventId: null as string | null | undefined },
+      }
+    )
 
-      rerender({ lastReadEventId: null })
-      expect(result.current.dividerEventId).toBe("event_1")
-      expect(result.current.isDimmed).toBe(false)
+    rerender({ lastReadEventId: null })
+    expect(result.current.dividerEventId).toBe("event_1")
 
-      // Auto-mark-as-read clears the live unread, but the divider stays latched
-      // at its position for the rest of the reading session.
-      rerender({ lastReadEventId: "event_2" })
-      expect(result.current.firstUnreadEventId).toBeUndefined()
-      expect(result.current.dividerEventId).toBe("event_1")
-      expect(result.current.isDimmed).toBe(false)
-
-      // After the dim delay it settles to gray but remains present.
-      act(() => {
-        vi.advanceTimersByTime(3000)
-      })
-      expect(result.current.dividerEventId).toBe("event_1")
-      expect(result.current.isDimmed).toBe(true)
-    } finally {
-      vi.useRealTimers()
-    }
+    // Auto-mark-as-read clears the live unread, but the divider stays latched
+    // at its position for the rest of the reading session.
+    rerender({ lastReadEventId: "event_2" })
+    expect(result.current.firstUnreadEventId).toBeUndefined()
+    expect(result.current.dividerEventId).toBe("event_1")
   })
 
   it("re-latches at the new stream's first unread when switching streams", () => {
@@ -158,7 +144,6 @@ describe("useUnreadDivider", () => {
       lastReadEventId: "event_9",
     })
     expect(result.current.dividerEventId).toBeUndefined()
-    expect(result.current.isDimmed).toBe(false)
   })
 
   it("latches off scroll-to-first-unread once a stream is deep-linked, even after the ?m= param clears", () => {

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import type { StreamEvent } from "@threa/types"
 import { useScrollToElement } from "./use-scroll-to-element"
 
@@ -38,6 +38,11 @@ interface UseUnreadDividerResult {
   dividerEventId: string | undefined
   /** Whether the divider has settled to its muted (gray) resting state */
   isDimmed: boolean
+  /**
+   * Dismiss the latched divider for the rest of this reading session (Escape
+   * "escapes the unread block"). Stays dismissed until the stream changes.
+   */
+  dismiss: () => void
 }
 
 /**
@@ -96,7 +101,13 @@ export function useUnreadDivider({
   if (!latchRef.current.eventId && firstUnreadEventId) {
     latchRef.current.eventId = firstUnreadEventId
   }
-  const displayedUnreadId = latchRef.current.eventId
+
+  // Explicit dismissal (Escape). A latched divider has no clear-on-read, so a
+  // separate flag overrides it; reset on stream change so re-entering a stream
+  // with unread shows the divider again.
+  const [dismissedStreamId, setDismissedStreamId] = useState<string | undefined>(undefined)
+  const dismiss = useCallback(() => setDismissedStreamId(streamId), [streamId])
+  const displayedUnreadId = dismissedStreamId === streamId ? undefined : latchRef.current.eventId
 
   // Hold the divider red on (re)latch, then settle it to gray after a few
   // seconds. Keyed on the latched id so an auto-mark-as-read that clears the
@@ -134,5 +145,6 @@ export function useUnreadDivider({
     firstUnreadEventId,
     dividerEventId: displayedUnreadId,
     isDimmed,
+    dismiss,
   }
 }

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback, type RefObject } from "react"
 import type { StreamEvent } from "@threa/types"
 import { useScrollToElement } from "./use-scroll-to-element"
 
@@ -36,13 +36,68 @@ interface UseUnreadDividerResult {
   firstUnreadEventId: string | undefined
   /** The event ID where the divider should be shown, or undefined if hidden */
   dividerEventId: string | undefined
-  /** Whether the divider has settled to its muted (gray) resting state */
-  isDimmed: boolean
   /**
    * Dismiss the latched divider for the rest of this reading session (Escape
    * "escapes the unread block"). Stays dismissed until the stream changes.
    */
   dismiss: () => void
+}
+
+/**
+ * Drive the unread divider's red → muted-gray "freshness" fade. The stream opens
+ * at the live bottom, so the divider usually starts off-screen; the timer must
+ * wait until the row has actually entered the viewport, or it would settle to
+ * gray before the viewer ever scrolls up to see it. Returns `isDimmed`.
+ */
+export function useDividerDim(
+  scrollContainerRef: RefObject<HTMLElement | null>,
+  dividerEventId: string | undefined,
+  streamId: string
+): boolean {
+  const [isDimmed, setIsDimmed] = useState(false)
+  const [seen, setSeen] = useState(false)
+
+  // Reset when the stream or the latched divider changes.
+  useEffect(() => {
+    setSeen(false)
+    setIsDimmed(false)
+  }, [streamId, dividerEventId])
+
+  // Latch `seen` the first time the divider row intersects the viewport. Once
+  // seen, the effect re-runs and detaches (early return) — it's a one-shot.
+  useEffect(() => {
+    if (!dividerEventId || seen) return
+    const el = scrollContainerRef.current
+    let raf = 0
+    const check = () => {
+      raf = 0
+      const scroller = scrollContainerRef.current
+      if (!scroller) return
+      const row = scroller.querySelector<HTMLElement>(`[data-event-id="${CSS.escape(dividerEventId)}"]`)
+      if (!row) return
+      const sr = scroller.getBoundingClientRect()
+      const rr = row.getBoundingClientRect()
+      if (rr.top < sr.bottom && rr.bottom > sr.top) setSeen(true)
+    }
+    const schedule = () => {
+      if (!raf) raf = requestAnimationFrame(check)
+    }
+    schedule()
+    el?.addEventListener("scroll", schedule, { passive: true })
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      el?.removeEventListener("scroll", schedule)
+    }
+  }, [dividerEventId, streamId, seen, scrollContainerRef])
+
+  // Start the red → gray countdown only once the divider has been seen.
+  useEffect(() => {
+    if (!dividerEventId || !seen) return
+    const dimTimer = setTimeout(() => setIsDimmed(true), 3000)
+    return () => clearTimeout(dimTimer)
+  }, [dividerEventId, seen])
+
+  return isDimmed
 }
 
 /**
@@ -109,17 +164,6 @@ export function useUnreadDivider({
   const dismiss = useCallback(() => setDismissedStreamId(streamId), [streamId])
   const displayedUnreadId = dismissedStreamId === streamId ? undefined : latchRef.current.eventId
 
-  // Hold the divider red on (re)latch, then settle it to gray after a few
-  // seconds. Keyed on the latched id so an auto-mark-as-read that clears the
-  // live unread mid-countdown can't cancel the timer and strand it on red.
-  const [isDimmed, setIsDimmed] = useState(false)
-  useEffect(() => {
-    setIsDimmed(false)
-    if (!displayedUnreadId) return
-    const dimTimer = setTimeout(() => setIsDimmed(true), 3000)
-    return () => clearTimeout(dimTimer)
-  }, [displayedUnreadId])
-
   // Latch deep-link mode per stream. The `?m=` param is auto-cleared from the
   // URL ~3s after a deep-link lands, flipping highlightMessageId to null.
   // Without this latch the scroll-to-first-unread gate below would re-arm at
@@ -144,7 +188,6 @@ export function useUnreadDivider({
   return {
     firstUnreadEventId,
     dividerEventId: displayedUnreadId,
-    isDimmed,
     dismiss,
   }
 }

--- a/tests/browser/edit-last-message.spec.ts
+++ b/tests/browser/edit-last-message.spec.ts
@@ -145,6 +145,14 @@ test.describe("Edit last message (ArrowUp)", () => {
       })
     }
 
+    // Mark the stream read for User A before reloading. The cold-load scroll now
+    // lands on the first unread message (Slack-style); with the 20 fillers
+    // unread, User A would land near the top with their first message in view.
+    // This test needs that first message scrolled OFF-screen so ArrowUp can pull
+    // it back, which is the at-the-tail state a viewer who has read the channel
+    // gets — so read it first, then reload lands at the bottom.
+    await userA.page.request.post(`/api/workspaces/${workspaceId}/streams/read-all`)
+
     // ── User A: hard-reload to get a fresh bootstrap with filler messages ──
     // Navigate to about:blank first to fully teardown React state (TanStack cache,
     // hook state), then navigate to the stream URL. This gets a clean bootstrap from

--- a/tests/browser/edit-last-message.spec.ts
+++ b/tests/browser/edit-last-message.spec.ts
@@ -156,12 +156,11 @@ test.describe("Edit last message (ArrowUp)", () => {
     const lastFillerEl = userA.page.getByRole("main").locator(".message-item").getByText(`${fillerText} #20`).first()
     await expect(lastFillerEl).toBeVisible({ timeout: 15000 })
 
-    // Cold load now lands on the first unread message (Slack-style), so with the
-    // 20 unread fillers User A starts near the top with their own first message in
-    // view. Scroll to the live tail so it goes off-screen — the precondition for
-    // the ArrowUp scroll-into-view below. Retry the scroll-then-check: until the
-    // cold-load settle converges it can re-pin the first-unread row back to the
-    // top, so a single scroll can be undone.
+    // Cold load opens at the live bottom (the tail), so with the 20 fillers after
+    // it User A's first message is already off-screen above. Re-assert that via a
+    // scroll-to-tail — the precondition for the ArrowUp scroll-into-view below —
+    // and retry the scroll-then-check so a settle still converging its final
+    // scroll position can't leave a single scroll undone.
     const firstMessageEl = userA.page.getByRole("main").locator(".message-item").getByText(firstMessage).first()
     await expect(async () => {
       await lastFillerEl.scrollIntoViewIfNeeded()

--- a/tests/browser/edit-last-message.spec.ts
+++ b/tests/browser/edit-last-message.spec.ts
@@ -145,14 +145,6 @@ test.describe("Edit last message (ArrowUp)", () => {
       })
     }
 
-    // Mark the stream read for User A before reloading. The cold-load scroll now
-    // lands on the first unread message (Slack-style); with the 20 fillers
-    // unread, User A would land near the top with their first message in view.
-    // This test needs that first message scrolled OFF-screen so ArrowUp can pull
-    // it back, which is the at-the-tail state a viewer who has read the channel
-    // gets — so read it first, then reload lands at the bottom.
-    await userA.page.request.post(`/api/workspaces/${workspaceId}/streams/read-all`)
-
     // ── User A: hard-reload to get a fresh bootstrap with filler messages ──
     // Navigate to about:blank first to fully teardown React state (TanStack cache,
     // hook state), then navigate to the stream URL. This gets a clean bootstrap from
@@ -164,10 +156,17 @@ test.describe("Edit last message (ArrowUp)", () => {
     const lastFillerEl = userA.page.getByRole("main").locator(".message-item").getByText(`${fillerText} #20`).first()
     await expect(lastFillerEl).toBeVisible({ timeout: 15000 })
 
-    // After bootstrap + initial auto-scroll, the latest message should be in viewport
-    // and User A's first message should be scrolled off-screen
+    // Cold load now lands on the first unread message (Slack-style), so with the
+    // 20 unread fillers User A starts near the top with their own first message in
+    // view. Scroll to the live tail so it goes off-screen — the precondition for
+    // the ArrowUp scroll-into-view below. Retry the scroll-then-check: until the
+    // cold-load settle converges it can re-pin the first-unread row back to the
+    // top, so a single scroll can be undone.
     const firstMessageEl = userA.page.getByRole("main").locator(".message-item").getByText(firstMessage).first()
-    await expect(firstMessageEl).not.toBeInViewport({ timeout: 5000 })
+    await expect(async () => {
+      await lastFillerEl.scrollIntoViewIfNeeded()
+      await expect(firstMessageEl).not.toBeInViewport()
+    }).toPass({ timeout: 10000 })
 
     // Press ArrowUp in the empty composer: the inline edit form opens AND the
     // off-screen target scrolls into view. Both are re-issued under load — the


### PR DESCRIPTION
> [!IMPORTANT]
> **Direction update (dogfooding `693ac19`).** The original design landed you *on the first unread* (Slack's "open where you left off"). Testing on staging, we flipped to the other Slack mode: **open at the live bottom**, keep the unread preserved, and surface a top **"N new messages ↑"** button that jumps up to the "New" divider. The sections below describe the original landing; the current behavior is:
>
> - **Opens at the live bottom**, following the tail (the pre-existing cold-load behavior — `useTimelineScroll` is reverted to bottom-only).
> - **Read advances only through a *contiguous* run from where you left off** (`useLastSeenEvent`'s read frontier, pure `advanceFrontier` + unit-tested). Landing at the bottom leaves a gap above the read pointer, so it does **not** mark the unread read — the original "marks everything read" bug stays fixed. Scrolling up to the divider and reading down advances it; **Escape** marks all read.
> - **"N new messages ↑"** button at the top of the viewport (shown while unread sits above the fold) jumps to the divider and stops following the tail. The unread divider is a bookmark only (`scrollToUnread: false`).
> - Still in place from earlier rounds: `partial` mark-as-read (advance the pointer without optimistically zeroing the badge), the desktop **Escape** handler (mark-all-read + dismiss divider, with the tooltip-aware overlay guard), `useUnreadDivider.dismiss()`.

---

## Problem

Opening a stream marked **everything** read ~500ms after view, regardless of where the unread were. `useAutoMarkAsRead` (`apps/frontend/src/hooks/use-auto-mark-as-read.ts`) fired `markAsRead(streamId, events[events.length-1].id)` — the tail of the loaded window — on a debounce whenever the page was foregrounded and a count was elevated. So you'd open an unread channel, read the first screenful, and the rest below the fold would be silently marked read and lost. There was also no way to "escape" the unread state without scrolling.

This is the deferred follow-up to #1014 (which made the unread divider persistent). Two asks, both confirmed against Slack by the user:

1. **Progressive read** — don't advance read state past what the viewer has actually scrolled into view; unread below the fold stays unread until reached.
2. **Escape escapes the unread block** (desktop) — Slack's Esc-marks-channel-read: mark read, drop the divider, resume tailing.

Progressive read is only meaningful if you *land* on the first unread instead of the bottom — otherwise the bottom-most-seen row is the tail and everything is "seen". So landing-at-first-unread is the third, prerequisite piece.

## Solution

Three coupled changes: land the cold-load scroll on the first unread row, track the bottom-most row the viewer has actually seen and only mark up to it, and a desktop Escape that fully reads + resumes tail.

### How it works

**Land on first unread** (`use-timeline-scroll.ts`). The cold-load settle is generalized from `settleToBottom(maxMs)` to `settle(pin, maxMs)`. When the stream has an unread target, the initial-scroll layout effect pins the first-unread row near the top (`pinToIndex` → `scrollToIndex(idx, { align: "start", offset: -56 })`, the 56px revealing the divider + a sliver of context) and leaves `isFollowingTailRef=false` so new messages don't yank the reader down. The decision waits on `readStateResolved` so unread-vs-bottom is decided once, not corrected mid-settle; `stream-content.tsx` feeds the target index lazily via `initialUnreadIndexRef` (written after the divider computes, read in the layout effect) and gates on `lastReadEventId !== undefined`, with a 1000ms `readGateTimedOut` floor so a never-resolving read position can't hold the skeleton mask up. The divider hook's own `scrollIntoView` is now plain/thread-only (`scrollToUnread: !useVirtualized`) — the scroll engine owns the virtualized landing.

**Progressive mark** (`use-last-seen-event.ts`, new). `useLastSeenEvent` scans `[data-event-id]` rows in the scroll container on scroll (rAF-coalesced) and on content growth, and tracks the bottom-most row whose top has crossed the viewport bottom — excluding the band behind the floating composer (`--composer-height`). The seen index is monotonic and reset per stream. `useAutoMarkAsRead` marks up to that row, not the tail. When the bottom-most visible row is **not** the last rendered row (`atLastRow=false`), the mark is `partial`.

**Partial mark** (`use-unread-counts.ts`). A partial `markAsRead` advances only the read pointer (`membership.lastReadEventId`, the stream + membership mirrors in cache and IDB); it does **not** optimistically zero the badge. The server `stream:read` round-trip sets the true remaining count via the existing `applyStreamReadOrdinal`. A full mark is byte-for-byte the prior behavior.

**Escape** (`stream-content.tsx` + `use-unread-divider.ts`). A desktop, document-level keydown — active only while a divider is shown — marks the stream fully read (last loaded event), calls the new `dismiss()` on the divider (a latched divider has no clear-on-read), and `scrollToBottom({ force: true })` to resume tailing. Guarded against composer/editor/search focus and against open Radix overlays.

### Key design decisions

**1. Partial marks must not optimistically zero the badge — verified, load-bearing.** The unread system is ordinal-based and the read position MAX-merges (`apps/frontend/src/sync/unread-counters.ts` `applyStreamReadOrdinal`: `read = max(prevRead, lastReadOrdinal)`, where `prevRead = latest - unread`). If a mid-window mark forced `unread=0`, that implies `read=latest`, and a later `stream:read` for the mid ordinal can *never* lower it back — the badge would stickily over-clear. So mid-window marks skip the optimistic counter write and let the server round-trip own the count. The backend (`apps/backend/src/features/streams/service.ts:1678`) already computes `lastReadOrdinal` from the passed eventId and emits `stream:read`, so a positive remainder comes back. Reviewer-confirmed against both the reducer and the backend emission.

**2. Wait for the read position before deciding the landing.** Landing before `lastReadEventId` resolves would pick the bottom, and a late correction would fight the cold-load settle (the exact flake #1014's `readStateResolved` gate guards). Gating the scroll on the same signal makes the choice once. The 1000ms floor is insurance against a read position that never resolves (e.g. a non-member preview) hanging the mask.

**3. Suppress follow re-arm during the unread landing.** The settle's programmatic pins fire `scroll` → `handleScroll`; if the first-unread row is within the at-bottom band (a few unread), it would re-arm follow and the ResizeObserver would fight the pin and snap to the bottom. A `landedOnUnreadRef` keeps follow disarmed until a genuine user gesture clears it — so a near-bottom unread row still lands on the divider, and a real scroll-to-tail still re-arms normally. (Caught in self-review; see Design evolution.)

**4. Escape coordinates with overlays.** Radix listens for Escape in the capture phase and does not stop propagation, so a bubble-phase document handler would co-fire — closing a move dialog/dropdown *and* marking read. The handler bails when an open `[role=dialog|alertdialog|menu][data-state=open]` or `[data-radix-popper-content-wrapper]` is present. (Caught in self-review; see Design evolution.)

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | Track the bottom-most seen row (monotonic, per stream); pure `pickBottomSeenId` + the scanning hook |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | Unit tests for `pickBottomSeenId` |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | Generalize settle to `settle(pin, maxMs)`; add `pinToIndex`, `readStateResolved` gate, `getInitialScrollIndex`; land on first-unread without following tail; `landedOnUnreadRef` to suppress re-arm during the landing |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | Mark up to the seen event; `partial` option (with `lastMarkedPartialRef` so a partial→full transition at the same event re-fires) |
| `apps/frontend/src/hooks/use-unread-counts.ts` | `markAsRead(streamId, eventId, { partial })`; partial advances only the read pointer, never the optimistic counters |
| `apps/frontend/src/hooks/use-unread-divider.ts` | Add `dismiss()` to clear the latched divider for the session (Escape) |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Wire `useLastSeenEvent` + partial auto-mark; feed the unread landing target; `readGateTimedOut` floor; desktop Escape handler |
| `apps/frontend/src/components/timeline/event-list.tsx` | `findEventItemIndex` — item index by event id (mirrors `isFirstUnread`) for the landing target |
| `apps/frontend/src/hooks/index.ts` | Export `useLastSeenEvent` |
| `*.test.ts(x)` | Tests for partial mark (auto-mark + unread-counts), divider `dismiss`, `findEventItemIndex` |

## Out of scope (deliberate)

- **Escape marks up to the last *loaded* event**, not the absolute channel tail. If you're deep in history with newer events unloaded, those stay unread (Slack marks the whole channel). Left as a follow-up — flag if the full-channel semantics are wanted.
- **Mentions below the fold.** The server's `stream:read` zeroes mention/activity counts for the stream even on a partial read (existing backend semantic); a mid-fold mention is cleared. Not touched here.
- **Thread (plain-scroll) landing** still uses the divider's own `scrollIntoView`; only the virtualized timeline lands via the scroll engine. Progressive marking applies to both.

## Design evolution (self-review)

Two parallel reviewer agents over the diff turned up three things, all fixed in this branch:

- The read-state reviewer flagged a `partial`-vs-`lastEventId` timing skew (a scheduled partial mark could fire as full across an `atLastRow` flip, and a partial-then-tail-at-same-event cleared the badge only via the round-trip). Fixed by making the skip guard partial-aware (`lastMarkedPartialRef`) and adding `partial` to the effect deps, so a partial→full at the same event re-fires and the fire-time triple stays consistent.
- The scroll reviewer flagged the follow-re-arm tug-of-war (decision #3) and the Radix-Escape co-fire (decision #4); both fixed.

## Test plan

- [x] `apps/frontend` hooks + timeline suites — 769 pass (`bunx vitest run src/hooks src/components/timeline`)
- [x] New/updated unit tests: `pickBottomSeenId` (7), `findEventItemIndex` (3), partial mark in `use-auto-mark-as-read` (incl. partial→full re-fire) and `use-unread-counts` (badge stays, pointer advances), divider `dismiss`
- [x] `#1014` guardrails green: `use-unread-divider.test.ts`, broad sweep (859 across hooks/sync/sidebar earlier)
- [x] Full monorepo `tsc --noEmit` + `eslint` clean (pre-commit hook, exit 0)
- [ ] Browser E2E for the cold-load landing / progressive marking — **not run locally** (needs webServer + postgres + minio); relies on CI. The landing behavior in particular exercises real virtua measurement that jsdom can't reproduce.

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQs8HMgoPq3FonaHK64kaG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784476518&installation_id=129946197&pr_number=1017&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1017&signature=9b9f595d550db92cde470635ffbf781fb68b4734808c59e81c8158b6f6687c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
