### PR TITLE
fix(pwa): park new SW until reload + 404 missing assets, ending deploy-skew bricks

### DIFF
--- a/apps/frontend/functions/assets/[[path]].test.ts
+++ b/apps/frontend/functions/assets/[[path]].test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { onRequest } from "./[[path]]"
+
+function context(next: Response) {
+  return {
+    request: new Request("https://app.threa.io/assets/workspace-layout-AbC123.js"),
+    next: async () => next,
+  }
+}
+
+describe("assets onRequest", () => {
+  it("converts the SPA html fallback (missing chunk) into a no-store 404", async () => {
+    const fallback = new Response("<!doctype html><html></html>", {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8", "cache-control": "public, max-age=31536000, immutable" },
+    })
+
+    const res = await onRequest(context(fallback))
+
+    expect(res.status).toBe(404)
+    expect(res.headers.get("cache-control")).toBe("no-store")
+    expect(res.headers.get("content-type")).toContain("text/plain")
+  })
+
+  it("passes a real JS asset through untouched, immutable header intact", async () => {
+    const asset = new Response("export const x = 1", {
+      status: 200,
+      headers: { "content-type": "application/javascript", "cache-control": "public, max-age=31536000, immutable" },
+    })
+
+    const res = await onRequest(context(asset))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("cache-control")).toContain("immutable")
+    expect(await res.text()).toBe("export const x = 1")
+  })
+
+  it("passes a real CSS asset through untouched", async () => {
+    const asset = new Response("body{}", {
+      status: 200,
+      headers: { "content-type": "text/css" },
+    })
+
+    const res = await onRequest(context(asset))
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("text/css")
+  })
+})

--- a/apps/frontend/functions/assets/[[path]].ts
+++ b/apps/frontend/functions/assets/[[path]].ts
@@ -1,0 +1,42 @@
+/**
+ * Cloudflare Pages Function for /assets/* (auto-scoped: wrangler generates a
+ * _routes.json that only invokes this for asset paths; navigations bypass it).
+ *
+ * The problem it fixes: when a content-hashed chunk no longer exists on the live
+ * deployment, the SPA `_redirects` fallback (`/* /index.html 200`) answers the
+ * /assets/*.js request with index.html — HTML, status 200 — and `public/_headers`
+ * stamps /assets/* `immutable, max-age=1yr`. The browser (and the CF edge) then
+ * cache that HTML-as-JS for a year, so the tab's dynamic import() keeps parsing
+ * HTML as a module and stays bricked until the cache expires. Clearing the SW and
+ * CacheStorage can't evict the edge copy.
+ *
+ * Here we run the normal asset pipeline via next(): a real asset comes back with
+ * its own immutable headers untouched. Only when the pipeline falls through to
+ * the HTML shell (the asset is gone) do we replace it with a real 404 marked
+ * no-store, so import() fails cleanly and transiently — recoverable on the next
+ * load instead of permanently poisoned.
+ */
+interface AssetsFunctionContext {
+  request: Request
+  next: () => Promise<Response>
+}
+
+export async function onRequest(context: AssetsFunctionContext): Promise<Response> {
+  const response = await context.next()
+
+  // Real assets are application/javascript, text/css, image/*, font/* — never
+  // HTML. An HTML response on an /assets/* path means the static asset was
+  // missing and the SPA fallback served index.html.
+  const contentType = response.headers.get("content-type") ?? ""
+  if (contentType.includes("text/html")) {
+    return new Response("Asset not found", {
+      status: 404,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    })
+  }
+
+  return response
+}

--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { reloadForUpdate, shouldNotifyUpdate, RELOAD_FRESH_ACK_TIMEOUT_MS } from "./use-app-update"
-import { SW_MSG_RELOAD_FRESH } from "@/lib/sw-messages"
+import { reloadForUpdate, shouldNotifyUpdate, RELOAD_FALLBACK_TIMEOUT_MS } from "./use-app-update"
+import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
 
 const RUNNING = "abc1234"
 
@@ -33,11 +33,26 @@ describe("reloadForUpdate", () => {
   const swDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
   let reloadSpy: ReturnType<typeof vi.fn>
 
-  const setController = (controller: unknown): void => {
-    Object.defineProperty(navigator, "serviceWorker", {
-      configurable: true,
-      value: { controller, addEventListener: vi.fn() },
-    })
+  type Waiting = { postMessage: ReturnType<typeof vi.fn> }
+  type Registration = { waiting: Waiting | null; update: ReturnType<typeof vi.fn> }
+
+  /**
+   * Stub navigator.serviceWorker. `registration: undefined` models getRegistration
+   * resolving with no registration; a registration with `waiting: null` models no
+   * parked worker. `fire("controllerchange")` invokes captured listeners so a test
+   * can simulate the new worker taking control.
+   */
+  const setServiceWorker = (opts: { registration?: Registration }) => {
+    const listeners: Record<string, Array<() => void>> = {}
+    const sw = {
+      getRegistration: vi.fn(async () => opts.registration),
+      addEventListener: vi.fn((type: string, cb: () => void) => {
+        ;(listeners[type] ??= []).push(cb)
+      }),
+      fire: (type: string) => listeners[type]?.forEach((cb) => cb()),
+    }
+    Object.defineProperty(navigator, "serviceWorker", { configurable: true, value: sw })
+    return sw
   }
 
   beforeEach(() => {
@@ -60,41 +75,40 @@ describe("reloadForUpdate", () => {
     }
   })
 
-  it("reloads immediately when no SW controls the page (navigation already hits network)", async () => {
-    setController(null)
+  it("reloads immediately when no worker is waiting, even after nudging update", async () => {
+    const update = vi.fn(async () => {})
+    setServiceWorker({ registration: { waiting: null, update } })
+
     await reloadForUpdate()
+
+    expect(update).toHaveBeenCalledOnce()
     expect(reloadSpy).toHaveBeenCalledOnce()
   })
 
-  it("asks the controlling SW for a fresh navigation, then reloads once it acks", async () => {
-    let received: { type: string } | undefined
-    const controller = {
-      postMessage: vi.fn((message: { type: string }, transfer?: Transferable[]) => {
-        received = message
-        // Mimic the SW: ack on the transferred port so the reload proceeds.
-        const port = transfer?.[0] as MessagePort | undefined
-        port?.postMessage({ ok: true })
-      }),
-    }
-    setController(controller)
+  it("activates the parked worker and reloads once it takes control", async () => {
+    const waiting = { postMessage: vi.fn() }
+    const update = vi.fn(async () => {})
+    const sw = setServiceWorker({ registration: { waiting, update } })
 
     await reloadForUpdate()
 
-    expect(controller.postMessage).toHaveBeenCalledOnce()
-    expect(received).toEqual({ type: SW_MSG_RELOAD_FRESH })
-    await vi.waitFor(() => expect(reloadSpy).toHaveBeenCalledOnce())
-  })
-
-  it("reloads anyway when the SW never acks (wedged worker can't strand Reload)", async () => {
-    vi.useFakeTimers()
-    // Controller that swallows the message without acking.
-    setController({ postMessage: vi.fn() })
-
-    const promise = reloadForUpdate()
+    expect(update).not.toHaveBeenCalled() // already waiting — no need to nudge
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: SW_MSG_SKIP_WAITING })
     expect(reloadSpy).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(RELOAD_FRESH_ACK_TIMEOUT_MS)
-    await promise
+    sw.fire("controllerchange")
+    expect(reloadSpy).toHaveBeenCalledOnce()
+  })
+
+  it("reloads anyway when the worker never claims (wedged worker can't strand Reload)", async () => {
+    vi.useFakeTimers()
+    const waiting = { postMessage: vi.fn() }
+    setServiceWorker({ registration: { waiting, update: vi.fn(async () => {}) } })
+
+    await reloadForUpdate()
+    expect(reloadSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(RELOAD_FALLBACK_TIMEOUT_MS)
     expect(reloadSpy).toHaveBeenCalledOnce()
   })
 })

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -3,23 +3,23 @@ import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
 import { getNotifiedVersion, setNotifiedVersion } from "@/lib/app-update-version"
-import { SW_MSG_RELOAD_FRESH } from "@/lib/sw-messages"
+import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
 
 const POLL_INTERVAL = 300_000 // 5 minutes
 const TOAST_ID = "app-update"
 const IS_DEV = import.meta.env.DEV
 
 /**
- * Cap how long the Reload action waits for the SW to acknowledge the
- * network-fresh request before reloading anyway. The ack is near-instant; this
- * only guards against a wedged SW so Reload can never hang.
+ * Cap how long the Reload action waits for the parked SW to take control before
+ * reloading anyway. `controllerchange` is near-instant after skipWaiting; this
+ * only guards against a wedged/absent worker so Reload can never hang.
  */
-export const RELOAD_FRESH_ACK_TIMEOUT_MS = 1500
+export const RELOAD_FALLBACK_TIMEOUT_MS = 3000
 
 /**
- * Tell the browser to check for a new service worker. The SW's install handler
- * calls skipWaiting() unconditionally, so it activates immediately — no need
- * to post a message or check registration.waiting.
+ * Tell the browser to check for a new service worker. A newer sw.js installs and
+ * then parks in `waiting` (it no longer skipWaiting()s on its own), so this only
+ * stages the update — reloadForUpdate activates it on the user's click.
  */
 async function triggerSwUpdate(): Promise<void> {
   const registration = await navigator.serviceWorker?.getRegistration()
@@ -28,50 +28,52 @@ async function triggerSwUpdate(): Promise<void> {
 }
 
 /**
- * Ask the controlling SW to serve the next navigation from the network, then
- * resolve once it acks (or the timeout elapses). The ack guarantees the SW has
- * set its one-shot flag before we trigger the navigation, so the reload that
- * follows is the one served fresh.
- */
-function requestFreshNav(controller: ServiceWorker): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const channel = new MessageChannel()
-    const timer = setTimeout(resolve, RELOAD_FRESH_ACK_TIMEOUT_MS)
-    channel.port1.onmessage = () => {
-      clearTimeout(timer)
-      resolve()
-    }
-    try {
-      controller.postMessage({ type: SW_MSG_RELOAD_FRESH }, [channel.port2])
-    } catch {
-      clearTimeout(timer)
-      resolve()
-    }
-  })
-}
-
-/**
  * Reload onto the new build.
  *
- * The SW serves navigations cache-first from the build-atomic precache, so a
- * plain reload returns whatever build the *currently controlling* SW precached
- * — and right after a deploy that is still the old build, so the version toast
- * just reappears. Waiting for the new SW to install and claim before reloading
- * is racy (a slow/throttled install reloads onto the old shell anyway), so
- * instead we ask the controlling SW to serve this one navigation from the
- * network. The reload then fetches the freshly-deployed index.html (and its new
- * hashed assets) directly, landing on the new build in one click regardless of
- * SW-update timing. The new SW installs in the background as usual.
+ * The new SW installs but parks in `waiting` so this tab keeps its own build's
+ * worker + precache (and can always load its own chunks). On the user's click we
+ * post SW_MSG_SKIP_WAITING to the waiting worker; it activates and claims the
+ * page, which fires `controllerchange`, and we reload — landing on the new
+ * build's precached shell and chunks in one atomic step. The fallback timeout
+ * reloads anyway if the worker never claims.
  *
- * No controller (first load before the SW claims) means the navigation already
- * hits the network, so a plain reload is correct.
+ * No waiting worker (first load, SW unsupported, or already activated) means a
+ * plain reload already lands on the current build.
  */
 export async function reloadForUpdate(): Promise<void> {
-  const controller = navigator.serviceWorker?.controller
-  if (controller) {
-    await requestFreshNav(controller)
+  const registration = await navigator.serviceWorker?.getRegistration()
+  if (!registration) {
+    window.location.reload()
+    return
   }
-  window.location.reload()
+
+  let waiting = registration.waiting
+  if (!waiting) {
+    // The toast can fire before the new sw.js finishes installing; nudge the
+    // update and re-check so a quick click still finds the parked worker rather
+    // than plain-reloading back onto the current build.
+    try {
+      await registration.update()
+    } catch {
+      // Offline or update failed — fall through to a plain reload below.
+    }
+    waiting = registration.waiting
+  }
+
+  if (!waiting) {
+    window.location.reload()
+    return
+  }
+
+  let reloaded = false
+  const reloadOnce = (): void => {
+    if (reloaded) return
+    reloaded = true
+    window.location.reload()
+  }
+  navigator.serviceWorker.addEventListener("controllerchange", reloadOnce, { once: true })
+  setTimeout(reloadOnce, RELOAD_FALLBACK_TIMEOUT_MS)
+  waiting.postMessage({ type: SW_MSG_SKIP_WAITING })
 }
 
 /**

--- a/apps/frontend/src/lib/sw-messages.ts
+++ b/apps/frontend/src/lib/sw-messages.ts
@@ -19,12 +19,13 @@ export const SW_MSG_CLEAR_NOTIFICATIONS = "CLEAR_NOTIFICATIONS"
 export const SW_MSG_QUEUE_BOOTSTRAP_SYNC = "QUEUE_BOOTSTRAP_SYNC"
 
 /**
- * Posted from the app to the SW (the controlling worker) to serve the *next*
- * navigation from the network instead of the cache-first precache shell. Used by
- * the "new version" reload so the reload lands on the freshly-deployed build
- * rather than the old build the current SW precached.
+ * Posted from the app to the *waiting* SW to activate it (`skipWaiting`). The new
+ * SW otherwise stays parked so the open tab keeps its own build's worker and
+ * precache for its whole life — never a mid-session precache swap that 404s a
+ * lazy chunk. The app reloads on the resulting `controllerchange` so the
+ * navigation lands on the new build's precache.
  */
-export const SW_MSG_RELOAD_FRESH = "RELOAD_FRESH"
+export const SW_MSG_SKIP_WAITING = "SKIP_WAITING"
 
 /** Cache name used by the SW to stash share-target POST data (files + text) for the app to read. */
 export const SHARE_TARGET_CACHE = "share-target"

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -8,30 +8,24 @@ import {
   SW_MSG_SUBSCRIPTION_CHANGED,
   SW_MSG_CLEAR_NOTIFICATIONS,
   SW_MSG_QUEUE_BOOTSTRAP_SYNC,
-  SW_MSG_RELOAD_FRESH,
+  SW_MSG_SKIP_WAITING,
   SHARE_TARGET_CACHE,
 } from "./lib/sw-messages"
 
 declare const self: ServiceWorkerGlobalScope
 
-/**
- * One-shot: serve the next app-shell navigation from the network instead of the
- * cache-first precache. Set by the "new version" reload (SW_MSG_RELOAD_FRESH)
- * so the reload fetches the freshly-deployed index.html — the precache here is
- * still the *old* build until the new SW installs and claims, so a plain
- * cache-first reload would just re-serve the old client. In-memory is fine: the
- * page reloads within milliseconds of the ack, so the flag never needs to
- * survive an SW restart, and if it somehow does reset we fall back to the safe
- * cache-first path (no worse than before).
- */
-let serveNextNavFromNetwork = false
-
+// A freshly-installed SW stays parked in `waiting` (no auto-skipWaiting on
+// install) until the user accepts the in-app update toast, which posts
+// SW_MSG_SKIP_WAITING. Activating immediately + clients.claim() used to swap the
+// precache out from under a still-running old page (the focus/poll-driven update
+// check installs the new SW within seconds of a deploy), so the page's next lazy
+// import() of *its own* chunk missed the now-replaced precache, fell through to
+// the network, and 404'd because that build was no longer live — bricking the
+// tab. Parking the new SW keeps each tab on its own build's worker + precache
+// for its whole life; the swap happens only on the user-driven reload.
 self.addEventListener("message", (event) => {
-  if (event.data?.type !== SW_MSG_RELOAD_FRESH) return
-  serveNextNavFromNetwork = true
-  // Ack so the page reloads only once the flag is set, guaranteeing the
-  // navigation that follows is the one served from the network.
-  event.ports[0]?.postMessage({ ok: true })
+  if (event.data?.type !== SW_MSG_SKIP_WAITING) return
+  void self.skipWaiting()
 })
 
 /** Extend NotificationOptions with properties supported by browsers but missing from TS lib types. */
@@ -60,9 +54,9 @@ const AVATAR_CACHE = "threa-avatars-v1"
 const AVATAR_PATH_RE = /^\/api\/workspaces\/[^/]+\/(?:users|bots)\/[^/]+\/avatar\//
 const AVATAR_CACHE_MAX_ENTRIES = 300
 
-// Activate new service worker immediately so users get fresh code
-// without needing to close all tabs.
-self.addEventListener("install", () => self.skipWaiting())
+// No install listener: the new SW must NOT skipWaiting on its own (see the
+// SW_MSG_SKIP_WAITING handler above). It activates only when the open page
+// accepts the update and posts that message, then reloads onto it.
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     (async () => {
@@ -98,9 +92,9 @@ cleanupOutdatedCaches()
 // HTML against build-B's now-missing assets — the post-deploy "unstyled page"
 // failure (where _redirects' `/* /index.html 200` SPA fallback serves HTML in
 // place of deleted asset URLs, so React never mounts). Zero network on the
-// boot critical path; post-deploy freshness comes from the SW update
-// lifecycle (skipWaiting/clients.claim above) surfaced by the in-app
-// version.json update toast.
+// boot critical path; post-deploy freshness comes from the parked-SW update
+// lifecycle (SW_MSG_SKIP_WAITING above) surfaced by the in-app version.json
+// update toast.
 self.addEventListener("fetch", (event) => {
   // Only app-shell GET navigations belong here. Web Share Target launches use
   // a POST navigation to /share, which must fall through to the handler below.
@@ -121,21 +115,10 @@ self.addEventListener("fetch", (event) => {
 
   event.respondWith(
     (async () => {
-      // One-shot network-first: the user clicked "Reload" on the new-version
-      // toast. Fetch the freshly-deployed shell so the reload lands on the new
-      // build instead of this (old) SW's precached shell. Falls through to the
-      // precache if the network fails (offline) so the reload still yields a
-      // working app.
-      if (serveNextNavFromNetwork) {
-        serveNextNavFromNetwork = false
-        try {
-          return await fetch(event.request)
-        } catch {
-          // Offline — fall through to the precached shell below.
-        }
-      }
       // matchPrecache resolves workbox's revisioned cache key, so this is the
-      // exact index.html that ships with the precached asset bundle.
+      // exact index.html that ships with this SW's precached asset bundle. Each
+      // tab keeps its own build's SW until the user-driven update reload, so this
+      // shell always matches the chunks the running page will import.
       const precached = await matchPrecache("/index.html")
       if (precached) return precached
       // First ever launch / precache unavailable — go to network.

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -132,9 +132,10 @@ export default defineConfig({
     },
   },
   test: {
-    // Two projects so the Node build-script tests under scripts/ don't drag in
-    // the jsdom UI bootstrap (./src/test/setup.ts → @/db, localStorage, DOM
-    // polyfills) that has nothing to do with a filesystem script.
+    // Two projects so the Node build-script and Pages-Function tests don't drag
+    // in the jsdom UI bootstrap (./src/test/setup.ts → @/db, localStorage, DOM
+    // polyfills) that has nothing to do with a filesystem script or an edge
+    // function.
     projects: [
       {
         extends: true,
@@ -149,10 +150,10 @@ export default defineConfig({
       {
         extends: true,
         test: {
-          name: "scripts",
+          name: "node",
           globals: true,
           environment: "node",
-          include: ["scripts/**/*.test.ts"],
+          include: ["scripts/**/*.test.ts", "functions/**/*.test.ts"],
         },
       },
     ],


### PR DESCRIPTION
## Problem

A new build deploys; an already-open tab navigates to a route whose chunk hasn't loaded yet → `TypeError: Failed to fetch dynamically imported module: …/assets/workspace-layout-<hash>.js` → the tab bricks on the "Update needed" screen. Retention (#1007) reduced it but didn't end it. There are **two compounding root causes**:

**1. The SW swaps the precache out from under the running page.** The SW `skipWaiting()`s on install and `clients.claim()`s on activate (`apps/frontend/src/sw.ts`), and `useAppUpdate` nudges `registration.update()` on tab focus, a 5-minute poll, and every socket reconnect. So within seconds of a deploy the new SW seizes the still-running **old** page and `cleanupOutdatedCaches()` deletes the old precache. The page is now build N's JS controlled by build N+1's SW with N's precache gone — its next lazy `import()` of *its own* chunk misses the precache, falls through to the network, and 404s because build N is no longer the live deploy. The mechanism meant to keep users fresh is what breaks them. (The precache normally makes this impossible: it holds every chunk; we were deleting it mid-session.)

**2. A missing `/assets/*` is cached as immutable HTML, so the failure is permanent.** `public/_redirects` (`/* /index.html 200`) answers a missing chunk with `index.html` — 200, `text/html` — and `public/_headers` stamps `/assets/*` `immutable, max-age=1yr`. The bad HTML-as-JS response is pinned for a year in the browser HTTP cache **and at the CF edge**. `import()` keeps parsing HTML as a module; "Clear cache & reload" / `runSwRecovery` clears the SW + CacheStorage but can't evict the edge, so the tab stays bricked → the "Update needed / Visit /recover" screen (recovery exhausted its attempts).

## Solution

Remove the cause (the precache swap) and remove the permanence (the immutable-HTML poison).

### How it works

**1. Park the new SW until the user reloads (`sw.ts`, `use-app-update.ts`, `sw-messages.ts`).** Drop `skipWaiting()` on install — a new SW installs and stays in `waiting`. It activates only when the open page accepts the update toast and posts `SW_MSG_SKIP_WAITING`; the app reloads on the resulting `controllerchange`, landing on the new build's precached shell **and** chunks atomically. Each tab keeps its own build's worker + precache for its whole life, so it can always load its own chunks — version skew becomes structurally impossible for a given tab. `reloadForUpdate` first nudges `registration.update()` so a click that beats the install still finds the parked worker, with a `RELOAD_FALLBACK_TIMEOUT_MS` (3s) guard so a wedged worker can't strand Reload. Replaces the old `RELOAD_FRESH` network-first-navigation hack (removed). `clients.claim()` on activate is kept (correct on first install and at the user-driven swap).

**2. Missing `/assets/*` → real 404, never immutable HTML (`functions/assets/[[path]].ts`).** A Cloudflare Pages Function on `/assets/*` runs the normal asset pipeline via `next()`: a real asset passes through with its immutable headers intact; when the pipeline falls through to the HTML shell (asset gone), it returns `404` with `Cache-Control: no-store`. So any residual chunk miss (multi-tab skew, a user who ignores the toast for days, a mid-deploy edge propagation race) fails cleanly and transiently — recoverable on the next load instead of poisoning the browser/edge cache for a year.

**3. vitest split (`vite.config.ts`).** A jsdom `frontend` project and a `node` project, so the Pages Function and build-script tests run without the UI bootstrap (`./src/test/setup.ts` → `@/db`, DOM polyfills).

### Why not just retention or just client recovery

Retention (#1007) keeps old chunk *files* alive but does nothing for the precache swap (#1) or an edge that cached HTML during a propagation race (#2). Client recovery can't evict the CF edge, and it *unregisters the SW* — deleting the one precache that still had the old chunks — so it can make things worse. #1 stops the skew; #2 makes any leftover miss recoverable. Retention stays as defense-in-depth.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/functions/assets/[[path]].ts` | Pages Function: missing `/assets/*` → `404 no-store` instead of immutable HTML |
| `apps/frontend/functions/assets/[[path]].test.ts` | 3 tests: html fallback → 404 no-store; JS/CSS assets pass through |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sw.ts` | Remove `skipWaiting()` on install; add `SW_MSG_SKIP_WAITING` handler; remove `serveNextNavFromNetwork`/`RELOAD_FRESH` machinery |
| `apps/frontend/src/hooks/use-app-update.ts` | `reloadForUpdate` does the skip-waiting → `controllerchange` → reload handshake (nudges `update()`, 3s fallback); drop `requestFreshNav` |
| `apps/frontend/src/lib/sw-messages.ts` | `SW_MSG_RELOAD_FRESH` → `SW_MSG_SKIP_WAITING` |
| `apps/frontend/src/hooks/use-app-update.test.ts` | Rewritten for the new handshake (no-waiting reload, activate-on-controllerchange, timeout fallback) |
| `apps/frontend/vite.config.ts` | vitest `node` project also covers `functions/**/*.test.ts` |

## Out of scope (deliberate)

- **Recovery reorder** (don't unregister the SW first — it's the precache that serves old chunks). Worth doing, but with #1+#2 in place recovery is rarely reached; separate follow-up to keep this PR focused.
- **`apps/backoffice`** has the same SW/`_headers` shape; left out to keep this scoped to the user-facing app.
- **Retention concurrency** (`cancel-in-progress` can skip the save step) — minor, defense-in-depth layer, separate change.

## Test plan

- [x] `vitest` full frontend suite — **2959 pass / 271 files** (both projects)
- [x] `use-app-update.test.ts` — 8 pass (handshake, nudge, controllerchange, timeout fallback)
- [x] `functions/assets/[[path]].test.ts` — 3 pass (404 no-store on html; JS/CSS passthrough)
- [x] `tsc --noEmit` frontend clean; pre-commit lint hook passed
- [ ] **CF integration not exercisable offline** — needs **staging verification**: (a) `wrangler pages deploy dist` (run with `workingDirectory: apps/frontend`) actually compiles `functions/` and auto-scopes `_routes.json` to `/assets/*`; (b) `next()` returns the SPA HTML fallback for a missing asset; (c) `_headers` does **not** re-stamp `immutable` over the Function's `no-store` 404. If (c) fails, the fallback is to serve `/assets/*` through the worker. Will verify on `staging.threa.io` before relying on it in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeKiRFBN6SWYHNq3S1zc1q)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784494865&installation_id=129946197&pr_number=1018&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1018&signature=a32719060d6a1eb261abebe477c5447d9f7bfe325c5d5057220361a8d883e6e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->