### PR TITLE
fix(backend): clear bot-invocation traces stuck red after a successful long-running turn

### DIFF
--- a/apps/backend/src/features/agents/session-repository.ts
+++ b/apps/backend/src/features/agents/session-repository.ts
@@ -612,8 +612,21 @@ export const AgentSessionRepository = {
       lastSeenSequence: bigint
       responseMessageId?: string | null
       sentMessageIds?: string[]
+      /**
+       * Also complete a FAILED session, not just a RUNNING one. A bot
+       * invocation whose claim is still valid can only have reached FAILED via
+       * orphan-session-cleanup's stale-heartbeat scan — a genuine `/fail` flips
+       * the claim, which blocks completion upstream. When such a turn finishes
+       * successfully its trace must end COMPLETED, not stay stuck red, so the
+       * completion recovers that orphan false-positive. The status-guarded
+       * UPDATE keeps this race-safe against a concurrent cleanup (INV-20).
+       */
+      recoverFromFailed?: boolean
     }
   ): Promise<AgentSession | null> {
+    const allowedStatuses = params.recoverFromFailed
+      ? [SessionStatuses.RUNNING, SessionStatuses.FAILED]
+      : [SessionStatuses.RUNNING]
     const result = await db.query<SessionRow>(
       sql`
         UPDATE agent_sessions
@@ -623,9 +636,10 @@ export const AgentSessionRepository = {
           response_message_id = ${params.responseMessageId ?? null},
           sent_message_ids = ${params.sentMessageIds ?? null},
           current_step_type = NULL,
+          error = NULL,
           completed_at = NOW()
         WHERE id = ${id}
-          AND status = ${SessionStatuses.RUNNING}
+          AND status = ANY(${allowedStatuses})
         RETURNING ${sql.raw(SESSION_SELECT_FIELDS)}
       `
     )

--- a/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
+++ b/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
@@ -23,7 +23,7 @@ function createResponse(): Response {
   return res
 }
 
-function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknown }) {
+function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknown; sessionStatus?: string }) {
   spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
   spyOn(BotRepository, "findById").mockResolvedValue({ id: "bot_1", name: "Pi", archivedAt: null } as never)
   spyOn(dbModule, "withTransaction").mockImplementation(((_pool: unknown, fn: (c: unknown) => unknown) =>
@@ -31,9 +31,9 @@ function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknow
 
   spyOn(AgentSessionRepository, "findById").mockResolvedValue({
     id: "binv_1",
-    status: AgentSessionStatuses.RUNNING,
+    status: params.sessionStatus ?? AgentSessionStatuses.RUNNING,
   } as never)
-  spyOn(AgentSessionRepository, "completeSession").mockResolvedValue({
+  const completeSession = spyOn(AgentSessionRepository, "completeSession").mockResolvedValue({
     id: "binv_1",
     createdAt: new Date("2026-06-11T09:00:00.000Z"),
     completedAt: new Date("2026-06-11T09:00:05.000Z"),
@@ -128,7 +128,7 @@ function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknow
     body: { instanceId: "inst_1", claimToken: "tok_1", finalMessageMarkdown: "High tide is at 14:32." },
   } as unknown as Request
 
-  return { handlers, req, emitted, appendStep, insertEvent, createMessageInTransaction }
+  return { handlers, req, emitted, appendStep, insertEvent, createMessageInTransaction, completeSession }
 }
 
 describe("completeBotInvocation synthesized-trace floor", () => {
@@ -186,6 +186,29 @@ describe("completeBotInvocation synthesized-trace floor", () => {
     const completedEvent = insertEvent.mock.calls[0]?.[1] as unknown as { payload: Record<string, unknown> }
     expect(completedEvent.payload).toMatchObject({ stepCount: 1 })
     expect(emitted.filter((e) => e.event === "agent_session:step:completed")).toHaveLength(0)
+  })
+})
+
+describe("completeBotInvocation orphan recovery", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  // A long-running turn can be marked FAILED by orphan-session-cleanup's
+  // stale-heartbeat scan while it is in fact alive (the claim is still being
+  // renewed). When it later completes successfully its trace must end COMPLETED,
+  // not stay stuck red — completion recovers the orphan false-positive.
+  it("recovers a FAILED (orphaned) session to completed when the turn finishes", async () => {
+    const { handlers, req, emitted, completeSession } = arrangeCompletion({
+      existingSteps: [{ id: "step_1", stepType: AgentStepTypes.TOOL_CALL }],
+      sessionStatus: AgentSessionStatuses.FAILED,
+    })
+
+    await handlers.completeBotInvocation(req, createResponse())
+
+    expect(completeSession).toHaveBeenCalledTimes(1)
+    expect(completeSession.mock.calls[0]?.[2]).toMatchObject({ recoverFromFailed: true })
+    expect(emitted.some((e) => e.event === "agent_session:completed")).toBe(true)
   })
 })
 

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1315,6 +1315,15 @@ export function createPublicApiHandlers({
         claimTtlSeconds: data.claimTtlSeconds,
       })
       if (!renewed) throw new HttpError("Invocation claim not found", { status: 404, code: "NOT_FOUND" })
+      // A claim renewal is the external runtime's liveness signal between trace
+      // steps. Bot invocations reuse the invocation id as the agent session id,
+      // so bump the session heartbeat too — otherwise a long-running turn that
+      // renews its claim but goes longer than orphan-session-cleanup's stale
+      // threshold without POSTing /steps is falsely marked orphaned (FAILED)
+      // while it is in fact alive. Mirrors the enclave's session-heartbeat
+      // callback and the in-process companion's heartbeat interval. No-ops for
+      // session-control invocations, which create no agent session.
+      await AgentSessionRepository.updateHeartbeat(pool, req.params.invocationId)
       res.json({
         data: {
           invocationId: renewed.id,
@@ -1665,12 +1674,19 @@ export function createPublicApiHandlers({
           })
         }
         const session = await AgentSessionRepository.findById(client, completed.id)
-        if (session?.status === AgentSessionStatuses.RUNNING) {
+        // RUNNING is the happy path; FAILED is recoverable here. Reaching this
+        // point means the claim was still valid (findActiveClaimForUpdate above
+        // succeeded), so the only way the session is FAILED is an orphan
+        // false-positive from cleanup's stale-heartbeat scan — the turn really
+        // did finish and send its reply, so finalize it COMPLETED rather than
+        // leaving the trace stuck red.
+        if (session?.status === AgentSessionStatuses.RUNNING || session?.status === AgentSessionStatuses.FAILED) {
           const latestSequence = await eventService.getLatestSequence(completed.responseStreamId)
           const finalizedSession = await AgentSessionRepository.completeSession(client, completed.id, {
             lastSeenSequence: latestSequence ?? 0n,
             responseMessageId: message?.id ?? null,
             sentMessageIds: message ? [message.id] : [],
+            recoverFromFailed: true,
           })
           if (finalizedSession) {
             let steps = await AgentSessionRepository.findStepsBySession(client, completed.id)

--- a/apps/backend/src/features/public-api/renew-heartbeat.test.ts
+++ b/apps/backend/src/features/public-api/renew-heartbeat.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { AgentSessionRepository } from "../agents"
+
+// Renewing a bot invocation claim is the external runtime's liveness signal
+// between trace steps. Because bot invocations reuse the invocation id as the
+// agent session id, renewal must also bump the session heartbeat — otherwise a
+// long-running turn that renews but goes quiet on /steps is falsely orphaned
+// (FAILED) by cleanup while it is in fact alive.
+
+function createResponse(): Response {
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock(() => res) as unknown as Response["json"]
+  return res
+}
+
+function arrangeRenew(renewed: unknown) {
+  const updateHeartbeat = spyOn(AgentSessionRepository, "updateHeartbeat").mockResolvedValue(undefined as never)
+  const renewInvocationClaim = mock(() => Promise.resolve(renewed))
+  const botRuntimeService = { renewInvocationClaim } as unknown as PublicApiDeps["botRuntimeService"]
+
+  const pool = { __pool: true } as unknown as PublicApiDeps["pool"]
+  const handlers = createPublicApiHandlers({
+    eventService: {} as PublicApiDeps["eventService"],
+    streamService: {} as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService,
+    labelService: {} as PublicApiDeps["labelService"],
+    labelAssignmentService: {} as PublicApiDeps["labelAssignmentService"],
+    pool,
+    io: {} as PublicApiDeps["io"],
+  })
+
+  const req = {
+    workspaceId: "ws_1",
+    params: { invocationId: "binv_1" },
+    botApiKey: { botId: "bot_1" },
+    body: { instanceId: "inst_1", claimToken: "tok_1" },
+  } as unknown as Request
+
+  return { handlers, req, updateHeartbeat, pool }
+}
+
+describe("renewBotInvocationClaim", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("bumps the agent session heartbeat so a renewing turn is not orphan-failed", async () => {
+    const { handlers, req, updateHeartbeat, pool } = arrangeRenew({
+      id: "binv_1",
+      status: "claimed",
+      claimExpiresAt: new Date("2026-06-11T09:02:00.000Z"),
+    })
+
+    await handlers.renewBotInvocationClaim(req, createResponse())
+
+    expect(updateHeartbeat).toHaveBeenCalledTimes(1)
+    expect(updateHeartbeat.mock.calls[0]).toEqual([pool, "binv_1"])
+  })
+
+  it("does not bump the heartbeat when the claim is gone (404)", async () => {
+    const { handlers, req, updateHeartbeat } = arrangeRenew(null)
+
+    await expect(handlers.renewBotInvocationClaim(req, createResponse())).rejects.toMatchObject({ status: 404 })
+    expect(updateHeartbeat).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Long-running remote-agent traces (Pi harness, Claude Code channel) showed as **failed (red)** in the trace dialog and the timeline card even though the turn was working fine — it kept streaming steps and ultimately sent its reply. Reported against a real `binv_…` invocation trace where "it's still sending things, it always did not fail, it's working perfectly... but they're still marked as red."

A bot invocation carries two independent liveness clocks that had drifted apart:

1. **The claim** — `bot_invocations.claim_expires_at`, renewed by the runtime well under its TTL. `claude-code-remote` renews every `CLAIM_TTL_SECONDS / 3` ≈ 40s (TTL 120s, `extensions/claude-code-remote/src/channel-server.ts`); `pi-remote` renews on its poll loop (`claimTtlSeconds: 120`). This is the runtime's real "I'm alive" signal.
2. **The agent-session heartbeat** — `agent_sessions.heartbeat_at`, which `createOrphanSessionCleanup` (`apps/backend/src/features/agents/orphan-session-cleanup.ts`) uses to mark stale RUNNING sessions FAILED after 60s (`findOrphaned`, `staleThresholdSeconds = 60`). For bot invocations this column was bumped **only** when the runtime POSTed `/steps` (via `updateCurrentStepType` in `trace-steps.ts`). Claim renewal never touched it.

So during any >60s gap between trace steps (a long build, a long thinking phase, waiting on the host session) the turn was alive and renewing its claim, but the heartbeat went stale → orphan cleanup flipped the session to FAILED and emitted `agent_session:failed` (the red). The runtime, oblivious, kept POSTing steps (content kept appearing) and eventually called `/complete` — which sent the message but only finalized the session in `completeBotInvocation` **`if (session?.status === RUNNING)`**. Since it was now FAILED, completion silently skipped finalizing, `agent_session:completed` never fired, and the trace stayed red forever.

The in-process companion (15s `updateHeartbeat` interval, `companion/session.ts`) and the E2E enclave (heartbeat callback, `enclave-runtimes/session-handlers.ts`) never hit this — only the bot-invocation path lacked a between-steps heartbeat.

## Solution

Give the bot-invocation path the same between-steps heartbeat the other runtimes have, and make a successful completion authoritative over a stale-heartbeat failure.

### How it works

1. **Bump the session heartbeat on claim renewal.** `renewBotInvocationClaim` (`handlers.ts`) now calls `AgentSessionRepository.updateHeartbeat(pool, req.params.invocationId)` after the claim renews. Bot invocations reuse the invocation id as the agent session id, so this keeps the session fresh on the runtime's actual liveness cadence — mirroring the enclave's heartbeat callback and the companion's interval. It no-ops for session-control invocations (those create no agent session) and for already-terminal sessions (`findOrphaned` only scans RUNNING).

2. **Recover an orphan-failed session on successful completion.** `completeBotInvocation` finalizes the session when it is `RUNNING` **or** `FAILED`, passing `recoverFromFailed: true`. `completeSession` (`session-repository.ts`) gains that opt-in: its guard becomes `status = ANY(['running','failed'])` and it clears `error = NULL`. The status-guarded UPDATE stays race-safe against a concurrent cleanup (INV-20): cleanup's `updateStatus(..., onlyIfStatus: RUNNING)` and this completion can't both win.

3. **Renders as one card.** No frontend change. `event-list.tsx` already groups a session's `agent_session:*` events into one `session_group`, and `agent-session-event.tsx`'s `deriveStatus` applies completed-over-failed precedence ("intermediate failures can be recovered"). The recovered turn (started → failed → completed) collapses to a single "Session complete".

### Key design decisions

**1. Heartbeat on renew rather than teaching `findOrphaned` about claims.** The orphan detector is deliberately runtime-agnostic — it scans `heartbeat_at` and knows nothing about enclaves, companions, or bot invocations. Each runtime feeds it liveness through that one column. Joining `agent_sessions` to `bot_invocations` inside `findOrphaned` would fix the symptom but couple the agents feature to another feature's table and special-case one runtime in the generic detector. Bumping the heartbeat on renew keeps the detector generic and makes the bot path consistent with the enclave/companion.

**2. Recovery is safe because reaching completion proves the claim was valid.** `completeBotInvocation` only proceeds past `findActiveClaimForUpdate`, which requires `status = 'claimed' AND claim_token = … AND claim_expires_at > NOW()`. A genuine `/fail` (`failBotInvocation`) flips `bot_invocations.status` to `'failed'`, which makes that lookup 404 — so we never reach the finalize block after a real failure. Therefore a FAILED **agent session** at the completion point is exclusively an orphan-cleanup artifact, and recovering it to COMPLETED is correct, not a mask over a real error.

**3. `error = NULL` on completion is unconditional.** A COMPLETED session should carry no error; for the RUNNING path `error` is already NULL (no-op), and on recovery it clears the stale `"Session orphaned (stale heartbeat)"` string. Correct for every caller of `completeSession`.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/session-repository.ts` | `completeSession` gains opt-in `recoverFromFailed` (guard `status = ANY([running,failed])`, clears `error`). Default behavior unchanged for all existing callers. |
| `apps/backend/src/features/public-api/handlers.ts` | `renewBotInvocationClaim` bumps the session heartbeat after renew; `completeBotInvocation` finalizes from RUNNING **or** FAILED with `recoverFromFailed: true`. |
| `apps/backend/src/features/public-api/complete-invocation-floor.test.ts` | Adds the orphan-recovery case: a FAILED session completes with `recoverFromFailed: true` and emits `agent_session:completed`; helper parametrized with `sessionStatus`. |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/public-api/renew-heartbeat.test.ts` | Renew bumps `updateHeartbeat(pool, invocationId)`; no bump when the claim is gone (404). |

## Out of scope (deliberate)

- **Sealed (E2E) completion recovery.** `completeBotInvocationSealed` goes through `authorizeSealedInvocationCallback` → `assertSessionRunning`, which rejects an orphan-failed session before finalize. The heartbeat-on-renew fix (#1) protects the sealed path from the orphan race too, so this is now a rare residual rather than the reported defect. Granting sealed completions the same recovery would mean relaxing `assertSessionRunning`, which also gates `/sealed-steps` and `/sealed-steps/started` — broader blast radius, left for a focused follow-up.
- **`failBotInvocation` emitting its own `agent_session:failed` lifecycle.** A genuine `/fail` still relies on orphan cleanup to flip the session and emit the lifecycle (pre-existing behavior). Unchanged here.

## Test plan

- [x] `bun test apps/backend/src/features/public-api/complete-invocation-floor.test.ts apps/backend/src/features/public-api/renew-heartbeat.test.ts` — 11 pass
- [x] `bun test apps/backend/src/features/public-api apps/backend/src/features/bot-runtimes` — 150 pass
- [x] `bun test apps/backend/src/features/agents/session-repository.test.ts apps/backend/src/features/agents/orphan-session-cleanup.test.ts` — 9 pass
- [x] Backend typecheck (`@threa/backend`) — exit 0
- [x] Self-review: manual correctness + claim-verification pass over the 4-file diff against the code (heartbeat cadences, claim-validity-implies-not-genuinely-failed, INV-20 race-safety, frontend grouping/precedence). No findings.
- [ ] No live-DB harness in this slice, so `completeSession`'s `status = ANY(...)` guard and the renew heartbeat write are covered via stubbed repo spies (the established pattern in these handler tests), not integration-tested against Postgres.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUBtyyCYYB4zi4bf1WtczD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784496037&installation_id=129946197&pr_number=1020&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1020&signature=b76640d7f93f89bec5e71d053e2f285d381ab1e8960d1710335d52a7b59c6f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->