### PR TITLE
fix(editor): guard external-content sync so a failed setContent can't wedge the composer

### DIFF
--- a/apps/frontend/src/components/editor/apply-external-content.test.ts
+++ b/apps/frontend/src/components/editor/apply-external-content.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import type { JSONContent } from "@threa/types"
+import { applyExternalEditorContent, type ExternalContentEditor } from "./apply-external-content"
+
+const DOC: JSONContent = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }] }
+
+/**
+ * A structural editor fake. `setContentImpl` runs inside the mocked `setContent`
+ * and receives the editor, so a case can throw or simulate the contenteditable
+ * replace dropping focus (`editor.isFocused = false`).
+ */
+function makeEditor(opts: { isFocused?: boolean; setContentImpl?: (editor: ExternalContentEditor) => void } = {}): {
+  editor: ExternalContentEditor
+  setContent: ReturnType<typeof vi.fn>
+  focus: ReturnType<typeof vi.fn>
+} {
+  const focus = vi.fn()
+  const editor: ExternalContentEditor = {
+    isFocused: opts.isFocused ?? false,
+    commands: {
+      setContent: vi.fn(() => opts.setContentImpl?.(editor)),
+      focus,
+    },
+  }
+  return { editor, setContent: editor.commands.setContent as ReturnType<typeof vi.fn>, focus }
+}
+
+describe("applyExternalEditorContent", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("applies the content and clears the internal-update guard", () => {
+    const { editor, setContent } = makeEditor()
+    const isInternalUpdate = { current: false }
+
+    const applied = applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(applied).toBe(true)
+    expect(setContent).toHaveBeenCalledWith(DOC)
+    expect(isInternalUpdate.current).toBe(false)
+  })
+
+  it("never strands the internal-update guard when setContent throws", () => {
+    // The load-bearing guarantee: a throw must not leave `isInternalUpdate` true,
+    // which would freeze the editor and swallow every later onUpdate (the composer
+    // going dead until a remount — the draft-restore failure this hardens).
+    const { editor } = makeEditor({
+      setContentImpl: () => {
+        throw new Error("unparseable doc")
+      },
+    })
+    const isInternalUpdate = { current: false }
+
+    const applied = applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(applied).toBe(false)
+    expect(isInternalUpdate.current).toBe(false)
+  })
+
+  it("restores focus after a successful replace if focus was dropped", () => {
+    // contenteditable replace can drop focus; the helper re-focuses to keep the
+    // mobile keyboard open.
+    const { editor, focus } = makeEditor({
+      isFocused: true,
+      setContentImpl: (e) => {
+        e.isFocused = false
+      },
+    })
+    const isInternalUpdate = { current: false }
+
+    applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not try to restore focus when the content failed to apply", () => {
+    const { editor, focus } = makeEditor({
+      isFocused: true,
+      setContentImpl: () => {
+        throw new Error("boom")
+      },
+    })
+    const isInternalUpdate = { current: false }
+
+    applyExternalEditorContent(editor, DOC, isInternalUpdate)
+
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/editor/apply-external-content.ts
+++ b/apps/frontend/src/components/editor/apply-external-content.ts
@@ -1,0 +1,53 @@
+import type { JSONContent } from "@threa/types"
+
+/**
+ * The minimal editor surface the external-content sync touches. Kept structural
+ * so the guard can be unit-tested with a fake whose `setContent` throws, without
+ * standing up a real TipTap instance (the rest of the suite mocks the editor).
+ */
+export interface ExternalContentEditor {
+  isFocused: boolean
+  commands: {
+    setContent: (content: JSONContent) => void
+    focus: () => void
+  }
+}
+
+/**
+ * Apply an externally-supplied value (e.g. a restored draft body) to the editor,
+ * guarding the `isInternalUpdate` flag so a throw can NEVER strand it `true`.
+ *
+ * Stranding it true is the load-bearing failure: it both freezes the editor on
+ * the stale doc AND turns every later `onUpdate` into a no-op, so the composer
+ * goes dead — typing isn't even persisted — until a remount (the "draft restore
+ * did nothing until I refreshed" report). The `finally` makes that impossible.
+ *
+ * Returns whether the content was applied; the caller retries on `false` so the
+ * (correct) source content still reaches the editor rather than leaving a blank
+ * composer over a draft the restore already checked out of the stash.
+ */
+export function applyExternalEditorContent(
+  editor: ExternalContentEditor,
+  editableValue: JSONContent,
+  isInternalUpdate: { current: boolean }
+): boolean {
+  const hadFocus = editor.isFocused
+  let applied = false
+  isInternalUpdate.current = true
+  try {
+    editor.commands.setContent(editableValue)
+    applied = true
+  } catch (err) {
+    console.error("Editor failed to apply external content", err)
+  } finally {
+    isInternalUpdate.current = false
+  }
+
+  // Mobile browsers can drop focus when contenteditable content is replaced.
+  // Restore it to keep the virtual keyboard open — only when we actually applied.
+  if (applied && hadFocus && !editor.isFocused) {
+    editor.commands.focus()
+  }
+
+  return applied
+}

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -5,6 +5,7 @@ import type { ResolvedPos } from "@tiptap/pm/model"
 import type { PluginKey } from "@tiptap/pm/state"
 import { useParams } from "react-router-dom"
 import { createEditorExtensions } from "./editor-extensions"
+import { applyExternalEditorContent } from "./apply-external-content"
 import { getDictationChunkPositions } from "./dictation-chunk-extension"
 import { EditorBehaviors, isSuggestionActive } from "./editor-behaviors"
 import { EditorToolbar } from "./editor-toolbar"
@@ -221,6 +222,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 ) {
   const containerRef = useRef<HTMLDivElement>(null)
   const isInternalUpdate = useRef(false)
+  // Retry trigger + bounded counter for the external-value sync below. If
+  // applying restored content throws, we re-run the sync on the next frame so
+  // the body still lands rather than leaving the composer blank over a draft
+  // that the restore already checked out of the stash (the "dead until refresh"
+  // draft-restore failure).
+  const [externalSyncNonce, setExternalSyncNonce] = useState(0)
+  const externalSyncFailuresRef = useRef(0)
   const [isFocused, setIsFocused] = useState(false)
   const [hasSelection, setHasSelection] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
@@ -754,18 +762,26 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
 
     const currentJson = JSON.stringify(editor.getJSON())
     const newJson = JSON.stringify(editableValue)
-    if (newJson !== currentJson) {
-      const hadFocus = editor.isFocused
-      isInternalUpdate.current = true
-      editor.commands.setContent(editableValue)
-      isInternalUpdate.current = false
-      // Mobile browsers can drop focus when contenteditable content is replaced.
-      // Restore it to keep the virtual keyboard open.
-      if (hadFocus && !editor.isFocused) {
-        editor.commands.focus()
-      }
+    if (newJson === currentJson) {
+      externalSyncFailuresRef.current = 0
+      return
     }
-  }, [editableValue, editor])
+
+    if (applyExternalEditorContent(editor, editableValue, isInternalUpdate)) {
+      externalSyncFailuresRef.current = 0
+      return
+    }
+
+    // The source content is correct (it reached us as `value`); the editor just
+    // failed to take it. Re-run next frame so the restored body still lands
+    // instead of leaving a blank composer over a now-checked-out draft. Bounded
+    // so a genuinely unparseable doc can't spin.
+    if (externalSyncFailuresRef.current < 3) {
+      externalSyncFailuresRef.current += 1
+      const raf = requestAnimationFrame(() => setExternalSyncNonce((n) => n + 1))
+      return () => cancelAnimationFrame(raf)
+    }
+  }, [editableValue, editor, externalSyncNonce])
 
   // Re-parse content when mentionables load or currentUser becomes known (for correct mention type colors)
   useEffect(() => {
@@ -799,15 +815,24 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       const markdown = serializeToMarkdown(editor.getJSON())
       if (markdown) {
         isInternalUpdate.current = true
-        editor.commands.setContent(
-          parseMarkdown(
-            markdown,
-            enableMentions ? getMentionType : undefined,
-            enableEmoji ? toEmoji : undefined,
-            markdownParseOptions
+        try {
+          editor.commands.setContent(
+            parseMarkdown(
+              markdown,
+              enableMentions ? getMentionType : undefined,
+              enableEmoji ? toEmoji : undefined,
+              markdownParseOptions
+            )
           )
-        )
-        isInternalUpdate.current = false
+        } catch (err) {
+          // Same guard as the external-value sync: a throw must not strand the
+          // flag true, or every later onUpdate is swallowed and the composer
+          // goes dead. The reparse is cosmetic, so dropping it leaves the
+          // already-displayed content intact.
+          console.error("Editor failed to reparse content for mention types", err)
+        } finally {
+          isInternalUpdate.current = false
+        }
       }
     }
   }, [

--- a/apps/frontend/src/hooks/use-stash-composer.integration.test.tsx
+++ b/apps/frontend/src/hooks/use-stash-composer.integration.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { createElement, type ReactNode } from "react"
+import type { JSONContent } from "@threa/types"
+import { db } from "@/db"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
+import { useDraftComposer } from "./use-draft-composer"
+import { useStashComposer } from "./use-stash-composer"
+import { upsertLoadedDraft, stashLoadedDraft } from "./use-draft-message"
+import * as currentUserHook from "./use-current-workspace-user-id"
+import * as e2eSessionStore from "@/stores/e2e-session-store"
+
+// Real data layer (fake-indexeddb), real composer + stash hooks. The only seams
+// are the viewer id + E2E session, defaulted to "no viewer / locked" so the
+// plaintext path runs without an AuthProvider — exactly as use-draft-message.test.ts.
+const LOCKED_SESSION = {
+  status: "locked",
+  keyId: null,
+  publicKey: null,
+  privateKey: null,
+  deviceTrusted: false,
+  error: null,
+} as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+const workspaceId = "ws_123"
+const streamId = "stream_456"
+const draftKey = `stream:${streamId}`
+
+/**
+ * A faithful "large message with an attachment": several text blocks plus an
+ * inline `attachmentReference` chip — the shape of the real scratchpad draft
+ * that failed to restore (a pasted image embedded in a multi-paragraph note).
+ */
+const BIG_BODY: JSONContent = {
+  type: "doc",
+  content: [
+    { type: "paragraph", content: [{ type: "text", text: "First paragraph of a long note." }] },
+    { type: "paragraph", content: [{ type: "text", text: "Second paragraph with more detail." }] },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Here is the screenshot " },
+        {
+          type: "attachmentReference",
+          attrs: {
+            id: "attach_big",
+            filename: "pasted-image-1.png",
+            mimeType: "image/png",
+            sizeBytes: 380784,
+            status: "uploaded",
+            imageIndex: 1,
+            error: null,
+          },
+        },
+      ],
+    },
+    { type: "paragraph", content: [{ type: "text", text: "Closing thoughts." }] },
+  ],
+}
+const BIG_ATTACHMENT = { id: "attach_big", filename: "pasted-image-1.png", mimeType: "image/png", sizeBytes: 380784 }
+const AMBIENT_BODY: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "ambient draft" }] }],
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(MemoryRouter, { initialEntries: ["/"] }, children)
+}
+
+function useRestoreHarness() {
+  const composer = useDraftComposer({ workspaceId, draftKey, scopeId: streamId })
+  const stash = useStashComposer(composer, workspaceId, draftKey)
+  return { composer, stash }
+}
+
+describe("stash restore — no-limbo invariant (real data layer)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Seed the scope with a stashed "big" draft (body + inline attachment) and a
+   * separate loaded ambient draft — the exact shape of the reported bug (a stash
+   * pile where the user restores the long, attachment-carrying entry).
+   */
+  async function seedStashAndAmbient(): Promise<{ bigId: string }> {
+    const big = await upsertLoadedDraft(workspaceId, draftKey, {
+      contentJson: BIG_BODY,
+      attachments: [BIG_ATTACHMENT],
+    })
+    await stashLoadedDraft(workspaceId, draftKey) // detach -> big becomes a stash entry
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: AMBIENT_BODY, attachments: [] })
+    await seedDraftCacheFromIdb(workspaceId)
+    return { bigId: big.id }
+  }
+
+  it("restores the big draft's body into the composer AND keeps the row recoverable", async () => {
+    const { bigId } = await seedStashAndAmbient()
+
+    const { result } = renderHook(() => useRestoreHarness(), { wrapper })
+
+    // Composer starts on the ambient draft.
+    await waitFor(() => expect(result.current.composer.content).toEqual(AMBIENT_BODY))
+
+    await act(async () => {
+      await result.current.stash.handleRestoreStashed(bigId)
+    })
+
+    // 1) The restored body is VISIBLE in the composer (not blank) — no limbo.
+    await waitFor(() => expect(result.current.composer.content).toEqual(BIG_BODY))
+    // 2) Its attachment chip came back with it.
+    await waitFor(() => expect(result.current.composer.pendingAttachments.map((a) => a.id)).toContain("attach_big"))
+    // 3) The draft row was never destroyed — it is still on disk and now the loaded one.
+    expect(await db.drafts.get(bigId)).toBeDefined()
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId)
+    // 4) The previously-loaded ambient draft is preserved as a stash sibling (swap, not clobber).
+    await waitFor(() => expect(result.current.stash.drafts.some((d) => d.contentJson)).toBe(true))
+  })
+})

--- a/apps/frontend/src/hooks/use-stash-composer.test.ts
+++ b/apps/frontend/src/hooks/use-stash-composer.test.ts
@@ -12,9 +12,13 @@ import { upsertLoadedDraft, stashLoadedDraft } from "./use-draft-message"
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
 
-// Real data layer (fake-indexeddb), real composer + stash hooks. The only seams
-// are the viewer id + E2E session, defaulted to "no viewer / locked" so the
-// plaintext path runs without an AuthProvider — exactly as use-draft-message.test.ts.
+// Hook-level test (renderHook), like its siblings use-draft-message.test.ts and
+// use-draft-composer.test.ts: it pins the no-limbo DATA invariant of restore
+// against the real data layer (fake-indexeddb). It deliberately does not mount a
+// component — RichEditor is mocked suite-wide, so a mounted flow wouldn't exercise
+// the real editor sync anyway; that hop is unit-tested in apply-external-content.test.ts.
+// The only seams are the viewer id + E2E session, defaulted to "no viewer / locked"
+// so the plaintext path runs without an AuthProvider.
 const LOCKED_SESSION = {
   status: "locked",
   keyId: null,
@@ -96,19 +100,19 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
    * separate loaded ambient draft — the exact shape of the reported bug (a stash
    * pile where the user restores the long, attachment-carrying entry).
    */
-  async function seedStashAndAmbient(): Promise<{ bigId: string }> {
+  async function seedStashAndAmbient(): Promise<{ bigId: string; ambientId: string }> {
     const big = await upsertLoadedDraft(workspaceId, draftKey, {
       contentJson: BIG_BODY,
       attachments: [BIG_ATTACHMENT],
     })
     await stashLoadedDraft(workspaceId, draftKey) // detach -> big becomes a stash entry
-    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: AMBIENT_BODY, attachments: [] })
+    const ambient = await upsertLoadedDraft(workspaceId, draftKey, { contentJson: AMBIENT_BODY, attachments: [] })
     await seedDraftCacheFromIdb(workspaceId)
-    return { bigId: big.id }
+    return { bigId: big.id, ambientId: ambient.id }
   }
 
   it("restores the big draft's body into the composer AND keeps the row recoverable", async () => {
-    const { bigId } = await seedStashAndAmbient()
+    const { bigId, ambientId } = await seedStashAndAmbient()
 
     const { result } = renderHook(() => useRestoreHarness(), { wrapper })
 
@@ -127,6 +131,6 @@ describe("stash restore — no-limbo invariant (real data layer)", () => {
     expect(await db.drafts.get(bigId)).toBeDefined()
     expect((await db.composerLoaded.get(draftKey))?.draftId).toBe(bigId)
     // 4) The previously-loaded ambient draft is preserved as a stash sibling (swap, not clobber).
-    await waitFor(() => expect(result.current.stash.drafts.some((d) => d.contentJson)).toBe(true))
+    await waitFor(() => expect(result.current.stash.drafts.some((d) => d.id === ambientId)).toBe(true))
   })
 })


### PR DESCRIPTION
## Problem

A draft restore (stash → composer) intermittently restored **nothing** — the composer stayed blank and felt dead until a full page refresh, which then loaded the draft perfectly. Reported against a "large message with an attachment."

Read-only prod forensics on the actual rows narrowed it down and ruled out the obvious suspects:

- The stream (`stream_01KVGSGW…`) is a **plaintext scratchpad**, not E2E — no decrypt-on-restore path involved.
- The draft (`draft_mqle4ox2…`) is small: 5 top-level blocks, ~4 KB of content JSON, with one inline pasted image. The 372 KB PNG renders as a lightweight `[Image #1]` chip (`AttachmentReferenceView`) — it never loads the bytes inline — so neither body size nor image weight is on the restore path.

So "large message" was a misperception, and size/encryption/heavy-rendering are all out. The load-bearing clue is that a **refresh always recovered it**: the persisted state (the `composerLoaded` pointer + the IDB draft row) was already correct, so the data-layer restore succeeded and only the **live editor re-hydration** failed.

Two things make that failure a trap rather than a cosmetic glitch:

1. **Restore is a pointer swap.** `restoreStashedDraftToComposer` is a pure `db.composerLoaded.put` (`use-draft-message.ts`), and `useStashedDrafts` returns every draft for the scope *except* the loaded one (`use-stashed-drafts.ts`). So the instant the pointer moves, the draft **leaves the stash list**. If the editor then doesn't show it, it's gone from the stash *and* blank in the composer — limbo, recoverable only by refresh. (It's never *lost*: the row + pointer persist. That's exactly why refresh worked.)
2. **The editor sync could wedge.** The external-value sync did `isInternalUpdate.current = true` → `editor.commands.setContent(...)` → reset, with no guard. If `setContent` throws, the flag is stranded `true`. `onUpdate` early-returns on that flag (`if (isInternalUpdate.current) return`, `rich-editor.tsx`), so a stranded `true` both freezes the editor on the stale doc **and** turns every later keystroke into a no-op — the composer goes fully dead (typing isn't even saved) until a remount.

## Solution

Close the limbo at both layers: prove the data-layer restore never loses the draft, and make the editor hop unwedgeable and self-healing.

### How it works

- **`applyExternalEditorContent`** (new) wraps the `setContent` in `try/finally`, so `isInternalUpdate` can **never** strand `true` — the "composer goes dead until refresh" failure becomes impossible. Returns whether the content applied, and restores focus (the contenteditable-replace-drops-focus case) only on success.
- **Bounded retry.** When `applyExternalEditorContent` reports the editor didn't take the content, the sync re-runs on the next frame (via a `requestAnimationFrame` → `externalSyncNonce` bump, capped at 3) so the *correct* source content still lands instead of leaving a blank composer over a now-checked-out draft. The happy path is unchanged — it resets the failure counter and returns without scheduling anything.
- **Same guard on the mention-reparse** `setContent` in `rich-editor.tsx` — identical stranding risk; a throw there now drops the cosmetic reparse instead of killing the composer.

## Key design decisions

**1. Retry, not just `try/finally`.** `try/finally` alone un-wedges the editor but, if `setContent` failed, leaves it blank — and since `editableValue` is unchanged, the effect won't re-run on its own. That's still limbo. The bounded retry is what guarantees the restored body actually reaches the editor. Capped at 3 so a genuinely unparseable doc can't spin.

**2. Extract a pure helper rather than inline the guard.** The rest of the editor suite mocks `RichEditor` (there is no real-TipTap test harness), so an inline `try/finally` would be untestable. A small structural helper (`ExternalContentEditor`) lets a unit test supply a fake whose `setContent` throws and assert the flag is not stranded — the one guarantee that matters.

**3. Don't touch the hook re-hydration.** The integration test confirms `useDraftComposer`/`useStashComposer` already land the body in `composer.content` and never lose the row. The delicate late-hydrate rising-edge logic (which guards the send-clear re-fill case) is left alone.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/editor/apply-external-content.ts` | The `try/finally`-guarded external-content apply + structural `ExternalContentEditor` type. |
| `apps/frontend/src/components/editor/apply-external-content.test.ts` | Unit tests: applies + clears the flag, **never strands the flag on throw**, focus-restore on success, no focus-restore on failure. |
| `apps/frontend/src/hooks/use-stash-composer.integration.test.tsx` | Real-data-layer (fake-indexeddb) no-limbo invariant: a stash→restore of a plaintext draft with an inline attachment lands the body, restores the chip, keeps the row, preserves the swapped-out sibling. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/editor/rich-editor.tsx` | External-value sync routes through `applyExternalEditorContent` + bounded rAF retry (`externalSyncNonce`/`externalSyncFailuresRef`); mention-reparse `setContent` wrapped in the same `try/finally`. |

## Out of scope (deliberate)

- **The exact `setContent` throw is not reproduced.** With no real-TipTap harness and small plaintext input, I could not force the deterministic failing line. The editor hardening is therefore **defensive** — it makes the "dead until refresh" mode impossible and matches the symptom, rather than proving it was the precise trigger this time. The integration test proves the half I *can* exercise end-to-end (the no-limbo data invariant).
- **The rAF retry loop itself is not unit-tested** (same harness gap). The helper's `applied`/throw branches that *drive* the retry are tested; the effect wiring is read-verified.
- No change to the hook re-hydration state machine, the pointer-swap semantics, or any persistence path.

## Test plan

- [x] `bunx vitest run src/components/editor/apply-external-content.test.ts src/hooks/use-stash-composer.integration.test.tsx` — 5 pass (4 helper + 1 integration)
- [x] `bunx vitest run src/components/editor src/components/composer src/hooks/use-draft-composer.test.ts src/hooks/use-draft-message.test.ts` — 502 pass, 31 files (no regressions)
- [x] Full monorepo `tsc --noEmit` clean (run by the pre-commit hook) + eslint clean on changed files
- [ ] Not manually reproduced/fixed against a live failing restore — no deterministic repro for the underlying `setContent` throw (see Out of scope)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcBAou68634An4bfDoGy5d)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784523179&installation_id=129946197&pr_number=1022&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1022&signature=a3ba52778560b3002ae7c0ee545f9b3e6d19867feafe6e2e87d599c9cacf387e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->