### PR TITLE
fix(frontend): let markdown tables flow instead of forcing full width

### DIFF
--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -372,10 +372,12 @@ export const markdownComponents: Components = {
     return null
   },
 
-  // Tables - use Shadcn UI Table
+  // Tables - use Shadcn UI Table. Let content set the width so long paths,
+  // URLs, and paragraphs flow naturally and the wrapper scrolls horizontally
+  // on narrow viewports instead of crushing cells into tight wrapping.
   table: ({ children }) => (
     <div className="my-2 overflow-x-auto">
-      <Table>{children}</Table>
+      <Table className="w-auto table-auto">{children}</Table>
     </div>
   ),
   thead: ({ children }) => <TableHeader>{children}</TableHeader>,


### PR DESCRIPTION
## Problem

Timeline markdown tables rendered with `Table`'s default `w-full`, so on narrow/mobile viewports the browser squeezed every column to fit the screen. Long paths, URLs, and code tokens had no room and wrapped one character (or one word) per line, making tables like the code-review summary hard to read even though the wrapper already supported horizontal scroll.

## Solution

Stop forcing markdown tables to 100 % width. Let the table size itself from its content and rely on the existing `overflow-x-auto` wrapper to scroll horizontally when the content is wider than the message column.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/markdown/components.tsx` | Markdown `table` component now passes `className="w-auto table-auto"` to the Shadcn `Table` so content-driven column widths replace full-width squeezing. |

## Out of scope (deliberate)

Composer tables (`apps/frontend/src/index.css`) keep their fixed-layout, full-width styling. They are editable and use TipTap's table controls; changing their layout could break column resizing and WYSIWYG parity is a separate concern from the read-only timeline tables shown in the screenshot.

## Test plan

- [x] `apps/frontend` `bun run test -- src/components/ui/markdown-content.test.tsx --run` — 50 pass
- [x] `apps/frontend` `bun run typecheck` — clean
- [x] Pre-commit lint / typecheck / migration checks — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784526189&installation_id=129946197&pr_number=1023&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1023&signature=b38692e37b960fbc93739ea944120f3aaf1849487d1db696cabb97073337f999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->