### PR TITLE
feat(frontend): show attached external agent in scratchpad companion settings

### DIFF
--- a/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
+++ b/apps/frontend/src/components/stream-settings/agent-settings-panel.tsx
@@ -3,7 +3,9 @@ import { Moon, Sparkles } from "lucide-react"
 import { CompanionModes, type CompanionMode, type ToolPrivacyCategory, type ToolPrivacyPolicy } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
+import type { ActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { ToolPolicyControl } from "./tool-policy-picker"
+import { ExternalAgentIndicator } from "./external-agent-indicator"
 
 export interface AgentToolPolicyBinding {
   value: ToolPrivacyPolicy
@@ -20,6 +22,8 @@ interface AgentSettingsPanelProps {
   companionBusy?: boolean
   /** Tool-access section; omit to hide it (e.g. the viewer isn't the owner). */
   toolPolicy?: AgentToolPolicyBinding
+  /** External agent attached to the scratchpad, surfaced above the mode radios. */
+  externalAgent?: ActiveBotPresence | null
 }
 
 /**
@@ -33,9 +37,12 @@ export function AgentSettingsPanel({
   onCompanionModeChange,
   companionBusy,
   toolPolicy,
+  externalAgent,
 }: AgentSettingsPanelProps) {
   return (
     <div className="space-y-4">
+      {externalAgent && <ExternalAgentIndicator agent={externalAgent} />}
+
       <div className="space-y-2">
         <Label className="text-sm font-medium">Companion mode</Label>
         <div role="radiogroup" aria-label="Companion mode" className="grid grid-cols-2 gap-2">

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utils"
 import { useUpdateCompanionMode } from "@/hooks/use-streams"
+import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import {
   CompanionModes,
   type CompanionMode,
@@ -11,6 +12,7 @@ import {
   type ToolPrivacyPolicy,
 } from "@threa/types"
 import { ToolPolicyPicker } from "./tool-policy-picker"
+import { ExternalAgentIndicator } from "./external-agent-indicator"
 
 interface CompanionTabProps {
   workspaceId: string
@@ -31,6 +33,7 @@ export function CompanionTab({
   canManageToolPolicy,
 }: CompanionTabProps) {
   const { mutateAsync: updateCompanionMode, isPending } = useUpdateCompanionMode(workspaceId, stream.id)
+  const externalAgent = useActiveBotPresence(workspaceId, stream.id)
 
   // On encrypted scratchpads Ariadne runs in the enclave (never the plaintext
   // companion path), so the toggle is a real control here too: Companion =
@@ -50,6 +53,8 @@ export function CompanionTab({
 
   return (
     <div className="space-y-6 p-1">
+      {externalAgent && <ExternalAgentIndicator agent={externalAgent} />}
+
       <div className="space-y-3">
         <div className="space-y-1">
           <Label className="text-sm font-medium">Companion mode</Label>

--- a/apps/frontend/src/components/stream-settings/external-agent-indicator.tsx
+++ b/apps/frontend/src/components/stream-settings/external-agent-indicator.tsx
@@ -1,0 +1,43 @@
+import { BotRuntimeStatuses } from "@threa/types"
+import { cn } from "@/lib/utils"
+import type { ActiveBotPresence } from "@/hooks/use-active-bot-presence"
+
+interface ExternalAgentIndicatorProps {
+  agent: ActiveBotPresence
+}
+
+/**
+ * Read-only signal that an external agent (a bot runtime, e.g. a Pi remote) is
+ * attached to this scratchpad. External attachment is orthogonal to companion
+ * mode — it's granted through bot channel access, not the companion radio — so
+ * the settings surfaces show it rather than letting it hide behind a Quiet/
+ * Companion choice that doesn't describe it. The green dot mirrors the header
+ * pill: connected when the runtime is available/busy, grey otherwise.
+ */
+export function ExternalAgentIndicator({ agent }: ExternalAgentIndicatorProps) {
+  const connected =
+    agent.presence?.status === BotRuntimeStatuses.AVAILABLE || agent.presence?.status === BotRuntimeStatuses.BUSY
+
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-border bg-secondary/50 p-3">
+      <span
+        className={cn(
+          "mt-1 inline-block size-2 shrink-0 rounded-full",
+          connected ? "bg-emerald-500" : "bg-muted-foreground/40"
+        )}
+        aria-hidden="true"
+      />
+      <div className="space-y-0.5">
+        <p className="text-sm font-medium text-foreground">
+          {agent.bot.avatarEmoji ? `${agent.bot.avatarEmoji} ` : ""}
+          {agent.bot.name}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {connected
+            ? "External agent connected — it reads and replies to messages here."
+            : "External agent attached, not connected — it will read and reply once its runtime reconnects."}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx
@@ -8,7 +8,10 @@ import type { ToolPrivacyCategory, ToolPrivacyPolicy } from "@threa/types"
 import { streamKeys } from "@/hooks"
 import * as streamsHooks from "@/hooks/use-streams"
 import * as workspacesHooks from "@/hooks/use-workspaces"
+import * as workspaceStore from "@/stores/workspace-store"
 import { LiveAgentSettings } from "./live-agent-settings"
+
+type WorkspaceBot = ReturnType<typeof workspaceStore.useWorkspaceBots>[number]
 
 const companionMutate = vi.fn(async () => {})
 const toolMutate = vi.fn(async () => {})
@@ -27,6 +30,7 @@ beforeEach(() => {
   vi.spyOn(workspacesHooks, "useCurrentWorkspaceUser").mockReturnValue({
     id: "user_owner",
   } as unknown as ReturnType<typeof workspacesHooks.useCurrentWorkspaceUser>)
+  vi.spyOn(workspaceStore, "useWorkspaceBots").mockReturnValue([])
 })
 
 function seedAndRender(opts: {
@@ -34,12 +38,20 @@ function seedAndRender(opts: {
   allowed?: ToolPrivacyPolicy
   configured?: ToolPrivacyCategory[]
   e2e?: boolean
+  botMemberIds?: string[]
+  botRuntimePresence?: Record<string, { status: string } | null>
+  bots?: WorkspaceBot[]
 }) {
+  if (opts.bots) {
+    vi.spyOn(workspaceStore, "useWorkspaceBots").mockReturnValue(opts.bots)
+  }
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   queryClient.setQueryData(streamKeys.bootstrap("ws_1", "stream_sp"), {
     stream: { createdBy: opts.createdBy ?? "user_owner" },
     allowedToolCategories: opts.allowed ?? null,
     configuredToolCategories: opts.configured,
+    botMemberIds: opts.botMemberIds,
+    botRuntimePresence: opts.botRuntimePresence,
   })
   function Wrapper({ children }: { children: ReactNode }) {
     return createElement(QueryClientProvider, { client: queryClient }, createElement(TooltipProvider, null, children))
@@ -72,5 +84,34 @@ describe("LiveAgentSettings", () => {
 
     expect(screen.queryByRole("switch", { name: /restrict tool access/i })).not.toBeInTheDocument()
     expect(screen.getByRole("radio", { name: /companion/i })).toBeInTheDocument()
+  })
+
+  it("surfaces an attached, connected external agent above the mode radios", () => {
+    seedAndRender({
+      botMemberIds: ["bot_pi"],
+      botRuntimePresence: { bot_pi: { status: "available" } },
+      bots: [{ id: "bot_pi", name: "Pi Remote" } as WorkspaceBot],
+    })
+
+    expect(screen.getByText("Pi Remote")).toBeInTheDocument()
+    expect(screen.getByText(/connected/i)).toBeInTheDocument()
+    expect(screen.getByText(/reads and replies/i)).toBeInTheDocument()
+  })
+
+  it("shows an attached external agent as not connected when its runtime is offline", () => {
+    seedAndRender({
+      botMemberIds: ["bot_pi"],
+      botRuntimePresence: { bot_pi: { status: "offline" } },
+      bots: [{ id: "bot_pi", name: "Pi Remote" } as WorkspaceBot],
+    })
+
+    expect(screen.getByText("Pi Remote")).toBeInTheDocument()
+    expect(screen.getByText(/not connected/i)).toBeInTheDocument()
+  })
+
+  it("shows no external-agent indicator when none is attached", () => {
+    seedAndRender({})
+
+    expect(screen.queryByText(/external agent/i)).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
+++ b/apps/frontend/src/components/stream-settings/live-agent-settings.tsx
@@ -4,6 +4,7 @@ import type { CompanionMode, StreamBootstrap, ToolPrivacyPolicy } from "@threa/t
 import { streamKeys } from "@/hooks"
 import { useUpdateCompanionMode, useUpdateToolPolicy } from "@/hooks/use-streams"
 import { useCurrentWorkspaceUser } from "@/hooks/use-workspaces"
+import { useActiveBotPresence } from "@/hooks/use-active-bot-presence"
 import { AgentSettingsPanel } from "./agent-settings-panel"
 
 interface LiveAgentSettingsProps {
@@ -25,6 +26,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
   const { mutateAsync: updateCompanionMode, isPending: companionBusy } = useUpdateCompanionMode(workspaceId, streamId)
   const { mutateAsync: updateToolPolicy, isPending: toolBusy } = useUpdateToolPolicy(workspaceId, streamId)
   const currentUser = useCurrentWorkspaceUser(workspaceId)
+  const externalAgent = useActiveBotPresence(workspaceId, streamId)
 
   // Cache-only observer: re-renders when a mutation patches the bootstrap.
   const { data: bootstrap } = useQuery({
@@ -58,6 +60,7 @@ export function LiveAgentSettings({ workspaceId, streamId, companionMode, e2e }:
       companionMode={companionMode}
       onCompanionModeChange={handleCompanion}
       companionBusy={companionBusy}
+      externalAgent={externalAgent}
       toolPolicy={
         isOwner
           ? {


### PR DESCRIPTION
## Problem

PR #1011 added an "External" state to the scratchpad header pill: when an external agent (a bot runtime, e.g. a Pi remote) is attached, the pill swaps its Companion/Quiet label for a connection dot + "External". But the two surfaces you open to *configure* a scratchpad's companion behavior never learned about it:

- the **pill popover** (`AgentSettingsPanel`, rendered by `LiveAgentSettings`), and
- the **stream settings → Companion tab** (`CompanionTab`)

both render only the Quiet/Companion radio pair. So a scratchpad wired to an external agent shows "Quiet" (or "Companion") there with no hint an agent is attached — the exact gap reported: "no indication that an external agent is attached … the third option is missing."

## Solution

Surface the external-agent attachment as a read-only indicator above the mode radios on both settings surfaces, derived from the same `useActiveBotPresence` source the header pill already uses.

It is deliberately **not** a third `companionMode` value. `companionMode` is `["off", "on"]` and governs only whether Ariadne (the in-process companion) replies — `companion-outbox-handler.ts` dispatches the persona job purely on `companionMode === "on"`. External attachment is orthogonal: it's a `bot_channel_access` grant with its own runtime presence, independent of the radio. An agent can be attached with companion on *or* off. Making "External" a fake third radio would misrepresent that model and couple two independent controls, so the radios keep governing Ariadne and the indicator reports the attachment alongside them. Detaching/attaching an agent already lives in the Members tab ("People and bot access").

### How it works

- `ExternalAgentIndicator` (new) takes an `ActiveBotPresence` and renders the agent's name (+ `avatarEmoji` when set) with a status dot: emerald when the runtime is `available`/`busy` (`BotRuntimeStatuses.AVAILABLE`/`BUSY`), grey otherwise — the same connected/not-connected rule as the header pill (`stream.tsx`).
- `AgentSettingsPanel` gains an optional `externalAgent?: ActiveBotPresence | null` prop and renders the indicator above the radio group when set.
- `LiveAgentSettings` (persisted scratchpads) calls `useActiveBotPresence(workspaceId, streamId)` and passes it through. `DraftAgentSettings` doesn't pass it — drafts aren't server-persisted, so they have no presence — and the optional prop leaves the draft popover unchanged.
- `CompanionTab` (settings dialog) calls the same hook and renders the indicator above its mode section.

`useActiveBotPresence` is a cache-only observer over the stream bootstrap (`botMemberIds` + `botRuntimePresence`), so the indicator re-renders on `bot_runtime:presence` updates without issuing its own fetch or room-join.

## Key design decisions

**1. Indicator, not a third radio** — `companionMode` stays `off`/`on`; external attachment is reported, not selected. Rationale above: the two are orthogonal in the data model and backend dispatch, and the existing attach/detach control is the Members tab.

**2. One shared component for both surfaces** — `AgentSettingsPanel` (popover) and `CompanionTab` (dialog) render the same `ExternalAgentIndicator` rather than each hand-rolling the dot + copy (INV-35/37). The connected-dot rule is defined once and matches the header pill.

**3. Test types `WorkspaceBot` via `ReturnType<typeof useWorkspaceBots>`** — caught in self-review: the first version imported `CachedBot` from `@/db/database`, which the no-restricted-imports rule (INV-15) blocks even in component test files. Reworked to derive the type from the store hook, no `@/db` import.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/stream-settings/external-agent-indicator.tsx` | Read-only attached-external-agent indicator (name + connected/not-connected dot), shared by both settings surfaces |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/stream-settings/agent-settings-panel.tsx` | Optional `externalAgent` prop; renders the indicator above the mode radios |
| `apps/frontend/src/components/stream-settings/live-agent-settings.tsx` | Reads `useActiveBotPresence` and passes it to the panel |
| `apps/frontend/src/components/stream-settings/companion-tab.tsx` | Reads `useActiveBotPresence` and renders the indicator above the mode section |
| `apps/frontend/src/components/stream-settings/live-agent-settings.test.tsx` | Coverage for attached+connected, attached+offline, and no-agent cases; `WorkspaceBot` type + `useWorkspaceBots` spy |

## Out of scope (deliberate)

- **Attach/detach control** — unchanged; that's the Members tab ("People and bot access"). This PR is visibility only, matching the report's "at the very least be able to see."
- **`DraftAgentSettings`** — left as-is; drafts can't have an attachment, so the optional prop is simply not passed.
- **Sidebar scratchpad item** — `scratchpad-item.tsx` shows a lock/sparkles decoration but no external-agent glyph. Not touched here; the report was about the settings surfaces.

## Test plan

- [x] `bun vitest run src/components/stream-settings/` — 28 pass (7 files), incl. 3 new external-agent cases
- [x] `eslint src/` (frontend) — clean (after fixing the INV-15 import flagged by the pre-commit hook)
- [x] `tsc --noEmit` across all apps — clean (verified by the pre-commit hook on the pushed commit)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9kojRry23xrB4NJ2TyGva)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784542899&installation_id=129946197&pr_number=1024&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1024&signature=0df1ff6eecf92fa39a1c4d47b03694394b3359f2eda02845c5fe238aedfe687a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->