### PR TITLE
fix(timeline): re-scan read frontier on content resize so short streams mark read

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1484,6 +1484,10 @@ export function StreamContent({
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
+    // Observe the virtualized content box so a settle/embed resize re-scans even
+    // when the stream is too short to scroll. The plain path's content lives in
+    // the scroller itself, so the hook's container fallback covers it.
+    contentRef: useVirtualized ? virtualContentRef : undefined,
     events: displayEvents,
     streamId,
     lastReadEventId,

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1485,8 +1485,12 @@ export function StreamContent({
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     // Observe the virtualized content box so a settle/embed resize re-scans even
-    // when the stream is too short to scroll. The plain path's content lives in
-    // the scroller itself, so the hook's container fallback covers it.
+    // when the stream is too short to scroll. The plain (thread) path has no
+    // separate content box; the hook then observes the scroller itself, which
+    // catches viewport/keyboard resizes but NOT inner embed growth (a fixed-
+    // height overflow container's own box doesn't change as content grows) — a
+    // short thread ending in a late-loading card staying unread is a known
+    // follow-up, not covered here.
     contentRef: useVirtualized ? virtualContentRef : undefined,
     events: displayEvents,
     streamId,

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1025,6 +1025,9 @@ export function StreamContent({
 
   // Unified API regardless of scroll mode
   const scrollContainerRef = useVirtualized ? virtuosoScrollerRef : plainScrollRef
+  // Content box for the plain (thread) scroller — its height tracks scrollHeight,
+  // so observing it (not the fixed h-full scroller) catches embed/image growth.
+  const plainContentRef = useRef<HTMLDivElement>(null)
   const isScrolledFarFromBottom = useVirtualized ? virtualIsScrolledFar : plainIsScrolledFar
   const scrollToBottom = useVirtualized ? virtualScrollToBottom : plainScrollToBottom
   const disableAutoScroll = useVirtualized ? virtualDisableAutoScroll : plainDisableAutoScroll
@@ -1484,14 +1487,12 @@ export function StreamContent({
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
-    // Observe the virtualized content box so a settle/embed resize re-scans even
-    // when the stream is too short to scroll. The plain (thread) path has no
-    // separate content box; the hook then observes the scroller itself, which
-    // catches viewport/keyboard resizes but NOT inner embed growth (a fixed-
-    // height overflow container's own box doesn't change as content grows) — a
-    // short thread ending in a late-loading card staying unread is a known
-    // follow-up, not covered here.
-    contentRef: useVirtualized ? virtualContentRef : undefined,
+    // Observe the scrolling content box (its height tracks scrollHeight) so a
+    // settle / embed / image resize re-scans even when the stream is too short
+    // to scroll. Both paths pass one — the virtualized list's inner content div
+    // and the plain (thread) scroller's content wrapper. Observing the scroller
+    // itself wouldn't catch it: a fixed h-full box doesn't change as content grows.
+    contentRef: useVirtualized ? virtualContentRef : plainContentRef,
     events: displayEvents,
     streamId,
     lastReadEventId,
@@ -1843,38 +1844,40 @@ export function StreamContent({
                   onScroll={plainHandleScroll}
                   {...batchPointerHandlers}
                 >
-                  {isThread && parentMessage && parentStreamId && (
-                    <ThreadParentMessage
-                      event={parentMessage}
+                  <div ref={plainContentRef}>
+                    {isThread && parentMessage && parentStreamId && (
+                      <ThreadParentMessage
+                        event={parentMessage}
+                        workspaceId={workspaceId}
+                        streamId={parentStreamId}
+                        replyCount={displayEvents.length}
+                      />
+                    )}
+                    {isFetchingOlder && (
+                      <div className="flex justify-center py-2">
+                        <p className="text-sm text-muted-foreground">Loading older messages...</p>
+                      </div>
+                    )}
+                    <EventList
+                      timelineItems={timelineItems}
+                      isLoading={isLoading}
                       workspaceId={workspaceId}
-                      streamId={parentStreamId}
-                      replyCount={displayEvents.length}
+                      streamId={streamId}
+                      highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
+                      firstUnreadEventId={dividerEventId}
+                      isDividerDimmed={isDividerDimmed}
+                      agentActivity={agentActivity}
+                      hideSessionCards={isChannel}
+                      newMessageIds={newMessageIds}
+                      batch={batchState}
+                      conversationOverlay={activeConversationOverlay}
                     />
-                  )}
-                  {isFetchingOlder && (
-                    <div className="flex justify-center py-2">
-                      <p className="text-sm text-muted-foreground">Loading older messages...</p>
-                    </div>
-                  )}
-                  <EventList
-                    timelineItems={timelineItems}
-                    isLoading={isLoading}
-                    workspaceId={workspaceId}
-                    streamId={streamId}
-                    highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
-                    firstUnreadEventId={dividerEventId}
-                    isDividerDimmed={isDividerDimmed}
-                    agentActivity={agentActivity}
-                    hideSessionCards={isChannel}
-                    newMessageIds={newMessageIds}
-                    batch={batchState}
-                    conversationOverlay={activeConversationOverlay}
-                  />
-                  {isFetchingNewer && (
-                    <div className="flex justify-center py-2">
-                      <p className="text-sm text-muted-foreground">Loading newer messages...</p>
-                    </div>
-                  )}
+                    {isFetchingNewer && (
+                      <div className="flex justify-center py-2">
+                        <p className="text-sm text-muted-foreground">Loading newer messages...</p>
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
             </div>

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest"
-import { pickVisibleRange, advanceFrontier, type VisibleRow } from "./use-last-seen-event"
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import type { StreamEvent } from "@threa/types"
+import { pickVisibleRange, advanceFrontier, useLastSeenEvent, type VisibleRow } from "./use-last-seen-event"
 
 // Viewport spans y=0..100. Rows are in chronological (DOM) order.
 const VIEWPORT_TOP = 0
@@ -94,5 +96,104 @@ describe("advanceFrontier", () => {
 
   it("treats an exactly-contiguous top (frontier + 1) as no gap", () => {
     expect(advanceFrontier(9, 10, 14)).toBe(14)
+  })
+})
+
+describe("useLastSeenEvent re-scan on content resize", () => {
+  // The container viewport spans y=0..100; rows carry mutable rects so a test
+  // can "grow" the content (an embed loading) between scans.
+  let roCallbacks: ResizeObserverCallback[]
+  const saved: Record<string, unknown> = {}
+
+  beforeEach(() => {
+    roCallbacks = []
+    const g = globalThis as Record<string, unknown>
+    saved.raf = g.requestAnimationFrame
+    saved.caf = g.cancelAnimationFrame
+    saved.ro = g.ResizeObserver
+    // Run rAF synchronously so a scheduled scan resolves within the act() block.
+    // Return 0 (not a truthy id): the hook assigns the return value to its `raf`
+    // guard *after* the callback runs here, so a truthy id would wedge the guard
+    // and swallow the next schedule().
+    g.requestAnimationFrame = (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }
+    g.cancelAnimationFrame = () => {}
+    // jsdom has no ResizeObserver; capture the callback so the test can fire it.
+    g.ResizeObserver = class {
+      constructor(cb: ResizeObserverCallback) {
+        roCallbacks.push(cb)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  afterEach(() => {
+    const g = globalThis as Record<string, unknown>
+    g.requestAnimationFrame = saved.raf
+    g.cancelAnimationFrame = saved.caf
+    g.ResizeObserver = saved.ro
+  })
+
+  function rect(top: number, bottom: number): DOMRect {
+    return {
+      top,
+      bottom,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: bottom - top,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+
+  function fireResize() {
+    act(() => {
+      for (const cb of roCallbacks) cb([], {} as ResizeObserver)
+    })
+  }
+
+  it("advances the frontier to the trailing row when an embed resizes it into view without a scroll", () => {
+    // A short stream that fits the viewport fires no scroll event. The last row
+    // starts below the fold (its embed hasn't loaded), so the first scan can't
+    // reach it; a ResizeObserver-driven re-scan must mark it once it lands.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: -50, bottom: -10 }, // scrolled above the viewport (already read)
+      e1: { top: 10, bottom: 60 }, // visible
+      e2: { top: 130, bottom: 180 }, // below the fold — not yet seen
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [{ id: "e0" }, { id: "e1" }, { id: "e2" }] as unknown as StreamEvent[]
+    const scrollContainerRef = { current: container }
+
+    const { result } = renderHook(() =>
+      useLastSeenEvent({ scrollContainerRef, events, streamId: "stream_1", lastReadEventId: "e0", enabled: true })
+    )
+
+    // First scan: e2 is below the fold, so the frontier stops at e1.
+    expect(result.current.lastSeenEventId).toBe("e1")
+    expect(result.current.atLastRow).toBe(false)
+
+    // The embed loads and the trailing row resizes into the viewport.
+    positions.e2 = { top: 65, bottom: 95 }
+    fireResize()
+
+    // The re-scan reaches the last row — the message that was stuck unread.
+    expect(result.current.lastSeenEventId).toBe("e2")
+    expect(result.current.atLastRow).toBe(true)
   })
 })

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -47,6 +47,15 @@ export function advanceFrontier(frontier: number, topIdx: number, botIdx: number
 interface UseLastSeenEventOptions {
   /** The owned scroll container (virtualized timeline or plain thread scroller). */
   scrollContainerRef: React.RefObject<HTMLElement | null>
+  /**
+   * The scrolling content box inside the container (its height = scrollHeight).
+   * Observed for size changes so the scan re-runs when rows grow after the last
+   * scroll — the open-at-bottom settle finishing, or async embeds (link/GitHub
+   * cards, images) loading. Without it a short stream that fits the viewport,
+   * and so fires no scroll event, would never re-scan and the trailing rows
+   * would stay unread. Falls back to the container when omitted.
+   */
+  contentRef?: React.RefObject<HTMLElement | null>
   /** The loaded event window, used to map a visible row back to its position. */
   events: StreamEvent[]
   streamId: string
@@ -87,6 +96,7 @@ interface UseLastSeenEventResult {
  */
 export function useLastSeenEvent({
   scrollContainerRef,
+  contentRef,
   events,
   streamId,
   lastReadEventId,
@@ -190,11 +200,23 @@ export function useLastSeenEvent({
     }
     schedule()
     el?.addEventListener("scroll", schedule, { passive: true })
+    // Re-scan when the rendered geometry changes without a scroll: the
+    // open-at-bottom settle finishing, or async embeds (link/GitHub cards,
+    // images) loading and resizing the trailing rows. On a short stream that
+    // can't scroll this is the ONLY thing that brings the last rows into the
+    // seen frontier — otherwise they stay unread with no gesture to fix it.
+    const content = contentRef?.current ?? null
+    const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(schedule) : null
+    if (ro) {
+      if (el) ro.observe(el)
+      if (content && content !== el) ro.observe(content)
+    }
     return () => {
       if (raf) cancelAnimationFrame(raf)
       el?.removeEventListener("scroll", schedule)
+      ro?.disconnect()
     }
-  }, [enabled, streamId, recompute, scrollContainerRef])
+  }, [enabled, streamId, recompute, scrollContainerRef, contentRef])
 
   // Re-scan when the window grows (live append) or the read pointer moves under
   // us (external read), so the frontier and the affordance stay current.


### PR DESCRIPTION
## Problem

After #1017 a stream opens at the live bottom and the read frontier
(`useLastSeenEvent`) advances only through the contiguous run of rows the viewer
actually has on screen. The frontier is recomputed in two places: a `scroll`
listener, and an effect keyed on `events.length` / `readIndex`. Neither fires
when row **geometry** changes without a scroll or a new event.

That gap is invisible on a long stream — you scroll, the listener fires, rows get
marked. But on a stream short enough to fit the viewport there is nothing to
scroll, so after the initial scan the frontier is frozen. Two things move the
rows right after that scan and neither re-scans:

1. the open-at-bottom **settle** finishing (the list pins to bottom behind the
   skeleton mask), and
2. **async embeds** — link/GitHub/Cloudflare cards and images — loading and
   growing the trailing rows into their final positions.

Result (reproduced on prod, `#gh-notifications`): the last messages sit fully
visible above the composer but stay unread, with no scroll gesture available to
nudge them into the seen band. The unread count never clears.

## Solution

Give the frontier a third trigger: observe the scrolling content box with a
`ResizeObserver` and re-run the same scan on any post-scan resize.

### How it works

- `useLastSeenEvent` gains an optional `contentRef` — the content box inside the
  scroller whose height tracks `scrollHeight`. In the scroll-listener effect it
  now also creates a `ResizeObserver(schedule)` and observes both the container
  (`el`, for viewport changes) and the content box (when distinct, for content
  growth). `schedule` is the existing rAF-debounced wrapper around `recompute`,
  so the resize path reuses the exact scan the scroll path uses — no second code
  path. The observer is disconnected in the effect cleanup alongside the scroll
  listener.
- `stream-content.tsx` passes `contentRef: useVirtualized ? virtualContentRef : undefined`.
  `virtualContentRef` is the `<div ref={contentRef}>` from `useTimelineScroll`
  that wraps the `Virtualizer` rows plus the `ComposerFooterSpacer`; when an
  embed grows a row, that box's height changes and the observer fires. The plain
  (thread) path keeps its content directly inside the scroller, so the hook's
  `content === el` guard falls back to observing the container alone.

The frontier math (`advanceFrontier`, `pickVisibleRange`) is unchanged — this
only changes *when* the scan runs, not what it concludes. Marking stays
conservative: a resize that doesn't bring a contiguous trailing row into view
leaves the frontier where it was.

## Key design decisions

**1. `ResizeObserver` on the content box, not a poll or a settle flag.** A resize
observer catches every cause at once — settle, embeds, image decode, font swap,
orientation — rather than wiring each event source in. Keying off an
`isInitialSettling` flag would fix the settle race but not the embeds that load
seconds later; those are the actual culprit in the screenshot.

**2. Reuse `schedule`, observe both nodes.** The observer callback is the same
rAF-coalesced `schedule` the scroll listener uses, so a burst of resizes
collapses to one scan per frame and the resize/scroll paths can't disagree.
Observing `el` as well keeps viewport-size changes (mobile keyboard, rotation)
covered without a separate observer.

**3. Conservative `typeof ResizeObserver !== "undefined"` guard.** Keeps the hook
safe under non-DOM test/SSR contexts; when absent the behavior is exactly the
prior scroll-only one.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | Add optional `contentRef`; create/observe/disconnect a `ResizeObserver` in the scroll-listener effect so geometry changes re-run the scan. |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Pass `virtualContentRef` as `contentRef` on the virtualized path (plain path falls back to the container). |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | Add a mounted-hook regression test for the resize re-scan. |

## Out of scope (deliberate)

- The plain (non-virtualized) thread path is not given a dedicated content box to
  observe — it has no single wrapper today, and its content also re-scans on the
  `events.length` path. If a short thread with late-loading embeds shows the same
  symptom, that's a follow-up.
- No change to the frontier semantics, the partial-mark lifecycle, or the divider
  — purely a re-scan trigger.

## Test plan

- [x] `bunx vitest run src/hooks/use-last-seen-event.test.ts` — 14 pass (includes the new resize regression test, which fails without the fix: with no observer created, the simulated resize is a no-op and the frontier stays at `e1`).
- [x] `bunx vitest run` on the neighboring suites (`use-unread-divider`, `stream-content`, `event-list`) — 93 pass.
- [x] `tsc --noEmit` (frontend `typecheck`) clean.
- [x] Pre-commit hook: eslint + full-monorepo `tsc --noEmit` clean.
- [ ] Not exercised in a real browser against a live embed-loading stream — the failure is timing/geometry-driven, so it's covered by the unit reproduction (stubbed `ResizeObserver` + mutable row rects) rather than an E2E.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQs8HMgoPq3FonaHK64kaG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784547572&installation_id=129946197&pr_number=1026&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1026&signature=0de97840e07056c905da58e4a88a833b92db9643d9ad8ca60c0e12f1c2d73098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->