### PR TITLE
fix(frontend): show full stream name in the mobile action drawer

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -125,7 +125,6 @@ export function ScratchpadItem({
   const drawerPreview: SidebarActionPreview | null =
     preview && preview.content
       ? {
-          streamName: isDraft ? `${name} (draft)` : name,
           authorName: getActorName(preview.authorId, preview.authorType),
           content: truncateContent(preview.content, 140, toEmoji),
           createdAt: preview.createdAt,
@@ -236,6 +235,7 @@ export function ScratchpadItem({
           open={drawerOpen}
           onOpenChange={setDrawerOpen}
           actions={actions}
+          streamName={isDraft ? `${name} (draft)` : name}
           title={`Actions for ${name}`}
           description="Choose an action for this stream."
           preview={drawerPreview}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx
@@ -176,6 +176,7 @@ describe("sidebar-actions", () => {
 
       renderWithRouter(
         <SidebarActionDrawer
+          streamName="General"
           title="Actions for General"
           description="Choose an action for this stream."
           open={true}
@@ -190,7 +191,6 @@ describe("sidebar-actions", () => {
             },
           ]}
           preview={{
-            streamName: "General",
             authorName: "Ariadne",
             content: "Latest update from the stream",
             createdAt: "2026-03-03T10:00:00Z",
@@ -198,6 +198,7 @@ describe("sidebar-actions", () => {
         />
       )
 
+      expect(screen.getByText("General")).toBeInTheDocument()
       expect(screen.getByText("Ariadne")).toBeInTheDocument()
       expect(screen.getByText("Latest update from the stream")).toBeInTheDocument()
 
@@ -228,10 +229,10 @@ describe("sidebar-actions", () => {
           open={false}
           onOpenChange={vi.fn()}
           actions={[]}
+          streamName="Taylor"
           title="Actions for Taylor"
           description="Choose an action for this stream."
           preview={{
-            streamName: "Taylor",
             content: "No messages yet",
           }}
         />

--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
@@ -40,7 +40,6 @@ export interface SidebarActionItem {
 }
 
 export interface SidebarActionPreview {
-  streamName: string
   authorName?: string
   content: string
   createdAt?: string
@@ -310,6 +309,8 @@ interface SidebarActionDrawerProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   actions: SidebarActionItem[]
+  /** Full stream name shown as the drawer's visible title — wraps rather than truncating so long names stay readable on the cramped sidebar. */
+  streamName?: string
   title?: string
   description?: string
   header?: ReactNode
@@ -320,12 +321,13 @@ export function SidebarActionDrawer({
   open,
   onOpenChange,
   actions,
+  streamName,
   title = "Sidebar actions",
   description = "Choose an action.",
   header,
   preview,
 }: SidebarActionDrawerProps) {
-  const hasVisibleContent = actions.length > 0 || preview != null || header != null
+  const hasVisibleContent = actions.length > 0 || preview != null || header != null || streamName != null
 
   if (!open && !hasVisibleContent) return null
 
@@ -334,7 +336,6 @@ export function SidebarActionDrawer({
     (preview ? (
       <div className="px-4 pt-1 pb-3">
         <div className="rounded-xl bg-muted/60 px-3.5 py-2.5">
-          <p className="mb-1 text-sm font-medium text-foreground">{preview.streamName}</p>
           {(preview.authorName || preview.createdAt) && (
             <div className="mb-1 flex items-center gap-1.5 text-[13px] text-muted-foreground">
               {preview.authorName && <span className="truncate">{preview.authorName}</span>}
@@ -352,6 +353,12 @@ export function SidebarActionDrawer({
       <DrawerContent className="max-h-[85dvh]">
         <DrawerTitle className="sr-only">{title}</DrawerTitle>
         <DrawerDescription className="sr-only">{description}</DrawerDescription>
+
+        {streamName && (
+          <div className="px-4 pt-2 pb-1">
+            <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
+          </div>
+        )}
 
         {resolvedHeader}
 

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -301,14 +301,12 @@ export function StreamItem({
   let drawerPreview: SidebarActionPreview | null = null
   if (preview?.content) {
     drawerPreview = {
-      streamName: name,
       authorName: getActorName(preview.authorId, preview.authorType),
       content: truncateContent(preview.content, 140, toEmoji),
       createdAt: preview.createdAt,
     }
   } else if (stream.type === StreamTypes.DM) {
     drawerPreview = {
-      streamName: name,
       content: "No messages yet",
     }
   }
@@ -430,6 +428,7 @@ export function StreamItem({
           open={drawerOpen}
           onOpenChange={setDrawerOpen}
           actions={actions}
+          streamName={name}
           title={`Actions for ${name}`}
           description="Choose an action for this stream."
           preview={drawerPreview}

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -531,7 +531,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
                 description="Choose an action for this stream."
                 header={
                   <div className="px-4 pt-2 pb-3">
-                    <p className="truncate text-base font-semibold text-foreground">
+                    <p className="break-words text-base font-semibold text-foreground">
                       {decryptedPanelName ?? streamLabel(stream)}
                     </p>
                     <p className="mt-0.5 text-xs text-muted-foreground">

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -623,7 +623,7 @@ export function StreamPage() {
                   description="Choose an action for this stream."
                   header={
                     <div className="px-4 pt-2 pb-3">
-                      <p className="truncate text-base font-semibold text-foreground">{streamName}</p>
+                      <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
                         {stream ? getStreamTypeLabel(stream.type) : "Stream"} actions
                       </p>


### PR DESCRIPTION
## Problem

On mobile, long-pressing a stream in the sidebar opens `SidebarActionDrawer` (`apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx`). The stream's name was only surfaced *inside the message preview box* (`preview.streamName`), which has two gaps:

- A stream with **no recent message** built no `drawerPreview` at all (`StreamItem` only sets it when `preview?.content`, or for a DM placeholder), so the drawer showed actions with **no name anywhere** — the `DrawerTitle` carrying `Actions for ${name}` is `sr-only`.
- The open-stream header drawers (`pages/stream.tsx`, `components/thread/stream-panel.tsx`) did render the name, but with `truncate`, so long names were clipped.

Since the sidebar already truncates long names in the row, the drawer was the natural place to read the full name — and it often didn't show one.

## Solution

Give `SidebarActionDrawer` a dedicated, always-visible `streamName` title rendered at the top of the drawer with `break-words` (wraps instead of truncating), independent of whether a message preview exists. The name now renders once, as a title, on every sidebar/scratchpad drawer; the preview box drops to author + content only.

### How it works

- `SidebarActionDrawer` gains an optional `streamName?: string` prop, rendered as `<p className="break-words text-base font-semibold text-foreground">` above `resolvedHeader`. `hasVisibleContent` also keys on `streamName != null` so a name-only drawer stays mounted while closing.
- `SidebarActionPreview` loses its `streamName` field; the preview box no longer renders the name line. `StreamItem` and `ScratchpadItem` pass `streamName` to the drawer instead (scratchpad keeps its `(draft)` suffix).
- `pages/stream.tsx` and `components/thread/stream-panel.tsx` keep their existing `header` (name + type-label subtitle) but switch the title from `truncate` to `break-words`, for the same "see the full name" fix.

### Key design decisions

**Dedicated title prop, not reuse of `header` or `preview`.** `header` and `preview` are mutually exclusive in the drawer (`header ?? (preview ? … : null)`), so threading the name through `header` on the sidebar items would have dropped the message preview. A separate `streamName` slot renders the name *and* the preview, and there's no double-render because the sidebar items pass `streamName` + `preview` while the open-stream/footer drawers pass `header` only.

**`break-words`, not `truncate`.** The whole point is reading the full name, so the title wraps to as many lines as needed rather than clipping with an ellipsis.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx` | Add `streamName` prop + always-visible wrapping title; drop `streamName` from `SidebarActionPreview` and the preview box |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Pass `streamName={name}`; remove `streamName` from the two `drawerPreview` branches |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx` | Pass `streamName` (with `(draft)` suffix); remove it from `drawerPreview` |
| `apps/frontend/src/pages/stream.tsx` | Header title `truncate` → `break-words` |
| `apps/frontend/src/components/thread/stream-panel.tsx` | Header title `truncate` → `break-words` |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.test.tsx` | Move `streamName` to the prop; assert the title renders |

## Out of scope (deliberate)

- `sidebar-footer.tsx` (identity/account drawer) keeps its `header`-only layout — it has no stream and no long-name problem.

## Test plan

- [x] `bun run test src/components/layout/sidebar/sidebar-actions.test.tsx` — 10 pass
- [x] `bun run test` for `stream-item.test.tsx` + `scratchpad-item.test.tsx` — 13 pass
- [x] `tsc -p apps/frontend/tsconfig.json --noEmit` clean (and the pre-commit hook ran the full monorepo lint + typecheck)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjNezwJiFVpmJH8Bxi83UG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784568470&installation_id=129946197&pr_number=1029&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1029&signature=5adb7057e0fc7dceae2a5c9c197aee95c8d7060ed69c53e2bd6402b80cd52418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->