### PR TITLE
fix(pi-remote): preserve unknown top-level fields in saveConfig

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -782,3 +782,104 @@ describe("defaultDisplayNameFor", () => {
     expect(__testing.defaultDisplayNameFor("/Users/kris/dev/personal/threa", "  Work Pi  ")).toBe("Work Pi - threa")
   })
 })
+
+describe("buildPersistedConfig", () => {
+  test("preserves hand-edited top-level fields from on-disk config not present in memory", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        linkedSessions: { session_a: { linkId: "a", rootStreamId: "s1", activeStreamId: "s1", runtimeSessionId: "rs1", streamUrlPath: "/s1" } },
+      } as never,
+      {
+        defaultLabel: "coding",
+        pollMs: 5000,
+      } as never
+    )
+    // In-memory required fields present
+    expect(result.baseUrl).toBe("https://app.threa.io")
+    expect(result.workspaceId).toBe("ws_123")
+    // Hand-edited fields from on-disk absent from the in-memory config survive
+    expect(result.defaultLabel).toBe("coding")
+    expect(result.pollMs).toBe(5000)
+    // linkedSessions from in-memory still present
+    expect(result.linkedSessions).toMatchObject({ session_a: { linkId: "a" } })
+  })
+
+  test("in-memory defined fields override on-disk values", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://staging.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+      } as never,
+      {
+        baseUrl: "https://app.threa.io",
+      } as never
+    )
+    expect(result.baseUrl).toBe("https://staging.threa.io")
+  })
+
+  test("merges linkedSessions from both sides, in-memory keys win", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        linkedSessions: {
+          session_b: { linkId: "b", rootStreamId: "s1", activeStreamId: "s1", runtimeSessionId: "rs2", streamUrlPath: "/s1" },
+        },
+      } as never,
+      {
+        linkedSessions: {
+          session_a: { linkId: "a", rootStreamId: "s1", activeStreamId: "s1", runtimeSessionId: "rs1", streamUrlPath: "/s1" },
+        },
+      } as never
+    )
+    expect(result.linkedSessions).toMatchObject({
+      session_a: { linkId: "a" },
+      session_b: { linkId: "b" },
+    })
+  })
+
+  test("removes migrated global enabled flag from output", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        enabled: true,
+      } as never,
+      { enabled: true } as never
+    )
+    expect(result.enabled).toBeUndefined()
+  })
+
+  test("migrates global streamCursors from either side", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+        streamCursors: { stream_b: "50" },
+      } as never,
+      {
+        streamCursors: { stream_a: "42" },
+      } as never
+    )
+    expect(result.streamCursors).toMatchObject({ stream_a: "42", stream_b: "50" })
+  })
+
+  test("skips writing streamCursors when neither side has cursors", () => {
+    const result = __testing.buildPersistedConfig(
+      {
+        baseUrl: "https://app.threa.io",
+        workspaceId: "ws_123",
+        apiKey: "threa_bk_test",
+      } as never,
+      {} as never
+    )
+    expect(result.streamCursors).toBeUndefined()
+  })
+})

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -314,43 +314,44 @@ function acquireConfigLockSync(): (() => void) | undefined {
   return undefined
 }
 
-function saveConfig(): void {
-  if (!config) return
-  const persisted: Config = { ...config }
-  // Keep a copy because `persisted.streamCursors` is removed from the
-  // canonical write shape before the legacy cursor merge below.
-  const inMemoryStreamCursors = persisted.streamCursors
+function buildPersistedConfig(
+  inMemory: Config,
+  onDisk: Partial<Config> | undefined
+): Record<string, unknown> {
+  // Start from on-disk fields so hand-edited / unknown top-level keys the
+  // runtime doesn't manage survive the write. Overlay every field the runtime
+  // has in-memory but skip undefined optionals so a hand-edited defaultLabel
+  // on disk isn't erased by the runtime's unset optional.
+  const persisted: Record<string, unknown> = { ...(onDisk ?? {}) }
+  const inMemoryStreamCursors = inMemory.streamCursors
+  for (const [key, value] of Object.entries(inMemory)) {
+    if (value !== undefined) persisted[key] = value
+  }
+  // enabled is migrated to per-session link state; strip the global flag.
+  // streamCursors is merged below and written only when either side is non-empty.
   delete persisted.enabled
   delete persisted.streamCursors
+  // Merge linkedSessions so concurrent Pi instances (each owning a distinct key,
+  // keyed by runtimeSessionId) don't clobber each other's links (INV-20).
+  if (onDisk?.linkedSessions && inMemory.linkedSessions) {
+    persisted.linkedSessions = { ...onDisk.linkedSessions, ...inMemory.linkedSessions }
+  }
+  // Legacy global cursors: merge either side. Migrated into per-link
+  // streamCursors by migrateSessionState; this branch only matters for
+  // upgraded installs that still carry the global map on disk.
+  if (onDisk?.streamCursors || inMemoryStreamCursors) {
+    persisted.streamCursors = { ...(onDisk?.streamCursors ?? {}), ...(inMemoryStreamCursors ?? {}) }
+  }
+  return persisted
+}
+
+function saveConfig(): void {
+  if (!config) return
   mkdirSync(dirname(CONFIG_PATH), { recursive: true })
-  // Hold the cross-process lock across the entire read-merge-write so a
-  // concurrent Pi instance can't read a pre-merge snapshot and then overwrite
-  // this instance's just-merged `linkedSessions`/`streamCursors` (INV-20).
-  // If the lock can't be acquired, skip — never write unlocked (INV-20).
   const release = acquireConfigLockSync()
   if (!release) return
   try {
-    // Merge with whatever is on disk so concurrent Pi instances (each owning a
-    // distinct `linkedSessions` key, keyed by runtimeSessionId) don't clobber
-    // each other's links. Without this, a read-modify-write from instance A
-    // overwrites instance B's `linkedSessions` entry because A only has its own
-    // link in memory. This instance's own keys win over stale on-disk copies.
-    // Non-mergeable fields (baseUrl/workspaceId/apiKey/...) keep the in-memory
-    // (just-edited) value.
-    const onDisk = readStoredConfig()
-    if (onDisk?.linkedSessions && persisted.linkedSessions) {
-      const merged = { ...onDisk.linkedSessions, ...persisted.linkedSessions }
-      persisted.linkedSessions = merged
-    }
-    // Legacy global cursors: merge either side. They've been migrated into
-    // per-link `streamCursors` by `migrateSessionState`, so this branch only
-    // matters for upgraded installs that still carry the global map on disk.
-    if (onDisk?.streamCursors || inMemoryStreamCursors) {
-      const mergedCursors = { ...(onDisk?.streamCursors ?? {}), ...(inMemoryStreamCursors ?? {}) }
-      persisted.streamCursors = mergedCursors
-    }
-    // Atomic write via temp + rename so a crash or a concurrent reader never
-    // sees a half-written file.
+    const persisted = buildPersistedConfig(config, readStoredConfig())
     const tmp = `${CONFIG_PATH}.${process.pid}.tmp`
     writeFileSync(tmp, `${JSON.stringify(persisted, null, 2)}\n`)
     renameSync(tmp, CONFIG_PATH)
@@ -2503,6 +2504,7 @@ export const __testing = {
   formatToolCallTrace,
   formatToolResultTrace,
   buildClaimInvocationPayload,
+  buildPersistedConfig,
   buildRuntimeCapabilities,
   getRuntimeCommand,
   parseSessionControlCommand,


### PR DESCRIPTION
## Problem

`saveConfig()` in `extensions/pi-remote/src/threa-remote.ts` drops hand-edited top-level fields from `~/.pi/agent/threa-remote.json`. It builds the persisted object from in-memory config only (`{ ...config }`), then merges just `linkedSessions` and `streamCursors` from disk. Any other field — `defaultLabel`, `pollMs`, or unknown keys added by hand — is silently deleted on the next write.

## Solution

Extract the merge logic into `buildPersistedConfig()`, a pure function that starts from spread on-disk fields (so unknown/hand-edited keys survive) and overlays only *defined* values from the in-memory config (so managed fields like `baseUrl`/`apiKey` still win, but an unset optional like `config.defaultLabel = undefined` does not erase a hand-edited value on disk).

### How it works

- `buildPersistedConfig(inMemory, onDisk)` starts with `{ ...(onDisk ?? {}) }` — every field on disk is the baseline
- Iterates `Object.entries(inMemory)` and writes each non-`undefined` value onto the result — managed fields with a runtime value override disk, but unset optionals don't overwrite
- Deletes `enabled` (migrated to per-session link state) and `streamCursors` (merged below)
- Merges `linkedSessions` from both sides so concurrent Pi instances (INV-20) don't clobber each other's session links
- Conditionally writes `streamCursors` when either side has entries
- `saveConfig()` is simplified to a thin lock+write shell that delegates to `buildPersistedConfig`

### Key design decisions

**1. Spread on-disk first, overlay in-memory second** — the reverse of the old approach. This is the minimal pivot: any property in the on-disk JSON that the runtime doesn't know about (or whose value is unset) survives. The lock guard (INV-20) still covers the entire read-merge-write.

**2. Skip undefined values during overlay** — `for (const [key, value] of Object.entries(inMemory)) { if (value !== undefined) ... }`. Without this, `{ ...onDisk, ...config }` would set `defaultLabel: undefined` when the runtime hasn't loaded one, erasing the hand-edited value.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/pi-remote/src/threa-remote.ts` | Extract `buildPersistedConfig` (+40/-33) |
| `extensions/pi-remote/src/threa-remote.test.ts` | 6 new tests for field preservation (+101/-0) |

## Test plan

- [x] `bun test ./extensions/pi-remote/src/threa-remote.test.ts` — 91 pass, 164 expect calls

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784568492&installation_id=129946197&pr_number=1030&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1030&signature=cfb05f94084ae0d6fb4eb572758f87e8de69484de33b164c45f74555e27f3e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->