### PR TITLE
Make activity feed more readable, Slack-style

### DIFF
--- a/apps/frontend/src/components/activity/activity-content.tsx
+++ b/apps/frontend/src/components/activity/activity-content.tsx
@@ -27,17 +27,28 @@ const DEFAULT_DISPLAY: ActivityDisplay = ACTIVITY_DISPLAY.message
 interface ActivityPreviewProps {
   contentPreview: string
   toEmoji?: (shortcode: string) => string | null
+  /** Reaction glyph rendered ahead of the text (e.g. 👍). */
+  emoji?: string | null
+  /** Unread rows render the content at full strength; read rows are dimmed. */
+  isUnread?: boolean
 }
 
 /**
- * Single-line preview of the message that triggered the activity.
- * Strips markdown, collapses newlines, optionally resolves emoji shortcodes,
- * and renders nothing when there's no displayable content.
+ * The message that triggered the activity — the actual payload of the
+ * notification, so it carries the visual weight (body size, foreground colour)
+ * while the actor/verb/stream line above it stays a muted caption. Strips
+ * markdown, collapses newlines, optionally resolves emoji shortcodes, and
+ * clamps to two lines.
  */
-export function ActivityPreview({ contentPreview, toEmoji }: ActivityPreviewProps) {
+export function ActivityPreview({ contentPreview, toEmoji, emoji, isUnread }: ActivityPreviewProps) {
   const previewText = stripMarkdownToInline(contentPreview, toEmoji)
-  if (!previewText) return null
-  return <p className="mt-0.5 text-xs text-muted-foreground truncate">{previewText}</p>
+  if (!previewText && !emoji) return null
+  return (
+    <p className={cn("mt-1 text-sm leading-snug line-clamp-2", isUnread ? "text-foreground" : "text-foreground/80")}>
+      {emoji && <span className="mr-1 align-middle">{emoji}</span>}
+      {previewText}
+    </p>
+  )
 }
 
 interface ActivityContentProps {
@@ -71,20 +82,34 @@ export function ActivityContent({
   let verb = display.kind === "actor-prefixed" && isSelf ? display.selfVerb : display.verb
   if (!hasStream && activityType === "saved_reminder") verb = STANDALONE_REMINDER_VERB
   const showActor = display.kind === "actor-prefixed" && !isSelf
-  const showEmoji = activityType === "reaction" && emoji
+  const reactionEmoji = activityType === "reaction" ? emoji : null
 
   return (
-    <div className="flex-1 min-w-0">
-      <div className="flex items-baseline gap-1.5 text-sm">
-        {showActor && <span className={cn("font-medium", isUnread && "font-semibold")}>{actorName}</span>}
-        <span className="text-muted-foreground">{verb}</span>
-        {hasStream && <span className="font-medium truncate">{streamName}</span>}
-        {showEmoji && <span className="shrink-0">{emoji}</span>}
+    <div className="min-w-0 flex-1">
+      {/* Caption line. The whole actor/verb/stream cluster lives in one
+          `truncate` block so it ellipsises as a unit on one line — the actor
+          name can never wrap — and the timestamp stays pinned to the right edge
+          (using the horizontal room that used to sit empty on mobile). */}
+      <div className="flex items-baseline gap-2">
+        <div className="min-w-0 flex-1 truncate text-[13px] leading-tight text-muted-foreground">
+          {showActor && <span className="font-semibold text-foreground">{actorName}</span>}
+          {showActor && " "}
+          {verb}
+          {hasStream && " "}
+          {hasStream && <span className="font-medium text-foreground">{streamName}</span>}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <RelativeTime date={createdAt} terse className="text-xs tabular-nums text-muted-foreground/70" />
+          {/* Unread marker, right-aligned with the time. Space is reserved when
+              read (transparent) so toggling read/unread never shifts the row
+              (INV-21). Self rows are always read, so they get no marker. */}
+          {!isSelf && (
+            <span aria-hidden className={cn("h-1.5 w-1.5 rounded-full", isUnread ? "bg-blue-500" : "bg-transparent")} />
+          )}
+        </div>
       </div>
 
-      <ActivityPreview contentPreview={contentPreview} toEmoji={toEmoji} />
-
-      <RelativeTime date={createdAt} className="text-xs text-muted-foreground/60 mt-1 block" />
+      <ActivityPreview contentPreview={contentPreview} toEmoji={toEmoji} emoji={reactionEmoji} isUnread={isUnread} />
     </div>
   )
 }

--- a/apps/frontend/src/components/activity/activity-item.tsx
+++ b/apps/frontend/src/components/activity/activity-item.tsx
@@ -3,7 +3,6 @@ import { Bell } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { PersonaAvatar } from "@/components/persona-avatar"
-import { UnreadDot } from "./unread-dot"
 import { ActivityContent } from "./activity-content"
 import type { Activity } from "@threa/types"
 
@@ -60,13 +59,12 @@ export function ActivityItem({
         if (isUnread) onMarkAsRead(activity.id)
       }}
       className={cn(
-        "group flex items-start gap-3 rounded-lg px-4 py-3 transition-colors",
+        "group flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors sm:px-4 sm:py-3",
         isUnread && "bg-primary/5 hover:bg-primary/10",
         !isUnread && !isSelf && "hover:bg-muted/50",
         isSelf && "opacity-75 hover:bg-muted/40 hover:opacity-100"
       )}
     >
-      <UnreadDot isUnread={isUnread} />
       {renderAvatar({ isReminder, isPersona, isSystem, isBot, actorAvatar, actorName })}
       <ActivityContent
         actorName={actorName}
@@ -96,16 +94,16 @@ function renderAvatar(params: {
   // instead of "T for Threa" so the avatar matches the verb ("Reminder for…").
   if (isReminder) {
     return (
-      <div className="h-7 w-7 shrink-0 rounded-[8px] bg-amber-500/10 text-amber-500 flex items-center justify-center">
+      <div className="h-8 w-8 shrink-0 rounded-[8px] bg-amber-500/10 text-amber-500 flex items-center justify-center">
         <Bell className="h-4 w-4" />
       </div>
     )
   }
   if (isPersona) {
-    return <PersonaAvatar slug={actorAvatar.slug} fallback={actorAvatar.fallback} size="sm" />
+    return <PersonaAvatar slug={actorAvatar.slug} fallback={actorAvatar.fallback} size="md" />
   }
   return (
-    <Avatar className="h-7 w-7 rounded-[8px] shrink-0">
+    <Avatar className="h-8 w-8 rounded-[8px] shrink-0">
       {actorAvatar.avatarUrl && <AvatarImage src={actorAvatar.avatarUrl} alt={actorName} />}
       <AvatarFallback
         className={cn(

--- a/apps/frontend/src/components/activity/activity-skeleton.tsx
+++ b/apps/frontend/src/components/activity/activity-skeleton.tsx
@@ -2,14 +2,16 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 export function ActivitySkeleton() {
   return (
-    <div className="flex flex-col gap-2 px-4 py-2">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex items-start gap-3 py-3">
-          <Skeleton className="h-2 w-2 rounded-full mt-2" />
+    <div className="flex flex-col gap-0.5 px-3 py-2 sm:px-4">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 py-2.5 sm:py-3">
+          <Skeleton className="h-8 w-8 rounded-[8px] shrink-0" />
           <div className="flex-1 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <Skeleton className="h-3 w-40" />
+              <Skeleton className="h-3 w-8 shrink-0" />
+            </div>
             <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-3 w-1/2" />
-            <Skeleton className="h-3 w-20" />
           </div>
         </div>
       ))}

--- a/apps/frontend/src/components/activity/unread-dot.tsx
+++ b/apps/frontend/src/components/activity/unread-dot.tsx
@@ -1,9 +1,0 @@
-import { cn } from "@/lib/utils"
-
-export function UnreadDot({ isUnread }: { isUnread: boolean }) {
-  return (
-    <div className="mt-2 flex-shrink-0">
-      <div className={cn("h-2 w-2 rounded-full transition-colors", isUnread ? "bg-blue-500" : "bg-transparent")} />
-    </div>
-  )
-}


### PR DESCRIPTION
## Summary

The activity rows buried the actual notification. The triggering message sat in tiny muted text on its own truncated line while the actor/verb/stream caption took the visual weight, the timestamp wasted a third line, and the actor name could wrap mid-row — leaving a lot of empty horizontal space, especially on mobile. This reworks the row hierarchy (Slack-style) while staying inside the existing design system: same primitives, fonts, and colors.

## What changed

**`activity-content.tsx`**
- **The message content is now the headline** — body-size, foreground color, two-line clamp. It's the payload of the notification, so it carries the weight. The actor/verb/stream line became a small muted caption above it.
- **Actor name can no longer wrap.** The whole `actor · verb · stream` cluster lives in one `truncate` block, so it ellipsizes as a unit on one line.
- **Timestamp pinned to the right edge** of the caption line (terse: "2h"), using the horizontal room that sat empty on mobile and dropping the wasted third line.
- The unread marker is now a small dot beside the timestamp, with space reserved when read so toggling read/unread never shifts the row (INV-21).
- Reaction emoji now leads the message preview ("👍 the message text") instead of floating in the caption.

**`activity-item.tsx`**
- Dropped the dedicated left unread-dot column — reclaims width on narrow screens.
- Avatars bumped to 32px for a stronger anchor against the two-line content; tighter row padding on mobile (`px-3 py-2.5`, widening at `sm`).

**Housekeeping**
- Deleted the now-unused `UnreadDot` component (INV-38).
- Updated `ActivitySkeleton` to mirror the new layout.

## Notes for reviewers
- `ActivityPreview` stays exported and its existing tests pass unchanged (the emoji/unread props are optional, so the standalone test path is unaffected).
- Worth a look on a phone-width viewport to confirm the density feels right.

## Verification
- `bun run --filter @threa/frontend typecheck` — clean
- `bun run --filter @threa/frontend test src/components/activity/activity-content.test.tsx` — 6 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jz2GT32UGnEk53cj53chY

---
_Generated by [Claude Code](https://claude.ai/code/session_014jz2GT32UGnEk53cj53chY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784571642&installation_id=129946197&pr_number=1032&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1032&signature=c31dcbd9355e944fb37c327f817bbc4468e07ab285d700427344590ad18b4832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->