### PR TITLE
fix(sync): seed the cursor from the bootstrap's sync head on cold boot

### DIFF
--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -15,6 +15,7 @@ import type { AvatarService } from "./avatar-service"
 import type { LabelService, LabelAssignmentService } from "../labels"
 import { getEmojiList } from "../emoji"
 import { getEffectiveLevel } from "../streams"
+import { SyncLogRepository } from "../sync"
 import { BotRepository, serializeBot } from "../public-api"
 import { displayNameFromWorkos, type WorkosOrgService } from "@threa/backend-common"
 import { HttpError } from "../../lib/errors"
@@ -140,6 +141,14 @@ export function createWorkspaceHandlers({
     async bootstrap(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
+
+      // Read the sync-log head BEFORE the snapshot queries below: every
+      // projection then observes a DB state at or after this read, so the
+      // snapshot reflects everything `<= syncHead` (read-before-stamp). The
+      // client seeds its sync cursor here on first connect, making the connect
+      // bootstrap the single authority for `<= head` — catch-up starts at head
+      // instead of a stale cursor that would collapse into a second bootstrap.
+      const { head: syncHead } = await SyncLogRepository.getHeadAndRetainedFrom(pool, workspaceId)
 
       const [
         workspace,
@@ -269,6 +278,7 @@ export function createWorkspaceHandlers({
           viewerPermissions,
           viewerIsPlatformAdmin,
           configuredToolCategories,
+          syncHead: syncHead.toString(),
         },
       })
     },

--- a/apps/backend/tests/client.ts
+++ b/apps/backend/tests/client.ts
@@ -668,6 +668,7 @@ export interface WorkspaceBootstrapData {
   activityCounts: Record<string, number>
   unreadActivityCount: number
   viewerPermissions: WorkspacePermissionSlug[]
+  syncHead?: string
 }
 
 export async function getWorkspaceBootstrap(client: TestClient, workspaceId: string): Promise<WorkspaceBootstrapData> {
@@ -678,6 +679,27 @@ export async function getWorkspaceBootstrap(client: TestClient, workspaceId: str
     throw new Error(`Get workspace bootstrap failed: ${JSON.stringify(data)}`)
   }
   return data.data
+}
+
+export interface SyncCatchUpResult {
+  entries: Array<{ syncId: string; eventType: string; payload: unknown; createdAt: string }>
+  head: string
+  requiresBootstrap?: boolean
+}
+
+export async function getSyncCatchUp(
+  client: TestClient,
+  workspaceId: string,
+  after: string = "0"
+): Promise<SyncCatchUpResult> {
+  // The sync endpoint returns the catch-up body directly (not wrapped in `data`).
+  const { status, data } = await client.get<SyncCatchUpResult>(
+    `/api/workspaces/${workspaceId}/sync?after=${after}&limit=100`
+  )
+  if (status !== 200) {
+    throw new Error(`Sync catch-up failed: ${JSON.stringify(data)}`)
+  }
+  return data
 }
 
 /**

--- a/apps/backend/tests/e2e/sync-bootstrap-head.test.ts
+++ b/apps/backend/tests/e2e/sync-bootstrap-head.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect, beforeAll } from "bun:test"
+import {
+  TestClient,
+  loginAs,
+  createWorkspace,
+  createChannel,
+  sendMessage,
+  getWorkspaceBootstrap,
+  getSyncCatchUp,
+} from "../client"
+
+/**
+ * The workspace bootstrap carries the sync-log head it was read against so the
+ * client can seed its catch-up cursor on first connect (and avoid a redundant
+ * second bootstrap). This verifies the field is present and stays consistent
+ * with the value the catch-up endpoint reports.
+ */
+describe("Workspace bootstrap sync head", () => {
+  let client: TestClient
+  let workspaceId: string
+  let streamId: string
+
+  beforeAll(async () => {
+    client = new TestClient()
+    await loginAs(client, "sync-head-test@example.com", "Sync Head Test User")
+    const workspace = await createWorkspace(client, "Sync Head Workspace")
+    workspaceId = workspace.id
+    const channel = await createChannel(client, workspaceId, "sync-head")
+    streamId = channel.id
+  })
+
+  test("bootstrap returns a syncHead consistent with the catch-up endpoint", async () => {
+    await sendMessage(client, workspaceId, streamId, "drives a sync-log entry")
+
+    // The sync-log entry is written by the outbox dispatcher after the message
+    // commits, so poll until the head reflects it.
+    let bootstrapHead = "0"
+    const deadline = Date.now() + 5000
+    while (Date.now() < deadline) {
+      bootstrapHead = (await getWorkspaceBootstrap(client, workspaceId)).syncHead ?? "0"
+      if (BigInt(bootstrapHead) > 0n) break
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    expect(BigInt(bootstrapHead) > 0n).toBe(true)
+
+    const catchUp = await getSyncCatchUp(client, workspaceId, "0")
+
+    // The bootstrap head is read before the snapshot, so it is a lower bound of
+    // the catch-up head read moments later — never ahead of it.
+    expect(BigInt(bootstrapHead)).toBeLessThanOrEqual(BigInt(catchUp.head))
+  })
+})

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -1056,6 +1056,46 @@ describe("SyncEngine sync cursor (active mode)", () => {
     engine.destroy()
   })
 
+  it("seeds the cursor from the bootstrap's sync head on first connect so a stale cursor does not double-bootstrap", async () => {
+    // Cold boot of a returning user: a stale cursor survives in IDB from a prior
+    // session. Without the head seed, catch-up would read from "10", see the
+    // whole gap to head, and collapse into a SECOND full bootstrap on top of the
+    // connect one. The connect bootstrap carries the head it was read against, so
+    // the cursor jumps there and catch-up finds nothing.
+    await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
+    const catchUp = vi.fn(async (_workspaceId: string, params: { after: string; limit: number }) => {
+      // From the seeded head there is no gap; from the stale cursor the server
+      // would report the span as unhealable (below the retained floor), which is
+      // exactly what the old path turned into a second bootstrap.
+      if (BigInt(params.after) >= 5000n) return emptyPage("5000")
+      return { entries: [], head: "5000", requiresBootstrap: true } satisfies SyncCatchUpResponse
+    })
+    const deps = makeActiveDeps(catchUp)
+    deps.workspaceService.bootstrap = vi.fn(async () => ({ ...makeWorkspaceBootstrap(), syncHead: "5000" }))
+    const engine = new SyncEngine(deps)
+
+    await engine.onConnect(asSocket(new MockSocket()))
+
+    // Catch-up runs from the seeded head, not the stale cursor.
+    await vi.waitFor(() =>
+      expect(catchUp).toHaveBeenCalledWith(
+        "ws_1",
+        { after: "5000", limit: expect.any(Number) },
+        expect.any(AbortSignal)
+      )
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(catchUp).not.toHaveBeenCalledWith(
+      "ws_1",
+      { after: "10", limit: expect.any(Number) },
+      expect.any(AbortSignal)
+    )
+    expect(deps.workspaceService.bootstrap).toHaveBeenCalledTimes(1)
+    expect(engine.getSyncCursor()).toBe("5000")
+    engine.destroy()
+  })
+
   it("buffers live events while catch-up runs and splices those above the catch-up position afterwards", async () => {
     await db.syncCursors.put({ key: "ws_1:sync-log", cursor: "10", updatedAt: Date.now() })
     let resolveFirstPage: ((value: SyncCatchUpResponse) => void) | undefined

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -667,6 +667,17 @@ export class SyncEngine {
 
         // Write to TanStack cache (bridge for coordinated-loading, sidebar loading/error)
         queryClient.setQueryData(workspaceKeys.bootstrap(workspaceId), bootstrap)
+
+        // Cold-boot single bootstrap: this first-connect snapshot is the
+        // authority for everything <= its sync head (read-before-stamp on the
+        // backend). Jump the cursor there so the catch-up that runs next sees no
+        // gap — otherwise a stale cursor persisted from a prior session makes
+        // catch-up collapse the gap into a SECOND full bootstrap. Reconnects are
+        // excluded: their cursor marks the disconnect window catch-up must heal.
+        if (!_isReconnect && this.eventGate && bootstrap.syncHead) {
+          this.syncLogCursor?.advance(bootstrap.syncHead)
+          this.noteSeenHead(bootstrap.syncHead)
+        }
       }
 
       this.lastWorkspaceError = null

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1309,6 +1309,17 @@ export interface WorkspaceBootstrap {
    * payloads (absent reads as "all gateable").
    */
   configuredToolCategories?: ToolPrivacyCategory[]
+  /**
+   * Workspace-global sync-log head (`MAX(sync_id)`) read just before this
+   * snapshot was assembled, so the snapshot reflects everything `<= syncHead`
+   * (read-before-stamp). On the first socket connect the client seeds its sync
+   * cursor here: the connect bootstrap is the authority for everything
+   * `<= head`, so catch-up starts at head and never collapses into a second
+   * full bootstrap. Stringified BIGINT, matching `SyncCatchUpResponse.head`.
+   * Optional: payloads cached before this field shipped (and the catch-up-driven
+   * reconnect bootstraps that reuse this shape) omit it.
+   */
+  syncHead?: string
 }
 
 export interface PendingInvitation {


### PR DESCRIPTION
## What

On a **cold boot**, the workspace does a redundant **second full bootstrap**. This eliminates it by having the bootstrap response carry the sync-log head and seeding the client cursor from it on the first connect.

## Why

`SyncEngine.onConnect()` is the only thing that fetches the workspace bootstrap (the `useWorkspaceBootstrap` hook is dead — no production caller). On the first connect it runs:

1. `runBootstrap(isReconnect=false)` → a **full** workspace snapshot fetch.
2. `runCatchUp("connect")` → pages the sync log from the persisted cursor.

A **returning user** still holds a *stale* sync cursor in IndexedDB from a prior session. `initializeActiveCursor` only seeds the cursor to head when it's *null* (fresh install), so the stale cursor survives. Catch-up then reads from that old position, sees the whole gap to head, and the collapse / below-floor logic (introduced by #1021 on this branch) heals it by running **`runBootstrap(forceFull)` — a second full snapshot**. That's the "cold boot double bootstrap."

Fresh installs never hit it: their cursor is null → seeded to head → catch-up finds nothing.

## How

- **`packages/types`** — add optional `syncHead` to `WorkspaceBootstrap` (stringified BIGINT, matching `SyncCatchUpResponse.head`).
- **Backend handler** (`features/workspaces/handlers.ts`) — read the sync-log head **before** assembling the snapshot, so the snapshot reflects everything `<= syncHead` (read-before-stamp), and return it. Reuses `SyncLogRepository.getHeadAndRetainedFrom` (the same read catch-up uses, so the values stay consistent).
- **Frontend `SyncEngine`** — on the **first** connect only, seed the cursor from `bootstrap.syncHead` after the snapshot is applied. Catch-up then starts at head and finds no gap → no second bootstrap.

**Reconnects are untouched**: their cursor still marks the disconnect window catch-up must heal, so the collapse / below-floor path keeps working there.

### Why it's safe

This is exactly what the collapse branch already does (`cursorStore.advance(head)` and treat the full snapshot as the authority for everything `<= head`) — minus the redundant second fetch. Reading the head before the snapshot makes `syncHead` a lower bound of the snapshot's coverage, so nothing `<= head` is ever skipped; events above it are healed by catch-up/live delivery as before.

## File changes

- `packages/types/src/api.ts` — `syncHead?: string` on `WorkspaceBootstrap`.
- `apps/backend/src/features/workspaces/handlers.ts` — read head first, include `syncHead` in the response.
- `apps/frontend/src/sync/sync-engine.ts` — seed cursor from `bootstrap.syncHead` on first connect.
- `apps/frontend/src/sync/sync-engine.test.ts` — new regression test (cold boot + stale cursor → exactly one bootstrap; fails on the old code).
- `apps/backend/tests/client.ts` — `syncHead` on the test bootstrap type + `getSyncCatchUp` helper.
- `apps/backend/tests/e2e/sync-bootstrap-head.test.ts` — new e2e: bootstrap `syncHead` is present and consistent with the catch-up endpoint head.

## Testing

All run against a real Postgres (+pgvector) and MinIO provisioned in the session:

- Frontend sync suite: **252/252** (incl. the new test, which fails on `main`'s behavior).
- Backend unit: **1967/1967**.
- New backend e2e + `realtime.test.ts` + `sync-catch-up` integration: **pass**.
- Pre-commit hook: full monorepo typecheck, migration check, and OpenAPI-doc check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3RwMKi9kZ8d6Ptfhpn7aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3RwMKi9kZ8d6Ptfhpn7aK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784573073&installation_id=129946197&pr_number=1033&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1033&signature=4a6827a237287245da9b79915682b2a4750d6f9a73b05088d417e964cace3993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->