### PR TITLE
feat(drafts): synchronous localStorage staging so a fast type-then-reload never loses content

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -17,6 +17,7 @@ import {
   useWorkspaceUsers,
 } from "@/stores/workspace-store"
 import { hasSeededDraftCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
+import { reconcileStagedDrafts } from "@/sync/draft-sync"
 import { useSyncSnapshot, useSyncStatus } from "@/sync/sync-status"
 import { debugBootstrap, isBootstrapDebugEnabled } from "@/lib/bootstrap-debug"
 import {
@@ -141,9 +142,20 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
 
   useEffect(() => {
     let cancelled = false
-    seedDraftCacheFromIdb(workspaceId).then(() => {
+    // Recover any synchronously-staged composer content into IDB BEFORE seeding
+    // the draft cache, so a draft typed-then-reloaded (before its debounce
+    // reached IDB) is already present when the composer first reads. A failed
+    // recovery must never block the app — seed regardless.
+    const run = async () => {
+      try {
+        await reconcileStagedDrafts(workspaceId)
+      } catch (err) {
+        console.error("Failed to recover staged drafts", err)
+      }
+      await seedDraftCacheFromIdb(workspaceId)
       if (!cancelled) setPrimedDraftWorkspaceId(workspaceId)
-    })
+    }
+    void run()
     return () => {
       cancelled = true
     }

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, act, waitFor } from "@testing-library/react"
-import { useDraftMessage, getDraftMessageKey, upsertLoadedDraft, resolveLoadedDraft } from "./use-draft-message"
+import {
+  useDraftMessage,
+  getDraftMessageKey,
+  upsertLoadedDraft,
+  resolveLoadedDraft,
+  clearLoadedDraft,
+  stashLoadedDraft,
+} from "./use-draft-message"
+import { readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
 import { getScopeResolveSeq, resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
 import { ContextRefKinds, type JSONContent } from "@threa/types"
 import type { DraftContextRef } from "@/lib/context-bag/types"
@@ -822,5 +830,104 @@ describe("useDraftMessage", () => {
         expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
       })
     })
+  })
+})
+
+describe("draft staging (synchronous reload safety)", () => {
+  const UNLOCKED_SESSION = {
+    status: "unlocked",
+    keyId: "ek_test",
+    publicKey: null,
+    privateKey: {} as CryptoKey,
+    deviceTrusted: true,
+    error: null,
+  } as ReturnType<typeof e2eSessionStore.useE2eSession>
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    localStorage.clear()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue(null)
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(LOCKED_SESSION)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("stages a plaintext keystroke synchronously, before the debounce reaches IDB", async () => {
+    const { result, unmount } = renderHook(() => useDraftMessage(workspaceId, draftKey))
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    act(() => {
+      result.current.saveDraftDebounced(makeDoc("typed fast"))
+    })
+
+    // The synchronous stage has happened even though the 500ms debounce has not —
+    // this is the content a same-tick reload would otherwise lose.
+    expect(readStagedDraft(workspaceId, draftKey)?.contentJson).toEqual(makeDoc("typed fast"))
+    // IDB is still empty until the debounce fires.
+    expect(await db.drafts.where("scope").equals(draftKey).count()).toBe(0)
+
+    unmount()
+  })
+
+  it("never stages an E2E keystroke (no plaintext at rest, E2EE-4)", async () => {
+    vi.spyOn(currentUserHook, "useCurrentWorkspaceUserId").mockReturnValue("user_1")
+    vi.spyOn(e2eSessionStore, "useE2eSession").mockReturnValue(UNLOCKED_SESSION)
+
+    const { result, unmount } = renderHook(() => useDraftMessage(workspaceId, draftKey, "stream_e2e_root"))
+    await act(async () => {
+      await seedDraftCacheFromIdb(workspaceId)
+    })
+
+    act(() => {
+      result.current.saveDraftDebounced(makeDoc("secret"))
+    })
+
+    expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
+    unmount()
+  })
+
+  it("clears the staging buffer on discard (clearLoadedDraft)", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("hello"), attachments: [] })
+    stageDraftContent(workspaceId, draftKey, makeDoc("hello world"))
+
+    await clearLoadedDraft(workspaceId, draftKey)
+
+    expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
+  })
+
+  it("clears the staging buffer on send (resolveLoadedDraft) so sent content can't be recovered", async () => {
+    await db.drafts.put({
+      id: "draft_sent",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("sent message"),
+      attachments: [],
+      baseVersion: 2,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: "draft_sent" })
+    stageDraftContent(workspaceId, draftKey, makeDoc("sent message"))
+
+    await resolveLoadedDraft(workspaceId, draftKey)
+
+    expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
+  })
+
+  it("clears the staging buffer on stash", async () => {
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("to stash"), attachments: [] })
+    stageDraftContent(workspaceId, draftKey, makeDoc("to stash"))
+
+    await stashLoadedDraft(workspaceId, draftKey)
+
+    expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -7,6 +7,7 @@ import {
   resolveLoadedDraft,
   clearLoadedDraft,
   stashLoadedDraft,
+  restoreStashedDraftToComposer,
 } from "./use-draft-message"
 import { readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
 import { getScopeResolveSeq, resetDraftResolutionGuard } from "@/sync/draft-resolution-guard"
@@ -928,6 +929,25 @@ describe("draft staging (synchronous reload safety)", () => {
 
     await stashLoadedDraft(workspaceId, draftKey)
 
+    expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
+  })
+
+  it("clears the staging buffer on stash-restore so a reload can't overwrite the restored draft", async () => {
+    // Loaded draft A (with staged keystrokes) plus a separate stash entry B.
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("draft A"), attachments: [] })
+    await db.drafts.put({
+      id: "draft_B",
+      workspaceId,
+      scope: draftKey,
+      contentJson: makeDoc("draft B"),
+      attachments: [],
+      clientUpdatedAt: Date.now(),
+    })
+    stageDraftContent(workspaceId, draftKey, makeDoc("draft A edited"))
+
+    await restoreStashedDraftToComposer(workspaceId, draftKey, "draft_B")
+
+    // The swapped-out draft's buffer is gone, so reconcile can't apply it over B.
     expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
   })
 })

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -11,6 +11,7 @@ import {
   useDraftsFromStore,
 } from "@/stores/draft-store"
 import { enqueueDraftUpsert, migrateLocalDraftScope, syncDraftRemoval, syncDraftResolution } from "@/sync/draft-sync"
+import { clearStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
 import { getScopeResolveSeq, markDraftResolved, recordScopeResolved } from "@/sync/draft-resolution-guard"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { type JSONContent, draftStreamScope, draftThreadScope } from "@threa/types"
@@ -246,6 +247,9 @@ async function removeLoadedDraftLocally(
  * drift doesn't matter.
  */
 export async function clearLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+  // Drop the staging buffer first (synchronous) so a racing flush or a reload
+  // can't recover the discarded content back into the composer.
+  clearStagedDraft(workspaceId, scope)
   const { loadedId, baseVersion } = await removeLoadedDraftLocally(workspaceId, scope)
   // Sync side-effect after the local state is fully cleared.
   if (loadedId) await syncDraftRemoval(workspaceId, loadedId, baseVersion)
@@ -258,6 +262,10 @@ export async function clearLoadedDraft(workspaceId: string, scope: string): Prom
  * entry instead of being collaterally deleted (plan §resolve-on-send).
  */
 export async function resolveLoadedDraft(workspaceId: string, scope: string): Promise<void> {
+  // Drop the staging buffer first (synchronous) so the just-sent content can't be
+  // recovered by a reload, nor re-staged by a debounced flush racing the teardown
+  // — the same resurrection class the resolution guard below closes.
+  clearStagedDraft(workspaceId, scope)
   // Bump the scope's resolve sequence BEFORE the async teardown so a debounced
   // save already in flight can't re-create the draft once the pointer is cleared
   // (see the guard in `upsertLoadedDraft`). Ordering matters: this synchronous
@@ -281,6 +289,7 @@ export async function resolveLoadedDraft(workspaceId: string, scope: string): Pr
  * promotion / discard flows to clear a scope entirely.
  */
 export async function purgeScopeDrafts(workspaceId: string, scope: string): Promise<void> {
+  clearStagedDraft(workspaceId, scope)
   // Read + delete the rows AND clear the loaded pointer atomically: `baseVersion`
   // reflects any server confirmation that landed before the delete (ghost-draft
   // race), and clearing the pointer inside the txn prevents an inbound echo from
@@ -306,6 +315,10 @@ export async function purgeScopeDrafts(workspaceId: string, scope: string): Prom
  * cleared only when it referenced a purged plaintext row.
  */
 export async function purgePlaintextScopeDrafts(workspaceId: string, scope: string): Promise<void> {
+  // E2EE-4 defense in depth: an encrypted scope must never have a plaintext
+  // staging buffer. The write path already gates staging on encryption, so this
+  // only ever clears a stray entry written before the stream was known to be E2E.
+  clearStagedDraft(workspaceId, scope)
   let clearedPointer = false
   const removed = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
     const found = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
@@ -337,6 +350,10 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
 export async function stashLoadedDraft(workspaceId: string, scope: string): Promise<string | null> {
   const draftId = (await db.composerLoaded.get(scope))?.draftId ?? null
   if (!draftId) return null
+  // The caller flushed the live editor into the row before stashing, so the
+  // staged buffer is now redundant; drop it so a reload doesn't recover the
+  // stashed body back into the (now draft-less) composer as a new loaded draft.
+  clearStagedDraft(workspaceId, scope)
   await db.composerLoaded.delete(scope)
   setComposerLoadedInCache(workspaceId, scope, null)
   return draftId
@@ -519,6 +536,13 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       if (debounceRef.current) {
         clearTimeout(debounceRef.current)
       }
+      // Synchronously stage the keystroke so a reload before the debounce fires
+      // can't lose it (the debounce only reaches IDB after DEBOUNCE_MS). Plaintext
+      // only: an E2E draft must never write its body to disk unsealed (E2EE-4), and
+      // there is no synchronous seal — its reload-loss window stays open by design.
+      // The gate is read live (the timer-fire seal uses the same ref) so a value
+      // typed while plaintext is never staged after the stream became encrypted.
+      if (!e2eGateRef.current.enabled) stageDraftContent(workspaceId, draftKey, contentJson)
       // `saveDraft` reads the live E2E gate when the timer fires, so a value typed
       // while the stream was plaintext is sealed (or dropped) — never written as
       // plaintext — if the stream became encrypted in the meantime (E2EE-4).
@@ -527,7 +551,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
         void saveDraft(contentJson)
       }, DEBOUNCE_MS)
     },
-    [saveDraft]
+    [saveDraft, workspaceId, draftKey]
   )
 
   /**

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -372,6 +372,11 @@ export async function restoreStashedDraftToComposer(
   scope: string,
   draftId: string
 ): Promise<void> {
+  // Drop the staging buffer: it holds the keystrokes for the draft being swapped
+  // OUT (already flushed to its own row by the caller), so leaving it would let a
+  // reload before the next keystroke recover that stale body over the draft we
+  // just restored — corrupting it. The restored draft re-stages on its first edit.
+  clearStagedDraft(workspaceId, scope)
   await db.composerLoaded.put({ scope, workspaceId, draftId })
   setComposerLoadedInCache(workspaceId, scope, draftId)
 }
@@ -540,9 +545,12 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
       // can't lose it (the debounce only reaches IDB after DEBOUNCE_MS). Plaintext
       // only: an E2E draft must never write its body to disk unsealed (E2EE-4), and
       // there is no synchronous seal — its reload-loss window stays open by design.
-      // The gate is read live (the timer-fire seal uses the same ref) so a value
-      // typed while plaintext is never staged after the stream became encrypted.
-      if (!e2eGateRef.current.enabled) stageDraftContent(workspaceId, draftKey, contentJson)
+      // Gate on the render value `e2eEnabled`, not `e2eGateRef` (which trails a
+      // prop change by one effect): this runs synchronously at keystroke time, and
+      // the callback re-binds when `e2eEnabled` flips, so a stream that just became
+      // encrypted never stages a plaintext keystroke. (The seal at timer-fire still
+      // reads the ref, the right source for that deferred point.)
+      if (!e2eEnabled) stageDraftContent(workspaceId, draftKey, contentJson)
       // `saveDraft` reads the live E2E gate when the timer fires, so a value typed
       // while the stream was plaintext is sealed (or dropped) — never written as
       // plaintext — if the stream became encrypted in the meantime (E2EE-4).
@@ -551,7 +559,7 @@ export function useDraftMessage(workspaceId: string, draftKey: string, e2eStream
         void saveDraft(contentJson)
       }, DEBOUNCE_MS)
     },
-    [saveDraft, workspaceId, draftKey]
+    [saveDraft, workspaceId, draftKey, e2eEnabled]
   )
 
   /**

--- a/apps/frontend/src/lib/drafts/draft-staging.test.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import type { JSONContent } from "@threa/types"
+import { clearStagedDraft, listStagedDrafts, readStagedDraft, stageDraftContent } from "./draft-staging"
+
+const workspaceId = "ws_1"
+const scope = "stream:stream_1"
+
+const makeDoc = (text: string): JSONContent => ({
+  type: "doc",
+  content: [{ type: "paragraph", content: text ? [{ type: "text", text }] : undefined }],
+})
+
+const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe("stageDraftContent / readStagedDraft", () => {
+  it("round-trips the staged content", () => {
+    const doc = makeDoc("hello")
+    stageDraftContent(workspaceId, scope, doc)
+
+    const staged = readStagedDraft(workspaceId, scope)
+    expect(staged?.scope).toBe(scope)
+    expect(staged?.contentJson).toEqual(doc)
+    expect(typeof staged?.clientUpdatedAt).toBe("number")
+  })
+
+  it("overwrites the previous staged value (latest keystroke wins)", () => {
+    stageDraftContent(workspaceId, scope, makeDoc("hel"))
+    stageDraftContent(workspaceId, scope, makeDoc("hello"))
+
+    expect(readStagedDraft(workspaceId, scope)?.contentJson).toEqual(makeDoc("hello"))
+  })
+
+  it("clears the key instead of staging empty content", () => {
+    stageDraftContent(workspaceId, scope, makeDoc("hello"))
+    stageDraftContent(workspaceId, scope, EMPTY_DOC)
+
+    expect(readStagedDraft(workspaceId, scope)).toBeNull()
+  })
+
+  it("does not stage an oversized payload, dropping any prior buffer", () => {
+    stageDraftContent(workspaceId, scope, makeDoc("small"))
+    const huge = makeDoc("x".repeat(300 * 1024))
+    stageDraftContent(workspaceId, scope, huge)
+
+    // Too large to stage cheaply — the debounce still carries it to IDB, but the
+    // smaller stale buffer must not survive (it would recover the wrong body).
+    expect(readStagedDraft(workspaceId, scope)).toBeNull()
+  })
+
+  it("returns null for a corrupt entry", () => {
+    localStorage.setItem(`threa:draft-stage:${workspaceId}:${scope}`, "{not json")
+    expect(readStagedDraft(workspaceId, scope)).toBeNull()
+  })
+})
+
+describe("clearStagedDraft", () => {
+  it("removes the staged entry and is idempotent when absent", () => {
+    stageDraftContent(workspaceId, scope, makeDoc("hello"))
+    clearStagedDraft(workspaceId, scope)
+    expect(readStagedDraft(workspaceId, scope)).toBeNull()
+    // Second clear is a no-op, not a throw.
+    expect(() => clearStagedDraft(workspaceId, scope)).not.toThrow()
+  })
+})
+
+describe("listStagedDrafts", () => {
+  it("lists every staged entry for the workspace and ignores other workspaces", () => {
+    stageDraftContent(workspaceId, "stream:a", makeDoc("a"))
+    stageDraftContent(workspaceId, "thread:b", makeDoc("b"))
+    stageDraftContent("ws_other", "stream:c", makeDoc("c"))
+
+    const entries = listStagedDrafts(workspaceId)
+    expect(entries.map((e) => e.scope).sort()).toEqual(["stream:a", "thread:b"])
+    expect(listStagedDrafts("ws_other").map((e) => e.scope)).toEqual(["stream:c"])
+  })
+
+  it("returns an empty list when nothing is staged", () => {
+    expect(listStagedDrafts(workspaceId)).toEqual([])
+  })
+})

--- a/apps/frontend/src/lib/drafts/draft-staging.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.ts
@@ -35,13 +35,14 @@ import { isEmptyContent } from "@/lib/prosemirror-utils"
 const PREFIX = "threa:draft-stage:"
 
 /**
- * Skip staging a serialized payload larger than this. A pathological paste (a
- * whole document into the composer) would make the synchronous per-keystroke
- * write janky and could exhaust the localStorage quota; the debounced IDB write
- * still persists it, so the only cost of skipping is the reload-loss window for
- * that one outsized draft.
+ * Skip staging a serialized payload longer than this (measured in `string.length`,
+ * i.e. UTF-16 code units — localStorage stores UTF-16, so the on-disk cost is
+ * roughly twice this in bytes, ~512KB). A pathological paste (a whole document
+ * into the composer) would make the synchronous per-keystroke write janky and eat
+ * into the localStorage quota; the debounced IDB write still persists it, so the
+ * only cost of skipping is the reload-loss window for that one outsized draft.
  */
-const MAX_STAGED_BYTES = 256 * 1024
+const MAX_STAGED_CHARS = 256 * 1024
 
 export interface StagedDraft {
   scope: string
@@ -78,7 +79,7 @@ export function stageDraftContent(workspaceId: string, scope: string, contentJso
       return
     }
     const raw = JSON.stringify({ contentJson, clientUpdatedAt: Date.now() })
-    if (raw.length > MAX_STAGED_BYTES) {
+    if (raw.length > MAX_STAGED_CHARS) {
       // Too large to stage cheaply — drop any prior buffer and let the debounce
       // carry it to IDB. Leaving a stale smaller entry would recover the wrong body.
       localStorage.removeItem(keyFor(workspaceId, scope))
@@ -125,11 +126,17 @@ export function listStagedDrafts(workspaceId: string): StagedDraft[] {
   const prefix = workspacePrefix(workspaceId)
   const out: StagedDraft[] = []
   try {
+    // Snapshot the keys before reading. `localStorage.length`/`key(i)` index a
+    // LIVE store, so another tab writing/removing a key mid-iteration would shift
+    // indices and silently skip an entry; collect first, then read each (a
+    // since-deleted key reads back null and is skipped).
+    const keys: string[] = []
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i)
-      if (!key || !key.startsWith(prefix)) continue
-      const scope = key.slice(prefix.length)
-      const entry = readStagedDraft(workspaceId, scope)
+      if (key && key.startsWith(prefix)) keys.push(key)
+    }
+    for (const key of keys) {
+      const entry = readStagedDraft(workspaceId, key.slice(prefix.length))
       if (entry) out.push(entry)
     }
   } catch {

--- a/apps/frontend/src/lib/drafts/draft-staging.ts
+++ b/apps/frontend/src/lib/drafts/draft-staging.ts
@@ -1,0 +1,139 @@
+/**
+ * Synchronous, crash-safe staging area for in-progress composer content.
+ *
+ * The composer debounces its write to IndexedDB (`use-draft-message.ts`,
+ * `DEBOUNCE_MS`). That leaves a window — type, then reload before the debounce
+ * fires — where the keystrokes live only in React state and the editor, both of
+ * which a reload wipes. Losing user content is the cardinal sin the draft system
+ * is built to avoid, so this module closes the window with a write that is
+ * durable the instant a keystroke is handled: `localStorage.setItem` is
+ * synchronous, so by the time the browser processes a subsequent reload task the
+ * value is already on disk.
+ *
+ * The three persistence layers each have their own write cadence:
+ *  - **localStorage (here):** every change, synchronous — the crash-safe buffer.
+ *  - **IndexedDB:** debounced (the existing 500ms), the local source of truth.
+ *  - **server:** mirrored from IDB through the offline op queue (unchanged).
+ *
+ * Recovery is content-diff, not timestamp: `reconcileStagedDrafts`
+ * (`sync/draft-sync.ts`) compares a staged entry against the IDB draft and only
+ * recovers what genuinely differs, deferring cross-device conflicts to the
+ * existing `version`/split machinery. Comparing wall-clock timestamps across
+ * devices is unsafe (a roamed draft carries another device's clock), so we never
+ * do — see the design notes in `docs/features/architecture/drafts.md`.
+ *
+ * **Plaintext only (E2EE-4).** An encrypted draft is sealed before it ever
+ * touches disk; staging it would write plaintext at rest. So E2E scopes never
+ * stage here — the caller gates on encryption — and the reconcile refuses to
+ * apply a staged entry over a sealed row. The reload-loss window stays open for
+ * E2E drafts, which is the correct trade: there is no synchronous seal.
+ */
+
+import type { JSONContent } from "@threa/types"
+import { isEmptyContent } from "@/lib/prosemirror-utils"
+
+const PREFIX = "threa:draft-stage:"
+
+/**
+ * Skip staging a serialized payload larger than this. A pathological paste (a
+ * whole document into the composer) would make the synchronous per-keystroke
+ * write janky and could exhaust the localStorage quota; the debounced IDB write
+ * still persists it, so the only cost of skipping is the reload-loss window for
+ * that one outsized draft.
+ */
+const MAX_STAGED_BYTES = 256 * 1024
+
+export interface StagedDraft {
+  scope: string
+  contentJson: JSONContent
+  /** Authoring-device clock (ms). Kept for ordering/debugging only — recovery is content-diff, never a cross-device timestamp compare. */
+  clientUpdatedAt: number
+}
+
+function workspacePrefix(workspaceId: string): string {
+  return `${PREFIX}${workspaceId}:`
+}
+
+function keyFor(workspaceId: string, scope: string): string {
+  return `${workspacePrefix(workspaceId)}${scope}`
+}
+
+function storageAvailable(): boolean {
+  return typeof localStorage !== "undefined"
+}
+
+/**
+ * Synchronously stage the composer's current plaintext content for `scope`.
+ * Overwrites the previous staged value (the latest keystroke wins). Empty
+ * content clears the key instead of staging it — an emptied editor must not
+ * resurrect on reload, and deletion propagation is the debounce's job, not the
+ * buffer's. Best-effort: a quota/private-mode failure is swallowed because the
+ * debounced IDB write still stands.
+ */
+export function stageDraftContent(workspaceId: string, scope: string, contentJson: JSONContent): void {
+  if (!storageAvailable()) return
+  try {
+    if (isEmptyContent(contentJson)) {
+      localStorage.removeItem(keyFor(workspaceId, scope))
+      return
+    }
+    const raw = JSON.stringify({ contentJson, clientUpdatedAt: Date.now() })
+    if (raw.length > MAX_STAGED_BYTES) {
+      // Too large to stage cheaply — drop any prior buffer and let the debounce
+      // carry it to IDB. Leaving a stale smaller entry would recover the wrong body.
+      localStorage.removeItem(keyFor(workspaceId, scope))
+      return
+    }
+    localStorage.setItem(keyFor(workspaceId, scope), raw)
+  } catch {
+    // Quota exceeded / storage disabled — never interrupt typing. The local
+    // copy reaches IDB on the debounce regardless.
+  }
+}
+
+/** Read the staged plaintext entry for `scope`, or null when absent/corrupt. */
+export function readStagedDraft(workspaceId: string, scope: string): StagedDraft | null {
+  if (!storageAvailable()) return null
+  try {
+    const raw = localStorage.getItem(keyFor(workspaceId, scope))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { contentJson?: unknown; clientUpdatedAt?: unknown }
+    if (!parsed || typeof parsed !== "object" || !parsed.contentJson) return null
+    return {
+      scope,
+      contentJson: parsed.contentJson as JSONContent,
+      clientUpdatedAt: typeof parsed.clientUpdatedAt === "number" ? parsed.clientUpdatedAt : Date.now(),
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Remove the staged entry for `scope`. Idempotent; safe when absent. */
+export function clearStagedDraft(workspaceId: string, scope: string): void {
+  if (!storageAvailable()) return
+  try {
+    localStorage.removeItem(keyFor(workspaceId, scope))
+  } catch {
+    // Ignore — a failed clear at worst leaves a stale buffer the next reconcile drops.
+  }
+}
+
+/** Every staged entry for a workspace (used by the startup reconcile). */
+export function listStagedDrafts(workspaceId: string): StagedDraft[] {
+  if (!storageAvailable()) return []
+  const prefix = workspacePrefix(workspaceId)
+  const out: StagedDraft[] = []
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (!key || !key.startsWith(prefix)) continue
+      const scope = key.slice(prefix.length)
+      const entry = readStagedDraft(workspaceId, scope)
+      if (entry) out.push(entry)
+    }
+  } catch {
+    return out
+  }
+  return out
+}

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -849,6 +849,18 @@ describe("reconcileStagedDrafts", () => {
     expect(readStagedDraft(workspaceId, loadedScope)).toBeNull()
   })
 
+  it("keeps the staged buffer when the recovery write fails (no loss, retried next load)", async () => {
+    stageDraftContent(workspaceId, loadedScope, makeDoc("unflushed tail"))
+    const putSpy = vi.spyOn(db.drafts, "put").mockRejectedValueOnce(new Error("idb boom"))
+
+    await reconcileStagedDrafts(workspaceId)
+
+    // The buffer is the only copy of the tail — it must survive a transient write
+    // failure so the next load can retry, rather than being cleared away.
+    expect(readStagedDraft(workspaceId, loadedScope)?.contentJson).toEqual(makeDoc("unflushed tail"))
+    putSpy.mockRestore()
+  })
+
   it("clears a staged entry whose content is empty without creating a draft", async () => {
     // Write an empty-content buffer directly (the public stage helper refuses to).
     localStorage.setItem(

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -16,9 +16,11 @@ import {
   executeDraftResolve,
   executeDraftUpsert,
   hasPendingDraftUpsert,
+  reconcileStagedDrafts,
   syncDraftResolution,
   type DraftsServiceLike,
 } from "./draft-sync"
+import { readStagedDraft, stageDraftContent } from "@/lib/drafts/draft-staging"
 
 const workspaceId = "ws_1"
 const userId = "user_1"
@@ -67,6 +69,7 @@ function localDraft(overrides: Partial<CachedDraft> = {}): CachedDraft {
 beforeEach(async () => {
   resetDraftStoreCache()
   resetDraftResolutionGuard()
+  localStorage.clear()
   await db.drafts.clear()
   await db.composerLoaded.clear()
   await db.pendingOperations.clear()
@@ -761,5 +764,101 @@ describe("deleteDraftById — the single user-initiated delete path", () => {
     await deleteDraftById(workspaceId, "draft_missing")
 
     expect(await db.pendingOperations.where("type").equals("delete_draft").toArray()).toHaveLength(0)
+  })
+})
+
+describe("reconcileStagedDrafts", () => {
+  const loadedScope = "stream:stream_recover"
+
+  async function setLoaded(row: CachedDraft) {
+    await db.drafts.put(row)
+    await db.composerLoaded.put({ scope: row.scope, workspaceId, draftId: row.id })
+  }
+
+  it("recovers an un-flushed tail (staged differs from the loaded IDB draft)", async () => {
+    await setLoaded(
+      localDraft({
+        id: "draft_recover1",
+        scope: loadedScope,
+        contentJson: makeDoc("hello"),
+        baseVersion: 4,
+        attachments: [{ id: "att_1", filename: "f.txt", mimeType: "text/plain", sizeBytes: 1 }],
+      })
+    )
+    stageDraftContent(workspaceId, loadedScope, makeDoc("hello world"))
+
+    await reconcileStagedDrafts(workspaceId)
+
+    const recovered = await db.drafts.get("draft_recover1")
+    expect(recovered?.contentJson).toEqual(makeDoc("hello world"))
+    // Sync bookkeeping + attachments survive a body-only recovery.
+    expect(recovered?.baseVersion).toBe(4)
+    expect(recovered?.attachments).toHaveLength(1)
+    // Mirrored to the backend so cross-device drift splits on bootstrap.
+    expect(await hasPendingDraftUpsert("draft_recover1")).toBe(true)
+    // Buffer consumed.
+    expect(readStagedDraft(workspaceId, loadedScope)).toBeNull()
+  })
+
+  it("drops a staged entry already captured by the last flush (no redundant push)", async () => {
+    await setLoaded(
+      localDraft({ id: "draft_recover2", scope: loadedScope, contentJson: makeDoc("same"), baseVersion: 2 })
+    )
+    stageDraftContent(workspaceId, loadedScope, makeDoc("same"))
+
+    await reconcileStagedDrafts(workspaceId)
+
+    expect(await hasPendingDraftUpsert("draft_recover2")).toBe(false)
+    expect(readStagedDraft(workspaceId, loadedScope)).toBeNull()
+  })
+
+  it("creates a draft + loaded pointer when the scope has none", async () => {
+    stageDraftContent(workspaceId, loadedScope, makeDoc("brand new"))
+
+    await reconcileStagedDrafts(workspaceId)
+
+    const pointer = await db.composerLoaded.get(loadedScope)
+    expect(pointer?.draftId).toBeTruthy()
+    const created = pointer?.draftId ? await db.drafts.get(pointer.draftId) : undefined
+    expect(created?.contentJson).toEqual(makeDoc("brand new"))
+    expect(created?.baseVersion).toBeUndefined()
+    expect(await hasPendingDraftUpsert(pointer!.draftId!)).toBe(true)
+  })
+
+  it("never applies plaintext over a sealed (E2E) loaded draft (E2EE-4)", async () => {
+    await setLoaded(
+      localDraft({
+        id: "draft_sealed",
+        scope: loadedScope,
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+        ciphertext: "sealed-bytes",
+        envelope: { v: 1 },
+        e2eVersion: 1,
+        baseVersion: 1,
+      })
+    )
+    stageDraftContent(workspaceId, loadedScope, makeDoc("plaintext leak"))
+
+    await reconcileStagedDrafts(workspaceId)
+
+    const row = await db.drafts.get("draft_sealed")
+    expect(row?.ciphertext).toBe("sealed-bytes")
+    expect(row?.contentJson).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+    expect(await hasPendingDraftUpsert("draft_sealed")).toBe(false)
+    // Stale/foreign buffer is still cleared.
+    expect(readStagedDraft(workspaceId, loadedScope)).toBeNull()
+  })
+
+  it("clears a staged entry whose content is empty without creating a draft", async () => {
+    // Write an empty-content buffer directly (the public stage helper refuses to).
+    localStorage.setItem(
+      `threa:draft-stage:${workspaceId}:${loadedScope}`,
+      JSON.stringify({ contentJson: { type: "doc", content: [{ type: "paragraph" }] }, clientUpdatedAt: Date.now() })
+    )
+
+    await reconcileStagedDrafts(workspaceId)
+
+    expect(await db.composerLoaded.get(loadedScope)).toBeUndefined()
+    expect(readStagedDraft(workspaceId, loadedScope)).toBeNull()
   })
 })

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -608,12 +608,16 @@ export async function reconcileStagedDrafts(workspaceId: string): Promise<void> 
     try {
       await applyStagedDraft(workspaceId, entry)
     } catch (err) {
+      // Keep the buffer on failure (a transient IDB error) — it is the only copy
+      // of an un-flushed tail, so dropping it here would be the very loss this
+      // recovery exists to prevent. The next load retries.
       console.error("Failed to recover staged draft", err)
-    } finally {
-      // The buffer has served its purpose for this load whether or not it
-      // applied; clear it so it can't accumulate or re-recover stale content.
-      clearStagedDraft(workspaceId, entry.scope)
+      continue
     }
+    // Cleared only after the write succeeded — including the no-op paths
+    // (already-durable, sealed-scope, empty) which return normally — so the
+    // buffer can't accumulate or re-recover content already in IDB.
+    clearStagedDraft(workspaceId, entry.scope)
   }
 }
 
@@ -634,6 +638,10 @@ async function applyStagedDraft(workspaceId: string, entry: StagedDraft): Promis
   // split for this id instead of accepting a newer server row over the tail we
   // are about to recover (the same "unpushed edits win, server arbitrates" rule
   // `applyDraftUpserted` follows). Mirrors the draft to the backend either way.
+  // The two writes aren't atomic, but a crash in between is harmless: an op with
+  // no row no-ops at drain (`executeDraftUpsert` returns on a missing row), and
+  // the staging buffer — cleared only after this whole apply succeeds — still
+  // holds the content, so the next load recovers it.
   await enqueueDraftUpsert(workspaceId, id)
   // Preserve the loaded draft's sync bookkeeping + sidecars (baseVersion,
   // attachments, contextRefs) so recovering a typed tail can't wipe them; only

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -17,7 +17,8 @@ import type {
   UpsertDraftInput,
   UpsertDraftResponse,
 } from "@threa/types"
-import { EMPTY_DOC } from "@/lib/prosemirror-utils"
+import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
+import { clearStagedDraft, listStagedDrafts, type StagedDraft } from "@/lib/drafts/draft-staging"
 import { isResolvedDraftEcho } from "./draft-resolution-guard"
 
 /**
@@ -577,6 +578,81 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
       pendingUpsertIds.add(local.id)
     }
   }
+}
+
+// ============================================================================
+// Startup recovery — flush the synchronous staging buffer into IDB
+// ============================================================================
+
+/**
+ * Recover any synchronously-staged composer content (`lib/drafts/draft-staging`)
+ * into IDB. Runs once at workspace load, BEFORE the draft cache seeds, so the
+ * recovered body is already in `db.drafts` when the composer first reads — no
+ * flash of an empty editor, no parallel read path in the composer.
+ *
+ * Recovery is content-diff, never a timestamp compare: a staged entry whose body
+ * matches the loaded IDB draft was already flushed (drop it); a body that
+ * differs is an un-flushed tail (type-then-reload) and is written into IDB and
+ * queued for push. Enqueuing the push means a draft that drifted on another
+ * device while this tab was gone resolves through the server's split on the next
+ * bootstrap — local wins, never overwrite, never lose. Comparing this device's
+ * staged clock against a roamed draft's foreign clock would be unsafe, so we
+ * don't.
+ *
+ * Writes go straight to IDB (not the in-memory cache) so they can't flip the
+ * draft cache "ready" with a partial set before `seedDraftCacheFromIdb` runs.
+ */
+export async function reconcileStagedDrafts(workspaceId: string): Promise<void> {
+  const staged = listStagedDrafts(workspaceId)
+  for (const entry of staged) {
+    try {
+      await applyStagedDraft(workspaceId, entry)
+    } catch (err) {
+      console.error("Failed to recover staged draft", err)
+    } finally {
+      // The buffer has served its purpose for this load whether or not it
+      // applied; clear it so it can't accumulate or re-recover stale content.
+      clearStagedDraft(workspaceId, entry.scope)
+    }
+  }
+}
+
+async function applyStagedDraft(workspaceId: string, entry: StagedDraft): Promise<void> {
+  if (isEmptyContent(entry.contentJson)) return
+  const loadedId = (await db.composerLoaded.get(entry.scope))?.draftId ?? null
+  const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+
+  // Never apply plaintext over a sealed row (E2EE-4). Staging is plaintext-only,
+  // so a sealed loaded draft means this entry is stale or foreign — drop it.
+  if (existing?.ciphertext != null) return
+  // Already durable — the last debounced flush captured exactly this body.
+  if (existing && JSON.stringify(existing.contentJson) === JSON.stringify(entry.contentJson)) return
+
+  const id = existing?.id ?? generateLocalDraftId()
+  // Mark the draft dirty BEFORE writing it. A sync bootstrap can run concurrently
+  // at boot; with the pending upsert already in place it defers to the server
+  // split for this id instead of accepting a newer server row over the tail we
+  // are about to recover (the same "unpushed edits win, server arbitrates" rule
+  // `applyDraftUpserted` follows). Mirrors the draft to the backend either way.
+  await enqueueDraftUpsert(workspaceId, id)
+  // Preserve the loaded draft's sync bookkeeping + sidecars (baseVersion,
+  // attachments, contextRefs) so recovering a typed tail can't wipe them; only
+  // the body and its clock advance.
+  const row: CachedDraft = existing
+    ? { ...existing, contentJson: entry.contentJson, clientUpdatedAt: entry.clientUpdatedAt }
+    : {
+        id,
+        workspaceId,
+        scope: entry.scope,
+        contentJson: entry.contentJson,
+        attachments: [],
+        clientUpdatedAt: entry.clientUpdatedAt,
+      }
+
+  await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+    await db.drafts.put(row)
+    if (!existing) await db.composerLoaded.put({ scope: entry.scope, workspaceId, draftId: id })
+  })
 }
 
 // ============================================================================

--- a/docs/features/architecture/drafts.md
+++ b/docs/features/architecture/drafts.md
@@ -10,6 +10,7 @@ entry_points:
   - apps/frontend/src/sync/draft-sync.ts
   - apps/frontend/src/hooks/use-draft-message.ts
   - apps/frontend/src/sync/draft-resolution-guard.ts
+  - apps/frontend/src/lib/drafts/draft-staging.ts
 public_site: false
 summary: >
   A draft is a first-class row that mirrors from the device to the backend and
@@ -138,6 +139,47 @@ re-running it on reconnect is always safe.
 That is the core. The rest is reference for when you are working on the edges.
 
 ## Details worth knowing
+
+### The synchronous staging buffer closes the debounce gap
+
+The IndexedDB write is debounced (`DEBOUNCE_MS`, 500ms), which leaves a window the
+composer cannot afford to lose: type, then reload before the debounce fires, and the
+keystrokes — living only in React state and the editor — are gone. Losing user content
+is the one thing this feature exists to prevent, so a third persistence layer sits in
+front of IDB: `apps/frontend/src/lib/drafts/draft-staging.ts`, a synchronous
+`localStorage` buffer keyed `threa:draft-stage:{workspaceId}:{scope}`. The three layers
+each write on their own cadence — **localStorage on every change** (synchronous, so it is
+on disk before the browser can process a subsequent reload task), **IDB on the debounce**
+(unchanged), **server from IDB** through the op queue (unchanged). `saveDraftDebounced`
+stages synchronously before it arms the timer; the timer still does the real IDB write.
+
+Recovery is **content-diff, never a timestamp compare**. On workspace load,
+`reconcileStagedDrafts` (`draft-sync.ts`) runs _before_ the draft cache seeds (so the
+recovered body is in `db.drafts` when the composer first reads — no empty flash, no second
+read path in the composer) and writes straight to IDB (so it can't flip the cache "ready"
+with a partial set). For each staged entry it compares the body against the scope's loaded
+IDB draft: identical means the last flush already captured it (drop the buffer); different
+means an un-flushed tail (write it into the draft, preserving `baseVersion` / attachments /
+context refs, and enqueue a push). Enqueuing the push is what makes cross-device safe — a
+draft that drifted on another device while this tab was gone resolves through the server's
+split on the next bootstrap, so local edits win without overwriting. Comparing this
+device's staged clock against a roamed draft's foreign clock would be unsafe, so the
+buffer's `clientUpdatedAt` is for ordering/debugging only and never gates recovery.
+
+The buffer is cleared synchronously, first thing, on every teardown that ends an edit —
+discard, resolve-on-send, stash, scope purge — so a just-sent draft cannot be recovered or
+re-staged by a racing flush (the same resurrection class the resolution guard below
+closes). An emptied editor clears it too (deletion propagation is the debounce's job, not
+the buffer's), and a payload over 256KB is skipped so a pathological paste can't jank the
+synchronous write or exhaust the quota; the debounce still carries it to IDB. Every
+`localStorage` access is wrapped — a quota error or private-mode block must never interrupt
+typing.
+
+**Plaintext only (E2EE-4).** An encrypted draft is sealed before it touches disk, and
+there is no synchronous seal, so E2E scopes never stage — the write gates on encryption and
+`reconcileStagedDrafts` refuses to apply a staged body over a sealed row. The reload-loss
+window therefore stays open for E2E drafts; that is the deliberate trade (no-plaintext-at-
+rest outranks closing the gap for the minority of encrypted scratchpads).
 
 ### Resolve-on-send is a separate, CAS-guarded path
 
@@ -274,5 +316,8 @@ contiguity / `broadcastSequence` machinery (INV-61) correctly does not apply to 
 - `apps/frontend/src/hooks/use-draft-message.ts`: the composer's write path, including
   the E2E seal-on-save and resolve-vs-discard split.
 - `apps/frontend/src/sync/draft-resolution-guard.ts`: the post-send resurrection guard.
+- `apps/frontend/src/lib/drafts/draft-staging.ts`: the synchronous `localStorage` buffer
+  that survives a reload before the IDB debounce fires; recovered by
+  `reconcileStagedDrafts` (`draft-sync.ts`) at workspace load.
 - `apps/frontend/src/lib/crypto/seal-draft.ts`: seal/open a draft body and attachments
   on the message E2E path.


### PR DESCRIPTION
## Problem

The composer debounces its write to IndexedDB (`use-draft-message.ts`, `DEBOUNCE_MS = 500`). A keystroke does `setContent(newContent)` (React state) + `saveDraftDebounced(newContent)`, and the latter only reaches IDB after 500ms of quiet. Type, then reload inside that window, and the keystrokes are gone — they lived only in React state and the TipTap editor, both wiped by the reload. Losing in-progress user content is the cardinal sin the whole draft system is built to avoid ("duplicated drafts are acceptable; lost drafts are not"), and this was a real, easily-hit hole.

## Solution

Add a third persistence layer in front of IDB: a **synchronous `localStorage` staging buffer**, written on every change before the debounce arms, so the content is on disk before the browser can process a subsequent reload task. The three layers now each have their own cadence:

- **localStorage** — every change, synchronous (the crash/reload-safe buffer).
- **IndexedDB** — debounced (the existing 500ms), the local source of truth (unchanged).
- **server** — mirrored from IDB through the offline op queue (unchanged).

The framing rule for recovery is **content-diff, never a cross-device timestamp compare** — comparing this device's clock against a roamed draft's foreign clock would be unsafe, and cross-device conflicts already have a correct resolver (the `version`/split machinery).

### How it works

- **Stage on change.** `saveDraftDebounced` (`use-draft-message.ts`) calls `stageDraftContent(workspaceId, draftKey, contentJson)` synchronously before arming the timer. Key: `threa:draft-stage:{workspaceId}:{scope}`. The debounced `saveDraft` → IDB path is untouched.
- **Recover at load.** `reconcileStagedDrafts` (`draft-sync.ts`) runs in `CoordinatedLoadingProvider` **before** `seedDraftCacheFromIdb`, so a recovered body is already in `db.drafts` when the composer first reads — no empty flash, no second read path in the composer. It writes straight to IDB (not the in-memory cache) so it can't flip the draft cache "ready" with a partial set.
- **Content-diff, not timestamp.** For each staged entry, if its body equals the scope's loaded IDB draft, the last debounced flush already captured it → drop the buffer. If it differs, it's an un-flushed tail → write it into the draft (preserving `baseVersion` / attachments / context refs via `{ ...existing }`) and enqueue a push.
- **Cross-device safety via the existing split.** Recovery enqueues the push *before* the IDB write, so a sync bootstrap racing at boot sees the pending upsert and defers to the server split for that id (the same "unpushed edits win, server arbitrates" rule `applyDraftUpserted` already follows) instead of overwriting the tail with a newer server row. A draft that drifted on another device while the tab was gone thus resolves to two rows, never an overwrite.
- **Clear on every teardown.** `clearStagedDraft` is called synchronously, first thing, in `clearLoadedDraft` (discard), `resolveLoadedDraft` (send), `stashLoadedDraft`, `purgeScopeDrafts`, and `purgePlaintextScopeDrafts` — so a just-sent draft can't be recovered or re-staged by a racing flush (the same resurrection class the resolution guard closes). An emptied editor clears the key too (deletion propagation stays the debounce's job).

### Key design decisions

**1. Plaintext only — E2E drafts deliberately keep today's behavior (E2EE-4).** Staging the composer's `contentJson` writes plaintext to disk. The E2E draft design seals before anything touches disk and stores ciphertext only; there is no synchronous seal (WebCrypto is async). So `saveDraftDebounced` gates staging on `!e2eGateRef.current.enabled`, and `reconcileStagedDrafts` refuses to apply a staged body over a sealed row (`existing?.ciphertext != null`). The reload-loss window stays open for encrypted scratchpads — that is the correct trade per the project precedence (correctness/safety first; no-plaintext-at-rest outranks closing the gap for the minority of E2E scopes). `purgePlaintextScopeDrafts` also clears any stray staged plaintext on E2E composer mount as defense in depth.

**2. No clear-on-flush; content-diff reconcile instead.** The naive "flush localStorage→IDB then clear the key" is a race: a keystroke typed during the async IDB write would be cleared before its own debounce flushes it. Not clearing on flush and resolving staleness by content-diff at load is race-free and avoids comparing timestamps across devices.

**3. Reconcile before the cache seeds, writing IDB directly.** Recovering through the draft-store cache helpers would mark `hasSeededDraftCache` true with a partial set. Writing raw IDB rows before `seedDraftCacheFromIdb` keeps the cache-ready signal honest and gives the composer the content on first paint.

**4. Size cap + total try/catch.** A payload over 256KB is skipped (the debounce still carries it to IDB) so a pathological paste can't jank the synchronous write or exhaust the quota. Every `localStorage` access is wrapped — a quota error or private-mode block must never interrupt typing.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/drafts/draft-staging.ts` | Synchronous `localStorage` staging buffer: `stageDraftContent` / `readStagedDraft` / `clearStagedDraft` / `listStagedDrafts`, plaintext-only, size-capped, fully guarded. |
| `apps/frontend/src/lib/drafts/draft-staging.test.ts` | Unit tests: round-trip, latest-wins, empty clears, oversize skip, corrupt entry, workspace scoping. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-draft-message.ts` | Stage synchronously in `saveDraftDebounced` (plaintext gate); clear staging at every teardown (`clearLoadedDraft`, `resolveLoadedDraft`, `stashLoadedDraft`, `purgeScopeDrafts`, `purgePlaintextScopeDrafts`). |
| `apps/frontend/src/sync/draft-sync.ts` | `reconcileStagedDrafts` + `applyStagedDraft`: content-diff recovery into IDB, push-before-write for boot-race safety, refuse over sealed rows. |
| `apps/frontend/src/contexts/coordinated-loading-context.tsx` | Run `reconcileStagedDrafts` before `seedDraftCacheFromIdb`; never block the app on a failed recovery. |
| `apps/frontend/src/hooks/use-draft-message.test.ts` | Tests: plaintext stages synchronously before the debounce; E2E never stages; discard/send/stash clear the buffer. |
| `apps/frontend/src/sync/draft-sync.test.ts` | Tests: recover un-flushed tail (preserving baseVersion/attachments), drop already-flushed, create when absent, refuse over sealed, clear on empty. |
| `docs/features/architecture/drafts.md` | New "synchronous staging buffer" subsection + entry-point listing. |

## Out of scope (deliberate)

- **E2E drafts** — no synchronous seal exists, so the reload-loss window stays open for encrypted scopes (see decision 1).
- **Cross-tab live reactivity** on the staging key (the `storage` event) — durability is handled by the startup reconcile; the existing IDB/Dexie-liveQuery story covers same-origin tabs.
- **Deletion propagation via the buffer** — emptying the editor clears the key; propagating a delete remains the debounce's job.

## Test plan

- [x] `apps/frontend` full suite — 3026 pass (`bun run test`)
- [x] `draft-staging.test.ts` (8) + `draft-sync.test.ts` (57) + `use-draft-message.test.ts` (incl. 5 new staging cases) + `coordinated-loading-context.test.tsx` (24) — all pass
- [x] `tsc --noEmit` across the monorepo — clean
- [x] `eslint` + `prettier --check` on changed files — clean
- [ ] Playwright `test:e2e` — not run (needs the full backend/DB harness, unavailable in this environment); the change is covered by the unit/integration suites above

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fge23FT6fenFa2wk867AaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fge23FT6fenFa2wk867AaQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784576735&installation_id=129946197&pr_number=1036&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1036&signature=69f0a5ad712526133c37f2766a624f634c01b6609a03b79b488734ff6a6f8f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->