### PR TITLE
fix(timeline): clear stuck unread divider on cold-loaded short streams (read-frontier late-mount)

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -981,6 +981,7 @@ export function StreamContent({
     listRef,
     scrollerRef: virtualScrollerRef,
     registerScroller: registerVirtualScroller,
+    scrollerEl: virtualScrollerEl,
     contentRef: virtualContentRef,
     shift,
     isScrolledFarFromBottom: virtualIsScrolledFar,
@@ -1489,6 +1490,12 @@ export function StreamContent({
   const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
+    // The virtualized scroller late-mounts via a ref callback, AFTER
+    // `autoMarkEnabled` flips true — pass the mounted element so the read-frontier
+    // scan re-arms its observers once the scroller exists. The plain thread
+    // scroller mounts synchronously with the content, so it has no element to
+    // track (the ref is already live when enabled flips).
+    scrollContainerEl: useVirtualized ? virtualScrollerEl : null,
     // Observe the scrolling content box (its height tracks scrollHeight) so a
     // settle / embed / image resize re-scans even when the stream is too short
     // to scroll. Both paths pass one — the virtualized list's inner content div

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -126,9 +126,9 @@ describe("useAutoMarkAsRead", () => {
     // user is clearly reading stays unread (a persisted mark-unread divider
     // stuck red across a cold app resume).
     hasFocus = false
-    const matchMediaSpy = vi
-      .spyOn(window, "matchMedia")
-      .mockImplementation((query: string) => ({ matches: query.includes("coarse"), media: query }) as MediaQueryList)
+    vi.spyOn(window, "matchMedia").mockImplementation(
+      (query: string) => ({ matches: query.includes("coarse"), media: query }) as MediaQueryList
+    )
 
     renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
 
@@ -137,7 +137,6 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
-    matchMediaSpy.mockRestore()
   })
 
   it("waits until the tab is visible and focused again before sending the read event", () => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -118,6 +118,28 @@ describe("useAutoMarkAsRead", () => {
     expect(mockPostMessage).not.toHaveBeenCalled()
   })
 
+  it("marks read on a touch device that is visible but reports no focus", () => {
+    // Mobile browsers / installed PWAs routinely report `document.hasFocus()` ===
+    // false while the page is the foreground the user is looking at (and the
+    // resume `focus` event often never fires). On a coarse-pointer device,
+    // visible must be enough — otherwise auto-mark wedges off and a stream the
+    // user is clearly reading stays unread (a persisted mark-unread divider
+    // stuck red across a cold app resume).
+    hasFocus = false
+    const matchMediaSpy = vi
+      .spyOn(window, "matchMedia")
+      .mockImplementation((query: string) => ({ matches: query.includes("coarse"), media: query }) as MediaQueryList)
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
+    matchMediaSpy.mockRestore()
+  })
+
   it("waits until the tab is visible and focused again before sending the read event", () => {
     renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
 

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -4,6 +4,7 @@ import { useAutoMarkAsRead } from "./use-auto-mark-as-read"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "../lib/sw-messages"
 import * as useUnreadCountsModule from "./use-unread-counts"
 import * as useActivityCountsModule from "./use-activity-counts"
+import * as useMobileModule from "./use-mobile"
 
 const mockMarkAsRead = vi.fn()
 const mockGetUnreadCount = vi.fn()
@@ -14,6 +15,10 @@ let unreadCount = 1
 let activityCount = 0
 let hasFocus = true
 let visibilityState: DocumentVisibilityState = "visible"
+// Device shape — drives the phone-like focus relaxation. Defaults are a desktop
+// (fine pointer, wide viewport): focus is required. Touch/tablet tests flip these.
+let isMobileViewport = false
+let isCoarsePointer = false
 
 const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState")
 const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
@@ -39,9 +44,14 @@ describe("useAutoMarkAsRead", () => {
     activityCount = 0
     hasFocus = true
     visibilityState = "visible"
+    isMobileViewport = false
+    isCoarsePointer = false
 
     mockGetUnreadCount.mockImplementation(() => unreadCount)
     mockGetActivityCount.mockImplementation(() => activityCount)
+
+    vi.spyOn(useMobileModule, "useIsMobile").mockImplementation(() => isMobileViewport)
+    vi.spyOn(useMobileModule, "useIsCoarsePointer").mockImplementation(() => isCoarsePointer)
 
     vi.spyOn(useUnreadCountsModule, "useUnreadCounts").mockReturnValue({
       markAsRead: mockMarkAsRead,
@@ -118,17 +128,16 @@ describe("useAutoMarkAsRead", () => {
     expect(mockPostMessage).not.toHaveBeenCalled()
   })
 
-  it("marks read on a touch device that is visible but reports no focus", () => {
+  it("marks read on a phone-like device (coarse + narrow) that is visible but reports no focus", () => {
     // Mobile browsers / installed PWAs routinely report `document.hasFocus()` ===
     // false while the page is the foreground the user is looking at (and the
-    // resume `focus` event often never fires). On a coarse-pointer device,
-    // visible must be enough — otherwise auto-mark wedges off and a stream the
-    // user is clearly reading stays unread (a persisted mark-unread divider
-    // stuck red across a cold app resume).
+    // resume `focus` event often never fires). On a phone-like device, visible
+    // must be enough — otherwise auto-mark wedges off and a stream the user is
+    // clearly reading stays unread (a persisted mark-unread divider stuck red
+    // across a cold app resume).
     hasFocus = false
-    vi.spyOn(window, "matchMedia").mockImplementation(
-      (query: string) => ({ matches: query.includes("coarse"), media: query }) as MediaQueryList
-    )
+    isMobileViewport = true
+    isCoarsePointer = true
 
     renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
 
@@ -137,6 +146,42 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
+  })
+
+  it("does NOT mark read on a coarse-but-wide device (tablet / iPad split view) while unfocused", () => {
+    // A coarse pointer alone is not "phone-like": an iPad in Split View / Stage
+    // Manager is coarse but wide, and an unfocused pane there means the user is
+    // working in the OTHER app — exactly the false-positive the focus gate
+    // exists to prevent. The relaxation requires BOTH coarse and a phone-width
+    // viewport, so a wide coarse device stays focus-gated.
+    hasFocus = false
+    isCoarsePointer = true
+    isMobileViewport = false
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("does NOT mark read on a phone-like device while the tab is hidden", () => {
+    // The phone relaxation drops only the FOCUS requirement, never visibility —
+    // a backgrounded PWA the user has switched away from must not auto-read.
+    hasFocus = false
+    visibilityState = "hidden"
+    isMobileViewport = true
+    isCoarsePointer = true
+
+    renderHook(() => useAutoMarkAsRead("ws_123", "stream_123", "event_123"))
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
   })
 
   it("waits until the tab is visible and focused again before sending the read event", () => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 import { useUnreadCounts } from "./use-unread-counts"
 import { useActivityCounts } from "./use-activity-counts"
 import { usePageActivity } from "./use-page-activity"
+import { useIsMobile, useIsCoarsePointer } from "./use-mobile"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "../lib/sw-messages"
 
 interface UseAutoMarkAsReadOptions {
@@ -38,7 +39,20 @@ export function useAutoMarkAsRead(
   const { enabled = true, debounceMs = 500, partial = false } = options
   const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
-  const { isActive } = usePageActivity()
+  const { isVisible, isFocused } = usePageActivity()
+  const isMobile = useIsMobile()
+  const isCoarsePointer = useIsCoarsePointer()
+  // Focus tells you which of several overlapping windows the user is working in —
+  // a fine-pointer, multi-window (desktop) signal. On a phone-like device (coarse
+  // pointer AND a phone-width viewport) `document.hasFocus()` is an unreliable
+  // proxy for attention: mobile browsers and installed PWAs routinely report no
+  // focus while the page is the foreground, and the resume `focus` event often
+  // never fires — so there a visible page is "active". A coarse-but-wide device
+  // (tablet, iPad split view) keeps the focus gate, so working in the adjacent
+  // pane does not auto-read this one. This relaxation is deliberately local to
+  // auto-read; `usePageActivity().isActive` stays the strict visible-and-focused
+  // signal its other consumers (socket, connection status, app-update) rely on.
+  const canAutoRead = isVisible && (isFocused || (isMobile && isCoarsePointer))
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
   // Track the partial-ness of the last mark so a partial→full transition at the
@@ -64,7 +78,7 @@ export function useAutoMarkAsRead(
   }, [streamId])
 
   useEffect(() => {
-    if (!enabled || !lastEventId || !isActive) return
+    if (!enabled || !lastEventId || !canAutoRead) return
 
     const unreadCount = getUnreadCount(streamId)
     const activityCount = getActivityCount(streamId)
@@ -104,5 +118,5 @@ export function useAutoMarkAsRead(
         clearTimeout(timerRef.current)
       }
     }
-  }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, isActive])
+  }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, canAutoRead])
 }

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -99,7 +99,7 @@ describe("advanceFrontier", () => {
   })
 })
 
-describe("useLastSeenEvent re-scan on content resize", () => {
+describe("useLastSeenEvent re-scan triggers", () => {
   // The container viewport spans y=0..100; rows carry mutable rects so a test
   // can "grow" the content (an embed loading) between scans.
   let roCallbacks: ResizeObserverCallback[]
@@ -197,6 +197,66 @@ describe("useLastSeenEvent re-scan on content resize", () => {
     fireResize()
 
     // The re-scan reaches the last row — the message that was stuck unread.
+    expect(result.current.lastSeenEventId).toBe("e2")
+    expect(result.current.atLastRow).toBe(true)
+  })
+
+  it("re-arms the scan when the virtualized scroller late-mounts after enabled (scrollContainerEl)", () => {
+    // The bug behind the stuck-unread divider: the virtualized timeline flips
+    // `enabled` true BEFORE virtua mounts its scroller (a ref callback). The
+    // attach effect must re-run when the element finally mounts — a ref change
+    // alone never re-runs an effect, so a viewport-fitting stream (no scroll to
+    // re-trigger a scan) would leave its frontier stuck and the divider red.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: -50, bottom: -10 }, // already read, scrolled above
+      e1: { top: 10, bottom: 55 }, // visible
+      e2: { top: 60, bottom: 95 }, // visible (short stream fits the viewport)
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [
+      { id: "e0", sequence: "0" },
+      { id: "e1", sequence: "1" },
+      { id: "e2", sequence: "2" },
+    ] as unknown as StreamEvent[]
+    // The ref starts null (scroller not mounted) and is populated by virtua's ref
+    // callback when it mounts — mirrored here by mutating `.current`.
+    const scrollContainerRef: { current: HTMLElement | null } = { current: null }
+
+    const { result, rerender } = renderHook(
+      ({ el }) =>
+        useLastSeenEvent({
+          scrollContainerRef,
+          scrollContainerEl: el,
+          events,
+          streamId: "stream_1",
+          lastReadEventId: "e0",
+          enabled: true,
+        }),
+      { initialProps: { el: null as HTMLElement | null } }
+    )
+
+    // Scroller not mounted yet → nothing to scan, frontier can't advance.
+    expect(result.current.lastSeenEventId).toBeUndefined()
+
+    // Virtua mounts the scroller: the ref goes live AND the element surfaces as
+    // reactive state. The element dep is what re-runs the attach effect; mutating
+    // the ref alone (no element change) would not, which is the original bug.
+    act(() => {
+      scrollContainerRef.current = container
+      rerender({ el: container })
+    })
+
+    // Re-armed: the frontier advances to the trailing visible row, so auto-read
+    // can fire and the divider clears.
     expect(result.current.lastSeenEventId).toBe("e2")
     expect(result.current.atLastRow).toBe(true)
   })

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -48,6 +48,16 @@ interface UseLastSeenEventOptions {
   /** The owned scroll container (virtualized timeline or plain thread scroller). */
   scrollContainerRef: React.RefObject<HTMLElement | null>
   /**
+   * The mounted scroller element as reactive state, when the owner tracks it
+   * (the virtualized timeline late-mounts its scroller via a ref callback). The
+   * attach effect depends on it so the scroll listener + ResizeObserver are
+   * armed once the element actually exists — a ref alone never re-runs the
+   * effect, so a window that fits the viewport (no scroll to re-trigger a scan)
+   * would otherwise never advance the frontier. `null` for owners whose scroller
+   * mounts synchronously with `enabled` (the plain thread scroller).
+   */
+  scrollContainerEl?: HTMLElement | null
+  /**
    * The scrolling content box inside the container (its height = scrollHeight).
    * Observed for size changes so the scan re-runs when rows grow after the last
    * scroll — the open-at-bottom settle finishing, or async embeds (link/GitHub
@@ -96,6 +106,7 @@ interface UseLastSeenEventResult {
  */
 export function useLastSeenEvent({
   scrollContainerRef,
+  scrollContainerEl,
   contentRef,
   events,
   streamId,
@@ -228,10 +239,14 @@ export function useLastSeenEvent({
 
   // Attach the scroll listener and seed an initial scan. The initial scan covers
   // a window that fits the viewport with no scroll (no scroll event would fire).
-  // `enabled` flips true exactly when the scroller is mounted, so the ref is live.
+  // The virtualized timeline late-mounts its scroller AFTER `enabled` flips, so
+  // this effect depends on the mounted element (`scrollContainerEl`), not just
+  // `enabled`: a ref change never re-runs an effect, so without the element dep
+  // the ResizeObserver would arm against a null scroller and a viewport-fitting
+  // window (no scroll to re-trigger a scan) would never advance the frontier.
   useEffect(() => {
     if (!enabled) return
-    const el = scrollContainerRef.current
+    const el = scrollContainerEl ?? scrollContainerRef.current
     let raf = 0
     const schedule = () => {
       if (raf) return
@@ -264,7 +279,7 @@ export function useLastSeenEvent({
       el?.removeEventListener("scroll", onScroll)
       ro?.disconnect()
     }
-  }, [enabled, streamId, recompute, scrollContainerRef, contentRef])
+  }, [enabled, streamId, recompute, scrollContainerRef, scrollContainerEl, contentRef])
 
   // Re-scan when the window grows (live append) or the read pointer moves under
   // us (external read), so the frontier and the affordance stay current.

--- a/apps/frontend/src/hooks/use-mobile.tsx
+++ b/apps/frontend/src/hooks/use-mobile.tsx
@@ -20,3 +20,24 @@ function getSnapshot() {
 export function useIsMobile() {
   return useSyncExternalStore(subscribe, getSnapshot)
 }
+
+const coarsePointerQuery = "(pointer: coarse)"
+
+// Same shared-subscription pattern as useIsMobile: one matchMedia listener for
+// the primary pointer being coarse (touch), regardless of caller count.
+const coarseMql = typeof window !== "undefined" ? window.matchMedia(coarsePointerQuery) : null
+
+function subscribeCoarse(onChange: () => void) {
+  coarseMql?.addEventListener("change", onChange)
+  return () => coarseMql?.removeEventListener("change", onChange)
+}
+
+function getCoarseSnapshot() {
+  return coarseMql?.matches ?? false
+}
+
+/** True when the device's primary pointer is coarse (touch), e.g. a phone or
+ *  tablet. Paired with {@link useIsMobile} to detect a phone-like device. */
+export function useIsCoarsePointer() {
+  return useSyncExternalStore(subscribeCoarse, getCoarseSnapshot)
+}

--- a/apps/frontend/src/hooks/use-page-activity.ts
+++ b/apps/frontend/src/hooks/use-page-activity.ts
@@ -6,23 +6,6 @@ export interface PageActivityState {
   isActive: boolean
 }
 
-// Window focus only tells you which of several overlapping windows the user is
-// working in — a desktop concern. On a touch device `document.hasFocus()` is an
-// unreliable proxy for "the user is looking at this": mobile browsers and
-// installed PWAs routinely report no focus while the page is the foreground, and
-// the `focus` event frequently never fires when a PWA resumes from the
-// background. So gate "active" on focus only when the primary pointer is fine
-// (mouse/trackpad); on a coarse pointer (touch), a visible page is active.
-function isCoarsePointer(): boolean {
-  return typeof window !== "undefined" && typeof window.matchMedia === "function"
-    ? window.matchMedia("(pointer: coarse)").matches
-    : false
-}
-
-function deriveIsActive(isVisible: boolean, isFocused: boolean): boolean {
-  return isVisible && (isFocused || isCoarsePointer())
-}
-
 export function getPageActivityState(): PageActivityState {
   if (typeof document === "undefined") {
     return {
@@ -38,7 +21,7 @@ export function getPageActivityState(): PageActivityState {
   return {
     isVisible,
     isFocused,
-    isActive: deriveIsActive(isVisible, isFocused),
+    isActive: isVisible && isFocused,
   }
 }
 
@@ -67,5 +50,5 @@ export function usePageActivity(): PageActivityState {
     }
   }, [])
 
-  return { isVisible, isFocused, isActive: deriveIsActive(isVisible, isFocused) }
+  return { isVisible, isFocused, isActive: isVisible && isFocused }
 }

--- a/apps/frontend/src/hooks/use-page-activity.ts
+++ b/apps/frontend/src/hooks/use-page-activity.ts
@@ -6,6 +6,23 @@ export interface PageActivityState {
   isActive: boolean
 }
 
+// Window focus only tells you which of several overlapping windows the user is
+// working in — a desktop concern. On a touch device `document.hasFocus()` is an
+// unreliable proxy for "the user is looking at this": mobile browsers and
+// installed PWAs routinely report no focus while the page is the foreground, and
+// the `focus` event frequently never fires when a PWA resumes from the
+// background. So gate "active" on focus only when the primary pointer is fine
+// (mouse/trackpad); on a coarse pointer (touch), a visible page is active.
+function isCoarsePointer(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(pointer: coarse)").matches
+    : false
+}
+
+function deriveIsActive(isVisible: boolean, isFocused: boolean): boolean {
+  return isVisible && (isFocused || isCoarsePointer())
+}
+
 export function getPageActivityState(): PageActivityState {
   if (typeof document === "undefined") {
     return {
@@ -21,7 +38,7 @@ export function getPageActivityState(): PageActivityState {
   return {
     isVisible,
     isFocused,
-    isActive: isVisible && isFocused,
+    isActive: deriveIsActive(isVisible, isFocused),
   }
 }
 
@@ -50,5 +67,5 @@ export function usePageActivity(): PageActivityState {
     }
   }, [])
 
-  return { isVisible, isFocused, isActive: isVisible && isFocused }
+  return { isVisible, isFocused, isActive: deriveIsActive(isVisible, isFocused) }
 }

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -65,6 +65,11 @@ interface UseTimelineScrollReturn {
   /** Ref callback for the scrollable `<div>` — use as its `ref`. Keeps
    *  `scrollerRef` current and re-arms the ResizeObserver once it mounts. */
   registerScroller: (node: HTMLDivElement | null) => void
+  /** The mounted scroller element as reactive state (null until virtua mounts
+   *  it). Consumers whose effects must re-run when the scroller late-mounts
+   *  (e.g. the read-frontier scan in `useLastSeenEvent`) depend on this, not the
+   *  ref — a ref change does not re-run an effect. */
+  scrollerEl: HTMLDivElement | null
   /** Ref for the inner content wrapper (sized to the full scroll height). */
   contentRef: React.RefObject<HTMLDivElement | null>
   /**
@@ -546,6 +551,7 @@ export function useTimelineScroll({
     listRef,
     scrollerRef,
     registerScroller,
+    scrollerEl,
     contentRef,
     shift,
     isScrolledFarFromBottom,


### PR DESCRIPTION
## Summary

Fixes the bug where a stream that was **marked unread in a prior session** stays stuck with a red unread divider (and unread badge) after a cold app resume, when the whole conversation fits one screen — auto-read never fires and the divider never clears.

**The diagnosis changed after browser verification.** The original commits on this branch (`7a8cce1`, `8fa67e1`) treated the **focus gate** as the cause (relaxing `document.hasFocus()` on touch). Running the real stack + real virtualized timeline showed that is **not** the primary cause: even fully focused (`isFocused: true`, `isActive: true`, `unreadCount: 2`), `lastSeenEventId` **never emits**, so auto-read never fires regardless of focus.

### Root cause (primary)

`useLastSeenEvent`'s observer-attach effect runs when `autoMarkEnabled` flips true (`!isDraft && !isLoading && !isJumpMode`), but **virtua late-mounts its scroller via a ref callback AFTER that**. The effect captured a null element, armed no scroll listener / `ResizeObserver`, and never re-ran (a ref change does not re-run an effect). On a viewport-fitting stream there is no scroll to re-trigger a scan, so the read frontier never advanced → divider stuck. It's a mount-timing race, so it's platform-agnostic; it surfaced on mobile PWA cold-resume where the short-stream + timing conditions coincide.

This is the codebase's own "late-mount" lesson: `useTimelineScroll` already tracks the mounted scroller as **state** (`scrollerEl`) so *its* observers re-arm on mount. The read-frontier scanner was simply never given that signal.

**Fix:** expose `scrollerEl` from `useTimelineScroll` and feed it to `useLastSeenEvent`, whose attach effect now depends on it. The plain (thread) scroller mounts synchronously with its content, so it passes `null`.

### Secondary fix (focus gate, now done right)

After the primary fix, the focus gate is still a *real secondary* gate (verified: a visible-but-unfocused fine-pointer device stays blocked; a coarse phone clears). The provisional approach baked the relaxation into the **shared** `usePageActivity().isActive`, overloading a primitive that `socket-context`, `connection-status`, and `use-app-update` also read.

**Fix:** revert `use-page-activity` to the strict `isActive = isVisible && isFocused`, and compute the relaxed gate **locally** in `useAutoMarkAsRead`, relaxing focus only on a **phone-like** device — coarse pointer **and** a phone-width viewport. A coarse-but-wide device (iPad Split View / Stage Manager) keeps the focus gate, so working in the adjacent pane does not auto-read this one.

## Verification

Browser-verified end-to-end against the real stack + virtualized timeline (cold reload of a short, marked-unread stream):

| Scenario | `lastSeen` emits | gate | marks read |
|----------|:---:|:---:|:---:|
| focused (fine pointer) | yes (after fix) | active | yes |
| unfocused (fine pointer) | yes | blocked | no -> yes once focused |
| unfocused (coarse + narrow) | yes | relaxed | yes |

Before the primary fix, the focused case did **not** emit `lastSeen` — proving the focus relaxation alone would not have fixed the bug.

## Tests

- `use-last-seen-event.test.ts`: re-arms the scan when the scroller late-mounts (`scrollContainerEl` null → element).
- `use-auto-mark-as-read.test.ts`: phone-like (coarse + narrow) unfocused → marks; coarse-but-wide tablet → does not; hidden phone → does not; desktop unfocused → does not. (Hook spies replace the old `matchMedia` poke, since the device hooks now use module-scope subscriptions — INV-48.)

## File changes

**Primary (b):**
- `hooks/use-timeline-scroll.ts` — expose the mounted `scrollerEl` state.
- `hooks/use-last-seen-event.ts` — accept `scrollContainerEl`; attach effect depends on it.
- `components/timeline/stream-content.tsx` — pass the virtualized `scrollerEl` through.

**Secondary (a):**
- `hooks/use-page-activity.ts` — revert to strict `isActive` (net-zero vs `main`).
- `hooks/use-mobile.tsx` — add reactive `useIsCoarsePointer`.
- `hooks/use-auto-mark-as-read.ts` — localized phone-like focus relaxation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
