### PR TITLE
docs: add concision directive to CLAUDE.md working style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Default implementation mode for routine tasks: **minimal patch**. Do not refacto
 
 ## Working Style
 
+Be extremely concise, sacrifice grammar for sake of concision.
+
 Read this before asking the user anything.
 
 **Search before you ask.** If a question has a factual answer in the repo ("is there a sync path from control-plane to backend?", "which model does persona X use?", "how does auth flow through the workspace-router?"), it is your job to find it. Use Grep, Glob, and the Agent tool. Start from `docs/system-overview.md`, `docs/architecture.md`, `docs/core-concepts.md`, then `apps/*/src/` and the relevant feature folder under `apps/backend/src/features/`. Escalate to the user only when (a) the search genuinely came back empty, (b) the decision is a preference the code cannot reveal, or (c) the action is destructive or irreversible.


### PR DESCRIPTION
## Problem

The Working Style section of `CLAUDE.md` set behavioral guidance for agents but said nothing about output verbosity, leaving response length to default model behavior.

## Solution

Add one directive to the top of the **Working Style** section instructing agents to favor concision over grammatical completeness.

## Files changed

| File | Change |
| ---- | ------ |
| `CLAUDE.md` | Add "Be extremely concise, sacrifice grammar for sake of concision." as the lead line of the Working Style section |

## Test plan

- [x] Docs-only change; no code paths touched, nothing to run.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoG2iEV65qK1rRgubwR8qQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784618930&installation_id=129946197&pr_number=1038&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1038&signature=55c2c51edd656895da03e915701406a58f5bd8c9d5edf661f4dbb0b96d679f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->