### PR TITLE
feat(claude-code-channel): send interim messages + idle (not absolute) turn timeout

### DIFF
--- a/docs/claude-code-channel.md
+++ b/docs/claude-code-channel.md
@@ -76,15 +76,20 @@ A claim holds a lease (`claimTtlSeconds`, max 300) that expires if not renewed, 
 
 The channel handles one turn at a time. A message you send while Claude is still working waits in Threa until the current turn completes, then gets claimed and pushed. The one exception is a permission verdict (below), which is pulled through immediately so a blocked turn can continue.
 
-## Outbound: the reply tool completes the invocation
+## Outbound: send for progress, reply to finish
 
-The channel exposes one tool, `reply(invocation_id, text)`. Claude is told (via the server's `instructions`, which land in its system prompt) to call it exactly once per `<channel>` event. When Claude calls it:
+The channel exposes two output tools, and Claude is told (via the server's `instructions`, which land in its system prompt) how they differ:
 
-1. The channel looks up the in-flight invocation by `invocation_id`.
-2. It calls `POST /bot-invocations/:id/complete` with `finalMessageMarkdown: text`. That posts the reply into the scratchpad and closes the invocation.
-3. It clears the in-flight entry, and when nothing is in flight, flips presence back to `available`.
+- **`send(invocation_id, text)`** posts a progress or intermediate message and leaves the request open. Claude can call it any number of times during a turn. It posts via `POST /streams/:id/messages` (the same path the permission relay uses) — the invocation stays in flight, so presence stays `busy`.
+- **`reply(invocation_id, text)`** posts the final message and closes the request. Claude calls it once, last. It calls `POST /bot-invocations/:id/complete` with `finalMessageMarkdown: text`, which posts the reply into the scratchpad and closes the invocation; the channel then clears the in-flight entry and, when nothing is in flight, flips presence back to `available`.
 
-The `reply` tool is the only path back to Threa, which is why the instructions insist on it. As a safety net, an in-flight invocation that is never answered is force-closed after `replyTimeoutMs` (default 30 minutes) with a short notice, so a session can't get wedged in `busy` forever.
+Splitting the two means a long turn isn't silent until a single terminal reply — it can stream updates as it works and finish with a summary. This is the only path back to Threa, which is why the instructions insist on ending with `reply`.
+
+### The idle-timeout safety net
+
+A turn that goes silent without a `reply` would otherwise wedge the session in `busy` forever (the next message can't be claimed while one is in flight). So an in-flight invocation is force-closed after `idleTimeoutMs` (default 60 minutes, `THREA_IDLE_TIMEOUT_MS`) of **inactivity**. It's an _idle_ timer, not an absolute one: every `send` and every tool-approval prompt resets it, so an actively-working turn is never reaped — only one that has genuinely gone quiet. If the reaped turn had already `send`-ed something, it closes silently (`noResponse`); otherwise it posts a short "ended without a reply" notice.
+
+The one case the heartbeat can't cover is a single long-running tool call (a 40-minute test run): Claude is blocked awaiting the tool and can't `send` in the middle of it. The idle window must therefore exceed the longest single operation — raise `THREA_IDLE_TIMEOUT_MS` if a turn does heavy uninterrupted work. (This replaced an earlier fixed 30-minute reply timeout that force-closed long turns at exactly 30 minutes regardless of whether they were still working.)
 
 ## Attachments
 
@@ -117,7 +122,7 @@ The local terminal dialog stays open the whole time, so whichever answer arrives
 | ----------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
 | Where it runs                             | Inside Pi, via Pi's extension API                         | A subprocess Claude Code spawns over stdio                           |
 | How it gets a prompt                      | Claims invocation, injects via `pi.sendUserMessage`       | Claims invocation, pushes a `notifications/claude/channel` event     |
-| How it returns a reply                    | Hooks Pi's `agent_end`, posts the captured assistant text | Claude calls the `reply` tool, which completes the invocation        |
+| How it returns a reply                    | Hooks Pi's `agent_end`, posts the captured assistant text | Claude calls `send` for progress and `reply` to finish the turn      |
 | Trace detail                              | Rich per-tool steps (it hooks Pi's tool events)           | One "working" step (a channel can't see Claude's tool calls)         |
 | Session control (`/compact`, `/model`, …) | Yes                                                       | No (a channel can't drive Claude's session)                          |
 | Permission prompts                        | N/A (Pi runs the model in-process)                        | Relayed into the scratchpad as messages                              |

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -136,7 +136,7 @@ The channel uploads the file (one per `THREA_ATTACH:` line; paths resolve agains
 | `THREA_DEFAULT_LABEL`      | `defaultLabel`     | (none)                 | Label applied to scratchpads this channel creates (only on first creation, not re-link) |
 | `THREA_PERMISSION_RELAY`   | `permissionRelay`  | `true`                 | Relay tool-approval prompts into the scratchpad                                         |
 | `THREA_POLL_MS`            | `pollMs`           | `3000`                 | Backstop claim poll (the socket pushes faster)                                          |
-| `THREA_REPLY_TIMEOUT_MS`   | `replyTimeoutMs`   | `1800000`              | Close an unanswered request after this many ms                                          |
+| `THREA_IDLE_TIMEOUT_MS`    | `idleTimeoutMs`    | `3600000`              | Force-close a turn after this much inactivity (each `send` / approval resets it)        |
 | `THREA_INSTANCE_ID`        | `instanceId`       | derived                | Override the per-directory instance id                                                  |
 | `THREA_RUNTIME_SESSION_ID` | `runtimeSessionId` | derived                | Override the per-directory session id                                                   |
 
@@ -149,10 +149,16 @@ bun test
 bun run typecheck
 ```
 
+## Sending multiple messages per turn
+
+Claude has two output tools. `send` posts a progress or intermediate message into the scratchpad and leaves the request open — call it as often as you like during a long task. `reply` posts the final message and closes the request; call it once, last. So a long turn can stream updates as it works and finish with a summary, instead of going silent until a single terminal reply.
+
+Each `send` (and each tool-approval prompt) also counts as a sign of life that resets the idle timeout, so an actively-working turn is never force-closed.
+
 ## Limitations
 
-- A channel only sees the inbound message and the reply, not Claude's individual tool calls, so the Threa trace card shows a single "working" step rather than the per-tool trace a Pi session produces.
-- Claude must call the `reply` tool to close a request. If a turn ends without a reply, the request is force-closed after `replyTimeoutMs` with a short notice.
+- A channel only sees the inbound message and Claude's `send`/`reply` calls, not its individual tool calls, so the Threa trace card shows a single "working" step rather than the per-tool trace a Pi session produces.
+- Claude can't `send` a heartbeat while blocked on a single long tool call (e.g. a 40-minute test run). The idle timeout must exceed your longest single operation — raise `THREA_IDLE_TIMEOUT_MS` if needed. A turn that goes idle without a `reply` is force-closed (silently if it already `send`-ed something, otherwise with a short "ended without a reply" notice).
 - One turn at a time: a message sent while Claude is still working is handled after the current reply (a permission verdict is the exception and goes through immediately).
 
 ## Roadmap (parity with `pi-remote`)

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -219,6 +219,33 @@ describe("ChannelServer.handleSend", () => {
     expect(res.isError).toBe(true)
     expect(calls.sendMessage).toEqual([])
   })
+
+  test("reports a closed turn when the idle timeout fires mid-send", async () => {
+    const { client, calls } = makeFakeClient()
+    const server = new ChannelServer(makeConfig(), client)
+    const invocation = makeInvocation({ id: "binv_race", responseStreamId: "stream_turn" })
+    seedInflight(server, invocation)
+
+    // Simulate onReplyTimeout firing during the post: the entry is removed from
+    // the in-flight map while sendMessage is in flight.
+    ;(client as unknown as { sendMessage: (s: string, b: Record<string, unknown>) => Promise<void> }).sendMessage =
+      async (streamId, body) => {
+        ;(server as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_race")
+        calls.sendMessage.push({ streamId, body })
+      }
+
+    const res = (await (
+      server as unknown as {
+        handleSend: (id: string, text: string) => Promise<{ isError?: boolean; content: { text: string }[] }>
+      }
+    ).handleSend("binv_race", "progress")) as { isError?: boolean; content: { text: string }[] }
+
+    // The message still posted (it can't be un-posted), but the result is not a
+    // clean "sent" — it tells Claude the turn already closed.
+    expect(calls.sendMessage[0]?.streamId).toBe("stream_turn")
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain("already closed")
+  })
 })
 
 describe("ChannelServer.onReplyTimeout", () => {

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -1,6 +1,49 @@
 import { describe, expect, test } from "bun:test"
-import { buildInstructions, formatInvocationContent, parsePermissionVerdict } from "./channel-server"
-import type { ClaimedInvocation } from "./threa-client"
+import { ChannelServer, buildInstructions, formatInvocationContent, parsePermissionVerdict } from "./channel-server"
+import type { ThreaChannelConfig } from "./config"
+import type { ClaimedInvocation, ThreaClient } from "./threa-client"
+
+function makeConfig(overrides?: Partial<ThreaChannelConfig>): ThreaChannelConfig {
+  return {
+    baseUrl: "https://app.threa.io",
+    workspaceId: "ws_1",
+    apiKey: "threa_bk_test",
+    displayName: "Claude Code - test",
+    instanceId: "cc-test",
+    runtimeSessionId: "ccs-test",
+    permissionRelay: false,
+    pollMs: 3000,
+    idleTimeoutMs: 3_600_000,
+    ...overrides,
+  }
+}
+
+/** A ThreaClient stub that records the calls the send/timeout paths make. */
+function makeFakeClient() {
+  const calls = {
+    sendMessage: [] as Array<{ streamId: string; body: Record<string, unknown> }>,
+    complete: [] as Array<{ id: string; body: Record<string, unknown> }>,
+  }
+  const client = {
+    sendMessage: async (streamId: string, body: Record<string, unknown>) => {
+      calls.sendMessage.push({ streamId, body })
+    },
+    complete: async (id: string, body: Record<string, unknown>) => {
+      calls.complete.push({ id, body })
+    },
+    upsertPresence: async () => undefined,
+    uploadAttachment: async () => {
+      throw new Error("unexpected upload in test")
+    },
+  }
+  return { client: client as unknown as ThreaClient, calls }
+}
+
+/** Seed an in-flight turn the way handleClaimed would, with a harmless deadline timer. */
+function seedInflight(server: ChannelServer, invocation: ClaimedInvocation, sentCount = 0): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(server as any).inflight.set(invocation.id, { invocation, deadline: setTimeout(() => {}, 1e9), sentCount })
+}
 
 function makeInvocation(partial: Partial<ClaimedInvocation>): ClaimedInvocation {
   return {
@@ -123,8 +166,82 @@ describe("buildInstructions", () => {
     expect(text).toContain("invocation_id")
   })
 
+  test("documents both the send and reply tools", () => {
+    const text = buildInstructions(false)
+    expect(text).toContain("`send`")
+    expect(text).toContain("`reply`")
+    expect(text).toContain("invocation_id")
+  })
+
   test("mentions permission forwarding only when relay is enabled", () => {
     expect(buildInstructions(true).toLowerCase()).toContain("approv")
     expect(buildInstructions(false).toLowerCase()).not.toContain("approv")
+  })
+})
+
+describe("ChannelServer.handleSend", () => {
+  test("posts an interim message to the turn's stream and keeps the request open", async () => {
+    const { client, calls } = makeFakeClient()
+    const server = new ChannelServer(makeConfig(), client)
+    const invocation = makeInvocation({ id: "binv_send", responseStreamId: "stream_turn" })
+    seedInflight(server, invocation)
+
+    const res = await (server as unknown as { handleSend: (id: string, text: string) => Promise<unknown> }).handleSend(
+      invocation.id,
+      "halfway there"
+    )
+
+    expect(res).toEqual({ content: [{ type: "text", text: "sent" }] })
+    expect(calls.sendMessage[0]).toEqual({
+      streamId: "stream_turn",
+      body: {
+        content: "halfway there",
+        clientMessageId: "ccsend-binv_send-1",
+        metadata: { "cc.channel.invocationId": "binv_send", "cc.channel.interim": "true" },
+      },
+    })
+    // The turn is not completed, and the send is counted toward the idle-timeout policy.
+    expect(calls.complete).toEqual([])
+    expect(
+      (server as unknown as { inflight: Map<string, { sentCount: number }> }).inflight.get("binv_send")?.sentCount
+    ).toBe(1)
+    ;(server as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_send")
+  })
+
+  test("errors without posting when the invocation is not open", async () => {
+    const { client, calls } = makeFakeClient()
+    const server = new ChannelServer(makeConfig(), client)
+
+    const res = (await (
+      server as unknown as { handleSend: (id: string, text: string) => Promise<{ isError?: boolean }> }
+    ).handleSend("binv_missing", "hi")) as { isError?: boolean }
+
+    expect(res.isError).toBe(true)
+    expect(calls.sendMessage).toEqual([])
+  })
+})
+
+describe("ChannelServer.onReplyTimeout", () => {
+  test("posts the no-reply notice when the turn sent nothing", async () => {
+    const { client, calls } = makeFakeClient()
+    const server = new ChannelServer(makeConfig(), client)
+    seedInflight(server, makeInvocation({ id: "binv_silent" }), 0)
+
+    await (server as unknown as { onReplyTimeout: (id: string) => Promise<void> }).onReplyTimeout("binv_silent")
+
+    expect(calls.complete[0]?.body.finalMessageMarkdown).toContain("without sending a reply")
+    expect(calls.complete[0]?.body.noResponse).toBeUndefined()
+    expect((server as unknown as { inflight: Map<string, unknown> }).inflight.has("binv_silent")).toBe(false)
+  })
+
+  test("closes silently when the turn already sent interim messages", async () => {
+    const { client, calls } = makeFakeClient()
+    const server = new ChannelServer(makeConfig(), client)
+    seedInflight(server, makeInvocation({ id: "binv_progress" }), 2)
+
+    await (server as unknown as { onReplyTimeout: (id: string) => Promise<void> }).onReplyTimeout("binv_progress")
+
+    expect(calls.complete[0]?.body.noResponse).toBe(true)
+    expect(calls.complete[0]?.body.finalMessageMarkdown).toBeUndefined()
   })
 })

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -85,8 +85,9 @@ export function buildInstructions(permissionRelay: boolean): string {
     "",
     "For each such event:",
     "- Do the work it asks for in this session, against the real files.",
-    "- Then call the `reply` tool exactly once, passing the `invocation_id` from that event's tag and your answer as `text`. The reply tool is the ONLY way your answer reaches the user, and it closes the request on Threa — so always reply, even with a short acknowledgement.",
-    "- One reply per invocation_id. If several events arrive together, reply to each by its own id.",
+    "- While you work, call the `send` tool to post progress or intermediate messages back to the scratchpad (passing the same `invocation_id`). It does NOT close the request, so you can call it as many times as you like — use it for partial answers, status on a long task, or anything worth surfacing before you're done. On a long task, send something periodically: it keeps the user informed and keeps the request from being closed for inactivity.",
+    "- When you are finished, call the `reply` tool exactly once with the `invocation_id` and your final answer. `reply` posts the message AND closes the request on Threa, so call it last. If you have nothing to add after your `send` messages, still call `reply` (a short 'Done.' is fine) to close cleanly.",
+    "- One `reply` per invocation_id. If several events arrive together, answer each by its own id.",
     "",
     "Attachments. If a message has attachments, the channel downloads them into the working directory and lists each local path under the event — read them from those paths. To send a local file back, add a line `THREA_ATTACH: path/to/file` to your reply text (one per file; paths resolve against the working directory); the channel uploads it and replaces the line with an attachment link.",
   ]
@@ -101,7 +102,13 @@ export function buildInstructions(permissionRelay: boolean): string {
 
 interface Inflight {
   invocation: ClaimedInvocation
+  // Idle-timeout timer; reset on every sign of life (a `send`, a permission
+  // request) so an actively-working turn is never reaped, only a silent one.
   deadline: ReturnType<typeof setTimeout>
+  // Count of interim `send` messages posted during this turn. When the idle
+  // timeout fires after at least one send, the turn closes silently instead of
+  // posting the "ended without a reply" notice — the user already heard from it.
+  sentCount: number
   // The reply after THREA_ATTACH uploads, cached when a complete() fails so the
   // retry reuses the same uploads instead of orphaning a fresh copy each time.
   prepared?: { markdown: string; attachmentIds: string[] }
@@ -158,9 +165,25 @@ export class ChannelServer {
     this.mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: [
         {
+          name: "send",
+          description:
+            "Post a progress or intermediate message to the Threa scratchpad WITHOUT closing the request. Call as many times as you like during a turn; finish with `reply`.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              invocation_id: {
+                type: "string",
+                description: "The invocation_id from the <channel> event you are working on.",
+              },
+              text: { type: "string", description: "The message to post, as markdown." },
+            },
+            required: ["invocation_id", "text"],
+          },
+        },
+        {
           name: "reply",
           description:
-            "Send your answer back to the Threa scratchpad and close the request. Call once per invocation_id.",
+            "Post your final answer to the Threa scratchpad and close the request. Call once per invocation_id, last.",
           inputSchema: {
             type: "object",
             properties: {
@@ -177,7 +200,7 @@ export class ChannelServer {
     }))
 
     this.mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
-      if (req.params.name !== "reply") {
+      if (req.params.name !== "reply" && req.params.name !== "send") {
         return { isError: true, content: [{ type: "text", text: `Unknown tool: ${req.params.name}` }] }
       }
       const args = (req.params.arguments ?? {}) as { invocation_id?: unknown; text?: unknown }
@@ -186,10 +209,10 @@ export class ChannelServer {
       if (!invocationId || !text.trim()) {
         return {
           isError: true,
-          content: [{ type: "text", text: "reply requires a non-empty invocation_id and text." }],
+          content: [{ type: "text", text: `${req.params.name} requires a non-empty invocation_id and text.` }],
         }
       }
-      return this.handleReply(invocationId, text)
+      return req.params.name === "send" ? this.handleSend(invocationId, text) : this.handleReply(invocationId, text)
     })
 
     if (this.config.permissionRelay) {
@@ -328,8 +351,11 @@ export class ChannelServer {
       }
     }
 
-    const deadline = setTimeout(() => void this.onReplyTimeout(invocation.id), this.config.replyTimeoutMs)
-    this.inflight.set(invocation.id, { invocation, deadline })
+    this.inflight.set(invocation.id, {
+      invocation,
+      deadline: this.scheduleIdleTimeout(invocation.id),
+      sentCount: 0,
+    })
     // This is the turn Claude is now executing; a permission prompt it triggers
     // belongs in this invocation's stream (see handlePermissionRequest).
     this.activeTurnStreamId = invocation.responseStreamId
@@ -377,6 +403,48 @@ export class ChannelServer {
     }
   }
 
+  // --- Send (interim) -------------------------------------------------------
+
+  /** Post a progress message into the turn's stream without closing the request. */
+  private async handleSend(
+    invocationId: string,
+    text: string
+  ): Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }> {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `No open request with invocation_id ${invocationId} — interim messages need an open request (it may have been answered or closed).`,
+          },
+        ],
+      }
+    }
+    // Stable per-send client id so a retry after a network failure dedupes
+    // instead of double-posting; commit the counter only once the post lands.
+    const seq = entry.sentCount + 1
+    try {
+      const { markdown } = await uploadReplyAttachments(this.client, text, process.cwd())
+      await this.client.sendMessage(entry.invocation.responseStreamId, {
+        content: markdown,
+        clientMessageId: `ccsend-${invocationId}-${seq}`,
+        metadata: { "cc.channel.invocationId": invocationId, "cc.channel.interim": "true" },
+      })
+    } catch (error) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Failed to post message to Threa: ${this.summarize(error)}` }],
+      }
+    }
+    entry.sentCount = seq
+    // A send is a sign of life: push the idle timeout out so a turn that keeps
+    // posting progress is never force-closed.
+    this.touchIdleTimeout(invocationId)
+    return { content: [{ type: "text", text: "sent" }] }
+  }
+
   // --- Reply ----------------------------------------------------------------
 
   private async handleReply(
@@ -421,8 +489,12 @@ export class ChannelServer {
     } catch (error) {
       // Re-arm (with a fresh deadline) so Claude can retry the reply. Safe from
       // double-complete because the original deadline was already cleared.
-      const deadline = setTimeout(() => void this.onReplyTimeout(invocationId), this.config.replyTimeoutMs)
-      this.inflight.set(invocationId, { invocation: entry.invocation, deadline, prepared })
+      this.inflight.set(invocationId, {
+        invocation: entry.invocation,
+        deadline: this.scheduleIdleTimeout(invocationId),
+        sentCount: entry.sentCount,
+        prepared,
+      })
       await this.syncPresence()
       return {
         isError: true,
@@ -436,15 +508,22 @@ export class ChannelServer {
     return { content: [{ type: "text", text: "sent" }] }
   }
 
+  /** Fired when a turn goes idle (no `reply`/`send`/permission activity) for the whole idle window. */
   private async onReplyTimeout(invocationId: string): Promise<void> {
     const entry = this.inflight.get(invocationId)
     if (!entry) return
     this.clearInflight(invocationId)
+    // If the turn already posted interim messages, the user has heard from it —
+    // close silently rather than posting a misleading "no reply" notice.
+    const closeBody =
+      entry.sentCount > 0
+        ? { noResponse: true }
+        : { finalMessageMarkdown: "_Claude Code ended the turn without sending a reply._" }
     await this.client
       .complete(invocationId, {
         instanceId: this.config.instanceId,
         claimToken: entry.invocation.claimToken,
-        finalMessageMarkdown: "_Claude Code ended the turn without sending a reply._",
+        ...closeBody,
         metadata: { "cc.channel.invocationId": invocationId, "cc.channel.timedOut": "true" },
       })
       .catch((error) => log(`timeout completion failed: ${this.summarize(error)}`))
@@ -459,6 +538,18 @@ export class ChannelServer {
     this.inflight.delete(invocationId)
   }
 
+  private scheduleIdleTimeout(invocationId: string): ReturnType<typeof setTimeout> {
+    return setTimeout(() => void this.onReplyTimeout(invocationId), this.config.idleTimeoutMs)
+  }
+
+  /** Reset an in-flight turn's idle timeout after a sign of life (a `send`, a permission prompt). */
+  private touchIdleTimeout(invocationId: string): void {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) return
+    clearTimeout(entry.deadline)
+    entry.deadline = this.scheduleIdleTimeout(invocationId)
+  }
+
   // --- Permission relay -----------------------------------------------------
 
   private async handlePermissionRequest(params: z.infer<typeof PermissionRequestSchema>["params"]): Promise<void> {
@@ -466,11 +557,16 @@ export class ChannelServer {
     // reply), falling back to the scratchpad root.
     const targetStreamId = this.activeTurnStreamId ?? this.link?.rootStreamId
     if (!targetStreamId) return
-    // Drop the open request after the same window we give a reply, so an
+    // A pending tool approval is a sign of life: keep the turn it belongs to from
+    // being reaped for inactivity while it waits on the user's verdict.
+    for (const [id, entry] of this.inflight) {
+      if (entry.invocation.responseStreamId === targetStreamId) this.touchIdleTimeout(id)
+    }
+    // Drop the open request after the same idle window we give a turn, so an
     // abandoned/cancelled prompt the user never answers doesn't leak forever.
     const existing = this.openPermissions.get(params.request_id)
     if (existing) clearTimeout(existing.cleanup)
-    const cleanup = setTimeout(() => this.openPermissions.delete(params.request_id), this.config.replyTimeoutMs)
+    const cleanup = setTimeout(() => this.openPermissions.delete(params.request_id), this.config.idleTimeoutMs)
     this.openPermissions.set(params.request_id, { cleanup })
     const preview = params.input_preview ? `\n\n\`${params.input_preview.slice(0, 200)}\`` : ""
     const content = [

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -438,7 +438,25 @@ export class ChannelServer {
         content: [{ type: "text", text: `Failed to post message to Threa: ${this.summarize(error)}` }],
       }
     }
-    entry.sentCount = seq
+    // The idle timer can fire during the awaits above — unlike handleReply, which
+    // clears its deadline up front, this path must keep the turn open and can't.
+    // If it fired, onReplyTimeout already removed this entry and completed the
+    // turn, so the message we just posted landed on a closed turn. Report that
+    // instead of a clean "sent" (and don't touch the dead entry), so Claude
+    // doesn't then try to reply to a request that's gone.
+    const live = this.inflight.get(invocationId)
+    if (!live) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `Message posted, but request ${invocationId} had already closed for inactivity — it is complete; do not reply to it.`,
+          },
+        ],
+      }
+    }
+    live.sentCount = seq
     // A send is a sign of life: push the idle timeout out so a turn that keeps
     // posting progress is never force-closed.
     this.touchIdleTimeout(invocationId)

--- a/extensions/claude-code-remote/src/config.ts
+++ b/extensions/claude-code-remote/src/config.ts
@@ -20,8 +20,15 @@ export interface ThreaChannelConfig {
   permissionRelay: boolean
   /** Backstop claim-poll cadence; the `/bot` socket pushes work faster than this. */
   pollMs: number
-  /** Safety net: an in-flight invocation with no `reply` is force-closed after this. */
-  replyTimeoutMs: number
+  /**
+   * Safety net for a wedged turn: an in-flight invocation is force-closed after
+   * this much *inactivity*. Every `send` (and tool-approval activity) resets it,
+   * so an actively-working turn never trips it — only one that went silent
+   * without a `reply`. Must exceed the longest single tool call Claude makes
+   * (e.g. a long test run), since Claude can't `send` a heartbeat while blocked
+   * on a tool.
+   */
+  idleTimeoutMs: number
 }
 
 const UNSAFE_ID_CHARS = /[^A-Za-z0-9_-]+/g
@@ -56,7 +63,7 @@ export interface RawConfig {
   defaultLabel?: unknown
   permissionRelay?: unknown
   pollMs?: unknown
-  replyTimeoutMs?: unknown
+  idleTimeoutMs?: unknown
   instanceId?: unknown
   runtimeSessionId?: unknown
 }
@@ -138,7 +145,7 @@ export function loadConfig(input: LoadConfigInput): LoadConfigResult {
       runtimeSessionId,
       permissionRelay: parseBool(env.THREA_PERMISSION_RELAY ?? file.permissionRelay, true),
       pollMs: parseNum(env.THREA_POLL_MS ?? file.pollMs, 3000, 1000),
-      replyTimeoutMs: parseNum(env.THREA_REPLY_TIMEOUT_MS ?? file.replyTimeoutMs, 1_800_000, 60_000),
+      idleTimeoutMs: parseNum(env.THREA_IDLE_TIMEOUT_MS ?? file.idleTimeoutMs, 3_600_000, 60_000),
     },
   }
 }


### PR DESCRIPTION
## Problem

A Claude Code channel turn (`extensions/claude-code-remote/`) could only ever emit **one** message — the single terminal `reply` that also closes the bot-invocation — and was force-closed at a hard **30-minute** wall regardless of whether Claude was still working.

The wall was `onReplyTimeout` in `channel-server.ts`: when the channel claims a message it sets `setTimeout(…, replyTimeoutMs)` (`config.ts` default `1_800_000`). The timer is **absolute from claim time** and nothing resets it, so a turn that runs longer than 30 minutes is reaped and the scratchpad gets `_Claude Code ended the turn without sending a reply._` — even mid-work. That's the "finished at exactly 30 minutes, flat" the report described. The claim lease itself is renewed continuously (`startRenewTimer`, every `CLAIM_TTL_SECONDS/3`), so the lease was never the problem — only this local timer.

Two limitations, one root cause: the turn model was rigidly one-invocation → one-`reply`, with a fixed deadline.

## Solution

Split outbound into two tools and turn the deadline into an *idle* timer instead of an absolute one.

- **`send(invocation_id, text)`** posts a progress/intermediate message and leaves the request open. Callable any number of times per turn.
- **`reply(invocation_id, text)`** is unchanged: posts the final message and closes the invocation.

Because the channel hears Claude only through its tool calls, each `send` doubles as a heartbeat that pushes the idle deadline out. The two features are the same fix: a long turn that streams progress can't be reaped, and the user sees it working instead of waiting on a silent 30 minutes.

No backend change — both wire paths already exist and are already used by this extension: `send` posts via `POST /streams/:id/messages` (the path the permission relay already uses; `sendMessageSchema` accepts `{ content, clientMessageId?, metadata? }`), and the silent-close path uses `complete`'s existing `noResponse: true`.

### How it works

1. **`send` tool** (`handleSend`) — looks up the in-flight invocation, runs the text through `uploadReplyAttachments` (so `THREA_ATTACH:` works in interim messages too), and `client.sendMessage(responseStreamId, …)`. The invocation stays in flight, so presence stays `busy`. Returns an error (like `reply`) if the id isn't open.
2. **Idle timeout** — `scheduleIdleTimeout` / `touchIdleTimeout` replace the inline `setTimeout`. `handleSend` calls `touchIdleTimeout` after a successful post; `handlePermissionRequest` resets the deadline of the turn whose `responseStreamId` matches the prompt's target stream (a pending tool approval is also a sign of life). Default raised 30 → 60 min: `idleTimeoutMs` / `THREA_IDLE_TIMEOUT_MS`, `3_600_000`, clamped to a 60s floor.
3. **Silent close when it already spoke** — `onReplyTimeout` now branches on `sentCount`: if the turn posted at least one interim message, it closes with `{ noResponse: true }` (no message) instead of the misleading "ended without a reply" notice; an entirely silent turn still gets the notice.
4. **Instructions** (`buildInstructions`, which land in Claude's system prompt) now describe both tools: `send` freely for progress, `reply` once to finish.

### Key design decisions

**1. Idle timer, not "raise the number" or "remove the timer."** The timeout exists for a real wedge — Claude ends a turn without `reply`, leaving presence `busy` and the next message queued behind it forever (`claimDrain` breaks while `inflight.size > 0`). Removing it reintroduces that wedge; a bigger absolute number just moves the guillotine. An idle timer keeps the wedge-recovery while never reaping an active turn. 60 min balances the two costs: long enough for a silent operation, short enough that a genuinely-forgotten `reply` unblocks the queue within an hour.

**2. `send` is additive; `reply` keeps its exact semantics.** Existing behaviour and the "always end with `reply`" instruction are preserved, so nothing regresses. If Claude `send`s its answer but forgets `reply`, decision #3 makes that benign — the content is already delivered and the turn closes quietly on idle.

**3. Stable per-send `clientMessageId` (`ccsend-<invocationId>-<seq>`), committed only on success.** `seq = sentCount + 1`; `entry.sentCount` advances only after the post resolves. A retry after a network failure reuses the same id (backend can dedupe) rather than double-posting.

**4. Config rename, no alias (INV-49).** `replyTimeoutMs` / `THREA_REPLY_TIMEOUT_MS` → `idleTimeoutMs` / `THREA_IDLE_TIMEOUT_MS`, since the semantics changed from "time to reply" to "time idle". This is a deliberate breaking rename: a user with the **old** env var set would fall back to the 60-min default until they update it. Acceptable for a weeks-old experimental extension with a single operator; flagged here rather than carrying a deprecated alias.

## Honest limit (documented)

A channel can't `send` a heartbeat *during* a single blocking tool call — Claude is awaiting the tool. So a 40-minute uninterrupted `Bash` run still needs the idle window to exceed it; `THREA_IDLE_TIMEOUT_MS` is the knob. This is called out in both the README and `docs/claude-code-channel.md`. (Minor: a `send` whose text is *only* a `THREA_ATTACH:` line inherits `uploadReplyAttachments`'s `"Done."` fallback for the empty body — harmless, not worth a branch.)

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/channel-server.ts` | Add `send` tool + `handleSend`; `scheduleIdleTimeout`/`touchIdleTimeout` helpers; `Inflight.sentCount`; idle-reset on send + permission prompt; `onReplyTimeout` silent-close branch; two-tool instructions |
| `extensions/claude-code-remote/src/config.ts` | Rename `replyTimeoutMs`→`idleTimeoutMs`, `THREA_REPLY_TIMEOUT_MS`→`THREA_IDLE_TIMEOUT_MS`, default 30→60 min, doc the inactivity semantics |
| `extensions/claude-code-remote/src/channel-server.test.ts` | Tests for `send` (post + keep-open, unknown-invocation error), both `onReplyTimeout` branches, and the two-tool instructions |
| `extensions/claude-code-remote/README.md` | "Sending multiple messages per turn" section; config table + limitations updated |
| `docs/claude-code-channel.md` | "Outbound: send for progress, reply to finish" + "The idle-timeout safety net" rewrite; comparison-table row |

## Out of scope (deliberate)

- **No turn-end detection.** The Claude Code channel protocol sends the channel no "turn complete" / idle notification (confirmed against the channels reference) — the heartbeat *must* come from Claude's own tool calls, which is why the idle window is the backstop rather than a precise close.
- **Per-tool trace** stays a single "working" step — unchanged; still the standing parity gap with `pi-remote`.

## Test plan

- [x] `extensions/claude-code-remote` — `bun test`: 55 pass, 0 fail (5 new)
- [x] `extensions/claude-code-remote` — `bunx tsc --noEmit` clean
- [x] Pre-commit hooks ran repo-wide on the staged files: prettier, all-app eslint, `astro check`, dockerfile/migration checks, and full-monorepo `tsc --noEmit` — all green
- [ ] No live MCP harness drives the real Claude Code ↔ channel handshake; the new tests are unit-level against `handleSend`/`onReplyTimeout` via a fake `ThreaClient`, matching the existing test style for this extension

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784626464&installation_id=129946197&pr_number=1041&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1041&signature=ec4d914fd6ffa7f16e38e774b4b7365402fb4bf04da6a8c53574673d501859a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->