### PR TITLE
feat(mentions): render mention/channel pointer-link markdown as chips on the frontend

### DIFF
--- a/apps/frontend/src/components/ui/markdown-content.test.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect } from "vitest"
-import { render as rtlRender, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import { render as rtlRender, screen, fireEvent } from "@testing-library/react"
 import type { ReactElement } from "react"
 import { MemoryRouter } from "react-router-dom"
+import { StreamTypes } from "@threa/types"
+import { MentionProvider, type MentionType } from "@/lib/markdown/mention-context"
+import { ChannelLinkProvider } from "@/lib/markdown/channel-link-context"
+import type { Mentionable } from "@/components/editor/triggers/types"
 import { MarkdownContent } from "./markdown-content"
 
 // MarkdownLink intercepts same-origin links through useNavigate, which requires
@@ -144,6 +148,61 @@ describe("MarkdownContent", () => {
       const link = screen.getByRole("link", { name: "outside" })
       expect(link).toHaveAttribute("target", "_blank")
       expect(link).toHaveAttribute("rel", "noopener noreferrer")
+    })
+  })
+
+  describe("mention/channel pointer links (INV-64)", () => {
+    const MENTIONABLES: Mentionable[] = [
+      { id: "usr_1", slug: "pierre", name: "Pierre", type: "user" },
+      { id: "usr_me", slug: "self", name: "Me", type: "user", isCurrentUser: true },
+      { id: "persona_1", slug: "ariadne", name: "Ariadne", type: "persona" },
+    ]
+    const STREAMS = [{ id: "stream_1", type: StreamTypes.CHANNEL, slug: "general" }]
+
+    const renderPointer = (content: string, onMentionClick?: (slug: string, type: MentionType, id?: string) => void) =>
+      render(
+        <MentionProvider mentionables={MENTIONABLES} onMentionClick={onMentionClick}>
+          <ChannelLinkProvider workspaceId="ws_1" streams={STREAMS}>
+            <MarkdownContent content={content} />
+          </ChannelLinkProvider>
+        </MentionProvider>
+      )
+
+    it("renders a user mention pointer as a chip, not a broken link", () => {
+      renderPointer("Hey [@pierre](user:usr_1)")
+      expect(screen.getByText("@pierre")).toBeInTheDocument()
+      expect(screen.queryByRole("link", { name: "@pierre" })).not.toBeInTheDocument()
+    })
+
+    it("colors a persona mention from the scheme, not the slug→type default", () => {
+      renderPointer("[@ariadne](persona:persona_1)")
+      // triggerStyles.persona — distinct from the user/blue styling the bare-slug
+      // fallback would have applied if the slug weren't in the mentionables map.
+      expect(screen.getByText("@ariadne")).toHaveClass("text-primary")
+    })
+
+    it("renders a channel pointer as a link to the stream by id", () => {
+      renderPointer("See [#general](channel:stream_1)")
+      const link = screen.getByRole("link", { name: "#general" })
+      expect(link).toHaveAttribute("href", "/w/ws_1/s/stream_1")
+    })
+
+    it("renders an unknown/inaccessible channel id as plain text, not a dead link", () => {
+      renderPointer("[#ghost](channel:stream_unknown)")
+      expect(screen.getByText("#ghost")).toBeInTheDocument()
+      expect(screen.queryByRole("link", { name: "#ghost" })).not.toBeInTheDocument()
+    })
+
+    it("navigates a user mention by the embedded id, not the slug", () => {
+      const onMentionClick = vi.fn()
+      renderPointer("[@pierre](user:usr_1)", onMentionClick)
+      fireEvent.click(screen.getByText("@pierre"))
+      expect(onMentionClick).toHaveBeenCalledWith("pierre", "user", "usr_1")
+    })
+
+    it("upgrades the current user's own mention to the 'me' styling", () => {
+      renderPointer("[@self](user:usr_me)")
+      expect(screen.getByText("@self")).toHaveClass("font-semibold")
     })
   })
 

--- a/apps/frontend/src/components/ui/markdown-content.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.tsx
@@ -113,7 +113,7 @@ export function MarkdownWithMentions({ content, className, mentionables }: Markd
 export interface MentionableMarkdownWrapperProps {
   children: ReactNode
   mentionables: Mentionable[]
-  onMentionClick?: (slug: string, type: MentionType) => void
+  onMentionClick?: (slug: string, type: MentionType, id?: string) => void
 }
 
 /**

--- a/apps/frontend/src/components/ui/markdown-content.tsx
+++ b/apps/frontend/src/components/ui/markdown-content.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo, type ReactNode } from "react"
 import Markdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { normalizeMarkdownTables } from "@threa/prosemirror"
+import { normalizeMarkdownTables, parseMentionPointerHref } from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
 import { markdownComponents } from "@/lib/markdown/components"
 import { MentionProvider, type MentionType } from "@/lib/markdown/mention-context"
@@ -50,6 +50,12 @@ function urlTransform(url: string): string {
   // Allow giphy: protocol so the link renderer can swap the anchor for the
   // inline GIF embed. Same reasoning as the pointer protocols above.
   if (url.startsWith("giphy:")) {
+    return url
+  }
+  // Allow the mention/channel pointer schemes (user:/persona:/bot:/broadcast:/
+  // channel:) so MarkdownLink can render them as chips (INV-64). Without this,
+  // react-markdown blanks the unknown scheme and the chip degrades to bare text.
+  if (parseMentionPointerHref(url)) {
     return url
   }
   // For other URLs, use default behavior (returns url as-is for http/https/mailto)

--- a/apps/frontend/src/lib/markdown/channel-link-context.tsx
+++ b/apps/frontend/src/lib/markdown/channel-link-context.tsx
@@ -3,6 +3,10 @@ import { StreamTypes, type StreamType } from "@threa/types"
 
 interface ChannelLinkContextValue {
   getChannelUrl: (slug: string) => string | null
+  /** Resolve a channel URL from a `stream_` id (the authoritative pointer-link
+   *  reference, INV-64). Returns null for ids that aren't a known channel, so an
+   *  inaccessible or non-channel stream renders as plain text, not a dead link. */
+  getChannelUrlById: (id: string) => string | null
 }
 
 const ChannelLinkContext = createContext<ChannelLinkContextValue | null>(null)
@@ -20,13 +24,17 @@ interface ChannelLinkProviderProps {
 export function ChannelLinkProvider({ workspaceId, streams, children }: ChannelLinkProviderProps) {
   const value = useMemo<ChannelLinkContextValue>(() => {
     const slugToUrl = new Map<string, string>()
+    const idToUrl = new Map<string, string>()
     for (const stream of streams) {
-      if (stream.type === StreamTypes.CHANNEL && stream.slug) {
-        slugToUrl.set(stream.slug, `/w/${workspaceId}/s/${stream.id}`)
+      if (stream.type === StreamTypes.CHANNEL) {
+        const url = `/w/${workspaceId}/s/${stream.id}`
+        idToUrl.set(stream.id, url)
+        if (stream.slug) slugToUrl.set(stream.slug, url)
       }
     }
     return {
       getChannelUrl: (slug: string) => slugToUrl.get(slug) ?? null,
+      getChannelUrlById: (id: string) => idToUrl.get(id) ?? null,
     }
   }, [workspaceId, streams])
 
@@ -43,4 +51,16 @@ export function useChannelUrl(): (slug: string) => string | null {
     return () => null
   }
   return context.getChannelUrl
+}
+
+/**
+ * Hook to get channel URL from a `stream_` id (pointer-link mentions).
+ * Returns null resolver if not within ChannelLinkProvider.
+ */
+export function useChannelUrlById(): (id: string) => string | null {
+  const context = useContext(ChannelLinkContext)
+  if (!context) {
+    return () => null
+  }
+  return context.getChannelUrlById
 }

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -1,7 +1,13 @@
 import type { Components } from "react-markdown"
 import { Children, isValidElement, type ReactNode, type MouseEvent } from "react"
 import { useNavigate, useParams } from "react-router-dom"
-import { parseGiphyHref, parseMemoHref, parseQuoteHref, parseSharedMessageHref } from "@threa/prosemirror"
+import {
+  parseGiphyHref,
+  parseMemoHref,
+  parseMentionPointerHref,
+  parseQuoteHref,
+  parseSharedMessageHref,
+} from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
 import { resolveInternalAppPath } from "@/lib/internal-url"
 import { classifyDraftLink } from "@/lib/in-app-links"
@@ -10,7 +16,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { MemoChip } from "@/components/memo-embed/memo-chip"
 import { GifChip } from "@/components/giphy/gif-chip"
-import { ProcessedChildren } from "./mention-renderer"
+import { PointerMentionChip, ProcessedChildren } from "./mention-renderer"
 import { useAttachmentContext } from "./attachment-context"
 import { useLinkPreviewContext } from "./link-preview-context"
 import { QuoteReplyBlock } from "./quote-reply-block"
@@ -144,6 +150,18 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
         {label}
       </a>
     )
+  }
+
+  // `user:`/`persona:`/`bot:`/`broadcast:`/`channel:` pointer — render the inline
+  // mention/channel chip (INV-64). The id rides on the href; the slug is the link
+  // text. Rendered directly (not via ProcessedChildren) so the label isn't
+  // re-scanned as a bare `@slug`.
+  const mentionPointer = href ? parseMentionPointerHref(href) : null
+  if (mentionPointer) {
+    const label = extractTextFromChildren(children)
+    const sigil = mentionPointer.kind === "channel" ? "#" : "@"
+    const slug = label.startsWith(sigil) ? label.slice(sigil.length) : label
+    return <PointerMentionChip pointer={mentionPointer} slug={slug} />
   }
 
   if (href?.startsWith("attachment:")) {

--- a/apps/frontend/src/lib/markdown/mention-context.tsx
+++ b/apps/frontend/src/lib/markdown/mention-context.tsx
@@ -5,14 +5,19 @@ export type MentionType = "user" | "persona" | "bot" | "broadcast" | "me"
 
 interface MentionContextValue {
   getMentionType: (slug: string) => MentionType
-  onMentionClick?: (slug: string, type: MentionType) => void
+  /**
+   * `id` is the resolved actor id from a pointer-link mention (INV-64) — when
+   * present, navigate by it directly rather than re-resolving the slug (slugs
+   * are mutable). The bare-slug render path omits it.
+   */
+  onMentionClick?: (slug: string, type: MentionType, id?: string) => void
 }
 
 const MentionContext = createContext<MentionContextValue | null>(null)
 
 interface MentionProviderProps {
   mentionables: Mentionable[]
-  onMentionClick?: (slug: string, type: MentionType) => void
+  onMentionClick?: (slug: string, type: MentionType, id?: string) => void
   children: ReactNode
 }
 
@@ -46,7 +51,7 @@ export function useMentionType(): (slug: string) => MentionType {
   return context.getMentionType
 }
 
-export function useMentionClick(): ((slug: string, type: MentionType) => void) | undefined {
+export function useMentionClick(): ((slug: string, type: MentionType, id?: string) => void) | undefined {
   const context = useContext(MentionContext)
   return context?.onMentionClick
 }

--- a/apps/frontend/src/lib/markdown/mention-renderer.tsx
+++ b/apps/frontend/src/lib/markdown/mention-renderer.tsx
@@ -77,7 +77,7 @@ function TriggerChip({ type, text }: TriggerChipProps) {
   }
 
   return (
-    <span className={cn(chipBase, "cursor-pointer", style)}>
+    <span className={cn(chipBase, style)}>
       {prefix}
       {text}
     </span>
@@ -130,7 +130,7 @@ export function PointerMentionChip({ pointer, slug }: { pointer: ActorHrefPointe
     )
   }
 
-  return <span className={cn(chipBase, "cursor-pointer", style)}>@{slug}</span>
+  return <span className={cn(chipBase, style)}>@{slug}</span>
 }
 
 // `(?=\s|$)` keeps the command name a whole token, so a path segment like the

--- a/apps/frontend/src/lib/markdown/mention-renderer.tsx
+++ b/apps/frontend/src/lib/markdown/mention-renderer.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from "react"
 import { Link } from "react-router-dom"
+import type { ActorHrefPointer } from "@threa/prosemirror"
 import { cn } from "@/lib/utils"
 import { useMentionType, useMentionClick } from "./mention-context"
-import { useChannelUrl } from "./channel-link-context"
+import { useChannelUrl, useChannelUrlById } from "./channel-link-context"
 import { useEmojiLookup } from "./emoji-context"
 import { useIsKnownCommand } from "./command-list-context"
 import { MENTION_PATTERN, isValidSlug } from "@threa/types"
@@ -81,6 +82,55 @@ function TriggerChip({ type, text }: TriggerChipProps) {
       {text}
     </span>
   )
+}
+
+/**
+ * Render a pointer-link mention/channel (`[@slug](user:usr_x)` etc.) as a chip.
+ * The type comes from the URL scheme (authoritative, INV-64) — not the slug→type
+ * map the bare-slug path falls back to — and navigation uses the embedded id, so
+ * a renamed slug never mis-colors or breaks the link. The visible label is still
+ * the slug carried in the link text (resolving id → current name is separate
+ * visual-identity work).
+ */
+export function PointerMentionChip({ pointer, slug }: { pointer: ActorHrefPointer; slug: string }) {
+  const getChannelUrlById = useChannelUrlById()
+  const getMentionType = useMentionType()
+  const onMentionClick = useMentionClick()
+
+  if (pointer.kind === "channel") {
+    const url = getChannelUrlById(pointer.id)
+    if (url) {
+      return (
+        <Link
+          to={url}
+          className={cn(chipBase, "hover:underline underline-offset-2 decoration-current/50", triggerStyles.channel)}
+        >
+          #{slug}
+        </Link>
+      )
+    }
+    return <span className={cn(chipBase, triggerStyles.channel)}>#{slug}</span>
+  }
+
+  // "me" is viewer-relative; the scheme only knows "user", so upgrade to the
+  // "me" styling when the slug resolves to the current viewer.
+  const displayType = pointer.mentionType === "user" && getMentionType(slug) === "me" ? "me" : pointer.mentionType
+  const style = triggerStyles[displayType]
+  const isClickable = onMentionClick && pointer.mentionType === "user"
+
+  if (isClickable) {
+    return (
+      <button
+        type="button"
+        onClick={() => onMentionClick(slug, displayType, pointer.id)}
+        className={cn(chipBase, "cursor-pointer hover:underline", style)}
+      >
+        @{slug}
+      </button>
+    )
+  }
+
+  return <span className={cn(chipBase, "cursor-pointer", style)}>@{slug}</span>
 }
 
 // `(?=\s|$)` keeps the command name a whole token, so a path segment like the

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -363,8 +363,14 @@ function MentionableWrapper({ children, mentionables }: Omit<MentionableMarkdown
   const { openUserProfile } = useUserProfile()
 
   const handleMentionClick = useCallback(
-    (slug: string, type: MentionType) => {
+    (slug: string, type: MentionType, id?: string) => {
       if (type !== "user" && type !== "me") return
+      // Pointer-link mentions carry the resolved id (INV-64) — use it directly
+      // rather than re-resolving a (mutable) slug. Bare-slug mentions fall back.
+      if (id) {
+        openUserProfile(id)
+        return
+      }
       const mentionable = mentionables.find((m) => m.slug === slug)
       if (mentionable) openUserProfile(mentionable.id)
     },

--- a/packages/prosemirror/src/index.ts
+++ b/packages/prosemirror/src/index.ts
@@ -33,10 +33,15 @@ export {
   parseMemoHref,
   buildGiphyHref,
   parseGiphyHref,
+  parseMentionPointerHref,
   type QuoteHref,
   type SharedMessageHref,
   type MemoHref,
   type GiphyHref,
+  type MentionPointerType,
+  type MentionHrefPointer,
+  type ChannelHrefPointer,
+  type ActorHrefPointer,
 } from "./pointer-urls"
 export {
   collectAttachmentReferenceIds,

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -794,6 +794,12 @@ describe("@threa/prosemirror mention/channel pointer round-trip (INV-64)", () =>
     expect(nodes.some((node) => node.type === "channelLink" && node.attrs?.id === "not_stream")).toBe(false)
   })
 
+  it("does not materialize a mention pointer whose label strips to an empty slug", () => {
+    const parsed = parseMarkdown("[@](user:usr_1)")
+    const nodes = parsed.content?.[0]?.content ?? []
+    expect(nodes.some((node) => node.type === "mention")).toBe(false)
+  })
+
   it("does not materialize a mention pointer whose id prefix mismatches the scheme", () => {
     const parsed = parseMarkdown("[@x](user:persona_1)")
     const nodes = parsed.content?.[0]?.content ?? []

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -7,19 +7,21 @@
  */
 
 import type { JSONContent, JSONContentMark } from "@threa/types"
-import {
-  actorTypeFromMentionId,
-  isResolvedChannelLinkId,
-  MENTION_BROADCAST_CHANNEL,
-  MENTION_BROADCAST_HERE,
-} from "@threa/types"
+import { actorTypeFromMentionId, isResolvedChannelLinkId } from "@threa/types"
 import {
   escapeMarkdownLinkText,
   parseAttachmentMetadata,
   serializeAttachmentMetadata,
   unescapeMarkdownLinkText,
 } from "./attachment-markdown"
-import { buildGiphyHref, buildMemoHref, buildQuoteHref, buildSharedMessageHref, parseGiphyHref } from "./pointer-urls"
+import {
+  buildGiphyHref,
+  buildMemoHref,
+  buildQuoteHref,
+  buildSharedMessageHref,
+  parseGiphyHref,
+  parseMentionPointerHref,
+} from "./pointer-urls"
 
 /**
  * Inline markdown pattern - captures each format type in separate groups.
@@ -890,15 +892,14 @@ function buildTableCell(type: "tableHeader" | "tableCell", text: string, options
   }
 }
 
-const MENTION_POINTER_SCHEMES = ["user", "persona", "bot"] as const
-
 /**
  * Parse an actor/channel pointer link — `[@slug](user:usr_x)`,
  * `[@here](broadcast:here)`, `[#slug](channel:stream_x)` — into its node, or
  * null when the url isn't one of these reserved schemes (so the caller falls
  * back to a normal link). The id rides on the wire (INV-64), so no DB lookup is
- * needed here. Gated by the same enableMentions/enableChannels options as the
- * bare `@slug`/`#slug` forms.
+ * needed here; `parseMentionPointerHref` is the shared decoder the react-markdown
+ * renderer uses too. Gated by the same enableMentions/enableChannels options as
+ * the bare `@slug`/`#slug` forms.
  */
 function parseActorPointer(
   url: string,
@@ -906,32 +907,19 @@ function parseActorPointer(
   allowMentions: boolean,
   allowChannels: boolean
 ): JSONContent | null {
-  // Reject malformed reserved pointers (an id whose prefix doesn't match the
-  // scheme, or an empty slug) so a hand-written `channel:not_stream` or
-  // `user:persona_x` never persists an inconsistent node (INV-64, INV-2).
-  if (url.startsWith("channel:")) {
-    if (!allowChannels) return null
-    const id = url.slice("channel:".length)
-    const slug = stripMentionSigil(label, "#")
-    return slug && isResolvedChannelLinkId(id) ? { type: "channelLink", attrs: { id, slug } } : null
+  const pointer = parseMentionPointerHref(url)
+  if (!pointer) return null
+  if (pointer.kind === "channel") {
+    return allowChannels
+      ? { type: "channelLink", attrs: { id: pointer.id, slug: stripMentionSigil(label, "#") } }
+      : null
   }
-  if (url === MENTION_BROADCAST_HERE || url === MENTION_BROADCAST_CHANNEL) {
-    if (!allowMentions) return null
-    const slug = stripMentionSigil(label, "@")
-    return slug ? { type: "mention", attrs: { id: url, slug, mentionType: "broadcast" } } : null
-  }
-  for (const scheme of MENTION_POINTER_SCHEMES) {
-    const prefix = `${scheme}:`
-    if (url.startsWith(prefix)) {
-      if (!allowMentions) return null
-      const id = url.slice(prefix.length)
-      const slug = stripMentionSigil(label, "@")
-      return slug && actorTypeFromMentionId(id) === scheme
-        ? { type: "mention", attrs: { id, slug, mentionType: scheme } }
-        : null
-    }
-  }
-  return null
+  return allowMentions
+    ? {
+        type: "mention",
+        attrs: { id: pointer.id, slug: stripMentionSigil(label, "@"), mentionType: pointer.mentionType },
+      }
+    : null
 }
 
 function stripMentionSigil(label: string, sigil: string): string {

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -909,16 +909,15 @@ function parseActorPointer(
 ): JSONContent | null {
   const pointer = parseMentionPointerHref(url)
   if (!pointer) return null
+  // An all-sigil label (`[@](user:usr_x)`) strips to an empty slug; reject it
+  // so an empty-slug node — which serializes to nothing — never persists.
   if (pointer.kind === "channel") {
-    return allowChannels
-      ? { type: "channelLink", attrs: { id: pointer.id, slug: stripMentionSigil(label, "#") } }
-      : null
+    const slug = stripMentionSigil(label, "#")
+    return allowChannels && slug ? { type: "channelLink", attrs: { id: pointer.id, slug } } : null
   }
-  return allowMentions
-    ? {
-        type: "mention",
-        attrs: { id: pointer.id, slug: stripMentionSigil(label, "@"), mentionType: pointer.mentionType },
-      }
+  const slug = stripMentionSigil(label, "@")
+  return allowMentions && slug
+    ? { type: "mention", attrs: { id: pointer.id, slug, mentionType: pointer.mentionType } }
     : null
 }
 

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -1,5 +1,43 @@
 import { describe, expect, it } from "bun:test"
-import { buildMemoHref, parseMemoHref } from "./pointer-urls"
+import { buildMemoHref, parseMemoHref, parseMentionPointerHref } from "./pointer-urls"
+
+describe("parseMentionPointerHref", () => {
+  it("decodes user/persona/bot mention schemes to kind + id + type", () => {
+    expect(parseMentionPointerHref("user:usr_1")).toEqual({ kind: "mention", mentionType: "user", id: "usr_1" })
+    expect(parseMentionPointerHref("persona:persona_1")).toEqual({
+      kind: "mention",
+      mentionType: "persona",
+      id: "persona_1",
+    })
+    expect(parseMentionPointerHref("bot:bot_1")).toEqual({ kind: "mention", mentionType: "bot", id: "bot_1" })
+  })
+
+  it("decodes broadcast sentinels (id is the full sentinel)", () => {
+    expect(parseMentionPointerHref("broadcast:here")).toEqual({
+      kind: "mention",
+      mentionType: "broadcast",
+      id: "broadcast:here",
+    })
+    expect(parseMentionPointerHref("broadcast:channel")).toEqual({
+      kind: "mention",
+      mentionType: "broadcast",
+      id: "broadcast:channel",
+    })
+  })
+
+  it("decodes a channel scheme to a stream id", () => {
+    expect(parseMentionPointerHref("channel:stream_1")).toEqual({ kind: "channel", id: "stream_1" })
+  })
+
+  it("returns null for non-pointer hrefs and empty ids", () => {
+    expect(parseMentionPointerHref("https://example.com")).toBeNull()
+    expect(parseMentionPointerHref("attachment:att_1")).toBeNull()
+    expect(parseMentionPointerHref("memo:memo_1")).toBeNull()
+    expect(parseMentionPointerHref("broadcast:everyone")).toBeNull()
+    expect(parseMentionPointerHref("user:")).toBeNull()
+    expect(parseMentionPointerHref("channel:")).toBeNull()
+  })
+})
 
 describe("parseMemoHref", () => {
   it("round-trips a canonical memo id", () => {

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -37,6 +37,13 @@ describe("parseMentionPointerHref", () => {
     expect(parseMentionPointerHref("user:")).toBeNull()
     expect(parseMentionPointerHref("channel:")).toBeNull()
   })
+
+  it("returns null when the id prefix mismatches the scheme (INV-64, INV-2)", () => {
+    expect(parseMentionPointerHref("user:persona_1")).toBeNull()
+    expect(parseMentionPointerHref("persona:usr_1")).toBeNull()
+    expect(parseMentionPointerHref("bot:usr_1")).toBeNull()
+    expect(parseMentionPointerHref("channel:usr_1")).toBeNull()
+  })
 })
 
 describe("parseMemoHref", () => {

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -21,7 +21,12 @@
  * construction.
  */
 
-import { MENTION_BROADCAST_CHANNEL, MENTION_BROADCAST_HERE } from "@threa/types"
+import {
+  actorTypeFromMentionId,
+  isResolvedChannelLinkId,
+  MENTION_BROADCAST_CHANNEL,
+  MENTION_BROADCAST_HERE,
+} from "@threa/types"
 
 export interface QuoteHref {
   streamId: string
@@ -174,9 +179,12 @@ const MENTION_POINTER_SCHEMES = ["user", "persona", "bot"] as const
  * construction.
  */
 export function parseMentionPointerHref(href: string): ActorHrefPointer | null {
+  // The id must carry the authoritative prefix for its scheme (INV-64, INV-2):
+  // `channel:` → `stream_`, `user:` → `usr_`, etc. A mismatched or prefixless id
+  // (`channel:not_stream`, `user:persona_x`) is rejected, not decoded as resolved.
   if (href.startsWith("channel:")) {
     const id = href.slice("channel:".length)
-    return id ? { kind: "channel", id } : null
+    return isResolvedChannelLinkId(id) ? { kind: "channel", id } : null
   }
   if (href === MENTION_BROADCAST_HERE || href === MENTION_BROADCAST_CHANNEL) {
     return { kind: "mention", mentionType: "broadcast", id: href }
@@ -185,7 +193,7 @@ export function parseMentionPointerHref(href: string): ActorHrefPointer | null {
     const prefix = `${scheme}:`
     if (href.startsWith(prefix)) {
       const id = href.slice(prefix.length)
-      return id ? { kind: "mention", mentionType: scheme, id } : null
+      return actorTypeFromMentionId(id) === scheme ? { kind: "mention", mentionType: scheme, id } : null
     }
   }
   return null

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -21,6 +21,8 @@
  * construction.
  */
 
+import { MENTION_BROADCAST_CHANNEL, MENTION_BROADCAST_HERE } from "@threa/types"
+
 export interface QuoteHref {
   streamId: string
   messageId: string
@@ -142,6 +144,51 @@ export function parseGiphyHref(href: string): GiphyHref | null {
 
   const dims = queryIndex >= 0 ? parseGiphyDimensions(body.slice(queryIndex + 1)) : undefined
   return dims ? { giphyUrl, ...dims } : { giphyUrl }
+}
+
+export type MentionPointerType = "user" | "persona" | "bot" | "broadcast"
+
+export interface MentionHrefPointer {
+  kind: "mention"
+  mentionType: MentionPointerType
+  /** A `usr_`/`persona_`/`bot_` actor id, or a `broadcast:here`/`broadcast:channel` sentinel. */
+  id: string
+}
+
+export interface ChannelHrefPointer {
+  kind: "channel"
+  /** A `stream_` id. */
+  id: string
+}
+
+export type ActorHrefPointer = MentionHrefPointer | ChannelHrefPointer
+
+const MENTION_POINTER_SCHEMES = ["user", "persona", "bot"] as const
+
+/**
+ * Decode a mention/channel pointer link href — `user:usr_x`, `persona:persona_x`,
+ * `bot:bot_x`, `broadcast:here`/`broadcast:channel`, `channel:stream_x` — into its
+ * kind + actor/stream id (INV-64), or null when the href isn't one of these
+ * reserved schemes. Shared by the markdown parser (`parseMarkdown`) and the
+ * react-markdown renderer so the wire format and the rendered chip agree by
+ * construction.
+ */
+export function parseMentionPointerHref(href: string): ActorHrefPointer | null {
+  if (href.startsWith("channel:")) {
+    const id = href.slice("channel:".length)
+    return id ? { kind: "channel", id } : null
+  }
+  if (href === MENTION_BROADCAST_HERE || href === MENTION_BROADCAST_CHANNEL) {
+    return { kind: "mention", mentionType: "broadcast", id: href }
+  }
+  for (const scheme of MENTION_POINTER_SCHEMES) {
+    const prefix = `${scheme}:`
+    if (href.startsWith(prefix)) {
+      const id = href.slice(prefix.length)
+      return id ? { kind: "mention", mentionType: scheme, id } : null
+    }
+  }
+  return null
 }
 
 function isPositiveInt(value: number | undefined): value is number {


### PR DESCRIPTION
> **Stacked on [#1043](https://github.com/threahq/threa/pull/1043)** — base branch is `improve/mentioning`, not `main`. Review/merge #1043 first; I'll rebase this onto `main` once it lands.

## Problem

#1043 makes the backend serialize mentions/channels to attachment-style pointer links — `[@pierre](user:usr_x)`, `[@ariadne](persona:persona_x)`, `[@here](broadcast:here)`, `[#general](channel:stream_x)`. The **timeline renders message bodies from `contentMarkdown` via react-markdown** (`MarkdownContent`), not from `contentJson` — confirmed at `message-event.tsx:525` (`contentJson` is only used to seed the editor in edit mode). So the pointer form is the primary display path, and the react-markdown renderer doesn't understand the new schemes:

- `urlTransform` (`markdown-content.tsx`) blanks the unknown scheme → `href=""`.
- `MarkdownLink` falls through to the external-link branch, and the link text (`@pierre`) gets re-scanned by the bare-slug `renderMentions` path — so a mention degrades to a slug-typed chip wrapped in a dead `<a href="">`, with the wrong color for personas/bots (the slug→type map defaults unknown slugs to `user`) and no id available for navigation.

The editor *parse* path was already safe (it routes through the shared `@threa/prosemirror` `parseMarkdown`, which #1043 taught the schemes); strip surfaces are safe (`stripMarkdown` reduces `[text](url)` → `text`). This PR closes the *render* gap.

## Solution

Teach the react-markdown renderer to render the pointer form as a proper chip, driven by a decoder shared with the markdown parser so they can't drift.

### How it works

1. **Shared decoder** — `parseMentionPointerHref(href)` in `@threa/prosemirror` (`pointer-urls.ts`, alongside `parseMemoHref`/`parseGiphyHref`) decodes `user:`/`persona:`/`bot:`/`broadcast:`/`channel:` → `{ kind, mentionType, id }`. `markdown.ts`'s `parseActorPointer` is refactored to use it, so the wire parser and the renderer agree by construction.
2. **`urlTransform`** (`markdown-content.tsx`) allows the pointer schemes (via the decoder) so the href reaches `MarkdownLink` instead of being blanked.
3. **`MarkdownLink`** detects a pointer href and renders `PointerMentionChip` directly (not through `ProcessedChildren`, so the label isn't re-scanned as a bare slug).
4. **`PointerMentionChip`** (`mention-renderer.tsx`) — **type from the scheme** (authoritative; fixes persona/bot miscoloring), **navigation by the embedded id** (robust to slug renames — the whole point of INV-64), **slug as the display label** (resolving `id → current name` stays deferred as the separate visual-identity work).
5. **Navigation by id** — channels resolve through a new `getChannelUrlById` on `ChannelLinkProvider` (access-safe: only ids in the viewer's known-channel set link, others render as plain text); user mentions pass the id through `onMentionClick(slug, type, id)` so `workspace-layout` calls `openUserProfile(id)` directly instead of re-resolving the slug.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/pointer-urls.ts` | New shared `parseMentionPointerHref` decoder + pointer types |
| `packages/prosemirror/src/index.ts` | Export the decoder + types |
| `packages/prosemirror/src/markdown.ts` | `parseActorPointer` reuses the shared decoder (no behavior change) |
| `apps/frontend/src/components/ui/markdown-content.tsx` | `urlTransform` allows the pointer schemes |
| `apps/frontend/src/lib/markdown/components.tsx` | `MarkdownLink` renders `PointerMentionChip` for pointer hrefs |
| `apps/frontend/src/lib/markdown/mention-renderer.tsx` | New `PointerMentionChip` (scheme-typed, id-nav) |
| `apps/frontend/src/lib/markdown/mention-context.tsx` | `onMentionClick` takes an optional `id` |
| `apps/frontend/src/lib/markdown/channel-link-context.tsx` | `getChannelUrlById` (access-safe) |
| `apps/frontend/src/pages/workspace-layout.tsx` | Navigate user mentions by id when present |
| `*.test.*` | `parseMentionPointerHref` unit tests + renderer pointer-chip tests |

## Out of scope (deliberate)

- **Display label stays the historical slug** carried in the link text. Resolving `id → current name` is the visual-identity work flagged in #1043; this PR keeps the current-display behavior and only fixes type/nav.
- The bare-slug `TriggerChip` path is unchanged (still serves unresolved/legacy content).

## Test plan

- [x] `bun run typecheck` — clean across all 14 packages/apps
- [x] `bun run lint` — clean
- [x] `packages/prosemirror` — `pointer-urls.test.ts` (new `parseMentionPointerHref` cases) + `markdown.test.ts` — 77 pass (refactor behavior-preserving)
- [x] Frontend via **vitest** — `markdown-content.test.tsx` (6 new pointer-chip cases: user/persona chip styling from scheme, channel link by id, unknown-channel → plain text, user click → `onMentionClick(slug, type, id)`, `me` upgrade) + `mention-renderer.test.tsx` — 97 pass; broad `lib/markdown`/`timeline`/`editor` sweep — 782 pass
- [ ] 7 failures in `collapse-cache.test.ts` are **pre-existing and unrelated** (a localStorage/jsdom env quirk on this machine; not in this diff) — confirmed identical with the change stashed.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784668266&installation_id=129946197&pr_number=1044&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1044&signature=e8528b29bdb138b17919825c800d40b57513d6900fdd8fb7fb7463ce512d5178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->