### PR TITLE
fix: align grouped messages in compact density

### DIFF
--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -726,6 +726,13 @@
   border-radius: 0.375rem;
 }
 
+/* The continuation gutter must reserve the same width as the compact avatar so
+   grouped follow-up messages align under the head's content instead of 8px to
+   its right. Width only — the spacer keeps its h-5 hover-timestamp box. */
+[data-message-display="compact"] .message-avatar-spacer {
+  width: 1.5rem;
+}
+
 [data-message-display="compact"] .message-content {
   gap: 0.5rem;
 }


### PR DESCRIPTION
## Problem

In **Compact** message density, grouped follow-up messages render ~8px to the right of the first message in the group instead of aligning under it. The first message's content lines up with the author name; continuation messages drift right.

Cause: the compact stylesheet shrinks the head avatar to 24px via `[data-message-display="compact"] .message-avatar` (`apps/frontend/src/index.css`), but the continuation gutter — the `.message-avatar-spacer` element that holds the on-hover HH:MM micro-time and the batch-selection dot (`message-event.tsx:573` and `:408`) — keeps its default Tailwind `w-8` (32px). With the compact 8px row gap, the head's content starts at 24+8=32px while continuation content starts at 32+8=40px. In Comfortable density both gutters are `w-8`, so the bug only appears in Compact.

## Solution

Add a compact-only width override for `.message-avatar-spacer` matching the avatar's compact width, so both gutters reserve 24px and continuation content lines up under the head's content. Width only — the spacer keeps its `h-5` hover-timestamp box, so vertical alignment and row height are unchanged. The class-targeted rule covers both continuation surfaces (timestamp gutter and batch-selection dot).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/index.css` | Add `[data-message-display="compact"] .message-avatar-spacer { width: 1.5rem }` so the continuation gutter matches the compact 24px avatar |

## Test plan

- [x] Pre-commit hook: full-monorepo lint + `tsc --noEmit` (all workspaces) + migration/dockerfile/OpenAPI checks — clean
- [ ] No automated coverage — pure-CSS box-model alignment, not unit-testable. Verified by geometry: compact head gutter (24px avatar + 8px gap) now equals continuation gutter (24px spacer + 8px gap), both → 32px content offset. Comfortable density unaffected (no `data-message-display="compact"` ⇒ both stay `w-8`).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784668768&installation_id=129946197&pr_number=1045&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1045&signature=0910d9b77b4d4e7e970ceae3cf311347bfb8ebd5a90e6d6815670db01e657290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->