### PR TITLE
feat(streams): rich-text descriptions — storage + write path (PR 1/4)

### DIFF
--- a/apps/backend/src/db/migrations/20260622003412_stream_description_json.sql
+++ b/apps/backend/src/db/migrations/20260622003412_stream_description_json.sql
@@ -1,0 +1,10 @@
+-- Rich-text stream descriptions. `description_json` holds the canonical
+-- ProseMirror document (mirrors messages' `content_json`); the existing
+-- `description` TEXT column becomes the derived markdown projection that feeds
+-- the `search_vector` generated column and the public-API wire format. Nullable
+-- because a description is optional and `NULL` means "no rich description yet" —
+-- legacy rows keep their plaintext `description` and render as markdown until
+-- the first rich edit populates this column. No DB enum / JSON validation here
+-- (INV-3); the shape is validated in app code against `threaDocumentSchema`.
+ALTER TABLE streams
+  ADD COLUMN description_json JSONB;

--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -25,6 +25,7 @@ function fakeStream(overrides: Partial<Stream> = {}): Stream {
     displayName: "Test DM",
     slug: null,
     description: null,
+    descriptionJson: null,
     visibility: Visibilities.PRIVATE,
     parentStreamId: null,
     parentMessageId: null,

--- a/apps/backend/src/features/saved-messages/service.test.ts
+++ b/apps/backend/src/features/saved-messages/service.test.ts
@@ -32,6 +32,7 @@ function fakeStream(overrides: Partial<Stream> = {}): Stream {
     displayName: "General",
     slug: "general",
     description: null,
+    descriptionJson: null,
     visibility: Visibilities.PUBLIC,
     parentStreamId: null,
     parentMessageId: null,

--- a/apps/backend/src/features/scheduled-messages/service.test.ts
+++ b/apps/backend/src/features/scheduled-messages/service.test.ts
@@ -25,6 +25,7 @@ function fakeStream(overrides: Partial<Stream> = {}): Stream {
     displayName: "General",
     slug: "general",
     description: null,
+    descriptionJson: null,
     visibility: Visibilities.PUBLIC,
     parentStreamId: null,
     parentMessageId: null,

--- a/apps/backend/src/features/streams/description.test.ts
+++ b/apps/backend/src/features/streams/description.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeStreamDescription } from "./description"
+
+describe("normalizeStreamDescription", () => {
+  test("returns undefined when neither field is supplied (leave untouched)", () => {
+    expect(normalizeStreamDescription({})).toBeUndefined()
+  })
+
+  test("parses a markdown description into canonical ProseMirror + markdown", () => {
+    const result = normalizeStreamDescription({ description: "Hello **world**" })
+    expect(result?.descriptionJson?.type).toBe("doc")
+    // Markdown is re-derived from the parsed JSON, so the projection round-trips.
+    expect(result?.description).toBe("Hello **world**")
+  })
+
+  test("derives the markdown projection from a ProseMirror description", () => {
+    const result = normalizeStreamDescription({
+      descriptionJson: {
+        type: "doc",
+        content: [{ type: "heading", attrs: { level: 1 }, content: [{ type: "text", text: "Title" }] }],
+      },
+    })
+    expect(result?.description).toBe("# Title")
+    expect(result?.descriptionJson?.content?.[0]?.type).toBe("heading")
+  })
+
+  test("folds raw emoji to canonical shortcodes in the derived markdown", () => {
+    const result = normalizeStreamDescription({ description: "Great 👍" })
+    expect(result?.description).toBe("Great :+1:")
+  })
+
+  test("prefers descriptionJson over a supplied markdown description", () => {
+    const result = normalizeStreamDescription({
+      description: "ignored markdown",
+      descriptionJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "kept" }] }] },
+    })
+    expect(result?.description).toBe("kept")
+  })
+
+  test("empty markdown clears the description", () => {
+    expect(normalizeStreamDescription({ description: "   " })).toEqual({ description: null, descriptionJson: null })
+  })
+
+  test("an empty document clears the description", () => {
+    expect(normalizeStreamDescription({ descriptionJson: { type: "doc", content: [{ type: "paragraph" }] } })).toEqual({
+      description: null,
+      descriptionJson: null,
+    })
+  })
+})

--- a/apps/backend/src/features/streams/description.ts
+++ b/apps/backend/src/features/streams/description.ts
@@ -1,0 +1,45 @@
+import { parseMarkdown, serializeToMarkdown } from "@threa/prosemirror"
+import { type JSONContent, type ThreaDocument, validateContent } from "@threa/types"
+import { normalizeMessage, toEmoji } from "../emoji"
+
+export interface StreamDescriptionInput {
+  /** Markdown description (external/public-API wire); parsed to ProseMirror. */
+  description?: string
+  /** Rich-text description (ProseMirror); the canonical internal input. */
+  descriptionJson?: JSONContent
+}
+
+export interface NormalizedStreamDescription {
+  /** Markdown projection for the `description` column (search + wire). */
+  description: string | null
+  /** Canonical ProseMirror for the `description_json` column. */
+  descriptionJson: ThreaDocument | null
+}
+
+/**
+ * Resolve a description create/update into the canonical pair stored on a
+ * stream: `descriptionJson` (ProseMirror) plus its derived markdown projection.
+ * Mirrors the message content pipeline (INV-58) — the markdown is always derived
+ * from the JSON, never trusted from the client, so the two columns can't diverge
+ * and the markdown-only readers (search, public-API wire) stay consistent.
+ *
+ * Returns `undefined` when the caller supplied neither field — the description
+ * is left untouched. An empty document (or empty markdown) resolves to
+ * `{ description: null, descriptionJson: null }`, clearing the description.
+ */
+export function normalizeStreamDescription(input: StreamDescriptionInput): NormalizedStreamDescription | undefined {
+  let json: JSONContent
+  if (input.descriptionJson !== undefined) {
+    json = input.descriptionJson
+  } else if (input.description !== undefined) {
+    json = parseMarkdown(normalizeMessage(input.description), undefined, toEmoji)
+  } else {
+    return undefined
+  }
+
+  const markdown = normalizeMessage(serializeToMarkdown(json))
+  if (!markdown.trim()) {
+    return { description: null, descriptionJson: null }
+  }
+  return { description: markdown, descriptionJson: validateContent(json) }
+}

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -26,6 +26,8 @@ import {
   E2E_ACTOR_KINDS,
   E2E_KEY_WRAP_RECIPIENT_KINDS,
   TOOL_PRIVACY_CATEGORIES,
+  threaDocumentSchema,
+  STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH,
 } from "@threa/types"
 import type { Pool } from "pg"
 import { PersonaRepository, getResolver, fetchStreamBag, contextBagSchema } from "../agents"
@@ -138,7 +140,8 @@ const updateStreamSchema = z
         message: "Slug must start with a letter and contain only lowercase letters, numbers, hyphens, or underscores",
       })
       .optional(),
-    description: z.string().max(500).optional(),
+    description: z.string().max(STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH).optional(),
+    descriptionJson: threaDocumentSchema.optional(),
     visibility: visibilitySchema.optional(),
     memoryMode: memoryModeSchema.optional(),
     // Optional encrypted name. Strict base64 so a malformed ciphertext can't be
@@ -640,7 +643,16 @@ export function createStreamHandlers({
 
       const data = validateRequest(schema, req.body)
 
-      const { displayName, slug, description, visibility, memoryMode, sealedNameCiphertext, sealedNameEnvelope } = data
+      const {
+        displayName,
+        slug,
+        description,
+        descriptionJson,
+        visibility,
+        memoryMode,
+        sealedNameCiphertext,
+        sealedNameEnvelope,
+      } = data
 
       // Schema guarantees one of: both set, both null (clear), or both omitted.
       let sealedName: { ciphertext: string; envelope: unknown } | null | undefined
@@ -654,6 +666,7 @@ export function createStreamHandlers({
         displayName,
         slug,
         description,
+        descriptionJson,
         visibility,
         memoryMode,
         sealedName,

--- a/apps/backend/src/features/streams/notification-resolver.test.ts
+++ b/apps/backend/src/features/streams/notification-resolver.test.ts
@@ -12,6 +12,7 @@ function makeStream(overrides: Partial<Stream> = {}): Stream {
     displayName: null,
     slug: null,
     description: null,
+    descriptionJson: null,
     visibility: "private",
     parentStreamId: "stream_channel",
     parentMessageId: "msg_1",

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -8,6 +8,7 @@ import type {
   MemoryMode,
   ThreadSummary,
   E2eActor,
+  ThreaDocument,
 } from "@threa/types"
 import { StreamTypes } from "@threa/types"
 import { parseArchiveStatusFilter, type ArchiveStatus } from "../../lib/sql-filters"
@@ -21,6 +22,7 @@ interface StreamRow {
   display_name: string | null
   slug: string | null
   description: string | null
+  description_json: ThreaDocument | null
   visibility: string
   parent_stream_id: string | null
   parent_message_id: string | null
@@ -97,6 +99,7 @@ export interface Stream {
   displayName: string | null
   slug: string | null
   description: string | null
+  descriptionJson: ThreaDocument | null
   visibility: Visibility
   parentStreamId: string | null
   parentMessageId: string | null
@@ -138,7 +141,8 @@ export interface InsertStreamParams {
   type: StreamType
   displayName?: string
   slug?: string
-  description?: string
+  description?: string | null
+  descriptionJson?: ThreaDocument | null
   visibility?: Visibility
   parentStreamId?: string
   parentMessageId?: string
@@ -155,7 +159,8 @@ export interface UpdateStreamParams {
   // the authoritative name lives in `e2e_streams.name_ciphertext`.
   displayName?: string | null
   slug?: string
-  description?: string
+  description?: string | null
+  descriptionJson?: ThreaDocument | null
   visibility?: Visibility
   companionMode?: CompanionMode
   companionPersonaId?: string | null
@@ -191,6 +196,7 @@ function mapRowToStream(row: StreamRow): Stream {
     displayName: row.display_name,
     slug: row.slug,
     description: row.description,
+    descriptionJson: row.description_json,
     visibility: row.visibility as Visibility,
     parentStreamId: row.parent_stream_id,
     parentMessageId: row.parent_message_id,
@@ -244,7 +250,7 @@ function mapRowToStreamWithPreview(row: StreamWithPreviewRow): StreamWithPreview
 }
 
 const SELECT_FIELDS = `
-  id, workspace_id, type, display_name, slug, description, visibility,
+  id, workspace_id, type, display_name, slug, description, description_json, visibility,
   parent_stream_id, parent_message_id, root_stream_id,
   companion_mode, companion_persona_id, memory_mode,
   created_by, created_at, updated_at, archived_at, display_name_generated_at
@@ -254,7 +260,7 @@ const SELECT_FIELDS = `
 // plaintext rows visible (the `e2e_owner_user_key_id` projection is just
 // NULL for them) so callers don't have to branch on stream type.
 const SELECT_FIELDS_WITH_E2E = `
-  s.id, s.workspace_id, s.type, s.display_name, s.slug, s.description, s.visibility,
+  s.id, s.workspace_id, s.type, s.display_name, s.slug, s.description, s.description_json, s.visibility,
   s.parent_stream_id, s.parent_message_id, s.root_stream_id,
   s.companion_mode, s.companion_persona_id, s.memory_mode,
   s.created_by, s.created_at, s.updated_at, s.archived_at, s.display_name_generated_at,
@@ -660,7 +666,7 @@ export const StreamRepository = {
   async insert(db: Querier, params: InsertStreamParams): Promise<Stream> {
     const result = await db.query<StreamRow>(sql`
       INSERT INTO streams (
-        id, workspace_id, type, display_name, slug, description, visibility,
+        id, workspace_id, type, display_name, slug, description, description_json, visibility,
         parent_stream_id, parent_message_id, root_stream_id,
         companion_mode, companion_persona_id, memory_mode, uniqueness_key, created_by
       ) VALUES (
@@ -670,6 +676,7 @@ export const StreamRepository = {
         ${params.displayName ?? null},
         ${params.slug ?? null},
         ${params.description ?? null},
+        ${params.descriptionJson ? JSON.stringify(params.descriptionJson) : null},
         ${params.visibility ?? "private"},
         ${params.parentStreamId ?? null},
         ${params.parentMessageId ?? null},
@@ -795,6 +802,10 @@ export const StreamRepository = {
     if (params.description !== undefined) {
       sets.push(`description = $${paramIndex++}`)
       values.push(params.description)
+    }
+    if (params.descriptionJson !== undefined) {
+      sets.push(`description_json = $${paramIndex++}`)
+      values.push(params.descriptionJson === null ? null : JSON.stringify(params.descriptionJson))
     }
     if (params.visibility !== undefined) {
       sets.push(`visibility = $${paramIndex++}`)

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1480,3 +1480,53 @@ describe("StreamService.updateStream sealed-name handling", () => {
     expect(mockUpdateSealedName).not.toHaveBeenCalled()
   })
 })
+
+describe("StreamService.updateStream description", () => {
+  let service: StreamService
+
+  beforeEach(() => {
+    service = new StreamService({} as never)
+    mockFindById.mockReset()
+    mockUpdate.mockReset()
+    mockInsertOutbox.mockReset()
+  })
+
+  test("persists the canonical descriptionJson plus its derived markdown and emits stream:updated", async () => {
+    const stream = { id: "stream_1", workspaceId: "ws_1" } as never
+    mockUpdate.mockResolvedValue(stream)
+    mockFindById.mockResolvedValue(stream)
+
+    await service.updateStream("stream_1", {
+      descriptionJson: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "About this channel" }] }],
+      },
+    })
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      {},
+      "stream_1",
+      expect.objectContaining({
+        description: "About this channel",
+        descriptionJson: expect.objectContaining({ type: "doc" }),
+      })
+    )
+    expect(mockInsertOutbox).toHaveBeenCalledWith(
+      {},
+      "stream:updated",
+      expect.objectContaining({ streamId: "stream_1" })
+    )
+  })
+
+  test("leaves the description columns untouched when neither field is supplied", async () => {
+    const stream = { id: "stream_1", workspaceId: "ws_1" } as never
+    mockUpdate.mockResolvedValue(stream)
+    mockFindById.mockResolvedValue(stream)
+
+    await service.updateStream("stream_1", { displayName: "Renamed" })
+
+    const params = mockUpdate.mock.calls[0]![2] as Record<string, unknown>
+    expect(params).not.toHaveProperty("description")
+    expect(params).not.toHaveProperty("descriptionJson")
+  })
+})

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1,7 +1,14 @@
 import { z } from "zod"
 import { Pool } from "pg"
 import { withClient, withTransaction, type Querier } from "../../db"
-import { StreamRepository, Stream, StreamWithPreview, LastMessagePreview, type DmPeer } from "./repository"
+import {
+  StreamRepository,
+  Stream,
+  StreamWithPreview,
+  LastMessagePreview,
+  type DmPeer,
+  type UpdateStreamParams,
+} from "./repository"
 import { StreamMemberRepository, StreamMember } from "./member-repository"
 import { StreamEventRepository, type StreamEvent } from "./event-repository"
 import { MessageRepository } from "../messaging"
@@ -39,6 +46,7 @@ import {
   type E2eKeyRollInput,
   type E2eActorRewrapInput,
   type ToolPrivacyPolicy,
+  type JSONContent,
 } from "@threa/types"
 import { ContextBagRepository } from "../agents"
 import { E2eStreamsRepository, E2eStreamActorsRepository, StreamE2eKeyWrapsRepository } from "../e2e-streams"
@@ -53,6 +61,7 @@ import { BotRepository } from "../public-api/bot-repository"
 import { streamTypeSchema, visibilitySchema, companionModeSchema, memoryModeSchema } from "../../lib/schemas"
 import { isAllowedLevel } from "./notification-config"
 import { StreamPoliciesRepository } from "./policy-repository"
+import { normalizeStreamDescription } from "./description"
 
 const DM_UNIQUENESS_KEY_PREFIX = "dm"
 
@@ -425,12 +434,14 @@ export class StreamService {
   async createScratchpadInTransaction(db: Querier, params: CreateScratchpadParams): Promise<Stream> {
     const id = streamId()
 
+    const description = normalizeStreamDescription({ description: params.description })
     const stream = await StreamRepository.insert(db, {
       id,
       workspaceId: params.workspaceId,
       type: StreamTypes.SCRATCHPAD,
       displayName: params.displayName,
-      description: params.description,
+      description: description?.description ?? undefined,
+      descriptionJson: description?.descriptionJson ?? undefined,
       visibility: Visibilities.PRIVATE,
       companionMode: params.companionMode ?? CompanionModes.OFF,
       companionPersonaId: params.companionPersonaId,
@@ -496,12 +507,14 @@ export class StreamService {
         throw new DuplicateSlugError(params.slug)
       }
 
+      const description = normalizeStreamDescription({ description: params.description })
       const stream = await StreamRepository.insert(client, {
         id,
         workspaceId: params.workspaceId,
         type: StreamTypes.CHANNEL,
         slug: params.slug,
-        description: params.description,
+        description: description?.description ?? undefined,
+        descriptionJson: description?.descriptionJson ?? undefined,
         visibility: params.visibility ?? Visibilities.PUBLIC,
         createdBy: params.createdBy,
       })
@@ -802,7 +815,10 @@ export class StreamService {
     data: {
       displayName?: string | null
       slug?: string
+      /** Markdown description (external/wire). Derived to `descriptionJson`. */
       description?: string
+      /** Rich-text description (ProseMirror), canonical internal input. */
+      descriptionJson?: JSONContent
       visibility?: Visibility
       memoryMode?: MemoryMode
       /**
@@ -816,7 +832,13 @@ export class StreamService {
       sealedName?: { ciphertext: string; envelope: unknown } | null
     }
   ): Promise<Stream | null> {
-    const { sealedName, ...streamData } = data
+    const { sealedName, description, descriptionJson, ...rest } = data
+    const streamData: UpdateStreamParams = { ...rest }
+    const normalizedDescription = normalizeStreamDescription({ description, descriptionJson })
+    if (normalizedDescription) {
+      streamData.description = normalizedDescription.description
+      streamData.descriptionJson = normalizedDescription.descriptionJson
+    }
     if (sealedName) {
       // Setting a sealed name is a sealed-only E2E rename: the authoritative name
       // lives in the ciphertext, so scrub the plaintext `display_name` to null —

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -434,14 +434,14 @@ export class StreamService {
   async createScratchpadInTransaction(db: Querier, params: CreateScratchpadParams): Promise<Stream> {
     const id = streamId()
 
-    const description = normalizeStreamDescription({ description: params.description })
+    const normalizedDescription = normalizeStreamDescription({ description: params.description })
     const stream = await StreamRepository.insert(db, {
       id,
       workspaceId: params.workspaceId,
       type: StreamTypes.SCRATCHPAD,
       displayName: params.displayName,
-      description: description?.description ?? undefined,
-      descriptionJson: description?.descriptionJson ?? undefined,
+      description: normalizedDescription?.description ?? undefined,
+      descriptionJson: normalizedDescription?.descriptionJson ?? undefined,
       visibility: Visibilities.PRIVATE,
       companionMode: params.companionMode ?? CompanionModes.OFF,
       companionPersonaId: params.companionPersonaId,
@@ -507,14 +507,14 @@ export class StreamService {
         throw new DuplicateSlugError(params.slug)
       }
 
-      const description = normalizeStreamDescription({ description: params.description })
+      const normalizedDescription = normalizeStreamDescription({ description: params.description })
       const stream = await StreamRepository.insert(client, {
         id,
         workspaceId: params.workspaceId,
         type: StreamTypes.CHANNEL,
         slug: params.slug,
-        description: description?.description ?? undefined,
-        descriptionJson: description?.descriptionJson ?? undefined,
+        description: normalizedDescription?.description ?? undefined,
+        descriptionJson: normalizedDescription?.descriptionJson ?? undefined,
         visibility: params.visibility ?? Visibilities.PUBLIC,
         createdBy: params.createdBy,
       })

--- a/apps/backend/src/features/system-messages/service.test.ts
+++ b/apps/backend/src/features/system-messages/service.test.ts
@@ -18,6 +18,7 @@ function fakeStream(overrides: Partial<Stream> = {}): Stream {
     displayName: "Threa",
     slug: null,
     description: null,
+    descriptionJson: null,
     visibility: Visibilities.PRIVATE,
     parentStreamId: null,
     parentMessageId: null,

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -47,6 +47,9 @@ interface CreateStreamInputBase {
   type: StreamType
   displayName?: string
   slug?: string
+  /** Rich-text description (ProseMirror); backend derives the markdown projection. */
+  descriptionJson?: JSONContent
+  /** Markdown description (external/wire); backend parses it to `descriptionJson`. */
   description?: string
   visibility?: Visibility
   companionMode?: CompanionMode
@@ -84,6 +87,16 @@ export type CreateStreamInput =
 export interface UpdateStreamInput {
   displayName?: string
   slug?: string
+  /**
+   * Rich-text description as a ProseMirror document (canonical, INV-58). Internal
+   * clients send this; the backend derives the markdown projection. An empty doc
+   * clears the description. Prefer this over `description` from app code.
+   */
+  descriptionJson?: JSONContent
+  /**
+   * Markdown description. The external/public-API wire format — the backend
+   * parses it to `descriptionJson`. Internal clients should send `descriptionJson`.
+   */
   description?: string
   visibility?: Visibility
   companionMode?: CompanionMode

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -11,6 +11,13 @@ export const StreamTypes = {
 
 export const DM_PARTICIPANT_COUNT = 2
 
+/**
+ * Upper bound on the markdown projection of a stream description. Generous enough
+ * for a rich multi-paragraph note (descriptions collapse in the UI past a few
+ * lines) while still bounding the markdown that feeds search + the public-API wire.
+ */
+export const STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH = 10_000
+
 export const VISIBILITY_OPTIONS = ["public", "private"] as const
 export type Visibility = (typeof VISIBILITY_OPTIONS)[number]
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -174,7 +174,15 @@ export interface Stream {
   type: StreamType
   displayName: string | null
   slug: string | null
+  /** Markdown projection of the description (derived from `descriptionJson`). */
   description: string | null
+  /**
+   * Canonical rich-text description (ProseMirror), mirroring `Message.contentJson`.
+   * `null` when the stream has no rich description; absent on cached rows synced
+   * before rich descriptions shipped — render those from `description` markdown.
+   * The backend always sends it (possibly `null`) on a freshly-fetched stream.
+   */
+  descriptionJson?: ThreaDocument | null
   visibility: Visibility
   parentStreamId: string | null
   parentMessageId: string | null

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,7 @@ export {
   type StreamType,
   StreamTypes,
   DM_PARTICIPANT_COUNT,
+  STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH,
   // Visibility
   VISIBILITY_OPTIONS,
   type Visibility,


### PR DESCRIPTION
First PR of a stacked series adding **rich-text stream descriptions** (rendered as a system-style timeline event, editable in scratchpads + channels, settable via the public API). This PR lays the data-model + write-path foundation only — **no UI and no timeline event yet**.

## Problem

A stream's `description` is plain text end-to-end: a `TEXT` column, a `string` on `Stream`, a `<Textarea maxLength={500}>` in stream settings. The goal is to make descriptions behave like message bodies — full rich text, authored in the composer, rendered with the normal markdown pipeline, settable as markdown over the public API. Messages already solved this exact shape (`content_json` canonical + `content_markdown` derived, INV-58); descriptions should mirror it rather than invent a parallel scheme.

## Solution

Add `description_json` (JSONB) as the canonical ProseMirror document and keep the existing `description` (TEXT) as its **derived markdown projection** — the same split messages use (`content_json` / `content_markdown`). Markdown is always derived from the JSON, never trusted from the client, so the two columns can't diverge and the markdown-only readers (the `search_vector` generated column, the public-API wire) stay consistent.

### How it works

1. **Migration** `20260622003412_stream_description_json.sql` — one `ALTER TABLE streams ADD COLUMN description_json JSONB` (nullable). No rename, no `search_vector` change: `description` stays the markdown the generated tsvector already indexes. Legacy plaintext rows keep rendering from `description` until a rich edit populates the JSON.
2. **`normalizeStreamDescription`** (`apps/backend/src/features/streams/description.ts`) is the single normalize/derive chokepoint, analogous to messaging's `deriveContentMarkdown` + `normalizeContent`:
   - given `descriptionJson` → derive markdown via `serializeToMarkdown` + `normalizeMessage`;
   - given markdown `description` (public API / legacy) → `parseMarkdown` to JSON, then re-derive the markdown;
   - returns `undefined` when neither field is supplied (leave untouched); an empty doc / empty markdown resolves to `{ description: null, descriptionJson: null }` (clear).
3. **Service** (`StreamService.updateStream`, `createScratchpad`, `createChannel`) calls the normalizer and persists both columns inside the existing transaction; `updateStream` still emits the same `stream:updated` outbox event (INV-4/7).
4. **Repository** reads/writes `description_json` alongside `description` (`SELECT_FIELDS`, `SELECT_FIELDS_WITH_E2E`, `insert`, `update`); JSONB written via `JSON.stringify`, the same pattern as `MessageRepository`.
5. **Validation** (INV-55): `updateStreamSchema` accepts `descriptionJson` validated against `threaDocumentSchema`, and the markdown `description` cap moves from 500 to `STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH` (10,000) to allow rich multi-paragraph notes.

### Key design decisions

**1. Keep `description` (markdown) as the column/field name; add `description_json`.** The alternative — rename `description` → `description_markdown` to match messages exactly — would have to drop and recreate the `search_vector` generated column that depends on it, for no behavioral gain. Keeping the name means a one-line migration, a stable public-API wire field, and zero churn at the ~dozens of read sites. The naming is slightly less symmetric than `content_markdown` but the storage semantics are identical.

**2. `Stream.descriptionJson` is optional on the domain (wire) type, required on the backend repo type.** The backend's `mapRowToStream` always sets it, so required there catches bugs. On the shared `Stream` (also the shape of `CachedStream` consumers), optional matches the established precedent for fields added after launch (`memoryMode?`, the e2e fields) — absent on rows cached before this shipped, always sent (possibly `null`) by a freshly-fetched stream. This is what keeps the frontend ripple to zero in this PR; the cache + editor wiring lands with the editor PR.

**3. Derive markdown from JSON on both paths, rather than storing client markdown verbatim (as message send does).** Slightly stricter than the message path, which keeps the normalized input markdown. For descriptions there's only ever one authored representation in play, so always projecting from the canonical JSON guarantees `description == serialize(descriptionJson)` and removes any drift between search/wire and the rich body.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260622003412_stream_description_json.sql` | Add `description_json JSONB` to `streams` |
| `apps/backend/src/features/streams/description.ts` | `normalizeStreamDescription` — the markdown↔ProseMirror derive chokepoint |
| `apps/backend/src/features/streams/description.test.ts` | Unit tests for the normalizer (round-trip, emoji fold, clear, untouched) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/domain.ts` | Add optional `Stream.descriptionJson: ThreaDocument \| null` |
| `packages/types/src/api.ts` | Add `descriptionJson?: JSONContent` to `UpdateStreamInput` + `CreateStreamInputBase` |
| `packages/types/src/constants.ts` + `index.ts` | Add + export `STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH` (10,000) |
| `apps/backend/src/features/streams/repository.ts` | Read/write `description_json`; `descriptionJson` on `Stream`/insert/update params |
| `apps/backend/src/features/streams/service.ts` | Normalize + persist both columns on create + update |
| `apps/backend/src/features/streams/handlers.ts` | `updateStreamSchema.descriptionJson` (`threaDocumentSchema`); raise markdown cap; forward to service |
| `apps/backend/src/features/streams/service.test.ts` | Service wiring tests for the description update path |
| `…/{activity,saved-messages,scheduled-messages,system-messages}/service.test.ts`, `streams/notification-resolver.test.ts` | Add `descriptionJson: null` to `Stream` test fixtures |

## Out of scope (deliberate — later PRs in the stack)

- **Timeline "set the description" system event** (actor mention chip + message-style collapsible body) — PR 2.
- **Rich-text editor in stream settings** (reuse `RichEditor`, enable for scratchpads, send `descriptionJson`, no image upload) + frontend cache (`CachedStream.descriptionJson`) wiring — PR 3. The existing `<Textarea>` still works today: its markdown is parsed and stored, so descriptions set now already populate `description_json`.
- **Public API `PATCH` to set the description** (+ `streams:write` scope) — PR 4. `GET` already returns `description` markdown.
- **Mentions inside descriptions** authored via the editor will serialize/store, but mention-id resolution at a write chokepoint is not added here.

## Test plan

- [x] `bun test apps/backend/src/features/streams/description.test.ts` — 7 pass (normalizer round-trip / emoji / clear / untouched / json-precedence)
- [x] `bun test apps/backend/src/features/streams/` + the 4 fixture-touched suites — 188 pass
- [x] `bun run typecheck` (full monorepo, 14 projects) — clean
- [x] `bun run check:migrations` — 174 migrations clean (INV-1/3/17)
- [x] Migration applied against a scratch DB through all 174 migrations — `description_json` lands as `jsonb` nullable, `description` stays `text` nullable
- [x] Pre-commit hook (prettier + eslint + full typecheck + OpenAPI `--check`) — clean
- [ ] No live-DB integration test for the repo round-trip — the streams repo/service suites are mock-based here, so the SQL is covered by the scratch-DB migration apply + the mock-level service wiring assertions, not an integration test

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784674377&installation_id=129946197&pr_number=1048&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1048&signature=9a8d4a33c4cfb9ffdb1fbd9f4efac58143cee72ed03fcb47a7559f6a6438c29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->