### PR TITLE
feat(frontend): opt-in Unread sidebar section (sticky tray)

### DIFF
--- a/apps/backend/src/features/sidebar-config/handlers.ts
+++ b/apps/backend/src/features/sidebar-config/handlers.ts
@@ -25,6 +25,9 @@ const sidebarSectionSpecSchema = z.discriminatedUnion("kind", [
     name: z.string().trim().min(1).max(MAX_CUSTOM_SECTION_NAME_LENGTH),
     streamIds: z.array(z.string().min(1).max(64)).max(MAX_CUSTOM_SECTION_STREAM_IDS).optional().default([]),
   }),
+  // Unread section: draws no membership of its own (the unread signal is live),
+  // so the spec carries nothing beyond its kind.
+  z.object({ kind: z.literal("unread") }),
   z.object({ kind: z.literal("quicklinks") }),
 ])
 

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -51,7 +51,13 @@ function makeItem(overrides: ItemOverrides): StreamItemData {
 function makeInput(
   over: Partial<ResolveSectionsInput> & Pick<ResolveSectionsInput, "processedStreams">
 ): ResolveSectionsInput {
-  return { virtualDmStreams: [], getUnreadCount: () => 0, streamIdsByLabel: new Map(), ...over }
+  return {
+    virtualDmStreams: [],
+    getUnreadCount: () => 0,
+    streamIdsByLabel: new Map(),
+    unreadStreamIds: new Set(),
+    ...over,
+  }
 }
 
 /**
@@ -358,7 +364,9 @@ describe("resolveSections — custom sections", () => {
 
 describe("resolveSections — Unread section", () => {
   const SECTIONS_VERSION = SIDEBAR_CONFIG_VERSION
-  // Unread at the top, then the two smart buckets it draws from.
+  // Unread at the top, then the two smart buckets it draws from. Membership is
+  // the sticky tray (`unreadStreamIds`), supplied by the caller — the resolver no
+  // longer derives it from live counts (muting etc. is decided upstream).
   const unreadFirst = {
     version: SECTIONS_VERSION,
     basePreset: "smart" as const,
@@ -370,16 +378,15 @@ describe("resolveSections — Unread section", () => {
     quickLinks: [],
   }
 
-  it("pulls unread streams out of the smart buckets into Unread", () => {
+  it("pulls tray members out of the smart buckets into Unread", () => {
     const processedStreams = [
       makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
       makeItem({ id: "r1", section: "recent", activity: 5 }),
     ]
-    const getUnreadCount = unreadFrom(new Set(["u1"]))
 
-    expect(shape({ processedStreams, getUnreadCount }, unreadFirst)).toEqual([
+    expect(shape({ processedStreams, unreadStreamIds: new Set(["u1"]) }, unreadFirst)).toEqual([
       { id: "unread", items: ["u1"] },
-      // u1 left Recent for Unread; r1 (read) stays.
+      // u1 moved to Unread; r1 (not in the tray) stays in Recent.
       { id: "recent", items: ["r1"] },
       { id: "other", items: [] },
     ])
@@ -399,32 +406,15 @@ describe("resolveSections — Unread section", () => {
       makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
       makeItem({ id: "r1", section: "recent", activity: 5 }),
     ]
-    const getUnreadCount = unreadFrom(new Set(["u1"]))
 
-    expect(shape({ processedStreams, getUnreadCount }, recentFirst)).toEqual([
+    expect(shape({ processedStreams, unreadStreamIds: new Set(["u1"]) }, recentFirst)).toEqual([
       // Recent loses u1 to Unread even though it is ordered above it.
       { id: "recent", items: ["r1"] },
       { id: "unread", items: ["u1"] },
     ])
   })
 
-  it("excludes muted unread streams (quiet urgency), leaving them in their bucket", () => {
-    const processedStreams = [
-      makeItem({ id: "u_active", section: "recent", urgency: "activity", activity: 9 }),
-      // Muted: unread count > 0 but urgency stays "quiet".
-      makeItem({ id: "u_muted", section: "recent", urgency: "quiet", activity: 5 }),
-    ]
-    const getUnreadCount = unreadFrom(new Set(["u_active", "u_muted"]))
-
-    expect(shape({ processedStreams, getUnreadCount }, unreadFirst)).toEqual([
-      { id: "unread", items: ["u_active"] },
-      // The muted unread stays in Recent rather than resurfacing in Unread.
-      { id: "recent", items: ["u_muted"] },
-      { id: "other", items: [] },
-    ])
-  })
-
-  it("keeps a custom-filed unread stream in its custom home (and duplicates it into Unread)", () => {
+  it("drops the ghost: a custom-filed tray member shows only in Unread, not its custom home", () => {
     const config = {
       version: SECTIONS_VERSION,
       basePreset: "smart" as const,
@@ -442,19 +432,17 @@ describe("resolveSections — Unread section", () => {
       makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
       makeItem({ id: "c1", section: "recent", urgency: "activity", activity: 5 }),
     ]
-    const getUnreadCount = unreadFrom(new Set(["u1", "c1"]))
 
-    expect(shape({ processedStreams, getUnreadCount }, config)).toEqual([
-      // Both unread streams surface here, by activity.
+    expect(shape({ processedStreams, unreadStreamIds: new Set(["u1", "c1"]) }, config)).toEqual([
+      // Both tray members surface here, by activity — one copy each, no ghost.
       { id: "unread", items: ["u1", "c1"] },
-      // u1 (no home) left Recent; c1 was always in its custom home.
       { id: "recent", items: [] },
-      // c1 stays in its hard-location home — the home copy the UI renders dimmed.
-      { id: customSectionId("sec_1"), items: ["c1"] },
+      // c1's custom home is empty while it's in the tray (it returns when cleared).
+      { id: customSectionId("sec_1"), items: [] },
     ])
   })
 
-  it("keeps a labeled unread stream in its label lens (and duplicates it into Unread)", () => {
+  it("drops the ghost: a labeled tray member shows only in Unread, not its label lens", () => {
     const config = {
       version: SECTIONS_VERSION,
       basePreset: "smart" as const,
@@ -466,28 +454,49 @@ describe("resolveSections — Unread section", () => {
       quickLinks: [],
     }
     const processedStreams = [makeItem({ id: "l1", section: "recent", urgency: "activity", activity: 5 })]
-    const getUnreadCount = unreadFrom(new Set(["l1"]))
     const streamIdsByLabel = new Map([["lbl_1", new Set(["l1"])]])
 
-    expect(shape({ processedStreams, getUnreadCount, streamIdsByLabel }, config)).toEqual([
+    expect(shape({ processedStreams, streamIdsByLabel, unreadStreamIds: new Set(["l1"]) }, config)).toEqual([
       { id: "unread", items: ["l1"] },
       { id: "recent", items: [] },
-      // The label lens keeps its unread stream (dimmed in the UI).
-      { id: labelSectionId("lbl_1"), items: ["l1"] },
+      // The label lens is empty while l1 is in the tray — no dimmed duplicate.
+      { id: labelSectionId("lbl_1"), items: [] },
     ])
   })
 
-  it("leaves the buckets untouched when no Unread section is in the layout", () => {
+  it("keeps a read-but-not-cleared member in Unread and out of its home (sticky)", () => {
+    const config = {
+      version: SECTIONS_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "unread", spec: { kind: "unread" as const } },
+        {
+          id: customSectionId("sec_1"),
+          spec: { kind: "custom" as const, sectionId: "sec_1", name: "Pinned", streamIds: ["c1"] },
+        },
+      ],
+      quickLinks: [],
+    }
+    // c1 is read now (getUnreadCount default 0) but still in the tray.
+    const processedStreams = [makeItem({ id: "c1", section: "recent", urgency: "quiet", activity: 5 })]
+
+    expect(shape({ processedStreams, unreadStreamIds: new Set(["c1"]) }, config)).toEqual([
+      // It lingers in Unread (de-emphasized in the UI), not bouncing back home on read.
+      { id: "unread", items: ["c1"] },
+      { id: customSectionId("sec_1"), items: [] },
+    ])
+  })
+
+  it("leaves the buckets untouched when the tray is empty", () => {
     const processedStreams = [makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 })]
-    const getUnreadCount = unreadFrom(new Set(["u1"]))
-    // Default Smart preset has no Unread section, so u1 stays in Recent.
-    const recent = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams, getUnreadCount })).find(
+    // No Unread section / empty tray, so u1 stays in Recent.
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams })).find(
       (r) => r.section.id === "recent"
     )
     expect(recent?.items.map((i) => i.id)).toEqual(["u1"])
   })
 
-  it("pulls unread streams out of type sections into Unread (All preset path)", () => {
+  it("pulls tray members out of type sections into Unread (All preset path)", () => {
     const config = {
       version: SECTIONS_VERSION,
       basePreset: "all" as const,
@@ -501,11 +510,10 @@ describe("resolveSections — Unread section", () => {
       makeItem({ id: "dm_unread", type: StreamTypes.DM, urgency: "activity", activity: 9 }),
       makeItem({ id: "dm_read", type: StreamTypes.DM, urgency: "quiet", activity: 5 }),
     ]
-    const getUnreadCount = unreadFrom(new Set(["dm_unread"]))
 
-    expect(shape({ processedStreams, getUnreadCount }, config)).toEqual([
+    expect(shape({ processedStreams, unreadStreamIds: new Set(["dm_unread"]) }, config)).toEqual([
       { id: "unread", items: ["dm_unread"] },
-      // The unread DM leaves its type section for Unread; the read DM stays.
+      // The tray member leaves its type section for Unread; the other DM stays.
       { id: "dms", items: ["dm_read"] },
     ])
   })

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -486,6 +486,29 @@ describe("resolveSections — Unread section", () => {
     )
     expect(recent?.items.map((i) => i.id)).toEqual(["u1"])
   })
+
+  it("pulls unread streams out of type sections into Unread (All preset path)", () => {
+    const config = {
+      version: SECTIONS_VERSION,
+      basePreset: "all" as const,
+      sections: [
+        { id: "unread", spec: { kind: "unread" as const } },
+        { id: "dms", spec: { kind: "type" as const, streamType: "dm" as const } },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "dm_unread", type: StreamTypes.DM, urgency: "activity", activity: 9 }),
+      makeItem({ id: "dm_read", type: StreamTypes.DM, urgency: "quiet", activity: 5 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["dm_unread"]))
+
+    expect(shape({ processedStreams, getUnreadCount }, config)).toEqual([
+      { id: "unread", items: ["dm_unread"] },
+      // The unread DM leaves its type section for Unread; the read DM stays.
+      { id: "dms", items: ["dm_read"] },
+    ])
+  })
 })
 
 describe("findSourceLabelId", () => {

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts
@@ -356,6 +356,138 @@ describe("resolveSections — custom sections", () => {
   })
 })
 
+describe("resolveSections — Unread section", () => {
+  const SECTIONS_VERSION = SIDEBAR_CONFIG_VERSION
+  // Unread at the top, then the two smart buckets it draws from.
+  const unreadFirst = {
+    version: SECTIONS_VERSION,
+    basePreset: "smart" as const,
+    sections: [
+      { id: "unread", spec: { kind: "unread" as const } },
+      { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+      { id: "other", spec: { kind: "smart" as const, bucket: "other" as const } },
+    ],
+    quickLinks: [],
+  }
+
+  it("pulls unread streams out of the smart buckets into Unread", () => {
+    const processedStreams = [
+      makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
+      makeItem({ id: "r1", section: "recent", activity: 5 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["u1"]))
+
+    expect(shape({ processedStreams, getUnreadCount }, unreadFirst)).toEqual([
+      { id: "unread", items: ["u1"] },
+      // u1 left Recent for Unread; r1 (read) stays.
+      { id: "recent", items: ["r1"] },
+      { id: "other", items: [] },
+    ])
+  })
+
+  it("takes precedence over a bucket ordered above it", () => {
+    const recentFirst = {
+      version: SECTIONS_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        { id: "unread", spec: { kind: "unread" as const } },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
+      makeItem({ id: "r1", section: "recent", activity: 5 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["u1"]))
+
+    expect(shape({ processedStreams, getUnreadCount }, recentFirst)).toEqual([
+      // Recent loses u1 to Unread even though it is ordered above it.
+      { id: "recent", items: ["r1"] },
+      { id: "unread", items: ["u1"] },
+    ])
+  })
+
+  it("excludes muted unread streams (quiet urgency), leaving them in their bucket", () => {
+    const processedStreams = [
+      makeItem({ id: "u_active", section: "recent", urgency: "activity", activity: 9 }),
+      // Muted: unread count > 0 but urgency stays "quiet".
+      makeItem({ id: "u_muted", section: "recent", urgency: "quiet", activity: 5 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["u_active", "u_muted"]))
+
+    expect(shape({ processedStreams, getUnreadCount }, unreadFirst)).toEqual([
+      { id: "unread", items: ["u_active"] },
+      // The muted unread stays in Recent rather than resurfacing in Unread.
+      { id: "recent", items: ["u_muted"] },
+      { id: "other", items: [] },
+    ])
+  })
+
+  it("keeps a custom-filed unread stream in its custom home (and duplicates it into Unread)", () => {
+    const config = {
+      version: SECTIONS_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "unread", spec: { kind: "unread" as const } },
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        {
+          id: customSectionId("sec_1"),
+          spec: { kind: "custom" as const, sectionId: "sec_1", name: "Pinned", streamIds: ["c1"] },
+        },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [
+      makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 }),
+      makeItem({ id: "c1", section: "recent", urgency: "activity", activity: 5 }),
+    ]
+    const getUnreadCount = unreadFrom(new Set(["u1", "c1"]))
+
+    expect(shape({ processedStreams, getUnreadCount }, config)).toEqual([
+      // Both unread streams surface here, by activity.
+      { id: "unread", items: ["u1", "c1"] },
+      // u1 (no home) left Recent; c1 was always in its custom home.
+      { id: "recent", items: [] },
+      // c1 stays in its hard-location home — the home copy the UI renders dimmed.
+      { id: customSectionId("sec_1"), items: ["c1"] },
+    ])
+  })
+
+  it("keeps a labeled unread stream in its label lens (and duplicates it into Unread)", () => {
+    const config = {
+      version: SECTIONS_VERSION,
+      basePreset: "smart" as const,
+      sections: [
+        { id: "unread", spec: { kind: "unread" as const } },
+        { id: "recent", spec: { kind: "smart" as const, bucket: "recent" as const } },
+        { id: labelSectionId("lbl_1"), spec: { kind: "label" as const, labelId: "lbl_1" } },
+      ],
+      quickLinks: [],
+    }
+    const processedStreams = [makeItem({ id: "l1", section: "recent", urgency: "activity", activity: 5 })]
+    const getUnreadCount = unreadFrom(new Set(["l1"]))
+    const streamIdsByLabel = new Map([["lbl_1", new Set(["l1"])]])
+
+    expect(shape({ processedStreams, getUnreadCount, streamIdsByLabel }, config)).toEqual([
+      { id: "unread", items: ["l1"] },
+      { id: "recent", items: [] },
+      // The label lens keeps its unread stream (dimmed in the UI).
+      { id: labelSectionId("lbl_1"), items: ["l1"] },
+    ])
+  })
+
+  it("leaves the buckets untouched when no Unread section is in the layout", () => {
+    const processedStreams = [makeItem({ id: "u1", section: "recent", urgency: "activity", activity: 9 })]
+    const getUnreadCount = unreadFrom(new Set(["u1"]))
+    // Default Smart preset has no Unread section, so u1 stays in Recent.
+    const recent = resolveSections(SMART_SIDEBAR_CONFIG, makeInput({ processedStreams, getUnreadCount })).find(
+      (r) => r.section.id === "recent"
+    )
+    expect(recent?.items.map((i) => i.id)).toEqual(["u1"])
+  })
+})
+
 describe("findSourceLabelId", () => {
   const config = {
     version: SIDEBAR_CONFIG_VERSION,

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -2,7 +2,7 @@ import { type StreamType, StreamTypes } from "@threa/types"
 import { ALL_SECTIONS, SMART_SECTIONS } from "./config"
 import type { SidebarConfig, SidebarSection, SidebarSectionSpec } from "./sidebar-config"
 import type { SectionKey, StreamItemData } from "./types"
-import { isUnreadStream, sortStreams } from "./utils"
+import { sortStreams } from "./utils"
 
 type TypeSectionStream = Extract<StreamType, "scratchpad" | "channel" | "dm">
 
@@ -10,6 +10,18 @@ type TypeSectionStream = Extract<StreamType, "scratchpad" | "channel" | "dm">
 const IMPORTANT_LIMIT = 10
 /** Recent shows at most this many reads; unreads beyond it still surface (see below). */
 const RECENT_LIMIT = 5
+
+const EMPTY_SET: ReadonlySet<string> = new Set()
+
+/** Merge id sets, returning the single non-empty input unchanged when there is only one. */
+function union(...sets: ReadonlySet<string>[]): ReadonlySet<string> {
+  const nonEmpty = sets.filter((set) => set.size > 0)
+  if (nonEmpty.length === 0) return EMPTY_SET
+  if (nonEmpty.length === 1) return nonEmpty[0]
+  const out = new Set<string>()
+  for (const set of nonEmpty) for (const id of set) out.add(id)
+  return out
+}
 
 export interface ResolveSectionsInput {
   /** Real streams, already filtered + enriched with urgency/section. */
@@ -22,6 +34,17 @@ export interface ResolveSectionsInput {
    * Drives `{ kind: "label" }` sections; an absent label resolves to empty.
    */
   streamIdsByLabel: Map<string, Set<string>>
+  /**
+   * The Unread tray: stream ids held by the dedicated Unread section for this
+   * viewing session (see `useStickyUnread`). A stream stays here once it goes
+   * unread until the session ends or the viewer clears it — so the set holds
+   * read-but-not-yet-cleared streams too, not just currently-unread ones. Empty
+   * unless the layout has an `{ kind: "unread" }` section. Members render only in
+   * Unread; every other section excludes them, so the sidebar doesn't reflow each
+   * time one is read. Drives both the Unread section's contents and the
+   * exclusion the other sections apply.
+   */
+  unreadStreamIds: ReadonlySet<string>
 }
 
 export interface ResolvedSection {
@@ -64,12 +87,13 @@ export function findSourceLabelId(streamId: string, resolved: ResolvedSection[])
  * out-rank label sections (a stream filed into a custom section is withheld
  * from the label lens too); among label sections, the topmost one wins.
  *
- * The Unread section (when present) trumps the smart/type buckets the same way:
- * every unread stream is withheld from them and shown in Unread instead,
- * regardless of layout order. But its precedence stops at the hard locations —
- * an unread stream filed into a custom section or carrying a pinned label keeps
- * its home (shown dimmed there) AND is duplicated into Unread, so the Unread
- * section never claims any stream out of a custom/label home below it.
+ * The Unread tray ({@link ResolveSectionsInput.unreadStreamIds}) trumps every
+ * other section: a stream in the tray shows **only** in the Unread section, drawn
+ * out of its smart/type bucket and its custom/label home alike, so there is one
+ * copy (no dimmed ghost) and the rest of the sidebar doesn't reflow as the tray
+ * fills and drains. The tray is sticky — a member stays after it's read until the
+ * session ends or the viewer clears it — so the membership is supplied as a set
+ * rather than recomputed from live unread counts here.
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
   const claimed = new Set<string>()
@@ -80,12 +104,6 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
   // so the label lens claims them out of the smart/type buckets — a labeled
   // stream lives under its label, not its automatic bucket, regardless of order.
   const labeledClaimed = new Set<string>()
-  // Unread streams, withheld from the smart/type buckets so the Unread section
-  // surfaces them instead — only when that section is actually in the layout.
-  // Hard-location homes (custom/label) keep their unread streams, so this only
-  // gates the automatic buckets, never the homes.
-  const unreadClaimed = new Set<string>()
-  const hasUnreadSection = config.sections.some((section) => section.spec.kind === "unread")
   for (const section of config.sections) {
     if (section.spec.kind === "custom") for (const id of section.spec.streamIds) customClaimed.add(id)
     if (section.spec.kind === "label") {
@@ -93,16 +111,11 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
       if (ids) for (const id of ids) labeledClaimed.add(id)
     }
   }
-  if (hasUnreadSection) {
-    for (const stream of input.processedStreams) {
-      if (isUnreadStream(stream, input.getUnreadCount(stream.id))) unreadClaimed.add(stream.id)
-    }
-  }
   return config.sections.map((section) => {
-    const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed, unreadClaimed)
-    // The Unread section never claims its streams: the smart/type buckets already
-    // exclude them via `unreadClaimed`, and the custom/label homes intentionally
-    // keep (and dim) theirs — claiming would hide a home copy resolving below.
+    const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed)
+    // The Unread section never claims its streams: every other section already
+    // excludes the tray via `unreadStreamIds`, and claiming would also block a
+    // tray member from returning to its home section once the tray is cleared.
     if (section.spec.kind !== "unread") for (const item of items) claimed.add(item.id)
     return { section, items }
   })
@@ -113,33 +126,22 @@ function resolveItems(
   input: ResolveSectionsInput,
   claimed: ReadonlySet<string>,
   customClaimed: ReadonlySet<string>,
-  labeledClaimed: ReadonlySet<string>,
-  unreadClaimed: ReadonlySet<string>
+  labeledClaimed: ReadonlySet<string>
 ): StreamItemData[] {
-  // A custom section draws only its own membership, minus anything an earlier
-  // custom section already took (single-membership; topmost custom wins). It
-  // keeps its unread streams (shown dimmed), so `unreadClaimed` never applies.
-  if (spec.kind === "custom") return resolveCustomSection(spec.streamIds, input, claimed)
-  // A label lens shows its streams out of the buckets, but a stream filed into a
-  // custom section still trumps the label — fold custom membership into the
-  // exclusion. Topmost label wins via the running `claimed` set. Like custom
-  // sections it keeps its unread streams (dimmed), so `unreadClaimed` is omitted.
-  if (spec.kind === "label") {
-    const exclude = customClaimed.size === 0 ? claimed : new Set([...claimed, ...customClaimed])
-    return resolveLabelSection(spec.labelId, input, exclude)
-  }
-  // Every unread stream, regardless of where it would otherwise sit — including
-  // streams in a custom/label home, which are duplicated here (and dimmed in
-  // their home). Drawn independent of `claimed` so a home resolving above still
-  // surfaces its copy here.
+  const unread = input.unreadStreamIds
+  // The Unread tray draws its members regardless of the running claims (nothing
+  // above can have taken them, since every other section excludes the tray).
   if (spec.kind === "unread") return resolveUnreadSection(input)
-  // Smart/type buckets never show a stream that was filed into a custom section,
-  // carries a pinned label, or (when an Unread section exists) is unread, so fold
-  // all three memberships into their exclusion set on top of the running claims.
-  const exclude =
-    customClaimed.size === 0 && labeledClaimed.size === 0 && unreadClaimed.size === 0
-      ? claimed
-      : new Set([...claimed, ...customClaimed, ...labeledClaimed, ...unreadClaimed])
+  // A custom section draws its own membership minus anything an earlier custom
+  // section took (single-membership; topmost custom wins) and minus the tray.
+  if (spec.kind === "custom") return resolveCustomSection(spec.streamIds, input, union(claimed, unread))
+  // A label lens shows its streams out of the buckets, but a stream filed into a
+  // custom section trumps the label, and a tray member shows only in Unread —
+  // fold both into the exclusion. Topmost label wins via the running `claimed`.
+  if (spec.kind === "label") return resolveLabelSection(spec.labelId, input, union(claimed, customClaimed, unread))
+  // Smart/type buckets never show a stream filed into a custom section, carrying a
+  // pinned label, or held in the Unread tray — fold all three into the exclusion.
+  const exclude = union(claimed, customClaimed, labeledClaimed, unread)
   if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input, exclude)
   if (spec.kind === "type") return resolveTypeSection(spec.streamType, input, exclude)
   // Quick links draw no streams — the block renders its own link list, so the
@@ -148,14 +150,19 @@ function resolveItems(
 }
 
 /**
- * Every stream the viewer has unread (non-muted) messages in, by activity. Draws
- * from real streams only (synthetic DM drafts have nothing unread). Ignores the
- * running `claimed` set on purpose: a custom/label home resolving above keeps its
- * copy, and this section surfaces the same stream again so the unread is never
- * buried behind a collapsed home.
+ * The Unread tray's members (see {@link ResolveSectionsInput.unreadStreamIds}),
+ * by activity. Draws from real streams only — synthetic DM drafts are never in
+ * the tray. Read-but-not-yet-cleared members are kept (the set holds them); they
+ * sort by the same activity key as everything else, so a stream keeps its slot
+ * when it's read instead of jumping, and the row de-emphasizes in place.
  */
-function resolveUnreadSection({ processedStreams, getUnreadCount }: ResolveSectionsInput): StreamItemData[] {
-  const items = processedStreams.filter((stream) => isUnreadStream(stream, getUnreadCount(stream.id)))
+function resolveUnreadSection({
+  processedStreams,
+  unreadStreamIds,
+  getUnreadCount,
+}: ResolveSectionsInput): StreamItemData[] {
+  if (unreadStreamIds.size === 0) return []
+  const items = processedStreams.filter((stream) => unreadStreamIds.has(stream.id))
   return sortStreams(items, "activity", getUnreadCount)
 }
 

--- a/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
+++ b/apps/frontend/src/components/layout/sidebar/resolve-sections.ts
@@ -2,7 +2,7 @@ import { type StreamType, StreamTypes } from "@threa/types"
 import { ALL_SECTIONS, SMART_SECTIONS } from "./config"
 import type { SidebarConfig, SidebarSection, SidebarSectionSpec } from "./sidebar-config"
 import type { SectionKey, StreamItemData } from "./types"
-import { sortStreams } from "./utils"
+import { isUnreadStream, sortStreams } from "./utils"
 
 type TypeSectionStream = Extract<StreamType, "scratchpad" | "channel" | "dm">
 
@@ -63,6 +63,13 @@ export function findSourceLabelId(streamId: string, resolved: ResolvedSection[])
  * layout order rather than competing for the topmost claim. Custom sections
  * out-rank label sections (a stream filed into a custom section is withheld
  * from the label lens too); among label sections, the topmost one wins.
+ *
+ * The Unread section (when present) trumps the smart/type buckets the same way:
+ * every unread stream is withheld from them and shown in Unread instead,
+ * regardless of layout order. But its precedence stops at the hard locations —
+ * an unread stream filed into a custom section or carrying a pinned label keeps
+ * its home (shown dimmed there) AND is duplicated into Unread, so the Unread
+ * section never claims any stream out of a custom/label home below it.
  */
 export function resolveSections(config: SidebarConfig, input: ResolveSectionsInput): ResolvedSection[] {
   const claimed = new Set<string>()
@@ -73,6 +80,12 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
   // so the label lens claims them out of the smart/type buckets — a labeled
   // stream lives under its label, not its automatic bucket, regardless of order.
   const labeledClaimed = new Set<string>()
+  // Unread streams, withheld from the smart/type buckets so the Unread section
+  // surfaces them instead — only when that section is actually in the layout.
+  // Hard-location homes (custom/label) keep their unread streams, so this only
+  // gates the automatic buckets, never the homes.
+  const unreadClaimed = new Set<string>()
+  const hasUnreadSection = config.sections.some((section) => section.spec.kind === "unread")
   for (const section of config.sections) {
     if (section.spec.kind === "custom") for (const id of section.spec.streamIds) customClaimed.add(id)
     if (section.spec.kind === "label") {
@@ -80,9 +93,17 @@ export function resolveSections(config: SidebarConfig, input: ResolveSectionsInp
       if (ids) for (const id of ids) labeledClaimed.add(id)
     }
   }
+  if (hasUnreadSection) {
+    for (const stream of input.processedStreams) {
+      if (isUnreadStream(stream, input.getUnreadCount(stream.id))) unreadClaimed.add(stream.id)
+    }
+  }
   return config.sections.map((section) => {
-    const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed)
-    for (const item of items) claimed.add(item.id)
+    const items = resolveItems(section.spec, input, claimed, customClaimed, labeledClaimed, unreadClaimed)
+    // The Unread section never claims its streams: the smart/type buckets already
+    // exclude them via `unreadClaimed`, and the custom/label homes intentionally
+    // keep (and dim) theirs — claiming would hide a home copy resolving below.
+    if (section.spec.kind !== "unread") for (const item of items) claimed.add(item.id)
     return { section, items }
   })
 }
@@ -92,30 +113,50 @@ function resolveItems(
   input: ResolveSectionsInput,
   claimed: ReadonlySet<string>,
   customClaimed: ReadonlySet<string>,
-  labeledClaimed: ReadonlySet<string>
+  labeledClaimed: ReadonlySet<string>,
+  unreadClaimed: ReadonlySet<string>
 ): StreamItemData[] {
   // A custom section draws only its own membership, minus anything an earlier
-  // custom section already took (single-membership; topmost custom wins).
+  // custom section already took (single-membership; topmost custom wins). It
+  // keeps its unread streams (shown dimmed), so `unreadClaimed` never applies.
   if (spec.kind === "custom") return resolveCustomSection(spec.streamIds, input, claimed)
   // A label lens shows its streams out of the buckets, but a stream filed into a
   // custom section still trumps the label — fold custom membership into the
-  // exclusion. Topmost label wins via the running `claimed` set.
+  // exclusion. Topmost label wins via the running `claimed` set. Like custom
+  // sections it keeps its unread streams (dimmed), so `unreadClaimed` is omitted.
   if (spec.kind === "label") {
     const exclude = customClaimed.size === 0 ? claimed : new Set([...claimed, ...customClaimed])
     return resolveLabelSection(spec.labelId, input, exclude)
   }
-  // Smart/type buckets never show a stream that was filed into a custom section
-  // or that carries a pinned label, so fold both memberships into their
-  // exclusion set on top of the running claims.
+  // Every unread stream, regardless of where it would otherwise sit — including
+  // streams in a custom/label home, which are duplicated here (and dimmed in
+  // their home). Drawn independent of `claimed` so a home resolving above still
+  // surfaces its copy here.
+  if (spec.kind === "unread") return resolveUnreadSection(input)
+  // Smart/type buckets never show a stream that was filed into a custom section,
+  // carries a pinned label, or (when an Unread section exists) is unread, so fold
+  // all three memberships into their exclusion set on top of the running claims.
   const exclude =
-    customClaimed.size === 0 && labeledClaimed.size === 0
+    customClaimed.size === 0 && labeledClaimed.size === 0 && unreadClaimed.size === 0
       ? claimed
-      : new Set([...claimed, ...customClaimed, ...labeledClaimed])
+      : new Set([...claimed, ...customClaimed, ...labeledClaimed, ...unreadClaimed])
   if (spec.kind === "smart") return resolveSmartBucket(spec.bucket, input, exclude)
   if (spec.kind === "type") return resolveTypeSection(spec.streamType, input, exclude)
   // Quick links draw no streams — the block renders its own link list, so the
   // resolved section is a positional placeholder the stream list renders specially.
   return []
+}
+
+/**
+ * Every stream the viewer has unread (non-muted) messages in, by activity. Draws
+ * from real streams only (synthetic DM drafts have nothing unread). Ignores the
+ * running `claimed` set on purpose: a custom/label home resolving above keeps its
+ * copy, and this section surfaces the same stream again so the unread is never
+ * buried behind a collapsed home.
+ */
+function resolveUnreadSection({ processedStreams, getUnreadCount }: ResolveSectionsInput): StreamItemData[] {
+  const items = processedStreams.filter((stream) => isUnreadStream(stream, getUnreadCount(stream.id)))
+  return sortStreams(items, "activity", getUnreadCount)
 }
 
 /**

--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -37,6 +37,8 @@ interface ScratchpadItemProps {
   compact?: boolean
   showPreviewOnHover?: boolean
   scrollContainerRef?: RefObject<HTMLDivElement | null>
+  /** Trailing "· home" hint — set only in the Unread section. See {@link StreamItem}. */
+  homeHint?: string
 }
 
 export function ScratchpadItem({
@@ -49,6 +51,7 @@ export function ScratchpadItem({
   compact = false,
   showPreviewOnHover = false,
   scrollContainerRef,
+  homeHint,
 }: ScratchpadItemProps) {
   const navigate = useNavigate()
   const archiveStream = useArchiveStream(workspaceId)
@@ -194,6 +197,7 @@ export function ScratchpadItem({
                     <span className={cn("truncate text-sm", hasUnread ? "font-semibold" : "font-medium")}>
                       {name}
                       {isDraft && <span className="ml-1.5 text-xs text-muted-foreground font-normal">(draft)</span>}
+                      {homeHint && <span className="text-xs text-muted-foreground font-normal"> · {homeHint}</span>}
                     </span>
                   )}
                   <div className="ml-auto flex items-center gap-1.5">

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -296,13 +296,6 @@ interface StreamSectionProps {
   state?: CollapseState
   onToggle?: () => void
   action?: ReactNode
-  /**
-   * Rendered in place of the row list when the section has no items (and isn't
-   * collapsed). Lets a persistent section — e.g. Unread, which stays in the
-   * layout once added — hold its space with an "all caught up" placeholder
-   * instead of collapsing to just a header (which shifts everything below it).
-   */
-  emptyState?: ReactNode
   /** Show compact view (title only, no preview) */
   compact?: boolean
   /** Show preview on hover when compact (only works with compact=true) */
@@ -355,7 +348,6 @@ export function StreamSection({
   streamDragEnabled = false,
   dimReadRows = false,
   homeHintFor,
-  emptyState,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -394,8 +386,6 @@ export function StreamSection({
       />
 
       {!isCollapsed && items.length > 0 && <div className="mt-1 flex flex-col gap-0.5">{items.map(renderRow)}</div>}
-
-      {!isCollapsed && items.length === 0 && emptyState}
 
       {!isCollapsed && action}
     </div>

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -9,7 +9,7 @@ import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
 import { StreamItem } from "./stream-item"
 import { DraggableStreamRow } from "./sidebar-dnd"
 import type { StreamItemData } from "./types"
-import { getActivityTime } from "./utils"
+import { getActivityTime, isUnreadStream } from "./utils"
 
 interface SectionHeaderProps {
   label: string
@@ -204,6 +204,53 @@ export function SectionHeader({
   )
 }
 
+interface RenderRowOptions {
+  workspaceId: string
+  activeStreamId?: string
+  allStreams: StreamItemData[]
+  getUnreadCount: (streamId: string) => number
+  getMentionCount: (streamId: string) => number
+  compact: boolean
+  showPreviewOnHover: boolean
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
+  streamDragEnabled: boolean
+  dimUnread: boolean
+}
+
+/**
+ * One stream row, shared by the binary and tiered sections. Wraps as a drag
+ * source only when dragging is on (desktop) and the row is a persisted stream —
+ * drafts (incl. virtual DMs) carry transient ids that must never be filed into
+ * config, and wrapping a disabled row would register a dead draggable for
+ * nothing. A dimmed (unread-in-its-hard-location-home) row gets an opacity
+ * wrapper — opacity only, so nothing shifts (INV-21).
+ */
+function renderSectionRow(stream: StreamItemData, opts: RenderRowOptions): ReactNode {
+  const item = (
+    <StreamItem
+      workspaceId={opts.workspaceId}
+      stream={stream}
+      isActive={stream.id === opts.activeStreamId}
+      unreadCount={opts.getUnreadCount(stream.id)}
+      mentionCount={opts.getMentionCount(stream.id)}
+      allStreams={opts.allStreams}
+      compact={opts.compact}
+      showPreviewOnHover={opts.showPreviewOnHover}
+      scrollContainerRef={opts.scrollContainerRef}
+    />
+  )
+  const dragEnabled = opts.streamDragEnabled && !isDraftId(stream.id)
+  const row = dragEnabled ? <DraggableStreamRow streamId={stream.id}>{item}</DraggableStreamRow> : item
+  const dimmed = opts.dimUnread && isUnreadStream(stream, opts.getUnreadCount(stream.id))
+  return dimmed ? (
+    <div key={stream.id} className="opacity-50 transition-opacity">
+      {row}
+    </div>
+  ) : (
+    <Fragment key={stream.id}>{row}</Fragment>
+  )
+}
+
 /** Sum unread counts across a list of streams. */
 function sumUnread(items: StreamItemData[], getUnreadCount: (streamId: string) => number): number {
   let total = 0
@@ -261,6 +308,13 @@ interface StreamSectionProps {
   addMenuActions?: SidebarActionItem[] | null
   /** When true, each stream row is a drag source for filing into a custom section (desktop). */
   streamDragEnabled?: boolean
+  /**
+   * Dim unread rows in this section. Set for custom/label homes when the layout
+   * has an Unread section: the unread stream's active copy lives up in Unread, so
+   * its hard-location home shows a dimmed ghost rather than reading as a second
+   * live location. Un-dims the moment the stream is read (it leaves Unread too).
+   */
+  dimUnread?: boolean
 }
 
 /** Simple binary collapsible section used for Important / Recent. */
@@ -286,38 +340,25 @@ export function StreamSection({
   addTooltip,
   addMenuActions,
   streamDragEnabled = false,
+  dimUnread = false,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
   const mentionAggregate = sumMentions(items, getMentionCount)
 
-  const renderRow = (stream: StreamItemData) => {
-    const item = (
-      <StreamItem
-        workspaceId={workspaceId}
-        stream={stream}
-        isActive={stream.id === activeStreamId}
-        unreadCount={getUnreadCount(stream.id)}
-        mentionCount={getMentionCount(stream.id)}
-        allStreams={allStreams}
-        compact={compact}
-        showPreviewOnHover={showPreviewOnHover}
-        scrollContainerRef={scrollContainerRef}
-      />
-    )
-    // Wrap as a drag source only when dragging is on (desktop) and the row is a
-    // persisted stream — drafts (incl. virtual DMs) carry transient ids that
-    // must never be filed into config, and wrapping a disabled row would
-    // register a dead draggable for nothing.
-    const dragEnabled = streamDragEnabled && !isDraftId(stream.id)
-    return dragEnabled ? (
-      <DraggableStreamRow key={stream.id} streamId={stream.id}>
-        {item}
-      </DraggableStreamRow>
-    ) : (
-      <Fragment key={stream.id}>{item}</Fragment>
-    )
-  }
+  const renderRow = (stream: StreamItemData) =>
+    renderSectionRow(stream, {
+      workspaceId,
+      activeStreamId,
+      allStreams,
+      getUnreadCount,
+      getMentionCount,
+      compact,
+      showPreviewOnHover,
+      scrollContainerRef,
+      streamDragEnabled,
+      dimUnread,
+    })
 
   return (
     <div className="mb-4">
@@ -398,6 +439,7 @@ export function TieredStreamSection({
   addTooltip,
   addMenuActions,
   streamDragEnabled = false,
+  dimUnread = false,
 }: TieredStreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -416,30 +458,19 @@ export function TieredStreamSection({
   const isMoreOpen = moreState === "open"
   const visibleItems = isMoreOpen ? [...activeItems, ...quietItems] : [...activeItems, ...quietVisible]
 
-  const renderItem = (stream: StreamItemData) => {
-    const item = (
-      <StreamItem
-        workspaceId={workspaceId}
-        stream={stream}
-        isActive={stream.id === activeStreamId}
-        unreadCount={getUnreadCount(stream.id)}
-        mentionCount={getMentionCount(stream.id)}
-        allStreams={allStreams}
-        compact={compact}
-        showPreviewOnHover={showPreviewOnHover}
-        scrollContainerRef={scrollContainerRef}
-      />
-    )
-    // Drag source only for persisted streams when dragging is on; see StreamSection.renderRow.
-    const dragEnabled = streamDragEnabled && !isDraftId(stream.id)
-    return dragEnabled ? (
-      <DraggableStreamRow key={stream.id} streamId={stream.id}>
-        {item}
-      </DraggableStreamRow>
-    ) : (
-      <Fragment key={stream.id}>{item}</Fragment>
-    )
-  }
+  const renderItem = (stream: StreamItemData) =>
+    renderSectionRow(stream, {
+      workspaceId,
+      activeStreamId,
+      allStreams,
+      getUnreadCount,
+      getMentionCount,
+      compact,
+      showPreviewOnHover,
+      scrollContainerRef,
+      streamDragEnabled,
+      dimUnread,
+    })
 
   return (
     <div className="mb-4">

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -9,7 +9,7 @@ import { SidebarActionMenu, type SidebarActionItem } from "./sidebar-actions"
 import { StreamItem } from "./stream-item"
 import { DraggableStreamRow } from "./sidebar-dnd"
 import type { StreamItemData } from "./types"
-import { getActivityTime, isUnreadStream } from "./utils"
+import { getActivityTime } from "./utils"
 
 interface SectionHeaderProps {
   label: string
@@ -214,7 +214,8 @@ interface RenderRowOptions {
   showPreviewOnHover: boolean
   scrollContainerRef?: RefObject<HTMLDivElement | null>
   streamDragEnabled: boolean
-  dimUnread: boolean
+  dimReadRows: boolean
+  homeHintFor?: (streamId: string) => string | null
 }
 
 /**
@@ -222,8 +223,8 @@ interface RenderRowOptions {
  * source only when dragging is on (desktop) and the row is a persisted stream —
  * drafts (incl. virtual DMs) carry transient ids that must never be filed into
  * config, and wrapping a disabled row would register a dead draggable for
- * nothing. A dimmed (unread-in-its-hard-location-home) row gets an opacity
- * wrapper — opacity only, so nothing shifts (INV-21).
+ * nothing. In the Unread section an already-read (sticky) row gets an opacity
+ * wrapper so it reads as handled — opacity only, so nothing shifts (INV-21).
  */
 function renderSectionRow(stream: StreamItemData, opts: RenderRowOptions): ReactNode {
   const item = (
@@ -237,11 +238,12 @@ function renderSectionRow(stream: StreamItemData, opts: RenderRowOptions): React
       compact={opts.compact}
       showPreviewOnHover={opts.showPreviewOnHover}
       scrollContainerRef={opts.scrollContainerRef}
+      homeHint={opts.homeHintFor?.(stream.id) ?? undefined}
     />
   )
   const dragEnabled = opts.streamDragEnabled && !isDraftId(stream.id)
   const row = dragEnabled ? <DraggableStreamRow streamId={stream.id}>{item}</DraggableStreamRow> : item
-  const dimmed = opts.dimUnread && isUnreadStream(stream, opts.getUnreadCount(stream.id))
+  const dimmed = opts.dimReadRows && opts.getUnreadCount(stream.id) === 0
   return dimmed ? (
     <div key={stream.id} className="opacity-50 transition-opacity">
       {row}
@@ -309,12 +311,16 @@ interface StreamSectionProps {
   /** When true, each stream row is a drag source for filing into a custom section (desktop). */
   streamDragEnabled?: boolean
   /**
-   * Dim unread rows in this section. Set for custom/label homes when the layout
-   * has an Unread section: the unread stream's active copy lives up in Unread, so
-   * its hard-location home shows a dimmed ghost rather than reading as a second
-   * live location. Un-dims the moment the stream is read (it leaves Unread too).
+   * Dim already-read rows. Set on the Unread section: a member that's been read
+   * lingers (sticky) but de-emphasizes in place, so the row reads as "handled"
+   * without leaving its slot. Un-dims nothing else — other sections never set it.
    */
-  dimUnread?: boolean
+  dimReadRows?: boolean
+  /**
+   * Resolve a row's trailing "· home" hint (its custom section / pinned label).
+   * Set only on the Unread section, where rows are drawn out of their home.
+   */
+  homeHintFor?: (streamId: string) => string | null
 }
 
 /** Simple binary collapsible section used for Important / Recent. */
@@ -340,7 +346,8 @@ export function StreamSection({
   addTooltip,
   addMenuActions,
   streamDragEnabled = false,
-  dimUnread = false,
+  dimReadRows = false,
+  homeHintFor,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -357,7 +364,8 @@ export function StreamSection({
       showPreviewOnHover,
       scrollContainerRef,
       streamDragEnabled,
-      dimUnread,
+      dimReadRows,
+      homeHintFor,
     })
 
   return (
@@ -439,7 +447,8 @@ export function TieredStreamSection({
   addTooltip,
   addMenuActions,
   streamDragEnabled = false,
-  dimUnread = false,
+  dimReadRows = false,
+  homeHintFor,
 }: TieredStreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -469,7 +478,8 @@ export function TieredStreamSection({
       showPreviewOnHover,
       scrollContainerRef,
       streamDragEnabled,
-      dimUnread,
+      dimReadRows,
+      homeHintFor,
     })
 
   return (

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -296,6 +296,13 @@ interface StreamSectionProps {
   state?: CollapseState
   onToggle?: () => void
   action?: ReactNode
+  /**
+   * Rendered in place of the row list when the section has no items (and isn't
+   * collapsed). Lets a persistent section — e.g. Unread, which stays in the
+   * layout once added — hold its space with an "all caught up" placeholder
+   * instead of collapsing to just a header (which shifts everything below it).
+   */
+  emptyState?: ReactNode
   /** Show compact view (title only, no preview) */
   compact?: boolean
   /** Show preview on hover when compact (only works with compact=true) */
@@ -348,6 +355,7 @@ export function StreamSection({
   streamDragEnabled = false,
   dimReadRows = false,
   homeHintFor,
+  emptyState,
 }: StreamSectionProps) {
   const isCollapsed = state === "collapsed"
   const unreadAggregate = sumUnread(items, getUnreadCount)
@@ -386,6 +394,8 @@ export function StreamSection({
       />
 
       {!isCollapsed && items.length > 0 && <div className="mt-1 flex flex-col gap-0.5">{items.map(renderRow)}</div>}
+
+      {!isCollapsed && items.length === 0 && emptyState}
 
       {!isCollapsed && action}
     </div>

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -243,14 +243,19 @@ function renderSectionRow(stream: StreamItemData, opts: RenderRowOptions): React
   )
   const dragEnabled = opts.streamDragEnabled && !isDraftId(stream.id)
   const row = dragEnabled ? <DraggableStreamRow streamId={stream.id}>{item}</DraggableStreamRow> : item
-  const dimmed = opts.dimReadRows && opts.getUnreadCount(stream.id) === 0
-  return dimmed ? (
-    <div key={stream.id} className="opacity-50 transition-opacity">
-      {row}
-    </div>
-  ) : (
-    <Fragment key={stream.id}>{row}</Fragment>
-  )
+  // The Unread section dims already-read rows in place. Keep a stable <div>
+  // wrapper there (toggling opacity via class) so reading a row animates instead
+  // of remounting it — a <div>/<Fragment> swap would change the element type and
+  // tear down the row. Other sections stay wrapper-free.
+  if (opts.dimReadRows) {
+    const dimmed = opts.getUnreadCount(stream.id) === 0
+    return (
+      <div key={stream.id} className={cn("transition-opacity", dimmed && "opacity-50")}>
+        {row}
+      </div>
+    )
+  }
+  return <Fragment key={stream.id}>{row}</Fragment>
 }
 
 /** Sum unread counts across a list of streams. */

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -374,17 +374,19 @@ function customSectionPresentation(name: string): SectionPresentation {
 /**
  * Presentation for the Unread section. A priority surface like Important — a
  * plain binary collapse (no tiered "N more" tail, since every row here is one the
- * viewer is working through) — and hidden entirely when the tray is empty, so it
- * never leaves an empty header behind once the viewer has caught up. The header's
- * gold-dot title is supplied as `titleContent` by the stream list (a colored
- * emoji would break the gold-on-paper palette); no icon string here.
+ * viewer is working through). Unlike the smart buckets it is NOT hidden when
+ * empty: once the viewer adds it, it stays put and shows an "all caught up"
+ * placeholder, so catching up doesn't make the whole section (and everything
+ * below it) jump. The header's gold-dot title is supplied as `titleContent` by
+ * the stream list (a colored emoji would break the gold-on-paper palette); no
+ * icon string here.
  */
 const UNREAD_PRESENTATION: SectionPresentation = {
   label: "Unread",
   tiered: false,
   compact: true,
   showPreviewOnHover: true,
-  hideWhenEmpty: true,
+  hideWhenEmpty: false,
   defaultCollapse: "open",
 }
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -27,6 +27,9 @@ import { SMART_SECTIONS } from "./config"
  */
 export type { SidebarConfig, SidebarSection, SidebarSectionSpec, SidebarBasePreset }
 
+/** Stable section id for the Unread section — doubles as its collapse-state key. */
+export const UNREAD_SECTION_ID = "unread"
+
 /**
  * Section id for a label lens. Deterministic (one section per label) so the
  * toggle below is idempotent and the id doubles as the collapse-state key.
@@ -77,6 +80,8 @@ export function sectionIdForSpec(spec: SidebarSectionSpec): string {
       return labelSectionId(spec.labelId)
     case "custom":
       return customSectionId(spec.sectionId)
+    case "unread":
+      return UNREAD_SECTION_ID
     case "quicklinks":
       return QUICK_LINKS_SECTION_ID
   }
@@ -366,11 +371,28 @@ function customSectionPresentation(name: string): SectionPresentation {
   }
 }
 
+/**
+ * Presentation for the Unread section. A priority surface like Important — a
+ * plain binary collapse (no tiered "N more" tail, since every row here is an
+ * unread the viewer wants to see) — and hidden entirely when nothing is unread,
+ * so it never leaves an empty header behind once the viewer catches up.
+ */
+const UNREAD_PRESENTATION: SectionPresentation = {
+  label: "Unread",
+  icon: "🔵",
+  tiered: false,
+  compact: true,
+  showPreviewOnHover: true,
+  hideWhenEmpty: true,
+  defaultCollapse: "open",
+}
+
 /** Resolve how a section should render from its spec. */
 export function sectionPresentation(spec: SidebarSectionSpec): SectionPresentation {
   if (spec.kind === "type") return TYPE_PRESENTATION[spec.streamType]
   if (spec.kind === "label") return LABEL_PRESENTATION
   if (spec.kind === "custom") return customSectionPresentation(spec.name)
+  if (spec.kind === "unread") return UNREAD_PRESENTATION
   if (spec.kind === "quicklinks") return QUICK_LINKS_PRESENTATION
 
   const config = SMART_SECTIONS[spec.bucket]

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.ts
@@ -373,13 +373,14 @@ function customSectionPresentation(name: string): SectionPresentation {
 
 /**
  * Presentation for the Unread section. A priority surface like Important — a
- * plain binary collapse (no tiered "N more" tail, since every row here is an
- * unread the viewer wants to see) — and hidden entirely when nothing is unread,
- * so it never leaves an empty header behind once the viewer catches up.
+ * plain binary collapse (no tiered "N more" tail, since every row here is one the
+ * viewer is working through) — and hidden entirely when the tray is empty, so it
+ * never leaves an empty header behind once the viewer has caught up. The header's
+ * gold-dot title is supplied as `titleContent` by the stream list (a colored
+ * emoji would break the gold-on-paper palette); no icon string here.
  */
 const UNREAD_PRESENTATION: SectionPresentation = {
   label: "Unread",
-  icon: "🔵",
   tiered: false,
   compact: true,
   showPreviewOnHover: true,

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -114,6 +114,7 @@ export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: Sidebar
   const addableSpecs = useMemo<SidebarSectionSpec[]>(() => {
     const specs: SidebarSectionSpec[] = []
     if (!hasSection(config, { kind: "quicklinks" })) specs.push({ kind: "quicklinks" })
+    if (!hasSection(config, { kind: "unread" })) specs.push({ kind: "unread" })
     for (const bucket of SIDEBAR_SECTION_KEYS) {
       const spec: SidebarSectionSpec = { kind: "smart", bucket }
       if (!hasSection(config, spec)) specs.push(spec)

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -43,6 +43,18 @@ interface AddWiring {
   addMenuActions?: SidebarActionItem[]
 }
 
+/** Unread section header: a gold thread dot + the label, matching the section
+ *  header's uppercase styling. Gold (not a colored emoji) keeps the palette
+ *  (DESIGN.md §0). Top-level per INV-18. */
+function UnreadSectionTitle({ label }: { label: string }) {
+  return (
+    <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
+      {label}
+    </span>
+  )
+}
+
 interface SidebarStreamListProps {
   workspaceId: string
   hasError: boolean
@@ -89,6 +101,12 @@ interface SidebarStreamListProps {
    * when set to "ask".
    */
   onStreamMovedFromLabel: (streamId: string, sourceLabelId: string) => void
+  /** Resolve a stream's "· home" hint (custom section / pinned label) for Unread rows. */
+  homeHintFor: (streamId: string) => string | null
+  /** True when the Unread tray holds already-read members — shows the "Clear read" affordance. */
+  hasReadResidue: boolean
+  /** Flush the read members from the Unread tray (they return to their home sections). */
+  onClearReadUnread: () => void
   scrollContainerRef: RefObject<HTMLDivElement | null>
 }
 
@@ -111,6 +129,9 @@ export function SidebarStreamList({
   onFileStreamToSection,
   onAssignStreamLabel,
   onStreamMovedFromLabel,
+  homeHintFor,
+  hasReadResidue,
+  onClearReadUnread,
   scrollContainerRef,
 }: SidebarStreamListProps) {
   // Drag-to-file is a mouse interaction; a finger does the same through the
@@ -191,11 +212,6 @@ export function SidebarStreamList({
 
   const draggingStream = draggingStreamId ? processedStreams.find((s) => s.id === draggingStreamId) : null
 
-  // When an Unread section is in the layout it surfaces the live copy of every
-  // unread stream; a stream in a hard-location home (custom/label) stays there
-  // too, so dim its home copy rather than read as a second live location.
-  const hasUnreadSection = resolvedSections.some(({ section }) => section.spec.kind === "unread")
-
   return (
     <SidebarLabelsProvider workspaceId={workspaceId}>
       <DndContext
@@ -220,7 +236,12 @@ export function SidebarStreamList({
           // cache; a section whose label was archived/deleted is an orphan — skip it.
           const label = section.spec.kind === "label" ? labelsById.get(section.spec.labelId) : undefined
           if (section.spec.kind === "label" && !label) return null
-          const titleContent = label ? <LabelChip label={label} /> : undefined
+          const isUnread = section.spec.kind === "unread"
+          // Unread's header is a gold dot + label (a colored emoji would break the
+          // gold-on-paper palette); label sections use their tinted chip.
+          let titleContent: ReactNode = undefined
+          if (label) titleContent = <LabelChip label={label} />
+          else if (isUnread) titleContent = <UnreadSectionTitle label={presentation.label} />
           // Label sections get an "open" affordance to their landing page.
           const titleHref = label ? `/w/${workspaceId}/labels/${label.id}` : undefined
           const headerLabel = label ? label.name : presentation.label
@@ -228,7 +249,18 @@ export function SidebarStreamList({
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
           const add = addWiringFor(section.spec)
-          const dimUnread = hasUnreadSection && (section.spec.kind === "custom" || section.spec.kind === "label")
+          // The Unread section holds read-but-not-cleared members (sticky); dim those
+          // in place and offer "Clear read" to flush them back to their homes.
+          const clearReadAction =
+            isUnread && hasReadResidue ? (
+              <button
+                type="button"
+                onClick={onClearReadUnread}
+                className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors hover:text-foreground"
+              >
+                Clear read
+              </button>
+            ) : undefined
 
           const sectionEl = presentation.tiered ? (
             <TieredStreamSection
@@ -255,7 +287,6 @@ export function SidebarStreamList({
               addTooltip={add?.addTooltip}
               addMenuActions={add?.addMenuActions}
               streamDragEnabled={streamDragEnabled}
-              dimUnread={dimUnread}
             />
           ) : (
             <StreamSection
@@ -272,11 +303,13 @@ export function SidebarStreamList({
               getMentionCount={getMentionCount}
               state={state}
               onToggle={onToggle}
+              action={clearReadAction}
               compact={presentation.compact}
               showPreviewOnHover={presentation.showPreviewOnHover}
               scrollContainerRef={scrollContainerRef}
               streamDragEnabled={streamDragEnabled}
-              dimUnread={dimUnread}
+              dimReadRows={isUnread}
+              homeHintFor={isUnread ? homeHintFor : undefined}
             />
           )
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -257,7 +257,7 @@ export function SidebarStreamList({
           if (isUnread) {
             unreadFooter =
               items.length === 0 ? (
-                <p className="mt-0.5 px-3 py-1 text-center text-[11px] italic text-muted-foreground/50">
+                <p className="mt-0.5 flex min-h-[2.25rem] items-center justify-center px-3 text-center text-[11px] italic text-muted-foreground/50">
                   All caught up
                 </p>
               ) : (
@@ -265,7 +265,7 @@ export function SidebarStreamList({
                   type="button"
                   onClick={onClearReadUnread}
                   disabled={!hasReadResidue}
-                  className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:opacity-40"
+                  className="mt-0.5 flex min-h-[2.25rem] w-full items-center justify-center px-3 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   Clear read
                 </button>

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useState, type ReactNode, type RefObject } from "react"
+import { Check } from "lucide-react"
 import {
   DndContext,
   DragOverlay,
@@ -52,6 +53,18 @@ function UnreadSectionTitle({ label }: { label: string }) {
       <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
       {label}
     </span>
+  )
+}
+
+/** Placeholder shown when the (persistent) Unread section has nothing in it, so
+ *  catching up holds the section's space instead of collapsing it. Roughly one
+ *  row tall to match a stream item. Top-level per INV-18. */
+function UnreadEmptyState() {
+  return (
+    <div className="mt-1 flex min-h-[2.75rem] items-center gap-2 px-2 text-sm text-muted-foreground/60">
+      <Check className="h-4 w-4 shrink-0" />
+      All caught up
+    </div>
   )
 }
 
@@ -250,17 +263,20 @@ export function SidebarStreamList({
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
           const add = addWiringFor(section.spec)
           // The Unread section holds read-but-not-cleared members (sticky); dim those
-          // in place and offer "Clear read" to flush them back to their homes.
-          const clearReadAction =
-            isUnread && hasReadResidue ? (
-              <button
-                type="button"
-                onClick={onClearReadUnread}
-                className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors hover:text-foreground"
-              >
-                Clear read
-              </button>
-            ) : undefined
+          // in place and offer "Clear read" to flush them back to their homes. The
+          // control is always mounted (just disabled when there's nothing to clear)
+          // so toggling it on/off never reflows the section.
+          const clearReadAction = isUnread ? (
+            <button
+              type="button"
+              onClick={onClearReadUnread}
+              disabled={!hasReadResidue}
+              className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:opacity-40"
+            >
+              Clear read
+            </button>
+          ) : undefined
+          const emptyState = isUnread ? <UnreadEmptyState /> : undefined
 
           const sectionEl = presentation.tiered ? (
             <TieredStreamSection
@@ -304,6 +320,7 @@ export function SidebarStreamList({
               state={state}
               onToggle={onToggle}
               action={clearReadAction}
+              emptyState={emptyState}
               compact={presentation.compact}
               showPreviewOnHover={presentation.showPreviewOnHover}
               scrollContainerRef={scrollContainerRef}

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -191,6 +191,11 @@ export function SidebarStreamList({
 
   const draggingStream = draggingStreamId ? processedStreams.find((s) => s.id === draggingStreamId) : null
 
+  // When an Unread section is in the layout it surfaces the live copy of every
+  // unread stream; a stream in a hard-location home (custom/label) stays there
+  // too, so dim its home copy rather than read as a second live location.
+  const hasUnreadSection = resolvedSections.some(({ section }) => section.spec.kind === "unread")
+
   return (
     <SidebarLabelsProvider workspaceId={workspaceId}>
       <DndContext
@@ -223,6 +228,7 @@ export function SidebarStreamList({
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
           const add = addWiringFor(section.spec)
+          const dimUnread = hasUnreadSection && (section.spec.kind === "custom" || section.spec.kind === "label")
 
           const sectionEl = presentation.tiered ? (
             <TieredStreamSection
@@ -249,6 +255,7 @@ export function SidebarStreamList({
               addTooltip={add?.addTooltip}
               addMenuActions={add?.addMenuActions}
               streamDragEnabled={streamDragEnabled}
+              dimUnread={dimUnread}
             />
           ) : (
             <StreamSection
@@ -269,6 +276,7 @@ export function SidebarStreamList({
               showPreviewOnHover={presentation.showPreviewOnHover}
               scrollContainerRef={scrollContainerRef}
               streamDragEnabled={streamDragEnabled}
+              dimUnread={dimUnread}
             />
           )
 

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -1,5 +1,4 @@
 import { Fragment, useState, type ReactNode, type RefObject } from "react"
-import { Check } from "lucide-react"
 import {
   DndContext,
   DragOverlay,
@@ -53,18 +52,6 @@ function UnreadSectionTitle({ label }: { label: string }) {
       <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
       {label}
     </span>
-  )
-}
-
-/** Placeholder shown when the (persistent) Unread section has nothing in it, so
- *  catching up holds the section's space instead of collapsing it. Roughly one
- *  row tall to match a stream item. Top-level per INV-18. */
-function UnreadEmptyState() {
-  return (
-    <div className="mt-1 flex min-h-[2.75rem] items-center gap-2 px-2 text-sm text-muted-foreground/60">
-      <Check className="h-4 w-4 shrink-0" />
-      All caught up
-    </div>
   )
 }
 
@@ -262,21 +249,28 @@ export function SidebarStreamList({
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
           const add = addWiringFor(section.spec)
-          // The Unread section holds read-but-not-cleared members (sticky); dim those
-          // in place and offer "Clear read" to flush them back to their homes. The
-          // control is always mounted (just disabled when there's nothing to clear)
-          // so toggling it on/off never reflows the section.
-          const clearReadAction = isUnread ? (
-            <button
-              type="button"
-              onClick={onClearReadUnread}
-              disabled={!hasReadResidue}
-              className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:opacity-40"
-            >
-              Clear read
-            </button>
-          ) : undefined
-          const emptyState = isUnread ? <UnreadEmptyState /> : undefined
+          // The Unread section keeps a single, same-footprint footer so it never
+          // reflows: an empty tray shows a quiet "All caught up", otherwise the
+          // "Clear read" control (disabled when there's nothing read to flush).
+          // Never both at once.
+          let unreadFooter: ReactNode = undefined
+          if (isUnread) {
+            unreadFooter =
+              items.length === 0 ? (
+                <p className="mt-0.5 px-3 py-1 text-center text-[11px] italic text-muted-foreground/50">
+                  All caught up
+                </p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onClearReadUnread}
+                  disabled={!hasReadResidue}
+                  className="mt-0.5 flex w-full items-center justify-center px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:opacity-40"
+                >
+                  Clear read
+                </button>
+              )
+          }
 
           const sectionEl = presentation.tiered ? (
             <TieredStreamSection
@@ -319,8 +313,7 @@ export function SidebarStreamList({
               getMentionCount={getMentionCount}
               state={state}
               onToggle={onToggle}
-              action={clearReadAction}
-              emptyState={emptyState}
+              action={unreadFooter}
               compact={presentation.compact}
               showPreviewOnHover={presentation.showPreviewOnHover}
               scrollContainerRef={scrollContainerRef}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -44,6 +44,7 @@ import { SidebarFooter } from "./sidebar-footer"
 import { GettingStarted, useGettingStarted } from "./getting-started"
 import { SidebarEditorDialog } from "./sidebar-editor"
 import { resolveSections } from "./resolve-sections"
+import { useStickyUnread } from "./use-sticky-unread"
 import { setStreamCustomSection } from "./sidebar-config"
 import { RemoveLabelDialog } from "./remove-label-dialog"
 import type { SidebarActionItem } from "./sidebar-actions"
@@ -242,9 +243,44 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     return map
   }, [labelAssignments])
 
+  const hasUnreadSection = useMemo(
+    () => sidebarConfig.sections.some((s) => s.spec.kind === "unread"),
+    [sidebarConfig.sections]
+  )
+
+  // The Unread tray's membership: sticky for the session so working through it
+  // doesn't reflow the sidebar on every read. Only accumulates when the layout
+  // actually has an Unread section.
+  const stickyUnread = useStickyUnread(workspaceId, processedStreams, getUnreadCount, hasUnreadSection)
+
+  // For Unread rows (drawn out of their home), a "· home" hint naming the custom
+  // section or pinned label the stream lives in. Custom filing trumps a label,
+  // matching the resolver's precedence.
+  const homeHintById = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const s of sidebarConfig.sections) {
+      if (s.spec.kind === "custom") for (const id of s.spec.streamIds) map.set(id, s.spec.name)
+    }
+    for (const s of sidebarConfig.sections) {
+      if (s.spec.kind !== "label") continue
+      const label = labelsById.get(s.spec.labelId)
+      const ids = streamIdsByLabel.get(s.spec.labelId)
+      if (!label || !ids) continue
+      for (const id of ids) if (!map.has(id)) map.set(id, label.name)
+    }
+    return map
+  }, [sidebarConfig.sections, labelsById, streamIdsByLabel])
+
   const resolvedSections = useMemo(
-    () => resolveSections(sidebarConfig, { processedStreams, virtualDmStreams, getUnreadCount, streamIdsByLabel }),
-    [sidebarConfig, processedStreams, virtualDmStreams, getUnreadCount, streamIdsByLabel]
+    () =>
+      resolveSections(sidebarConfig, {
+        processedStreams,
+        virtualDmStreams,
+        getUnreadCount,
+        streamIdsByLabel,
+        unreadStreamIds: stickyUnread.streamIds,
+      }),
+    [sidebarConfig, processedStreams, virtualDmStreams, getUnreadCount, streamIdsByLabel, stickyUnread.streamIds]
   )
 
   // The Quick Links block renders only when the user keeps it in their layout —
@@ -523,6 +559,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
             onFileStreamToSection={handleFileStreamToSection}
             onAssignStreamLabel={handleAssignStreamLabel}
             onStreamMovedFromLabel={handleStreamMovedFromLabel}
+            homeHintFor={(id) => homeHintById.get(id) ?? null}
+            hasReadResidue={stickyUnread.hasReadResidue}
+            onClearReadUnread={stickyUnread.clearRead}
             quickLinksSlot={
               hasQuickLinksSection ? (
                 <SidebarQuickLinks

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -190,6 +190,12 @@ interface StreamItemProps {
   showPreviewOnHover?: boolean
   /** Reference to scroll container for position tracking */
   scrollContainerRef?: RefObject<HTMLDivElement | null>
+  /**
+   * A trailing "· home" hint naming where this stream lives (its custom section
+   * or pinned label). Set only in the Unread section, where a row is drawn out of
+   * its home — so the viewer still sees where it belongs without a duplicate row.
+   */
+  homeHint?: string
 }
 
 export function StreamItem({
@@ -203,6 +209,7 @@ export function StreamItem({
   compact = false,
   showPreviewOnHover = false,
   scrollContainerRef,
+  homeHint,
 }: StreamItemProps) {
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
@@ -336,6 +343,7 @@ export function StreamItem({
         showPreviewOnHover={showPreviewOnHover}
         showUrgencyStrip={showUrgencyStrip}
         scrollContainerRef={scrollContainerRef}
+        homeHint={homeHint}
       />
     )
   }
@@ -382,14 +390,16 @@ export function StreamItem({
                     className={cn(
                       "truncate text-sm",
                       hasUnread ? "font-semibold" : "font-medium",
-                      // The truncation ellipsis inherits the color of this element. When a grey parent-stream
-                      // context trails the title it's the usual cut point, so tint the container grey (and keep
-                      // the title itself at foreground) so the ellipsis matches the text it's shortening.
-                      threadRootContext && "text-muted-foreground/60"
+                      // The truncation ellipsis inherits the color of this element. When a grey trailing
+                      // context (parent stream, or the Unread "· home" hint) trails the title it's the usual
+                      // cut point, so tint the container grey (and keep the title itself at foreground) so the
+                      // ellipsis matches the text it's shortening.
+                      (threadRootContext || homeHint) && "text-muted-foreground/60"
                     )}
                   >
-                    {threadRootContext ? <span className="text-foreground">{name}</span> : name}
+                    {threadRootContext || homeHint ? <span className="text-foreground">{name}</span> : name}
                     {threadRootContext && <span className="font-normal text-xs"> · {threadRootContext}</span>}
+                    {!threadRootContext && homeHint && <span className="font-normal text-xs"> · {homeHint}</span>}
                   </span>
                   {stream.type === StreamTypes.CHANNEL && stream.visibility === Visibilities.PRIVATE && (
                     <Lock className="h-3 w-3 shrink-0 text-muted-foreground/60" />

--- a/apps/frontend/src/components/layout/sidebar/use-sticky-unread.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/use-sticky-unread.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import { StreamTypes, Visibilities } from "@threa/types"
+import { useStickyUnread } from "./use-sticky-unread"
+import type { StreamItemData, UrgencyLevel } from "./types"
+
+function item(id: string, urgency: UrgencyLevel = "quiet"): StreamItemData {
+  return {
+    id,
+    workspaceId: "ws_1",
+    type: StreamTypes.CHANNEL,
+    displayName: id,
+    slug: id,
+    description: null,
+    visibility: Visibilities.PRIVATE,
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "user_1",
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+    archivedAt: null,
+    lastMessagePreview: null,
+    urgency,
+    section: "recent",
+  }
+}
+
+/** getUnreadCount over a set of unread ids. */
+function counts(unread: Set<string>) {
+  return (id: string) => (unread.has(id) ? 1 : 0)
+}
+
+describe("useStickyUnread", () => {
+  it("holds a stream that goes unread, and keeps it after it's read (sticky)", () => {
+    const streams = [item("a", "activity"), item("b")]
+    let unread = new Set(["a"])
+    const { result, rerender } = renderHook(
+      ({ u }: { u: Set<string> }) => useStickyUnread("ws_1", streams, counts(u), true),
+      { initialProps: { u: unread } }
+    )
+
+    expect([...result.current.streamIds]).toEqual(["a"])
+    expect(result.current.hasReadResidue).toBe(false)
+
+    // a is read — it stays in the tray, now flagged as read residue.
+    unread = new Set()
+    rerender({ u: unread })
+    expect([...result.current.streamIds]).toEqual(["a"])
+    expect(result.current.hasReadResidue).toBe(true)
+
+    // clearRead flushes the read member.
+    act(() => result.current.clearRead())
+    expect([...result.current.streamIds]).toEqual([])
+  })
+
+  it("excludes muted streams — quiet urgency never enters the tray even with unread", () => {
+    const streams = [item("muted", "quiet")]
+    const { result } = renderHook(() => useStickyUnread("ws_1", streams, counts(new Set(["muted"])), true))
+    expect([...result.current.streamIds]).toEqual([])
+  })
+
+  it("holds nothing when disabled (no Unread section in the layout)", () => {
+    const streams = [item("a", "activity")]
+    const { result } = renderHook(() => useStickyUnread("ws_1", streams, counts(new Set(["a"])), false))
+    expect([...result.current.streamIds]).toEqual([])
+  })
+
+  it("prunes a held stream once it no longer exists (archived/left)", () => {
+    let streams = [item("a", "activity"), item("b", "activity")]
+    const unread = new Set(["a", "b"])
+    const { result, rerender } = renderHook(
+      ({ s }: { s: StreamItemData[] }) => useStickyUnread("ws_1", s, counts(unread), true),
+      { initialProps: { s: streams } }
+    )
+    expect([...result.current.streamIds].sort()).toEqual(["a", "b"])
+
+    // b disappears from the stream list — it should drop out of the tray.
+    streams = [item("a", "activity")]
+    rerender({ s: streams })
+    expect([...result.current.streamIds]).toEqual(["a"])
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/use-sticky-unread.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/use-sticky-unread.test.tsx
@@ -68,6 +68,24 @@ describe("useStickyUnread", () => {
     expect([...result.current.streamIds]).toEqual([])
   })
 
+  it("clears the tray the moment it's disabled, and repopulates when re-enabled", () => {
+    const streams = [item("a", "activity")]
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useStickyUnread("ws_1", streams, counts(new Set(["a"])), on),
+      { initialProps: { on: true } }
+    )
+    expect([...result.current.streamIds]).toEqual(["a"])
+
+    // Removing the Unread section empties the tray with no stale frame.
+    rerender({ on: false })
+    expect([...result.current.streamIds]).toEqual([])
+    expect(result.current.hasReadResidue).toBe(false)
+
+    // Re-adding it starts fresh and re-collects the currently-unread streams.
+    rerender({ on: true })
+    expect([...result.current.streamIds]).toEqual(["a"])
+  })
+
   it("prunes a held stream once it no longer exists (archived/left)", () => {
     let streams = [item("a", "activity"), item("b", "activity")]
     const unread = new Set(["a", "b"])

--- a/apps/frontend/src/components/layout/sidebar/use-sticky-unread.ts
+++ b/apps/frontend/src/components/layout/sidebar/use-sticky-unread.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useState } from "react"
+import type { StreamItemData } from "./types"
+import { isUnreadStream } from "./utils"
+
+export interface StickyUnread {
+  /** Stream ids held by the Unread section: every stream that has gone unread this
+   *  session and not yet been cleared, including ones since read. */
+  streamIds: ReadonlySet<string>
+  /** True when at least one held stream has already been read — so a "clear" affordance is worth showing. */
+  hasReadResidue: boolean
+  /** Drop the already-read members; the still-unread ones stay. */
+  clearRead: () => void
+}
+
+const EMPTY: ReadonlySet<string> = new Set()
+
+function sameMembers(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const id of a) if (!b.has(id)) return false
+  return true
+}
+
+/**
+ * Membership for the dedicated Unread section. A stream enters the moment it goes
+ * unread (and isn't muted) and **stays until the session ends or the viewer
+ * clears it** — even after it's read — so working through the tray doesn't reflow
+ * the sidebar on every read. The set is in-memory and per-session: it resets when
+ * the workspace changes or the app reloads, which is what "for this session"
+ * means. Stale ids (a held stream that was archived/left) are pruned so the tray
+ * can't leak across a long session.
+ *
+ * `enabled` is whether the layout actually has an Unread section; when false the
+ * tray stays empty so nothing is withheld from the normal sections.
+ */
+export function useStickyUnread(
+  workspaceId: string,
+  streams: StreamItemData[],
+  getUnreadCount: (streamId: string) => number,
+  enabled: boolean
+): StickyUnread {
+  const [held, setHeld] = useState<ReadonlySet<string>>(EMPTY)
+
+  // A new workspace is a new session — start its tray empty.
+  useEffect(() => {
+    setHeld(EMPTY)
+  }, [workspaceId])
+
+  useEffect(() => {
+    if (!enabled) {
+      setHeld((prev) => (prev.size === 0 ? prev : EMPTY))
+      return
+    }
+    setHeld((prev) => {
+      const existing = new Set(streams.map((s) => s.id))
+      const next = new Set<string>()
+      // Keep previously-held members that still exist (read or not), then add
+      // anything currently unread. Pruning to `existing` drops archived/left rows.
+      for (const id of prev) if (existing.has(id)) next.add(id)
+      for (const s of streams) if (isUnreadStream(s, getUnreadCount(s.id))) next.add(s.id)
+      return sameMembers(prev, next) ? prev : next
+    })
+  }, [enabled, streams, getUnreadCount])
+
+  const clearRead = useCallback(() => {
+    setHeld((prev) => {
+      const next = new Set<string>()
+      for (const s of streams) if (prev.has(s.id) && isUnreadStream(s, getUnreadCount(s.id))) next.add(s.id)
+      return sameMembers(prev, next) ? prev : next
+    })
+  }, [streams, getUnreadCount])
+
+  let hasReadResidue = false
+  for (const s of streams) {
+    if (held.has(s.id) && !isUnreadStream(s, getUnreadCount(s.id))) {
+      hasReadResidue = true
+      break
+    }
+  }
+
+  return { streamIds: held, hasReadResidue, clearRead }
+}

--- a/apps/frontend/src/components/layout/sidebar/use-sticky-unread.ts
+++ b/apps/frontend/src/components/layout/sidebar/use-sticky-unread.ts
@@ -69,13 +69,21 @@ export function useStickyUnread(
     })
   }, [streams, getUnreadCount])
 
+  // Disabling takes effect in the same render rather than waiting for the effect
+  // above to clear `held` — so removing the Unread section can't withhold its
+  // former members from their home sections for a frame. (The effect still
+  // empties `held` so re-enabling starts from a clean tray.)
+  const streamIds = enabled ? held : EMPTY
+
   let hasReadResidue = false
-  for (const s of streams) {
-    if (held.has(s.id) && !isUnreadStream(s, getUnreadCount(s.id))) {
-      hasReadResidue = true
-      break
+  if (enabled) {
+    for (const s of streams) {
+      if (held.has(s.id) && !isUnreadStream(s, getUnreadCount(s.id))) {
+        hasReadResidue = true
+        break
+      }
     }
   }
 
-  return { streamIds: held, hasReadResidue, clearRead }
+  return { streamIds, hasReadResidue, clearRead }
 }

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -38,6 +38,16 @@ export function calculateUrgency(
   return "quiet"
 }
 
+/**
+ * Whether a stream counts as unread for the dedicated Unread section: it has
+ * unread messages and isn't muted. A muted stream reads as "quiet" urgency even
+ * with unread messages (see {@link calculateUrgency}) and must not resurface —
+ * the same rule {@link categorizeStream} uses to keep muted unreads out of Recent.
+ */
+export function isUnreadStream(stream: { urgency: UrgencyLevel }, unreadCount: number): boolean {
+  return unreadCount > 0 && stream.urgency !== "quiet"
+}
+
 /** Categorize stream into smart section */
 export function categorizeStream(stream: StreamWithPreview, unreadCount: number, urgency: UrgencyLevel): SectionKey {
   if (urgency === "mentions" || (urgency === "ai" && unreadCount > 0)) {

--- a/docs/features/public/configurable-sidebar.md
+++ b/docs/features/public/configurable-sidebar.md
@@ -5,8 +5,8 @@ audience: public
 surfaces: [sidebar, labels-page, stream-topbar]
 public_site: false
 summary: >
-  Arrange your stream sidebar into reorderable sections (smart buckets, stream types, or
-  labels) and start from a Smart or All preset.
+  Arrange your stream sidebar into reorderable sections (smart buckets, stream types,
+  labels, or an Unread tray) and start from a Smart or All preset.
 related: [concepts/subscribe-then-bootstrap.md]
 ---
 
@@ -15,7 +15,7 @@ related: [concepts/subscribe-then-bootstrap.md]
 Your sidebar is an ordered list of sections, saved per workspace. Each section is its own
 filter over your streams, and you pick which sections show and in what order.
 
-There are three kinds of section:
+There are four kinds of section:
 
 - **Smart buckets.** Important, Recent, and Everything Else. Recent shows your active
   streams, with anything unread always surfaced. Important collects mentions and unread AI
@@ -25,6 +25,8 @@ There are three kinds of section:
 - **Labels.** Add a label to the sidebar and it becomes its own section listing the
   streams that carry it. The section header shows the label's chip: its emoji or color dot
   and name.
+- **Unread.** An optional tray that gathers everything unread into one place. Opt-in — add
+  it from the customize dialog. See "The Unread tray" below.
 
 Two presets give you a starting point:
 
@@ -36,11 +38,26 @@ Switching presets reseeds the section list.
 The sidebar also has quick links (drafts, saved, files, scheduled, memory, labels,
 activity). You can reorder them and hide the ones you don't use.
 
+## The Unread tray
+
+Add the Unread section and it collects every stream with unread messages into one place,
+so you're not hunting for them across buckets. Muted streams stay out.
+
+While a stream is in the tray it shows there **only** — it's pulled out of its smart bucket
+and out of any label or section it normally lives under, with a small "· home" note on the
+row so you can still see where it lives, rather than appearing twice.
+
+The tray is sticky for the session. Once a stream lands in it, it stays — de-emphasized —
+even after you've read it, so working through your unreads doesn't reshuffle the sidebar
+underneath you. It resets when you leave the workspace, or you can hit **Clear read** to
+send the ones you've already read back to their home sections. The section stays put even
+when there's nothing in it, showing a quiet _All caught up_ instead of disappearing.
+
 ## How you use it
 
 - **Customize dialog.** Drag to reorder sections, add a section (a smart bucket, a stream
-  type, or a label), remove sections, or switch preset. The same dialog reorders and hides
-  quick links. Changes save right away and sync across your devices.
+  type, a label, or the Unread tray), remove sections, or switch preset. The same dialog
+  reorders and hides quick links. Changes save right away and sync across your devices.
 - **Labels page.** Each label has a "Show in sidebar" toggle, so you can add one as a
   section without opening the editor.
 - **Stream top bar.** A stream's labels show as a small stack: up to three marks plus a
@@ -59,8 +76,12 @@ Still in progress, which is why it isn't on the marketing site yet.
   lists Pinned so it slots into place once pinning lands.
 - **Label sections are additive.** A labeled stream shows in its label section and still
   appears in its smart or type bucket. There's no per-section "hide if already shown above"
-  option; smart and type buckets don't overlap, so it hasn't been needed.
+  option; smart and type buckets don't overlap, so it hasn't been needed. The Unread tray
+  is the one exception — it relocates its streams rather than duplicating them.
 - **"Everything Else" is a smart bucket**, not a separate configurable section.
+- **The Unread tray is opt-in and session-scoped.** It's in neither preset — you add it
+  from the customize dialog. Its membership lives for the session and resets on reload or
+  workspace switch; it isn't saved.
 - **The top-bar label stack is display-only.** You add and remove labels from the label
   picker, not from the stack.
 

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -49,13 +49,14 @@ export type SidebarSectionSpec =
    */
   | { kind: "custom"; sectionId: string; name: string; streamIds: string[] }
   /**
-   * The Unread section: every stream the viewer has unread (non-muted) messages
-   * in, regardless of the bucket / type / custom section / label it otherwise
-   * sits in. When present it **trumps the smart/type buckets** — an unread stream
-   * is pulled out of them and shown here instead. A stream filed into a custom
-   * section or carrying a pinned label keeps its hard location: it stays in that
-   * home (rendered dimmed) AND surfaces here, so it never looks like it's in two
-   * places at once. Draws no membership of its own; the unread signal is live.
+   * The Unread tray: an opt-in section that gathers the viewer's unread streams
+   * into one place. When present it **trumps every other section** — a member is
+   * drawn out of its smart/type bucket AND its custom-section / label home and
+   * shown only here, so there's one copy (no dimmed duplicate). Carries no
+   * persisted membership of its own: the set is resolved on the client and is
+   * sticky for the session (see `useStickyUnread`) — a stream enters when it goes
+   * unread and stays, de-emphasized, until the viewer leaves the workspace or
+   * clears it, rather than tracking the live unread signal moment to moment.
    */
   | { kind: "unread" }
   /**

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -49,6 +49,16 @@ export type SidebarSectionSpec =
    */
   | { kind: "custom"; sectionId: string; name: string; streamIds: string[] }
   /**
+   * The Unread section: every stream the viewer has unread (non-muted) messages
+   * in, regardless of the bucket / type / custom section / label it otherwise
+   * sits in. When present it **trumps the smart/type buckets** — an unread stream
+   * is pulled out of them and shown here instead. A stream filed into a custom
+   * section or carrying a pinned label keeps its hard location: it stays in that
+   * home (rendered dimmed) AND surfaces here, so it never looks like it's in two
+   * places at once. Draws no membership of its own; the unread signal is live.
+   */
+  | { kind: "unread" }
+  /**
    * The Quick Links block (Drafts / Saved / Files / …). A position-only marker:
    * the links themselves — their order and per-link visibility — live in
    * {@link SidebarConfig.quickLinks}, independent of this section's placement, so
@@ -181,6 +191,7 @@ function isRenderableSectionSpec(spec: SidebarSectionSpec | undefined | null): s
         typeof spec.name === "string" &&
         spec.name.trim().length > 0
       )
+    case "unread":
     case "quicklinks":
       return true
     default:


### PR DESCRIPTION
## Problem

The sidebar groups streams into smart buckets (Important / Recent / Other), stream-type sections, pinned label lenses, and custom sections — but there's no single place to see everything currently unread. Unread streams scatter across whichever bucket they were categorized into (`categorizeStream` in `apps/frontend/src/components/layout/sidebar/utils.ts`), and a stream filed into a custom section or carrying a pinned label has a **hard location** and never surfaces in a bucket. A dedicated "what do I still need to read" view didn't exist.

## Solution

A new `{ kind: "unread" }` sidebar section, opt-in via the sidebar editor's Add tray, that gathers every unread stream into one place. Two design decisions (both made in review — see **Design evolution**) shape how it feels:

- **Sticky for the session.** A stream enters an in-memory tray the moment it goes unread (muted streams excluded) and **stays until the viewer leaves the workspace or hits "Clear read"** — even after it's read, where it lingers de-emphasized in place. Reading a stream no longer yanks it back to its home bucket, so the sidebar stops reflowing on every read.
- **One copy, no ghost.** A tray member shows **only** in Unread — drawn out of its smart bucket *and* its custom-section / label home — with a muted "· home" hint on the row instead of a dimmed duplicate. When the tray is cleared, members return to their homes.

### How it works

1. **Type + wire contract.** `SidebarSectionSpec` (`packages/types/src/sidebar.ts`) gains `{ kind: "unread" }`; `isRenderableSectionSpec` accepts it, and the backend `sidebarSectionSpecSchema` discriminated union (`apps/backend/src/features/sidebar-config/handlers.ts`) gains the matching `z.literal("unread")` — write-validation and read-rendering stay in lockstep.

2. **Tray membership (`useStickyUnread`).** A per-workspace, in-memory `Set<string>`: adds any currently-unread non-muted stream (`isUnreadStream` = `unreadCount > 0 && urgency !== "quiet"`, the same rule that keeps muted unreads out of Recent), keeps members after they're read, prunes ids whose stream no longer exists, and resets when the workspace changes (a reload is a new session). Exposes `clearRead()` (drop the read members) and `hasReadResidue`. Only accumulates when the layout actually has an Unread section.

3. **Resolution (`resolveSections`).** The tray is passed in as `unreadStreamIds` and excluded from **every** other section (smart, type, custom, label) via a small `union(...)` helper — so a member shows only in Unread regardless of layout order, and there's no second (dimmed) copy. `resolveUnreadSection` returns the tray's members sorted by activity; read-but-sticky members keep their activity slot, so reading one de-emphasizes it in place rather than reordering. The Unread section never adds to the running `claimed` set, so a member can return to its home once the tray is cleared.

4. **Presentation.** `sectionPresentation` → `UNREAD_PRESENTATION` (binary collapse, `hideWhenEmpty`). The header is a **gold thread dot + "Unread"** (`UnreadSectionTitle`), not a colored emoji — `DESIGN.md` §0: gold (`--primary`) carries all emphasis; there's no blue in the token system. Read tray rows dim in place (opacity only — no layout shift, INV-21). The "· home" hint renders as a muted suffix (reusing the thread-root-context slot in `StreamItem`, mirrored in `ScratchpadItem`). "Clear read" is a quiet control at the foot of the section, shown only when there's read residue.

### Key design decisions

**1. A distinct section `kind`, not a smart bucket.** Smart buckets partition on a per-stream `section` field; the tray is cross-cutting (drawn from every bucket/type/home at once) and order-independent, so it can't be a bucket. Kept out of the default presets — opt-in.

**2. Sticky membership lives in a hook, not the resolver.** The resolver stays pure and takes the tray as data (`unreadStreamIds`); the stateful "what has been unread this session" logic is isolated in `useStickyUnread`. Muting is decided there too, so the resolver has no urgency/mute knowledge.

**3. No reorder animation.** `DESIGN.md` §0 calls for short, subtle motion and no flips. Sticky membership is what removes the jarring reflow; adding a FLIP/list-move animation would fight the design system.

### Design evolution

The first version of this PR (commits before `b510190`) **moved** unread streams out of their bucket on read and left a **dimmed ghost** copy in any custom/label home. Review feedback: the constant reflow on read felt unstable, and the duplicate ghost looked cluttered. Reworked to the sticky tray + single-copy model above — the dimming/duplication path is gone, and the resolver simplified to one exclusion set shared by every section.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/layout/sidebar/use-sticky-unread.ts` | Per-session Unread tray membership (sticky, muted-excluded, self-pruning) + `clearRead` |
| `apps/frontend/src/components/layout/sidebar/use-sticky-unread.test.tsx` | Hook tests: sticky-after-read, muting, disabled, pruning |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/sidebar.ts` | `{ kind: "unread" }` union member + `isRenderableSectionSpec` |
| `apps/backend/src/features/sidebar-config/handlers.ts` | `z.literal("unread")` schema member |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.ts` | `unreadStreamIds` excluded from every section via `union(...)`; `resolveUnreadSection` draws the tray |
| `apps/frontend/src/components/layout/sidebar/utils.ts` | `isUnreadStream` predicate (unread + non-muted) |
| `apps/frontend/src/components/layout/sidebar/sidebar-config.ts` | `UNREAD_SECTION_ID`, `UNREAD_PRESENTATION` (gold-dot title, no emoji), wiring |
| `apps/frontend/src/components/layout/sidebar/sections.tsx` | shared `renderSectionRow`; `dimReadRows` (de-emphasize read tray rows) + `homeHintFor` |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx`, `scratchpad-item.tsx` | optional `homeHint` "· home" suffix |
| `apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx` | `UnreadSectionTitle`, "Clear read" control, tray wiring |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | `useStickyUnread`, home-hint map, feed `unreadStreamIds` into the resolver |
| `apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx` | offer the Unread section in the Add tray |
| `apps/frontend/src/components/layout/sidebar/resolve-sections.test.ts` | resolver tests for the tray model (drop-ghost, sticky-read, precedence, type path) |

## Out of scope (deliberate)

- **Not in the default presets** — opt-in via the editor.
- **Tray is session-only** — it intentionally resets on reload / workspace switch; not persisted to the backend config.
- **No happy-path toast** — clearing/reading shows its result on screen (INV-63).

## Test plan

- [x] Frontend `vitest run src/components/layout/sidebar/` — 148 pass (13 files), incl. rewritten resolver tests + new `useStickyUnread` hook tests
- [x] `bun run typecheck` — all workspaces clean; full pre-commit gate (lint + typecheck + astro + migrations + API-doc check) passed
- [ ] Backend `sidebar-config/service.test.ts` — not run: live-Postgres integration test (`127.0.0.1:5454`, unavailable here). The backend change is a purely additive discriminated-union member, covered by typecheck.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)