### PR TITLE
fix(commands): tighten pasted slash-command detection (token boundary + known-command gate)

### DIFF
--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -298,7 +298,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
   // Filtered for autocomplete dropdown only
   const { suggestionConfig: mentionConfig, renderMentionList } = useMentionSuggestion(mentionStreamContext)
   const { suggestionConfig: channelConfig, renderChannelList } = useChannelSuggestion()
-  const { suggestionConfig: commandConfig, renderCommandList } = useCommandSuggestion({
+  const {
+    suggestionConfig: commandConfig,
+    renderCommandList,
+    isKnownCommand: isKnownSlashCommand,
+  } = useCommandSuggestion({
     includeMemoSearch: enableMemoEmbed,
     includeGiphy: giphyEnabled,
     includeSnippet: snippetEnabled,
@@ -330,10 +334,13 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
       enableMentions,
       enableChannels,
       enableSlashCommands: enableCommands,
+      // Pasted markdown only becomes a command node for a real command; a
+      // stray `/User` from a filepath stays text.
+      isKnownCommand: enableCommands ? isKnownSlashCommand : undefined,
       enableEmoji,
       emojiAsText: true,
     }),
-    [enableMentions, enableChannels, enableCommands, enableEmoji]
+    [enableMentions, enableChannels, enableCommands, enableEmoji, isKnownSlashCommand]
   )
   const editableValue = useMemo(
     () => emojiAtomToEditableText(value, enableEmoji ? toEmoji : undefined),

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -342,6 +342,11 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
     }),
     [enableMentions, enableChannels, enableCommands, enableEmoji, isKnownSlashCommand]
   )
+  // Same stale-closure guard as the refs above: the paste / beforeinput handlers
+  // live in TipTap's `editorProps` (set once), but these options change when the
+  // command set does, so the handlers must read the latest via the ref.
+  const markdownParseOptionsRef = useRef(markdownParseOptions)
+  markdownParseOptionsRef.current = markdownParseOptions
   const editableValue = useMemo(
     () => emojiAtomToEditableText(value, enableEmoji ? toEmoji : undefined),
     [value, enableEmoji, toEmoji]
@@ -650,7 +655,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
           text,
           enableMentions ? getMentionTypeRef.current : undefined,
           enableEmoji ? toEmojiRef.current : undefined,
-          markdownParseOptions
+          markdownParseOptionsRef.current
         )
         if (handled) {
           event.preventDefault()
@@ -683,7 +688,7 @@ export const RichEditor = forwardRef<RichEditorHandle, RichEditorProps>(function
               event as InputEvent,
               enableMentions ? getMentionTypeRef.current : undefined,
               enableEmoji ? toEmojiRef.current : undefined,
-              markdownParseOptions
+              markdownParseOptionsRef.current
             )
           ) {
             return true

--- a/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
+++ b/apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx
@@ -183,9 +183,20 @@ export function useCommandSuggestion({
     renderList,
   })
 
+  // Predicate over the editor's effective command set, for the markdown parser
+  // on paste: a pasted `/cmd` only becomes a command node when it's real.
+  const isKnownCommand = useCallback(
+    (name: string) => {
+      const lower = name.toLowerCase()
+      return commands.some((cmd) => cmd.name.toLowerCase() === lower)
+    },
+    [commands]
+  )
+
   return {
     suggestionConfig,
     renderCommandList: renderSuggestionList,
     isActive,
+    isKnownCommand,
   }
 }

--- a/apps/frontend/src/lib/markdown/mention-renderer.tsx
+++ b/apps/frontend/src/lib/markdown/mention-renderer.tsx
@@ -83,7 +83,9 @@ function TriggerChip({ type, text }: TriggerChipProps) {
   )
 }
 
-const COMMAND_PATTERN = /^(\s*)(\/)([\w-]+)/
+// `(?=\s|$)` keeps the command name a whole token, so a path segment like the
+// `/model` in `/model/checkpoints` isn't rendered as a `/model` command chip.
+const COMMAND_PATTERN = /^(\s*)(\/)([\w-]+)(?=\s|$)/
 
 const CHANNEL_PATTERN = /(?<![a-z0-9])#([a-z][a-z0-9-]*[a-z0-9]|[a-z])(?![a-z0-9_.-])/g
 

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -650,6 +650,38 @@ describe("mention/channel whitespace boundary", () => {
   })
 })
 
+describe("slash command boundary", () => {
+  it("does not claim a leading filepath as a slash command (paste regression)", () => {
+    const result = parseMarkdown("/User/kristofferremback/dev/personal")
+    const content = result.content?.[0]?.content
+
+    expect(content).toEqual([{ type: "text", text: "/User/kristofferremback/dev/personal" }])
+  })
+
+  it("does not claim a two-segment path like /foo/bar", () => {
+    const result = parseMarkdown("/foo/bar")
+    const content = result.content?.[0]?.content
+
+    expect(content?.[0]?.type).not.toBe("slashCommand")
+    expect(content?.[0]).toEqual({ type: "text", text: "/foo/bar" })
+  })
+
+  it("still parses a bare /command at end of line", () => {
+    const result = parseMarkdown("/help")
+    const content = result.content?.[0]?.content
+
+    expect(content?.[0]).toEqual({ type: "slashCommand", attrs: { name: "help" } })
+  })
+
+  it("still parses /command followed by args", () => {
+    const result = parseMarkdown("/model gpt-4")
+    const content = result.content?.[0]?.content
+
+    expect(content?.[0]).toEqual({ type: "slashCommand", attrs: { name: "model" } })
+    expect(content?.[1]).toEqual({ type: "text", text: " gpt-4" })
+  })
+})
+
 describe("@threa/prosemirror table round-trip", () => {
   function cell(type: "tableHeader" | "tableCell", text: string): JSONContent {
     return {

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -680,6 +680,20 @@ describe("slash command boundary", () => {
     expect(content?.[0]).toEqual({ type: "slashCommand", attrs: { name: "model" } })
     expect(content?.[1]).toEqual({ type: "text", text: " gpt-4" })
   })
+
+  it("does not materialize a command node for an unknown name when isKnownCommand is supplied", () => {
+    const result = parseMarkdown("/User", undefined, undefined, { isKnownCommand: (name) => name === "help" })
+    const content = result.content?.[0]?.content
+
+    expect(content).toEqual([{ type: "text", text: "/User" }])
+  })
+
+  it("materializes a command node for a known name when isKnownCommand is supplied", () => {
+    const result = parseMarkdown("/help", undefined, undefined, { isKnownCommand: (name) => name === "help" })
+    const content = result.content?.[0]?.content
+
+    expect(content?.[0]).toEqual({ type: "slashCommand", attrs: { name: "help" } })
+  })
 })
 
 describe("@threa/prosemirror table round-trip", () => {

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -440,6 +440,13 @@ export interface ParseMarkdownOptions {
   enableSlashCommands?: boolean
   enableEmoji?: boolean
   /**
+   * Only materialize a `slashCommand` node when the name is an actual command.
+   * Supplied by composer surfaces (the editor's known command set) so a pasted
+   * `/User` isn't claimed as a command. Absent → any well-formed `/cmd` is
+   * accepted, matching the prior behavior for backend ingestion and tests.
+   */
+  isKnownCommand?: (name: string) => boolean
+  /**
    * Keep resolved emoji shortcodes as editable text instead of atom nodes.
    * Useful for composer surfaces where mobile browsers struggle with deleting
    * adjacent contenteditable=false emoji atoms.
@@ -855,13 +862,16 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
       return "user"
     })
 
-  // The command name must be a whole token: the `(?=\s|$)` boundary stops a
-  // leading filepath like `/User/kristofferremback/dev` (pasted markdown) from
-  // being claimed as a `/User` slash command — only `/cmd`, `/cmd args`, or
-  // `/cmd` at end-of-line match.
+  // Two gates before a leading `/word` becomes a command node:
+  //  1. the `(?=\s|$)` boundary keeps the name a whole token, so a pasted
+  //     filepath like `/User/kristofferremback/dev` isn't claimed as `/User`;
+  //  2. `isKnownCommand` (when supplied) rejects a lone `/User` that clears the
+  //     boundary but isn't a registered command. Absent the predicate, any
+  //     well-formed `/cmd` is accepted (backend ingestion, tests).
   const commandMatch = allowSlashCommands ? text.match(/^(\s*)(\/)([\w-]+)(?=\s|$)/) : null
+  const commandIsKnown = commandMatch ? (options.isKnownCommand?.(commandMatch[3]) ?? true) : false
   let processText = text
-  if (commandMatch) {
+  if (commandMatch && commandIsKnown) {
     if (commandMatch[1]) {
       result.push({ type: "text", text: commandMatch[1] })
     }

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -855,7 +855,11 @@ function parseInlineMarkdown(text: string, options: ParseOptions = {}): JSONCont
       return "user"
     })
 
-  const commandMatch = allowSlashCommands ? text.match(/^(\s*)(\/)([\w-]+)/) : null
+  // The command name must be a whole token: the `(?=\s|$)` boundary stops a
+  // leading filepath like `/User/kristofferremback/dev` (pasted markdown) from
+  // being claimed as a `/User` slash command — only `/cmd`, `/cmd args`, or
+  // `/cmd` at end-of-line match.
+  const commandMatch = allowSlashCommands ? text.match(/^(\s*)(\/)([\w-]+)(?=\s|$)/) : null
   let processText = text
   if (commandMatch) {
     if (commandMatch[1]) {


### PR DESCRIPTION
## Problem

Pasting a filepath that starts with a slash — `/User/kristofferremback/dev/personal` — was parsed as a `/User` slash command. The paste path runs through `parseMarkdown`, whose command detection was too loose on two counts:

1. `/^(\s*)(\/)([\w-]+)/` had no boundary after the name, so it claimed the first path segment (`/User`).
2. Even a lone `/User` (no path) would become a command node, though `User` isn't a registered command.

Both produce a `slashCommand` node that then surfaces as an unknown command.

## Solution

Two gates before a leading `/word` becomes a `slashCommand` node, both in `parseInlineMarkdown`:

1. **Token boundary** — `(?=\s|$)` so the command name must be a whole token followed by whitespace or end-of-line. `/User/…/…` no longer matches; `/help` and `/model gpt-4` still do.
2. **Known-command gate** — a new optional `isKnownCommand(name)` predicate on `ParseMarkdownOptions`. The parser materializes the node only when it returns true. **Absent the predicate, behavior is unchanged** (any well-formed `/cmd` is accepted), so backend ingestion and existing callers are untouched. The composer supplies its effective command set on paste, bringing the parse path in line with the render side (`renderMentions` already gates on `isKnownCommand`).

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/markdown.ts` | `(?=\s|$)` boundary on the command regex; `isKnownCommand?` parse option; gate node creation on it |
| `apps/frontend/src/lib/markdown/mention-renderer.tsx` | Same `(?=\s|$)` boundary on the render-side `COMMAND_PATTERN` |
| `apps/frontend/src/components/editor/triggers/use-command-suggestion.tsx` | Expose `isKnownCommand` (over the effective command set the hook already computes) |
| `apps/frontend/src/components/editor/rich-editor.tsx` | Pass `isKnownCommand` into `markdownParseOptions` (paste / set-content) |
| `packages/prosemirror/src/markdown.test.ts` | 6 tests: filepath + two-segment path rejected, bare `/help` and `/model gpt-4` still parse, unknown name with predicate → text, known name with predicate → node |

The send-time parsers (`apps/frontend/src/lib/commands.ts`, `apps/backend/src/features/commands/parser.ts`) are already end-anchored (`/^\/([\w-]+)(?:\s+(.*))?$/`), so a path segment never matched them — no change needed there.

## Test plan

- [x] `bun run typecheck` — clean across all packages/apps
- [x] `bun run lint` — clean
- [x] `bun test packages/prosemirror/src/markdown.test.ts` — 55 pass (incl. 6 boundary + known-command cases)
- [x] Frontend `src/components/editor` + `lib/commands` suites via vitest — 376 pass (the `useCommandSuggestion` / `rich-editor` wiring breaks nothing)
- [ ] 7 failures in `collapse-cache.test.ts` are pre-existing and unrelated (localStorage/jsdom env on this machine; exists on `main`, not in this diff)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
