### PR TITLE
feat(board): board view design + read-only workspace board (slice 1)

### DIFF
--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -36,6 +36,7 @@ describe("Conversation Handlers", () => {
   )
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
+  const mockGetFlag = mock(() => Promise.resolve("on" as string))
 
   const handlers = createConversationHandlers({
     conversationService: {
@@ -47,6 +48,9 @@ describe("Conversation Handlers", () => {
     streamService: {
       validateStreamAccess: mockValidateStreamAccess,
     } as never,
+    featureFlagService: {
+      getFlag: mockGetFlag,
+    } as never,
   })
 
   beforeEach(() => {
@@ -55,10 +59,12 @@ describe("Conversation Handlers", () => {
     mockListByWorkspace.mockReset()
     mockGetById.mockReset()
     mockGetMessages.mockReset()
+    mockGetFlag.mockReset()
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
     mockListByWorkspace.mockResolvedValue({ conversations: [], nextCursor: null })
+    mockGetFlag.mockResolvedValue("on")
     mockGetById.mockResolvedValue({
       id: "conv_1",
       streamId: "stream_1",
@@ -93,6 +99,17 @@ describe("Conversation Handlers", () => {
   })
 
   describe("listByWorkspace", () => {
+    test("404s when the board-view feature flag is not 'on'", async () => {
+      mockGetFlag.mockResolvedValue("off")
+      await expect(handlers.listByWorkspace(mockReq({ query: {} }), mockRes())).rejects.toMatchObject({ status: 404 })
+      expect(mockListByWorkspace).not.toHaveBeenCalled()
+    })
+
+    test("checks the board-view flag for the viewer", async () => {
+      await handlers.listByWorkspace(mockReq({ query: {} }), mockRes())
+      expect(mockGetFlag).toHaveBeenCalledWith("ws_1", "usr_1", "board-view")
+    })
+
     test("passes workspaceId, userId and validated query (incl. decoded cursor) to the service", async () => {
       const res = mockRes()
       await handlers.listByWorkspace(

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -31,12 +31,14 @@ function mockRes() {
 describe("Conversation Handlers", () => {
   const mockValidateStreamAccess = mock(() => Promise.resolve({ id: "stream_1", workspaceId: "ws_1" }))
   const mockListByStream = mock(() => Promise.resolve([] as Record<string, unknown>[]))
+  const mockListByWorkspace = mock(() => Promise.resolve([] as Record<string, unknown>[]))
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
 
   const handlers = createConversationHandlers({
     conversationService: {
       listByStream: mockListByStream,
+      listByWorkspace: mockListByWorkspace,
       getById: mockGetById,
       getMessages: mockGetMessages,
     } as never,
@@ -48,11 +50,13 @@ describe("Conversation Handlers", () => {
   beforeEach(() => {
     mockValidateStreamAccess.mockReset()
     mockListByStream.mockReset()
+    mockListByWorkspace.mockReset()
     mockGetById.mockReset()
     mockGetMessages.mockReset()
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
+    mockListByWorkspace.mockResolvedValue([])
     mockGetById.mockResolvedValue({
       id: "conv_1",
       streamId: "stream_1",
@@ -83,6 +87,31 @@ describe("Conversation Handlers", () => {
       mockValidateStreamAccess.mockRejectedValue(new StreamNotFoundError())
 
       await expect(handlers.listByStream(mockReq(), mockRes())).rejects.toThrow("Stream not found")
+    })
+  })
+
+  describe("listByWorkspace", () => {
+    test("passes workspaceId, userId and validated query to the service", async () => {
+      const res = mockRes()
+      await handlers.listByWorkspace(mockReq({ query: { status: "active", limit: "25" } }), res)
+
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", { status: "active", limit: 25 })
+    })
+
+    test("returns the conversations the service resolves", async () => {
+      const conversations = [{ id: "conv_1" }, { id: "conv_2" }]
+      mockListByWorkspace.mockResolvedValue(conversations)
+      const res = mockRes()
+
+      await handlers.listByWorkspace(mockReq({ query: {} }), res)
+
+      expect((res as unknown as { body: unknown }).body).toEqual({ conversations })
+    })
+
+    test("does not gate on a single stream's access (filtering is in-query)", async () => {
+      await handlers.listByWorkspace(mockReq({ query: {} }), mockRes())
+
+      expect(mockValidateStreamAccess).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -31,7 +31,9 @@ function mockRes() {
 describe("Conversation Handlers", () => {
   const mockValidateStreamAccess = mock(() => Promise.resolve({ id: "stream_1", workspaceId: "ws_1" }))
   const mockListByStream = mock(() => Promise.resolve([] as Record<string, unknown>[]))
-  const mockListByWorkspace = mock(() => Promise.resolve([] as Record<string, unknown>[]))
+  const mockListByWorkspace = mock(() =>
+    Promise.resolve({ conversations: [] as Record<string, unknown>[], nextCursor: null as string | null })
+  )
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
 
@@ -56,7 +58,7 @@ describe("Conversation Handlers", () => {
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
-    mockListByWorkspace.mockResolvedValue([])
+    mockListByWorkspace.mockResolvedValue({ conversations: [], nextCursor: null })
     mockGetById.mockResolvedValue({
       id: "conv_1",
       streamId: "stream_1",
@@ -91,21 +93,46 @@ describe("Conversation Handlers", () => {
   })
 
   describe("listByWorkspace", () => {
-    test("passes workspaceId, userId and validated query to the service", async () => {
+    test("passes workspaceId, userId and validated query (incl. decoded cursor) to the service", async () => {
       const res = mockRes()
-      await handlers.listByWorkspace(mockReq({ query: { status: "active", limit: "25" } }), res)
+      await handlers.listByWorkspace(
+        mockReq({ query: { status: "active", limit: "25", cursor: "2026-06-22T12:00:00.000Z|conv_9" } }),
+        res
+      )
 
-      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", { status: "active", limit: 25 })
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", {
+        status: "active",
+        limit: 25,
+        cursor: { lastActivityAt: "2026-06-22T12:00:00.000Z", id: "conv_9" },
+      })
     })
 
-    test("returns the conversations the service resolves", async () => {
+    test("passes cursor: undefined when none is supplied", async () => {
+      await handlers.listByWorkspace(mockReq({ query: {} }), mockRes())
+      expect(mockListByWorkspace).toHaveBeenCalledWith("ws_1", "usr_1", {
+        status: undefined,
+        limit: undefined,
+        cursor: undefined,
+      })
+    })
+
+    test("rejects a malformed cursor with a 400", async () => {
+      await expect(handlers.listByWorkspace(mockReq({ query: { cursor: "not-a-cursor" } }), mockRes())).rejects.toThrow(
+        "Invalid board cursor"
+      )
+    })
+
+    test("returns the paged result the service resolves", async () => {
       const conversations = [{ id: "conv_1" }, { id: "conv_2" }]
-      mockListByWorkspace.mockResolvedValue(conversations)
+      mockListByWorkspace.mockResolvedValue({ conversations, nextCursor: "2026-06-22T12:00:00.000Z|conv_2" })
       const res = mockRes()
 
       await handlers.listByWorkspace(mockReq({ query: {} }), res)
 
-      expect((res as unknown as { body: unknown }).body).toEqual({ conversations })
+      expect((res as unknown as { body: unknown }).body).toEqual({
+        conversations,
+        nextCursor: "2026-06-22T12:00:00.000Z|conv_2",
+      })
     })
 
     test("does not gate on a single stream's access (filtering is in-query)", async () => {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -4,11 +4,31 @@ import type { ConversationService } from "./service"
 import type { StreamService } from "../streams"
 import { CONVERSATION_STATUSES } from "@threa/types"
 import { validateRequest } from "../../lib/validation"
+import { HttpError } from "../../lib/errors"
 
 const listConversationsSchema = z.object({
   status: z.enum(CONVERSATION_STATUSES).optional(),
   limit: z.coerce.number().min(1).max(100).optional(),
 })
+
+// The board feed adds keyset pagination: `cursor` is an opaque `"<iso>|<id>"`
+// minted by a prior page's `nextCursor`.
+const listWorkspaceConversationsSchema = listConversationsSchema.extend({
+  cursor: z.string().min(1).optional(),
+})
+
+// Parse the opaque cursor, failing loudly (INV-11/32) on a malformed value
+// rather than silently restarting at page 1.
+function decodeBoardCursor(cursor: string | undefined): { lastActivityAt: string; id: string } | undefined {
+  if (!cursor) return undefined
+  const sep = cursor.indexOf("|")
+  const lastActivityAt = sep === -1 ? "" : cursor.slice(0, sep)
+  const id = sep === -1 ? "" : cursor.slice(sep + 1)
+  if (!lastActivityAt || !id || Number.isNaN(Date.parse(lastActivityAt))) {
+    throw new HttpError("Invalid board cursor", { status: 400, code: "INVALID_CURSOR" })
+  }
+  return { lastActivityAt, id }
+}
 
 const reassignMessageParamsSchema = z.object({
   conversationId: z.string().min(1),
@@ -30,10 +50,14 @@ export function createConversationHandlers({ conversationService, streamService 
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
 
-      const query = validateRequest(listConversationsSchema, req.query)
+      const query = validateRequest(listWorkspaceConversationsSchema, req.query)
 
-      const conversations = await conversationService.listByWorkspace(workspaceId, userId, query)
-      res.json({ conversations })
+      const result = await conversationService.listByWorkspace(workspaceId, userId, {
+        status: query.status,
+        limit: query.limit,
+        cursor: decodeBoardCursor(query.cursor),
+      })
+      res.json(result)
     },
 
     async listByStream(req: Request, res: Response) {

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { ConversationService } from "./service"
 import type { StreamService } from "../streams"
+import type { FeatureFlagService } from "../feature-flags"
 import { CONVERSATION_STATUSES } from "@threa/types"
 import { validateRequest } from "../../lib/validation"
 import { HttpError } from "../../lib/errors"
@@ -38,17 +39,25 @@ const reassignMessageParamsSchema = z.object({
 interface Dependencies {
   conversationService: ConversationService
   streamService: StreamService
+  featureFlagService: FeatureFlagService
 }
 
-export function createConversationHandlers({ conversationService, streamService }: Dependencies) {
+export function createConversationHandlers({ conversationService, streamService, featureFlagService }: Dependencies) {
   return {
     /**
      * Cross-stream board feed. Access is enforced inside the query (INV-62), so
      * there's no single stream to validate here — unlike {@link listByStream}.
+     * Gated behind the `board-view` feature flag: a viewer without it gets a 404,
+     * so the board isn't reachable even by hitting the endpoint directly.
      */
     async listByWorkspace(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!
+
+      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
+      if (boardFlag !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
 
       const query = validateRequest(listWorkspaceConversationsSchema, req.query)
 

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -22,6 +22,20 @@ interface Dependencies {
 
 export function createConversationHandlers({ conversationService, streamService }: Dependencies) {
   return {
+    /**
+     * Cross-stream board feed. Access is enforced inside the query (INV-62), so
+     * there's no single stream to validate here — unlike {@link listByStream}.
+     */
+    async listByWorkspace(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const query = validateRequest(listConversationsSchema, req.query)
+
+      const conversations = await conversationService.listByWorkspace(workspaceId, userId, query)
+      res.json({ conversations })
+    },
+
     async listByStream(req: Request, res: Response) {
       const userId = req.user!.id
       const workspaceId = req.workspaceId!

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -296,46 +296,48 @@ export const ConversationRepository = {
 
   /**
    * Cross-stream conversation feed for the workspace board. Differs from
-   * {@link findByWorkspace} in two board-critical ways:
+   * {@link findByWorkspace} in three board-critical ways:
    *  - access-filtered in SQL via the canonical thread→root predicate (INV-62),
-   *    so the LIMIT counts only conversations the viewer can actually read; and
+   *    so the LIMIT counts only conversations the viewer can actually read;
    *  - empty resolved shells (`cardinality(message_ids) = 0`, left behind when a
    *    conversation's last message is reassigned away) are excluded so the board
-   *    shows real topics, not tombstones.
+   *    shows real topics, not tombstones; and
+   *  - keyset-paginated on the total order `(last_activity_at, id) DESC` so the
+   *    full board is reachable a page at a time instead of silently truncating
+   *    at the first page. `id` is the tiebreaker that makes the order total (and
+   *    the cursor unambiguous) when timestamps collide.
    *
-   * `composeSql` (not `sql`) because the access predicate is a nested fragment;
-   * `SELECT_FIELDS` is pre-resolved through `sql` so its raw text inlines rather
-   * than being parametrized.
+   * `composeSql` (not `sql`) because the access predicate and the optional
+   * status/cursor conditions are nested fragments; `SELECT_FIELDS` is pre-resolved
+   * through `sql` so its raw text inlines rather than being parametrized. An
+   * absent optional condition splices in as an empty fragment.
    */
   async findByWorkspaceForViewer(
     db: Querier,
     workspaceId: string,
     userId: string,
-    options?: { status?: ConversationStatus; limit?: number }
+    options?: {
+      status?: ConversationStatus
+      limit?: number
+      cursor?: { lastActivityAt: string; id: string }
+    }
   ): Promise<Conversation[]> {
     const limit = options?.limit ?? 50
     const fields = sql`${sql.raw(SELECT_FIELDS)}`
     const access = streamAccessPredicateSql(workspaceId, userId, "conversations.stream_id")
-
-    if (options?.status) {
-      const result = await db.query<ConversationRow>(composeSql`
-        SELECT ${fields} FROM conversations
-        WHERE workspace_id = ${workspaceId}
-          AND status = ${options.status}
-          AND cardinality(message_ids) > 0
-          AND ${access}
-        ORDER BY last_activity_at DESC
-        LIMIT ${limit}
-      `)
-      return result.rows.map(mapRowToConversation)
-    }
+    const statusCond = options?.status ? composeSql`AND status = ${options.status}` : sql``
+    const cursorCond = options?.cursor
+      ? composeSql`AND (last_activity_at, id) < (${options.cursor.lastActivityAt}::timestamptz, ${options.cursor.id})`
+      : sql``
 
     const result = await db.query<ConversationRow>(composeSql`
       SELECT ${fields} FROM conversations
       WHERE workspace_id = ${workspaceId}
         AND cardinality(message_ids) > 0
+        ${statusCond}
+        ${cursorCond}
         AND ${access}
-      ORDER BY last_activity_at DESC
+      ORDER BY last_activity_at DESC, id DESC
       LIMIT ${limit}
     `)
     return result.rows.map(mapRowToConversation)

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -1,4 +1,5 @@
-import { sql, type Querier } from "../../db"
+import { sql, composeSql, type Querier } from "../../db"
+import { streamAccessPredicateSql } from "../streams"
 import { ConversationStatuses, type ConversationStatus } from "@threa/types"
 
 interface ConversationRow {
@@ -287,6 +288,53 @@ export const ConversationRepository = {
     const result = await db.query<ConversationRow>(sql`
       SELECT ${sql.raw(SELECT_FIELDS)} FROM conversations
       WHERE workspace_id = ${workspaceId}
+      ORDER BY last_activity_at DESC
+      LIMIT ${limit}
+    `)
+    return result.rows.map(mapRowToConversation)
+  },
+
+  /**
+   * Cross-stream conversation feed for the workspace board. Differs from
+   * {@link findByWorkspace} in two board-critical ways:
+   *  - access-filtered in SQL via the canonical thread→root predicate (INV-62),
+   *    so the LIMIT counts only conversations the viewer can actually read; and
+   *  - empty resolved shells (`cardinality(message_ids) = 0`, left behind when a
+   *    conversation's last message is reassigned away) are excluded so the board
+   *    shows real topics, not tombstones.
+   *
+   * `composeSql` (not `sql`) because the access predicate is a nested fragment;
+   * `SELECT_FIELDS` is pre-resolved through `sql` so its raw text inlines rather
+   * than being parametrized.
+   */
+  async findByWorkspaceForViewer(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    options?: { status?: ConversationStatus; limit?: number }
+  ): Promise<Conversation[]> {
+    const limit = options?.limit ?? 50
+    const fields = sql`${sql.raw(SELECT_FIELDS)}`
+    const access = streamAccessPredicateSql(workspaceId, userId, "conversations.stream_id")
+
+    if (options?.status) {
+      const result = await db.query<ConversationRow>(composeSql`
+        SELECT ${fields} FROM conversations
+        WHERE workspace_id = ${workspaceId}
+          AND status = ${options.status}
+          AND cardinality(message_ids) > 0
+          AND ${access}
+        ORDER BY last_activity_at DESC
+        LIMIT ${limit}
+      `)
+      return result.rows.map(mapRowToConversation)
+    }
+
+    const result = await db.query<ConversationRow>(composeSql`
+      SELECT ${fields} FROM conversations
+      WHERE workspace_id = ${workspaceId}
+        AND cardinality(message_ids) > 0
+        AND ${access}
       ORDER BY last_activity_at DESC
       LIMIT ${limit}
     `)

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -326,8 +326,15 @@ export const ConversationRepository = {
     const fields = sql`${sql.raw(SELECT_FIELDS)}`
     const access = streamAccessPredicateSql(workspaceId, userId, "conversations.stream_id")
     const statusCond = options?.status ? composeSql`AND status = ${options.status}` : sql``
+    // Keyset on `date_trunc('milliseconds', last_activity_at)` — NOT the raw
+    // column — because the cursor is minted from a JS Date (ms precision) while
+    // timestamptz stores microseconds. Comparing the raw µs value against an
+    // ms-truncated cursor would skip any row whose activity falls in the same
+    // millisecond as the boundary row but with smaller µs. Truncating both sides
+    // to ms makes the order total at the cursor's own granularity (id breaks ms
+    // ties), so no row is skipped or repeated across pages.
     const cursorCond = options?.cursor
-      ? composeSql`AND (last_activity_at, id) < (${options.cursor.lastActivityAt}::timestamptz, ${options.cursor.id})`
+      ? composeSql`AND (date_trunc('milliseconds', last_activity_at), id) < (${options.cursor.lastActivityAt}::timestamptz, ${options.cursor.id})`
       : sql``
 
     const result = await db.query<ConversationRow>(composeSql`
@@ -337,7 +344,7 @@ export const ConversationRepository = {
         ${statusCond}
         ${cursorCond}
         AND ${access}
-      ORDER BY last_activity_at DESC, id DESC
+      ORDER BY date_trunc('milliseconds', last_activity_at) DESC, id DESC
       LIMIT ${limit}
     `)
     return result.rows.map(mapRowToConversation)

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -52,6 +52,21 @@ export class ConversationService {
     return conversations.map(addStalenessFields)
   }
 
+  /**
+   * Cross-stream feed for the workspace board: all conversations the viewer can
+   * read, newest activity first. Access filtering happens in SQL (INV-62), so
+   * `userId` is required here unlike the stream-scoped {@link listByStream}.
+   */
+  async listByWorkspace(
+    workspaceId: string,
+    userId: string,
+    options?: ListConversationsOptions
+  ): Promise<ConversationWithStaleness[]> {
+    // Single query, INV-30
+    const conversations = await ConversationRepository.findByWorkspaceForViewer(this.pool, workspaceId, userId, options)
+    return conversations.map(addStalenessFields)
+  }
+
   async listByMessage(workspaceId: string, messageId: string): Promise<ConversationWithStaleness[]> {
     // Single query, INV-30
     const conversations = await ConversationRepository.findByMessageId(this.pool, workspaceId, messageId)

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -17,6 +17,11 @@ export interface ListConversationsOptions {
   limit?: number
 }
 
+export interface ListWorkspaceConversationsOptions extends ListConversationsOptions {
+  /** Keyset cursor from a prior page's `nextCursor` (the last row's activity + id). */
+  cursor?: { lastActivityAt: string; id: string }
+}
+
 export interface ReassignMessageParams {
   workspaceId: string
   /** Target conversation that should become the message's primary home. */
@@ -53,18 +58,29 @@ export class ConversationService {
   }
 
   /**
-   * Cross-stream feed for the workspace board: all conversations the viewer can
-   * read, newest activity first. Access filtering happens in SQL (INV-62), so
-   * `userId` is required here unlike the stream-scoped {@link listByStream}.
+   * Cross-stream feed for the workspace board: conversations the viewer can read,
+   * newest activity first, keyset-paginated. Access filtering happens in SQL
+   * (INV-62), so `userId` is required here unlike the stream-scoped
+   * {@link listByStream}. Returns `nextCursor` (opaque `"<iso>|<id>"`) when a full
+   * page came back, so the board pages on instead of silently truncating.
    */
   async listByWorkspace(
     workspaceId: string,
     userId: string,
-    options?: ListConversationsOptions
-  ): Promise<ConversationWithStaleness[]> {
+    options?: ListWorkspaceConversationsOptions
+  ): Promise<{ conversations: ConversationWithStaleness[]; nextCursor: string | null }> {
+    const limit = options?.limit ?? 50
     // Single query, INV-30
-    const conversations = await ConversationRepository.findByWorkspaceForViewer(this.pool, workspaceId, userId, options)
-    return conversations.map(addStalenessFields)
+    const rows = await ConversationRepository.findByWorkspaceForViewer(this.pool, workspaceId, userId, {
+      ...options,
+      limit,
+    })
+    const conversations = rows.map(addStalenessFields)
+    // A full page means there may be more; the last row's (activity, id) is the
+    // next cursor — matching the repo's `(last_activity_at, id) DESC` order.
+    const last = conversations.length === limit ? conversations[conversations.length - 1] : null
+    const nextCursor = last ? `${last.lastActivityAt.toISOString()}|${last.id}` : null
+    return { conversations, nextCursor }
   }
 
   async listByMessage(workspaceId: string, messageId: string): Promise<ConversationWithStaleness[]> {

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -266,7 +266,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const search = createSearchHandlers({ pool, searchService })
   const memo = createMemoHandlers({ pool, memoExplorerService })
   const emoji = createEmojiHandlers()
-  const conversation = createConversationHandlers({ conversationService, streamService })
+  const conversation = createConversationHandlers({ conversationService, streamService, featureFlagService })
   const command = createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService })
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
   const workspaceSettings = createWorkspaceSettingsHandlers({ workspaceSettingsService })

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -481,6 +481,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/attachments/:attachmentId/extraction", ...authed, attachment.getExtraction)
   app.delete("/api/workspaces/:workspaceId/attachments/:attachmentId", ...authed, attachment.delete)
 
+  app.get("/api/workspaces/:workspaceId/conversations", ...authed, conversation.listByWorkspace)
   app.get("/api/workspaces/:workspaceId/streams/:streamId/conversations", ...authed, conversation.listByStream)
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.getById)
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId/messages", ...authed, conversation.getMessages)

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -6,20 +6,34 @@ export interface ListConversationsParams {
   limit?: number
 }
 
+export interface ListWorkspaceConversationsParams extends ListConversationsParams {
+  /** Opaque keyset cursor from a prior page's `nextCursor`. */
+  cursor?: string
+}
+
+export interface WorkspaceConversationsPage {
+  conversations: ConversationWithStaleness[]
+  nextCursor: string | null
+}
+
 export const conversationsApi = {
   /**
-   * Cross-stream feed for the workspace board: all conversations the viewer can
-   * read, newest activity first. Access is enforced server-side (INV-62).
+   * Cross-stream feed for the workspace board: conversations the viewer can read,
+   * newest activity first, keyset-paginated. Access is enforced server-side
+   * (INV-62). A non-null `nextCursor` means there's another page.
    */
-  async listByWorkspace(workspaceId: string, params?: ListConversationsParams): Promise<ConversationWithStaleness[]> {
+  async listByWorkspace(
+    workspaceId: string,
+    params?: ListWorkspaceConversationsParams
+  ): Promise<WorkspaceConversationsPage> {
     const searchParams = new URLSearchParams()
     if (params?.status) searchParams.set("status", params.status)
     if (params?.limit) searchParams.set("limit", params.limit.toString())
+    if (params?.cursor) searchParams.set("cursor", params.cursor)
     const query = searchParams.toString()
-    const res = await api.get<{ conversations: ConversationWithStaleness[] }>(
+    return api.get<WorkspaceConversationsPage>(
       `/api/workspaces/${workspaceId}/conversations${query ? `?${query}` : ""}`
     )
-    return res.conversations
   },
 
   async listByStream(

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -7,6 +7,21 @@ export interface ListConversationsParams {
 }
 
 export const conversationsApi = {
+  /**
+   * Cross-stream feed for the workspace board: all conversations the viewer can
+   * read, newest activity first. Access is enforced server-side (INV-62).
+   */
+  async listByWorkspace(workspaceId: string, params?: ListConversationsParams): Promise<ConversationWithStaleness[]> {
+    const searchParams = new URLSearchParams()
+    if (params?.status) searchParams.set("status", params.status)
+    if (params?.limit) searchParams.set("limit", params.limit.toString())
+    const query = searchParams.toString()
+    const res = await api.get<{ conversations: ConversationWithStaleness[] }>(
+      `/api/workspaces/${workspaceId}/conversations${query ? `?${query}` : ""}`
+    )
+    return res.conversations
+  },
+
   async listByStream(
     workspaceId: string,
     streamId: string,

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,0 +1,49 @@
+import { Link } from "react-router-dom"
+import { cn } from "@/lib/utils"
+import { RelativeTime } from "@/components/relative-time"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { StatusBadge, CompletenessIndicator } from "@/components/conversations/conversation-item"
+import type { ConversationWithStaleness } from "@threa/types"
+
+interface BoardCardProps {
+  workspaceId: string
+  conversation: ConversationWithStaleness
+}
+
+/**
+ * A single board "post": one conversation rendered as a card that links to the
+ * conversation opened in its own stream (`?convView=open&conv=`). Cross-stream,
+ * so the stream label is shown — it's the context the in-stream conversation
+ * list doesn't need. Stale conversations dim, matching the in-stream list.
+ */
+export function BoardCard({ workspaceId, conversation }: BoardCardProps) {
+  const { streamId, topicSummary, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } =
+    conversation
+  const streamName = useStreamName(workspaceId, streamId, "generic") ?? "Unknown stream"
+  const to = `/w/${workspaceId}/s/${streamId}?convView=open&conv=${conversation.id}`
+
+  return (
+    <Link
+      to={to}
+      className={cn(
+        "block rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50",
+        temporalStaleness >= 3 && "opacity-60"
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs text-muted-foreground">{streamName}</p>
+          <p className="mt-0.5 truncate text-sm font-medium">{topicSummary || "Untitled conversation"}</p>
+          <div className="mt-1 flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{messageIds.length} messages</span>
+            <StatusBadge status={status} />
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-col items-end gap-1">
+          <CompletenessIndicator score={effectiveCompleteness} />
+          <RelativeTime date={lastActivityAt} className="text-xs text-muted-foreground" />
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -37,7 +37,9 @@ export function BoardCard({ workspaceId, conversation, title, contextLabel }: Bo
           <p className="truncate text-xs text-muted-foreground">{contextLabel}</p>
           <p className="mt-0.5 truncate text-sm font-medium">{title}</p>
           <div className="mt-1 flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">{messageIds.length} messages</span>
+            <span className="text-xs text-muted-foreground">
+              {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
+            </span>
             <StatusBadge status={status} />
           </div>
         </div>

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,25 +1,27 @@
 import { Link } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { RelativeTime } from "@/components/relative-time"
-import { useStreamName } from "@/hooks/use-stream-name"
 import { StatusBadge, CompletenessIndicator } from "@/components/conversations/conversation-item"
 import type { ConversationWithStaleness } from "@threa/types"
 
 interface BoardCardProps {
   workspaceId: string
   conversation: ConversationWithStaleness
+  /** The card's headline. The page resolves it: a scratchpad's own name, or the
+   * conversation's topic for channels/DMs (never the DM peer — that's a person). */
+  title: string
+  /** The small context line above the title: the stream the conversation lives
+   * in (channel name, DM peer), or "Scratchpad" when the name is the title. */
+  contextLabel: string
 }
 
 /**
- * A single board "post": one conversation rendered as a card that links to the
- * conversation opened in its own stream (`?convView=open&conv=`). Cross-stream,
- * so the stream label is shown — it's the context the in-stream conversation
- * list doesn't need. Stale conversations dim, matching the in-stream list.
+ * A single board "post": one conversation as a card linking to it opened in its
+ * own stream (`?convView=open&conv=`). Cross-stream, so it shows where the
+ * conversation lives. Stale conversations dim, matching the in-stream list.
  */
-export function BoardCard({ workspaceId, conversation }: BoardCardProps) {
-  const { streamId, topicSummary, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } =
-    conversation
-  const streamName = useStreamName(workspaceId, streamId, "generic") ?? "Unknown stream"
+export function BoardCard({ workspaceId, conversation, title, contextLabel }: BoardCardProps) {
+  const { streamId, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } = conversation
   const to = `/w/${workspaceId}/s/${streamId}?convView=open&conv=${conversation.id}`
 
   return (
@@ -32,8 +34,8 @@ export function BoardCard({ workspaceId, conversation }: BoardCardProps) {
     >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <p className="truncate text-xs text-muted-foreground">{streamName}</p>
-          <p className="mt-0.5 truncate text-sm font-medium">{topicSummary || "Untitled conversation"}</p>
+          <p className="truncate text-xs text-muted-foreground">{contextLabel}</p>
+          <p className="mt-0.5 truncate text-sm font-medium">{title}</p>
           <div className="mt-1 flex items-center gap-2">
             <span className="text-xs text-muted-foreground">{messageIds.length} messages</span>
             <StatusBadge status={status} />

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -159,7 +159,7 @@ function MessagePreview({ message, workspaceId, getActorName, onMessageClick }: 
   )
 }
 
-function StatusBadge({ status }: { status: string }) {
+export function StatusBadge({ status }: { status: string }) {
   switch (status) {
     case "active":
       return (
@@ -187,7 +187,7 @@ function StatusBadge({ status }: { status: string }) {
   }
 }
 
-function CompletenessIndicator({ score }: { score: number }) {
+export function CompletenessIndicator({ score }: { score: number }) {
   const clampedScore = Math.max(1, Math.min(7, score))
   const segments = 7
 

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -48,7 +48,9 @@ export function ConversationItem({
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">{topicSummary || "Untitled conversation"}</p>
                   <div className="flex items-center gap-2 mt-1">
-                    <span className="text-xs text-muted-foreground">{messageIds.length} messages</span>
+                    <span className="text-xs text-muted-foreground">
+                      {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
+                    </span>
                     <StatusBadge status={status} />
                   </div>
                 </div>

--- a/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.test.tsx
@@ -39,6 +39,7 @@ function renderQuickLinks(props: Partial<Parameters<typeof SidebarQuickLinks>[0]
         isScheduledPage={false}
         scheduledCount={0}
         isActivityPage={false}
+        isBoardPage={false}
         isMemoryPage={false}
         isFilesPage={false}
         isLabelsPage={false}
@@ -108,6 +109,7 @@ describe("SidebarQuickLinks", () => {
           isScheduledPage={false}
           scheduledCount={0}
           isActivityPage={false}
+          isBoardPage={false}
           isMemoryPage={false}
           isFilesPage={false}
           isLabelsPage={false}

--- a/apps/frontend/src/components/layout/sidebar/quick-links.tsx
+++ b/apps/frontend/src/components/layout/sidebar/quick-links.tsx
@@ -1,4 +1,14 @@
-import { Bell, Bookmark, Brain, CalendarClock, FileEdit, Paperclip, Tag, type LucideIcon } from "lucide-react"
+import {
+  Bell,
+  Bookmark,
+  Brain,
+  CalendarClock,
+  FileEdit,
+  LayoutGrid,
+  Paperclip,
+  Tag,
+  type LucideIcon,
+} from "lucide-react"
 import type { ReactNode } from "react"
 import { Link } from "react-router-dom"
 import type { SidebarQuickLink, SidebarQuickLinkKey } from "@threa/types"
@@ -14,6 +24,7 @@ import { MoreDivider, SectionHeader } from "./sections"
  * show-hide), so the two never drift.
  */
 export const QUICK_LINK_META: Record<SidebarQuickLinkKey, { label: string; icon: LucideIcon }> = {
+  board: { label: "Board", icon: LayoutGrid },
   drafts: { label: "Drafts", icon: FileEdit },
   saved: { label: "Saved", icon: Bookmark },
   files: { label: "Files", icon: Paperclip },
@@ -34,6 +45,7 @@ interface SidebarQuickLinksProps {
   isScheduledPage: boolean
   scheduledCount: number
   isActivityPage: boolean
+  isBoardPage: boolean
   isMemoryPage: boolean
   isFilesPage: boolean
   isLabelsPage: boolean
@@ -72,6 +84,7 @@ export function SidebarQuickLinks({
   isScheduledPage,
   scheduledCount,
   isActivityPage,
+  isBoardPage,
   isMemoryPage,
   isFilesPage,
   isLabelsPage,
@@ -84,6 +97,7 @@ export function SidebarQuickLinks({
   // The route/count signal data per key; presentation (label/icon) comes from
   // QUICK_LINK_META so the editor and the list stay in sync.
   const itemByKey: Record<SidebarQuickLinkKey, QuickLinkItem> = {
+    board: { to: `/w/${workspaceId}/board`, isActive: isBoardPage, unreadCount: 0, signalSlot: null },
     drafts: {
       to: `/w/${workspaceId}/drafts`,
       isActive: isDraftsPage,

--- a/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-config.test.ts
@@ -201,6 +201,7 @@ describe("moveQuickLink", () => {
     // Move "activity" (last) to the front (over "drafts").
     const moved = moveQuickLink(SMART_SIDEBAR_CONFIG, "activity", "drafts")
     expect(moved.quickLinks.map((l) => l.key)).toEqual([
+      "board",
       "activity",
       "drafts",
       "saved",

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.test.tsx
@@ -65,6 +65,7 @@ describe("SidebarEditorDialog", () => {
       // inside its row (so they appear in the DOM right after it), then the
       // sibling stream sections follow.
       "Reorder Quick Links",
+      "Reorder Board",
       "Reorder Drafts",
       "Reorder Saved",
       "Reorder Files",

--- a/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-editor.tsx
@@ -76,6 +76,9 @@ interface SidebarEditorDialogProps {
   workspaceId: string
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** Quick-link keys to hide from the reorder list (e.g. a flag-gated link the
+   * viewer doesn't have). Display-only — the stored config is left untouched. */
+  hiddenQuickLinkKeys?: readonly string[]
 }
 
 /**
@@ -88,8 +91,18 @@ interface SidebarEditorDialogProps {
  * cross-device sync) — there is no save step, so the live sidebar reflects each
  * change as it's made.
  */
-export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: SidebarEditorDialogProps) {
+export function SidebarEditorDialog({
+  workspaceId,
+  open,
+  onOpenChange,
+  hiddenQuickLinkKeys,
+}: SidebarEditorDialogProps) {
   const { config, setConfig, setBasePreset } = useSidebarConfig(workspaceId)
+  // Display-only filter: hide flag-gated links the viewer can't use, without
+  // mutating the stored config (so it returns intact if the flag flips on).
+  const visibleQuickLinks = hiddenQuickLinkKeys?.length
+    ? config.quickLinks.filter((link) => !hiddenQuickLinkKeys.includes(link.key))
+    : config.quickLinks
   const { preferences } = usePreferences()
   // dnd-kit applies its reorder transition via an inline style, which the global
   // `.reduced-motion` stylesheet rule can't reach — so gate it here.
@@ -207,7 +220,7 @@ export function SidebarEditorDialog({ workspaceId, open, onOpenChange }: Sidebar
                 sections={config.sections}
                 sectionIds={sectionIds}
                 labelsById={labelsById}
-                quickLinks={config.quickLinks}
+                quickLinks={visibleQuickLinks}
                 reduceMotion={reduceMotion}
                 onRemoveSection={(id) => setConfig(removeSection(config, id))}
                 onRenameCustomSection={(sectionId, name) => setConfig(renameCustomSection(config, sectionId, name))}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -52,7 +52,10 @@ import { calculateUrgency, categorizeStream } from "./utils"
 import type { StreamItemData } from "./types"
 import { resolveDmDisplayName, streamLabel } from "@/lib/streams"
 import type { CachedLabel } from "@/hooks"
-import { StreamTypes, Visibilities, LabelableResourceTypes } from "@threa/types"
+import { StreamTypes, Visibilities, LabelableResourceTypes, type SidebarQuickLinkKey } from "@threa/types"
+
+/** The flag-gated Board quick-link key — one constant for the filter + the editor. */
+const BOARD_QUICK_LINK_KEY: SidebarQuickLinkKey = "board"
 
 interface SidebarProps {
   workspaceId: string
@@ -116,6 +119,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // The Board is gated behind the board-view flag — hide its quick link (and its
   // editor row) for users without it, matching the route + endpoint gates.
   const boardEnabled = useFeatureFlag(workspaceId, "board-view") === "on"
+  const boardQuickLinks = boardEnabled
+    ? sidebarConfig.quickLinks
+    : sidebarConfig.quickLinks.filter((link) => link.key !== BOARD_QUICK_LINK_KEY)
   const isMemoryPage = splat === "memory" || location.pathname.endsWith("/memory")
   const isFilesPage = splat === "files" || location.pathname.endsWith("/files")
   const isLabelsPage = splat === "labels" || location.pathname.includes("/labels")
@@ -532,11 +538,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
               hasQuickLinksSection ? (
                 <SidebarQuickLinks
                   workspaceId={workspaceId}
-                  quickLinks={
-                    boardEnabled
-                      ? sidebarConfig.quickLinks
-                      : sidebarConfig.quickLinks.filter((link) => link.key !== "board")
-                  }
+                  quickLinks={boardQuickLinks}
                   isDraftsPage={isDraftsPage}
                   draftCount={draftCount}
                   isSavedPage={isSavedPage}
@@ -573,7 +575,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
         workspaceId={workspaceId}
         open={isEditorOpen}
         onOpenChange={setIsEditorOpen}
-        hiddenQuickLinkKeys={boardEnabled ? undefined : ["board"]}
+        hiddenQuickLinkKeys={boardEnabled ? undefined : [BOARD_QUICK_LINK_KEY]}
       />
       {labelRemovePrompt && (
         <RemoveLabelDialog

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -32,6 +32,7 @@ import {
   useWorkspaceLabelAssignments,
 } from "@/stores/workspace-store"
 import { useCoordinatedLoading, useSidebar, usePreferencesOptional } from "@/contexts"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { useCreateChannel } from "@/components/create-channel"
 import { Button } from "@/components/ui/button"
 import { SidebarShell } from "./sidebar-shell"
@@ -112,6 +113,9 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const isScheduledPage = splat === "scheduled" || window.location.pathname.includes("/scheduled")
   const isActivityPage = splat === "activity" || window.location.pathname.endsWith("/activity")
   const isBoardPage = splat === "board" || window.location.pathname.endsWith("/board")
+  // The Board is gated behind the board-view flag — hide its quick link (and its
+  // editor row) for users without it, matching the route + endpoint gates.
+  const boardEnabled = useFeatureFlag(workspaceId, "board-view") === "on"
   const isMemoryPage = splat === "memory" || location.pathname.endsWith("/memory")
   const isFilesPage = splat === "files" || location.pathname.endsWith("/files")
   const isLabelsPage = splat === "labels" || location.pathname.includes("/labels")
@@ -528,7 +532,11 @@ export function Sidebar({ workspaceId }: SidebarProps) {
               hasQuickLinksSection ? (
                 <SidebarQuickLinks
                   workspaceId={workspaceId}
-                  quickLinks={sidebarConfig.quickLinks}
+                  quickLinks={
+                    boardEnabled
+                      ? sidebarConfig.quickLinks
+                      : sidebarConfig.quickLinks.filter((link) => link.key !== "board")
+                  }
                   isDraftsPage={isDraftsPage}
                   draftCount={draftCount}
                   isSavedPage={isSavedPage}
@@ -561,7 +569,12 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           </>
         }
       />
-      <SidebarEditorDialog workspaceId={workspaceId} open={isEditorOpen} onOpenChange={setIsEditorOpen} />
+      <SidebarEditorDialog
+        workspaceId={workspaceId}
+        open={isEditorOpen}
+        onOpenChange={setIsEditorOpen}
+        hiddenQuickLinkKeys={boardEnabled ? undefined : ["board"]}
+      />
       {labelRemovePrompt && (
         <RemoveLabelDialog
           open

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -111,6 +111,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const isSavedPage = splat === "saved" || window.location.pathname.endsWith("/saved")
   const isScheduledPage = splat === "scheduled" || window.location.pathname.includes("/scheduled")
   const isActivityPage = splat === "activity" || window.location.pathname.endsWith("/activity")
+  const isBoardPage = splat === "board" || window.location.pathname.endsWith("/board")
   const isMemoryPage = splat === "memory" || location.pathname.endsWith("/memory")
   const isFilesPage = splat === "files" || location.pathname.endsWith("/files")
   const isLabelsPage = splat === "labels" || location.pathname.includes("/labels")
@@ -535,6 +536,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
                   isScheduledPage={isScheduledPage}
                   scheduledCount={scheduledCount}
                   isActivityPage={isActivityPage}
+                  isBoardPage={isBoardPage}
                   isMemoryPage={isMemoryPage}
                   isFilesPage={isFilesPage}
                   isLabelsPage={isLabelsPage}

--- a/apps/frontend/src/components/quick-switcher/commands.test.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.test.ts
@@ -106,6 +106,7 @@ describe("commands", () => {
 
     /** The palette destination each sidebar quick link must be reachable through. */
     const reachability: Record<SidebarQuickLinkKey, (ctx: ReturnType<typeof makeContext>) => void> = {
+      board: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/board`),
       drafts: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/drafts`),
       saved: ({ navigate }) => expect(navigate).toHaveBeenCalledWith(`/w/${WORKSPACE_ID}/saved`),
       files: ({ openExplorer }) => expect(openExplorer).toHaveBeenCalled(),

--- a/apps/frontend/src/components/quick-switcher/commands.ts
+++ b/apps/frontend/src/components/quick-switcher/commands.ts
@@ -6,6 +6,7 @@ import {
   CalendarClock,
   FileText,
   Hash,
+  LayoutGrid,
   ListTodo,
   Paperclip,
   Search,
@@ -212,9 +213,19 @@ export const commands: Command[] = [
       openSearch()
     },
   },
-  // Destination commands mirror the sidebar's Quick Links block (drafts, saved,
-  // files, scheduled, memory, labels, activity) so every standing view is
+  // Destination commands mirror the sidebar's Quick Links block (board, drafts,
+  // saved, files, scheduled, memory, labels, activity) so every standing view is
   // reachable from the palette, in the same order.
+  {
+    id: "view-board",
+    label: "View Board",
+    icon: LayoutGrid,
+    keywords: ["board", "posts", "topics", "conversations", "overview"],
+    action: ({ workspaceId, navigate, closeDialog }) => {
+      closeDialog()
+      navigate(`/w/${workspaceId}/board`)
+    },
+  },
   {
     id: "view-drafts",
     label: "View Drafts",

--- a/apps/frontend/src/components/quick-switcher/use-command-items.ts
+++ b/apps/frontend/src/components/quick-switcher/use-command-items.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { isDraftId } from "@/hooks"
+import { useFeatureFlag } from "@/hooks/use-feature-flags"
 import { rankMatches } from "@/lib/match-score"
 import { commands, type Command, type CommandContext } from "./commands"
 import { draftStreamCommands, streamCommands } from "./stream-commands"
@@ -25,6 +26,9 @@ export function rankCommands(candidates: Command[], query: string): Command[] {
 }
 
 export function useCommandItems({ query, commandContext }: UseCommandItemsParams): ModeResult {
+  // The "View Board" command is gated behind the board-view flag, matching the
+  // route + sidebar gates.
+  const boardEnabled = useFeatureFlag(commandContext.workspaceId, "board-view") === "on"
   const items = useMemo(() => {
     const { currentStreamId, currentStreamName } = commandContext
 
@@ -51,10 +55,11 @@ export function useCommandItems({ query, commandContext }: UseCommandItemsParams
     // cross-group ordering is the section order, not match quality.
     const contextualItems = rankCommands(contextualCommands, query).map((c) => toItem(c, contextualGroup))
 
-    const globalItems = rankCommands(commands, query).map((c) => toItem(c, "Commands"))
+    const globalCommands = boardEnabled ? commands : commands.filter((c) => c.id !== "view-board")
+    const globalItems = rankCommands(globalCommands, query).map((c) => toItem(c, "Commands"))
 
     return [...contextualItems, ...globalItems]
-  }, [query, commandContext])
+  }, [query, commandContext, boardEnabled])
 
   return {
     items,

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -63,6 +63,7 @@ export interface MessageService {
 }
 
 export interface ConversationService {
+  listByWorkspace: typeof conversationsApi.listByWorkspace
   listByStream: typeof conversationsApi.listByStream
   getById: typeof conversationsApi.getById
   getMessages: typeof conversationsApi.getMessages

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -8,6 +8,8 @@ export const conversationKeys = {
   all: ["conversations"] as const,
   list: (workspaceId: string, streamId: string, options?: { status?: string; limit?: number }) =>
     [...conversationKeys.all, "list", workspaceId, streamId, options ?? {}] as const,
+  workspaceList: (workspaceId: string, options?: { status?: string; limit?: number }) =>
+    [...conversationKeys.all, "workspaceList", workspaceId, options ?? {}] as const,
   byId: (workspaceId: string, conversationId: string) =>
     [...conversationKeys.all, "detail", workspaceId, conversationId] as const,
   messages: (conversationId: string) => ["conversations", conversationId, "messages"] as const,
@@ -54,6 +56,31 @@ interface UseConversationsOptions {
   status?: ConversationStatus
   limit?: number
   enabled?: boolean
+}
+
+/**
+ * Cross-stream conversation feed for the workspace board. Read-only bootstrap
+ * (the activity-feed pattern): `staleTime: Infinity` + `refetchOnMount` so the
+ * list is fresh each time the board is opened. Live per-event updates across
+ * streams aren't wired yet — conversation events are delivered only to per-stream
+ * rooms today (see board-view design doc), so that's a follow-up, not a gap here.
+ */
+export function useWorkspaceConversations(
+  workspaceId: string,
+  options?: { status?: ConversationStatus; limit?: number }
+) {
+  const conversationService = useConversationService()
+  const { status, limit } = options ?? {}
+
+  return useQuery({
+    queryKey: conversationKeys.workspaceList(workspaceId, { status, limit }),
+    queryFn: () => conversationService.listByWorkspace(workspaceId, { status, limit }),
+    staleTime: Infinity,
+    refetchOnMount: true,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    enabled: !!workspaceId,
+  })
 }
 
 export function useConversations(workspaceId: string, streamId: string, options?: UseConversationsOptions) {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useConversationService, useSocket, useSocketReconnectCount } from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import type { ConversationWithStaleness, ConversationStatus } from "@threa/types"
@@ -59,11 +59,13 @@ interface UseConversationsOptions {
 }
 
 /**
- * Cross-stream conversation feed for the workspace board. Read-only bootstrap
- * (the activity-feed pattern): `staleTime: Infinity` + `refetchOnMount` so the
- * list is fresh each time the board is opened. Live per-event updates across
- * streams aren't wired yet — conversation events are delivered only to per-stream
- * rooms today (see board-view design doc), so that's a follow-up, not a gap here.
+ * Cross-stream conversation feed for the workspace board, keyset-paginated.
+ * Read-only bootstrap (the activity-feed pattern): `staleTime: Infinity` +
+ * `refetchOnMount` so the list is fresh on open. Unlike the activity feed (which
+ * gets live updates via workspace-room socket handlers) the board has no socket
+ * subscription yet — conversation events are delivered only to per-stream rooms
+ * today (see board-view design doc) — so `refetchOnReconnect` is left ON: a
+ * reconnect is the board's only refresh path until cross-stream events land.
  */
 export function useWorkspaceConversations(
   workspaceId: string,
@@ -72,13 +74,15 @@ export function useWorkspaceConversations(
   const conversationService = useConversationService()
   const { status, limit } = options ?? {}
 
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: conversationKeys.workspaceList(workspaceId, { status, limit }),
-    queryFn: () => conversationService.listByWorkspace(workspaceId, { status, limit }),
+    queryFn: ({ pageParam }) => conversationService.listByWorkspace(workspaceId, { status, limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     staleTime: Infinity,
     refetchOnMount: true,
     refetchOnWindowFocus: false,
-    refetchOnReconnect: false,
+    refetchOnReconnect: true,
     enabled: !!workspaceId,
   })
 }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -6,6 +6,7 @@ import type { ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import { ServicesProvider, SidebarProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as contextsModule from "@/contexts"
 
@@ -36,14 +37,16 @@ function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): C
 
 function mountBoard(
   conversations: ConversationWithStaleness[],
-  opts: { nextCursor?: string | null; fail?: boolean } = {}
+  opts: { nextCursor?: string | null; fail?: boolean; boardFlag?: "on" | "off" } = {}
 ) {
-  const { nextCursor = null, fail = false } = opts
+  const { nextCursor = null, fail = false, boardFlag = "on" } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
     return { conversations, nextCursor }
   })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // The board is gated behind the board-view flag, read from the bootstrap cache.
+  queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), { featureFlags: { "board-view": boardFlag } })
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
@@ -104,6 +107,15 @@ describe("BoardPage", () => {
     mountBoard([makeConversation()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
     expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy()
+  })
+
+  it("does not render the board when the board-view flag is off", async () => {
+    const { listByWorkspace } = mountBoard([makeConversation()], { boardFlag: "off" })
+    // Gate redirects away — board content never appears and the feed isn't fetched.
+    await Promise.resolve()
+    expect(screen.queryByText("CC Teams tokens")).toBeNull()
+    expect(screen.queryByText("Board")).toBeNull()
+    expect(listByWorkspace).not.toHaveBeenCalled()
   })
 
   it("links each card to its conversation opened in its stream", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ConversationWithStaleness } from "@threa/types"
+import { BoardPage } from "./board"
+import { ServicesProvider, SidebarProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as contextsModule from "@/contexts"
+
+const WORKSPACE_ID = "ws_1"
+
+function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): ConversationWithStaleness {
+  const now = "2026-06-22T12:00:00.000Z"
+  return {
+    id: "conv_1",
+    streamId: "stream_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["msg_1", "msg_2", "msg_3"],
+    participantIds: ["usr_me"],
+    secondaryMessageIds: [],
+    topicSummary: "CC Teams tokens",
+    completenessScore: 4,
+    confidence: 0.8,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    temporalStaleness: 0,
+    effectiveCompleteness: 4,
+    ...overrides,
+  }
+}
+
+function mountBoard(conversations: ConversationWithStaleness[]) {
+  const listByWorkspace = vi.fn(async () => conversations)
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: { listByWorkspace } as never }}>
+          <SidebarProvider>
+            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
+              <Routes>
+                <Route path="/w/:workspaceId/board" element={<BoardPage />} />
+              </Routes>
+            </MemoryRouter>
+          </SidebarProvider>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+  return { listByWorkspace }
+}
+
+beforeEach(() => {
+  // BoardCard resolves the stream label via the workspace caches.
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  // RelativeTime reads timezone/locale from the preferences context.
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardPage", () => {
+  it("renders the empty state when there are no conversations", async () => {
+    mountBoard([])
+    expect(await screen.findByText("Nothing on the board yet")).toBeTruthy()
+  })
+
+  it("renders a conversation as a card with its title and message count", async () => {
+    mountBoard([makeConversation()])
+    expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
+    expect(screen.getByText("3 messages")).toBeTruthy()
+  })
+
+  it("links each card to its conversation opened in its stream", async () => {
+    mountBoard([makeConversation()])
+    const card = (await screen.findByText("CC Teams tokens")).closest("a")
+    expect(card?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?convView=open&conv=conv_1`)
+  })
+})

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ConversationWithStaleness } from "@threa/types"
@@ -112,7 +112,8 @@ describe("BoardPage", () => {
   it("does not render the board when the board-view flag is off", async () => {
     const { listByWorkspace } = mountBoard([makeConversation()], { boardFlag: "off" })
     // Gate redirects away — board content never appears and the feed isn't fetched.
-    await Promise.resolve()
+    // Flush effects so a (hypothetical) deferred mount would have its chance to fire.
+    await act(async () => {})
     expect(screen.queryByText("CC Teams tokens")).toBeNull()
     expect(screen.queryByText("Board")).toBeNull()
     expect(listByWorkspace).not.toHaveBeenCalled()

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -85,4 +85,31 @@ describe("BoardPage", () => {
     const card = (await screen.findByText("CC Teams tokens")).closest("a")
     expect(card?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?convView=open&conv=conv_1`)
   })
+
+  it("titles a scratchpad card with the scratchpad's name, not the generic topic", async () => {
+    vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
+      { id: "stream_sp", type: "scratchpad", displayName: "My Notes" },
+    ] as never)
+    mountBoard([makeConversation({ id: "conv_sp", streamId: "stream_sp", topicSummary: "Scratchpad" })])
+
+    expect(await screen.findByText("My Notes")).toBeTruthy() // title = scratchpad name
+    expect(screen.getByText("Scratchpad")).toBeTruthy() // context line = the type
+  })
+
+  it("keeps a DM peer (a person) as context, never as the card title", async () => {
+    vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
+      { id: "stream_dm", type: "dm", displayName: null },
+    ] as never)
+    vi.mocked(workspaceStoreModule.useWorkspaceDmPeers).mockReturnValue([
+      { streamId: "stream_dm", userId: "usr_pierre" },
+    ] as never)
+    vi.mocked(workspaceStoreModule.useWorkspaceUsers).mockReturnValue([{ id: "usr_pierre", name: "Pierre" }] as never)
+    mountBoard([makeConversation({ id: "conv_dm", streamId: "stream_dm", topicSummary: "Lunch plans" })])
+
+    const title = await screen.findByText("Lunch plans")
+    expect(title).toBeTruthy() // title = topic
+    // "Pierre" renders as the context line, and is not the title element.
+    expect(screen.getByText("Pierre")).toBeTruthy()
+    expect(title.textContent).not.toContain("Pierre")
+  })
 })

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -34,8 +34,15 @@ function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): C
   }
 }
 
-function mountBoard(conversations: ConversationWithStaleness[]) {
-  const listByWorkspace = vi.fn(async () => conversations)
+function mountBoard(
+  conversations: ConversationWithStaleness[],
+  opts: { nextCursor?: string | null; fail?: boolean } = {}
+) {
+  const { nextCursor = null, fail = false } = opts
+  const listByWorkspace = vi.fn(async () => {
+    if (fail) throw new Error("boom")
+    return { conversations, nextCursor }
+  })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
@@ -78,6 +85,25 @@ describe("BoardPage", () => {
     mountBoard([makeConversation()])
     expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
     expect(screen.getByText("3 messages")).toBeTruthy()
+  })
+
+  it("pluralizes a single message as '1 message'", async () => {
+    mountBoard([makeConversation({ messageIds: ["msg_only"] })])
+    expect(await screen.findByText("1 message")).toBeTruthy()
+    expect(screen.queryByText("1 messages")).toBeNull()
+  })
+
+  it("shows an error state with a retry, not the empty state, when the fetch fails", async () => {
+    mountBoard([], { fail: true })
+    expect(await screen.findByText("Couldn't load the board")).toBeTruthy()
+    expect(screen.getByText("Try again")).toBeTruthy()
+    expect(screen.queryByText("Nothing on the board yet")).toBeNull()
+  })
+
+  it("offers Load more when there is another page", async () => {
+    mountBoard([makeConversation()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
+    expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy()
   })
 
   it("links each card to its conversation opened in its stream", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { LayoutGrid } from "lucide-react"
 import { useParams } from "react-router-dom"
 import { StreamTypes } from "@threa/types"
+import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PageHeaderTabs } from "@/components/layout"
@@ -24,7 +25,9 @@ export function BoardPage() {
 }
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
-  const { data: conversations, isLoading } = useWorkspaceConversations(workspaceId, { limit: 100 })
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useWorkspaceConversations(workspaceId, { limit: 50 })
+  const conversations = useMemo(() => data?.pages.flatMap((page) => page.conversations) ?? [], [data])
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -54,7 +57,19 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         ))}
       </div>
     )
-  } else if (!conversations?.length) {
+  } else if (isError) {
+    // A failed fetch must read as a failure, not as the empty state's upbeat copy.
+    content = (
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+        <LayoutGrid className="h-8 w-8 text-muted-foreground" />
+        <p className="text-sm font-medium">Couldn't load the board</p>
+        <p className="max-w-sm text-sm text-muted-foreground">Something went wrong fetching your conversations.</p>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          Try again
+        </Button>
+      </div>
+    )
+  } else if (conversations.length === 0) {
     content = (
       <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
         <LayoutGrid className="h-8 w-8 text-muted-foreground" />
@@ -79,6 +94,17 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
             />
           )
         })}
+        {hasNextPage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-1 self-center"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </Button>
+        )}
       </div>
     )
   }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,10 +1,15 @@
+import { useMemo } from "react"
 import { LayoutGrid } from "lucide-react"
 import { useParams } from "react-router-dom"
+import { StreamTypes } from "@threa/types"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PageHeaderTabs } from "@/components/layout"
+import { resolveStreamName } from "@/lib/streams"
+import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
+import type { ConversationWithStaleness } from "@threa/types"
 
 /**
  * The board: a cross-stream wall of conversations (Threa's topic primitive)
@@ -20,6 +25,25 @@ export function BoardPage() {
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   const { data: conversations, isLoading } = useWorkspaceConversations(workspaceId, { limit: 100 })
+  const streams = useWorkspaceStreams(workspaceId)
+  const users = useWorkspaceUsers(workspaceId)
+  const dmPeers = useWorkspaceDmPeers(workspaceId)
+  const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
+
+  // A scratchpad IS its conversation, so its own name is the best title (the
+  // stored "Scratchpad" topicSummary is noise). For channels/DMs the topic is
+  // the title and the stream is context — never the DM peer as the title, since
+  // that name is a person, not a topic.
+  function labelsFor(conversation: ConversationWithStaleness): { title: string; contextLabel: string } {
+    const streamName = resolveStreamName(conversation.streamId, { streams, users, dmPeers }, "generic")
+    if (streamById.get(conversation.streamId)?.type === StreamTypes.SCRATCHPAD) {
+      return { title: streamName ?? "Scratchpad", contextLabel: "Scratchpad" }
+    }
+    return {
+      title: conversation.topicSummary?.trim() || "Untitled conversation",
+      contextLabel: streamName ?? "Unknown stream",
+    }
+  }
 
   let content
   if (isLoading) {
@@ -43,9 +67,18 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   } else {
     content = (
       <div className="flex flex-col gap-2 px-3">
-        {conversations.map((conversation) => (
-          <BoardCard key={conversation.id} workspaceId={workspaceId} conversation={conversation} />
-        ))}
+        {conversations.map((conversation) => {
+          const { title, contextLabel } = labelsFor(conversation)
+          return (
+            <BoardCard
+              key={conversation.id}
+              workspaceId={workspaceId}
+              conversation={conversation}
+              title={title}
+              contextLabel={contextLabel}
+            />
+          )
+        })}
       </div>
     )
   }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,11 +1,12 @@
 import { useMemo } from "react"
 import { AlertCircle, LayoutGrid } from "lucide-react"
-import { useParams } from "react-router-dom"
+import { Navigate, useParams } from "react-router-dom"
 import { StreamTypes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
 import { PageHeaderTabs } from "@/components/layout"
+import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
@@ -21,6 +22,20 @@ import type { ConversationWithStaleness } from "@threa/types"
 export function BoardPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   if (!workspaceId) return null
+  return <BoardPageGate workspaceId={workspaceId} />
+}
+
+/**
+ * The board is gated behind the `board-view` feature flag. While the bootstrap
+ * (and thus the flag) is still unknown, render nothing rather than redirect —
+ * redirecting on the default would bounce a flagged user who deep-links or
+ * refreshes on /board before the bootstrap cache is populated. The backend
+ * endpoint 404s without the flag too, so this is the UX half of the gate.
+ */
+function BoardPageGate({ workspaceId }: { workspaceId: string }) {
+  const boardFlag = useFeatureFlagWhenKnown(workspaceId, "board-view")
+  if (boardFlag === null) return null
+  if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
   return <BoardPageInner workspaceId={workspaceId} />
 }
 

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react"
-import { LayoutGrid } from "lucide-react"
+import { AlertCircle, LayoutGrid } from "lucide-react"
 import { useParams } from "react-router-dom"
 import { StreamTypes } from "@threa/types"
 import { Button } from "@/components/ui/button"
@@ -25,7 +25,7 @@ export function BoardPage() {
 }
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
-  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { limit: 50 })
   const conversations = useMemo(() => data?.pages.flatMap((page) => page.conversations) ?? [], [data])
   const streams = useWorkspaceStreams(workspaceId)
@@ -48,6 +48,11 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     }
   }
 
+  // Flat if-chain, not a nested ternary (INV-47 / no-nested-ternary).
+  let loadMoreLabel = "Load more"
+  if (isFetchingNextPage) loadMoreLabel = "Loading…"
+  else if (isFetchNextPageError) loadMoreLabel = "Retry"
+
   let content
   if (isLoading) {
     content = (
@@ -61,10 +66,10 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     // A failed fetch must read as a failure, not as the empty state's upbeat copy.
     content = (
       <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
-        <LayoutGrid className="h-8 w-8 text-muted-foreground" />
+        <AlertCircle className="h-8 w-8 text-destructive" />
         <p className="text-sm font-medium">Couldn't load the board</p>
         <p className="max-w-sm text-sm text-muted-foreground">Something went wrong fetching your conversations.</p>
-        <Button variant="outline" size="sm" onClick={() => refetch()}>
+        <Button variant="outline" onClick={() => refetch()} className="min-h-11">
           Try again
         </Button>
       </div>
@@ -95,15 +100,17 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
           )
         })}
         {hasNextPage && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="mt-1 self-center"
-            onClick={() => fetchNextPage()}
-            disabled={isFetchingNextPage}
-          >
-            {isFetchingNextPage ? "Loading…" : "Load more"}
-          </Button>
+          <div className="mt-1 flex flex-col items-center gap-1">
+            {isFetchNextPageError && <p className="text-xs text-destructive">Couldn't load more.</p>}
+            <Button
+              variant="ghost"
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+              className="min-h-11 px-6"
+            >
+              {loadMoreLabel}
+            </Button>
+          </div>
         )}
       </div>
     )

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,0 +1,67 @@
+import { LayoutGrid } from "lucide-react"
+import { useParams } from "react-router-dom"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Skeleton } from "@/components/ui/skeleton"
+import { PageHeaderTabs } from "@/components/layout"
+import { useWorkspaceConversations } from "@/hooks/use-conversations"
+import { BoardCard } from "@/components/board/board-card"
+
+/**
+ * The board: a cross-stream wall of conversations (Threa's topic primitive)
+ * ordered by recent activity — the read-only foundation of the board view
+ * (slice 1). Lenses and a scope filter land as tabs here later; for now a single
+ * "All" tab shows everything the viewer can read.
+ */
+export function BoardPage() {
+  const { workspaceId } = useParams<{ workspaceId: string }>()
+  if (!workspaceId) return null
+  return <BoardPageInner workspaceId={workspaceId} />
+}
+
+function BoardPageInner({ workspaceId }: { workspaceId: string }) {
+  const { data: conversations, isLoading } = useWorkspaceConversations(workspaceId, { limit: 100 })
+
+  let content
+  if (isLoading) {
+    content = (
+      <div className="flex flex-col gap-2 px-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-lg" />
+        ))}
+      </div>
+    )
+  } else if (!conversations?.length) {
+    content = (
+      <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+        <LayoutGrid className="h-8 w-8 text-muted-foreground" />
+        <p className="text-sm font-medium">Nothing on the board yet</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          As your conversations build up, the topics worth returning to surface here, newest activity first.
+        </p>
+      </div>
+    )
+  } else {
+    content = (
+      <div className="flex flex-col gap-2 px-3">
+        {conversations.map((conversation) => (
+          <BoardCard key={conversation.id} workspaceId={workspaceId} conversation={conversation} />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <PageHeaderTabs
+        backTo={`/w/${workspaceId}`}
+        icon={LayoutGrid}
+        title="Board"
+        value="all"
+        tabs={[{ value: "all", label: "All", href: `/w/${workspaceId}/board` }]}
+      />
+      <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
+        <main className="py-2">{content}</main>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -85,6 +85,11 @@ export const router = createBrowserRouter([
         lazy: async () => ({ Component: (await import("@/pages/scheduled")).ScheduledPage }),
       },
       {
+        path: "board",
+        HydrateFallback: FallbackLoader,
+        lazy: async () => ({ Component: (await import("@/pages/board")).BoardPage }),
+      },
+      {
         path: "activity/:filter?",
         HydrateFallback: FallbackLoader,
         lazy: async () => ({ Component: (await import("@/pages/activity")).ActivityPage }),

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -1,6 +1,6 @@
 # Exploration: The Board — a second way to interact with a stream
 
-Status: exploration / design, v2. Sibling to
+Status: exploration / design, v3. Sibling to
 [`nonlinear-stream-views-exploration.md`](./nonlinear-stream-views-exploration.md),
 which argues a stream is a container and the timeline is one projection. This
 doc designs the **board** as a co-equal interaction mode and as the home for
@@ -62,14 +62,14 @@ which is the whole "automatic organization that surfaces what matters" ethos
    changed its name. Fine for a living "what matters" wall; worth a light "this
    updates itself" mental model, not a fixed-artifact one.
 2. **Null titles.** `topicSummary` can be null → "Untitled conversation". A wall
-   of "Untitled" is bad. Mitigation: fall back to the entrypoint message's
-   stripped first line (INV-60) when title is null.
-3. **Scratchpads degenerate to one post.** The scratchpad path skips AI
-   segmentation and keeps a single conversation per scratchpad
-   (`boundary-extraction-service.ts:218-233`). So a scratchpad board = one card,
-   not a topic board. For a solo-first product this is the biggest gap — either
-   scope the board to channels/DMs first, or later enable topic segmentation for
-   scratchpads (a backend change).
+   of "Untitled" is bad. **Decided:** fall back to a stripped **excerpt of the
+   first message** (INV-60) when the title is null.
+3. **Scratchpads = one conversation.** The scratchpad path skips AI segmentation
+   and keeps a single conversation per scratchpad
+   (`boundary-extraction-service.ts:218-233`). **Decided:** accept it — a
+   scratchpad shows as one board card; we do _not_ build per-scratchpad topic
+   segmentation. (Want several scratchpad cards? Author them — each authored post
+   seeds its own conversation.)
 4. **Extraction latency.** A brand-new message becomes a conversation card
    asynchronously (outbox → worker → LLM). A just-posted topic appears after a
    short delay, not instantly.
@@ -172,6 +172,7 @@ Curation, then, is mostly _picking the lens_ — plus explicit save/pin for the
 manual override. And like the quiet collector learns from dismissals, the
 personal lens can get smarter over time (later). The structural lenses are free
 today; personal lenses need a per-viewer join (mentions/saved/participation).
+**Decided:** of the personal lenses, **Mine** ships first; Saved comes later.
 
 ## Default posture per stream type — the Q4 you asked me to explain
 
@@ -184,8 +185,9 @@ Q3, it mostly resolves:
   channel/DM you usually want the live conversation; the board is there when you
   want to triage. Revisit per-type later (a high-traffic channel or a
   knowledge-base stream might prefer board-default).
-- **Scratchpads → timeline only for now** (the one-conversation limitation
-  above) until per-scratchpad topic segmentation exists.
+- **Scratchpads → timeline default; one card on the board** (one conversation
+  per scratchpad, by decision). Author extra posts to a scratchpad for more
+  cards; no AI segmentation planned.
 
 ## Architecture sketch (reuse-first)
 
@@ -229,12 +231,13 @@ alongside as enrichment. Then:
 
 2. **Lenses + scope.** Structural lenses first (Active / Needs-resolution /
    Decisions — all from existing signals), then scope filter (per channel / DMs
-   / label), then personal lenses (Mine / Saved — need per-viewer joins).
+   / label), then the **Mine** personal lens (Saved later — needs a per-viewer
+   join).
 3. **Full act-from-the-board + corrections.** Reply in place, mark resolved,
    save/pin, plus the maturity corrections (retitle / merge / split) that feed
-   the eval loop. Reuses existing compose + reassign + saved paths. Per-scratchpad
-   topic segmentation for the _derived_ path becomes optional, since authored
-   posts already make scratchpad boards work.
+   the eval loop. Reuses existing compose + reassign + saved paths.
+   Per-scratchpad topic segmentation is **not planned** (scratchpad = one
+   conversation, by decision).
 
 ## The board as the forcing function for conversation maturity (Kris's reframe)
 
@@ -279,16 +282,20 @@ primitive. Worth a zeroth step: **measure the current floor** — sample real
 conversations (read-only) for title quality, null rate, cluster size, and status
 distribution, so "is it mature enough?" gets a number instead of a guess.
 
-## Open decisions remaining
+## Decisions (resolved 2026-06-22)
 
-1. **Null-title fallback** — entrypoint first-line (my lean) vs. hide untitled
-   vs. force a title-generation pass?
-2. **Scratchpad gap** — ship board for channels/DMs first and treat scratchpad
-   segmentation as later work, or invest in segmentation up front (it's the
-   solo-first surface)?
-3. **Lens priority** — confirm the structural set (Active / Needs-resolution /
-   Decisions) for phase 2; which personal lens matters most (Mine vs. Saved)?
-4. **Mutability UX** — how loud should "this card merged/retitled" be, if at all?
+1. **Null-title fallback** → a stripped **excerpt of the first message** (not
+   "Untitled"; no hiding, no extra generation pass).
+2. **Scratchpad gap** → **accept one conversation per scratchpad**; no
+   segmentation work. Multiple scratchpad cards come from authored posts.
+3. **First personal lens** → **Mine** (Saved later). Structural set confirmed:
+   Active / Needs-resolution / Decisions.
+4. **Mutability UX** → **skip** surfacing "merged/retitled" notices for now
+   (such notes get ignored anyway).
+
+With these, the design is settled. What remains is execution: **(0)** measure
+the derived-conversation floor (read-only), then **(1b)** build the authored
+board.
 
 ---
 

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -1,0 +1,172 @@
+# Exploration: The Board — a second way to interact with a stream
+
+Status: exploration / design. Sibling to
+[`nonlinear-stream-views-exploration.md`](./nonlinear-stream-views-exploration.md),
+which argues a stream is a container and the timeline is one projection. This
+doc takes the **board** projection seriously as a co-equal interaction mode and
+as the in-stream home for "find what matters." No code yet.
+
+## The thesis
+
+The timeline answers _"what is being said, in order."_ The board answers
+_"what matters in here, right now."_ Same stream, same access boundary
+(INV-62), two ways to interact:
+
+- **Timeline** — chronological, contiguous (INV-61), append-only feel. The room.
+- **Board** — posts as durable, resurfacing units ordered by what matters, not
+  by when they were typed. The pinboard / forum on the wall of that room.
+
+Both are first-class. A user toggles between them per stream; neither is "the
+real one." This is the same move Linear makes with list vs. board, or GitHub
+with the issues list vs. a project board — one dataset, two postures.
+
+## Why the board is where "find what matters" grows up
+
+Threa already _has_ a "find what matters" layer, but it lives **above** the
+stream — cross-workspace and ambient:
+
+- Sidebar **Important** section + urgency strip — "automatic organization that
+  surfaces what matters" (`docs/design-system.md:824`, `:753-799`).
+- The **quiet collector** — tier-2 GAM extraction lands per-assignee to-do
+  suggestions in the `/saved` _Suggested_ tab; pull-only, no badge
+  (`saved-suggestions/service.ts:39-45`, `config.ts:81-104`).
+- **Memory explorer** — surfaces extracted memos across streams (`/memory`).
+
+What's missing is the **mid-altitude** surface: _"within this stream, what
+matters?"_ The timeline can't answer that — it's strictly chronological, so the
+important decision from Tuesday is buried under today's chatter. The board is
+exactly that altitude. It can rank and group a single stream's content by
+signals Threa already computes, turning "find what matters" from an
+ambient/global feature into something you can _stand inside a stream and do_.
+
+The signals already exist (nothing new on the write path):
+
+| Signal             | Source (existing)                                                                                   | Board use                        |
+| ------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------- |
+| Last activity      | `threadSummary.lastReplyAt` (`domain.ts:413-429`)                                                   | resurface old posts on new reply |
+| Heat               | `replyCount`, `participants[≤3]` (`streams/repository.ts:992-1066`)                                 | rank busy posts                  |
+| Topic state        | conversations `status` ACTIVE/STALLED/RESOLVED, `completenessScore` (`conversations/repository.ts`) | "needs resolution" / "open" lens |
+| Captured knowledge | GAM memos w/ `knowledgeType` decision/fact (`memory`)                                               | "decisions" lens, post badges    |
+| Explicit intent    | saved items + quiet-collector suggestions (`saved-suggestions`)                                     | "action items" lens              |
+
+So the board's default ordering is **last activity** (Theo's "old post comes
+back to the top"), but its _reason for existing_ is that it's the one surface
+where those five signals can compose into lenses: **Active · Unanswered ·
+Decisions · Needs resolution · Mine**.
+
+## The one real design fork: what is a "post"?
+
+In Threa a reply creates a **thread** = a child stream hanging off a _message_
+(`parentStreamId` = the stream, `parentMessageId` = the message it replies to,
+`rootStreamId` = the root). A timeline message with `replyCount > 0` already
+renders as a `ThreadCard` (`timeline/thread-card.tsx:11-50`). So a "post" is
+naturally **a top-level message + its thread**. The fork is which top-level
+messages count:
+
+- **A) Every top-level message is a post.** Truest Facebook analog; board =
+  the timeline re-sorted by activity. Downside: every "lol" is a post; the board
+  is noisy and stops being a "what matters" surface.
+- **B) Only messages that have attracted a thread (`replyCount > 0`) are
+  posts.** Board = the subset that became conversations. Naturally a "what
+  matters" filter — things people engaged with. Downside: a brand-new important
+  post with no replies yet is invisible until someone replies.
+- **C) Hybrid (recommended): a post is a top-level message that is _either_
+  thread-bearing, saved, or carries a captured memo / is an open question.** The
+  board is "what matters," sourced from engagement _and_ Threa's own signals.
+  Start from B's query, union in saved/memo'd/flagged messages.
+
+Recommendation: ship **B** as the MVP (cheapest — it's exactly
+`findThreadSummaries` ordered differently), evolve to **C** as the "find what
+matters" lenses land. Avoid A; a re-sorted firehose isn't a new mode.
+
+Note this reuses existing primitives — no new "post" entity (INV-36 / INV-49).
+A post is a message; a thread is its comments; nesting is already unlimited.
+
+## Architecture sketch (reuse-first)
+
+### Route — a real segment, not a query param (INV-59)
+
+Timeline stays `s/:streamId`; board is `s/:streamId/board`. Distinct segments
+for a small fixed view set, per INV-59 ("URLs read naturally"). The toggle is a
+`<Link>`/`navigate()` between segments (INV-40); the view hook reads
+`useParams()` and defaults to timeline for the bare path. Today the stream page
+is one lazy route (`routes/index.tsx:122-125`); add a `board` child.
+
+### Data — one new ordered read, everything else exists
+
+The summary type and per-thread aggregation already exist
+(`streams/repository.ts:992-1066` `findThreadSummaries` → `Map<messageId,
+ThreadSummary>`, participants capped at 3 in SQL). The board needs the same
+shape but **ordered by `lastReplyAt` across the whole stream with pagination**,
+not keyed by a caller-supplied message-id set:
+
+```
+StreamRepository.listPosts(db, { rootStreamId, orderBy: 'lastReplyAt', limit, cursor, lens? })
+  -> { posts: Array<{ message, threadSummary }>, nextCursor }
+```
+
+A repository read (INV-5), called by a `BoardService` (INV-6), behind a thin
+handler `GET /streams/:streamId/board` (INV-34, Zod-validated query INV-55).
+Access is enforced with the canonical `checkStreamAccess` /
+`listAccessibleStreamIds` on the root (INV-62) — never a raw `stream_members`
+filter.
+
+### Live updates — reuse the stream's sync, don't bootstrap twice
+
+When you're in a stream the timeline is already bootstrapped and the socket room
+joined (subscribe-then-bootstrap, INV-53; events land in IDB via the
+`SocketEventGate`). Two layers:
+
+1. **Posts already on screen stay live for free** — a new reply emits
+   `message:updated { updateType: "reply_count", threadSummary }`
+   (`messaging/event-service.ts:355-377`); the board re-sorts on it instead of
+   leaving the card pinned. That single event _is_ the resurface signal.
+2. **The full ordered list** (incl. old posts outside the loaded timeline
+   window) comes from the board endpoint, bootstrapped activity-feed style
+   (`use-activity.ts`: `staleTime: Infinity`, `refetchOnMount`, invalidate on
+   socket event). The board query is invalidated on `message:created` /
+   `message:updated` for the room, same pattern as the activity feed.
+
+This keeps INV-61 untouched: the board is a separate projection; the contiguous
+timeline window keeps its `sequence`/`broadcastSequence` ordering. Resurfacing
+is forbidden in the timeline and free in the board precisely because they're
+different projections (the central claim of the sibling doc).
+
+### Component — `ThreadCard` is already the post card
+
+`ThreadCard` renders participants, reply count, latest-reply preview (stripped
+via `truncateContent`, INV-60), and relative time
+(`timeline/thread-card.tsx`). A `PostCard` is a thin wrapper: same body, plus
+the post's own author/first line as a title and (phase 2) lens badges
+(decision / unanswered / action). It returns null at `replyCount: 0` today, so
+moving to hybrid (C) means lifting that guard for saved/memo'd posts.
+
+## Phasing
+
+1. **Read-only recency board (MVP).** Fork B. `s/:streamId/board` lists
+   thread-bearing posts by `lastReplyAt`, re-sorting live on `message:updated`.
+   Proves the "container + projection" thesis and Theo's resurface behavior with
+   zero write-path or INV-61 risk. ~one repo read + one handler + one page,
+   reusing `ThreadCard` and the activity-feed bootstrap pattern.
+2. **"Find what matters" lenses.** Add Active / Unanswered / Decisions / Needs
+   resolution / Mine, each a `lens` param mapping to existing signals
+   (conversations `status`, memos `knowledgeType`, saved, mentions). This is the
+   payoff — the board becomes the per-stream "what matters" surface.
+3. **Post-first composition.** A "New post" affordance that starts a top-level
+   message _intended_ as a post (and optionally opens its thread immediately),
+   so the board is somewhere you _act_, not just read. Reuses the existing
+   compose + thread-create paths.
+
+## Open decisions (yours)
+
+1. **Post primitive** — B (thread-bearing only) for MVP, evolving to C
+   (+ saved/memo'd/flagged)? Or do you want A (every message) for a purer
+   Facebook feel? _Lean: B → C._
+2. **Lens set** — which of Active / Unanswered / Decisions / Needs-resolution /
+   Mine matter most for "find what matters"? Drives phase 2 scope.
+3. **Scope** — per-stream board only, or also a **workspace-wide board** (a
+   cross-stream "wall" of what matters everywhere — the activity feed's serious
+   sibling)? Per-stream first is the safe start.
+4. **Default posture per stream type** — channels default to board, scratchpads
+   to timeline, DMs to timeline? (Solo-first: scratchpad board could be a strong
+   personal "what matters" surface.)

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -6,11 +6,13 @@ which argues a stream is a container and the timeline is one projection. This
 doc designs the **board** as a co-equal interaction mode and as the home for
 "find what matters." No code yet.
 
-> **v2 pivot (after Kris's input + a code audit of the conversations
-> primitive):** the board's "post" is a **conversation** (Threa's AI-derived
-> topic cluster), not a thread; and the headline surface is a **workspace-wide
-> board as your entrypoint**, with per-stream as a scoped filter of the same
-> thing. v1's thread-as-post framing is preserved at the bottom as a fallback.
+> **v3 (after Kris's "turn it on its head"):** the board's "post" is a
+> **conversation**, but conversations are now seeded **two ways** — _authored_
+> (posting from the board declares a new topic; no AI needed) and _derived_ (AI
+> clustering, as before). Authored-first makes the board good from day one and
+> retires the maturity caveats. Headline surface stays a **workspace-wide board
+> as your entrypoint**, per-stream a scoped filter. v1's thread-as-post framing
+> is the de-risking appendix.
 
 ## The thesis
 
@@ -71,6 +73,57 @@ which is the whole "automatic organization that surfaces what matters" ethos
 4. **Extraction latency.** A brand-new message becomes a conversation card
    asynchronously (outbox → worker → LLM). A just-posted topic appears after a
    short delay, not instantly.
+
+## Turning it on its head: authored posts seed conversations (Kris's inversion)
+
+The biggest unlock in this thread. Instead of conversations being _only_
+derived (AI clusters timeline messages → board reads them), let **posting from
+the board start a conversation**. The post is the human-declared boundary: "this
+is a new topic." Its replies live in its thread; that thread _is_ the
+conversation.
+
+This unifies the two origins into one card type:
+
+- **Authored** — you click "New post", write it (and optionally title it). That
+  creates a conversation seeded with the post; replies attach to its thread. The
+  boundary is **declared, not inferred** — no AI required.
+- **Derived** — organic timeline messages still get auto-clustered as today.
+  Quality-dependent, but no longer load-bearing: it's the "we also catch what
+  you didn't explicitly post" bonus on top.
+
+**Why this is the right move: it retires the three caveats** — for authored
+posts, _the AI doesn't have to be great._
+| Caveat (derived-only) | Authored post |
+| --- | --- |
+| Null titles | You write the title (or its first line is the title). Never "Untitled". |
+| Mutable / merges under you | An authored post is a stable artifact; nothing re-clusters it. |
+| Scratchpads = one conversation | You post discrete topics to the scratchpad board → many posts, no AI segmentation needed. The solo-first gap dissolves. |
+
+It also reconciles the two instincts that were in tension: Theo's "**write a
+post**" (deliberate authoring, nested comments, resurfaces on reply) _and_
+Threa's "automatic organization that surfaces what matters" (derived
+conversations) — same board, both feed it. And every authored post is clean,
+human-labeled data, which makes the forcing-function loop below even stronger.
+
+**What it costs (the honest mechanics):**
+
+- A board post = create a message + open its thread (both exist) + **materialize
+  a conversation row** seeded with that message and `topicSummary = the title`.
+  Conversation creation exists only inside the extraction worker today
+  (`boundary-extraction-service.ts`), so this needs a direct
+  "create-conversation-from-message" service path + endpoint (modest).
+- The boundary-extraction worker must **not re-cluster an authored message** —
+  it needs to respect an explicit/locked assignment (a flag on the message or
+  conversation, or "skip messages with a human-declared boundary"). Small
+  addition, but real, and it's the load-bearing correctness bit (INV-20-style:
+  the human assignment wins over the async AI pass).
+- For authored posts where the thread is the conversation, the
+  thread↔conversation relationship is 1:1; derived conversations stay
+  many-messages-in-a-stream. The card renders the same either way.
+
+This is a strong enough reframe that **authored posting becomes the robust core
+of the board, and derived conversations ride alongside** — flipping the risk
+profile (see Phasing/Sequencing below).
 
 ## The workspace board as your entrypoint (Q3)
 
@@ -156,18 +209,32 @@ Q3, it mostly resolves:
 
 ## Phasing
 
-1. **Read-only workspace board (MVP).** `findByWorkspace` → endpoint
-   (access-filtered) → a page rendering conversation cards by `lastActivityAt`,
-   live via existing socket events. Default **Active** lens, **scope = all**.
-   Proves the entrypoint thesis with no write-path or INV-61 risk; titles fall
-   back to entrypoint first-line when null.
+The inversion changes the order. Two candidate entry points:
+
+- **0. Measure the floor (read-only, no build).** Pull a real sample of derived
+  conversations (read-only prod DB) → null-title rate, cluster sizes, status
+  distribution. Answers "how immature is it _today_" with a number, and tells us
+  how much the board would lean on authored vs derived. Cheap, do first.
+- **1a. Read-only derived board.** `findByWorkspace` → access-filtered endpoint
+  → page reusing `conversation-item`/`conversation-list`, Active lens, live via
+  existing sockets. Cheapest code, but quality rides on the AI; doubles as a
+  visual version of step 0.
+- **1b. Authored board (the robust core).** "New post" → create message + thread
+  - materialized conversation (titled) + extractor-skip-authored. More code, but
+    **deterministic and good from day one**, and it's the thing that makes the
+    board independent of AI quality. This is the real product.
+
+Recommended path: **0 → 1b**, letting derived conversations (1a's read) flow in
+alongside as enrichment. Then:
+
 2. **Lenses + scope.** Structural lenses first (Active / Needs-resolution /
    Decisions — all from existing signals), then scope filter (per channel / DMs
    / label), then personal lenses (Mine / Saved — need per-viewer joins).
-3. **Act from the board.** Open a conversation in place, reply to its
-   entrypoint, mark resolved, save/pin — so the board is somewhere you _work_,
-   not just scan. Reuses existing compose + reassign + saved paths.
-   (Later/maybe: per-scratchpad topic segmentation so scratchpad boards work.)
+3. **Full act-from-the-board + corrections.** Reply in place, mark resolved,
+   save/pin, plus the maturity corrections (retitle / merge / split) that feed
+   the eval loop. Reuses existing compose + reassign + saved paths. Per-scratchpad
+   topic segmentation for the _derived_ path becomes optional, since authored
+   posts already make scratchpad boards work.
 
 ## The board as the forcing function for conversation maturity (Kris's reframe)
 
@@ -196,9 +263,10 @@ The feedback loop is already half-built:
 
 ### Sequencing to de-risk (the one caution)
 
-If conversations are currently rough, making them the _default_ entrypoint on
-day one risks a wall of "Untitled" / mis-clustered cards — the product feeling
-broken. So promote in reversible stages:
+The inversion above softens this a lot: an **authored**-first board is clean
+from day one, so the staging below really applies to how much weight we put on
+the **derived** cards. If we lead with derived-only, the risk stands — a wall of
+"Untitled" / mis-clustered cards feels broken — so promote in reversible stages:
 
 1. **Secondary surface** — board ships as a nav item you open deliberately, not
    the landing page. Dogfood it; use the corrections; watch quality climb.

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -293,9 +293,45 @@ distribution, so "is it mature enough?" gets a number instead of a guess.
 4. **Mutability UX** → **skip** surfacing "merged/retitled" notices for now
    (such notes get ignored anyway).
 
-With these, the design is settled. What remains is execution: **(0)** measure
-the derived-conversation floor (read-only), then **(1b)** build the authored
-board.
+With these, the design is settled. Step **(0)** — measure the floor — is now
+done (below); what remains is **(1b)** build the authored board.
+
+## Floor measurement — real prod data (2026-06-22)
+
+Read-only pull (`cc_readonly`) over the live `conversations` table to size how
+much the _derived_ path can carry. Scale: **625 conversations / 2 workspaces /
+210 streams / 390 memos.**
+
+**Verdict: derived is more mature than feared on the things that gate a board —
+titles exist, clustering is real, the lifecycle runs. The actual gaps are title
+_quality_ and scratchpad generic titles — both prompt/fallback fixes, not
+architecture.**
+
+- **Titles present, 0% null.** The "wall of Untitled" risk is empirically ~zero.
+  But quality drifts: ~33% of titles run >8 words and lead with "Discussion
+  about …" framing (the `topicSummary` spec says 2–5 words, _no_ framing — it's
+  being ignored); casual one-line messages yield fragment-titles (the message
+  text itself). Only ~23% land in the 3–5-word sweet spot. → cheap pre-work win:
+  tighten the topic-summary prompt; it isn't following its own spec.
+- **Clustering is substantial.** 60% of conversations hold 4–20 messages; 17%
+  singletons, 3% empty shells. Not noise.
+- **Lifecycle works.** 70% active / 25% resolved / 5% stalled — resolution
+  actually happens (feeds the Needs-resolution lens and the resolved state).
+- **Scratchpads = exactly 1 conversation each** (105 scratchpads, 1 convo each)
+  — confirms the decision precisely. But each is titled "Scratchpad" (the stream
+  name), so the board's scratchpad slice would be 105 identical cards. → refine
+  decision #1: apply the first-message-excerpt fallback to the generic
+  "Scratchpad" title too, not just to null.
+- **Heavy concentration.** 454 of 485 DM conversations live in a single DM (an
+  AI-persona DM). A workspace board with no scope filter would be flooded by one
+  stream → the scope/lens filter is load-bearing, not optional.
+- **Memo coverage 11%** (69/625) — modest but real fuel for the Decisions lens.
+- **Realistic Active board ≈ 430 cards** (331 with ≥1 reply) — browsable; not
+  empty, not absurd.
+
+Net: green-light leaning on derived for channels/DMs; extend the title fallback
+to generic scratchpad names; and a quick topic-summary prompt-tightening pass is
+the highest-leverage pre-work before (or alongside) 1b.
 
 ---
 

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -169,6 +169,48 @@ Q3, it mostly resolves:
    not just scan. Reuses existing compose + reassign + saved paths.
    (Later/maybe: per-scratchpad topic segmentation so scratchpad boards work.)
 
+## The board as the forcing function for conversation maturity (Kris's reframe)
+
+Kris isn't sure conversations are mature enough yet — and that's exactly the
+point. Today conversations live in an _optional_ overlay
+(`convOverlay`/`convView`), so their quality is never under pressure; nobody is
+forced to confront a bad title or a mis-merge. Make conversations your
+**entrypoint** and their quality suddenly _matters_, every day, to the person
+most able to fix it. The board is the accountability surface that drags the
+primitive to maturity. The order of causation flips: **we don't wait for
+conversations to be good before building the board; the board is how they become
+good.**
+
+The feedback loop is already half-built:
+
+- The overlay already has a per-message **reassign** correction ("this message
+  belongs to…", desktop dropdown + mobile picker) — human-in-the-loop
+  relabeling exists today (`conversation-overlay`).
+- The board adds higher-altitude corrections — **retitle**, **merge**,
+  **split**, **mark resolved** — all already expressible as reassignments +
+  status writes, no new primitive.
+- Every correction is a **labeled example**: the board turns daily use into an
+  eval set for the boundary-extraction and topic-summary prompts (INV-44/45 —
+  evals call production entry points). Like the quiet collector learning from
+  dismissals, conversations improve the more the board is used.
+
+### Sequencing to de-risk (the one caution)
+
+If conversations are currently rough, making them the _default_ entrypoint on
+day one risks a wall of "Untitled" / mis-clustered cards — the product feeling
+broken. So promote in reversible stages:
+
+1. **Secondary surface** — board ships as a nav item you open deliberately, not
+   the landing page. Dogfood it; use the corrections; watch quality climb.
+2. **Quality bar** — define a floor from real data (null-title rate, correction
+   rate, % conversations carrying a memo) before promoting.
+3. **Promote to entrypoint** once the floor is cleared.
+
+Keeps the forcing-function benefit without betting the front door on an immature
+primitive. Worth a zeroth step: **measure the current floor** — sample real
+conversations (read-only) for title quality, null rate, cluster size, and status
+distribution, so "is it mature enough?" gets a number instead of a guess.
+
 ## Open decisions remaining
 
 1. **Null-title fallback** — entrypoint first-line (my lean) vs. hide untitled

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -1,172 +1,196 @@
 # Exploration: The Board — a second way to interact with a stream
 
-Status: exploration / design. Sibling to
+Status: exploration / design, v2. Sibling to
 [`nonlinear-stream-views-exploration.md`](./nonlinear-stream-views-exploration.md),
 which argues a stream is a container and the timeline is one projection. This
-doc takes the **board** projection seriously as a co-equal interaction mode and
-as the in-stream home for "find what matters." No code yet.
+doc designs the **board** as a co-equal interaction mode and as the home for
+"find what matters." No code yet.
+
+> **v2 pivot (after Kris's input + a code audit of the conversations
+> primitive):** the board's "post" is a **conversation** (Threa's AI-derived
+> topic cluster), not a thread; and the headline surface is a **workspace-wide
+> board as your entrypoint**, with per-stream as a scoped filter of the same
+> thing. v1's thread-as-post framing is preserved at the bottom as a fallback.
 
 ## The thesis
 
 The timeline answers _"what is being said, in order."_ The board answers
-_"what matters in here, right now."_ Same stream, same access boundary
-(INV-62), two ways to interact:
+_"what matters, right now."_ Same content, same access boundary (INV-62), two
+postures:
 
-- **Timeline** — chronological, contiguous (INV-61), append-only feel. The room.
-- **Board** — posts as durable, resurfacing units ordered by what matters, not
-  by when they were typed. The pinboard / forum on the wall of that room.
+- **Timeline** — chronological, contiguous (INV-61), append-only. The room.
+- **Board** — topics as durable, resurfacing cards ordered by what matters, not
+  by when they were typed. The pinboard on the wall.
 
-Both are first-class. A user toggles between them per stream; neither is "the
-real one." This is the same move Linear makes with list vs. board, or GitHub
-with the issues list vs. a project board — one dataset, two postures.
+Neither is "the real one." Linear does this with list vs. board; GitHub with
+the issues list vs. a project board — one dataset, two views.
 
-## Why the board is where "find what matters" grows up
+## The post = a conversation (verified viable)
 
-Threa already _has_ a "find what matters" layer, but it lives **above** the
-stream — cross-workspace and ambient:
+In Threa a reply creates a **thread** (a child stream off a message), so the
+obvious "post" is a thread. But Threa already derives a richer unit: a
+**conversation** — an AI-clustered topic _within_ a stream
+(`boundary-extraction-service.ts`). Kris's instinct was to use that as the post,
+and a code audit says it holds up:
 
-- Sidebar **Important** section + urgency strip — "automatic organization that
-  surfaces what matters" (`docs/design-system.md:824`, `:753-799`).
-- The **quiet collector** — tier-2 GAM extraction lands per-assignee to-do
-  suggestions in the `/saved` _Suggested_ tab; pull-only, no badge
-  (`saved-suggestions/service.ts:39-45`, `config.ts:81-104`).
-- **Memory explorer** — surfaces extracted memos across streams (`/memory`).
+| Need a post must meet    | Conversation today                                                                                                            | Cite                                             |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Stable identity          | `conv_` ULID, persists across reassign/merge/split; emptied → `resolved` shell (undo target), never deleted                   | `repository.ts:470-494`                          |
+| A title to render        | `topicSummary` — a 2–5 word, language-aware topic name (nullable → "Untitled")                                                | `boundary-extraction/config.ts:77-83`            |
+| An entrypoint message    | `messageIds[0]` (first _assigned_; ~chronological)                                                                            | `domain.ts:602`                                  |
+| Resurface on activity    | `lastActivityAt`, bumped on every touch; already the `ORDER BY` of list queries                                               | `repository.ts:497-504`                          |
+| Built-in "matters" state | `status` active/stalled/resolved · `completenessScore` 1–7 · read-time `temporalStaleness`/`effectiveCompleteness`            | `constants.ts:308-315`, `staleness.ts`           |
+| Works beyond channels    | runs on channels, **DMs**, threads, **scratchpads** — all non-E2E streams, user messages only                                 | `boundary-extraction-outbox-handler.ts:23-53`    |
+| Card UI already built    | `conversation-item.tsx` (StatusBadge, 7-seg completeness), `conversation-list.tsx` (sectioned by status), live socket updates | `use-conversations.ts`                           |
+| Knowledge link           | memos carry `source_conversation_id`; "decisions captured here" is one join                                                   | `memos` migration `:16`, `repository.ts:325-341` |
 
-What's missing is the **mid-altitude** surface: _"within this stream, what
-matters?"_ The timeline can't answer that — it's strictly chronological, so the
-important decision from Tuesday is buried under today's chatter. The board is
-exactly that altitude. It can rank and group a single stream's content by
-signals Threa already computes, turning "find what matters" from an
-ambient/global feature into something you can _stand inside a stream and do_.
+**Why this beats thread-as-post.** Conversations _subsume_ threads (a
+conversation spans a root message and its thread replies via
+`findByStreamIncludingThreads`), they exist in DMs and scratchpads where threads
+may not, they're **authored automatically** (no one has to remember to start a
+thread), and they ship with the exact state machine "find what matters" wants.
+It's also more Threa than Facebook: posts are _discovered_, not manually posted —
+which is the whole "automatic organization that surfaces what matters" ethos
+(`design-system.md:824`).
 
-The signals already exist (nothing new on the write path):
+**Honest caveats (decisions, not blockers):**
 
-| Signal             | Source (existing)                                                                                   | Board use                        |
-| ------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------- |
-| Last activity      | `threadSummary.lastReplyAt` (`domain.ts:413-429`)                                                   | resurface old posts on new reply |
-| Heat               | `replyCount`, `participants[≤3]` (`streams/repository.ts:992-1066`)                                 | rank busy posts                  |
-| Topic state        | conversations `status` ACTIVE/STALLED/RESOLVED, `completenessScore` (`conversations/repository.ts`) | "needs resolution" / "open" lens |
-| Captured knowledge | GAM memos w/ `knowledgeType` decision/fact (`memory`)                                               | "decisions" lens, post badges    |
-| Explicit intent    | saved items + quiet-collector suggestions (`saved-suggestions`)                                     | "action items" lens              |
+1. **Mutable posts.** A conversation can be retitled, merged, or split by the
+   next extraction pass. A card you saw yesterday may have absorbed another or
+   changed its name. Fine for a living "what matters" wall; worth a light "this
+   updates itself" mental model, not a fixed-artifact one.
+2. **Null titles.** `topicSummary` can be null → "Untitled conversation". A wall
+   of "Untitled" is bad. Mitigation: fall back to the entrypoint message's
+   stripped first line (INV-60) when title is null.
+3. **Scratchpads degenerate to one post.** The scratchpad path skips AI
+   segmentation and keeps a single conversation per scratchpad
+   (`boundary-extraction-service.ts:218-233`). So a scratchpad board = one card,
+   not a topic board. For a solo-first product this is the biggest gap — either
+   scope the board to channels/DMs first, or later enable topic segmentation for
+   scratchpads (a backend change).
+4. **Extraction latency.** A brand-new message becomes a conversation card
+   asynchronously (outbox → worker → LLM). A just-posted topic appears after a
+   short delay, not instantly.
 
-So the board's default ordering is **last activity** (Theo's "old post comes
-back to the top"), but its _reason for existing_ is that it's the one surface
-where those five signals can compose into lenses: **Active · Unanswered ·
-Decisions · Needs resolution · Mine**.
+## The workspace board as your entrypoint (Q3)
 
-## The one real design fork: what is a "post"?
+Kris: _"a workspace-wide board could be your entrypoint, where a filter/lens
+could be per-stream/channel."_ Agreed — make that the headline, not an add-on:
 
-In Threa a reply creates a **thread** = a child stream hanging off a _message_
-(`parentStreamId` = the stream, `parentMessageId` = the message it replies to,
-`rootStreamId` = the root). A timeline message with `replyCount > 0` already
-renders as a `ThreadCard` (`timeline/thread-card.tsx:11-50`). So a "post" is
-naturally **a top-level message + its thread**. The fork is which top-level
-messages count:
+- **Primary surface:** a workspace-wide board — a cross-stream wall of
+  conversation cards, ordered by `lastActivityAt`, with a **lens** selector and
+  a **scope** filter (all / one channel / DMs / a label).
+- **Per-stream board:** the same view scoped to one stream — a special case, not
+  a separate feature.
+- This is the activity feed's serious sibling: activity is a flat event log
+  ("who pinged me"); the board is the _topic_ log ("what threads of work are
+  alive"). It's a landing surface you _act_ from, not just read.
 
-- **A) Every top-level message is a post.** Truest Facebook analog; board =
-  the timeline re-sorted by activity. Downside: every "lol" is a post; the board
-  is noisy and stops being a "what matters" surface.
-- **B) Only messages that have attracted a thread (`replyCount > 0`) are
-  posts.** Board = the subset that became conversations. Naturally a "what
-  matters" filter — things people engaged with. Downside: a brand-new important
-  post with no replies yet is invisible until someone replies.
-- **C) Hybrid (recommended): a post is a top-level message that is _either_
-  thread-bearing, saved, or carries a captured memo / is an open question.** The
-  board is "what matters," sourced from engagement _and_ Threa's own signals.
-  Start from B's query, union in saved/memo'd/flagged messages.
+**The one real build for this:** a workspace-wide conversation list endpoint.
+`ConversationRepository.findByWorkspace` already exists
+(`repository.ts:270-294`) but is **not wired to any route** — current routes are
+strictly stream-scoped (`routes.ts:484-490`). So the spine query exists; it
+needs an HTTP endpoint plus access filtering via `listAccessibleStreamIds`
+(INV-62), never a raw `stream_members` filter.
 
-Recommendation: ship **B** as the MVP (cheapest — it's exactly
-`findThreadSummaries` ordered differently), evolve to **C** as the "find what
-matters" lenses land. Avoid A; a re-sorted firehose isn't a new mode.
+## Lenses — what I meant, and your "matters is personal" point (Q2)
 
-Note this reuses existing primitives — no new "post" entity (INV-36 / INV-49).
-A post is a message; a thread is its comments; nesting is already unlimited.
+A **lens** is a saved filter+sort over the board, each backed by a signal Threa
+_already_ computes — so the board doesn't decide what matters, it gives you the
+dials. Your point that "what matters is a question for the person" is exactly
+right, so split the dials in two:
+
+**Structural lenses (same signal for everyone):**
+
+- **Active** (default) — `lastActivityAt` desc. The resurfacing wall.
+- **Needs resolution** — `status = stalled`, or high `temporalStaleness` with
+  low `completenessScore`. Loose ends, things hanging.
+- **Decisions / Knowledge** — conversations with a captured memo
+  (`source_conversation_id`, `knowledgeType` decision/fact). What got settled.
+
+**Personal lenses (per-viewer — "matters to _you_"):**
+
+- **Mine / For you** — conversations you authored, participate in
+  (`participantIds`), are @-mentioned in, or have a quiet-collector to-do
+  assigned in (`saved-suggestions`).
+- **Saved** — conversations you explicitly saved/pinned.
+
+Curation, then, is mostly _picking the lens_ — plus explicit save/pin for the
+manual override. And like the quiet collector learns from dismissals, the
+personal lens can get smarter over time (later). The structural lenses are free
+today; personal lenses need a per-viewer join (mentions/saved/participation).
+
+## Default posture per stream type — the Q4 you asked me to explain
+
+Q4 was: _when you open something, which mode do you land in by default?_ Given
+Q3, it mostly resolves:
+
+- **Workspace entrypoint → board.** Landing on "what matters across everything"
+  beats landing in one chronological room.
+- **An individual stream → timeline by default, board a toggle.** Inside one
+  channel/DM you usually want the live conversation; the board is there when you
+  want to triage. Revisit per-type later (a high-traffic channel or a
+  knowledge-base stream might prefer board-default).
+- **Scratchpads → timeline only for now** (the one-conversation limitation
+  above) until per-scratchpad topic segmentation exists.
 
 ## Architecture sketch (reuse-first)
 
-### Route — a real segment, not a query param (INV-59)
-
-Timeline stays `s/:streamId`; board is `s/:streamId/board`. Distinct segments
-for a small fixed view set, per INV-59 ("URLs read naturally"). The toggle is a
-`<Link>`/`navigate()` between segments (INV-40); the view hook reads
-`useParams()` and defaults to timeline for the bare path. Today the stream page
-is one lazy route (`routes/index.tsx:122-125`); add a `board` child.
-
-### Data — one new ordered read, everything else exists
-
-The summary type and per-thread aggregation already exist
-(`streams/repository.ts:992-1066` `findThreadSummaries` → `Map<messageId,
-ThreadSummary>`, participants capped at 3 in SQL). The board needs the same
-shape but **ordered by `lastReplyAt` across the whole stream with pagination**,
-not keyed by a caller-supplied message-id set:
-
-```
-StreamRepository.listPosts(db, { rootStreamId, orderBy: 'lastReplyAt', limit, cursor, lens? })
-  -> { posts: Array<{ message, threadSummary }>, nextCursor }
-```
-
-A repository read (INV-5), called by a `BoardService` (INV-6), behind a thin
-handler `GET /streams/:streamId/board` (INV-34, Zod-validated query INV-55).
-Access is enforced with the canonical `checkStreamAccess` /
-`listAccessibleStreamIds` on the root (INV-62) — never a raw `stream_members`
-filter.
-
-### Live updates — reuse the stream's sync, don't bootstrap twice
-
-When you're in a stream the timeline is already bootstrapped and the socket room
-joined (subscribe-then-bootstrap, INV-53; events land in IDB via the
-`SocketEventGate`). Two layers:
-
-1. **Posts already on screen stay live for free** — a new reply emits
-   `message:updated { updateType: "reply_count", threadSummary }`
-   (`messaging/event-service.ts:355-377`); the board re-sorts on it instead of
-   leaving the card pinned. That single event _is_ the resurface signal.
-2. **The full ordered list** (incl. old posts outside the loaded timeline
-   window) comes from the board endpoint, bootstrapped activity-feed style
-   (`use-activity.ts`: `staleTime: Infinity`, `refetchOnMount`, invalidate on
-   socket event). The board query is invalidated on `message:created` /
-   `message:updated` for the room, same pattern as the activity feed.
-
-This keeps INV-61 untouched: the board is a separate projection; the contiguous
-timeline window keeps its `sequence`/`broadcastSequence` ordering. Resurfacing
-is forbidden in the timeline and free in the board precisely because they're
-different projections (the central claim of the sibling doc).
-
-### Component — `ThreadCard` is already the post card
-
-`ThreadCard` renders participants, reply count, latest-reply preview (stripped
-via `truncateContent`, INV-60), and relative time
-(`timeline/thread-card.tsx`). A `PostCard` is a thin wrapper: same body, plus
-the post's own author/first line as a title and (phase 2) lens badges
-(decision / unanswered / action). It returns null at `replyCount: 0` today, so
-moving to hybrid (C) means lifting that guard for saved/memo'd posts.
+- **Routes (INV-59):** workspace board at a real segment, e.g. `/w/:ws/board`
+  (sibling to `/activity`, `/memory`); per-stream at `s/:streamId/board`. Toggle
+  via `<Link>`/`navigate()` (INV-40); view from `useParams()`.
+- **Backend:** wire `findByWorkspace` behind `GET /workspaces/:ws/board`
+  (handler thin INV-34, Zod query INV-55, `BoardService` owns the read INV-6),
+  access-filtered by `listAccessibleStreamIds` (INV-62). `lens`/`scope`/`cursor`
+  as query params. Per-stream reuses the existing `listByStream`.
+- **Frontend:** the card (`conversation-item`) and list (`conversation-list`)
+  components already exist; the board is a new page that reuses them in a
+  cross-stream layout. Bootstrap activity-feed style (`use-activity.ts`:
+  `staleTime: Infinity`, `refetchOnMount`), stay live via the existing
+  `conversation:created/updated` socket events already handled in
+  `use-conversations.ts` (INV-53).
+- **INV-61 untouched:** the board is a separate projection; the contiguous
+  timeline keeps its `sequence`/`broadcastSequence` order. Resurfacing is
+  forbidden in the timeline and free in the board precisely because they're
+  different projections.
 
 ## Phasing
 
-1. **Read-only recency board (MVP).** Fork B. `s/:streamId/board` lists
-   thread-bearing posts by `lastReplyAt`, re-sorting live on `message:updated`.
-   Proves the "container + projection" thesis and Theo's resurface behavior with
-   zero write-path or INV-61 risk. ~one repo read + one handler + one page,
-   reusing `ThreadCard` and the activity-feed bootstrap pattern.
-2. **"Find what matters" lenses.** Add Active / Unanswered / Decisions / Needs
-   resolution / Mine, each a `lens` param mapping to existing signals
-   (conversations `status`, memos `knowledgeType`, saved, mentions). This is the
-   payoff — the board becomes the per-stream "what matters" surface.
-3. **Post-first composition.** A "New post" affordance that starts a top-level
-   message _intended_ as a post (and optionally opens its thread immediately),
-   so the board is somewhere you _act_, not just read. Reuses the existing
-   compose + thread-create paths.
+1. **Read-only workspace board (MVP).** `findByWorkspace` → endpoint
+   (access-filtered) → a page rendering conversation cards by `lastActivityAt`,
+   live via existing socket events. Default **Active** lens, **scope = all**.
+   Proves the entrypoint thesis with no write-path or INV-61 risk; titles fall
+   back to entrypoint first-line when null.
+2. **Lenses + scope.** Structural lenses first (Active / Needs-resolution /
+   Decisions — all from existing signals), then scope filter (per channel / DMs
+   / label), then personal lenses (Mine / Saved — need per-viewer joins).
+3. **Act from the board.** Open a conversation in place, reply to its
+   entrypoint, mark resolved, save/pin — so the board is somewhere you _work_,
+   not just scan. Reuses existing compose + reassign + saved paths.
+   (Later/maybe: per-scratchpad topic segmentation so scratchpad boards work.)
 
-## Open decisions (yours)
+## Open decisions remaining
 
-1. **Post primitive** — B (thread-bearing only) for MVP, evolving to C
-   (+ saved/memo'd/flagged)? Or do you want A (every message) for a purer
-   Facebook feel? _Lean: B → C._
-2. **Lens set** — which of Active / Unanswered / Decisions / Needs-resolution /
-   Mine matter most for "find what matters"? Drives phase 2 scope.
-3. **Scope** — per-stream board only, or also a **workspace-wide board** (a
-   cross-stream "wall" of what matters everywhere — the activity feed's serious
-   sibling)? Per-stream first is the safe start.
-4. **Default posture per stream type** — channels default to board, scratchpads
-   to timeline, DMs to timeline? (Solo-first: scratchpad board could be a strong
-   personal "what matters" surface.)
+1. **Null-title fallback** — entrypoint first-line (my lean) vs. hide untitled
+   vs. force a title-generation pass?
+2. **Scratchpad gap** — ship board for channels/DMs first and treat scratchpad
+   segmentation as later work, or invest in segmentation up front (it's the
+   solo-first surface)?
+3. **Lens priority** — confirm the structural set (Active / Needs-resolution /
+   Decisions) for phase 2; which personal lens matters most (Mine vs. Saved)?
+4. **Mutability UX** — how loud should "this card merged/retitled" be, if at all?
+
+---
+
+## Appendix: v1 fallback — thread-as-post
+
+If conversations prove too mutable or too dependent on extraction quality, the
+board can fall back to **threads as posts**: top-level messages with
+`replyCount > 0`, ordered by `threadSummary.lastReplyAt`
+(`streams/repository.ts:992-1066`), rendered with the existing `ThreadCard`,
+re-sorting on the existing `message:updated` event
+(`messaging/event-service.ts:355-377`). Cheaper and fully deterministic, but
+loses DMs/scratchpads coverage, the built-in status/completeness state, and the
+"discovered, not authored" quality. Forks considered: (A) every top-level
+message — too noisy; (B) thread-bearing only; (C) hybrid + saved/memo'd. Kept
+here as the de-risking option, not the primary plan.

--- a/docs/nonlinear-stream-views-exploration.md
+++ b/docs/nonlinear-stream-views-exploration.md
@@ -1,0 +1,161 @@
+# Exploration: Streams as containers, the timeline as one projection
+
+Status: exploration / not a plan. No code changes proposed yet.
+
+## Where this came from
+
+Theo's "I don't have time to build these things" video (the Slack rant near the
+end) asks for **Facebook "workplaces"** — really the Facebook _post_ primitive:
+
+- A post sits _between_ a channel and a thread.
+- Top-level comments **plus arbitrarily nested** sub-comments — reply to two
+  people under one comment without clogging the main thread.
+- "Most importantly: when someone leaves a comment on an old post, that post
+  gets brought to the top." Everywhere else, replying to an old thread leaves it
+  buried.
+
+The reflex is to read this as a missing feature. It mostly isn't — Threa
+already has the hard parts:
+
+- **Unlimited thread nesting** — threads are sub-streams
+  (`parentStreamId`/`parentMessageId`, `rootStreamId`), graph structure
+  (`docs/core-concepts.md:38-45`).
+- **Reply-to-a-specific-message** — quote replies + per-message threads.
+- **Activity bumping** — a new message bumps its root stream to the top of the
+  sidebar (`sidebar/utils.ts:88-94`; `streams/repository.ts:587`
+  `ORDER BY COALESCE(lm.created_at, s.created_at) DESC`).
+
+The single behavior Threa does _not_ do is the "most important" one: inside a
+stream, a **thread card is pinned to its parent message's chronological slot and
+never resurfaces** when the thread gets a new reply
+(`timeline/stream-content.tsx:557-566`; the timeline is strictly
+`sequence`-ordered). The _data_ to resurface already exists —
+`threadSummary.lastReplyAt` + `replyCount`, refreshed on every reply via a
+`message:updated` outbox event (`messaging/event-service.ts:355-377`).
+
+## The reframe
+
+The interesting move is not "add post-resurfacing to the timeline." It is to
+stop treating the chronological timeline as _what a stream is_.
+
+> A stream is an **access-controlled organizational container**. The
+> chronological timeline is one **projection** over the content it holds, not
+> the content itself.
+
+This is already true in the code, just not stated as a principle:
+
+- Access is a property of the container, not the row. Visibility resolves
+  through `root_stream_id` to the nearest non-thread ancestor; threads carry no
+  access of their own (INV-62, `streams/access.ts`). So "where can this be
+  viewed" is decided by the container, independent of how rows are ordered.
+- `broadcastSequence` / contiguity (INV-61) is a property of **the timeline
+  projection specifically** — it governs `TIMELINE_BROADCAST_EVENT_TYPES` rows
+  in the dense per-stream window so a missing number is always a real gap. It is
+  _not_ a constraint on the underlying data. A different projection of the same
+  stream (sorted by last activity, grouped by topic, ranked by relevance) does
+  not touch the timeline window and therefore does not fight INV-61. This is the
+  key unlock: **"old post comes back to the top" is forbidden inside the
+  contiguous timeline, but free in any other view.**
+
+## Threa already ships a portfolio of non-linear projections
+
+The same message graph is already projected several non-chronological ways. A
+"Facebook board" view would be one more member of this family, not a new axis.
+
+| Projection                                     | What it's a view _of_            | Ordering                               | Scope         | Authored by          |
+| ---------------------------------------------- | -------------------------------- | -------------------------------------- | ------------- | -------------------- |
+| **Timeline** (`s/:streamId`)                   | one stream's events              | `sequence` (chronological, contiguous) | single stream | users                |
+| **Activity** (`/activity[:filter]`)            | mentions / messages / reactions  | recency `DESC`                         | cross-stream  | derived from events  |
+| **Memory** (`/memory`)                         | extracted memos (GAM)            | semantic rank + metadata facets        | cross-stream  | AI extraction        |
+| **Conversations**                              | topic clusters _within_ a stream | LLM boundary assignment + staleness    | within-stream | AI extraction        |
+| **Search** (`/search`)                         | raw messages                     | relevance                              | cross-stream  | query                |
+| **Saved / Scheduled** (`/saved`, `/scheduled`) | curated items                    | status / time                          | cross-stream  | explicit user action |
+
+Citations: activity `pages/activity.tsx`, `activity/repository.ts:22-37`;
+memory `pages/memory.tsx`, `api/memos.ts`; conversations
+`conversations/repository.ts:34-49`, `boundary-extraction-service.ts`,
+`staleness.ts`; search `pages/search.tsx`, `search/use-message-search.ts`;
+routing `routes/index.tsx:68-136` (INV-59).
+
+Two of these are especially relevant to the "post" idea:
+
+- **Conversations** already cluster a stream's messages by _inferred topic_
+  (not chronology), are **stateful** (`status` ACTIVE/STALLED/RESOLVED,
+  `completenessScore`, `confidence`), and already track **`lastActivityAt`**,
+  bumped on each new message (`bumpActivityForIds`). This is the closest thing
+  Threa has to a "post that resurfaces on new activity" — but it has **no
+  first-class view surface**; it lives in the extraction pipeline and feeds
+  staleness opacity, not a board the user can browse.
+- **Thread cards** already render a thread as a standalone post-like object —
+  title-ish snippet, participant avatar stack (≤3), `replyCount`, `lastReplyAt`,
+  an active-session pulse (`timeline/thread-card.tsx:11-100`). But there is **no
+  "all threads / all posts" list surface**; the card only exists embedded at its
+  parent message's slot in the timeline.
+
+So the two pieces a "Facebook board" needs — a resurfacing, stateful grouping
+(conversations) and a post-shaped card (thread cards) — both already exist and
+are both currently _trapped_ inside other surfaces.
+
+## The missing projection: a Board / Posts view of a stream
+
+A per-stream view (new URL segment under `s/:streamId`, e.g. `.../board`, per
+INV-59) that lists the stream's **top-level threads as posts**, ordered by
+**last activity**, so an old post returns to the top when it gets a new reply.
+
+What it reuses, with nothing new on the write path:
+
+- `threadSummary.lastReplyAt`, `replyCount`, participants — already computed and
+  pushed on every reply (`event-service.ts:355-377`).
+- The thread-card shape — already the post object.
+- `message:updated { updateType: "reply_count", threadSummary }` — already the
+  resurface signal; a board re-sorts on it instead of leaving the card pinned.
+- INV-61 untouched — the board is a separate projection; the contiguous
+  timeline keeps its `sequence` order.
+
+This is the smallest thing that delivers Theo's "most important" behavior
+without the architectural fight, _and_ it generalizes: the same surface could
+toggle ordering (recent activity / new posts / unanswered) or grouping (by
+participant, by label, by the existing conversation topic).
+
+## Wider design space (worth sitting with before committing)
+
+If a stream is a container with multiple projections, the question stops being
+"add a board" and becomes "what is the set of views, and how does the user
+move between them?"
+
+- **Board / Posts** — threads as resurfacing posts (above). The literal answer.
+- **Topics** — surface the existing _conversations_ clustering as a browsable
+  view: a stream as a set of living topics, each with status and staleness,
+  resurfacing on activity. Arguably more "Threa-native" than a Facebook clone,
+  since the clustering is automatic and doesn't depend on users manually
+  starting threads.
+- **Outline / map** — the nesting graph itself as a navigable structure
+  (collapse/expand the tree), for streams used as a knowledge base rather than a
+  chat.
+- **View switcher as a first-class concept** — every stream exposes
+  `timeline | board | topics | …` and remembers per-stream (or per-stream-type)
+  default. Scratchpads might default to outline, channels to board, DMs to
+  timeline.
+
+Open questions:
+
+- Is a "post" a **top-level thread**, or the existing **conversation cluster**,
+  or a _new_ explicit primitive? (Strong lean: reuse, don't add a primitive —
+  threads and conversations already cover it; INV-36 says don't invent.)
+- Should resurfacing be **per-view only** (board re-sorts; timeline stays
+  contiguous), which is the INV-61-safe answer — yes, almost certainly.
+- Does the view belong **per-stream**, **cross-stream** (a workspace-wide "feed
+  of active posts", more like the Facebook wall), or both?
+- Where do **agents** read from? Theo's framing is that posts are a better
+  primitive for agents too. A board/topics projection with stable post IDs +
+  last-activity ordering is a cleaner agent surface than a raw timeline.
+
+## Suggested next step
+
+Not code yet. If this direction resonates, the cheapest high-signal step is a
+**read-only `board` projection of a single stream** (top-level threads as posts,
+ordered by `lastReplyAt`, re-sorting on the existing `message:updated` event) —
+because it reuses existing data end-to-end, validates the "stream is a
+container, view is a projection" thesis with zero write-path or INV-61 risk, and
+makes the "old post resurfaces" behavior real enough to feel before deciding how
+far to take the view system.

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -17,11 +17,15 @@
  * the default. Add a flag while rolling a feature out; delete it the moment
  * the rollout is done. A flag that survives long here is a smell.
  *
- * Currently empty: no rollout is in flight. The registry is meant to sit
- * empty between rollouts — adding a flag is a one-line entry here plus its
- * `getFlag` / `useFeatureFlag` call sites.
+ * Add a flag while rolling a feature out; delete it the moment the rollout is
+ * done. A flag that survives long here is a smell.
+ *
+ * - `board-view`: gates the workspace Board (a cross-stream view of
+ *   conversations). Off by default; flip to `on` per user from the backoffice.
  */
-export const FEATURE_FLAGS = {} as const satisfies Record<string, readonly [string, ...string[]]>
+export const FEATURE_FLAGS = {
+  "board-view": ["off", "on"],
+} as const satisfies Record<string, readonly [string, ...string[]]>
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS
 

--- a/packages/types/src/feature-flags.ts
+++ b/packages/types/src/feature-flags.ts
@@ -17,9 +17,6 @@
  * the default. Add a flag while rolling a feature out; delete it the moment
  * the rollout is done. A flag that survives long here is a smell.
  *
- * Add a flag while rolling a feature out; delete it the moment the rollout is
- * done. A flag that survives long here is a smell.
- *
  * - `board-view`: gates the workspace Board (a cross-stream view of
  *   conversations). Off by default; flip to `on` per user from the backoffice.
  */

--- a/packages/types/src/sidebar.ts
+++ b/packages/types/src/sidebar.ts
@@ -70,7 +70,16 @@ export type SidebarBasePreset = (typeof SIDEBAR_BASE_PRESETS)[number]
  * reorder them and set each one's visibility; the set itself is fixed (these are
  * the workspace's standing views).
  */
-export const SIDEBAR_QUICK_LINKS = ["drafts", "saved", "files", "scheduled", "memory", "labels", "activity"] as const
+export const SIDEBAR_QUICK_LINKS = [
+  "board",
+  "drafts",
+  "saved",
+  "files",
+  "scheduled",
+  "memory",
+  "labels",
+  "activity",
+] as const
 export type SidebarQuickLinkKey = (typeof SIDEBAR_QUICK_LINKS)[number]
 
 /** Stable section id for the Quick Links block — doubles as its collapse-state key. */


### PR DESCRIPTION
**Design docs:** [`docs/board-view-design.md`](../blob/claude/facebook-workspace-feature-kjvrg6/docs/board-view-design.md) · [`docs/nonlinear-stream-views-exploration.md`](../blob/claude/facebook-workspace-feature-kjvrg6/docs/nonlinear-stream-views-exploration.md)

## Problem

Threa has exactly one way to look at a stream: the chronological timeline. It answers "what is being said, in order" but not "what matters in here, right now" — Tuesday's decision is buried under today's chatter. Separately, the **conversations** primitive (AI-clustered topics per stream, with status/completeness/staleness) is computed for every stream but only ever surfaced inside one stream's optional overlay (`convView`/`convOverlay`); there is no cross-stream view of it, and `ConversationRepository.findByWorkspace` had **no callers and no HTTP route**.

This PR is the design of record for a second, co-equal way to interact with streams — the **board** — plus its first implementation slice.

## Solution

A cross-stream **board**: a wall of conversations rendered as cards, ordered by recent activity, scoped to what the viewer can read. This slice is read-only — the foundation the authored-post path (slice 2) and lenses/scope filter (slice 3) build on. The design (and the path that got here: conversation-as-post → workspace-board-as-entrypoint → authored-posts-seed-conversations, validated by a read-only prod floor measurement) is in `docs/board-view-design.md`.

### How it works

1. **Backend feed** — `ConversationRepository.findByWorkspaceForViewer` (`apps/backend/src/features/conversations/repository.ts`) selects a workspace's conversations ordered by `last_activity_at DESC`, access-filtered **in SQL** via the canonical `streamAccessPredicateSql(workspaceId, userId, "conversations.stream_id")` (INV-62) so the `LIMIT` counts only readable rows, and excludes empty resolved shells (`cardinality(message_ids) > 0`). It uses `composeSql` (the predicate is a nested fragment) and pre-resolves `SELECT_FIELDS` through `sql` so the raw column list inlines rather than being parametrized.
2. **Service + handler** — `ConversationService.listByWorkspace(workspaceId, userId, options)` maps `addStalenessFields` over the rows; the `listByWorkspace` handler validates the query with the existing `listConversationsSchema` (Zod, INV-55) and returns `{ conversations }`. Access is enforced in-query, so unlike `listByStream` the handler does **not** gate on a single stream.
3. **Route** — `GET /api/workspaces/:workspaceId/conversations` (sibling to the existing stream-scoped `/streams/:streamId/conversations`; distinct path depth, no collision with `/conversations/:conversationId`).
4. **Frontend feed** — `conversationsApi.listByWorkspace` + `useWorkspaceConversations` mirror the activity-feed bootstrap pattern (`staleTime: Infinity`, `refetchOnMount`), so the board is fresh each time it's opened.
5. **Page + card** — `pages/board.tsx` lists `BoardCard`s. Each card shows the conversation's title, the stream it lives in (resolved through the shared `useStreamName` resolver per the frontend CLAUDE.md), status, a 7-segment completeness indicator, and relative last-activity; it's a `<Link>` (INV-40) to the conversation opened in its stream (`/w/:ws/s/:streamId?convView=open&conv=:id`). `StatusBadge`/`CompletenessIndicator` are now exported from `conversation-item.tsx` and reused rather than reimplemented (INV-35).
6. **Discoverability** — a `/w/:workspaceId/board` route, a **Board** sidebar quick link (first in `SIDEBAR_QUICK_LINKS`, backfilled onto existing users' configs by `normalizeSidebarConfig`'s missing-key loop), and a "View Board" command in the ⌘K palette.

### Verification against prod

I ran the generated query read-only against the production DB. For the workspace with all 625 conversations (604 non-empty): a high-access user (195 stream memberships) sees **593/604**; a low-access user (3 memberships) sees **9** — the access predicate filters as intended (INV-62). The floor measurement that informed the design is recorded in the design doc's "Floor measurement" section.

### Key design decisions

**1. The "post" is a conversation, not a thread.** Conversations already carry a title (`topicSummary`), cover channels/DMs/threads/scratchpads, have stable identity, and ship the status/completeness state the board's future lenses need — verified in the design doc's audit. Threads are subsumed (a conversation spans a root message and its thread replies).

**2. Access filtered in SQL, not post-fetch.** Reusing `streamAccessPredicateSql` inside the query (the pattern `search`/`attachments` use) keeps the `LIMIT` correct — a post-fetch `listAccessibleStreamIds` intersection would under-fill pages when top rows are inaccessible. One canonical predicate, shared (INV-62).

**3. Read-only, no live cross-stream updates yet.** `conversation:*` outbox events are delivered only to per-stream rooms (`delivery-groups.ts`), never the workspace room, so a live board needs a delivery-group change — deliberately deferred. The board refetches on open; full liveness is a follow-up.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/pages/board.tsx` | The board page: header + list of `BoardCard`s, skeleton/empty states |
| `apps/frontend/src/pages/board.test.tsx` | Integration test — mounts the real page; asserts cards, empty state, deep-link href |
| `apps/frontend/src/components/board/board-card.tsx` | One conversation as a card linking to it in its stream |
| `docs/board-view-design.md` | The board design (v3 + decisions + prod floor measurement) |
| `docs/nonlinear-stream-views-exploration.md` | The thesis: streams as containers, timeline as one projection |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/repository.ts` | `findByWorkspaceForViewer` (access-filtered cross-stream feed) |
| `apps/backend/src/features/conversations/service.ts` | `listByWorkspace(workspaceId, userId, options)` |
| `apps/backend/src/features/conversations/handlers.ts` | `listByWorkspace` handler (in-query access, no single-stream gate) |
| `apps/backend/src/features/conversations/handlers.test.ts` | Tests for the new handler |
| `apps/backend/src/routes.ts` | `GET /api/workspaces/:workspaceId/conversations` |
| `apps/frontend/src/api/conversations.ts` | `listByWorkspace` client |
| `apps/frontend/src/contexts/services-context.tsx` | `ConversationService.listByWorkspace` in the typed interface |
| `apps/frontend/src/hooks/use-conversations.ts` | `useWorkspaceConversations` + `conversationKeys.workspaceList` |
| `apps/frontend/src/components/conversations/conversation-item.tsx` | Export `StatusBadge` / `CompletenessIndicator` for reuse |
| `apps/frontend/src/routes/index.tsx` | `/board` route |
| `apps/frontend/src/components/layout/sidebar/quick-links.tsx` | `board` meta + item + `isBoardPage` prop |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | Compute + pass `isBoardPage` |
| `apps/frontend/src/components/quick-switcher/commands.ts` | "View Board" palette command |
| `packages/types/src/sidebar.ts` | `"board"` added to `SIDEBAR_QUICK_LINKS` (first) |
| `…/sidebar/quick-links.test.tsx`, `…/sidebar-config.test.ts`, `…/sidebar-editor.test.tsx`, `…/quick-switcher/commands.test.ts` | Expectations updated for the new key |

## Out of scope (deliberate)

- **Authored posts** (slice 2) and **lenses + scope filter** (slice 3) — the board ships read-only first.
- **Live cross-stream updates** — needs a `delivery-groups.ts` change to route `conversation:*` to the workspace/user room; deferred.
- **Excerpt-of-first-message title fallback** (a recorded decision) — needs a message snippet in the payload; titles fall back to "Untitled conversation" for now. Prod floor shows **0% null titles**, so this is low-impact today.
- **`findByWorkspace`** (the pre-existing, still-unused sibling) left as-is rather than deleted in this PR.

## Test plan

- [x] Backend `bun test apps/backend/src/features/conversations/handlers.test.ts` — 9 pass
- [x] Frontend `board.test.tsx`, `quick-links.test.tsx`, `commands.test.ts`, `sidebar-config.test.ts`, `sidebar-editor.test.tsx`, `src/components/layout` — all pass (board 3, layout 151, etc.)
- [x] `bun test ./packages/types/src/sidebar.test.ts` — 9 pass
- [x] `tsc --noEmit` clean across `packages/types`, `apps/backend`, `apps/frontend`
- [x] Pre-commit gate (eslint all apps, typecheck all packages, astro, dockerfile, migrations, OpenAPI `--check`) — clean
- [x] Generated SQL validated read-only against prod (access filtering: 593/604 vs 9)
- [ ] Not run live in a browser this session — the integration test mounts the real `BoardPage` end to end instead; happy to screenshot against local data on request
- [ ] Pre-existing, unrelated failures left untouched: `apps/frontend/src/auth/context*.test.tsx` and `packages/types` `getAvatarUrl` (`localStorage.clear is not a function`) — confirmed failing with this diff fully stashed

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784753114&installation_id=129946197&pr_number=1054&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1054&signature=d151f57aa1b197b89ebe043aa33f450ab11fe8308a0dddb89014a48c22b0960b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->