### PR TITLE
feat(frontend): sidebar hint for streams with an unsent (loaded) draft

### DIFF
--- a/apps/frontend/src/components/draft-indicator.tsx
+++ b/apps/frontend/src/components/draft-indicator.tsx
@@ -1,0 +1,32 @@
+import { Pencil } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface DraftIndicatorProps {
+  className?: string
+}
+
+/**
+ * Sidebar hint that a stream has an unsent draft loaded into its composer — the
+ * user navigated away without sending or stashing it. The caller decides when to
+ * render it; a stashed draft holds no composer pointer for its scope, so it never
+ * qualifies (that's the loaded-vs-stashed distinction this hint draws).
+ */
+export function DraftIndicator({ className }: DraftIndicatorProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="img"
+          aria-label="Unsent draft"
+          className={cn("flex-shrink-0 text-muted-foreground cursor-default", className)}
+        >
+          <Pencil className="h-3 w-3" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="right" className="text-xs">
+        Unsent draft
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -10,6 +10,7 @@ import { useSealedNamePendingResolver } from "@/hooks/use-decrypted-stream-name"
 import {
   useActivityCounts,
   useAllDrafts,
+  streamIdsWithLoadedDraft,
   createDmDraftId,
   useDraftScratchpads,
   useLiveSavedCount,
@@ -124,6 +125,19 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const mutedStreamIdSet = useMemo(() => new Set(unreadState?.mutedStreamIds ?? []), [unreadState?.mutedStreamIds])
   const dmPeerByStreamId = useMemo(() => new Map(idbDmPeers.map((peer) => [peer.streamId, peer.userId])), [idbDmPeers])
 
+  // Streams the user stepped away from with an unsent (loaded, non-stashed)
+  // draft, surfaced as a per-row hint. The signature string keeps the derived
+  // Set referentially stable across draft edits that don't change membership, so
+  // the heavy `processedStreams` map below doesn't rebuild on every keystroke.
+  const loadedDraftStreamIdSignature = useMemo(
+    () => [...streamIdsWithLoadedDraft(allDrafts)].sort().join(","),
+    [allDrafts]
+  )
+  const streamsWithLoadedDraft = useMemo(
+    () => new Set(loadedDraftStreamIdSignature ? loadedDraftStreamIdSignature.split(",") : []),
+    [loadedDraftStreamIdSignature]
+  )
+
   const processedStreams = useMemo(() => {
     return idbStreams
       .filter((stream) => {
@@ -157,6 +171,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
           section,
           dmPeerUserId,
           nameDecrypting: isSealedNamePending(streamWithPreview),
+          hasLoadedDraft: streamsWithLoadedDraft.has(stream.id),
         }
       })
   }, [
@@ -172,6 +187,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
     unreadState,
     workspaceId,
     isSealedNamePending,
+    streamsWithLoadedDraft,
   ])
 
   // System streams are auto-created infrastructure — don't count toward "has content"

--- a/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.test.tsx
@@ -265,6 +265,57 @@ describe("StreamItem", () => {
     expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument()
   })
 
+  it("shows an unsent-draft hint on a stream with a loaded draft", () => {
+    const stream = createStream({ hasLoadedDraft: true })
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    expect(screen.getByRole("img", { name: "Unsent draft" })).toBeInTheDocument()
+  })
+
+  it("hides the unsent-draft hint on the active stream (its composer already shows the draft)", () => {
+    const stream = createStream({ hasLoadedDraft: true })
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    expect(screen.queryByRole("img", { name: "Unsent draft" })).not.toBeInTheDocument()
+  })
+
+  it("shows no unsent-draft hint when the stream has no loaded draft", () => {
+    const stream = createStream()
+
+    renderWithRouter(
+      <StreamItem
+        workspaceId="workspace_1"
+        stream={stream}
+        isActive={false}
+        unreadCount={0}
+        mentionCount={0}
+        allStreams={[stream]}
+      />
+    )
+
+    expect(screen.queryByRole("img", { name: "Unsent draft" })).not.toBeInTheDocument()
+  })
+
   it("renders a desktop context-menu trigger for DMs", () => {
     touchState.inputMode = "mouse"
     touchState.touchCapable = false

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -5,6 +5,7 @@ import { LabelPicker } from "@/components/labels/label-picker"
 import { SectionPicker } from "./section-picker"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
+import { DraftIndicator } from "@/components/draft-indicator"
 import { RelativeTime } from "@/components/relative-time"
 import { getThreadRootContext } from "@/components/thread/breadcrumb-helpers"
 import { isDraftId, useActors } from "@/hooks"
@@ -396,6 +397,8 @@ export function StreamItem({
                   )}
                   <div className="ml-auto flex items-center gap-1.5">
                     <StreamLabelDots streamId={stream.id} />
+                    {/* Suppressed on the active stream — its composer already shows the draft. */}
+                    {stream.hasLoadedDraft && !isActive && <DraftIndicator />}
                     <MentionIndicator count={mentionCount} />
                   </div>
                 </div>

--- a/apps/frontend/src/components/layout/sidebar/types.ts
+++ b/apps/frontend/src/components/layout/sidebar/types.ts
@@ -24,4 +24,11 @@ export interface StreamItemData extends StreamWithPreview {
    * row, so the leaf reads this as plain data without touching the session.
    */
   nameDecrypting?: boolean
+  /**
+   * True when the stream's composer holds an unsent draft that is loaded (not
+   * stashed) — the user stepped away without sending or stashing. Computed once
+   * in the sidebar builder and read by the row to show a draft hint, mirroring
+   * `nameDecrypting`.
+   */
+  hasLoadedDraft?: boolean
 }

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -123,7 +123,7 @@ export {
 } from "./use-mentionables"
 export type { MentionStreamContext } from "./use-mentionables"
 
-export { useAllDrafts, type UnifiedDraft, type DraftType } from "./use-all-drafts"
+export { useAllDrafts, streamIdsWithLoadedDraft, type UnifiedDraft, type DraftType } from "./use-all-drafts"
 
 export { useFormattedDate } from "./use-formatted-date"
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -9,7 +9,7 @@ import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
-import { useAllDrafts } from "./use-all-drafts"
+import { streamIdsWithLoadedDraft, useAllDrafts, type DraftType, type UnifiedDraft } from "./use-all-drafts"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const UNLOCKED_SESSION = {
@@ -182,5 +182,53 @@ describe("useAllDrafts E2E drafts", () => {
 
     await waitFor(() => expect(result.current.drafts.some((d) => d.id === "draft_locked")).toBe(true))
     expect(result.current.drafts.find((d) => d.id === "draft_locked")!.preview).toBe("Encrypted draft")
+  })
+})
+
+describe("streamIdsWithLoadedDraft", () => {
+  function unifiedDraft(overrides: Partial<UnifiedDraft> = {}): UnifiedDraft {
+    return {
+      id: "draft_1",
+      type: "channel" as DraftType,
+      streamId: "stream_1",
+      displayName: "General",
+      preview: "hello",
+      attachmentCount: 0,
+      updatedAt: 1000,
+      href: "/w/ws_1/s/stream_1",
+      groupLabel: "General",
+      isStashed: false,
+      ...overrides,
+    }
+  }
+
+  it("includes streams with a loaded draft but excludes stashed ones", () => {
+    const ids = streamIdsWithLoadedDraft([
+      unifiedDraft({ id: "draft_loaded", streamId: "stream_loaded", isStashed: false }),
+      unifiedDraft({ id: "draft_stashed", streamId: "stream_stashed", isStashed: true }),
+    ])
+    expect(ids).toEqual(new Set(["stream_loaded"]))
+  })
+
+  it("does not flag a stream whose only draft for the scope is stashed", () => {
+    const ids = streamIdsWithLoadedDraft([
+      unifiedDraft({ id: "draft_a", streamId: "stream_x", isStashed: true }),
+      unifiedDraft({ id: "draft_b", streamId: "stream_x", isStashed: true }),
+    ])
+    expect(ids.has("stream_x")).toBe(false)
+  })
+
+  it("excludes thread replies and scratchpads — only a stream's own composer draft counts", () => {
+    const ids = streamIdsWithLoadedDraft([
+      unifiedDraft({ id: "draft_thread", type: "thread", streamId: "stream_parent" }),
+      unifiedDraft({ id: "draft_scratch", type: "scratchpad", streamId: "draft_scratchpad_1" }),
+      unifiedDraft({ id: "draft_dm", type: "dm", streamId: "stream_dm" }),
+    ])
+    expect(ids).toEqual(new Set(["stream_dm"]))
+  })
+
+  it("ignores rows without a resolved stream id", () => {
+    const ids = streamIdsWithLoadedDraft([unifiedDraft({ streamId: null })])
+    expect(ids.size).toBe(0)
   })
 })

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -185,6 +185,25 @@ function resolveDraftLocation(
 }
 
 /**
+ * Stream ids whose composer holds a *loaded* (checked-in, non-stashed) draft,
+ * derived from {@link useAllDrafts} output. A stashed draft holds no composer
+ * pointer for its scope, so it is excluded — the sidebar hint marks only streams
+ * the user stepped away from without stashing. Thread replies and scratchpads are
+ * excluded too: a thread draft is not the stream's own composer draft, and a
+ * scratchpad is itself a draft. Empty drafts are already dropped upstream, so a
+ * row here is real, unsent content.
+ */
+export function streamIdsWithLoadedDraft(drafts: UnifiedDraft[]): Set<string> {
+  const ids = new Set<string>()
+  for (const draft of drafts) {
+    if (draft.isStashed || !draft.streamId) continue
+    if (draft.type === "thread" || draft.type === "scratchpad") continue
+    ids.add(draft.streamId)
+  }
+  return ids
+}
+
+/**
  * Hook to get all drafts (scratchpads + messages + stashed snapshots) for a
  * workspace. Returns a unified list sorted by recency; rows carry a
  * `groupLabel` so the drafts page can cluster them per stream/thread.


### PR DESCRIPTION
## Problem

A draft you start in a stream's composer is kept (loaded) when you navigate away, but nothing in the sidebar tells you it's there — you rediscover an unsent message only by reopening the stream or digging through the Drafts explorer. A *stashed* draft is different: you parked that one deliberately, so it shouldn't produce the same nudge.

## Solution

Show a small pencil hint on a sidebar stream row when its composer holds a loaded, non-empty draft — the "stepped away without sending or stashing" case. The loaded-vs-stashed line is the one the draft system already draws: a draft is *loaded* when its scope's `composerLoaded` pointer references it, *stashed* when it doesn't. `useAllDrafts` already exposes that as `isStashed`, so the hint reuses it instead of re-deriving the pointer rule.

### How it works

- `streamIdsWithLoadedDraft(drafts)` (`apps/frontend/src/hooks/use-all-drafts.ts`) is a pure transform over the existing `UnifiedDraft[]`: keep rows that are `!isStashed` with a resolved `streamId`, drop `thread` and `scratchpad` types (a thread reply isn't the stream's own composer draft; a scratchpad is itself a draft). Empty drafts are already filtered upstream by `useAllDrafts` — sealed E2E rows count there on the strength of their `ciphertext` — so a returned id is real, unsent content.
- The sidebar builder (`sidebar.tsx`) already calls `useAllDrafts(workspaceId)`, so the set comes from data on hand — no new store subscription. It's derived via a stable signature string (`[...set].sort().join(",")`) so the resulting `Set` keeps its identity across draft edits that don't change membership, and the heavy `processedStreams` map doesn't rebuild on every keystroke.
- Each row gets a `hasLoadedDraft` flag on `StreamItemData`, attached in the same map that sets `nameDecrypting` — so it reaches the leaf as plain data with no new prop drilling through `sections.tsx` / `sidebar-stream-list.tsx`.
- `StreamItem` renders `<DraftIndicator />` in the existing right-side cluster (next to the label dots and the mention `@`), gated on `stream.hasLoadedDraft && !isActive`.

### Key design decisions

**1. Suppress on the active stream** — the open stream's composer already shows the draft, so a sidebar dot there is noise (and the framing was "stepped away from the stream"). The gate is `!isActive` on the row; navigating away flips `isActive` and the hint appears.

**2. Stashed drafts never qualify** — routing through `isStashed` rather than "does any row exist for this scope" keeps a parked draft silent. This is the explicit requirement; the test `does not flag a stream whose only draft for the scope is stashed` pins it.

**3. Attach a flag, don't drill a callback** — `getUnreadCount`/`getMentionCount` are threaded as callbacks because section headers also aggregate them (`sumUnread`). The draft hint is row-only, so it rides `StreamItemData` like `nameDecrypting`: fewer touched files, one computation, and no per-row store subscription (which would fan out N Dexie live queries on the drafts table).

**4. Subtle, matches the existing vocabulary** — `DraftIndicator` mirrors `MentionIndicator`: a `lucide-react` `Pencil` at `h-3 w-3` in `text-muted-foreground` with a right-side tooltip ("Unsent draft"). `Pencil` is already the app's edit/draft glyph (`stream.tsx`, `saved-item.tsx`). It's conditionally rendered, so it reserves no space and causes no layout shift (INV-21); the tooltip is portal-based.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/draft-indicator.tsx` | Sidebar pencil + "Unsent draft" tooltip; accessible (`role="img"`, `aria-label`). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-all-drafts.ts` | Add pure `streamIdsWithLoadedDraft(drafts)` helper (loaded, non-thread, non-scratchpad). |
| `apps/frontend/src/hooks/index.ts` | Re-export the helper from the barrel. |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | Derive `streamsWithLoadedDraft` (stable signature) and set `hasLoadedDraft` per row. |
| `apps/frontend/src/components/layout/sidebar/types.ts` | Add `hasLoadedDraft?: boolean` to `StreamItemData`. |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Render `<DraftIndicator />` gated on `hasLoadedDraft && !isActive`. |
| `apps/frontend/src/hooks/use-all-drafts.test.ts` | 4 unit tests for `streamIdsWithLoadedDraft`. |
| `apps/frontend/src/components/layout/sidebar/stream-item.test.tsx` | 3 render tests (shows when loaded, hidden on active, hidden when absent). |

## Out of scope (deliberate)

- **Scratchpad rows** — scratchpads render via `ScratchpadItem` and are themselves drafts, so they get no "unsent draft" hint (and scratchpad-typed drafts are excluded from the set).
- **Thread drafts** — a loaded draft in a thread does not light up its parent channel row; only a stream's own `stream:{id}` composer draft counts.
- **Virtual (not-yet-created) DM drafts** — `virtualDmStreams` aren't built through the `processedStreams` map, so a draft typed into a never-opened DM won't flag until the DM exists. Rare; left for a follow-up.
- **Section-level aggregation** — collapsed section headers don't summarize "has drafts"; the hint is per visible row.

## Test plan

- [x] `vitest run` on the two affected files — 16 pass (7 new: 4 helper + 3 render)
- [x] `apps/frontend` `tsc --noEmit` — clean
- [x] `eslint` on all 8 changed files — clean
- [x] Full pre-commit hook (lint + typecheck across all workspaces, migration/docs checks) — passed
- [ ] No manual in-browser pass — verified via component tests (mounts a real `StreamItem` through the shared `TooltipProvider`) rather than a running app

<details>
<summary>📋 Full implementation plan</summary>

**Goal** — Surface a sidebar hint on streams the user stepped away from with an unsent draft, excluding stashed drafts.

**What was built** — A pure `streamIdsWithLoadedDraft` selector over `useAllDrafts` output; a `hasLoadedDraft` flag on `StreamItemData` set in the sidebar builder; a `DraftIndicator` leaf rendered by `StreamItem` when loaded and not active.

**Design decisions** — Reuse `isStashed` from `useAllDrafts` for the loaded/stashed line; attach a flag rather than drill a callback (row-only signal); stable signature to avoid `processedStreams` churn; suppress on the active stream; match `MentionIndicator`'s visual register (INV-21-safe).

**What's NOT included** — Scratchpad / thread / virtual-DM flagging, section aggregation (see Out of scope).

**Status** — Implemented, tested (16 pass), typecheck/lint clean, committed `9700a09`, pushed.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kaj8XexYUDbF9poxQ5tbuV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kaj8XexYUDbF9poxQ5tbuV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784756045&installation_id=129946197&pr_number=1056&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1056&signature=2832a7d53e2447ddec8114586f93dcd468ebc8491a425fbe2e0de42e082e8821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->