### PR TITLE
test(commands): drop redundant assertion in slash-command boundary test (CodeRabbit on #1053)

### DIFF
--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -662,7 +662,6 @@ describe("slash command boundary", () => {
     const result = parseMarkdown("/foo/bar")
     const content = result.content?.[0]?.content
 
-    expect(content?.[0]?.type).not.toBe("slashCommand")
     expect(content?.[0]).toEqual({ type: "text", text: "/foo/bar" })
   })
 


### PR DESCRIPTION
Follow-up to the now-merged #1053. CodeRabbit flagged a redundant narrow assertion in the slash-command boundary test: the `toEqual` already covers the node type, so the extra `.not.toBe(\"slashCommand\")` is superfluous (INV-24, one object comparison over chains of narrow assertions).

One line removed.

- [x] `bun test packages/prosemirror/src/markdown.test.ts` — 55 pass

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784759274&installation_id=129946197&pr_number=1058&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1058&signature=248478c0b7c2387fd61cde259a9817e53eccbc938e5059a446bc61b5c6ba2959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->