### PR TITLE
fix(activity): converge activity/unread counters by event, not by polling

### DIFF
--- a/apps/backend/src/features/activity/emit-counts.test.ts
+++ b/apps/backend/src/features/activity/emit-counts.test.ts
@@ -50,7 +50,16 @@ describe("emitActivityCountsForPairs", () => {
     ])
 
     expect(countSpy.mock.calls[0]?.[2]).toEqual([{ userId: "usr_a", streamId: "stream_1" }])
-    expect(insert.mock.calls).toHaveLength(1)
+    expect(insert.mock.calls.map(([, eventType, payload]) => ({ eventType, payload }))).toEqual([
+      {
+        eventType: "activity:counts",
+        payload: {
+          workspaceId: WS,
+          targetUserId: "usr_a",
+          counts: [{ streamId: "stream_1", mentionCount: 0, activityCount: 1 }],
+        },
+      },
+    ])
   })
 
   it("emits nothing for an empty pair list", async () => {

--- a/apps/backend/src/features/activity/emit-counts.test.ts
+++ b/apps/backend/src/features/activity/emit-counts.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, spyOn, afterEach, mock } from "bun:test"
+import { emitActivityCountsForPairs } from "./emit-counts"
+import { ActivityRepository } from "./repository"
+import { OutboxRepository } from "../../lib/outbox"
+
+const WS = "ws_test"
+
+describe("emitActivityCountsForPairs", () => {
+  afterEach(() => mock.restore())
+
+  it("recomputes each pair and emits one activity:counts per affected user", async () => {
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([
+        ["usr_a:stream_1", { mentionCount: 1, totalCount: 3 }],
+        ["usr_a:stream_2", { mentionCount: 0, totalCount: 0 }],
+        ["usr_b:stream_1", { mentionCount: 0, totalCount: 2 }],
+      ])
+    )
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await emitActivityCountsForPairs({} as any, WS, [
+      { userId: "usr_a", streamId: "stream_1" },
+      { userId: "usr_a", streamId: "stream_2" },
+      { userId: "usr_b", streamId: "stream_1" },
+    ])
+
+    const counts = insert.mock.calls.map((c) => c[2] as any)
+    const a = counts.find((p) => p.targetUserId === "usr_a")
+    const b = counts.find((p) => p.targetUserId === "usr_b")
+    expect(insert.mock.calls.every((c) => c[1] === "activity:counts")).toBe(true)
+    expect(a).toMatchObject({
+      workspaceId: WS,
+      counts: [
+        { streamId: "stream_1", mentionCount: 1, activityCount: 3 },
+        { streamId: "stream_2", mentionCount: 0, activityCount: 0 },
+      ],
+    })
+    expect(b).toMatchObject({ counts: [{ streamId: "stream_1", mentionCount: 0, activityCount: 2 }] })
+  })
+
+  it("dedupes repeated (user, stream) pairs before recomputing", async () => {
+    const countSpy = spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([["usr_a:stream_1", { mentionCount: 0, totalCount: 1 }]])
+    )
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await emitActivityCountsForPairs({} as any, WS, [
+      { userId: "usr_a", streamId: "stream_1" },
+      { userId: "usr_a", streamId: "stream_1" },
+    ])
+
+    expect(countSpy.mock.calls[0]?.[2]).toEqual([{ userId: "usr_a", streamId: "stream_1" }])
+    expect(insert.mock.calls).toHaveLength(1)
+  })
+
+  it("emits nothing for an empty pair list", async () => {
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+    await emitActivityCountsForPairs({} as any, WS, [])
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("defaults a pair with no unread rows to zero counts", async () => {
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(new Map())
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await emitActivityCountsForPairs({} as any, WS, [{ userId: "usr_a", streamId: "stream_1" }])
+
+    expect(insert.mock.calls[0]?.[2]).toMatchObject({
+      targetUserId: "usr_a",
+      counts: [{ streamId: "stream_1", mentionCount: 0, activityCount: 0 }],
+    })
+  })
+})

--- a/apps/backend/src/features/activity/emit-counts.ts
+++ b/apps/backend/src/features/activity/emit-counts.ts
@@ -1,0 +1,54 @@
+import type { PoolClient } from "pg"
+import { OutboxRepository } from "../../lib/outbox"
+import { ActivityRepository } from "./repository"
+
+interface UserStreamPair {
+  userId: string
+  streamId: string
+}
+
+function dedupePairs(pairs: UserStreamPair[]): UserStreamPair[] {
+  const seen = new Set<string>()
+  const out: UserStreamPair[] = []
+  for (const p of pairs) {
+    const key = `${p.userId}:${p.streamId}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(p)
+  }
+  return out
+}
+
+/**
+ * Recompute the absolute unread counts for the given (user, stream) pairs and
+ * emit one `activity:counts` per affected user, inside the caller's transaction
+ * (INV-7). The shared tail of every path that LOWERS or re-homes `user_activity`
+ * truth without creating a row — reaction removal, message move — so the badge
+ * converges on every session instead of stranding above the truth.
+ */
+export async function emitActivityCountsForPairs(
+  client: PoolClient,
+  workspaceId: string,
+  pairs: UserStreamPair[]
+): Promise<void> {
+  const unique = dedupePairs(pairs)
+  if (unique.length === 0) return
+
+  const counts = await ActivityRepository.countUnreadForPairs(client, workspaceId, unique)
+
+  const byUser = new Map<string, Array<{ streamId: string; mentionCount: number; activityCount: number }>>()
+  for (const { userId, streamId } of unique) {
+    const c = counts.get(`${userId}:${streamId}`)
+    const list = byUser.get(userId) ?? []
+    list.push({ streamId, mentionCount: c?.mentionCount ?? 0, activityCount: c?.totalCount ?? 0 })
+    byUser.set(userId, list)
+  }
+
+  for (const [userId, streamCounts] of byUser) {
+    await OutboxRepository.insert(client, "activity:counts", {
+      workspaceId,
+      targetUserId: userId,
+      counts: streamCounts,
+    })
+  }
+}

--- a/apps/backend/src/features/activity/outbox-handler.test.ts
+++ b/apps/backend/src/features/activity/outbox-handler.test.ts
@@ -94,6 +94,23 @@ function makeMessageCreatedEvent(
   }
 }
 
+function makeMessagesMovedEvent(
+  id: bigint,
+  overrides?: { workspaceId?: string; sourceStreamId?: string; destinationStreamId?: string; movedMessageIds?: unknown }
+) {
+  return {
+    id,
+    eventType: "messages:moved" as const,
+    payload: {
+      workspaceId: overrides?.workspaceId ?? "ws_test",
+      sourceStreamId: overrides?.sourceStreamId ?? "stream_src",
+      destinationStreamId: overrides?.destinationStreamId ?? "stream_dst",
+      movedMessageIds: "movedMessageIds" in (overrides ?? {}) ? overrides!.movedMessageIds : ["msg_1", "msg_2"],
+    },
+    createdAt: new Date(),
+  }
+}
+
 describe("ActivityFeedHandler", () => {
   beforeEach(() => {
     spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
@@ -473,5 +490,75 @@ describe("ActivityFeedHandler", () => {
     await new Promise((r) => setTimeout(r, 300))
 
     expect(result).toEqual({ status: "processed", processedIds: [1n, 2n, 3n] })
+  })
+
+  it("processMessagesMoved emits activity:counts for source and destination per affected user", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([makeMessagesMovedEvent(1n)] as any)
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({}))
+    spyOn(ActivityRepository, "findUserIdsByMessageIds").mockResolvedValue(["usr_a"])
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([
+        ["usr_a:stream_src", { mentionCount: 0, totalCount: 0 }],
+        ["usr_a:stream_dst", { mentionCount: 0, totalCount: 2 }],
+      ])
+    )
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const { handler } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insert.mock.calls.filter((c) => c[1] === "activity:counts").map((c) => c[2])).toEqual([
+      {
+        workspaceId: "ws_test",
+        targetUserId: "usr_a",
+        counts: [
+          { streamId: "stream_src", mentionCount: 0, activityCount: 0 },
+          { streamId: "stream_dst", mentionCount: 0, activityCount: 2 },
+        ],
+      },
+    ])
+  })
+
+  it("processMessagesMoved skips a malformed payload (empty movedMessageIds) before the E2E check", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([
+      makeMessagesMovedEvent(1n, { movedMessageIds: [] }),
+    ] as any)
+    const isE2e = spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const { handler } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insert).not.toHaveBeenCalled()
+    expect(isE2e).not.toHaveBeenCalled()
+  })
+
+  it("processMessagesMoved skips when the source stream is E2E", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([makeMessagesMovedEvent(1n)] as any)
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(true)
+    const findUsers = spyOn(ActivityRepository, "findUserIdsByMessageIds").mockResolvedValue([])
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const { handler } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(findUsers).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("processMessagesMoved emits nothing when no user has activity on the moved messages", async () => {
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([makeMessagesMovedEvent(1n)] as any)
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({}))
+    spyOn(ActivityRepository, "findUserIdsByMessageIds").mockResolvedValue([])
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const { handler } = createHandler()
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insert).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/activity/outbox-handler.ts
+++ b/apps/backend/src/features/activity/outbox-handler.ts
@@ -12,6 +12,7 @@ import { CursorLock, ensureListenerFromLatest, DebounceWithMaxWait, type Process
 import type { OutboxHandler } from "../../lib/outbox"
 import type { ActivityService } from "./service"
 import { ActivityRepository, type Activity } from "./repository"
+import { emitActivityCountsForPairs } from "./emit-counts"
 import { withTransaction } from "../../db"
 import { E2eStreamsRepository } from "../e2e-streams"
 
@@ -101,9 +102,11 @@ export class ActivityFeedHandler implements OutboxHandler {
             const activities = await this.processReactionAdded(event)
             await this.publishActivityCreated(activities)
           } else if (event.eventType === "reaction:removed") {
-            // Removed rows don't currently emit a compensating event —
-            // frontend subscribers detect stale entries on next fetch.
+            // Deleting the rows lowers the author's count; the service emits the
+            // recomputed absolute `activity:counts` in the same transaction.
             await this.processReactionRemoved(event)
+          } else if (event.eventType === "messages:moved") {
+            await this.processMessagesMoved(event)
           } else if (event.eventType === "saved_reminder:fired") {
             const activities = await this.processSavedReminderFired(event)
             await this.publishActivityCreated(activities)
@@ -301,6 +304,53 @@ export class ActivityFeedHandler implements OutboxHandler {
       messageId: payload.messageId,
       actorId: payload.userId,
       emoji: payload.emoji,
+    })
+  }
+
+  /**
+   * A message move re-homes its `user_activity` rows from the source stream to
+   * the destination thread (messaging's move transaction already did the
+   * `UPDATE … SET stream_id`). That silently shifts each affected user's
+   * per-stream counts, so recompute BOTH streams for every affected user and
+   * emit `activity:counts` — otherwise the source badge strands high and the
+   * destination reads low.
+   */
+  private async processMessagesMoved(event: { id: bigint; payload: unknown }): Promise<void> {
+    const payload = event.payload as {
+      workspaceId?: unknown
+      sourceStreamId?: unknown
+      destinationStreamId?: unknown
+      movedMessageIds?: unknown
+    }
+    if (
+      !payload ||
+      typeof payload.workspaceId !== "string" ||
+      typeof payload.sourceStreamId !== "string" ||
+      typeof payload.destinationStreamId !== "string" ||
+      !Array.isArray(payload.movedMessageIds) ||
+      payload.movedMessageIds.length === 0
+    ) {
+      logger.debug({ eventId: event.id.toString() }, "ActivityFeedHandler: malformed messages:moved event, skipping")
+      return
+    }
+    const { workspaceId, sourceStreamId, destinationStreamId } = payload
+    const movedMessageIds = payload.movedMessageIds as string[]
+
+    // E2E streams don't surface in the activity feed, so they have no counts to
+    // reconcile (the source-tree check covers a thread under an E2E root).
+    if (await E2eStreamsRepository.isE2eStream(this.db, workspaceId, sourceStreamId)) return
+
+    await withTransaction(this.db, async (client) => {
+      const userIds = await ActivityRepository.findUserIdsByMessageIds(client, workspaceId, movedMessageIds)
+      if (userIds.length === 0) return
+      await emitActivityCountsForPairs(
+        client,
+        workspaceId,
+        userIds.flatMap((userId) => [
+          { userId, streamId: sourceStreamId },
+          { userId, streamId: destinationStreamId },
+        ])
+      )
     })
   }
 

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -330,14 +330,39 @@ export const ActivityRepository = {
     }
   },
 
-  async markAsRead(db: Querier, activityId: string, userId: string): Promise<void> {
-    await db.query(sql`
+  /**
+   * Mark one activity row read. Returns the row's workspace + stream (so the
+   * caller can emit the stream's new absolute count) — or null when the row was
+   * already read / not found, which makes the emit idempotent.
+   */
+  async markAsRead(
+    db: Querier,
+    activityId: string,
+    userId: string
+  ): Promise<{ workspaceId: string; streamId: string | null } | null> {
+    const result = await db.query<{ workspace_id: string; stream_id: string | null }>(sql`
       UPDATE user_activity
       SET read_at = NOW()
       WHERE id = ${activityId}
         AND user_id = ${userId}
         AND read_at IS NULL
+      RETURNING workspace_id, stream_id
     `)
+    const row = result.rows[0]
+    return row ? { workspaceId: row.workspace_id, streamId: row.stream_id } : null
+  },
+
+  /** Distinct users with an activity row referencing any of these messages —
+   *  the audience whose per-stream counts a message move must reconcile. */
+  async findUserIdsByMessageIds(db: Querier, workspaceId: string, messageIds: string[]): Promise<string[]> {
+    if (messageIds.length === 0) return []
+    const result = await db.query<{ user_id: string }>(sql`
+      SELECT DISTINCT user_id
+      FROM user_activity
+      WHERE workspace_id = ${workspaceId}
+        AND message_id = ANY(${messageIds})
+    `)
+    return result.rows.map((r) => r.user_id)
   },
 
   async markStreamAsRead(db: Querier, userId: string, streamId: string): Promise<number> {

--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -8,6 +8,7 @@ import { PersonaRepository } from "../agents"
 import { BotRepository } from "../public-api"
 import { MessageRepository } from "../messaging"
 import * as dbModule from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
 import type { Stream } from "../streams"
 import type { Activity } from "./repository"
 
@@ -62,6 +63,7 @@ function fakeActivity(context: Record<string, unknown>): Activity[] {
 
 function setupService() {
   spyOn(dbModule, "withClient").mockImplementation(async (_pool: any, fn: any) => fn({} as any))
+  spyOn(dbModule, "withTransaction").mockImplementation(async (_pool: any, fn: any) => fn({} as any))
 
   return new ActivityService({ pool: {} as any })
 }
@@ -833,6 +835,100 @@ describe("ActivityService mention extraction", () => {
     expect(insertBatch.mock.calls[0][1]).toMatchObject({
       userIds: [TARGET_USER_ID],
       activityType: ActivityTypes.MENTION,
+    })
+  })
+})
+
+describe("ActivityService activity:counts convergence emits", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("markAllAsRead emits a clearAll when rows were marked read", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "markAllAsRead").mockResolvedValue(3)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.markAllAsRead(TARGET_USER_ID, WORKSPACE_ID)
+
+    expect(insert.mock.calls[0]?.[1]).toBe("activity:counts")
+    expect(insert.mock.calls[0]?.[2]).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      targetUserId: TARGET_USER_ID,
+      clearAll: true,
+      counts: [],
+    })
+  })
+
+  it("markAllAsRead emits nothing when no rows were unread", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "markAllAsRead").mockResolvedValue(0)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.markAllAsRead(TARGET_USER_ID, WORKSPACE_ID)
+
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("markAsRead emits the stream's recomputed absolute count", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "markAsRead").mockResolvedValue({ workspaceId: WORKSPACE_ID, streamId: STREAM_ID })
+    spyOn(ActivityRepository, "countUnreadForStream").mockResolvedValue({ mentionCount: 1, totalCount: 4 })
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.markAsRead("act_1", TARGET_USER_ID)
+
+    expect(insert.mock.calls[0]?.[1]).toBe("activity:counts")
+    expect(insert.mock.calls[0]?.[2]).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      targetUserId: TARGET_USER_ID,
+      counts: [{ streamId: STREAM_ID, mentionCount: 1, activityCount: 4 }],
+    })
+  })
+
+  it("markAsRead emits nothing for an already-read row", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "markAsRead").mockResolvedValue(null)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.markAsRead("act_1", TARGET_USER_ID)
+
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("markAsRead emits nothing for a stream-less (saved-reminder) row", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "markAsRead").mockResolvedValue({ workspaceId: WORKSPACE_ID, streamId: null })
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.markAsRead("act_1", TARGET_USER_ID)
+
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("processReactionRemoved emits the recomputed count for the reacted-to author, not the reactor self-row", async () => {
+    const service = setupService()
+    spyOn(ActivityRepository, "deleteReactionForEmoji").mockResolvedValue([
+      { userId: USER_ID, streamId: STREAM_ID, isSelf: false } as any,
+      { userId: TARGET_USER_ID, streamId: STREAM_ID, isSelf: true } as any,
+    ])
+    const countPairs = spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([[`${USER_ID}:${STREAM_ID}`, { mentionCount: 0, totalCount: 2 }]])
+    )
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+
+    await service.processReactionRemoved({
+      workspaceId: WORKSPACE_ID,
+      messageId: MESSAGE_ID,
+      actorId: TARGET_USER_ID,
+      emoji: ":eyes:",
+    })
+
+    // Only the non-self author row is recomputed/emitted.
+    expect(countPairs.mock.calls[0]?.[2]).toEqual([{ userId: USER_ID, streamId: STREAM_ID }])
+    expect(insert.mock.calls[0]?.[2]).toMatchObject({
+      targetUserId: USER_ID,
+      counts: [{ streamId: STREAM_ID, mentionCount: 0, activityCount: 2 }],
     })
   })
 })

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -15,7 +15,9 @@ import {
   isBroadcastSlug,
   type JSONContent,
 } from "@threa/types"
-import { withClient } from "../../db"
+import { withClient, withTransaction } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
+import { emitActivityCountsForPairs } from "./emit-counts"
 import { logger } from "../../lib/logger"
 
 interface ActivityServiceDeps {
@@ -355,6 +357,12 @@ export class ActivityService {
    * Remove the reaction activity rows that `processReactionAdded` created for
    * this exact (message, actor, emoji) triple. Other reactions from the same
    * actor on the same message are left intact.
+   *
+   * Deleting the rows lowers the reacted-to author's unread count, so in the
+   * same transaction (INV-7) recompute each affected (user, stream) absolute
+   * count and emit `activity:counts` — otherwise the badge stays stranded above
+   * the truth on every session (the bug this fixes). Only non-self rows with a
+   * stream move a badge; self rows were inserted already read.
    */
   async processReactionRemoved(params: {
     workspaceId: string
@@ -362,7 +370,15 @@ export class ActivityService {
     actorId: string
     emoji: string
   }): Promise<Activity[]> {
-    return ActivityRepository.deleteReactionForEmoji(this.pool, params)
+    return withTransaction(this.pool, async (client) => {
+      const deleted = await ActivityRepository.deleteReactionForEmoji(client, params)
+      await emitActivityCountsForPairs(
+        client,
+        params.workspaceId,
+        deleted.filter((a) => !a.isSelf && a.streamId).map((a) => ({ userId: a.userId, streamId: a.streamId! }))
+      )
+      return deleted
+    })
   }
 
   /**
@@ -526,8 +542,28 @@ export class ActivityService {
     return ActivityRepository.countUnreadForStream(this.pool, userId, workspaceId, streamId)
   }
 
+  /**
+   * Mark one activity row read and emit the stream's new absolute count so the
+   * badge converges on every session (the bare UPDATE used to emit nothing, so
+   * other tabs/devices stayed stale-high — INV-7). Stream-less saved-reminder
+   * rows carry no per-stream badge, so they skip the emit.
+   */
   async markAsRead(activityId: string, userId: string): Promise<void> {
-    await ActivityRepository.markAsRead(this.pool, activityId, userId)
+    await withTransaction(this.pool, async (client) => {
+      const marked = await ActivityRepository.markAsRead(client, activityId, userId)
+      if (!marked || !marked.streamId) return
+      const { mentionCount, totalCount } = await ActivityRepository.countUnreadForStream(
+        client,
+        userId,
+        marked.workspaceId,
+        marked.streamId
+      )
+      await OutboxRepository.insert(client, "activity:counts", {
+        workspaceId: marked.workspaceId,
+        targetUserId: userId,
+        counts: [{ streamId: marked.streamId, mentionCount, activityCount: totalCount }],
+      })
+    })
   }
 
   async markStreamActivityAsRead(userId: string, streamId: string): Promise<void> {
@@ -537,11 +573,23 @@ export class ActivityService {
     }
   }
 
+  /**
+   * Mark every activity row read and emit a clear-all so all sessions zero
+   * their activity/mention maps (the bare UPDATE used to emit nothing — INV-7).
+   */
   async markAllAsRead(userId: string, workspaceId: string): Promise<void> {
-    const count = await ActivityRepository.markAllAsRead(this.pool, userId, workspaceId)
-    if (count > 0) {
-      logger.debug({ userId, workspaceId, count }, "Marked all activity as read")
-    }
+    await withTransaction(this.pool, async (client) => {
+      const count = await ActivityRepository.markAllAsRead(client, userId, workspaceId)
+      if (count > 0) {
+        await OutboxRepository.insert(client, "activity:counts", {
+          workspaceId,
+          targetUserId: userId,
+          counts: [],
+          clearAll: true,
+        })
+        logger.debug({ userId, workspaceId, count }, "Marked all activity as read")
+      }
+    })
   }
 }
 

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -360,9 +360,9 @@ export class ActivityService {
    *
    * Deleting the rows lowers the reacted-to author's unread count, so in the
    * same transaction (INV-7) recompute each affected (user, stream) absolute
-   * count and emit `activity:counts` — otherwise the badge stays stranded above
-   * the truth on every session (the bug this fixes). Only non-self rows with a
-   * stream move a badge; self rows were inserted already read.
+   * count and emit `activity:counts`, keeping the badge from sitting above
+   * database truth. Only non-self rows with a stream move a badge; self rows
+   * were inserted already read.
    */
   async processReactionRemoved(params: {
     workspaceId: string
@@ -543,10 +543,9 @@ export class ActivityService {
   }
 
   /**
-   * Mark one activity row read and emit the stream's new absolute count so the
-   * badge converges on every session (the bare UPDATE used to emit nothing, so
-   * other tabs/devices stayed stale-high — INV-7). Stream-less saved-reminder
-   * rows carry no per-stream badge, so they skip the emit.
+   * Mark one activity row read and emit the stream's new absolute count in the
+   * same transaction (INV-7) so the badge converges on every session. Stream-less
+   * saved-reminder rows carry no per-stream badge, so they skip the emit.
    */
   async markAsRead(activityId: string, userId: string): Promise<void> {
     await withTransaction(this.pool, async (client) => {
@@ -574,8 +573,8 @@ export class ActivityService {
   }
 
   /**
-   * Mark every activity row read and emit a clear-all so all sessions zero
-   * their activity/mention maps (the bare UPDATE used to emit nothing — INV-7).
+   * Mark every activity row read and emit a clear-all in the same transaction
+   * (INV-7) so all sessions zero their activity/mention maps.
    */
   async markAllAsRead(userId: string, workspaceId: string): Promise<void> {
     await withTransaction(this.pool, async (client) => {

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -75,6 +75,7 @@ export type OutboxEventType =
   | "invitation:accepted"
   | "invitation:revoked"
   | "activity:created"
+  | "activity:counts"
   | "saved:upserted"
   | "saved:deleted"
   | "saved_reminder:fired"
@@ -570,6 +571,26 @@ export interface ActivityCreatedOutboxPayload extends WorkspaceScopedPayload {
   }
 }
 
+/**
+ * Absolute activity/mention counts for a target user, emitted when a path
+ * LOWERS or re-homes `user_activity` truth without creating a row (reaction
+ * removal, message move, Activity-page mark-read). The client SETS its per-
+ * stream counter maps from `counts` (and zeroes them all first when `clearAll`),
+ * so a count the `activity:created` family would otherwise strand converges —
+ * live and on offline catch-up replay. User-scoped like `activity:created`, but
+ * deliberately NOT consumed by the push handler (it notifies on nothing).
+ */
+export interface ActivityCountsOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  counts: Array<{
+    streamId: string
+    mentionCount: number
+    activityCount: number
+  }>
+  /** Zero every activity/mention count before applying `counts` (mark-all-read). */
+  clearAll?: boolean
+}
+
 export interface SavedUpsertedOutboxPayload extends WorkspaceScopedPayload {
   targetUserId: string
   saved: SavedMessageView
@@ -797,6 +818,7 @@ export interface OutboxEventPayloadMap {
   "invitation:accepted": InvitationAcceptedOutboxPayload
   "invitation:revoked": InvitationRevokedOutboxPayload
   "activity:created": ActivityCreatedOutboxPayload
+  "activity:counts": ActivityCountsOutboxPayload
   "saved:upserted": SavedUpsertedOutboxPayload
   "saved:deleted": SavedDeletedOutboxPayload
   "saved_reminder:fired": SavedReminderFiredOutboxPayload
@@ -921,6 +943,7 @@ export function isAuthorScopedEvent(event: OutboxEvent): event is OutboxEvent<Au
 /** Events that are scoped to a specific target user (delivered to that user's sockets) */
 export type UserScopedEventType =
   | "activity:created"
+  | "activity:counts"
   | "saved:upserted"
   | "saved:deleted"
   | "saved_reminder:fired"
@@ -935,6 +958,7 @@ export type UserScopedEventType =
 
 const USER_SCOPED_EVENTS: UserScopedEventType[] = [
   "activity:created",
+  "activity:counts",
   "saved:upserted",
   "saved:deleted",
   "saved_reminder:fired",

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1507,7 +1507,15 @@ export function StreamContent({
     lastReadEventId,
     enabled: autoMarkEnabled,
   })
-  useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
+  useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, {
+    enabled: autoMarkEnabled,
+    partial: !atLastRow,
+    // Heal target: when the viewer is caught up (atLastRow) but activity is
+    // stranded with no new message to scroll past, lastSeenEventId is undefined;
+    // re-marking up to the current read pointer clears the stuck activity rows.
+    readPointerEventId: lastReadEventId,
+    atLastRow,
+  })
 
   const isMobile = useIsMobile()
   const { markAsRead, markUnread, getUnreadCount } = useUnreadCounts(workspaceId)

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -284,4 +284,72 @@ describe("useAutoMarkAsRead", () => {
     expect(mockMarkAsRead).toHaveBeenLastCalledWith("stream_b", "event_shared", { partial: false })
     expect(mockMarkAsRead).toHaveBeenCalledTimes(2)
   })
+
+  it("heals a stranded badge: re-marks the read pointer when caught up with no new event seen", () => {
+    // lastEventId undefined (nothing new scrolled past) but the viewer is at the
+    // last row with activity still elevated — the phantom-badge case. Re-mark up
+    // to the current pointer to clear the stranded activity rows, as a full mark
+    // so the badge zeroes optimistically instead of glowing on.
+    unreadCount = 0
+    activityCount = 2
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_pointer", atLastRow: true })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_pointer", { partial: false })
+  })
+
+  it("does NOT heal while unread sits below the fold (not at the last row)", () => {
+    // Clearing activity is whole-stream, so a heal with unread below would wipe
+    // activity for messages the viewer hasn't reached. Gated on atLastRow.
+    unreadCount = 0
+    activityCount = 2
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_pointer", atLastRow: false })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("does NOT heal without a read pointer to mark up to", () => {
+    unreadCount = 0
+    activityCount = 2
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: null, atLastRow: true })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
+
+  it("does NOT advance the pointer when unread sits below with nothing seen and no activity", () => {
+    // Progressive-read contract: no seen-but-unmarked event and zero activity →
+    // nothing to mark; the heal must not fabricate a read.
+    unreadCount = 3
+    activityCount = 0
+
+    renderHook(() =>
+      useAutoMarkAsRead("ws_123", "stream_123", undefined, { readPointerEventId: "event_pointer", atLastRow: false })
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -16,6 +16,21 @@ interface UseAutoMarkAsReadOptions {
    * (Slack-style progressive read). Defaults false: mark fully read as before.
    */
   partial?: boolean
+  /**
+   * The viewer's current persisted read pointer. Used only as a heal target:
+   * when nothing new has been seen (`lastEventId` undefined) but the viewer is
+   * caught up to the last row with activity still elevated, re-marking up to
+   * this pointer clears the stranded activity rows (and emits the `stream:read`
+   * that zeroes the badge) without moving the read position. Null/undefined
+   * when nothing is read yet — no heal target, so the heal is skipped.
+   */
+  readPointerEventId?: string | null
+  /**
+   * Whether the read frontier has reached the last rendered row (a full read).
+   * Gates the heal above: clearing activity is whole-stream, not ordinal-scoped,
+   * so it must never fire while unread messages sit below the fold.
+   */
+  atLastRow?: boolean
 }
 
 /**
@@ -36,7 +51,7 @@ export function useAutoMarkAsRead(
   lastEventId: string | undefined,
   options: UseAutoMarkAsReadOptions = {}
 ) {
-  const { enabled = true, debounceMs = 500, partial = false } = options
+  const { enabled = true, debounceMs = 500, partial = false, readPointerEventId, atLastRow = false } = options
   const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
   const { isVisible, isFocused } = usePageActivity()
@@ -64,9 +79,13 @@ export function useAutoMarkAsRead(
   const streamIdRef = useRef(streamId)
   const lastEventIdRef = useRef(lastEventId)
   const partialRef = useRef(partial)
+  const readPointerEventIdRef = useRef(readPointerEventId)
+  const atLastRowRef = useRef(atLastRow)
   streamIdRef.current = streamId
   lastEventIdRef.current = lastEventId
   partialRef.current = partial
+  readPointerEventIdRef.current = readPointerEventId
+  atLastRowRef.current = atLastRow
 
   // The consumer (StreamContent) is not keyed by streamId, so this hook persists
   // across stream switches. Clear the dedup refs per stream — otherwise a prior
@@ -78,33 +97,47 @@ export function useAutoMarkAsRead(
   }, [streamId])
 
   useEffect(() => {
-    if (!enabled || !lastEventId || !canAutoRead) return
+    if (!enabled || !canAutoRead) return
 
     const unreadCount = getUnreadCount(streamId)
     const activityCount = getActivityCount(streamId)
 
     if (unreadCount === 0 && activityCount === 0) return
 
-    // Skip if already marked this event at the same partial-ness AND no pending
-    // activities to clear. Activities can arrive via activity:created while we're
-    // viewing the stream (the outbox handler is async), so we must re-fire to
-    // clear them even if lastEventId hasn't changed; likewise a partial→full
-    // transition at the same event must re-fire to clear the badge.
-    if (lastMarkedRef.current === lastEventId && lastMarkedPartialRef.current === partial && activityCount === 0) return
+    const target = resolveAutoReadTarget({ lastEventId, atLastRow, readPointerEventId, partial, activityCount })
+    if (!target) return
+
+    // Skip if already marked this exact target at the same partial-ness AND no
+    // pending activity to clear. Activity can arrive via activity:created while
+    // we're viewing (the outbox handler is async), and a no-counter-event
+    // backend clear can strand the badge, so re-fire to clear it even when the
+    // target is unchanged; a partial→full transition likewise re-fires.
+    if (
+      lastMarkedRef.current === target.eventId &&
+      lastMarkedPartialRef.current === target.partial &&
+      activityCount === 0
+    )
+      return
 
     if (timerRef.current) {
       clearTimeout(timerRef.current)
     }
 
     timerRef.current = setTimeout(() => {
-      // Read current values at execution time, not capture time, so a stream
+      // Resolve from refs at execution time, not capture time, so a stream
       // switch during the debounce window marks the stream actually in view.
       const currentStreamId = streamIdRef.current
-      const currentLastEventId = lastEventIdRef.current
-      if (currentLastEventId) {
-        markAsRead(currentStreamId, currentLastEventId, { partial: partialRef.current })
-        lastMarkedRef.current = currentLastEventId
-        lastMarkedPartialRef.current = partialRef.current
+      const resolved = resolveAutoReadTarget({
+        lastEventId: lastEventIdRef.current,
+        atLastRow: atLastRowRef.current,
+        readPointerEventId: readPointerEventIdRef.current,
+        partial: partialRef.current,
+        activityCount: getActivityCount(currentStreamId),
+      })
+      if (resolved) {
+        markAsRead(currentStreamId, resolved.eventId, { partial: resolved.partial })
+        lastMarkedRef.current = resolved.eventId
+        lastMarkedPartialRef.current = resolved.partial
         // Dismiss any push notification for this stream — the user is reading it
         navigator.serviceWorker?.controller?.postMessage({
           type: SW_MSG_CLEAR_NOTIFICATIONS,
@@ -118,5 +151,42 @@ export function useAutoMarkAsRead(
         clearTimeout(timerRef.current)
       }
     }
-  }, [enabled, streamId, lastEventId, partial, debounceMs, markAsRead, getUnreadCount, getActivityCount, canAutoRead])
+  }, [
+    enabled,
+    streamId,
+    lastEventId,
+    partial,
+    debounceMs,
+    markAsRead,
+    getUnreadCount,
+    getActivityCount,
+    canAutoRead,
+    atLastRow,
+    readPointerEventId,
+  ])
+}
+
+/**
+ * The event to mark read up to, and whether it's a partial mark. Normally the
+ * furthest SEEN event. When nothing new has been seen (`lastEventId` undefined)
+ * but the viewer is caught up to the last row with activity still elevated, the
+ * target is the existing read pointer — a heal that clears the stranded activity
+ * rows (and emits the `stream:read` that zeroes the badge) without moving the
+ * read position. The heal is a FULL mark so the badge clears optimistically; it
+ * is gated on `atLastRow` because clearing activity is whole-stream, never
+ * ordinal-scoped, so it must not fire while unread sits below the fold. Returns
+ * null when there's nothing to mark.
+ */
+function resolveAutoReadTarget(opts: {
+  lastEventId: string | undefined
+  atLastRow: boolean
+  readPointerEventId: string | null | undefined
+  partial: boolean
+  activityCount: number
+}): { eventId: string; partial: boolean } | null {
+  if (opts.lastEventId) return { eventId: opts.lastEventId, partial: opts.partial }
+  if (opts.atLastRow && opts.activityCount > 0 && opts.readPointerEventId) {
+    return { eventId: opts.readPointerEventId, partial: false }
+  }
+  return null
 }

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -5,6 +5,7 @@ import {
   applyStreamReadSet,
   applyStreamsReadAllOrdinals,
   applyActivityCounts,
+  applyActivityCountsBatch,
   type UnreadCounterState,
 } from "./unread-counters"
 
@@ -212,5 +213,55 @@ describe("applyActivityCounts", () => {
     const once = applyActivityCounts(state, "s1", { mentionCount: 0, activityCount: 2 })
     expect(applyActivityCounts(once, "s1", { mentionCount: 0, activityCount: 2 })).toEqual(once)
     expect(once.unreadActivityCount).toBe(2)
+  })
+})
+
+describe("applyActivityCountsBatch", () => {
+  it("SETS the listed streams' absolute counts and rederives the total", () => {
+    // s1 was stuck at 2 (a reaction removal cleared its rows); the event carries
+    // the recomputed 0, so the badge drops without touching s2.
+    const state = makeState({
+      mentionCounts: { s1: 1, s2: 1 },
+      activityCounts: { s1: 2, s2: 3 },
+      unreadActivityCount: 5,
+    })
+    const next = applyActivityCountsBatch(state, [{ streamId: "s1", mentionCount: 0, activityCount: 0 }])
+    expect(next.activityCounts).toEqual({ s1: 0, s2: 3 })
+    expect(next.mentionCounts).toEqual({ s1: 0, s2: 1 })
+    expect(next.unreadActivityCount).toBe(3)
+  })
+
+  it("clearAll zeroes every map first, then applies the listed counts (mark-all-read)", () => {
+    const state = makeState({
+      mentionCounts: { s1: 1, s2: 2 },
+      activityCounts: { s1: 2, s2: 3 },
+      unreadActivityCount: 5,
+    })
+    const next = applyActivityCountsBatch(state, [], { clearAll: true })
+    expect(next.activityCounts).toEqual({})
+    expect(next.mentionCounts).toEqual({})
+    expect(next.unreadActivityCount).toBe(0)
+  })
+
+  it("re-homes a move: source drops, destination rises, total unchanged", () => {
+    const state = makeState({ activityCounts: { src: 2, dst: 0 }, unreadActivityCount: 2 })
+    const next = applyActivityCountsBatch(state, [
+      { streamId: "src", mentionCount: 0, activityCount: 0 },
+      { streamId: "dst", mentionCount: 0, activityCount: 2 },
+    ])
+    expect(next.activityCounts).toEqual({ src: 0, dst: 2 })
+    expect(next.unreadActivityCount).toBe(2)
+  })
+
+  it("leaves the message-unread maps untouched (separate event family)", () => {
+    const state = makeState({
+      unreadCounts: { s1: 4 },
+      latestOrdinals: { s1: 9 },
+      activityCounts: { s1: 2 },
+      unreadActivityCount: 2,
+    })
+    const next = applyActivityCountsBatch(state, [{ streamId: "s1", mentionCount: 0, activityCount: 0 }])
+    expect(next.unreadCounts).toEqual({ s1: 4 })
+    expect(next.latestOrdinals).toEqual({ s1: 9 })
   })
 })

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -159,6 +159,35 @@ export function applyActivityCounts(
   }
 }
 
+/**
+ * Apply an `activity:counts` event — the absolute per-stream counts the backend
+ * emits when a path LOWERS or re-homes `user_activity` truth without creating a
+ * row (reaction removal, message move re-homing the rows, Activity-page
+ * mark-read). Each listed stream is SET (LWW, like `applyActivityCounts`);
+ * `clearAll` zeroes every activity/mention count first (mark-all-read) so
+ * streams the event doesn't list also drop. The message-unread maps
+ * (`unreadCounts`, `latestOrdinals`) ride their own absolute event family and
+ * are left untouched.
+ */
+export function applyActivityCountsBatch(
+  state: UnreadCounterState,
+  counts: Array<{ streamId: string; mentionCount: number; activityCount: number }>,
+  opts?: { clearAll?: boolean }
+): UnreadCounterState {
+  const mentionCounts = opts?.clearAll ? {} : { ...state.mentionCounts }
+  const activityCounts = opts?.clearAll ? {} : { ...state.activityCounts }
+  for (const c of counts) {
+    mentionCounts[c.streamId] = c.mentionCount
+    activityCounts[c.streamId] = c.activityCount
+  }
+  return {
+    ...state,
+    mentionCounts,
+    activityCounts,
+    unreadActivityCount: sumCounts(activityCounts),
+  }
+}
+
 /** The counter slice of a workspace bootstrap (`messageCounts` are the latest ordinals). */
 export function toCounterState(bootstrap: WorkspaceBootstrap): UnreadCounterState {
   return {

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1615,6 +1615,38 @@ describe("unread counter events (absolute payloads, sync phase 2c)", () => {
 
     cleanup()
   })
+
+  it("applies activity:counts: per-stream SET converges one stream; clearAll zeroes all", async () => {
+    const queryClient = new QueryClient()
+    await seedCounterFixture(queryClient) // activityCounts { stream_1: 1, stream_2: 1 }
+    const { emit, cleanup } = register(queryClient)
+
+    // A reaction removal recomputed stream_1 to 0; stream_2 is untouched.
+    emit("activity:counts", {
+      workspaceId: "ws_1",
+      targetUserId: "member_1",
+      counts: [{ streamId: "stream_1", mentionCount: 0, activityCount: 0 }],
+    })
+
+    let bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.activityCounts.stream_1).toBe(0)
+    expect(bootstrap?.activityCounts.stream_2).toBe(1)
+    expect(bootstrap?.mentionCounts.stream_1).toBe(0)
+    expect(bootstrap?.unreadActivityCount).toBe(1)
+
+    // Mark-all-read clears every stream's activity/mention.
+    emit("activity:counts", { workspaceId: "ws_1", targetUserId: "member_1", counts: [], clearAll: true })
+    bootstrap = queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap("ws_1"))
+    expect(bootstrap?.activityCounts).toEqual({})
+    expect(bootstrap?.unreadActivityCount).toBe(0)
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadActivityCount).toBe(0)
+    })
+
+    cleanup()
+  })
 })
 
 describe("latest ordinal seeding and reconnect merge (sync phase 2c)", () => {

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -19,6 +19,7 @@ import type {
   FeatureFlags,
   LastMessagePreview,
   ActivityCreatedPayload,
+  ActivityCountsPayload,
   SavedUpsertedPayload,
   SavedDeletedPayload,
   SavedReminderFiredPayload,
@@ -51,6 +52,7 @@ import { applyStreamBootstrapInCurrentTransaction } from "./stream-sync"
 import { applyDraftDeleted, applyDraftUpserted } from "./draft-sync"
 import {
   applyActivityCounts,
+  applyActivityCountsBatch,
   applyStreamActivityOrdinal,
   applyStreamReadOrdinal,
   applyStreamReadSet,
@@ -1362,6 +1364,17 @@ export function registerWorkspaceSocketHandlers(
     invalidateActivityFeed(true)
   }
 
+  // Absolute activity/mention counts emitted when a path lowers or re-homes
+  // user_activity truth without creating a row (reaction removal, message move,
+  // Activity-page mark-read). SET per stream (clearAll zeroes all first), so a
+  // count the activity:created family would strand converges — live and via
+  // catch-up replay (user-scoped, sync-logged like activity:created).
+  const handleActivityCounts = (payload: ActivityCountsPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+    commitCounter((state) => applyActivityCountsBatch(state, payload.counts, { clearAll: payload.clearAll }))
+    invalidateActivityFeed(true)
+  }
+
   // GAM memo extraction: surface new memos in the memory explorer without a
   // manual refresh. memo:created is workspace-group routed (sync log + emit),
   // so registering here puts memos on the sync catch-up path like every
@@ -1697,6 +1710,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("bot:created", handleBotCreated)
   socket.on("bot:updated", handleBotUpdated)
   socket.on("activity:created", handleActivityCreated)
+  socket.on("activity:counts", handleActivityCounts)
   socket.on("memo:created", handleMemoCreated)
   socket.on("invitation:sent", handleInvitationChanged)
   socket.on("invitation:accepted", handleInvitationChanged)
@@ -1746,6 +1760,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("bot:created", handleBotCreated)
     socket.off("bot:updated", handleBotUpdated)
     socket.off("activity:created", handleActivityCreated)
+    socket.off("activity:counts", handleActivityCounts)
     socket.off("memo:created", handleMemoCreated)
     socket.off("invitation:sent", handleInvitationChanged)
     socket.off("invitation:accepted", handleInvitationChanged)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1430,6 +1430,25 @@ export interface ActivityCreatedPayload {
   }
 }
 
+/**
+ * Absolute per-stream activity/mention counts, emitted when a path lowers or
+ * re-homes `user_activity` truth without creating a row (reaction removal,
+ * message move, Activity-page mark-read). Clients SET counters from `counts`
+ * (and zero all of them first when `clearAll`), so a count the
+ * `activity:created` family would otherwise strand converges — live and on
+ * offline catch-up replay.
+ */
+export interface ActivityCountsPayload {
+  workspaceId: string
+  targetUserId: string
+  counts: Array<{
+    streamId: string
+    mentionCount: number
+    activityCount: number
+  }>
+  clearAll?: boolean
+}
+
 export interface MarkAsReadInput {
   lastEventId: string
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -455,6 +455,7 @@ export type {
   // Activity
   Activity,
   ActivityCreatedPayload,
+  ActivityCountsPayload,
   // Saved messages
   SavedMessageView,
   SavedMessageSnapshot,


### PR DESCRIPTION
## Problem

The Activity badge (`Σ activityCounts`, `SidebarQuickLinks`) and the per-stream sidebar glow (`mentionCounts`, via `sections.tsx` `getMentionCount > 0`) could show a count with nothing behind it — a glowing "2" over an empty feed, "Mark all read" offered with nothing to read. Forensics on a real workspace (prod read-only) confirmed the reporting user had **zero** unread `user_activity` rows server-side while the UI showed a positive badge: client-side counter drift.

Root cause: the activity/mention counter maps are SET by `activity:created` and only lowered by `stream:read` (`applyStreamReadOrdinal`). Three backend paths LOWER or re-home `user_activity` truth **without emitting any counter event**, so the client maps strand high:

- **reaction removal** — deletes the rows, emitted nothing;
- **message move** — `UPDATE user_activity SET stream_id = …` re-homes the rows (`messaging/repository.ts`), so the source stream's count is never decremented;
- **Activity-page mark-read** — `markAll` / `markOne` did a bare DB write, so other tabs/devices never heard it.

## Solution

Make each silent path emit an absolute `activity:counts` event **in the same transaction as the mutation** (INV-7), user-scoped and sync-logged exactly like `activity:created` — so the badge converges live **and** on offline catch-up replay, with no polling. This is the event-sourced counterpart of `activity:created`/`stream:read`, not a side channel.

### How it works

1. **New `activity:counts` outbox event** (`lib/outbox/repository.ts`): `{ targetUserId, counts: [{ streamId, mentionCount, activityCount }], clearAll? }`. Added to `UserScopedEventType`/`USER_SCOPED_EVENTS`, so `resolveDeliveryGroups` routes it to `user:<id>` and the sync log admits it for that user's catch-up — same plumbing as `activity:created`. Deliberately **not** consumed by the push handler (it notifies on nothing).
2. **Emit sites**, each in-transaction:
   - `ActivityService.markAsRead` returns the marked row's stream (repo `RETURNING workspace_id, stream_id`) and emits that stream's recomputed count; `markAllAsRead` emits `clearAll`.
   - `processReactionRemoved` deletes then recomputes the affected non-self `(user, stream)` pairs and emits.
   - A new `messages:moved` branch in the activity outbox handler recomputes both source and destination for every affected user (`findUserIdsByMessageIds`) and emits.
   - All three share `emitActivityCountsForPairs` (`emit-counts.ts`): dedup pairs → `countUnreadForPairs` → one event per user.
3. **Client apply** (`workspace-sync.ts` `handleActivityCounts` → `applyActivityCountsBatch`): SET each listed stream's absolute count (`clearAll` zeroes every map first). Goes through `commitCounter`, so it folds into the catch-up batch on replay and writes immediately when live. Catch-up dispatch is automatic — `gate.dispatch(eventType, payload)` routes replayed entries to the same `socket.on` handler.

### Also: a progressive-read regression (separate bug, same symptom family)

`useAutoMarkAsRead` bailed on `!lastEventId` **before** it checked `activityCount` (its own comment says it must fire "when any is elevated"). On a fully-read stream `lastSeenEventId` is `undefined`, so activity that arrived with no new message to scroll past (a reaction while caught up) never cleared while viewing. When `atLastRow` with activity elevated, it now re-marks the current read pointer to clear it — gated on `atLastRow`, never on the optimistic `unreadCount` (pinned to 0 while viewing), so it can't clear unread below the fold (the backend clear is whole-stream).

### Key design decisions

**1. Event, not poll.** An earlier revision of this branch added a `GET /activity/counts` endpoint the client polled on focus to reconcile the maps. That papered over the drift with a REST poll foreign to the event-sourced, offline-first counter design (INV-4: real-time via outbox, never ad-hoc). This revision deletes that endpoint/hook and instead makes the three paths emit, so the counters are correct by construction and converge through the same sync-log replay as every other counter event — no extra fetch, online or offline.

**2. `clearAll` for mark-all-read.** Mark-all zeroes every stream including stream-less saved-reminder rows; enumerating streams would miss the null-stream key. `clearAll` zeroes the maps wholesale, then applies any listed counts. The other paths carry an explicit per-stream list.

**3. `messages:moved` handled in the activity feed handler, not the messaging service.** Keeps the `user_activity` projection logic in the activity feature (no messaging→activity import / feature cycle), and mirrors how `activity:created` is emitted downstream of `message:created` rather than inside the message transaction.

**4. `atLastRow`, not `unreadCount`, gates the heal.** While viewing, `applyStreamActivityOrdinal` pins the optimistic `unreadCount` to 0 even with unread below the fold, so it's an unreliable "caught up" signal; `atLastRow` (from `useLastSeenEvent`) is the real one.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/activity/emit-counts.ts` | Shared `emitActivityCountsForPairs` — recompute affected pairs, emit one `activity:counts` per user. |
| `apps/backend/src/features/activity/emit-counts.test.ts` | Tests for it (dedup, group-by-user, zero default, empty). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/outbox/repository.ts` | New `activity:counts` event type + payload, user-scoped classification. |
| `apps/backend/src/features/activity/service.ts` | `markAsRead`/`markAllAsRead`/`processReactionRemoved` emit `activity:counts` in-transaction. |
| `apps/backend/src/features/activity/repository.ts` | `markAsRead` returns the marked row; `findUserIdsByMessageIds` for moves. |
| `apps/backend/src/features/activity/outbox-handler.ts` | New `messages:moved` branch; reaction-removed comment. |
| `apps/backend/src/features/activity/service.test.ts` | Service emit tests (mark-all/mark-one/reaction-removed). |
| `apps/backend/src/features/activity/outbox-handler.test.ts` | `processMessagesMoved` coverage (source+dest emit, malformed/E2E skips, no-affected-users no-op). |
| `packages/types/src/api.ts`, `index.ts` | `ActivityCountsPayload` wire type + barrel export. |
| `apps/frontend/src/sync/unread-counters.ts` | `applyActivityCountsBatch` applier. |
| `apps/frontend/src/sync/workspace-sync.ts` | `handleActivityCounts` socket handler + register/cleanup. |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | `readPointerEventId`/`atLastRow` options + `resolveAutoReadTarget` heal. |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Pass `readPointerEventId`/`atLastRow`. |
| `apps/frontend/src/sync/unread-counters.test.ts`, `workspace-sync.test.ts`, `use-auto-mark-as-read.test.ts` | Applier, socket-handler, and heal tests. |

## Out of scope (deliberate)

- **Marking one stream-less saved-reminder row read cross-device.** `markOne` on a row with `streamId: null` can't key a per-stream count, so it skips the emit (same-device optimistic update still clears it). Rare; noted, not handled.

## Test plan

- [x] `apps/backend` activity unit suites — `service.test.ts` + `emit-counts.test.ts` (29 pass), `outbox-handler.test.ts` `processMessagesMoved` (4 pass), `lib/outbox/delivery-groups.test.ts` (12 pass, user-scoped routing). One pre-existing `outbox-handler.test.ts` case needs Postgres (`ECONNREFUSED` in the sandbox) — unrelated to this PR.
- [x] `apps/frontend` — `unread-counters.test.ts` + `workspace-sync.test.ts` + `sync-engine.test.ts` (117 pass), `sidebar/` + `pages/` + `timeline/` (484 pass), `use-auto-mark-as-read.test.ts`.
- [x] `bun run typecheck` clean across the monorepo; `prettier --check` clean. CI green on `207c9ac` (Lint, Tests, WorkOS, 4× browser-tests, evaluate-results, playwright-report merge).
- [ ] Not exercised end-to-end in a live app — a staging smoke-test (react then un-react while caught up; mark-all on one tab, watch another; move messages with unread activity) would be worth doing before merge.

<details>
<summary>📋 Design evolution</summary>

First revision (commit, since rewritten) added a `GET /activity/counts` endpoint + a `useActivityCountReconcile` hook that polled it on focus/mount and SET the counter maps from the server snapshot, fenced against live events. It worked, but it was a poll bolted onto an event-sourced, offline-first counter system — the reviewer's call ("the solution as a whole feels like a copout"). Rewritten to emit the missing counter events from the three silent paths instead, so convergence rides the existing sync-log replay with no extra fetch. The endpoint, hook, and `reconcileActivityCounts` applier were removed; the auto-read heal (a genuinely separate regression) was kept.

Follow-up commit `207c9ac` addressed CodeRabbit review: assert emitted event content instead of call counts (INV-23/24), add the `processMessagesMoved` test coverage above, and drop change-history phrasing from the `service.ts` comments (INV-25).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)