### PR TITLE
fix(frontend): stop fighting the iOS keyboard in the composer

### DIFF
--- a/apps/frontend/src/hooks/use-visual-viewport.test.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.test.ts
@@ -533,3 +533,108 @@ describe("useVisualViewport", () => {
     expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("")
   })
 })
+
+describe("useVisualViewport on iOS WebKit", () => {
+  // iOS overlays the keyboard instead of resizing the layout viewport and pans
+  // the visual viewport itself. The hook must stay passive there: report the
+  // open/closed boolean but never touch `--viewport-height` (driving it fought
+  // iOS's pan and threw the composer off-screen) and never scroll the page.
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
+  const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
+  const originalPlatform = Object.getOwnPropertyDescriptor(Navigator.prototype, "platform")
+
+  let fakeVV: FakeVisualViewport
+  let innerHeight: number
+
+  beforeEach(() => {
+    innerHeight = INNER_HEIGHT_DEFAULT
+    fakeVV = new FakeVisualViewport(INNER_HEIGHT_DEFAULT)
+
+    Object.defineProperty(window, "innerHeight", { configurable: true, get: () => innerHeight })
+    Object.defineProperty(window, "visualViewport", { configurable: true, get: () => fakeVV })
+    Object.defineProperty(navigator, "platform", { configurable: true, get: () => "iPhone" })
+
+    document.documentElement.style.removeProperty("--viewport-height")
+  })
+
+  afterEach(() => {
+    if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
+    else Reflect.deleteProperty(window, "visualViewport")
+    if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
+    if (originalPlatform) Object.defineProperty(Navigator.prototype, "platform", originalPlatform)
+    document.documentElement.style.removeProperty("--viewport-height")
+    vi.restoreAllMocks()
+  })
+
+  it("never writes --viewport-height — even on a real keyboard open", () => {
+    const { result } = renderHook(() => useVisualViewport(true))
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("")
+
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    Object.defineProperty(editable, "isContentEditable", { configurable: true, get: () => true })
+    editable.tabIndex = 0
+    document.body.appendChild(editable)
+    editable.focus()
+
+    // Keyboard overlays: innerHeight stays full, only the visual viewport shrinks.
+    act(() => {
+      fakeVV.height = 500
+      fakeVV.emitResize()
+    })
+
+    expect(result.current).toBe(true)
+    expect(document.documentElement.style.getPropertyValue("--viewport-height")).toBe("")
+
+    editable.remove()
+  })
+
+  it("does not scroll the page to cancel iOS's visual-viewport pan", () => {
+    const scrollSpy = vi.spyOn(window, "scrollTo")
+    renderHook(() => useVisualViewport(true))
+
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    Object.defineProperty(editable, "isContentEditable", { configurable: true, get: () => true })
+    editable.tabIndex = 0
+    document.body.appendChild(editable)
+    editable.focus()
+
+    act(() => {
+      fakeVV.height = 500
+      fakeVV.offsetTop = 120 // iOS panned the page up under the keyboard
+      fakeVV.emitResize()
+    })
+
+    expect(scrollSpy).not.toHaveBeenCalled()
+
+    editable.remove()
+  })
+
+  it("reports the keyboard closed again when the visual viewport grows back", () => {
+    const editable = document.createElement("div")
+    editable.contentEditable = "true"
+    Object.defineProperty(editable, "isContentEditable", { configurable: true, get: () => true })
+    editable.tabIndex = 0
+    document.body.appendChild(editable)
+    editable.focus()
+
+    const { result } = renderHook(() => useVisualViewport(true))
+
+    act(() => {
+      fakeVV.height = 500
+      fakeVV.emitResize()
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      editable.blur()
+      fakeVV.height = 800
+      fakeVV.offsetTop = 0
+      fakeVV.emitResize()
+    })
+    expect(result.current).toBe(false)
+
+    editable.remove()
+  })
+})

--- a/apps/frontend/src/hooks/use-visual-viewport.test.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.test.ts
@@ -541,7 +541,7 @@ describe("useVisualViewport on iOS WebKit", () => {
   // iOS's pan and threw the composer off-screen) and never scroll the page.
   const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport")
   const originalInnerHeight = Object.getOwnPropertyDescriptor(window, "innerHeight")
-  const originalPlatform = Object.getOwnPropertyDescriptor(Navigator.prototype, "platform")
+  const originalPlatform = Object.getOwnPropertyDescriptor(navigator, "platform")
 
   let fakeVV: FakeVisualViewport
   let innerHeight: number
@@ -561,7 +561,8 @@ describe("useVisualViewport on iOS WebKit", () => {
     if (originalVisualViewport) Object.defineProperty(window, "visualViewport", originalVisualViewport)
     else Reflect.deleteProperty(window, "visualViewport")
     if (originalInnerHeight) Object.defineProperty(window, "innerHeight", originalInnerHeight)
-    if (originalPlatform) Object.defineProperty(Navigator.prototype, "platform", originalPlatform)
+    if (originalPlatform) Object.defineProperty(navigator, "platform", originalPlatform)
+    else Reflect.deleteProperty(navigator, "platform")
     document.documentElement.style.removeProperty("--viewport-height")
     vi.restoreAllMocks()
   })

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -93,6 +93,44 @@ export function useVisualViewport(enabled: boolean): boolean {
     const vv = window.visualViewport
     const docEl = document.documentElement
 
+    // iOS WebKit ignores `interactive-widget=resizes-content`: the on-screen
+    // keyboard overlays the layout viewport instead of shrinking it
+    // (`window.innerHeight` stays full; only `visualViewport.height` shrinks),
+    // and WebKit pans the visual viewport itself to keep the focused field
+    // visible. The Chrome-Android machinery below fights that — it shrinks
+    // `--viewport-height` to the visual height and `scrollTo(0,0)`s to cancel
+    // the pan — which threw the bottom-anchored composer off-screen on iPhone.
+    // Stay passive here: never touch `--viewport-height` (iOS resolves `100dvh`
+    // correctly, so AppShell's fallback is right; the buggy `dvh` resolution
+    // the pinning works around is Chrome-only) and never cancel the pan, so
+    // WebKit's native keyboard avoidance lifts the composer into view. Only the
+    // open/closed boolean is reported (it gates safe-area padding and
+    // pull-to-refresh).
+    if (isIOS()) {
+      const measureOpen = () => {
+        const vvHeight = vv ? vv.height : window.innerHeight
+        const open = isEditableFocused() && vvHeight < window.innerHeight - KEYBOARD_THRESHOLD
+        setIsKeyboardOpen((prev) => (prev !== open ? open : prev))
+      }
+      measureOpen()
+      if (vv) {
+        vv.addEventListener("resize", measureOpen)
+        vv.addEventListener("scroll", measureOpen)
+      }
+      window.addEventListener("resize", measureOpen)
+      document.addEventListener("focusin", measureOpen)
+      document.addEventListener("focusout", measureOpen)
+      return () => {
+        if (vv) {
+          vv.removeEventListener("resize", measureOpen)
+          vv.removeEventListener("scroll", measureOpen)
+        }
+        window.removeEventListener("resize", measureOpen)
+        document.removeEventListener("focusin", measureOpen)
+        document.removeEventListener("focusout", measureOpen)
+      }
+    }
+
     baseHeight.current = window.innerHeight
     // Last value written to --viewport-height so we can skip redundant style
     // writes during the rAF poll loop and avoid invalidating every consumer
@@ -341,4 +379,17 @@ function isEditable(el: HTMLElement): boolean {
 function isEditableFocused(): boolean {
   const el = document.activeElement
   return el instanceof HTMLElement && isEditable(el)
+}
+
+/**
+ * True on iOS WebKit (iPhone/iPad — Safari and every iOS browser share the
+ * engine). Distinguishes the keyboard-overlay behavior, not the OS: iPadOS 13+
+ * reports as "MacIntel", told apart from a real Mac by its touch points (a
+ * trackpad reports 0). Called inside the effect, not memoized at module load,
+ * so tests can stub `navigator` before mounting the hook.
+ */
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false
+  if (/iPhone|iPod|iPad/.test(navigator.platform)) return true
+  return /Mac/.test(navigator.platform) && navigator.maxTouchPoints > 1
 }


### PR DESCRIPTION
## What

On iPhone, opening the keyboard threw the message composer off-screen. This adds an iOS-specific passive branch to `useVisualViewport` so WebKit's native keyboard avoidance handles the composer instead of the hook fighting it. The Android/Chrome path is unchanged.

## Why

The app sizes itself to a JS-pinned `--viewport-height`, and `useVisualViewport` was driving that on every device, plus calling `window.scrollTo(0, 0)` to cancel visual-viewport panning.

- **Android Chrome** honors the `interactive-widget=resizes-content` viewport meta tag (`index.html`): the keyboard shrinks the real layout viewport (`window.innerHeight`) together with the visual viewport, no panning — so shrinking `--viewport-height` cleanly lifts the composer above the keyboard. ✅
- **iOS WebKit ignores `interactive-widget`**: the keyboard *overlays* the layout viewport (`innerHeight` stays full, only `visualViewport.height` shrinks) and WebKit pans the visual viewport itself to keep the focused field visible. The hook fought that by shrinking `--viewport-height` to the visual height **and** `scrollTo(0,0)`-ing to cancel the pan — the tug-of-war threw the bottom-anchored composer off-screen. ❌

## How

`useVisualViewport` now detects iOS WebKit (iPhone/iPod/iPad, plus iPadOS-as-Mac via touch points) and, on iOS only:

- reports the keyboard open/closed boolean (still gates safe-area bottom padding and pull-to-refresh), but
- **never** writes `--viewport-height` — iOS resolves `100dvh` correctly, so AppShell's CSS fallback is right (the buggy `dvh` resolution the pinning works around is Chrome-only), and
- **never** calls `window.scrollTo(0, 0)` — so WebKit's native keyboard avoidance lifts the composer into view.

The entire Android/Chrome machinery (growth debounce, optimistic-close suppression, phantom-shrink clamp, reconcile) is byte-for-byte unchanged, so the platform that works today can't regress.

## Tests

- 3 new cases for the iOS branch: no `--viewport-height` write on a real keyboard open, no `scrollTo` pan-cancel even when `offsetTop > 0`, and the open/closed boolean toggles back to closed when the viewport grows again.
- All 19 tests in `use-visual-viewport.test.ts` pass; `bunx tsc --noEmit` clean; eslint clean on the changed files.

## Reviewer notes / testing caveat

This couldn't be verified on a physical iPhone from the dev environment — the on-device result of "let WebKit handle it" is a device behavior that can't be observed here. The change is low-risk (iOS-gated, Android untouched), so it's safe to test on-device. **Please confirm on an iPhone that the composer now sits just above the keyboard instead of flying off.** If it's still off, the fallback would be a `position: fixed` composer that explicitly tracks the `visualViewport` offset — a larger change deliberately avoided here unless the passive approach proves insufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMzpotJsh8pr2RZv5eZvX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784832767&installation_id=129946197&pr_number=1061&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1061&signature=9eaaf43c46160bba91219adbafa4607cceb99e33eee5d93b74151b0b7f2837b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->