### PR TITLE
feat(board): render the board as a feed of message-led posts

### DIFF
--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -32,7 +32,7 @@ describe("Conversation Handlers", () => {
   const mockValidateStreamAccess = mock(() => Promise.resolve({ id: "stream_1", workspaceId: "ws_1" }))
   const mockListByStream = mock(() => Promise.resolve([] as Record<string, unknown>[]))
   const mockListByWorkspace = mock(() =>
-    Promise.resolve({ conversations: [] as Record<string, unknown>[], nextCursor: null as string | null })
+    Promise.resolve({ posts: [] as Record<string, unknown>[], nextCursor: null as string | null })
   )
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
@@ -63,7 +63,7 @@ describe("Conversation Handlers", () => {
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
-    mockListByWorkspace.mockResolvedValue({ conversations: [], nextCursor: null })
+    mockListByWorkspace.mockResolvedValue({ posts: [], nextCursor: null })
     mockGetFlag.mockResolvedValue("on")
     mockGetById.mockResolvedValue({
       id: "conv_1",
@@ -140,14 +140,14 @@ describe("Conversation Handlers", () => {
     })
 
     test("returns the paged result the service resolves", async () => {
-      const conversations = [{ id: "conv_1" }, { id: "conv_2" }]
-      mockListByWorkspace.mockResolvedValue({ conversations, nextCursor: "2026-06-22T12:00:00.000Z|conv_2" })
+      const posts = [{ conversation: { id: "conv_1" } }, { conversation: { id: "conv_2" } }]
+      mockListByWorkspace.mockResolvedValue({ posts, nextCursor: "2026-06-22T12:00:00.000Z|conv_2" })
       const res = mockRes()
 
       await handlers.listByWorkspace(mockReq({ query: {} }), res)
 
       expect((res as unknown as { body: unknown }).body).toEqual({
-        conversations,
+        posts,
         nextCursor: "2026-06-22T12:00:00.000Z|conv_2",
       })
     })

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -117,6 +117,34 @@ export function createConversationHandlers({ conversationService, streamService,
     },
 
     /**
+     * The board card's "N more" expand: the full conversation as enriched board
+     * post messages (attachments + link previews), so revealed middle messages
+     * read like the rest of the post. Board-gated (404 without the flag), same
+     * as the workspace feed.
+     */
+    async getBoardMessages(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { conversationId } = req.params
+
+      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
+      if (boardFlag !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const messages = await conversationService.getBoardMessages(workspaceId, conversationId)
+      res.json({ messages })
+    },
+
+    /**
      * User correction from the timeline conversation overlay: make
      * `conversationId` the message's primary conversation. Applies the move
      * and records it as boundary-extraction feedback.

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -40,11 +40,16 @@ export interface BoardPostMessage {
   createdAt: Date
 }
 
-/** A conversation surfaced as a feed post: the grouping, its opening message, and the latest replies. */
+/** A conversation surfaced as a feed post: the grouping, its origin message, and the latest replies. */
 export interface BoardPost {
   conversation: ConversationWithStaleness
+  /** The post's origin: the conversation's first message, or — for a thread —
+   * the parent message in the parent stream that the thread descends from. */
   openingMessage: BoardPostMessage | null
+  /** The trailing reply messages (up to 3), chronological. */
   recentMessages: BoardPostMessage[]
+  /** Total replies under the origin (excludes the origin). Drives the "N more" gap. */
+  totalReplies: number
 }
 
 export interface ReassignMessageParams {
@@ -101,20 +106,39 @@ export class ConversationService {
     })
     const conversations = rows.map(addStalenessFields)
 
-    // Hydrate each post's opening message plus its last few replies so the board
+    // Resolve each conversation's stream so a thread post can show its true
+    // origin: a thread is its own stream, so its `messageIds` are the replies and
+    // the originating message lives in the parent stream (`parentMessageId`),
+    // never a member of the thread conversation.
+    const streamIds = [...new Set(conversations.map((c) => c.streamId))]
+    const streamById = new Map(
+      (streamIds.length > 0 ? await StreamRepository.findByIds(this.pool, streamIds) : []).map((s) => [s.id, s])
+    )
+
+    // Hydrate each post's origin message plus its last few replies so the board
     // renders real post content + reactions, not just a topic line. One batch
     // read over the union of needed ids (INV-56); the access filter already ran
     // in the conversation query, so these ids are all viewer-readable.
-    // `findByIds` carries reactions with each message.
-    const planByConversation = new Map<string, { openingId: string | undefined; recentIds: string[] }>()
+    const planByConversation = new Map<
+      string,
+      { originId: string | undefined; recentIds: string[]; totalReplies: number }
+    >()
     const idsToFetch = new Set<string>()
     for (const conversation of conversations) {
+      const stream = streamById.get(conversation.streamId)
       const ids = conversation.messageIds
-      const openingId = ids[0]
-      // Last 3, never including the opening at index 0.
-      const recentIds = ids.length > 1 ? ids.slice(Math.max(1, ids.length - 3)) : []
-      planByConversation.set(conversation.id, { openingId, recentIds })
-      if (openingId) idsToFetch.add(openingId)
+      let originId: string | undefined
+      let replyIds: string[]
+      if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
+        originId = stream.parentMessageId
+        replyIds = ids
+      } else {
+        originId = ids[0]
+        replyIds = ids.slice(1)
+      }
+      const recentIds = replyIds.slice(Math.max(0, replyIds.length - 3))
+      planByConversation.set(conversation.id, { originId, recentIds, totalReplies: replyIds.length })
+      if (originId) idsToFetch.add(originId)
       for (const id of recentIds) idsToFetch.add(id)
     }
     const ids = [...idsToFetch]
@@ -138,12 +162,17 @@ export class ConversationService {
 
     const posts: BoardPost[] = conversations.map((conversation) => {
       const plan = planByConversation.get(conversation.id)!
-      const opening = plan.openingId ? messageById.get(plan.openingId) : undefined
+      const opening = plan.originId ? messageById.get(plan.originId) : undefined
       const recentMessages = plan.recentIds
         .map((id) => messageById.get(id))
         .filter((m): m is Message => Boolean(m))
         .map(buildPostMessage)
-      return { conversation, openingMessage: opening ? buildPostMessage(opening) : null, recentMessages }
+      return {
+        conversation,
+        openingMessage: opening ? buildPostMessage(opening) : null,
+        recentMessages,
+        totalReplies: plan.totalReplies,
+      }
     })
 
     // A full page means there may be more; the last row's (activity, id) is the

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -36,10 +36,11 @@ export interface BoardPostMessage {
   createdAt: Date
 }
 
-/** A conversation surfaced as a feed post: the grouping plus its opening message. */
+/** A conversation surfaced as a feed post: the grouping, its opening message, and the latest replies. */
 export interface BoardPost {
   conversation: ConversationWithStaleness
   openingMessage: BoardPostMessage | null
+  recentMessages: BoardPostMessage[]
 }
 
 export interface ReassignMessageParams {
@@ -96,18 +97,33 @@ export class ConversationService {
     })
     const conversations = rows.map(addStalenessFields)
 
-    // Hydrate each post's opening message (the conversation's first primary
-    // message) so the board renders real post content + reactions, not just a
-    // topic line. One batch read keyed on the opening ids (INV-56); the access
-    // filter already ran in the conversation query, so these ids are all viewer-
-    // readable. `findByIds` carries reactions with each message.
-    const openingIds = conversations.map((c) => c.messageIds[0]).filter((id): id is string => Boolean(id))
-    const openingById: Map<string, Message> =
-      openingIds.length > 0 ? await MessageRepository.findByIds(this.pool, openingIds) : new Map()
+    // Hydrate each post's opening message plus its last few replies so the board
+    // renders real post content + reactions, not just a topic line. One batch
+    // read over the union of needed ids (INV-56); the access filter already ran
+    // in the conversation query, so these ids are all viewer-readable.
+    // `findByIds` carries reactions with each message.
+    const planByConversation = new Map<string, { openingId: string | undefined; recentIds: string[] }>()
+    const idsToFetch = new Set<string>()
+    for (const conversation of conversations) {
+      const ids = conversation.messageIds
+      const openingId = ids[0]
+      // Last 3, never including the opening at index 0.
+      const recentIds = ids.length > 1 ? ids.slice(Math.max(1, ids.length - 3)) : []
+      planByConversation.set(conversation.id, { openingId, recentIds })
+      if (openingId) idsToFetch.add(openingId)
+      for (const id of recentIds) idsToFetch.add(id)
+    }
+    const messageById: Map<string, Message> =
+      idsToFetch.size > 0 ? await MessageRepository.findByIds(this.pool, [...idsToFetch]) : new Map()
 
     const posts: BoardPost[] = conversations.map((conversation) => {
-      const opening = openingById.get(conversation.messageIds[0])
-      return { conversation, openingMessage: opening ? toBoardPostMessage(opening) : null }
+      const plan = planByConversation.get(conversation.id)!
+      const opening = plan.openingId ? messageById.get(plan.openingId) : undefined
+      const recentMessages = plan.recentIds
+        .map((id) => messageById.get(id))
+        .filter((m): m is Message => Boolean(m))
+        .map(toBoardPostMessage)
+      return { conversation, openingMessage: opening ? toBoardPostMessage(opening) : null, recentMessages }
     })
 
     // A full page means there may be more; the last row's (activity, id) is the

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -4,11 +4,13 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository } from "../streams"
+import { AttachmentRepository, toAttachmentSummary, type Attachment } from "../attachments"
+import { LinkPreviewRepository, toLinkPreviewSummary, type LinkPreview } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { conversationFeedbackId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
-import { StreamTypes, type ConversationStatus } from "@threa/types"
+import { StreamTypes, type AttachmentSummary, type ConversationStatus, type LinkPreviewSummary } from "@threa/types"
 
 export { ConversationWithStaleness }
 
@@ -33,6 +35,8 @@ export interface BoardPostMessage {
   authorType: Message["authorType"]
   contentMarkdown: string
   reactions: Record<string, string[]>
+  attachments: AttachmentSummary[]
+  linkPreviews: LinkPreviewSummary[]
   createdAt: Date
 }
 
@@ -113,8 +117,24 @@ export class ConversationService {
       if (openingId) idsToFetch.add(openingId)
       for (const id of recentIds) idsToFetch.add(id)
     }
+    const ids = [...idsToFetch]
     const messageById: Map<string, Message> =
-      idsToFetch.size > 0 ? await MessageRepository.findByIds(this.pool, [...idsToFetch]) : new Map()
+      ids.length > 0 ? await MessageRepository.findByIds(this.pool, ids) : new Map()
+    // Rich content the message row doesn't carry — attachments (images, files,
+    // gallery/download) and completed link previews — keyed by message id so the
+    // board renders posts with the same richness as the timeline.
+    const attachmentsByMessage: Map<string, Attachment[]> =
+      ids.length > 0 ? await AttachmentRepository.findByMessageIds(this.pool, ids) : new Map()
+    const linkPreviewsByMessage: Map<string, LinkPreview[]> =
+      ids.length > 0 ? await LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, ids) : new Map()
+
+    const buildPostMessage = (message: Message): BoardPostMessage => {
+      const attachments = (attachmentsByMessage.get(message.id) ?? []).map(toAttachmentSummary)
+      const linkPreviews = (linkPreviewsByMessage.get(message.id) ?? [])
+        .filter((p) => p.status === "completed")
+        .map((p, i) => toLinkPreviewSummary(p, i))
+      return toBoardPostMessage(message, attachments, linkPreviews)
+    }
 
     const posts: BoardPost[] = conversations.map((conversation) => {
       const plan = planByConversation.get(conversation.id)!
@@ -122,8 +142,8 @@ export class ConversationService {
       const recentMessages = plan.recentIds
         .map((id) => messageById.get(id))
         .filter((m): m is Message => Boolean(m))
-        .map(toBoardPostMessage)
-      return { conversation, openingMessage: opening ? toBoardPostMessage(opening) : null, recentMessages }
+        .map(buildPostMessage)
+      return { conversation, openingMessage: opening ? buildPostMessage(opening) : null, recentMessages }
     })
 
     // A full page means there may be more; the last row's (activity, id) is the
@@ -275,14 +295,20 @@ export class ConversationService {
   }
 }
 
-/** Project a full message down to the board post's opening-message fields. */
-function toBoardPostMessage(message: Message): BoardPostMessage {
+/** Project a full message + its hydrated rich content down to a board post message. */
+function toBoardPostMessage(
+  message: Message,
+  attachments: AttachmentSummary[],
+  linkPreviews: LinkPreviewSummary[]
+): BoardPostMessage {
   return {
     id: message.id,
     authorId: message.authorId,
     authorType: message.authorType,
     contentMarkdown: message.contentMarkdown,
     reactions: message.reactions,
+    attachments,
+    linkPreviews,
     createdAt: message.createdAt,
   }
 }

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -4,8 +4,8 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository } from "../streams"
-import { AttachmentRepository, toAttachmentSummary, type Attachment } from "../attachments"
-import { LinkPreviewRepository, toLinkPreviewSummary, type LinkPreview } from "../link-previews"
+import { AttachmentRepository, toAttachmentSummary } from "../attachments"
+import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { conversationFeedbackId } from "../../lib/id"
@@ -144,32 +144,17 @@ export class ConversationService {
     const ids = [...idsToFetch]
     const messageById: Map<string, Message> =
       ids.length > 0 ? await MessageRepository.findByIds(this.pool, ids) : new Map()
-    // Rich content the message row doesn't carry — attachments (images, files,
-    // gallery/download) and completed link previews — keyed by message id so the
-    // board renders posts with the same richness as the timeline.
-    const attachmentsByMessage: Map<string, Attachment[]> =
-      ids.length > 0 ? await AttachmentRepository.findByMessageIds(this.pool, ids) : new Map()
-    const linkPreviewsByMessage: Map<string, LinkPreview[]> =
-      ids.length > 0 ? await LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, ids) : new Map()
-
-    const buildPostMessage = (message: Message): BoardPostMessage => {
-      const attachments = (attachmentsByMessage.get(message.id) ?? []).map(toAttachmentSummary)
-      const linkPreviews = (linkPreviewsByMessage.get(message.id) ?? [])
-        .filter((p) => p.status === "completed")
-        .map((p, i) => toLinkPreviewSummary(p, i))
-      return toBoardPostMessage(message, attachments, linkPreviews)
-    }
+    const hydratedById = await this.hydrateBoardMessages(workspaceId, [...messageById.values()])
 
     const posts: BoardPost[] = conversations.map((conversation) => {
       const plan = planByConversation.get(conversation.id)!
-      const opening = plan.originId ? messageById.get(plan.originId) : undefined
+      const opening = plan.originId ? hydratedById.get(plan.originId) : undefined
       const recentMessages = plan.recentIds
-        .map((id) => messageById.get(id))
-        .filter((m): m is Message => Boolean(m))
-        .map(buildPostMessage)
+        .map((id) => hydratedById.get(id))
+        .filter((m): m is BoardPostMessage => Boolean(m))
       return {
         conversation,
-        openingMessage: opening ? buildPostMessage(opening) : null,
+        openingMessage: opening ?? null,
         recentMessages,
         totalReplies: plan.totalReplies,
       }
@@ -180,6 +165,42 @@ export class ConversationService {
     const last = conversations.length === limit ? conversations[conversations.length - 1] : null
     const nextCursor = last ? `${last.lastActivityAt.toISOString()}|${last.id}` : null
     return { posts, nextCursor }
+  }
+
+  /**
+   * Enrich a set of messages with their attachments + completed link previews —
+   * the rich content the message row doesn't carry. One batch read each (INV-56).
+   * Shared by the board feed and the board's on-expand message fetch so both
+   * render the same richness as the timeline.
+   */
+  private async hydrateBoardMessages(workspaceId: string, messages: Message[]): Promise<Map<string, BoardPostMessage>> {
+    const byId = new Map<string, BoardPostMessage>()
+    const ids = messages.map((m) => m.id)
+    if (ids.length === 0) return byId
+    const attachmentsByMessage = await AttachmentRepository.findByMessageIds(this.pool, ids)
+    const linkPreviewsByMessage = await LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, ids)
+    for (const message of messages) {
+      const attachments = (attachmentsByMessage.get(message.id) ?? []).map(toAttachmentSummary)
+      const linkPreviews = (linkPreviewsByMessage.get(message.id) ?? [])
+        .filter((p) => p.status === "completed")
+        .map((p, i) => toLinkPreviewSummary(p, i))
+      byId.set(message.id, toBoardPostMessage(message, attachments, linkPreviews))
+    }
+    return byId
+  }
+
+  /**
+   * The full conversation as board post messages (enriched with attachments +
+   * link previews), in message order — backs the board card's "N more" expand so
+   * the revealed middle messages read exactly like the opening + recent run.
+   */
+  async getBoardMessages(workspaceId: string, conversationId: string): Promise<BoardPostMessage[]> {
+    const conversation = await ConversationRepository.findById(this.pool, conversationId)
+    if (!conversation || conversation.workspaceId !== workspaceId || conversation.messageIds.length === 0) return []
+    const messagesMap = await MessageRepository.findByIds(this.pool, conversation.messageIds)
+    const ordered = conversation.messageIds.map((id) => messagesMap.get(id)).filter((m): m is Message => Boolean(m))
+    const hydratedById = await this.hydrateBoardMessages(workspaceId, ordered)
+    return conversation.messageIds.map((id) => hydratedById.get(id)).filter((m): m is BoardPostMessage => Boolean(m))
   }
 
   async listByMessage(workspaceId: string, messageId: string): Promise<ConversationWithStaleness[]> {

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -22,6 +22,26 @@ export interface ListWorkspaceConversationsOptions extends ListConversationsOpti
   cursor?: { lastActivityAt: string; id: string }
 }
 
+/**
+ * Opening message of a board post (internal, Date-typed; serialized to the wire
+ * `BoardPostMessage` by the handler). A lean projection of the full message —
+ * the fields the post card renders.
+ */
+export interface BoardPostMessage {
+  id: string
+  authorId: string
+  authorType: Message["authorType"]
+  contentMarkdown: string
+  reactions: Record<string, string[]>
+  createdAt: Date
+}
+
+/** A conversation surfaced as a feed post: the grouping plus its opening message. */
+export interface BoardPost {
+  conversation: ConversationWithStaleness
+  openingMessage: BoardPostMessage | null
+}
+
 export interface ReassignMessageParams {
   workspaceId: string
   /** Target conversation that should become the message's primary home. */
@@ -68,19 +88,33 @@ export class ConversationService {
     workspaceId: string,
     userId: string,
     options?: ListWorkspaceConversationsOptions
-  ): Promise<{ conversations: ConversationWithStaleness[]; nextCursor: string | null }> {
+  ): Promise<{ posts: BoardPost[]; nextCursor: string | null }> {
     const limit = options?.limit ?? 50
-    // Single query, INV-30
     const rows = await ConversationRepository.findByWorkspaceForViewer(this.pool, workspaceId, userId, {
       ...options,
       limit,
     })
     const conversations = rows.map(addStalenessFields)
+
+    // Hydrate each post's opening message (the conversation's first primary
+    // message) so the board renders real post content + reactions, not just a
+    // topic line. One batch read keyed on the opening ids (INV-56); the access
+    // filter already ran in the conversation query, so these ids are all viewer-
+    // readable. `findByIds` carries reactions with each message.
+    const openingIds = conversations.map((c) => c.messageIds[0]).filter((id): id is string => Boolean(id))
+    const openingById: Map<string, Message> =
+      openingIds.length > 0 ? await MessageRepository.findByIds(this.pool, openingIds) : new Map()
+
+    const posts: BoardPost[] = conversations.map((conversation) => {
+      const opening = openingById.get(conversation.messageIds[0])
+      return { conversation, openingMessage: opening ? toBoardPostMessage(opening) : null }
+    })
+
     // A full page means there may be more; the last row's (activity, id) is the
     // next cursor — matching the repo's `(last_activity_at, id) DESC` order.
     const last = conversations.length === limit ? conversations[conversations.length - 1] : null
     const nextCursor = last ? `${last.lastActivityAt.toISOString()}|${last.id}` : null
-    return { conversations, nextCursor }
+    return { posts, nextCursor }
   }
 
   async listByMessage(workspaceId: string, messageId: string): Promise<ConversationWithStaleness[]> {
@@ -222,5 +256,17 @@ export class ConversationService {
         previousConversation: updatedPrevious ? addStalenessFields(updatedPrevious) : null,
       }
     })
+  }
+}
+
+/** Project a full message down to the board post's opening-message fields. */
+function toBoardPostMessage(message: Message): BoardPostMessage {
+  return {
+    id: message.id,
+    authorId: message.authorId,
+    authorType: message.authorType,
+    contentMarkdown: message.contentMarkdown,
+    reactions: message.reactions,
+    createdAt: message.createdAt,
   }
 }

--- a/apps/backend/src/features/link-previews/index.ts
+++ b/apps/backend/src/features/link-previews/index.ts
@@ -1,7 +1,7 @@
 export { LinkPreviewRepository } from "./repository"
 export type { LinkPreview, InsertLinkPreviewParams, UpdateLinkPreviewParams, MessageLinkPreview } from "./repository"
 
-export { LinkPreviewService } from "./service"
+export { LinkPreviewService, toLinkPreviewSummary } from "./service"
 export type { LinkPreviewServiceDeps } from "./service"
 
 export { createLinkPreviewHandlers } from "./handlers"

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -288,7 +288,7 @@ export class LinkPreviewService {
   }
 }
 
-function toLinkPreviewSummary(preview: LinkPreview, position: number): LinkPreviewSummary {
+export function toLinkPreviewSummary(preview: LinkPreview, position: number): LinkPreviewSummary {
   return {
     id: preview.id,
     url: preview.url,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -485,6 +485,11 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.get("/api/workspaces/:workspaceId/streams/:streamId/conversations", ...authed, conversation.listByStream)
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.getById)
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId/messages", ...authed, conversation.getMessages)
+  app.get(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/board-messages",
+    ...authed,
+    conversation.getBoardMessages
+  )
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/reassign",
     ...authed,

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -1,5 +1,5 @@
 import { api } from "./client"
-import type { ConversationWithStaleness, ConversationStatus, Message } from "@threa/types"
+import type { ConversationWithStaleness, ConversationStatus, Message, BoardPost } from "@threa/types"
 
 export interface ListConversationsParams {
   status?: ConversationStatus
@@ -12,7 +12,7 @@ export interface ListWorkspaceConversationsParams extends ListConversationsParam
 }
 
 export interface WorkspaceConversationsPage {
-  conversations: ConversationWithStaleness[]
+  posts: BoardPost[]
   nextCursor: string | null
 }
 

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -1,5 +1,5 @@
 import { api } from "./client"
-import type { ConversationWithStaleness, ConversationStatus, Message, BoardPost } from "@threa/types"
+import type { ConversationWithStaleness, ConversationStatus, Message, BoardPost, BoardPostMessage } from "@threa/types"
 
 export interface ListConversationsParams {
   status?: ConversationStatus
@@ -61,6 +61,18 @@ export const conversationsApi = {
   async getMessages(workspaceId: string, conversationId: string): Promise<Message[]> {
     const res = await api.get<{ messages: Message[] }>(
       `/api/workspaces/${workspaceId}/conversations/${conversationId}/messages`
+    )
+    return res.messages
+  },
+
+  /**
+   * The board card's "N more" expand: the full conversation as enriched board
+   * post messages (attachments + link previews), so revealed messages render
+   * with the same richness as the opening + recent run.
+   */
+  async getBoardMessages(workspaceId: string, conversationId: string): Promise<BoardPostMessage[]> {
+    const res = await api.get<{ messages: BoardPostMessage[] }>(
+      `/api/workspaces/${workspaceId}/conversations/${conversationId}/board-messages`
     )
     return res.messages
   },

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -4,13 +4,17 @@ import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
-import { MarkdownContent } from "@/components/ui/markdown-content"
+import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
+import { LinkPreviewProvider } from "@/lib/markdown/link-preview-context"
+import { AttachmentList } from "@/components/timeline/attachment-list"
+import { LinkPreviewList } from "@/components/timeline/link-preview-list"
 import { MessageReactions } from "@/components/timeline/message-reactions"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useConversationService } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
-import type { AuthorType, BoardPost } from "@threa/types"
+import type { AttachmentSummary, AuthorType, BoardPost, LinkPreviewSummary } from "@threa/types"
 
 interface BoardCardProps {
   workspaceId: string
@@ -40,6 +44,10 @@ interface RenderableMessage {
   contentMarkdown: string
   reactions: Record<string, string[]>
   createdAt: string | Date
+  // Present on feed messages (BoardPostMessage); absent on messages fetched via
+  // getMessages on expand, which carry no enrichment.
+  attachments?: AttachmentSummary[]
+  linkPreviews?: LinkPreviewSummary[]
 }
 
 function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolean {
@@ -158,10 +166,39 @@ interface PostMessageProps {
 }
 
 function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, continuation }: PostMessageProps) {
+  const { formatTime, formatFull } = useFormattedDate()
   const hasReactions = Object.keys(message.reactions).length > 0
-  const body = (
+  const attachments = message.attachments ?? []
+  const linkPreviews = message.linkPreviews ?? []
+
+  const richBody = (
     <>
       <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
+      {attachments.length > 0 && <AttachmentList attachments={attachments} workspaceId={workspaceId} />}
+      {linkPreviews.length > 0 && (
+        <LinkPreviewList
+          messageId={message.id}
+          workspaceId={workspaceId}
+          previews={linkPreviews}
+          hydrateFromApi={false}
+        />
+      )}
+    </>
+  )
+  // The body renders real message content (mentions, attachments, link previews),
+  // so it gets the same markdown context wrappers the timeline uses. Attachments
+  // open the media gallery / download via AttachmentList.
+  const body = (
+    <>
+      <LinkPreviewProvider>
+        {attachments.length > 0 ? (
+          <AttachmentProvider workspaceId={workspaceId} attachments={attachments}>
+            {richBody}
+          </AttachmentProvider>
+        ) : (
+          richBody
+        )}
+      </LinkPreviewProvider>
       {hasReactions && (
         <MessageReactions
           reactions={message.reactions}
@@ -174,9 +211,17 @@ function PostMessage({ workspaceId, streamId, message, authorName, currentUserId
   )
 
   if (continuation) {
+    const sentAt = new Date(message.createdAt)
     return (
-      <div className="mt-0.5 flex gap-3">
-        <div className="w-8 shrink-0" aria-hidden />
+      <div className="group mt-0.5 flex gap-3">
+        {/* Gutter reveals the message time on hover (desktop), mirroring the
+            timeline's grouped-continuation micro-time. */}
+        <div
+          className="w-8 shrink-0 pt-0.5 text-right font-mono text-[10px] tabular-nums leading-5 text-transparent transition-colors group-hover:text-muted-foreground/60"
+          title={formatFull(sentAt)}
+        >
+          {formatTime(sentAt)}
+        </div>
         <div className="min-w-0 flex-1">{body}</div>
       </div>
     )

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -15,9 +15,7 @@ import type { AuthorType, BoardPost } from "@threa/types"
 interface BoardCardProps {
   workspaceId: string
   post: BoardPost
-  /** Topic of the grouping, resolved by the page (scratchpad name / channel topic). */
-  topic: string
-  /** Where the post lives (channel name, DM peer, "Scratchpad"), for the header. */
+  /** Where the post lives (channel name, DM peer, scratchpad name), for the header. */
   contextLabel: string
   /** Resolved stream type, selecting the context glyph. */
   streamType: string | undefined
@@ -28,6 +26,10 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
   scratchpad: FileEdit,
   dm: User,
 }
+
+/** Same-author messages within this window collapse into a continuation (no
+ * repeated header) — matches the timeline's grouping. */
+const GROUP_WINDOW_MS = 5 * 60_000
 
 /** The fields the post renderer reads — satisfied by both `BoardPostMessage`
  * (feed payload) and a full `Message` (fetched on expand). */
@@ -40,16 +42,23 @@ interface RenderableMessage {
   createdAt: string | Date
 }
 
+function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolean {
+  return (
+    prev.authorId === cur.authorId &&
+    prev.authorType === cur.authorType &&
+    Math.abs(new Date(cur.createdAt).getTime() - new Date(prev.createdAt).getTime()) < GROUP_WINDOW_MS
+  )
+}
+
 /**
- * One board post: a conversation rendered as a feed post. The opening message is
- * the body, the latest replies stack beneath it, and a collapsed "N more
- * messages" gap fills in on click. Messages render through the same primitives as
- * the timeline (`ActorAvatar`, `MarkdownContent`, `MessageReactions`) so a board
- * message reads exactly like a real message. The card itself delimits the
- * conversation, so replies aren't indented. The conversation is context (header),
- * not the unit.
+ * One board post: a conversation rendered as a feed post that reads like the
+ * stream timeline. Messages use the same primitives (`ActorAvatar`,
+ * `MarkdownContent`, `MessageReactions`) and the same same-author grouping, so a
+ * board message is indistinguishable from a real one. The card delimits the
+ * conversation (no reply indentation); a collapsed "N more messages" gap fills
+ * in on click. The stream it lives in is the header locator, not a topic line.
  */
-export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }: BoardCardProps) {
+export function BoardCard({ workspaceId, post, contextLabel, streamType }: BoardCardProps) {
   const { conversation, openingMessage, recentMessages } = post
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
@@ -77,64 +86,61 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
   const replies: RenderableMessage[] =
     expanded && allMessages ? allMessages.filter((m) => m.id !== openingMessage?.id) : recentMessages
   const loadingMore = expanded && !allMessages && !expandFailed
+  // No middle is hidden, so opening + replies form one uninterrupted run that
+  // groups across the boundary. Otherwise a gap row sits between them.
+  const contiguous = (expanded && !!allMessages) || (!expanded && hiddenCount === 0)
+
+  const renderMessage = (message: RenderableMessage, continuation: boolean) => (
+    <PostMessage
+      key={message.id}
+      workspaceId={workspaceId}
+      streamId={streamId}
+      message={message}
+      authorName={getActorName(message.authorId, message.authorType)}
+      currentUserId={currentUserId}
+      continuation={continuation}
+    />
+  )
 
   return (
     <div className="rounded-xl border bg-card p-3 sm:p-4">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
         <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
-        <span className="truncate">{contextLabel}</span>
-        {topic && (
-          <>
-            <span aria-hidden>·</span>
-            <span className="truncate">{topic}</span>
-          </>
-        )}
+        <span className="truncate font-medium">{contextLabel}</span>
         <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
       </div>
 
-      <div className="mt-3 flex flex-col gap-3">
-        {openingMessage && (
-          <PostMessage
-            workspaceId={workspaceId}
-            streamId={streamId}
-            message={openingMessage}
-            authorName={getActorName(openingMessage.authorId, openingMessage.authorType)}
-            currentUserId={currentUserId}
-            emphasis
-          />
+      <div className="mt-3 [&>*:first-child]:mt-0">
+        {contiguous ? (
+          (openingMessage ? [openingMessage, ...replies] : replies).map((message, i, all) =>
+            renderMessage(message, i > 0 && isContinuation(all[i - 1], message))
+          )
+        ) : (
+          <>
+            {openingMessage && renderMessage(openingMessage, false)}
+            {!expanded && hiddenCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+                {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
+              </button>
+            )}
+            {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
+            {expanded && expandFailed && (
+              <button
+                type="button"
+                onClick={() => void refetchMessages()}
+                className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+              >
+                Couldn't load messages. Retry.
+              </button>
+            )}
+            {replies.map((message, i) => renderMessage(message, i > 0 && isContinuation(replies[i - 1], message)))}
+          </>
         )}
-
-        {!expanded && hiddenCount > 0 && (
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            className="flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ChevronDown className="h-3.5 w-3.5" />
-            {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
-          </button>
-        )}
-        {loadingMore && <span className="text-xs text-muted-foreground">Loading messages…</span>}
-        {expanded && expandFailed && (
-          <button
-            type="button"
-            onClick={() => void refetchMessages()}
-            className="w-fit text-xs text-destructive underline underline-offset-2"
-          >
-            Couldn't load messages. Retry.
-          </button>
-        )}
-
-        {replies.map((message) => (
-          <PostMessage
-            key={message.id}
-            workspaceId={workspaceId}
-            streamId={streamId}
-            message={message}
-            authorName={getActorName(message.authorId, message.authorType)}
-            currentUserId={currentUserId}
-          />
-        ))}
       </div>
     </div>
   )
@@ -146,44 +152,59 @@ interface PostMessageProps {
   message: RenderableMessage
   authorName: string
   currentUserId: string | null
-  /** The opening post — a slightly larger avatar than a reply. */
-  emphasis?: boolean
+  /** A same-author follow-up: drop the avatar/header and align the body under
+   * the head row's content (matches the timeline's grouped continuations). */
+  continuation?: boolean
 }
 
-function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, emphasis }: PostMessageProps) {
+function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, continuation }: PostMessageProps) {
   const hasReactions = Object.keys(message.reactions).length > 0
+  const body = (
+    <>
+      <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
+      {hasReactions && (
+        <MessageReactions
+          reactions={message.reactions}
+          workspaceId={workspaceId}
+          messageId={message.id}
+          currentUserId={currentUserId}
+        />
+      )}
+    </>
+  )
+
+  if (continuation) {
+    return (
+      <div className="mt-0.5 flex gap-3">
+        <div className="w-8 shrink-0" aria-hidden />
+        <div className="min-w-0 flex-1">{body}</div>
+      </div>
+    )
+  }
 
   return (
-    <div className="flex items-start gap-2 sm:gap-3">
+    <div className="mt-3 flex items-start gap-3">
       <ActorAvatar
         actorId={message.authorId}
         actorType={message.authorType}
         workspaceId={workspaceId}
-        size={emphasis ? "md" : "sm"}
+        size="md"
         alt={authorName}
         showStatus={false}
       />
       <div className="min-w-0 flex-1">
-        <div className="flex items-baseline gap-2">
+        <div className="mb-0.5 flex items-baseline gap-2">
           <span className="truncate text-sm font-semibold">{authorName}</span>
-          {/* Permalink to the message in its stream timeline — the one navigation
-              affordance, so the interactive message body isn't wrapped in a link. */}
+          {/* Permalink to the message in its stream timeline — the body is
+              interactive, so navigation lives on the timestamp instead. */}
           <Link
             to={`/w/${workspaceId}/s/${streamId}?m=${message.id}`}
             className="shrink-0 text-xs text-muted-foreground hover:underline"
           >
-            <RelativeTime date={message.createdAt} terse />
+            <RelativeTime date={message.createdAt} />
           </Link>
         </div>
-        <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
-        {hasReactions && (
-          <MessageReactions
-            reactions={message.reactions}
-            workspaceId={workspaceId}
-            messageId={message.id}
-            currentUserId={currentUserId}
-          />
-        )}
+        {body}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -8,6 +8,8 @@ import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-co
 import { LinkPreviewProvider } from "@/lib/markdown/link-preview-context"
 import { AttachmentList } from "@/components/timeline/attachment-list"
 import { LinkPreviewList } from "@/components/timeline/link-preview-list"
+import { MemoPreviewList } from "@/components/timeline/memo-preview-list"
+import { GiphyPreviewList } from "@/components/timeline/giphy-preview-list"
 import { MessageReactions } from "@/components/timeline/message-reactions"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
@@ -83,8 +85,8 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     isError: expandFailed,
     refetch: refetchMessages,
   } = useQuery({
-    queryKey: conversationKeys.messages(conversation.id),
-    queryFn: () => conversationService.getMessages(workspaceId, conversation.id),
+    queryKey: conversationKeys.boardMessages(conversation.id),
+    queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
     enabled: expanded,
     staleTime: 60_000,
   })
@@ -193,6 +195,10 @@ function PostMessage({ workspaceId, streamId, message, authorName, currentUserId
           hydrateFromApi={false}
         />
       )}
+      {/* Memo + giphy embeds are parsed from the markdown, so they render here
+          just like the timeline — no extra payload needed. */}
+      <MemoPreviewList contentMarkdown={message.contentMarkdown} />
+      <GiphyPreviewList contentMarkdown={message.contentMarkdown} />
     </>
   )
   // The body renders real message content (mentions, attachments, link previews),

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,7 +1,8 @@
 import { Link } from "react-router-dom"
+import { Hash, FileEdit, User, MessageSquareText, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { RelativeTime } from "@/components/relative-time"
-import { StatusBadge, CompletenessIndicator } from "@/components/conversations/conversation-item"
+import { CompletenessIndicator } from "@/components/conversations/conversation-item"
 import type { ConversationWithStaleness } from "@threa/types"
 
 interface BoardCardProps {
@@ -10,42 +11,80 @@ interface BoardCardProps {
   /** The card's headline. The page resolves it: a scratchpad's own name, or the
    * conversation's topic for channels/DMs (never the DM peer — that's a person). */
   title: string
-  /** The small context line above the title: the stream the conversation lives
+  /** The small context line under the title: the stream the conversation lives
    * in (channel name, DM peer), or "Scratchpad" when the name is the title. */
   contextLabel: string
+  /** Resolved stream type, selecting the leading glyph. Falls back to a generic
+   * thread glyph when the stream isn't in the bootstrap cache. */
+  streamType: string | undefined
+}
+
+/** Leading glyph per stream type — mirrors the sidebar's stream-type vocabulary
+ * so a channel reads the same here as it does in the rail. */
+const TYPE_GLYPH: Record<string, { icon: LucideIcon; tint: string }> = {
+  channel: { icon: Hash, tint: "text-[hsl(200_60%_50%)]" },
+  scratchpad: { icon: FileEdit, tint: "text-primary" },
+  dm: { icon: User, tint: "text-muted-foreground" },
+}
+const FALLBACK_GLYPH = { icon: MessageSquareText, tint: "text-muted-foreground" }
+
+/** active is the resting state and most rows are active — surfacing it would be
+ * noise (INV-63 spirit). Only the states that ask for attention get a marker. */
+const STATUS_MARK: Record<string, { dot: string; label: string }> = {
+  stalled: { dot: "bg-amber-500", label: "Stalled" },
+  resolved: { dot: "bg-muted-foreground/40", label: "Resolved" },
 }
 
 /**
- * A single board "post": one conversation as a card linking to it opened in its
- * own stream (`?convView=open&conv=`). Cross-stream, so it shows where the
- * conversation lives. Stale conversations dim, matching the in-stream list.
+ * One board "post": a conversation (Threa's topic primitive) rendered as a quiet,
+ * scannable row — same rhythm as the activity feed and timeline, not a boxy card.
+ * Links to the conversation opened in its own stream. Cross-stream, so the leading
+ * glyph + context line show where it lives. Stale conversations dim.
  */
-export function BoardCard({ workspaceId, conversation, title, contextLabel }: BoardCardProps) {
+export function BoardCard({ workspaceId, conversation, title, contextLabel, streamType }: BoardCardProps) {
   const { streamId, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } = conversation
   const to = `/w/${workspaceId}/s/${streamId}?convView=open&conv=${conversation.id}`
+
+  const glyph = (streamType && TYPE_GLYPH[streamType]) || FALLBACK_GLYPH
+  const Glyph = glyph.icon
+  const statusMark = STATUS_MARK[status]
+  const messageCount = messageIds.length
 
   return (
     <Link
       to={to}
       className={cn(
-        "block rounded-lg border bg-card p-3 transition-colors hover:bg-accent/50",
-        temporalStaleness >= 3 && "opacity-60"
+        "group flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50 sm:px-4 sm:py-3",
+        temporalStaleness >= 3 && "opacity-60 hover:opacity-100"
       )}
     >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-xs text-muted-foreground">{contextLabel}</p>
-          <p className="mt-0.5 truncate text-sm font-medium">{title}</p>
-          <div className="mt-1 flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">
-              {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
-            </span>
-            <StatusBadge status={status} />
-          </div>
+      <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-muted">
+        <Glyph className={cn("h-4 w-4", glyph.tint)} />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="truncate text-sm font-medium">{title}</p>
+          <RelativeTime date={lastActivityAt} terse className="shrink-0 text-xs text-muted-foreground" />
         </div>
-        <div className="flex flex-shrink-0 flex-col items-end gap-1">
+        <div className="mt-0.5 flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="truncate">{contextLabel}</span>
+            <span aria-hidden>·</span>
+            <span className="shrink-0">
+              {messageCount} {messageCount === 1 ? "message" : "messages"}
+            </span>
+            {statusMark && (
+              <>
+                <span aria-hidden>·</span>
+                <span className="flex shrink-0 items-center gap-1">
+                  <span className={cn("h-1.5 w-1.5 rounded-full", statusMark.dot)} />
+                  {statusMark.label}
+                </span>
+              </>
+            )}
+          </div>
           <CompletenessIndicator score={effectiveCompleteness} />
-          <RelativeTime date={lastActivityAt} className="text-xs text-muted-foreground" />
         </div>
       </div>
     </Link>

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -11,6 +11,7 @@ import { LinkPreviewList } from "@/components/timeline/link-preview-list"
 import { MessageReactions } from "@/components/timeline/message-reactions"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useConversationService } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
@@ -67,15 +68,14 @@ function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolea
  * in on click. The stream it lives in is the header locator, not a topic line.
  */
 export function BoardCard({ workspaceId, post, contextLabel, streamType }: BoardCardProps) {
-  const { conversation, openingMessage, recentMessages } = post
+  const { conversation, openingMessage, recentMessages, totalReplies } = post
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const [expanded, setExpanded] = useState(false)
 
   const streamId = conversation.streamId
-  const messageCount = conversation.messageIds.length
-  const hiddenCount = Math.max(0, messageCount - (openingMessage ? 1 : 0) - recentMessages.length)
+  const hiddenCount = Math.max(0, totalReplies - recentMessages.length)
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
 
   const {
@@ -113,8 +113,14 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   return (
     <div className="rounded-xl border bg-card p-3 sm:p-4">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-        <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
-        <span className="truncate font-medium">{contextLabel}</span>
+        {/* The stream the post lives in — a real link back into it (INV-40). */}
+        <Link
+          to={`/w/${workspaceId}/s/${streamId}`}
+          className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
+        >
+          <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate font-medium">{contextLabel}</span>
+        </Link>
         <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
       </div>
 
@@ -167,7 +173,11 @@ interface PostMessageProps {
 
 function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, continuation }: PostMessageProps) {
   const { formatTime, formatFull } = useFormattedDate()
+  const { openUserProfile } = useUserProfile()
   const hasReactions = Object.keys(message.reactions).length > 0
+  // Users open their profile on click (same as the timeline); other actor types
+  // (persona/bot/system) are non-interactive.
+  const interactiveName = message.authorType === "user" && Boolean(message.authorId)
   const attachments = message.attachments ?? []
   const linkPreviews = message.linkPreviews ?? []
 
@@ -239,7 +249,17 @@ function PostMessage({ workspaceId, streamId, message, authorName, currentUserId
       />
       <div className="min-w-0 flex-1">
         <div className="mb-0.5 flex items-baseline gap-2">
-          <span className="truncate text-sm font-semibold">{authorName}</span>
+          {interactiveName ? (
+            <button
+              type="button"
+              onClick={() => openUserProfile(message.authorId)}
+              className="truncate text-left text-sm font-semibold hover:underline"
+            >
+              {authorName}
+            </button>
+          ) : (
+            <span className="truncate text-sm font-semibold">{authorName}</span>
+          )}
           {/* Permalink to the message in its stream timeline — the body is
               interactive, so navigation lives on the timestamp instead. */}
           <Link

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -6,7 +6,7 @@ import { PersonaAvatar } from "@/components/persona-avatar"
 import { RelativeTime } from "@/components/relative-time"
 import { useActors } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
-import { stripMarkdown } from "@/lib/markdown/strip"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
 import type { BoardPost } from "@threa/types"
 
 interface BoardCardProps {
@@ -44,7 +44,7 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
   const to = `/w/${workspaceId}/s/${conversation.streamId}?convView=open&conv=${conversation.id}`
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
   const messageCount = conversation.messageIds.length
-  const body = openingMessage ? stripMarkdown(openingMessage.contentMarkdown).trim() : ""
+  const body = openingMessage ? stripMarkdownToInline(openingMessage.contentMarkdown, toEmoji).trim() : ""
 
   const authorId = openingMessage?.authorId ?? null
   const authorType = openingMessage?.authorType ?? null
@@ -99,9 +99,7 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
 
           {topic && <p className="mt-0.5 truncate text-xs text-muted-foreground">{topic}</p>}
 
-          {body && (
-            <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-relaxed line-clamp-4">{body}</p>
-          )}
+          {body && <p className="mt-1.5 break-words text-sm leading-relaxed line-clamp-4">{body}</p>}
 
           <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
             {visibleReactions.map(([shortcode, users]) => (

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,90 +1,124 @@
 import { Link } from "react-router-dom"
-import { Hash, FileEdit, User, MessageSquareText, type LucideIcon } from "lucide-react"
+import { Hash, FileEdit, User, MessageSquareText, MessagesSquare, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { PersonaAvatar } from "@/components/persona-avatar"
 import { RelativeTime } from "@/components/relative-time"
-import { CompletenessIndicator } from "@/components/conversations/conversation-item"
-import type { ConversationWithStaleness } from "@threa/types"
+import { useActors } from "@/hooks"
+import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
+import { stripMarkdown } from "@/lib/markdown/strip"
+import type { BoardPost } from "@threa/types"
 
 interface BoardCardProps {
   workspaceId: string
-  conversation: ConversationWithStaleness
-  /** The card's headline. The page resolves it: a scratchpad's own name, or the
-   * conversation's topic for channels/DMs (never the DM peer — that's a person). */
-  title: string
-  /** The small context line under the title: the stream the conversation lives
-   * in (channel name, DM peer), or "Scratchpad" when the name is the title. */
+  post: BoardPost
+  /** Topic of the grouping, resolved by the page (scratchpad name / channel topic).
+   * Rendered as a subject line, not the headline — the message body is the unit. */
+  topic: string
+  /** Where the post lives (channel name, DM peer, "Scratchpad"), for the header. */
   contextLabel: string
-  /** Resolved stream type, selecting the leading glyph. Falls back to a generic
-   * thread glyph when the stream isn't in the bootstrap cache. */
+  /** Resolved stream type, selecting the context glyph. */
   streamType: string | undefined
 }
 
-/** Leading glyph per stream type — mirrors the sidebar's stream-type vocabulary
- * so a channel reads the same here as it does in the rail. */
-const TYPE_GLYPH: Record<string, { icon: LucideIcon; tint: string }> = {
-  channel: { icon: Hash, tint: "text-[hsl(200_60%_50%)]" },
-  scratchpad: { icon: FileEdit, tint: "text-primary" },
-  dm: { icon: User, tint: "text-muted-foreground" },
+const TYPE_GLYPH: Record<string, LucideIcon> = {
+  channel: Hash,
+  scratchpad: FileEdit,
+  dm: User,
 }
-const FALLBACK_GLYPH = { icon: MessageSquareText, tint: "text-muted-foreground" }
 
-/** active is the resting state and most rows are active — surfacing it would be
- * noise (INV-63 spirit). Only the states that ask for attention get a marker. */
-const STATUS_MARK: Record<string, { dot: string; label: string }> = {
-  stalled: { dot: "bg-amber-500", label: "Stalled" },
-  resolved: { dot: "bg-muted-foreground/40", label: "Resolved" },
-}
+const MAX_REACTIONS = 4
 
 /**
- * One board "post": a conversation (Threa's topic primitive) rendered as a quiet,
- * scannable row — same rhythm as the activity feed and timeline, not a boxy card.
- * Links to the conversation opened in its own stream. Cross-stream, so the leading
- * glyph + context line show where it lives. Stale conversations dim.
+ * One board post: a conversation surfaced as a feed post. The opening message is
+ * the body (the unit is a message), the conversation is context (the grouping).
+ * Reads like a re-organized timeline row, not a conversations-list card: author
+ * header, message content, reactions, and a reply count — no status/completeness
+ * chrome. Links to the conversation opened in its stream; stale posts dim.
  */
-export function BoardCard({ workspaceId, conversation, title, contextLabel, streamType }: BoardCardProps) {
-  const { streamId, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } = conversation
-  const to = `/w/${workspaceId}/s/${streamId}?convView=open&conv=${conversation.id}`
+export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }: BoardCardProps) {
+  const { conversation, openingMessage } = post
+  const { getActorName, getActorAvatar } = useActors(workspaceId)
+  const { toEmoji } = useWorkspaceEmoji(workspaceId)
 
-  const glyph = (streamType && TYPE_GLYPH[streamType]) || FALLBACK_GLYPH
-  const Glyph = glyph.icon
-  const statusMark = STATUS_MARK[status]
-  const messageCount = messageIds.length
+  const to = `/w/${workspaceId}/s/${conversation.streamId}?convView=open&conv=${conversation.id}`
+  const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
+  const messageCount = conversation.messageIds.length
+  const body = openingMessage ? stripMarkdown(openingMessage.contentMarkdown).trim() : ""
+
+  const authorId = openingMessage?.authorId ?? null
+  const authorType = openingMessage?.authorType ?? null
+  const authorName = openingMessage ? getActorName(authorId, authorType) : "Threa"
+  const avatar = getActorAvatar(authorId, authorType)
+
+  const reactions = Object.entries(openingMessage?.reactions ?? {})
+    .filter(([, users]) => users.length > 0)
+    .sort((a, b) => b[1].length - a[1].length)
+  const visibleReactions = reactions.slice(0, MAX_REACTIONS)
+  const reactionOverflow = reactions.length - visibleReactions.length
 
   return (
     <Link
       to={to}
       className={cn(
-        "group flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-muted/50 sm:px-4 sm:py-3",
-        temporalStaleness >= 3 && "opacity-60 hover:opacity-100"
+        "group block rounded-xl px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4",
+        conversation.temporalStaleness >= 3 && "opacity-60 hover:opacity-100"
       )}
     >
-      <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-muted">
-        <Glyph className={cn("h-4 w-4", glyph.tint)} />
-      </div>
+      <div className="flex items-start gap-3">
+        {authorType === "persona" ? (
+          <PersonaAvatar slug={avatar.slug} fallback={avatar.fallback} size="md" />
+        ) : (
+          <Avatar className="h-9 w-9 shrink-0 rounded-[10px]">
+            {avatar.avatarUrl && <AvatarImage src={avatar.avatarUrl} alt={authorName} />}
+            <AvatarFallback
+              className={cn(
+                "rounded-[10px] bg-muted text-xs text-foreground",
+                authorType === "bot" && "bg-emerald-500/10 text-emerald-600",
+                authorType === "system" && "bg-blue-500/10 text-blue-500"
+              )}
+            >
+              {avatar.fallback}
+            </AvatarFallback>
+          </Avatar>
+        )}
 
-      <div className="min-w-0 flex-1">
-        <div className="flex items-baseline justify-between gap-3">
-          <p className="truncate text-sm font-medium">{title}</p>
-          <RelativeTime date={lastActivityAt} terse className="shrink-0 text-xs text-muted-foreground" />
-        </div>
-        <div className="mt-0.5 flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-            <span className="truncate">{contextLabel}</span>
-            <span aria-hidden>·</span>
-            <span className="shrink-0">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-sm font-medium">{authorName}</span>
+            <span className="flex min-w-0 shrink items-center gap-1 text-xs text-muted-foreground">
+              <ContextGlyph className="h-3 w-3 shrink-0" />
+              <span className="truncate">{contextLabel}</span>
+            </span>
+            <RelativeTime
+              date={conversation.lastActivityAt}
+              terse
+              className="ml-auto shrink-0 text-xs text-muted-foreground"
+            />
+          </div>
+
+          {topic && <p className="mt-0.5 truncate text-xs text-muted-foreground">{topic}</p>}
+
+          {body && (
+            <p className="mt-1.5 whitespace-pre-wrap break-words text-sm leading-relaxed line-clamp-4">{body}</p>
+          )}
+
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+            {visibleReactions.map(([shortcode, users]) => (
+              <span
+                key={shortcode}
+                className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 leading-none"
+              >
+                <span>{toEmoji(shortcode) ?? shortcode}</span>
+                <span>{users.length}</span>
+              </span>
+            ))}
+            {reactionOverflow > 0 && <span>+{reactionOverflow}</span>}
+            <span className="inline-flex items-center gap-1">
+              <MessagesSquare className="h-3.5 w-3.5" />
               {messageCount} {messageCount === 1 ? "message" : "messages"}
             </span>
-            {statusMark && (
-              <>
-                <span aria-hidden>·</span>
-                <span className="flex shrink-0 items-center gap-1">
-                  <span className={cn("h-1.5 w-1.5 rounded-full", statusMark.dot)} />
-                  {statusMark.label}
-                </span>
-              </>
-            )}
           </div>
-          <CompletenessIndicator score={effectiveCompleteness} />
         </div>
       </div>
     </Link>

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -63,7 +63,11 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
   const hiddenCount = Math.max(0, messageCount - (openingMessage ? 1 : 0) - recentMessages.length)
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
 
-  const { data: allMessages } = useQuery({
+  const {
+    data: allMessages,
+    isError: expandFailed,
+    refetch: refetchMessages,
+  } = useQuery({
     queryKey: conversationKeys.messages(conversation.id),
     queryFn: () => conversationService.getMessages(workspaceId, conversation.id),
     enabled: expanded,
@@ -74,7 +78,7 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
   // Collapsed: just the trailing replies the feed already carried.
   const replies: RenderableMessage[] =
     expanded && allMessages ? allMessages.filter((m) => m.id !== openingMessage?.id) : recentMessages
-  const loadingMore = expanded && !allMessages
+  const loadingMore = expanded && !allMessages && !expandFailed
 
   return (
     <div className="rounded-xl border bg-card p-3 sm:p-4">
@@ -102,7 +106,7 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
           />
         )}
 
-        {(replies.length > 0 || hiddenCount > 0 || loadingMore) && (
+        {(replies.length > 0 || hiddenCount > 0 || loadingMore || (expanded && expandFailed)) && (
           <div className="ml-3 mt-1 flex flex-col gap-1 border-l pl-3 sm:ml-4 sm:pl-4">
             {!expanded && hiddenCount > 0 && (
               <button
@@ -115,6 +119,15 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
               </button>
             )}
             {loadingMore && <span className="py-0.5 text-xs text-muted-foreground">Loading messages…</span>}
+            {expanded && expandFailed && (
+              <button
+                type="button"
+                onClick={() => void refetchMessages()}
+                className="w-fit py-0.5 text-xs text-destructive underline underline-offset-2"
+              >
+                Couldn't load messages. Retry.
+              </button>
+            )}
             {replies.map((message) => (
               <PostMessage
                 key={message.id}

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,19 +1,23 @@
+import { useState } from "react"
 import { Link } from "react-router-dom"
-import { Hash, FileEdit, User, MessageSquareText, MessagesSquare, type LucideIcon } from "lucide-react"
+import { useQuery } from "@tanstack/react-query"
+import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { PersonaAvatar } from "@/components/persona-avatar"
 import { RelativeTime } from "@/components/relative-time"
 import { useActors } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
+import { useConversationService } from "@/contexts"
+import { conversationKeys } from "@/hooks/use-conversations"
 import { stripMarkdownToInline } from "@/lib/markdown/strip"
-import type { BoardPost } from "@threa/types"
+import type { ActorLookup } from "@/hooks/use-actors"
+import type { AuthorType, BoardPost } from "@threa/types"
 
 interface BoardCardProps {
   workspaceId: string
   post: BoardPost
-  /** Topic of the grouping, resolved by the page (scratchpad name / channel topic).
-   * Rendered as a subject line, not the headline — the message body is the unit. */
+  /** Topic of the grouping, resolved by the page (scratchpad name / channel topic). */
   topic: string
   /** Where the post lives (channel name, DM peer, "Scratchpad"), for the header. */
   contextLabel: string
@@ -29,53 +33,134 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
 
 const MAX_REACTIONS = 4
 
+/** The fields the post renderer reads — satisfied by both `BoardPostMessage`
+ * (feed payload) and a full `Message` (fetched on expand). */
+interface RenderableMessage {
+  id: string
+  authorId: string
+  authorType: AuthorType
+  contentMarkdown: string
+  reactions: Record<string, string[]>
+  createdAt: string | Date
+}
+
 /**
- * One board post: a conversation surfaced as a feed post. The opening message is
- * the body (the unit is a message), the conversation is context (the grouping).
- * Reads like a re-organized timeline row, not a conversations-list card: author
- * header, message content, reactions, and a reply count — no status/completeness
- * chrome. Links to the conversation opened in its stream; stale posts dim.
+ * One board post: a conversation rendered as a threaded feed post. The opening
+ * message is the body, the latest replies sit beneath it, and a collapsed
+ * "N more messages" gap fills in on click. The conversation is context (header),
+ * not the unit. Each message links to itself in its stream timeline — no
+ * conversations pane. Width is constrained by the page to match the timeline.
  */
 export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }: BoardCardProps) {
-  const { conversation, openingMessage } = post
-  const { getActorName, getActorAvatar } = useActors(workspaceId)
+  const { conversation, openingMessage, recentMessages } = post
+  const actors = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
+  const conversationService = useConversationService()
+  const [expanded, setExpanded] = useState(false)
 
-  const to = `/w/${workspaceId}/s/${conversation.streamId}?convView=open&conv=${conversation.id}`
-  const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
+  const streamId = conversation.streamId
   const messageCount = conversation.messageIds.length
-  const body = openingMessage ? stripMarkdownToInline(openingMessage.contentMarkdown, toEmoji).trim() : ""
+  const hiddenCount = Math.max(0, messageCount - (openingMessage ? 1 : 0) - recentMessages.length)
+  const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
 
-  const authorId = openingMessage?.authorId ?? null
-  const authorType = openingMessage?.authorType ?? null
-  const authorName = openingMessage ? getActorName(authorId, authorType) : "Threa"
-  const avatar = getActorAvatar(authorId, authorType)
+  const { data: allMessages } = useQuery({
+    queryKey: conversationKeys.messages(conversation.id),
+    queryFn: () => conversationService.getMessages(workspaceId, conversation.id),
+    enabled: expanded,
+    staleTime: 60_000,
+  })
 
-  const reactions = Object.entries(openingMessage?.reactions ?? {})
-    .filter(([, users]) => users.length > 0)
-    .sort((a, b) => b[1].length - a[1].length)
-  const visibleReactions = reactions.slice(0, MAX_REACTIONS)
-  const reactionOverflow = reactions.length - visibleReactions.length
+  // Expanded: the full conversation minus the opening (which renders above).
+  // Collapsed: just the trailing replies the feed already carried.
+  const replies: RenderableMessage[] =
+    expanded && allMessages ? allMessages.filter((m) => m.id !== openingMessage?.id) : recentMessages
+  const loadingMore = expanded && !allMessages
 
   return (
-    <Link
-      to={to}
-      className={cn(
-        "group block rounded-xl px-3 py-3 transition-colors hover:bg-muted/40 sm:px-4",
-        conversation.temporalStaleness >= 3 && "opacity-60 hover:opacity-100"
-      )}
-    >
-      <div className="flex items-start gap-3">
-        {authorType === "persona" ? (
-          <PersonaAvatar slug={avatar.slug} fallback={avatar.fallback} size="md" />
+    <div className="rounded-xl border bg-card p-3 sm:p-4">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{contextLabel}</span>
+        {topic && (
+          <>
+            <span aria-hidden>·</span>
+            <span className="truncate">{topic}</span>
+          </>
+        )}
+        <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
+      </div>
+
+      <div className="mt-2">
+        {openingMessage && (
+          <PostMessage
+            workspaceId={workspaceId}
+            streamId={streamId}
+            message={openingMessage}
+            actors={actors}
+            toEmoji={toEmoji}
+            emphasis
+          />
+        )}
+
+        {(replies.length > 0 || hiddenCount > 0 || loadingMore) && (
+          <div className="ml-3 mt-1 flex flex-col gap-1 border-l pl-3 sm:ml-4 sm:pl-4">
+            {!expanded && hiddenCount > 0 && (
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                className="flex w-fit items-center gap-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ChevronDown className="h-3.5 w-3.5" />
+                {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
+              </button>
+            )}
+            {loadingMore && <span className="py-0.5 text-xs text-muted-foreground">Loading messages…</span>}
+            {replies.map((message) => (
+              <PostMessage
+                key={message.id}
+                workspaceId={workspaceId}
+                streamId={streamId}
+                message={message}
+                actors={actors}
+                toEmoji={toEmoji}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface PostMessageProps {
+  workspaceId: string
+  streamId: string
+  message: RenderableMessage
+  actors: ActorLookup
+  toEmoji: (shortcode: string) => string | null
+  /** The opening post — slightly larger body clamp than a reply. */
+  emphasis?: boolean
+}
+
+function PostMessage({ workspaceId, streamId, message, actors, toEmoji, emphasis }: PostMessageProps) {
+  const name = actors.getActorName(message.authorId, message.authorType)
+  const avatar = actors.getActorAvatar(message.authorId, message.authorType)
+  const body = stripMarkdownToInline(message.contentMarkdown, toEmoji).trim()
+  const to = `/w/${workspaceId}/s/${streamId}?m=${message.id}`
+
+  return (
+    <Link to={to} className="-mx-2 block rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/50">
+      <div className="flex items-start gap-2">
+        {message.authorType === "persona" ? (
+          <PersonaAvatar slug={avatar.slug} fallback={avatar.fallback} size={emphasis ? "md" : "sm"} />
         ) : (
-          <Avatar className="h-9 w-9 shrink-0 rounded-[10px]">
-            {avatar.avatarUrl && <AvatarImage src={avatar.avatarUrl} alt={authorName} />}
+          <Avatar className={cn("shrink-0 rounded-[8px]", emphasis ? "h-8 w-8" : "h-6 w-6")}>
+            {avatar.avatarUrl && <AvatarImage src={avatar.avatarUrl} alt={name} />}
             <AvatarFallback
               className={cn(
-                "rounded-[10px] bg-muted text-xs text-foreground",
-                authorType === "bot" && "bg-emerald-500/10 text-emerald-600",
-                authorType === "system" && "bg-blue-500/10 text-blue-500"
+                "rounded-[8px] bg-muted text-xs text-foreground",
+                message.authorType === "bot" && "bg-emerald-500/10 text-emerald-600",
+                message.authorType === "system" && "bg-blue-500/10 text-blue-500"
               )}
             >
               {avatar.fallback}
@@ -85,40 +170,45 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
 
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-2">
-            <span className="truncate text-sm font-medium">{authorName}</span>
-            <span className="flex min-w-0 shrink items-center gap-1 text-xs text-muted-foreground">
-              <ContextGlyph className="h-3 w-3 shrink-0" />
-              <span className="truncate">{contextLabel}</span>
-            </span>
-            <RelativeTime
-              date={conversation.lastActivityAt}
-              terse
-              className="ml-auto shrink-0 text-xs text-muted-foreground"
-            />
+            <span className="truncate text-sm font-medium">{name}</span>
+            <RelativeTime date={message.createdAt} terse className="ml-auto shrink-0 text-xs text-muted-foreground" />
           </div>
-
-          {topic && <p className="mt-0.5 truncate text-xs text-muted-foreground">{topic}</p>}
-
-          {body && <p className="mt-1.5 break-words text-sm leading-relaxed line-clamp-4">{body}</p>}
-
-          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-            {visibleReactions.map(([shortcode, users]) => (
-              <span
-                key={shortcode}
-                className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 leading-none"
-              >
-                <span>{toEmoji(shortcode) ?? shortcode}</span>
-                <span>{users.length}</span>
-              </span>
-            ))}
-            {reactionOverflow > 0 && <span>+{reactionOverflow}</span>}
-            <span className="inline-flex items-center gap-1">
-              <MessagesSquare className="h-3.5 w-3.5" />
-              {messageCount} {messageCount === 1 ? "message" : "messages"}
-            </span>
-          </div>
+          {body && (
+            <p className={cn("mt-0.5 break-words text-sm leading-relaxed", emphasis ? "line-clamp-4" : "line-clamp-2")}>
+              {body}
+            </p>
+          )}
+          <ReactionChips reactions={message.reactions} toEmoji={toEmoji} />
         </div>
       </div>
     </Link>
+  )
+}
+
+function ReactionChips({
+  reactions,
+  toEmoji,
+}: {
+  reactions: Record<string, string[]>
+  toEmoji: (shortcode: string) => string | null
+}) {
+  const sorted = Object.entries(reactions)
+    .filter(([, users]) => users.length > 0)
+    .sort((a, b) => b[1].length - a[1].length)
+  if (sorted.length === 0) return null
+
+  const visible = sorted.slice(0, MAX_REACTIONS)
+  const overflow = sorted.length - visible.length
+
+  return (
+    <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+      {visible.map(([shortcode, users]) => (
+        <span key={shortcode} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 leading-none">
+          <span>{toEmoji(shortcode) ?? shortcode}</span>
+          <span>{users.length}</span>
+        </span>
+      ))}
+      {overflow > 0 && <span>+{overflow}</span>}
+    </div>
   )
 }

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -2,16 +2,14 @@ import { useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
-import { cn } from "@/lib/utils"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { PersonaAvatar } from "@/components/persona-avatar"
+import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+import { MessageReactions } from "@/components/timeline/message-reactions"
 import { useActors } from "@/hooks"
-import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useConversationService } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
-import { stripMarkdownToInline } from "@/lib/markdown/strip"
-import type { ActorLookup } from "@/hooks/use-actors"
 import type { AuthorType, BoardPost } from "@threa/types"
 
 interface BoardCardProps {
@@ -31,8 +29,6 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
   dm: User,
 }
 
-const MAX_REACTIONS = 4
-
 /** The fields the post renderer reads — satisfied by both `BoardPostMessage`
  * (feed payload) and a full `Message` (fetched on expand). */
 interface RenderableMessage {
@@ -45,16 +41,18 @@ interface RenderableMessage {
 }
 
 /**
- * One board post: a conversation rendered as a threaded feed post. The opening
- * message is the body, the latest replies sit beneath it, and a collapsed
- * "N more messages" gap fills in on click. The conversation is context (header),
- * not the unit. Each message links to itself in its stream timeline — no
- * conversations pane. Width is constrained by the page to match the timeline.
+ * One board post: a conversation rendered as a feed post. The opening message is
+ * the body, the latest replies stack beneath it, and a collapsed "N more
+ * messages" gap fills in on click. Messages render through the same primitives as
+ * the timeline (`ActorAvatar`, `MarkdownContent`, `MessageReactions`) so a board
+ * message reads exactly like a real message. The card itself delimits the
+ * conversation, so replies aren't indented. The conversation is context (header),
+ * not the unit.
  */
 export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }: BoardCardProps) {
   const { conversation, openingMessage, recentMessages } = post
-  const actors = useActors(workspaceId)
-  const { toEmoji } = useWorkspaceEmoji(workspaceId)
+  const { getActorName } = useActors(workspaceId)
+  const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const [expanded, setExpanded] = useState(false)
 
@@ -94,52 +92,49 @@ export function BoardCard({ workspaceId, post, topic, contextLabel, streamType }
         <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
       </div>
 
-      <div className="mt-2">
+      <div className="mt-3 flex flex-col gap-3">
         {openingMessage && (
           <PostMessage
             workspaceId={workspaceId}
             streamId={streamId}
             message={openingMessage}
-            actors={actors}
-            toEmoji={toEmoji}
+            authorName={getActorName(openingMessage.authorId, openingMessage.authorType)}
+            currentUserId={currentUserId}
             emphasis
           />
         )}
 
-        {(replies.length > 0 || hiddenCount > 0 || loadingMore || (expanded && expandFailed)) && (
-          <div className="ml-3 mt-1 flex flex-col gap-1 border-l pl-3 sm:ml-4 sm:pl-4">
-            {!expanded && hiddenCount > 0 && (
-              <button
-                type="button"
-                onClick={() => setExpanded(true)}
-                className="flex w-fit items-center gap-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <ChevronDown className="h-3.5 w-3.5" />
-                {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
-              </button>
-            )}
-            {loadingMore && <span className="py-0.5 text-xs text-muted-foreground">Loading messages…</span>}
-            {expanded && expandFailed && (
-              <button
-                type="button"
-                onClick={() => void refetchMessages()}
-                className="w-fit py-0.5 text-xs text-destructive underline underline-offset-2"
-              >
-                Couldn't load messages. Retry.
-              </button>
-            )}
-            {replies.map((message) => (
-              <PostMessage
-                key={message.id}
-                workspaceId={workspaceId}
-                streamId={streamId}
-                message={message}
-                actors={actors}
-                toEmoji={toEmoji}
-              />
-            ))}
-          </div>
+        {!expanded && hiddenCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronDown className="h-3.5 w-3.5" />
+            {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
+          </button>
         )}
+        {loadingMore && <span className="text-xs text-muted-foreground">Loading messages…</span>}
+        {expanded && expandFailed && (
+          <button
+            type="button"
+            onClick={() => void refetchMessages()}
+            className="w-fit text-xs text-destructive underline underline-offset-2"
+          >
+            Couldn't load messages. Retry.
+          </button>
+        )}
+
+        {replies.map((message) => (
+          <PostMessage
+            key={message.id}
+            workspaceId={workspaceId}
+            streamId={streamId}
+            message={message}
+            authorName={getActorName(message.authorId, message.authorType)}
+            currentUserId={currentUserId}
+          />
+        ))}
       </div>
     </div>
   )
@@ -149,79 +144,47 @@ interface PostMessageProps {
   workspaceId: string
   streamId: string
   message: RenderableMessage
-  actors: ActorLookup
-  toEmoji: (shortcode: string) => string | null
-  /** The opening post — slightly larger body clamp than a reply. */
+  authorName: string
+  currentUserId: string | null
+  /** The opening post — a slightly larger avatar than a reply. */
   emphasis?: boolean
 }
 
-function PostMessage({ workspaceId, streamId, message, actors, toEmoji, emphasis }: PostMessageProps) {
-  const name = actors.getActorName(message.authorId, message.authorType)
-  const avatar = actors.getActorAvatar(message.authorId, message.authorType)
-  const body = stripMarkdownToInline(message.contentMarkdown, toEmoji).trim()
-  const to = `/w/${workspaceId}/s/${streamId}?m=${message.id}`
+function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, emphasis }: PostMessageProps) {
+  const hasReactions = Object.keys(message.reactions).length > 0
 
   return (
-    <Link to={to} className="-mx-2 block rounded-lg px-2 py-1.5 transition-colors hover:bg-muted/50">
-      <div className="flex items-start gap-2">
-        {message.authorType === "persona" ? (
-          <PersonaAvatar slug={avatar.slug} fallback={avatar.fallback} size={emphasis ? "md" : "sm"} />
-        ) : (
-          <Avatar className={cn("shrink-0 rounded-[8px]", emphasis ? "h-8 w-8" : "h-6 w-6")}>
-            {avatar.avatarUrl && <AvatarImage src={avatar.avatarUrl} alt={name} />}
-            <AvatarFallback
-              className={cn(
-                "rounded-[8px] bg-muted text-xs text-foreground",
-                message.authorType === "bot" && "bg-emerald-500/10 text-emerald-600",
-                message.authorType === "system" && "bg-blue-500/10 text-blue-500"
-              )}
-            >
-              {avatar.fallback}
-            </AvatarFallback>
-          </Avatar>
-        )}
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-baseline gap-2">
-            <span className="truncate text-sm font-medium">{name}</span>
-            <RelativeTime date={message.createdAt} terse className="ml-auto shrink-0 text-xs text-muted-foreground" />
-          </div>
-          {body && (
-            <p className={cn("mt-0.5 break-words text-sm leading-relaxed", emphasis ? "line-clamp-4" : "line-clamp-2")}>
-              {body}
-            </p>
-          )}
-          <ReactionChips reactions={message.reactions} toEmoji={toEmoji} />
+    <div className="flex items-start gap-2 sm:gap-3">
+      <ActorAvatar
+        actorId={message.authorId}
+        actorType={message.authorType}
+        workspaceId={workspaceId}
+        size={emphasis ? "md" : "sm"}
+        alt={authorName}
+        showStatus={false}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="truncate text-sm font-semibold">{authorName}</span>
+          {/* Permalink to the message in its stream timeline — the one navigation
+              affordance, so the interactive message body isn't wrapped in a link. */}
+          <Link
+            to={`/w/${workspaceId}/s/${streamId}?m=${message.id}`}
+            className="shrink-0 text-xs text-muted-foreground hover:underline"
+          >
+            <RelativeTime date={message.createdAt} terse />
+          </Link>
         </div>
+        <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
+        {hasReactions && (
+          <MessageReactions
+            reactions={message.reactions}
+            workspaceId={workspaceId}
+            messageId={message.id}
+            currentUserId={currentUserId}
+          />
+        )}
       </div>
-    </Link>
-  )
-}
-
-function ReactionChips({
-  reactions,
-  toEmoji,
-}: {
-  reactions: Record<string, string[]>
-  toEmoji: (shortcode: string) => string | null
-}) {
-  const sorted = Object.entries(reactions)
-    .filter(([, users]) => users.length > 0)
-    .sort((a, b) => b[1].length - a[1].length)
-  if (sorted.length === 0) return null
-
-  const visible = sorted.slice(0, MAX_REACTIONS)
-  const overflow = sorted.length - visible.length
-
-  return (
-    <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-      {visible.map(([shortcode, users]) => (
-        <span key={shortcode} className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 leading-none">
-          <span>{toEmoji(shortcode) ?? shortcode}</span>
-          <span>{users.length}</span>
-        </span>
-      ))}
-      {overflow > 0 && <span>+{overflow}</span>}
     </div>
   )
 }

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -67,6 +67,7 @@ export interface ConversationService {
   listByStream: typeof conversationsApi.listByStream
   getById: typeof conversationsApi.getById
   getMessages: typeof conversationsApi.getMessages
+  getBoardMessages: typeof conversationsApi.getBoardMessages
   reassignMessage: typeof conversationsApi.reassignMessage
 }
 

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -13,6 +13,7 @@ export const conversationKeys = {
   byId: (workspaceId: string, conversationId: string) =>
     [...conversationKeys.all, "detail", workspaceId, conversationId] as const,
   messages: (conversationId: string) => ["conversations", conversationId, "messages"] as const,
+  boardMessages: (conversationId: string) => ["conversations", conversationId, "board-messages"] as const,
 }
 
 interface ConversationCreatedPayload {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, render, screen, within } from "@testing-library/react"
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
@@ -63,12 +63,16 @@ function makePost(
 
 function mountBoard(
   posts: BoardPost[],
-  opts: { nextCursor?: string | null; fail?: boolean; boardFlag?: "on" | "off" } = {}
+  opts: { nextCursor?: string | null; fail?: boolean; boardFlag?: "on" | "off"; failMessages?: boolean } = {}
 ) {
-  const { nextCursor = null, fail = false, boardFlag = "on" } = opts
+  const { nextCursor = null, fail = false, boardFlag = "on", failMessages = false } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
     return { posts, nextCursor }
+  })
+  const getMessages = vi.fn(async () => {
+    if (failMessages) throw new Error("boom")
+    return []
   })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   // The board is gated behind the board-view flag, read from the bootstrap cache.
@@ -76,9 +80,7 @@ function mountBoard(
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ServicesProvider
-          services={{ conversations: { listByWorkspace, getMessages: vi.fn(async () => []) } as never }}
-        >
+        <ServicesProvider services={{ conversations: { listByWorkspace, getMessages } as never }}>
           <SidebarProvider>
             <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
               <Routes>
@@ -131,6 +133,17 @@ describe("BoardPage", () => {
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)])
     expect(await screen.findByText("1 more message")).toBeTruthy()
     expect(screen.queryByText("1 more messages")).toBeNull()
+  })
+
+  it("offers a retry when expanding the middle fails", async () => {
+    const recent = [
+      makeOpeningMessage({ id: "m3" }),
+      makeOpeningMessage({ id: "m4" }),
+      makeOpeningMessage({ id: "m5" }),
+    ]
+    mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)], { failMessages: true })
+    fireEvent.click(await screen.findByText("1 more message"))
+    expect(await screen.findByText("Couldn't load messages. Retry.")).toBeTruthy()
   })
 
   it("shows no expander when the whole conversation already fits", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -79,7 +79,7 @@ function mountBoard(
     if (fail) throw new Error("boom")
     return { posts, nextCursor }
   })
-  const getMessages = vi.fn(async () => {
+  const getBoardMessages = vi.fn(async () => {
     if (failMessages) throw new Error("boom")
     return []
   })
@@ -89,7 +89,7 @@ function mountBoard(
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ServicesProvider services={{ conversations: { listByWorkspace, getMessages } as never }}>
+        <ServicesProvider services={{ conversations: { listByWorkspace, getBoardMessages } as never }}>
           <SidebarProvider>
             <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
               <Routes>

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -130,10 +130,9 @@ describe("BoardPage", () => {
     expect(await screen.findByText("Nothing on the board yet")).toBeTruthy()
   })
 
-  it("renders a post with its topic and opening-message body", async () => {
+  it("renders the opening-message body", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
-    expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
-    expect(screen.getByText("Rotate the tokens before Friday.")).toBeTruthy()
+    expect(await screen.findByText("Rotate the tokens before Friday.")).toBeTruthy()
   })
 
   it("collapses the middle as an 'N more messages' expander, pluralizing the count", async () => {
@@ -162,13 +161,13 @@ describe("BoardPage", () => {
   it("shows no expander when the whole conversation already fits", async () => {
     const recent = [makeOpeningMessage({ id: "m2" }), makeOpeningMessage({ id: "m3" })]
     mountBoard([makePost({ messageIds: ["m1", "m2", "m3"] }, { id: "m1" }, recent)])
-    await screen.findByText("CC Teams tokens")
+    await screen.findAllByText("Opening message body.")
     expect(screen.queryByText(/more messages?$/)).toBeNull()
   })
 
   it("renders reactions on the opening message", async () => {
-    mountBoard([makePost({}, { reactions: { ":tada:": ["usr_a", "usr_b"] } })])
-    await screen.findByText("CC Teams tokens")
+    mountBoard([makePost({ messageIds: ["m1"] }, { id: "m1", reactions: { ":tada:": ["usr_a", "usr_b"] } })])
+    await screen.findByText("Opening message body.")
     // No emoji map in the test cache, so the shortcode renders as-is with its count.
     expect(screen.getByText(":tada:")).toBeTruthy()
     expect(screen.getByText("2")).toBeTruthy()
@@ -180,8 +179,14 @@ describe("BoardPage", () => {
     const today = new Date().toISOString()
     const fiveDaysAgo = new Date(Date.now() - 5 * 86_400_000).toISOString()
     mountBoard([
-      makePost({ id: "conv_today", topicSummary: "Fresh topic", lastActivityAt: today }),
-      makePost({ id: "conv_old", streamId: "stream_2", topicSummary: "Older topic", lastActivityAt: fiveDaysAgo }),
+      makePost(
+        { id: "conv_today", messageIds: ["a1"], lastActivityAt: today },
+        { id: "a1", contentMarkdown: "Fresh body" }
+      ),
+      makePost(
+        { id: "conv_old", streamId: "stream_2", messageIds: ["b1"], lastActivityAt: fiveDaysAgo },
+        { id: "b1", contentMarkdown: "Older body" }
+      ),
     ])
 
     const todaySection = (await screen.findByText("Today")).closest("section")
@@ -189,8 +194,8 @@ describe("BoardPage", () => {
     expect(todaySection).not.toBeNull()
     expect(weekSection).not.toBeNull()
     // Each post sits under its own recency header.
-    expect(within(todaySection as HTMLElement).getByText("Fresh topic")).toBeTruthy()
-    expect(within(weekSection as HTMLElement).getByText("Older topic")).toBeTruthy()
+    expect(within(todaySection as HTMLElement).getByText("Fresh body")).toBeTruthy()
+    expect(within(weekSection as HTMLElement).getByText("Older body")).toBeTruthy()
   })
 
   it("shows an error state with a retry, not the empty state, when the fetch fails", async () => {
@@ -202,7 +207,7 @@ describe("BoardPage", () => {
 
   it("offers Load more when there is another page", async () => {
     mountBoard([makePost()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
-    expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
+    expect(await screen.findByText("Opening message body.")).toBeTruthy()
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy()
   })
 
@@ -211,7 +216,7 @@ describe("BoardPage", () => {
     // Gate redirects away — board content never appears and the feed isn't fetched.
     // Flush effects so a (hypothetical) deferred mount would have its chance to fire.
     await act(async () => {})
-    expect(screen.queryByText("CC Teams tokens")).toBeNull()
+    expect(screen.queryByText("Opening message body.")).toBeNull()
     expect(screen.queryByText("Board")).toBeNull()
     expect(listByWorkspace).not.toHaveBeenCalled()
   })
@@ -227,17 +232,16 @@ describe("BoardPage", () => {
     expect(permalink).toBeTruthy()
   })
 
-  it("uses the scratchpad's name as the topic, not the generic summary", async () => {
+  it("uses the scratchpad's name as the card's stream locator", async () => {
     vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
       { id: "stream_sp", type: "scratchpad", displayName: "My Notes" },
     ] as never)
-    mountBoard([makePost({ id: "conv_sp", streamId: "stream_sp", topicSummary: "Scratchpad" })])
+    mountBoard([makePost({ id: "conv_sp", streamId: "stream_sp" })])
 
-    expect(await screen.findByText("My Notes")).toBeTruthy() // topic = scratchpad name
-    expect(screen.getByText("Scratchpad")).toBeTruthy() // context line = the type
+    expect(await screen.findByText("My Notes")).toBeTruthy() // header locator = scratchpad name
   })
 
-  it("keeps a DM peer (a person) as context, never as the post topic", async () => {
+  it("resolves a DM peer as the card's stream locator", async () => {
     vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
       { id: "stream_dm", type: "dm", displayName: null },
     ] as never)
@@ -245,12 +249,9 @@ describe("BoardPage", () => {
       { streamId: "stream_dm", userId: "usr_pierre" },
     ] as never)
     vi.mocked(workspaceStoreModule.useWorkspaceUsers).mockReturnValue([{ id: "usr_pierre", name: "Pierre" }] as never)
-    mountBoard([makePost({ id: "conv_dm", streamId: "stream_dm", topicSummary: "Lunch plans" })])
+    mountBoard([makePost({ id: "conv_dm", streamId: "stream_dm", messageIds: ["d1"] }, { id: "d1" })])
 
-    const topic = await screen.findByText("Lunch plans")
-    expect(topic).toBeTruthy() // topic = topicSummary
-    // "Pierre" renders as the context line, and is not the topic element.
-    expect(screen.getByText("Pierre")).toBeTruthy()
-    expect(topic.textContent).not.toContain("Pierre")
+    // The DM peer's name is the header locator (where the post lives).
+    expect(await screen.findByText("Pierre")).toBeTruthy()
   })
 })

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -46,6 +46,8 @@ function makeOpeningMessage(overrides: Partial<BoardPostMessage> = {}): BoardPos
     authorType: "user",
     contentMarkdown: "Opening message body.",
     reactions: {},
+    attachments: [],
+    linkPreviews: [],
     createdAt: "2026-06-22T12:00:00.000Z",
     ...overrides,
   }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { act, render, screen } from "@testing-library/react"
+import { act, render, screen, within } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
@@ -130,6 +130,25 @@ describe("BoardPage", () => {
     // No emoji map in the test cache, so the shortcode renders as-is with its count.
     expect(screen.getByText(":tada:")).toBeTruthy()
     expect(screen.getByText("2")).toBeTruthy()
+  })
+
+  it("groups posts into recency sections under the right headers", async () => {
+    // Timestamps relative to now so the buckets are deterministic regardless of
+    // when the suite runs (recencyBucket compares against the current day).
+    const today = new Date().toISOString()
+    const fiveDaysAgo = new Date(Date.now() - 5 * 86_400_000).toISOString()
+    mountBoard([
+      makePost({ id: "conv_today", topicSummary: "Fresh topic", lastActivityAt: today }),
+      makePost({ id: "conv_old", streamId: "stream_2", topicSummary: "Older topic", lastActivityAt: fiveDaysAgo }),
+    ])
+
+    const todaySection = (await screen.findByText("Today")).closest("section")
+    const weekSection = screen.getByText("Earlier this week").closest("section")
+    expect(todaySection).not.toBeNull()
+    expect(weekSection).not.toBeNull()
+    // Each post sits under its own recency header.
+    expect(within(todaySection as HTMLElement).getByText("Fresh topic")).toBeTruthy()
+    expect(within(weekSection as HTMLElement).getByText("Older topic")).toBeTruthy()
   })
 
   it("shows an error state with a retry, not the empty state, when the fetch fails", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -51,11 +51,13 @@ function makeOpeningMessage(overrides: Partial<BoardPostMessage> = {}): BoardPos
 
 function makePost(
   convOverrides: Partial<ConversationWithStaleness> = {},
-  msgOverrides: Partial<BoardPostMessage> | null = {}
+  msgOverrides: Partial<BoardPostMessage> | null = {},
+  recentMessages: BoardPostMessage[] = []
 ): BoardPost {
   return {
     conversation: makeConversation(convOverrides),
     openingMessage: msgOverrides === null ? null : makeOpeningMessage(msgOverrides),
+    recentMessages,
   }
 }
 
@@ -74,7 +76,9 @@ function mountBoard(
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ServicesProvider services={{ conversations: { listByWorkspace } as never }}>
+        <ServicesProvider
+          services={{ conversations: { listByWorkspace, getMessages: vi.fn(async () => []) } as never }}
+        >
           <SidebarProvider>
             <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
               <Routes>
@@ -111,17 +115,29 @@ describe("BoardPage", () => {
     expect(await screen.findByText("Nothing on the board yet")).toBeTruthy()
   })
 
-  it("renders a post with its topic, body, and message count", async () => {
+  it("renders a post with its topic and opening-message body", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
     expect(screen.getByText("Rotate the tokens before Friday.")).toBeTruthy()
-    expect(screen.getByText("3 messages")).toBeTruthy()
   })
 
-  it("pluralizes a single message as '1 message'", async () => {
-    mountBoard([makePost({ messageIds: ["msg_only"] })])
-    expect(await screen.findByText("1 message")).toBeTruthy()
-    expect(screen.queryByText("1 messages")).toBeNull()
+  it("collapses the middle as an 'N more messages' expander, pluralizing the count", async () => {
+    // 5 messages: opening + 3 recent shown + 1 hidden in the middle.
+    const recent = [
+      makeOpeningMessage({ id: "m3" }),
+      makeOpeningMessage({ id: "m4" }),
+      makeOpeningMessage({ id: "m5" }),
+    ]
+    mountBoard([makePost({ messageIds: ["m1", "m2", "m3", "m4", "m5"] }, { id: "m1" }, recent)])
+    expect(await screen.findByText("1 more message")).toBeTruthy()
+    expect(screen.queryByText("1 more messages")).toBeNull()
+  })
+
+  it("shows no expander when the whole conversation already fits", async () => {
+    const recent = [makeOpeningMessage({ id: "m2" }), makeOpeningMessage({ id: "m3" })]
+    mountBoard([makePost({ messageIds: ["m1", "m2", "m3"] }, { id: "m1" }, recent)])
+    await screen.findByText("CC Teams tokens")
+    expect(screen.queryByText(/more messages?$/)).toBeNull()
   })
 
   it("renders reactions on the opening message", async () => {
@@ -174,10 +190,10 @@ describe("BoardPage", () => {
     expect(listByWorkspace).not.toHaveBeenCalled()
   })
 
-  it("links each post to its conversation opened in its stream", async () => {
+  it("links the opening message to itself in its stream timeline (no conversations pane)", async () => {
     mountBoard([makePost()])
-    const card = (await screen.findByText("CC Teams tokens")).closest("a")
-    expect(card?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?convView=open&conv=conv_1`)
+    const link = (await screen.findByText("Opening message body.")).closest("a")
+    expect(link?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?m=msg_1`)
   })
 
   it("uses the scratchpad's name as the topic, not the generic summary", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -10,6 +10,7 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
 import * as contextsModule from "@/contexts"
 
 const WORKSPACE_ID = "ws_1"
@@ -56,12 +57,16 @@ function makeOpeningMessage(overrides: Partial<BoardPostMessage> = {}): BoardPos
 function makePost(
   convOverrides: Partial<ConversationWithStaleness> = {},
   msgOverrides: Partial<BoardPostMessage> | null = {},
-  recentMessages: BoardPostMessage[] = []
+  recentMessages: BoardPostMessage[] = [],
+  totalReplies?: number
 ): BoardPost {
+  const conversation = makeConversation(convOverrides)
   return {
-    conversation: makeConversation(convOverrides),
+    conversation,
     openingMessage: msgOverrides === null ? null : makeOpeningMessage(msgOverrides),
     recentMessages,
+    // Default mirrors a non-thread post: every message after the origin is a reply.
+    totalReplies: totalReplies ?? Math.max(0, conversation.messageIds.length - 1),
   }
 }
 
@@ -118,6 +123,8 @@ beforeEach(() => {
     toggleReaction: vi.fn(),
     toggleByEmoji: vi.fn(),
   } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  // Author names open the profile via UserProfileProvider, not mounted here.
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
   // RelativeTime reads timezone/locale from the preferences context.
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: { timezone: "UTC", locale: "en-US" },

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, render, screen } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { ConversationWithStaleness } from "@threa/types"
+import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import { ServicesProvider, SidebarProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
@@ -35,14 +35,38 @@ function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): C
   }
 }
 
+function makeOpeningMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
+  return {
+    id: "msg_1",
+    // usr_me isn't in the mocked user cache, so the author renders as a short id
+    // — distinct from any DM-peer name asserted on elsewhere.
+    authorId: "usr_me",
+    authorType: "user",
+    contentMarkdown: "Opening message body.",
+    reactions: {},
+    createdAt: "2026-06-22T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function makePost(
+  convOverrides: Partial<ConversationWithStaleness> = {},
+  msgOverrides: Partial<BoardPostMessage> | null = {}
+): BoardPost {
+  return {
+    conversation: makeConversation(convOverrides),
+    openingMessage: msgOverrides === null ? null : makeOpeningMessage(msgOverrides),
+  }
+}
+
 function mountBoard(
-  conversations: ConversationWithStaleness[],
+  posts: BoardPost[],
   opts: { nextCursor?: string | null; fail?: boolean; boardFlag?: "on" | "off" } = {}
 ) {
   const { nextCursor = null, fail = false, boardFlag = "on" } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
-    return { conversations, nextCursor }
+    return { posts, nextCursor }
   })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   // The board is gated behind the board-view flag, read from the bootstrap cache.
@@ -66,10 +90,13 @@ function mountBoard(
 }
 
 beforeEach(() => {
-  // BoardCard resolves the stream label via the workspace caches.
+  // BoardCard resolves the stream label + author + emoji via the workspace caches.
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
   // RelativeTime reads timezone/locale from the preferences context.
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: { timezone: "UTC", locale: "en-US" },
@@ -84,16 +111,25 @@ describe("BoardPage", () => {
     expect(await screen.findByText("Nothing on the board yet")).toBeTruthy()
   })
 
-  it("renders a conversation as a card with its title and message count", async () => {
-    mountBoard([makeConversation()])
+  it("renders a post with its topic, body, and message count", async () => {
+    mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
+    expect(screen.getByText("Rotate the tokens before Friday.")).toBeTruthy()
     expect(screen.getByText("3 messages")).toBeTruthy()
   })
 
   it("pluralizes a single message as '1 message'", async () => {
-    mountBoard([makeConversation({ messageIds: ["msg_only"] })])
+    mountBoard([makePost({ messageIds: ["msg_only"] })])
     expect(await screen.findByText("1 message")).toBeTruthy()
     expect(screen.queryByText("1 messages")).toBeNull()
+  })
+
+  it("renders reactions on the opening message", async () => {
+    mountBoard([makePost({}, { reactions: { ":tada:": ["usr_a", "usr_b"] } })])
+    await screen.findByText("CC Teams tokens")
+    // No emoji map in the test cache, so the shortcode renders as-is with its count.
+    expect(screen.getByText(":tada:")).toBeTruthy()
+    expect(screen.getByText("2")).toBeTruthy()
   })
 
   it("shows an error state with a retry, not the empty state, when the fetch fails", async () => {
@@ -104,13 +140,13 @@ describe("BoardPage", () => {
   })
 
   it("offers Load more when there is another page", async () => {
-    mountBoard([makeConversation()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
+    mountBoard([makePost()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
     expect(await screen.findByText("CC Teams tokens")).toBeTruthy()
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy()
   })
 
   it("does not render the board when the board-view flag is off", async () => {
-    const { listByWorkspace } = mountBoard([makeConversation()], { boardFlag: "off" })
+    const { listByWorkspace } = mountBoard([makePost()], { boardFlag: "off" })
     // Gate redirects away — board content never appears and the feed isn't fetched.
     // Flush effects so a (hypothetical) deferred mount would have its chance to fire.
     await act(async () => {})
@@ -119,23 +155,23 @@ describe("BoardPage", () => {
     expect(listByWorkspace).not.toHaveBeenCalled()
   })
 
-  it("links each card to its conversation opened in its stream", async () => {
-    mountBoard([makeConversation()])
+  it("links each post to its conversation opened in its stream", async () => {
+    mountBoard([makePost()])
     const card = (await screen.findByText("CC Teams tokens")).closest("a")
     expect(card?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?convView=open&conv=conv_1`)
   })
 
-  it("titles a scratchpad card with the scratchpad's name, not the generic topic", async () => {
+  it("uses the scratchpad's name as the topic, not the generic summary", async () => {
     vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
       { id: "stream_sp", type: "scratchpad", displayName: "My Notes" },
     ] as never)
-    mountBoard([makeConversation({ id: "conv_sp", streamId: "stream_sp", topicSummary: "Scratchpad" })])
+    mountBoard([makePost({ id: "conv_sp", streamId: "stream_sp", topicSummary: "Scratchpad" })])
 
-    expect(await screen.findByText("My Notes")).toBeTruthy() // title = scratchpad name
+    expect(await screen.findByText("My Notes")).toBeTruthy() // topic = scratchpad name
     expect(screen.getByText("Scratchpad")).toBeTruthy() // context line = the type
   })
 
-  it("keeps a DM peer (a person) as context, never as the card title", async () => {
+  it("keeps a DM peer (a person) as context, never as the post topic", async () => {
     vi.mocked(workspaceStoreModule.useWorkspaceStreams).mockReturnValue([
       { id: "stream_dm", type: "dm", displayName: null },
     ] as never)
@@ -143,12 +179,12 @@ describe("BoardPage", () => {
       { streamId: "stream_dm", userId: "usr_pierre" },
     ] as never)
     vi.mocked(workspaceStoreModule.useWorkspaceUsers).mockReturnValue([{ id: "usr_pierre", name: "Pierre" }] as never)
-    mountBoard([makeConversation({ id: "conv_dm", streamId: "stream_dm", topicSummary: "Lunch plans" })])
+    mountBoard([makePost({ id: "conv_dm", streamId: "stream_dm", topicSummary: "Lunch plans" })])
 
-    const title = await screen.findByText("Lunch plans")
-    expect(title).toBeTruthy() // title = topic
-    // "Pierre" renders as the context line, and is not the title element.
+    const topic = await screen.findByText("Lunch plans")
+    expect(topic).toBeTruthy() // topic = topicSummary
+    // "Pierre" renders as the context line, and is not the topic element.
     expect(screen.getByText("Pierre")).toBeTruthy()
-    expect(title.textContent).not.toContain("Pierre")
+    expect(topic.textContent).not.toContain("Pierre")
   })
 })

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -7,7 +7,9 @@ import { BoardPage } from "./board"
 import { ServicesProvider, SidebarProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { workspaceKeys } from "@/hooks/use-workspaces"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
 import * as contextsModule from "@/contexts"
 
 const WORKSPACE_ID = "ws_1"
@@ -103,6 +105,17 @@ beforeEach(() => {
   vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  // BoardCard reads the viewer id for reaction state; sourced from auth, which
+  // isn't mounted in this harness.
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // Reactions reuse the timeline's <MessageReactions>, whose toggle hook reaches
+  // for the SyncEngine. Stub the hook so the real component still renders.
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
   // RelativeTime reads timezone/locale from the preferences context.
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: { timezone: "UTC", locale: "en-US" },
@@ -203,10 +216,15 @@ describe("BoardPage", () => {
     expect(listByWorkspace).not.toHaveBeenCalled()
   })
 
-  it("links the opening message to itself in its stream timeline (no conversations pane)", async () => {
+  it("permalinks each message to itself in its stream timeline (no conversations pane)", async () => {
     mountBoard([makePost()])
-    const link = (await screen.findByText("Opening message body.")).closest("a")
-    expect(link?.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/s/stream_1?m=msg_1`)
+    await screen.findByText("Opening message body.")
+    // The body renders as a real message (not wrapped in a link); the timestamp
+    // is the permalink into the stream.
+    const permalink = screen
+      .getAllByRole("link")
+      .find((a) => a.getAttribute("href") === `/w/${WORKSPACE_ID}/s/stream_1?m=msg_1`)
+    expect(permalink).toBeTruthy()
   })
 
   it("uses the scratchpad's name as the topic, not the generic summary", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -8,10 +8,44 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { PageHeaderTabs } from "@/components/layout"
 import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
+import { localStartOfDayMs } from "@/lib/dates"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
 import type { ConversationWithStaleness } from "@threa/types"
+
+/**
+ * Coarse recency bucket for a conversation's last activity, in device-local time
+ * (INV-42). The board is ordered by activity desc, so consecutive rows fall into
+ * monotonic buckets — grouping them gives the wall structure without disturbing
+ * the recency order. Day boundaries, not 24h windows, so "Yesterday" matches the
+ * user's calendar.
+ */
+function recencyBucket(date: Date | string, nowMs: number): string {
+  const daysAgo = Math.round((localStartOfDayMs(new Date(nowMs)) - localStartOfDayMs(new Date(date))) / 86_400_000)
+  if (daysAgo <= 0) return "Today"
+  if (daysAgo === 1) return "Yesterday"
+  if (daysAgo <= 6) return "Earlier this week"
+  if (daysAgo <= 30) return "This month"
+  return "Older"
+}
+
+interface BoardSection {
+  label: string
+  conversations: ConversationWithStaleness[]
+}
+
+/** Fold the recency-sorted feed into consecutive buckets, preserving order. */
+function groupByRecency(conversations: ConversationWithStaleness[], nowMs: number): BoardSection[] {
+  const sections: BoardSection[] = []
+  for (const conversation of conversations) {
+    const label = recencyBucket(conversation.lastActivityAt, nowMs)
+    const last = sections[sections.length - 1]
+    if (last?.label === label) last.conversations.push(conversation)
+    else sections.push({ label, conversations: [conversation] })
+  }
+  return sections
+}
 
 /**
  * The board: a cross-stream wall of conversations (Threa's topic primitive)
@@ -47,19 +81,26 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
+  const sections = useMemo(() => groupByRecency(conversations, Date.now()), [conversations])
 
   // A scratchpad IS its conversation, so its own name is the best title (the
   // stored "Scratchpad" topicSummary is noise). For channels/DMs the topic is
   // the title and the stream is context — never the DM peer as the title, since
   // that name is a person, not a topic.
-  function labelsFor(conversation: ConversationWithStaleness): { title: string; contextLabel: string } {
+  function labelsFor(conversation: ConversationWithStaleness): {
+    title: string
+    contextLabel: string
+    streamType: string | undefined
+  } {
     const streamName = resolveStreamName(conversation.streamId, { streams, users, dmPeers }, "generic")
-    if (streamById.get(conversation.streamId)?.type === StreamTypes.SCRATCHPAD) {
-      return { title: streamName ?? "Scratchpad", contextLabel: "Scratchpad" }
+    const streamType = streamById.get(conversation.streamId)?.type
+    if (streamType === StreamTypes.SCRATCHPAD) {
+      return { title: streamName ?? "Scratchpad", contextLabel: "Scratchpad", streamType }
     }
     return {
       title: conversation.topicSummary?.trim() || "Untitled conversation",
       contextLabel: streamName ?? "Unknown stream",
+      streamType,
     }
   }
 
@@ -71,9 +112,15 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   let content
   if (isLoading) {
     content = (
-      <div className="flex flex-col gap-2 px-3">
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-20 w-full rounded-lg" />
+      <div className="flex flex-col gap-0.5">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-3 px-3 py-2.5 sm:px-4 sm:py-3">
+            <Skeleton className="h-9 w-9 shrink-0 rounded-[10px]" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-3.5 w-2/5" />
+              <Skeleton className="h-3 w-3/5" />
+            </div>
+          </div>
         ))}
       </div>
     )
@@ -101,19 +148,29 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     )
   } else {
     content = (
-      <div className="flex flex-col gap-2 px-3">
-        {conversations.map((conversation) => {
-          const { title, contextLabel } = labelsFor(conversation)
-          return (
-            <BoardCard
-              key={conversation.id}
-              workspaceId={workspaceId}
-              conversation={conversation}
-              title={title}
-              contextLabel={contextLabel}
-            />
-          )
-        })}
+      <div className="flex flex-col">
+        {sections.map((section) => (
+          <section key={section.label} className="mb-2">
+            <h2 className="px-3 pb-1 pt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground sm:px-4">
+              {section.label}
+            </h2>
+            <div className="flex flex-col gap-0.5">
+              {section.conversations.map((conversation) => {
+                const { title, contextLabel, streamType } = labelsFor(conversation)
+                return (
+                  <BoardCard
+                    key={conversation.id}
+                    workspaceId={workspaceId}
+                    conversation={conversation}
+                    title={title}
+                    contextLabel={contextLabel}
+                    streamType={streamType}
+                  />
+                )
+              })}
+            </div>
+          </section>
+        ))}
         {hasNextPage && (
           <div className="mt-1 flex flex-col items-center gap-1">
             {isFetchNextPageError && <p className="text-xs text-destructive">Couldn't load more.</p>}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
 import { AlertCircle, LayoutGrid } from "lucide-react"
 import { Navigate, useParams } from "react-router-dom"
-import { StreamTypes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -83,26 +82,16 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
   const sections = useMemo(() => groupByRecency(posts, Date.now()), [posts])
 
-  // A scratchpad IS its conversation, so its own name is the best topic (the
-  // stored "Scratchpad" topicSummary is noise). For channels/DMs the topic is
-  // the topicSummary and the stream is context — never the DM peer as the topic,
-  // since that name is a person, not a topic.
+  // Where the post lives — the stream's own name (channel #slug, DM peer,
+  // scratchpad name), used as the card's locator. The glyph follows the type.
   function labelsFor(conversation: ConversationWithStaleness): {
-    title: string
     contextLabel: string
     streamType: string | undefined
   } {
     const streamName = resolveStreamName(conversation.streamId, { streams, users, dmPeers }, "generic")
-    const streamType = streamById.get(conversation.streamId)?.type
-    if (streamType === StreamTypes.SCRATCHPAD) {
-      return { title: streamName ?? "Scratchpad", contextLabel: "Scratchpad", streamType }
-    }
     return {
-      // The body carries the content, so an absent topic just omits the subject
-      // line rather than showing an "Untitled" placeholder.
-      title: conversation.topicSummary?.trim() ?? "",
       contextLabel: streamName ?? "Unknown stream",
-      streamType,
+      streamType: streamById.get(conversation.streamId)?.type,
     }
   }
 
@@ -161,13 +150,12 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
             </h2>
             <div className="flex flex-col gap-3">
               {section.posts.map((post) => {
-                const { title, contextLabel, streamType } = labelsFor(post.conversation)
+                const { contextLabel, streamType } = labelsFor(post.conversation)
                 return (
                   <BoardCard
                     key={post.conversation.id}
                     workspaceId={workspaceId}
                     post={post}
-                    topic={title}
                     contextLabel={contextLabel}
                     streamType={streamType}
                   />

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -114,13 +114,16 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   let content
   if (isLoading) {
     content = (
-      <div className="flex flex-col gap-0.5">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="flex items-start gap-3 px-3 py-2.5 sm:px-4 sm:py-3">
-            <Skeleton className="h-9 w-9 shrink-0 rounded-[10px]" />
-            <div className="min-w-0 flex-1 space-y-2">
-              <Skeleton className="h-3.5 w-2/5" />
-              <Skeleton className="h-3 w-3/5" />
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="rounded-xl border bg-card p-4">
+            <Skeleton className="h-3 w-1/3" />
+            <div className="mt-3 flex items-start gap-2">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-[8px]" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-3.5 w-1/4" />
+                <Skeleton className="h-3 w-4/5" />
+              </div>
             </div>
           </div>
         ))}
@@ -152,11 +155,11 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     content = (
       <div className="flex flex-col">
         {sections.map((section) => (
-          <section key={section.label} className="mb-2">
-            <h2 className="px-3 pb-1 pt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground sm:px-4">
+          <section key={section.label} className="mb-4">
+            <h2 className="px-1 pb-1.5 pt-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               {section.label}
             </h2>
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-3">
               {section.posts.map((post) => {
                 const { title, contextLabel, streamType } = labelsFor(post.conversation)
                 return (
@@ -200,7 +203,7 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         tabs={[{ value: "all", label: "All", href: `/w/${workspaceId}/board` }]}
       />
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
-        <main className="py-2">{content}</main>
+        <main className="mx-auto w-full max-w-[800px] px-2 py-3 sm:px-4">{content}</main>
       </ScrollArea>
     </div>
   )

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -12,12 +12,12 @@ import { localStartOfDayMs } from "@/lib/dates"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
-import type { ConversationWithStaleness } from "@threa/types"
+import type { BoardPost, ConversationWithStaleness } from "@threa/types"
 
 /**
- * Coarse recency bucket for a conversation's last activity, in device-local time
- * (INV-42). The board is ordered by activity desc, so consecutive rows fall into
- * monotonic buckets — grouping them gives the wall structure without disturbing
+ * Coarse recency bucket for a post's last activity, in device-local time
+ * (INV-42). The board is ordered by activity desc, so consecutive posts fall into
+ * monotonic buckets — grouping them gives the feed structure without disturbing
  * the recency order. Day boundaries, not 24h windows, so "Yesterday" matches the
  * user's calendar.
  */
@@ -32,26 +32,26 @@ function recencyBucket(date: Date | string, nowMs: number): string {
 
 interface BoardSection {
   label: string
-  conversations: ConversationWithStaleness[]
+  posts: BoardPost[]
 }
 
 /** Fold the recency-sorted feed into consecutive buckets, preserving order. */
-function groupByRecency(conversations: ConversationWithStaleness[], nowMs: number): BoardSection[] {
+function groupByRecency(posts: BoardPost[], nowMs: number): BoardSection[] {
   const sections: BoardSection[] = []
-  for (const conversation of conversations) {
-    const label = recencyBucket(conversation.lastActivityAt, nowMs)
+  for (const post of posts) {
+    const label = recencyBucket(post.conversation.lastActivityAt, nowMs)
     const last = sections[sections.length - 1]
-    if (last?.label === label) last.conversations.push(conversation)
-    else sections.push({ label, conversations: [conversation] })
+    if (last?.label === label) last.posts.push(post)
+    else sections.push({ label, posts: [post] })
   }
   return sections
 }
 
 /**
- * The board: a cross-stream wall of conversations (Threa's topic primitive)
- * ordered by recent activity — the read-only foundation of the board view
- * (slice 1). Lenses and a scope filter land as tabs here later; for now a single
- * "All" tab shows everything the viewer can read.
+ * The board: a cross-stream feed of posts (each conversation surfaced as a
+ * message-led post) ordered by recent activity, grouped into recency sections.
+ * Lenses and a scope filter land as tabs here later; for now a single "All" tab
+ * shows everything the viewer can read.
  */
 export function BoardPage() {
   const { workspaceId } = useParams<{ workspaceId: string }>()
@@ -76,17 +76,17 @@ function BoardPageGate({ workspaceId }: { workspaceId: string }) {
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { limit: 50 })
-  const conversations = useMemo(() => data?.pages.flatMap((page) => page.conversations) ?? [], [data])
+  const posts = useMemo(() => data?.pages.flatMap((page) => page.posts) ?? [], [data])
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
-  const sections = useMemo(() => groupByRecency(conversations, Date.now()), [conversations])
+  const sections = useMemo(() => groupByRecency(posts, Date.now()), [posts])
 
-  // A scratchpad IS its conversation, so its own name is the best title (the
+  // A scratchpad IS its conversation, so its own name is the best topic (the
   // stored "Scratchpad" topicSummary is noise). For channels/DMs the topic is
-  // the title and the stream is context — never the DM peer as the title, since
-  // that name is a person, not a topic.
+  // the topicSummary and the stream is context — never the DM peer as the topic,
+  // since that name is a person, not a topic.
   function labelsFor(conversation: ConversationWithStaleness): {
     title: string
     contextLabel: string
@@ -98,7 +98,9 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
       return { title: streamName ?? "Scratchpad", contextLabel: "Scratchpad", streamType }
     }
     return {
-      title: conversation.topicSummary?.trim() || "Untitled conversation",
+      // The body carries the content, so an absent topic just omits the subject
+      // line rather than showing an "Untitled" placeholder.
+      title: conversation.topicSummary?.trim() ?? "",
       contextLabel: streamName ?? "Unknown stream",
       streamType,
     }
@@ -136,7 +138,7 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         </Button>
       </div>
     )
-  } else if (conversations.length === 0) {
+  } else if (posts.length === 0) {
     content = (
       <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
         <LayoutGrid className="h-8 w-8 text-muted-foreground" />
@@ -154,15 +156,15 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
             <h2 className="px-3 pb-1 pt-3 text-xs font-medium uppercase tracking-wider text-muted-foreground sm:px-4">
               {section.label}
             </h2>
-            <div className="flex flex-col gap-0.5">
-              {section.conversations.map((conversation) => {
-                const { title, contextLabel, streamType } = labelsFor(conversation)
+            <div className="flex flex-col gap-1">
+              {section.posts.map((post) => {
+                const { title, contextLabel, streamType } = labelsFor(post.conversation)
                 return (
                   <BoardCard
-                    key={conversation.id}
+                    key={post.conversation.id}
                     workspaceId={workspaceId}
-                    conversation={conversation}
-                    title={title}
+                    post={post}
+                    topic={title}
                     contextLabel={contextLabel}
                     streamType={streamType}
                   />

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -656,13 +656,20 @@ export interface BoardPostMessage {
  */
 export interface BoardPost {
   conversation: ConversationWithStaleness
+  /**
+   * The post's origin message: the conversation's first message, or — for a
+   * thread conversation — the parent message in the parent stream the thread
+   * descends from (it isn't a member of the thread conversation itself).
+   */
   openingMessage: BoardPostMessage | null
   /**
-   * Up to the last three messages of the conversation, excluding the opening,
-   * in chronological order. The collapsed card shows opening + a "N more"
-   * expander + these; expanding fetches the full message list.
+   * Up to the last three reply messages (excluding the origin), chronological.
+   * The collapsed card shows origin + a "N more" expander + these; expanding
+   * fetches the full message list.
    */
   recentMessages: BoardPostMessage[]
+  /** Total replies under the origin (excludes it). Drives the "N more" gap. */
+  totalReplies: number
 }
 
 /**

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -640,6 +640,10 @@ export interface BoardPostMessage {
   authorType: AuthorType
   contentMarkdown: string
   reactions: Record<string, string[]>
+  /** Attachments (images/files) on this message — rendered with gallery + download. */
+  attachments: AttachmentSummary[]
+  /** Completed link previews for this message. */
+  linkPreviews: LinkPreviewSummary[]
   createdAt: string
 }
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -629,6 +629,32 @@ export interface ConversationWithStaleness extends Conversation {
 }
 
 /**
+ * The opening message of a board post — the conversation's first primary
+ * message, rendered as the post body. A lean projection of {@link Message}: the
+ * fields the board feed needs (author, content, reactions, time), not the full
+ * timeline message. `null` on a post whose opening message was deleted.
+ */
+export interface BoardPostMessage {
+  id: string
+  authorId: string
+  authorType: AuthorType
+  contentMarkdown: string
+  reactions: Record<string, string[]>
+  createdAt: string
+}
+
+/**
+ * One board post: a conversation (the grouping) surfaced as a feed post (the
+ * unit). The card renders `openingMessage` as the post body with the
+ * conversation as context, so the board reads as a re-organized timeline of
+ * messages rather than a conversations list.
+ */
+export interface BoardPost {
+  conversation: ConversationWithStaleness
+  openingMessage: BoardPostMessage | null
+}
+
+/**
  * Memo: Semantic pointer to valuable knowledge.
  * Following GAM paper: lightweight abstracts that guide retrieval at runtime.
  */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -645,13 +645,20 @@ export interface BoardPostMessage {
 
 /**
  * One board post: a conversation (the grouping) surfaced as a feed post (the
- * unit). The card renders `openingMessage` as the post body with the
- * conversation as context, so the board reads as a re-organized timeline of
- * messages rather than a conversations list.
+ * unit). The card renders `openingMessage` as the post body and `recentMessages`
+ * as the latest replies beneath it, with a collapsed "N more" gap between — so
+ * the board reads as a re-organized timeline of messages rather than a
+ * conversations list.
  */
 export interface BoardPost {
   conversation: ConversationWithStaleness
   openingMessage: BoardPostMessage | null
+  /**
+   * Up to the last three messages of the conversation, excluding the opening,
+   * in chronological order. The collapsed card shows opening + a "N more"
+   * expander + these; expanding fetches the full message list.
+   */
+  recentMessages: BoardPostMessage[]
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -277,6 +277,8 @@ export type {
   SourceItem,
   Conversation,
   ConversationWithStaleness,
+  BoardPost,
+  BoardPostMessage,
   Memo,
   PendingMemoItem,
   MemoStreamState,


### PR DESCRIPTION
## Problem

The read-only workspace board shipped in #1054 (`apps/frontend/src/pages/board.tsx`, `components/board/board-card.tsx`) rendered each conversation as a boxy bordered card in a flat, ungrouped list: topic line, status badge, and a 7-segment completeness bar. Two problems, per design review with Kris:

1. It read as a *conversations list* — borrowed wholesale from the in-stream `conversation-item` chrome (status badge + completeness bar) — and felt cluttered and unstructured next to the timeline and activity surfaces it sits beside.
2. It under-indexed on what these things actually are. The mental model: **the conversation is the grouping; the unit is a message.** The board should read as a re-organized timeline — a feed of posts — not a list of topic rows. The card had no message content, no author, no reactions; the feed payload (`ConversationWithStaleness`) carried none of that.

## Solution

Reframe the board as a feed of message-led posts. Each card is the conversation's **opening message** rendered as a post (author, body, reactions, reply count), with the conversation reduced to a quiet subject line above the body. The feed is grouped into recency sections. Status badge and completeness bar are gone.

This needs data the slice-1 feed didn't return, so the backend now hydrates each post's opening message.

### How it works

1. **Feed enrichment** — `ConversationService.listByWorkspace` (`apps/backend/src/features/conversations/service.ts`) still reads the access-filtered, keyset-paginated conversation page via `ConversationRepository.findByWorkspaceForViewer` (unchanged — INV-62 access predicate intact), then collects each conversation's `messageIds[0]` and batch-loads those opening messages in one `MessageRepository.findByIds` call (INV-56), which carries each message's aggregated reactions. The opening ids come from rows already passed through the workspace + access predicate, so they're trusted by provenance — the same pattern `getMessages` uses with `conversation.messageIds`.
2. **Wire shape** — new `BoardPost` / `BoardPostMessage` types in `packages/types/src/domain.ts`. `listByWorkspace` returns `{ posts, nextCursor }` (was `{ conversations, nextCursor }`); `nextCursor` is still minted from the last conversation's `(lastActivityAt, id)` to match the repo's `(last_activity_at, id) DESC` order. The handler is an unchanged pass-through.
3. **Post card** — `BoardCard` renders the author avatar + name (via `useActors`), the stream context with a type glyph, terse recency time, the opening-message body (`stripMarkdown` per INV-60, `line-clamp-4`), reaction chips (`useWorkspaceEmoji().toEmoji`, top 4 + overflow), and a reply count. The topic is a muted subject line, omitted when empty.
4. **Recency sections** — `groupByRecency` (`pages/board.tsx`) folds the activity-sorted feed into consecutive Today / Yesterday / Earlier this week / This month / Older buckets using device-local day boundaries (`localStartOfDayMs`, INV-42). Buckets are monotonic over the sorted feed, so grouping never disturbs the newest-first order, and it composes with keyset pagination (later pages extend later buckets).

### Key design decisions

**1. Opening-message reactions, not conversation-aggregated** — the post's reactions are the reactions on its opening message (= "reactions to the post"), not an aggregate across every message in the conversation. It's the cleaner Facebook-post analogy and bounds the read to one batch query. Aggregating across the conversation is a possible follow-up.

**2. Body is stripped, not rendered markdown** — `stripMarkdown` keeps block structure (newlines) but drops syntax, satisfying INV-60 and avoiding pulling the timeline's markdown/mention/attachment render stack into a feed. Trades formatted bold/lists/mentions for a robust, un-busy body. Richer rendering is a follow-up if wanted.

**3. Topic demoted to a subject line** — an absent `topicSummary` now omits the line rather than showing "Untitled conversation". The body carries the content, so there's no empty-headline problem to paper over.

**4. No live cross-stream updates (unchanged)** — `conversation:*` outbox events still deliver only to per-stream rooms, so the board refetches on open (bootstrap-style query: `staleTime: Infinity`, `refetchOnMount`). Routing those events to the workspace room is deliberately out of scope (handover follow-up #3).

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/domain.ts` | Add `BoardPost` / `BoardPostMessage` wire types |
| `packages/types/src/index.ts` | Export the two new types |
| `apps/backend/src/features/conversations/service.ts` | `listByWorkspace` hydrates opening messages + reactions, returns `{ posts, nextCursor }`; `toBoardPostMessage` projector |
| `apps/backend/src/features/conversations/handlers.test.ts` | Update the pass-through mock/assertions to the `posts` shape |
| `apps/frontend/src/api/conversations.ts` | `WorkspaceConversationsPage` → `{ posts, nextCursor }` |
| `apps/frontend/src/components/board/board-card.tsx` | Rewrite as a post card (author/body/reactions/count); drop status + completeness |
| `apps/frontend/src/pages/board.tsx` | Consume `posts`; recency-section grouping; flat-row skeleton; topic as subject line |
| `apps/frontend/src/pages/board.test.tsx` | `posts` shape + actor/emoji store mocks; assertions for topic/body/reactions |

## Out of scope (deliberate)

- **Authored posts** (the actual "slice 2" — posting from the board to seed a conversation, with the extractor skipping a human-declared boundary). Kris's ruling on the target stream — "a stream the user picks" — is recorded for that follow-up. This PR is the view reimagining that precedes it.
- **Live cross-stream updates** (delivery-group change) — see decision 4.
- **Conversation-aggregated reactions** and **rich markdown body** — see decisions 1–2.
- **Lenses / scope filter** — slice 3; the header keeps a single "All" tab.
- No schema change, no migration, no socket surface change.

## Test plan

- [x] Frontend `vitest run src/pages/board.test.tsx` — 10 pass (empty / post body+topic+count / pluralization / reactions / error / load-more / flag-off gate / link / scratchpad topic / DM-peer-as-context)
- [x] Backend `bun test src/features/conversations/` — 38 pass
- [x] Full-monorepo `tsc --noEmit` across all workspaces — clean (via pre-commit)
- [x] ESLint on touched backend + frontend files — clean (via pre-commit)
- [x] OpenAPI `--check` — up to date (the board route is internal/authed, not in the public-API registry)
- [x] Self-review: confirmed `findByIds` carries reactions, the opening-id provenance keeps INV-62/INV-8 intact, `nextCursor` still derives from the conversation order, and no DB/socket surface changed. Clean.
- [ ] No live app run in this session (remote env, no full stack) — verified visually via a faithful static mock of the real components (desktop + phone, light/dark)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUA6NZcwJaXY2WzsfGnKev)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784832804&installation_id=129946197&pr_number=1062&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1062&signature=eea2fc9e8571097e77ef3c9de8be431b5f526f787c82f91e41daf217b500f2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->