### PR TITLE
fix(frontend): viewport-aware composer-height fallback to stop desktop overlap

### DIFF
--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { applyPersistedComposerHeight, persistComposerHeight } from "./composer-height-storage"
+
+const DESKTOP_KEY = "threa:composer-height:desktop"
+const MOBILE_KEY = "threa:composer-height:mobile"
+
+// `isDesktopViewport` checks `matchMedia("(min-width: 640px)")`; everything else
+// the module reads (pointer, mobile) is irrelevant here.
+function stubViewport(isDesktop: boolean) {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: query.includes("min-width") ? isDesktop : false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }))
+}
+
+function rootComposerHeight(): string {
+  return document.documentElement.style.getPropertyValue("--composer-height")
+}
+
+// Node 25 ships a file-backed `localStorage` global that shadows jsdom's and
+// throws on mutation without `--localstorage-file`. Back the module's storage
+// with a plain Map so the test exercises real read/write behaviour.
+function stubStorage() {
+  const store = new Map<string, string>()
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size
+    },
+  })
+}
+
+beforeEach(() => {
+  stubStorage()
+  document.documentElement.style.removeProperty("--composer-height")
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("applyPersistedComposerHeight", () => {
+  it("falls back to the taller desktop default on desktop when nothing is persisted", () => {
+    stubViewport(true)
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("144px")
+  })
+
+  it("falls back to the collapsed mobile default on mobile when nothing is persisted", () => {
+    stubViewport(false)
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("80px")
+  })
+
+  it("does not let a mobile-measured height seed the desktop fallback", () => {
+    // Persist while on a narrow viewport, then boot on desktop. The desktop key
+    // is untouched, so the desktop default wins instead of the mobile height.
+    stubViewport(false)
+    persistComposerHeight(82)
+    stubViewport(true)
+    applyPersistedComposerHeight()
+    expect(localStorage.getItem(MOBILE_KEY)).toBe("82")
+    expect(localStorage.getItem(DESKTOP_KEY)).toBeNull()
+    expect(rootComposerHeight()).toBe("144px")
+  })
+
+  it("raises a too-small persisted desktop value to the desktop floor", () => {
+    stubViewport(true)
+    localStorage.setItem(DESKTOP_KEY, "60")
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("120px")
+  })
+
+  it("uses a genuine desktop measurement unchanged (not floored up)", () => {
+    stubViewport(true)
+    localStorage.setItem(DESKTOP_KEY, "168")
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("168px")
+  })
+
+  it("ignores out-of-bounds persisted values and uses the default", () => {
+    stubViewport(true)
+    localStorage.setItem(DESKTOP_KEY, "9999")
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("144px")
+  })
+})
+
+describe("persistComposerHeight", () => {
+  it("writes the measured height to the active viewport's key", () => {
+    stubViewport(true)
+    persistComposerHeight(150)
+    expect(localStorage.getItem(DESKTOP_KEY)).toBe("150")
+    expect(localStorage.getItem(MOBILE_KEY)).toBeNull()
+  })
+
+  it("round-trips a desktop measurement back onto :root", () => {
+    stubViewport(true)
+    persistComposerHeight(152)
+    document.documentElement.style.removeProperty("--composer-height")
+    applyPersistedComposerHeight()
+    expect(rootComposerHeight()).toBe("152px")
+  })
+
+  it("drops measurements outside the sanity window", () => {
+    stubViewport(true)
+    persistComposerHeight(12)
+    persistComposerHeight(999)
+    expect(localStorage.getItem(DESKTOP_KEY)).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/composer-height-storage.test.ts
+++ b/apps/frontend/src/lib/composer-height-storage.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile"
 import { applyPersistedComposerHeight, persistComposerHeight } from "./composer-height-storage"
 
 const DESKTOP_KEY = "threa:composer-height:desktop"
 const MOBILE_KEY = "threa:composer-height:mobile"
 
-// `isDesktopViewport` checks `matchMedia("(min-width: 640px)")`; everything else
-// the module reads (pointer, mobile) is irrelevant here.
+// Match the exact query `isDesktopViewport` issues. A loose `includes("min-width")`
+// match would let a regressed breakpoint value (or query shape) still flip
+// desktop detection and pass — this fails instead (INV-23). Built from the
+// shared constant so a deliberate breakpoint change doesn't false-fail.
+const DESKTOP_MEDIA_QUERY = `(min-width: ${MOBILE_BREAKPOINT}px)`
+
 function stubViewport(isDesktop: boolean) {
   vi.stubGlobal("matchMedia", (query: string) => ({
-    matches: query.includes("min-width") ? isDesktop : false,
+    matches: query === DESKTOP_MEDIA_QUERY ? isDesktop : false,
     media: query,
     onchange: null,
     addListener: () => {},

--- a/apps/frontend/src/lib/composer-height-storage.ts
+++ b/apps/frontend/src/lib/composer-height-storage.ts
@@ -1,3 +1,5 @@
+import { MOBILE_BREAKPOINT } from "@/hooks/use-mobile"
+
 /**
  * Persists the last-measured composer height and applies it as a global
  * fallback CSS variable on `:root` before the editor zone mounts.
@@ -19,26 +21,56 @@
  * composer's layout effect later corrects any residual drift pre-paint (and
  * notifies the timeline to re-anchor in the same frame), so there is no
  * visible jump.
+ *
+ * The persisted value and boot fallback are keyed by viewport class. The
+ * desktop composer carries an always-on bottom action bar and larger `sm:`
+ * shell padding the collapsed mobile composer doesn't, so its empty height
+ * (~140px) is far taller than mobile's (~80px). A single shared key let a
+ * height measured on one viewport seed the other's boot fallback — a mobile
+ * height applied on desktop reserves too little, so the taller desktop
+ * composer overlaps the last message and the scroll engine (which offsets by
+ * the same variable) can't bring it into view until live measurement catches
+ * up, and never if that measurement stalls.
  */
 
-const STORAGE_KEY = "threa:composer-height"
 const CSS_VAR = "--composer-height"
 
-// Sensible default when nothing has been persisted yet (e.g. brand-new
-// install). Matches the composer's empty-state height on standard density.
-const DEFAULT_HEIGHT_PX = 80
+const STORAGE_KEY_DESKTOP = "threa:composer-height:desktop"
+const STORAGE_KEY_MOBILE = "threa:composer-height:mobile"
+
+// Boot fallback when nothing is persisted yet for this viewport (e.g. a
+// brand-new install). Mobile matches the collapsed empty-state composer;
+// desktop must clear the editor + always-on action bar + `sm:` shell padding so
+// the timeline reserves enough space before the composer mounts and measures.
+const DEFAULT_HEIGHT_MOBILE_PX = 80
+const DEFAULT_HEIGHT_DESKTOP_PX = 144
+
+// Floor for the desktop boot value. A persisted desktop value below this is too
+// small to be a real desktop composer — a stale one-line disabled-banner
+// measurement, or a value left over from before per-viewport keying — and would
+// under-reserve, so it's raised to the floor. Kept below the empty desktop
+// composer height so a genuine measurement is never floored *up* (which would
+// over-reserve and reintroduce the reload jump this module exists to avoid).
+const MIN_HEIGHT_DESKTOP_PX = 120
 
 // Bounds that filter out clearly-bogus values from `localStorage` (corrupt
 // data, future viewport changes that no longer reflect the current chrome).
-// Inside this window the persisted value is "close enough" that the
-// post-mount correction is sub-pixel from the user's perspective.
 const MIN_HEIGHT_PX = 40
 const MAX_HEIGHT_PX = 400
 
-function readPersisted(): number | null {
+function isDesktopViewport(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false
+  return window.matchMedia(`(min-width: ${MOBILE_BREAKPOINT}px)`).matches
+}
+
+function storageKey(isDesktop: boolean): string {
+  return isDesktop ? STORAGE_KEY_DESKTOP : STORAGE_KEY_MOBILE
+}
+
+function readPersisted(key: string): number | null {
   if (typeof localStorage === "undefined") return null
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
+    const raw = localStorage.getItem(key)
     if (!raw) return null
     const parsed = Number.parseInt(raw, 10)
     if (!Number.isFinite(parsed)) return null
@@ -50,18 +82,23 @@ function readPersisted(): number | null {
 }
 
 /**
- * Reads the persisted composer height (if any) and applies it as the global
- * `--composer-height` fallback on `:root`. Called once at app boot from
- * `main.tsx`. Safe to call before React mounts.
+ * Reads the persisted composer height for the current viewport (if any) and
+ * applies it as the global `--composer-height` fallback on `:root`. Called once
+ * at app boot from `main.tsx`. Safe to call before React mounts.
  */
 export function applyPersistedComposerHeight(): void {
   if (typeof document === "undefined") return
-  const persisted = readPersisted() ?? DEFAULT_HEIGHT_PX
-  document.documentElement.style.setProperty(CSS_VAR, `${persisted}px`)
+  const isDesktop = isDesktopViewport()
+  const persisted = readPersisted(storageKey(isDesktop))
+  const applied = isDesktop
+    ? Math.max(persisted ?? DEFAULT_HEIGHT_DESKTOP_PX, MIN_HEIGHT_DESKTOP_PX)
+    : (persisted ?? DEFAULT_HEIGHT_MOBILE_PX)
+  document.documentElement.style.setProperty(CSS_VAR, `${applied}px`)
 }
 
 /**
- * Persists a freshly-measured composer height for the next page load.
+ * Persists a freshly-measured composer height for the next page load, keyed by
+ * the current viewport so mobile and desktop never seed each other's fallback.
  * No-op when the value is outside the sanity window so corrupt measurements
  * (e.g. during a transient layout glitch) don't poison subsequent boots.
  */
@@ -70,7 +107,7 @@ export function persistComposerHeight(heightPx: number): void {
   const rounded = Math.round(heightPx)
   if (rounded < MIN_HEIGHT_PX || rounded > MAX_HEIGHT_PX) return
   try {
-    localStorage.setItem(STORAGE_KEY, String(rounded))
+    localStorage.setItem(storageKey(isDesktopViewport()), String(rounded))
   } catch {
     // Storage quota / private-mode failures shouldn't crash the render path.
   }


### PR DESCRIPTION
## Problem

On desktop, the message composer intermittently overlapped the bottom of the last message and the content could not be scrolled into view.

The timeline reserves bottom space for the floating composer through the CSS variable `--composer-height`. Two things set it:

- **Live value** — `useComposerHeightPublish` (`apps/frontend/src/hooks/use-composer-height-publish.ts`) measures the composer with a `ResizeObserver` and writes the height onto the nearest `[data-editor-zone]`.
- **Boot fallback** — `applyPersistedComposerHeight()` in `apps/frontend/src/lib/composer-height-storage.ts` writes a value to `:root` before React mounts (so the timeline's footer spacer doesn't grow from `0px` mid-paint and jump the list).

That boot fallback was a flat `DEFAULT_HEIGHT_PX = 80`, commented as "the composer's empty-state height" — but that's the *collapsed mobile* composer. The desktop composer is ~140px: editor + the always-on `ComposerActionBar` + the larger `sm:` shell padding (`sm:pt-6 sm:pb-4`). Whenever the fallback was in play on desktop it reserved ~80px for a ~140px composer, leaving ~60px of the last message behind the composer — unreachable, because the scroll engine (`use-timeline-scroll.ts`) offsets by the same variable.

Two ways the fallback wins on desktop:

1. **Measurement stalls** — `useComposerHeightPublish`'s `write()` retries a zero measurement once on `requestAnimationFrame`; if it's still `0`, it gives up and the zone never gets its own value, so descendants inherit the `:root` fallback.
2. **Shared persistence key** — the single `threa:composer-height` localStorage key was written from any viewport. A height measured on mobile / a narrow window (or the one-line disabled-stream banner, which is a legitimately short composer) persisted ~80, then seeded *desktop's* `:root` on the next load.

Either way, desktop showed the mobile-sized fallback. This matches the user's diagnosis: "stuck in the default mode … on desktop we need a taller default."

## Solution

Make the fallback viewport-aware in `composer-height-storage.ts`. Live `ResizeObserver` measurement still overrides everything once the composer mounts — this only changes the pre-measure / measurement-stalls fallback.

### How it works

- **Viewport-aware default** — `isDesktopViewport()` checks `matchMedia("(min-width: <MOBILE_BREAKPOINT>px)")` (reusing `MOBILE_BREAKPOINT = 640` from `use-mobile`). Mobile keeps `DEFAULT_HEIGHT_MOBILE_PX = 80`; desktop falls back to `DEFAULT_HEIGHT_DESKTOP_PX = 144` (≈ the empty desktop composer).
- **Per-viewport persistence** — separate keys `threa:composer-height:mobile` and `threa:composer-height:desktop`. `persistComposerHeight` writes to the active viewport's key; `applyPersistedComposerHeight` reads it. A measurement on one viewport can no longer seed the other's boot fallback.
- **Desktop floor** — `applyPersistedComposerHeight` applies `Math.max(persisted, MIN_HEIGHT_DESKTOP_PX = 120)` on desktop, so a stale/too-small persisted desktop value (e.g. a leftover one-line disabled-banner measurement) can't under-reserve.

### Key design decisions

**1. Desktop floor `120` < default `144` < empty composer `~142`.** The floor is deliberately *below* the empty desktop composer height. A genuine desktop measurement (≥ ~142) is therefore never floored *up* — flooring up would over-reserve and reintroduce the reload jump this module exists to prevent. The floor only catches values that are clearly too small to be a real desktop composer.

**2. Per-viewport keys instead of just a taller default.** A taller default alone doesn't fix the recurring case: a poisoned ~80 persisted value bypasses the default entirely (`persisted ?? default`). Splitting the key by viewport is what actually stops mobile↔desktop cross-contamination — the most likely reason this recurred on desktop for a user who switches between the two. The old `threa:composer-height` key is abandoned; existing users fall to the (now correct) per-viewport default once and self-heal on first measurement.

**3. `144` is an approximation, by design.** Live measurement corrects the variable pre-paint in the composer's layout effect, so a couple of pixels of drift in the fallback is invisible in the normal case. The value's only job is to not *under*-reserve when measurement is unavailable; erring ~2px tall yields a hairline gap at worst instead of a 60px overlap.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/composer-height-storage.ts` | Viewport-aware default (mobile 80 / desktop 144), per-viewport storage keys, desktop floor (120); `isDesktopViewport()` via `matchMedia` + `MOBILE_BREAKPOINT` |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/composer-height-storage.test.ts` | Unit tests: desktop vs mobile default, cross-viewport isolation, desktop floor, genuine measurement passthrough, sanity bounds, persist→`:root` round-trip |

## Out of scope (deliberate)

- **The `write()` give-up-after-one-rAF retry** in `use-composer-height-publish.ts` is left as-is. The `ResizeObserver` is its safety net, and the viewport-aware fallback makes a stalled measurement harmless (it now reserves the right space). Hardening the retry is a separate, optional follow-up.
- No change to the live measurement path, the timeline spacer, or the scroll engine.

## Test plan

- [x] `apps/frontend` — `composer-height-storage.test.ts` (9) + `use-composer-height-publish.test.tsx` (7) — 16 pass
- [x] Full monorepo lint + `tsc --noEmit` across all workspaces — clean (ran in the pre-commit hook)
- [ ] No browser repro of the live overlap — it requires measurement to actually stall, which isn't deterministically reproducible. Verified via the unit tests and the CSS-derived height math (shell `sm:` padding 40 + card ~102 ≈ 142) instead.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784837586&installation_id=129946197&pr_number=1065&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1065&signature=e08ed55a8583f3da40a486f667eeed9d522cbf01b7596f6424a781f28043c30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->