### PR TITLE
fix(streams): minimal description_set timeline event (drop boxed card)

### DIFF
--- a/apps/frontend/src/components/timeline/description-set-event.tsx
+++ b/apps/frontend/src/components/timeline/description-set-event.tsx
@@ -95,7 +95,7 @@ function DescriptionBody({ markdown }: { markdown: string }) {
       {collapsed && (
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-muted/20"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-b from-transparent to-background"
         />
       )}
       {canToggle && (
@@ -139,8 +139,8 @@ export function DescriptionSetEvent({ event, workspaceId }: DescriptionSetEventP
 
   return (
     <div className="py-2 px-3 sm:px-6">
-      <p className="mb-1.5 text-center text-sm text-muted-foreground">{actor} set the description</p>
-      <div className="mx-auto max-w-2xl rounded-md border bg-muted/20 px-3 py-2">
+      <p className="text-center text-sm text-muted-foreground">{actor} set the description</p>
+      <div className="mx-auto mt-1.5 max-w-2xl border-l-2 border-border pl-3.5">
         <MarkdownBlockProvider messageId={event.id}>
           <DescriptionBody markdown={markdown} />
         </MarkdownBlockProvider>


### PR DESCRIPTION
## Problem

The `description_set` timeline row (shipped in #1049) rendered the description body inside a full-width `rounded-md border bg-muted/20` card. Against the surrounding timeline it read as a clunky input-like "square" rather than a system notification — out of step with the app's other system rows (`MembershipEvent`, `MemoCapturedEvent`), which are centered, muted, and chrome-free. Kris's feedback: "I'd expected a much more minimal, sleek formatted something instead of inside of a square."

## Solution

Drop the card. The attribution line stays centered and muted (matching the sibling system events); the body now hangs off a subtle `border-l-2 border-border` rule with `pl-3.5` — a lightened take on the app's existing blockquote vocabulary — instead of a bordered, filled box. The collapse fade gradient, which previously faded to the box fill (`to-muted/20`), now fades to `to-background` so a clamped long description dissolves into the page.

No behavior change: the actor mention chip + click-to-open-profile, the `MarkdownContent` rich-text rendering, and the measure-then-clamp Show more/less collapse are all untouched. The cleared-state row ("<actor> cleared the description") is unchanged.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/description-set-event.tsx` | Replace the bordered/muted-fill body card with a `border-l-2` left rule; fade the collapse gradient to `to-background` instead of `to-muted/20` |

## Test plan

- [x] `bunx vitest run src/components/timeline/description-set-event.test.tsx` — 4 pass (behavioral assertions unaffected: attribution, markdown body, cleared state, profile-click)
- [x] Full monorepo typecheck + all-app lint + migrations + OpenAPI `--check` (pre-commit hook) — clean
- [x] Visual check via a token-faithful HTML mock rendered in-browser (warm light theme: `--background 40 20% 98%`, `--border 35 15% 88%`, user mention chip `hsl(200 70% 50%)`) — short and collapsed-long descriptions both read as a clean system note; old boxed card kept for side-by-side comparison

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784838306&installation_id=129946197&pr_number=1066&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1066&signature=f7f3ecec95236210e738ff2f9a2523dd0a3ce9f9efa3f0f808d0b723790af740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->