### PR TITLE
feat(frontend): move unread-section status into the header row

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sections.test.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.test.tsx
@@ -50,3 +50,23 @@ describe("SectionHeader open link", () => {
     expect(screen.queryByRole("link", { name: /open/i })).not.toBeInTheDocument()
   })
 })
+
+describe("SectionHeader accessory", () => {
+  it("renders the headerAccessory and keeps its control out of the toggle path", async () => {
+    const onClear = vi.fn()
+    const { onToggle } = renderHeader({
+      headerAccessory: (
+        <button type="button" onClick={onClear}>
+          Clear read
+        </button>
+      ),
+    })
+
+    await userEvent.click(screen.getByRole("button", { name: "Clear read" }))
+
+    // The accessory's own click fires, but the header must not collapse as a side
+    // effect — the right zone stops propagation.
+    expect(onClear).toHaveBeenCalledTimes(1)
+    expect(onToggle).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/layout/sidebar/sections.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sections.tsx
@@ -47,6 +47,14 @@ interface SectionHeaderProps {
   addMenuActions?: SidebarActionItem[] | null
   /** Smaller header style used for nested subsections (e.g. "With activity" / "Rest"). */
   nested?: boolean
+  /**
+   * Trailing status/control rendered on the right of the header — used by the
+   * Unread section for its "All caught up" status and "Clear read" control.
+   * Lives in the header (not a footer row) so the status costs no extra row and
+   * swapping it never reflows the list below (INV-21). Sits left of the
+   * collapsed-state aggregate badge.
+   */
+  headerAccessory?: ReactNode
 }
 
 /** Section header with chevron state indicator. Consistent across all sidebar sections. */
@@ -64,6 +72,7 @@ export function SectionHeader({
   addTooltip,
   addMenuActions,
   nested = false,
+  headerAccessory,
 }: SectionHeaderProps) {
   const isInteractive = !!onToggle && !!state
   const isCollapsed = state === "collapsed"
@@ -128,6 +137,7 @@ export function SectionHeader({
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
     >
+      {headerAccessory}
       {titleHref && (
         <Link
           to={titleHref}
@@ -300,7 +310,8 @@ interface StreamSectionProps {
   getMentionCount: (streamId: string) => number
   state?: CollapseState
   onToggle?: () => void
-  action?: ReactNode
+  /** Trailing header status/control (e.g. Unread's "All caught up" / "Clear read"). */
+  headerAccessory?: ReactNode
   /** Show compact view (title only, no preview) */
   compact?: boolean
   /** Show preview on hover when compact (only works with compact=true) */
@@ -343,7 +354,7 @@ export function StreamSection({
   getMentionCount,
   state = "open",
   onToggle,
-  action,
+  headerAccessory,
   compact = false,
   showPreviewOnHover = false,
   scrollContainerRef,
@@ -388,16 +399,15 @@ export function StreamSection({
         onAdd={onAdd}
         addTooltip={addTooltip}
         addMenuActions={addMenuActions}
+        headerAccessory={headerAccessory}
       />
 
       {!isCollapsed && items.length > 0 && <div className="mt-1 flex flex-col gap-0.5">{items.map(renderRow)}</div>}
-
-      {!isCollapsed && action}
     </div>
   )
 }
 
-interface TieredStreamSectionProps extends Omit<StreamSectionProps, "action" | "state" | "onToggle"> {
+interface TieredStreamSectionProps extends Omit<StreamSectionProps, "state" | "onToggle"> {
   /** Parent section key (drives the "more" persistence key). */
   sectionKey: string
   /** Current parent open/collapsed state. */
@@ -411,7 +421,6 @@ interface TieredStreamSectionProps extends Omit<StreamSectionProps, "action" | "
   moreState: CollapseState
   /** Toggle the inline "more" expander. */
   onToggleMore: () => void
-  action?: ReactNode
 }
 
 /** Soft cap on visible items when the more expander is collapsed. */
@@ -444,7 +453,6 @@ export function TieredStreamSection({
   onToggle,
   moreState,
   onToggleMore,
-  action,
   compact = false,
   showPreviewOnHover = false,
   scrollContainerRef,
@@ -511,8 +519,6 @@ export function TieredStreamSection({
       {!isCollapsed && hasMore && (
         <MoreDivider isOpen={isMoreOpen} hiddenCount={quietHidden.length} onToggle={onToggleMore} />
       )}
-
-      {!isCollapsed && action}
     </div>
   )
 }

--- a/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx
@@ -13,6 +13,7 @@ import { useSidebar, type CollapseState } from "@/contexts"
 import { Button } from "@/components/ui/button"
 import { LabelChip } from "@/components/labels/label-chip"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { cn } from "@/lib/utils"
 import { streamLabel } from "@/lib/streams"
 import type { CachedLabel } from "@/hooks"
 import { StreamSection, TieredStreamSection } from "./sections"
@@ -45,11 +46,22 @@ interface AddWiring {
 
 /** Unread section header: a gold thread dot + the label, matching the section
  *  header's uppercase styling. Gold (not a colored emoji) keeps the palette
- *  (DESIGN.md §0). Top-level per INV-18. */
-function UnreadSectionTitle({ label }: { label: string }) {
+ *  (DESIGN.md §0). Top-level per INV-18. When `quiet` (the tray is empty) both
+ *  the dot and label drop to a muted tone so the caught-up header recedes
+ *  instead of advertising itself — the gold dot is reserved for "there's unread
+ *  here". */
+function UnreadSectionTitle({ label, quiet = false }: { label: string; quiet?: boolean }) {
   return (
-    <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-primary" aria-hidden />
+    <span
+      className={cn(
+        "flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide",
+        quiet ? "text-muted-foreground/50" : "text-muted-foreground"
+      )}
+    >
+      <span
+        className={cn("h-1.5 w-1.5 shrink-0 rounded-full", quiet ? "bg-muted-foreground/40" : "bg-primary")}
+        aria-hidden
+      />
       {label}
     </span>
   )
@@ -237,11 +249,13 @@ export function SidebarStreamList({
           const label = section.spec.kind === "label" ? labelsById.get(section.spec.labelId) : undefined
           if (section.spec.kind === "label" && !label) return null
           const isUnread = section.spec.kind === "unread"
+          const isEmptyUnread = isUnread && items.length === 0
           // Unread's header is a gold dot + label (a colored emoji would break the
-          // gold-on-paper palette); label sections use their tinted chip.
+          // gold-on-paper palette); label sections use their tinted chip. An empty
+          // tray mutes the dot + label so the caught-up header recedes.
           let titleContent: ReactNode = undefined
           if (label) titleContent = <LabelChip label={label} />
-          else if (isUnread) titleContent = <UnreadSectionTitle label={presentation.label} />
+          else if (isUnread) titleContent = <UnreadSectionTitle label={presentation.label} quiet={isEmptyUnread} />
           // Label sections get an "open" affordance to their landing page.
           const titleHref = label ? `/w/${workspaceId}/labels/${label.id}` : undefined
           const headerLabel = label ? label.name : presentation.label
@@ -249,27 +263,29 @@ export function SidebarStreamList({
           const state = getSectionState(section.id, presentation.defaultCollapse)
           const onToggle = () => toggleSectionState(section.id, presentation.defaultCollapse)
           const add = addWiringFor(section.spec)
-          // The Unread section keeps a single, same-footprint footer so it never
-          // reflows: an empty tray shows a quiet "All caught up", otherwise the
-          // "Clear read" control (disabled when there's nothing read to flush).
-          // Never both at once.
-          let unreadFooter: ReactNode = undefined
-          if (isUnread) {
-            unreadFooter =
-              items.length === 0 ? (
-                <p className="mt-0.5 flex min-h-[2.25rem] items-center justify-center px-3 text-center text-[11px] italic text-muted-foreground/50">
-                  All caught up
-                </p>
-              ) : (
-                <button
-                  type="button"
-                  onClick={onClearReadUnread}
-                  disabled={!hasReadResidue}
-                  className="mt-0.5 flex min-h-[2.25rem] w-full items-center justify-center px-3 text-[11px] uppercase tracking-wide text-muted-foreground/70 transition-colors enabled:hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  Clear read
-                </button>
-              )
+          // The Unread section's status rides in its header (right side), not a
+          // footer row — so an empty tray costs only the header, never a band of
+          // dead space. An empty tray shows a quiet "All caught up" and drops its
+          // chevron (state/onToggle below): with no rows there's nothing to
+          // collapse, so the header reads as pure status, not a toggle. A tray
+          // holding already-read members shows the "Clear read" control; a tray
+          // of only fresh unreads shows nothing (no disabled control to read as
+          // noise). Read residue is hidden while collapsed — rows out of view,
+          // the aggregate badge is the signal there. Swapping the accessory never
+          // reflows the list; the header is always present (INV-21).
+          let unreadAccessory: ReactNode = undefined
+          if (isEmptyUnread) {
+            unreadAccessory = <span className="text-[11px] italic text-muted-foreground/50">All caught up</span>
+          } else if (isUnread && hasReadResidue && state !== "collapsed") {
+            unreadAccessory = (
+              <button
+                type="button"
+                onClick={onClearReadUnread}
+                className="rounded px-1 text-[11px] uppercase tracking-wide text-muted-foreground/60 transition-colors hover:text-foreground"
+              >
+                Clear read
+              </button>
+            )
           }
 
           const sectionEl = presentation.tiered ? (
@@ -311,9 +327,9 @@ export function SidebarStreamList({
               activeStreamId={activeStreamId}
               getUnreadCount={getUnreadCount}
               getMentionCount={getMentionCount}
-              state={state}
-              onToggle={onToggle}
-              action={unreadFooter}
+              state={isEmptyUnread ? undefined : state}
+              onToggle={isEmptyUnread ? undefined : onToggle}
+              headerAccessory={unreadAccessory}
               compact={presentation.compact}
               showPreviewOnHover={presentation.showPreviewOnHover}
               scrollContainerRef={scrollContainerRef}


### PR DESCRIPTION
## Problem

The sidebar Unread section wasted a band of vertical space in an already-narrow sidebar:

- **Empty tray:** `SidebarStreamList` rendered "All caught up" as a centered footer block with `min-h-[2.25rem]` (a full ~36px row of mostly nothing) below the header.
- **Non-empty tray:** it always rendered a full-width "Clear read" button row — and when there was nothing read to flush (the common fresh-unread state) that button was disabled and greyed (`disabled:opacity-40`), so it read as "more than an entire row of just nothing with an unusable Clear read" (Kris's words).

The footer was a deliberate same-footprint design (never reflow on catch-up), but in use it just felt like dead space.

## Solution

Move the section's status off the footer and into the header's right-side zone, so an empty tray costs only the header row itself.

### How it works

A new `headerAccessory?: ReactNode` slot on `SectionHeader` renders inside the existing `rightContent` wrapper — the same zone as the "+" / open-link controls, which already calls `e.stopPropagation()` on click/keydown, so an interactive accessory (the Clear-read button) fires without toggling the section's collapse. `StreamSection` forwards the slot; the unread branch in `SidebarStreamList` fills it:

- **Empty (`isEmptyUnread`):** right-aligned, muted, italic "All caught up". The `UnreadSectionTitle` gains a `quiet` prop that drops the dot to `bg-muted-foreground/40` and the label to `text-muted-foreground/50`, so the whole header recedes; and the section is passed `state`/`onToggle` as `undefined`, routing it through `SectionHeader`'s existing static (non-interactive) variant — no chevron, no click-to-collapse (there are no rows to hide).
- **Already-read members present (`hasReadResidue`, not collapsed):** a small "Clear read" text control in the header.
- **Only fresh unreads:** nothing on the right — the disabled control is gone entirely.

The old footer mechanism (`action` prop) is removed from both `StreamSection` and `TieredStreamSection`.

### Key design decisions

**1. Header slot, not a footer — INV-21.** The header is always present, so swapping the accessory (status ↔ control ↔ nothing) never changes the header's vertical footprint and never reflows the rows below. This is strictly better than the old "same-footprint footer", which still occupied a row when empty.

**2. Reuse the stop-propagation zone instead of a bespoke handler.** Rendering the accessory in `rightContent` means the Clear-read button inherits the wrapper's propagation guard — clicking it can't collapse the section. No new event plumbing.

**3. Drop the chevron when empty.** An empty tray has nothing to collapse, so the toggle is noise. Passing `undefined` state/onToggle reuses the static-header path rather than adding an "empty" flag. The empty header also ignores any stale persisted "collapsed" state and always shows "All caught up" — there's nothing to hide, and there'd otherwise be no chevron to re-expand.

**4. Gold dot reserved for activity.** The gold `bg-primary` dot now signals "there's unread here"; when caught up, the muted dot + label match the "All caught up" tone so the row reads as one quiet status line.

**5. Clear-read hidden while collapsed.** With rows out of view, the aggregate count badge (collapsed-only) is the right signal; the residue control would act invisibly, so it's suppressed.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/sections.tsx` | Add `headerAccessory` slot to `SectionHeader` (rendered in `rightContent`) and forward it from `StreamSection`; remove the now-dead `action` prop from `StreamSection` and `TieredStreamSection` (INV-38). |
| `apps/frontend/src/components/layout/sidebar/sidebar-stream-list.tsx` | Replace the unread footer (`unreadFooter`/`action`) with the header `unreadAccessory` (empty → "All caught up", residue → "Clear read", else nothing); add `quiet` to `UnreadSectionTitle` to mute the dot+label when empty; pass `undefined` state/onToggle when empty to drop the chevron. |
| `apps/frontend/src/components/layout/sidebar/sections.test.tsx` | Add a test: the header accessory's control fires its own click without toggling the section. |

## Out of scope (deliberate)

- The sticky-unread tray data (`use-sticky-unread`, `hasReadResidue`, `clearRead`) is unchanged — this is purely the presentation of its status.
- No change to other sections' headers; the accessory slot is opt-in and only the unread section passes it.

## Test plan

- [x] `bun run test` (frontend) `sections.test.tsx` + `use-sticky-unread.test.tsx` — 10 pass
- [x] `tsc --noEmit` (frontend) — clean
- [x] `eslint` on the three changed files — clean
- [x] Visual check of all four states (empty / read-residue / fresh-unread, plus before) via a token-faithful static render
- [ ] Full repo suite / browser E2E — not run locally; left to CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784841023&installation_id=129946197&pr_number=1068&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1068&signature=91c6c8a8c55896c51991099bb7292b1bb515bc2fd27a9fbc7a3b1279ab13e001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->