### PR TITLE
docs: board realtime/sync model — ride the sync engine, not React-Query

### DIFF
--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -200,14 +200,115 @@ Q3, it mostly resolves:
   as query params. Per-stream reuses the existing `listByStream`.
 - **Frontend:** the card (`conversation-item`) and list (`conversation-list`)
   components already exist; the board is a new page that reuses them in a
-  cross-stream layout. Bootstrap activity-feed style (`use-activity.ts`:
-  `staleTime: Infinity`, `refetchOnMount`), stay live via the existing
-  `conversation:created/updated` socket events already handled in
-  `use-conversations.ts` (INV-53).
+  cross-stream layout. **Liveness and optimism ride the sync engine (IDB +
+  `SocketEventGate`), NOT React-Query — see "Realtime / sync model" below.**
+  Slice 1's React-Query `use-conversations` board hook is a deliberate stopgap
+  (it refetch-on-opens and feels junky), scheduled for migration onto the rails.
 - **INV-61 untouched:** the board is a separate projection; the contiguous
   timeline keeps its `sequence`/`broadcastSequence` order. Resurfacing is
   forbidden in the timeline and free in the board precisely because they're
   different projections.
+
+## Realtime / sync model — the board must ride the sync engine, not React-Query (Kris's "it feels junky")
+
+Dogfooding turned up the real risk to this whole idea: **it doesn't feel
+instant.** Kris typed a direct reply in a stream, opened the board, and his
+activity wasn't there — a refresh fixed it. For a surface meant to be a
+co-equal _way to interact_ (not just a read-only digest), seconds-late is
+disqualifying. The cause is two stacked problems, and the fix is to stop
+treating the conversation as an async digest and put it on the same rails as the
+timeline.
+
+**Root cause: conversations live on a different data-plane than messages.**
+
+- **Messages/timeline are instant** because they ride the sync engine:
+  IDB tables (`events`, `pendingMessages`, `streams` in
+  `apps/frontend/src/db/database.ts`) ← applied in `syncId` order by
+  `SocketEventGate` / `SyncEngine` (`apps/frontend/src/sync/`), read reactively
+  off IDB, and **optimistically** written on send as `pendingMessages` +
+  `events` with `_status: "pending"`, swapped when the authoritative
+  `message:created` socket event lands.
+- **Conversations are NOT in IDB at all.** `use-conversations.ts` is pure
+  React-Query (`useQuery`/`useInfiniteQuery`), refetch-on-open. So the board
+  **cannot** be live or optimistic no matter how fast the backend is. This — not
+  the AI — is the dominant cause of the junk.
+
+**Second cause: the bump is async even when it needn't be.** Message creation is
+fully synchronous (`messaging/event-service.ts`), but conversation assignment
+and the `last_activity_at` bump the board orders on happen _after_ the LLM:
+`message:created` → outbox → boundary-extraction worker → `extractor.extract()`
+(≈0.5–3s) → Phase-3 txn calls `bumpActivityForIds`. Yet the bump itself is just
+`UPDATE conversations SET last_activity_at = NOW()` — zero AI. It's slow only
+because it's bundled into the worker. (Proof a synchronous assignment path is
+viable: **scratchpads already assign in-transaction, no LLM**,
+`boundary-extraction-service.ts:218`.)
+
+### The reframe: explicit/implicit → **determinable / inferred** → sync / async
+
+Kris's instinct ("explicit conversations sync, implicit async") is right; the
+sharper axis is **"can we know the conversation from structure, without the
+AI?"** Most of what _feels_ interactive already can:
+
+| You send…                            | Conversation knowable w/o AI?     | Treatment                                  |
+| ------------------------------------ | --------------------------------- | ------------------------------------------ |
+| An **authored post**                 | Yes — you declared it             | **sync**: create + bump in the message txn |
+| A **reply inside a thread**          | Yes — the thread's conversation   | **sync**: bump in txn                      |
+| A **quote-reply** to a message       | Yes — that message's conversation | **sync**: bump in txn                      |
+| A **scratchpad** message             | Yes — the single conversation     | **sync** (already is)                      |
+| **Free-form** new line, busy channel | No — AI must cluster              | **async**: worker — fine, it's ambient     |
+
+Today threads and quote-replies _compute_ the structural signal
+(`parentMessageConversations`, `quotedConversations`) but feed it to the LLM as a
+mere candidate instead of taking it as a shortcut
+(`boundary-extraction-service.ts:100-122`). Kris's exact junky case — a direct
+reply — is structurally determinable, so it never needed to be async.
+
+### The plan
+
+**Backend:**
+
+- **Synchronous deterministic bump (C).** For the determinable rows above, write
+  the assignment + `last_activity_at = NOW()` in the **same transaction** as the
+  message (`messaging/event-service.ts`), and emit `conversation:bumped`
+  synchronously (event-source + projection together, INV-7). The LLM worker still
+  runs after to refine/split/merge — but the field the board sorts on is already
+  correct. Sync-bumping the structural parent is correct even if a later pass
+  splits the topic: the parent thread genuinely did just get activity.
+- **Deliver `conversation:*` to the workspace/user room (B).** Today
+  `delivery-groups.ts` routes them to per-stream rooms only, so the workspace
+  board never receives them. Add the workspace/user delivery group.
+
+**Frontend — put conversations on the sync rails (the actual fix):**
+
+1. Add a **`conversations` IDB store** (Dexie version bump in `db/database.ts`,
+   alongside `events`/`streams`).
+2. Board bootstrap **seeds IDB** (a one-shot fetch to fill the store is fine;
+   what's wrong is treating that query as the live store), subscribe-then-fetch
+   per INV-53.
+3. Apply `conversation:*` through **`SocketEventGate`** into the IDB store, in
+   `syncId` order, exactly like `message:created`.
+4. Board **reads conversations reactively from IDB** (the project's IDB-observer
+   pattern), so a card re-sorts the instant its row changes.
+5. **Optimism = a local pending IDB write**, not a query mutation: on a
+   determinable send, write the bumped `lastActivityAt` to the IDB conversation
+   row locally and reconcile when the authoritative `conversation:bumped`
+   arrives — the same `_status: "pending"` swap messages already use.
+
+**Ambient AI clustering stays async (E)** — nobody drives those cards in real
+time, so worker latency there is invisible.
+
+Net: determinable send → sync backend bump → authoritative event over the socket
+→ applied to IDB by the gate → board re-sorts live; and your own action shows
+instantly via the optimistic IDB write before the round-trip returns. The same
+mechanism that makes the timeline feel instant, now under the board.
+
+### Open decision
+
+Keep the **conversation as the single board card and make its bump synchronous**
+(C — recommended; one primitive, no dual render path, INV-29/43-clean), _or_
+**render interactive cards directly from thread/message data and treat the
+conversation row as pure async enrichment** (more faithful to "the thread is the
+synchronous backbone," but two card-fueling paths). Lean: C.
 
 ## Phasing
 


### PR DESCRIPTION
Design-doc only. No code changes. Extends `docs/board-view-design.md` (the board design of record; slice 1 shipped in #1054) with a **Realtime / sync model** section, prompted by dogfooding the merged board.

## Problem

The board feels junky to actually interact with: typing a direct reply in a stream, then opening the board, the activity isn't there until a manual refresh. For a surface meant to be a co-equal *way to interact* (not a read-only digest), seconds-late is disqualifying. The design doc didn't account for this — worse, its Architecture sketch actively prescribed the approach that causes it (`staleTime: Infinity`, `refetchOnMount`, "live via … socket events already handled in `use-conversations.ts`").

Two stacked causes, both verified against the code:

1. **Conversations live on a different data-plane than messages.** Messages/timeline are instant because they ride the sync engine — IDB tables (`events`, `pendingMessages`, `streams` in `apps/frontend/src/db/database.ts`) applied in `syncId` order by `SocketEventGate`/`SyncEngine` (`apps/frontend/src/sync/`), read reactively, optimistic on send (`_status: "pending"`, swapped on `message:created`). Conversations are **not in IDB at all** — `use-conversations.ts` is pure React-Query, refetch-on-open. So the board can't be live or optimistic regardless of backend speed.
2. **The `last_activity_at` bump is async even when it needn't be.** It runs in the boundary-extraction worker after the LLM (`message:created` → outbox → worker → `extractor.extract()` → Phase-3 `bumpActivityForIds`), yet the bump itself is just `UPDATE conversations SET last_activity_at = NOW()` — zero AI. Proof a synchronous assignment path is viable: scratchpads already assign in-transaction with no LLM (`boundary-extraction-service.ts:218`).

## Solution

Stop treating the conversation as an async digest; put it on the same rails as the timeline. The section reframes Kris's "explicit sync, implicit async" instinct as the sharper axis **determinable / inferred → sync / async** (a thread reply, quote-reply, authored post, and scratchpad message all have a structurally-knowable conversation; only free-form chatter needs the AI), and lays out the plan:

- **Backend:** synchronous in-transaction bump + `conversation:bumped` for determinable messages (`messaging/event-service.ts`); deliver `conversation:*` to the workspace/user room (today `delivery-groups.ts` routes them to per-stream rooms only, so the board never receives them).
- **Frontend:** add a `conversations` IDB store, apply `conversation:*` through `SocketEventGate`, read reactively from IDB, and make optimism a local pending IDB write — **not** a React-Query mutation. Ambient AI clustering stays async.

It also **corrects** the Architecture-sketch bullet that prescribed the React-Query path and flags slice 1's `use-conversations` board hook as a deliberate stopgap scheduled for migration (so the next agent treats the rewrite as intended, not a regression). One open decision is recorded: single conversation primitive + sync bump (lean) vs. rendering interactive cards from thread/message data.

## Files changed

| File | Change |
| ---- | ------ |
| `docs/board-view-design.md` | New "Realtime / sync model" section (+105/-4); corrected the Architecture-sketch liveness bullet |

## Test plan

- [x] Code claims in the new section verified against the source this session: conversations absent from IDB / `use-conversations` is React-Query (grep); IDB stores `events`/`pendingMessages`/`streams` and `SocketEventGate`/`SyncEngine` (`db/database.ts`, `sync/`); `conversation:*` → per-stream rooms (`delivery-groups.ts`); scratchpad in-txn assignment (`boundary-extraction-service.ts:218`); structural candidates fed to the LLM (`:107-153`); bump is `UPDATE … last_activity_at = NOW()` (`repository.ts:558`).
- [ ] No automated tests — docs-only change; nothing executable to run.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpkNvS7g1hzUPGVB7y4Xa6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784842252&installation_id=129946197&pr_number=1069&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1069&signature=cd0c60bec22a7290a72ee191ea09476cdab8b9ea29039dfcba210282db99fcac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->