### PR TITLE
fix(ci): dedupe deploy notifications, and list every commit since the last deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -6,6 +6,15 @@ on:
     types: [completed]
     branches: [main]
 
+# Collapse overlapping runs for the same commit into one. Close-together merges
+# can fire the workflow_run trigger more than once for a single head_sha; without
+# this each fires a full deploy (and a duplicate notify). Keyed on head_sha so
+# distinct commits still deploy independently; cancel-in-progress is safe because
+# the superseded run is byte-identical (same ref).
+concurrency:
+  group: deploy-cloudflare-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   deploy-frontend:
     name: Deploy Frontend

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
+# actions:read lists prior deploy runs; contents:read walks the commit range
+# between the last deploy and this one. Both are reads — no write scope needed.
 permissions:
   actions: read
   contents: read
@@ -58,7 +60,10 @@ jobs:
                   workflow_id: "deploy-cloudflare.yml",
                   branch: "main",
                   status: "success",
-                  per_page: 30,
+                  // Max page — the previous distinct-commit deploy is normally run N-1, but a
+                  // burst of same-sha re-runs could push it back; 100 is a comfortable margin
+                  // before the graceful head-commit-only fallback kicks in.
+                  per_page: 100,
                 })
                 const prev = data.workflow_runs.find((r) => r.id < run.id && r.head_sha !== headSha)
                 if (prev) {

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -45,11 +45,15 @@ jobs:
           MESSAGE=$(printf '%s **%s %s** on `main`\n\n`%s` — %s\nby @%s · [View run](%s)' \
             "$ICON" "$WORKFLOW_NAME" "$STATUS" "$SHORT_SHA" "$FIRST_LINE" "$ACTOR" "$RUN_URL")
 
-          # clientMessageId dedupes on accidental workflow_run redelivery (race-safe via backend ON CONFLICT).
+          # clientMessageId keys on the message's identity (workflow + commit + conclusion),
+          # not the run id, so a commit deployed twice — re-runs, GitHub workflow_run
+          # redelivery, or overlapping runs from close-together merges — collapses onto one
+          # message via the backend's ON CONFLICT (stream_id, client_message_id) guard. The
+          # content is fully derived from those three, so same key ⇒ identical message.
           # metadata lets future tooling query "every CI failure for commit X" etc. (AND-containment).
           PAYLOAD=$(jq -n \
             --arg content "$MESSAGE" \
-            --arg clientMessageId "ghactions:${WORKFLOW_RUN_ID}:${CONCLUSION}" \
+            --arg clientMessageId "ghactions:${WORKFLOW_NAME}:${HEAD_SHA}:${CONCLUSION}" \
             --arg workflow "$WORKFLOW_NAME" \
             --arg run_id "$WORKFLOW_RUN_ID" \
             --arg conclusion "$CONCLUSION" \

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -6,74 +6,124 @@ on:
     types: [completed]
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
       - name: Send Threa notification
+        uses: actions/github-script@v7
         env:
           THREA_BOT_API_KEY: ${{ secrets.THREA_BOT_API_KEY }}
-          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          COMMIT_MSG: ${{ github.event.workflow_run.head_commit.message }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
-        run: |
-          # Exit early for conclusions we don't care about
-          case "$WORKFLOW_NAME/$CONCLUSION" in
-            "Deploy Cloudflare/success"|"Deploy Cloudflare/failure"|"Deploy Cloudflare/timed_out") ;;
-            "CI/failure"|"CI/timed_out") ;;
-            *)
-              echo "No notification needed ($WORKFLOW_NAME / $CONCLUSION)"
-              exit 0
-              ;;
-          esac
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            const workflow = run.name
+            const conclusion = run.conclusion
+            const headSha = run.head_sha
+            const runUrl = run.html_url
+            const actor = run.triggering_actor?.login ?? run.actor?.login ?? "unknown"
 
-          SHORT_SHA="${HEAD_SHA:0:7}"
-          FIRST_LINE="${COMMIT_MSG%%$'\n'*}"
+            // Deploy: every conclusion worth surfacing. CI: only failures (success is
+            // implied by the deploy that follows it).
+            const announce =
+              (workflow === "Deploy Cloudflare" && ["success", "failure", "timed_out"].includes(conclusion)) ||
+              (workflow === "CI" && ["failure", "timed_out"].includes(conclusion))
+            if (!announce) {
+              core.info(`No notification needed (${workflow} / ${conclusion})`)
+              return
+            }
 
-          case "$CONCLUSION" in
-            success)   ICON="✅"; STATUS="succeeded" ;;
-            failure)   ICON="❌"; STATUS="failed" ;;
-            timed_out) ICON="⏱"; STATUS="timed out" ;;
-            *)         ICON="⚠️"; STATUS="$CONCLUSION" ;;
-          esac
+            const icon = { success: "✅", failure: "❌", timed_out: "⏱" }[conclusion] ?? "⚠️"
+            const status = { success: "succeeded", failure: "failed", timed_out: "timed out" }[conclusion] ?? conclusion
+            const short = (s) => s.slice(0, 7)
+            const firstLine = (msg) => (msg ?? "").split("\n", 1)[0]
 
-          # Build message with printf to avoid multiline YAML indentation issues
-          MESSAGE=$(printf '%s **%s %s** on `main`\n\n`%s` — %s\nby @%s · [View run](%s)' \
-            "$ICON" "$WORKFLOW_NAME" "$STATUS" "$SHORT_SHA" "$FIRST_LINE" "$ACTOR" "$RUN_URL")
+            // A deploy announces every commit since the last successful deploy, not just its
+            // tip. Close-together merges collapse into one deploy — the intermediate deploys
+            // are cancelled by concurrency (deploy-cloudflare.yml), so without this their
+            // commits would never be announced. The compare API walks prev-tip → this-tip;
+            // any failure falls back to the single head commit.
+            const MAX_LISTED = 20
+            let commits = [{ sha: headSha, message: run.head_commit?.message }]
+            let omitted = 0
+            if (workflow === "Deploy Cloudflare") {
+              try {
+                const { data } = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: "deploy-cloudflare.yml",
+                  branch: "main",
+                  status: "success",
+                  per_page: 30,
+                })
+                const prev = data.workflow_runs.find((r) => r.id < run.id && r.head_sha !== headSha)
+                if (prev) {
+                  const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    basehead: `${prev.head_sha}...${headSha}`,
+                  })
+                  const list = (cmp.data.commits ?? []).map((c) => ({ sha: c.sha, message: c.commit.message }))
+                  if (list.length > 0) {
+                    omitted = Math.max(0, list.length - MAX_LISTED)
+                    commits = list.slice(-MAX_LISTED)
+                  }
+                }
+              } catch (err) {
+                core.warning(`commit range lookup failed, using head commit only: ${err.message}`)
+              }
+            }
 
-          # clientMessageId keys on the message's identity (workflow + commit + conclusion),
-          # not the run id, so a commit deployed twice — re-runs, GitHub workflow_run
-          # redelivery, or overlapping runs from close-together merges — collapses onto one
-          # message via the backend's ON CONFLICT (stream_id, client_message_id) guard. The
-          # content is fully derived from those three, so same key ⇒ identical message.
-          # metadata lets future tooling query "every CI failure for commit X" etc. (AND-containment).
-          PAYLOAD=$(jq -n \
-            --arg content "$MESSAGE" \
-            --arg clientMessageId "ghactions:${WORKFLOW_NAME}:${HEAD_SHA}:${CONCLUSION}" \
-            --arg workflow "$WORKFLOW_NAME" \
-            --arg run_id "$WORKFLOW_RUN_ID" \
-            --arg conclusion "$CONCLUSION" \
-            --arg sha "$HEAD_SHA" \
-            --arg actor "$ACTOR" \
-            '{
-              content: $content,
-              clientMessageId: $clientMessageId,
+            let content
+            if (commits.length === 1 && omitted === 0) {
+              content =
+                `${icon} **${workflow} ${status}** on \`main\`\n\n` +
+                `\`${short(commits[0].sha)}\` — ${firstLine(commits[0].message)}\n` +
+                `by @${actor} · [View run](${runUrl})`
+            } else {
+              const total = commits.length + omitted
+              const lines = commits.map((c) => `- \`${short(c.sha)}\` — ${firstLine(c.message)}`)
+              if (omitted > 0) lines.unshift(`- …and ${omitted} earlier`)
+              content =
+                `${icon} **${workflow} ${status}** on \`main\` — ${total} commits\n\n` +
+                `${lines.join("\n")}\n` +
+                `by @${actor} · [View run](${runUrl})`
+            }
+
+            // clientMessageId keys on the message's identity (workflow + deploy tip + conclusion),
+            // not the run id, so a tip deployed twice — re-runs, workflow_run redelivery, overlapping
+            // close-together merges — collapses onto one message via the backend's
+            // ON CONFLICT (stream_id, client_message_id) guard. metadata lets future tooling query
+            // "every CI failure for commit X" etc. (AND-containment).
+            const payload = {
+              content,
+              clientMessageId: `ghactions:${workflow}:${headSha}:${conclusion}`,
               metadata: {
                 source: "github-actions",
-                "github.workflow.name": $workflow,
-                "github.workflow.run_id": $run_id,
-                "github.workflow.conclusion": $conclusion,
-                "github.commit.sha": $sha,
-                "github.actor": $actor
-              }
-            }')
+                "github.workflow.name": workflow,
+                "github.workflow.run_id": String(run.id),
+                "github.workflow.conclusion": conclusion,
+                "github.commit.sha": headSha,
+                "github.commit.count": String(commits.length + omitted),
+                "github.actor": actor,
+              },
+            }
 
-          curl -f --show-error -X POST \
-            "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/streams/stream_01KP36GA56WZREGN6VTKREWRM9/messages" \
-            -H "Authorization: Bearer $THREA_BOT_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD"
+            const res = await fetch(
+              "https://app.threa.io/api/v1/workspaces/ws_01KJDZZV5H57W3H2SJ11PA554B/streams/stream_01KP36GA56WZREGN6VTKREWRM9/messages",
+              {
+                method: "POST",
+                headers: {
+                  Authorization: `Bearer ${process.env.THREA_BOT_API_KEY}`,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+              }
+            )
+            if (!res.ok) {
+              throw new Error(`Threa API ${res.status}: ${await res.text()}`)
+            }

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -74,8 +74,12 @@ jobs:
                   })
                   const list = (cmp.data.commits ?? []).map((c) => ({ sha: c.sha, message: c.commit.message }))
                   if (list.length > 0) {
-                    omitted = Math.max(0, list.length - MAX_LISTED)
+                    // compareCommitsWithBasehead caps `commits` at 250; total_commits is the true
+                    // range size, so the "N commits" header and the omitted count stay honest even
+                    // when the listed bullets are capped.
+                    const total = cmp.data.total_commits ?? list.length
                     commits = list.slice(-MAX_LISTED)
+                    omitted = Math.max(0, total - commits.length)
                   }
                 }
               } catch (err) {


### PR DESCRIPTION
## Problem

The GitHub Actions deploy-notification stream (`stream_01KP36GA56WZREGN6VTKREWRM9`) had two related issues for merges that land close together:

1. **Duplicate messages.** Two byte-identical "✅ **Deploy Cloudflare succeeded**" messages for the same commit. Concrete case: sequence 628 and 629 are both "succeeded on `c45fe0c` — Surface external-agent attachment… (#1024)", ~3 min apart. Verified via the GitHub API: one CI run for `c45fe0c` (run #4509) produced **two** Deploy Cloudflare runs (#821, #822), both `run_attempt: 1`, both `head_sha c45fe0c`; each fired `notify.yml`. The backend dedupes on `ON CONFLICT (stream_id, client_message_id)` (`apps/backend/src/features/messaging/repository.ts:389`), but `notify.yml` keyed `clientMessageId` on the **run id** while the content depends only on workflow + commit + conclusion — so identical content, distinct keys, both inserted.

2. **Dropped commits.** Once the deploy workflow collapses overlapping runs (see the concurrency change below), the intermediate deploys are *cancelled* — so the commits they would have announced get no notification at all. Only the surviving deploy's tip commit was reported.

## Solution

- **Dedup by content identity.** Key `clientMessageId` on `workflow + head_sha + conclusion` instead of the run id, so two runs of the same tip collapse via the existing backend `ON CONFLICT`. Robust to re-runs and `workflow_run` redelivery, not just close-together merges.
- **Collapse the redundant deploy.** A `head_sha`-scoped top-level `concurrency` group on `deploy-cloudflare.yml` stops the duplicate deploy at the source.
- **Announce the whole range.** A deploy notification now lists every commit from the previous successful deploy's tip to this one — so commits whose own deploy was cancelled still get announced by the deploy that superseded them.

### How it works

1. `notify.yml` is rewritten in `actions/github-script`. For a Deploy Cloudflare run it finds the previous successful deploy run for `main` (`actions.listWorkflowRuns`, first run with `id < this.id` and a different `head_sha`), then walks `prevTip...thisTip` with `repos.compareCommitsWithBasehead` to get the commit list.
2. Rendering: a single commit keeps the compact one-line format; multiple commits render a markdown bullet list under a `— N commits` header, capped at `MAX_LISTED = 20` with a `…and N earlier` line. CI-failure notifications stay single-commit. Any lookup error falls back to the head commit (`core.warning` + single-commit message).
3. `clientMessageId = "ghactions:${workflow}:${headSha}:${conclusion}"` (~76 chars, within the public API's `clientMessageId: z.string().max(128)`, `schemas.ts:300`). A second post with the same key hits `ON CONFLICT … DO NOTHING` and returns the existing row.
4. `deploy-cloudflare.yml` gains `concurrency: { group: deploy-cloudflare-${{ github.event.workflow_run.head_sha }}, cancel-in-progress: true }`.
5. `notify.yml` gets a `permissions: { actions: read, contents: read }` block for the two API reads.

### Key design decisions

**1. Dedup on content identity, not run id.** The message text is run-agnostic (only a "View run" link differs). Collapsing two runs of the same commit+conclusion is lossless. A *failure* then a re-run *success* differ in `CONCLUSION`, so both still post.

**2. Baseline = previous successful deploy.** "Commits since last" means since the last commit that actually shipped. Using the previous successful *deploy* run's tip (not the previous CI run, not a fixed `HEAD~n`) is the honest definition of "what this deploy adds". Skipping same-`head_sha` previous runs avoids an empty range from a re-run/duplicate.

**3. github-script over bash.** The compare/list-runs calls are unworkable in `jq`/`curl`; the JS path also gives real error handling (`res.ok` check, warning-and-fallback) the old `curl -f` lacked.

**4. Keep both the dedup key and the deploy concurrency.** The concurrency guard reduces double *deploys*; the content-identity key independently absorbs `workflow_run` redelivery and manual re-runs. They are complementary, not redundant.

## Modified files

| File | Change |
| ---- | ------ |
| `.github/workflows/notify.yml` | Rewritten in `actions/github-script`: content-identity `clientMessageId`; deploy messages enumerate commits since the last successful deploy (compare API), capped at 20; `permissions` block; `res.ok` error handling. |
| `.github/workflows/deploy-cloudflare.yml` | Top-level `concurrency` group keyed on `github.event.workflow_run.head_sha`, `cancel-in-progress: true`. |

## Out of scope (deliberate)

- No backend change — the `ON CONFLICT (stream_id, client_message_id)` dedup already exists and is correct.
- Not backfilling/removing already-posted duplicates (e.g. sequence 629); this only affects future notifications.
- Compare API truncates at 250 commits; a deploy spanning more than that lists the most recent 20 with an "…and N earlier" count rather than paginating. A 250+ commit gap between deploys is not a real case here.

## Test plan

- [x] `notify.yml` parses as YAML; embedded script passes `node --check` (async-wrapped, as `github-script` runs it).
- [x] Formatting harness with mocked `github.rest` / `fetch` over 5 scenarios — single deploy, 3-commit collapse, 25-commit cap (`…and 5 earlier`), deploy failure, CI failure — all render correctly and the `clientMessageId` is stable per (workflow, tip, conclusion).
- [x] Dedup-key and metadata-value lengths checked against `z.string().max(128)` / metadata-schema caps.
- [ ] Not exercised end-to-end: workflow_run workflows only run on `main` after merge, so there's no local harness for the live API calls; the backend dedup path they rely on is unchanged and covered by existing tests.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_