### PR TITLE
fix: three unread/activity correctness bugs (stuck watermark, sidebar color, born-read activity)

### DIFF
--- a/apps/backend/src/features/activity/outbox-handler.test.ts
+++ b/apps/backend/src/features/activity/outbox-handler.test.ts
@@ -302,6 +302,53 @@ describe("ActivityFeedHandler", () => {
     })
   })
 
+  it("does not publish activity:created for born-read recipient rows", async () => {
+    // A born-read row (read_at set because the recipient had already read the
+    // message) must not push a live event — the client would re-add it to the
+    // badge it just cleared. The unread recipient still gets their event.
+    const bornRead = {
+      id: "act_bornread",
+      workspaceId: "ws_test",
+      userId: "usr_caughtup",
+      activityType: "message",
+      streamId: "stream_test",
+      messageId: "msg_test",
+      actorId: "usr_author",
+      actorType: "user",
+      context: {},
+      readAt: new Date("2025-01-01T00:00:00Z"),
+      createdAt: new Date("2025-01-01T00:00:00Z"),
+      isSelf: false,
+      emoji: null,
+    }
+    const unread = { ...bornRead, id: "act_unread", userId: "usr_behind", readAt: null }
+
+    const event = makeMessageCreatedEvent(1n)
+    spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([event] as any)
+    const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+    spyOn(ActivityRepository, "countUnreadForPairs").mockResolvedValue(
+      new Map([["usr_behind:stream_test", { mentionCount: 0, totalCount: 1 }]])
+    )
+    spyOn(dbModule, "withTransaction").mockImplementation(async (_pool, callback) => callback({} as any))
+
+    const { handler, activityService } = createHandler()
+    ;(activityService.processMessageNotifications as any).mockResolvedValue([bornRead, unread])
+
+    handler.handle()
+    await new Promise((r) => setTimeout(r, 300))
+
+    expect(insertSpy).toHaveBeenCalledWith(
+      {},
+      "activity:created",
+      expect.objectContaining({ targetUserId: "usr_behind" })
+    )
+    expect(insertSpy).not.toHaveBeenCalledWith(
+      {},
+      "activity:created",
+      expect.objectContaining({ targetUserId: "usr_caughtup" })
+    )
+  })
+
   it("should return no_events when batch is empty", async () => {
     spyOn(OutboxRepository, "fetchAfterId").mockResolvedValue([])
 

--- a/apps/backend/src/features/activity/outbox-handler.ts
+++ b/apps/backend/src/features/activity/outbox-handler.ts
@@ -316,13 +316,21 @@ export class ActivityFeedHandler implements OutboxHandler {
    * under absolute semantics.
    */
   private async publishActivityCreated(activities: Activity[]): Promise<void> {
-    if (activities.length === 0) return
+    // A born-read recipient row (read_at set at insert because the recipient had
+    // already read the source message) must not push a live activity:created: the
+    // client holds every non-self event as unread (the payload carries no read_at
+    // to check), so emitting one would re-add the row to the badge the instant the
+    // read cleared it. Self rows are also born read but stay emittable — the client
+    // skips them via isSelf, and the emission still refreshes the Activity feed.
+    // Born-read recipient rows surface as read on the feed's next fetch instead.
+    const emittable = activities.filter((activity) => activity.isSelf || activity.readAt === null)
+    if (emittable.length === 0) return
 
     await withTransaction(this.db, async (client) => {
       // Activities from one source event share a workspace, but group
       // defensively rather than assume it.
       const byWorkspace = new Map<string, Activity[]>()
-      for (const activity of activities) {
+      for (const activity of emittable) {
         const group = byWorkspace.get(activity.workspaceId) ?? []
         group.push(activity)
         byWorkspace.set(activity.workspaceId, group)

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -66,6 +66,13 @@ export interface InsertActivityBatchParams {
    * read so they show in the feed without inflating unread counts.
    */
   isSelf?: boolean
+  /**
+   * Recipients whose read watermark already covers this message. Their rows are
+   * inserted already read (read_at = NOW()) so an activity for a message the user
+   * has already read never resurfaces as unread — the same born-read treatment as
+   * self rows, applied per user rather than to the whole batch.
+   */
+  readUserIds?: ReadonlySet<string>
   /** Required when activityType === "reaction"; NULL for all other types. */
   emoji?: string | null
 }
@@ -164,8 +171,11 @@ export const ActivityRepository = {
     const ids = params.userIds.map(() => activityId())
     const contextJson = JSON.stringify(params.context ?? {})
     const isSelf = params.isSelf ?? false
-    const readAt = isSelf ? new Date() : null
     const emoji = params.emoji ?? null
+    // read_at is per-row: self rows are always born read; non-self rows are born
+    // read only for recipients whose watermark already covers this message.
+    const nowIso = new Date().toISOString()
+    const readAt = params.userIds.map((userId) => (isSelf || params.readUserIds?.has(userId) ? nowIso : null))
 
     const result = await db.query<ActivityRow>(sql`
       INSERT INTO user_activity (
@@ -174,7 +184,7 @@ export const ActivityRepository = {
       )
       SELECT
         id, workspace_id, user_id, activity_type, stream_id, message_id,
-        actor_id, actor_type, context, ${isSelf}, ${readAt}, ${emoji}
+        actor_id, actor_type, context, ${isSelf}, read_at, ${emoji}
       FROM UNNEST(
         ${ids}::text[],
         ${params.userIds.map(() => params.workspaceId)}::text[],
@@ -184,8 +194,9 @@ export const ActivityRepository = {
         ${params.userIds.map(() => params.messageId)}::text[],
         ${params.userIds.map(() => params.actorId)}::text[],
         ${params.userIds.map(() => params.actorType)}::text[],
-        ${params.userIds.map(() => contextJson)}::jsonb[]
-      ) AS t(id, workspace_id, user_id, activity_type, stream_id, message_id, actor_id, actor_type, context)
+        ${params.userIds.map(() => contextJson)}::jsonb[],
+        ${readAt}::timestamptz[]
+      ) AS t(id, workspace_id, user_id, activity_type, stream_id, message_id, actor_id, actor_type, context, read_at)
       ${conflictClauseFor(params.activityType)}
       RETURNING ${sql.raw(USER_ACTIVITY_COLUMNS)}
     `)

--- a/apps/backend/src/features/activity/service.test.ts
+++ b/apps/backend/src/features/activity/service.test.ts
@@ -3,7 +3,12 @@ import { ActivityTypes, AuthorTypes, CompanionModes, NotificationLevels, StreamT
 import { ActivityService } from "./service"
 import { ActivityRepository } from "./repository"
 import { UserRepository } from "../workspaces"
-import { StreamRepository, StreamMemberRepository, resolveNotificationLevelsForStream } from "../streams"
+import {
+  StreamRepository,
+  StreamMemberRepository,
+  StreamEventRepository,
+  resolveNotificationLevelsForStream,
+} from "../streams"
 import { PersonaRepository } from "../agents"
 import { BotRepository } from "../public-api"
 import { MessageRepository } from "../messaging"
@@ -63,6 +68,10 @@ function fakeActivity(context: Record<string, unknown>): Activity[] {
 
 function setupService() {
   spyOn(dbModule, "withClient").mockImplementation(async (_pool: any, fn: any) => fn({} as any))
+  // Born-read lookups default to "no resolvable message event / nobody caught
+  // up", so recipients insert unread as before; born-read tests override these.
+  spyOn(StreamEventRepository, "findByMessageId").mockResolvedValue(null)
+  spyOn(StreamMemberRepository, "membersReadThrough").mockResolvedValue(new Set())
 
   return new ActivityService({ pool: {} as any })
 }
@@ -287,6 +296,59 @@ describe("ActivityService author name resolution", () => {
     })
 
     expect(capturedContext?.authorName).toBeNull()
+  })
+})
+
+describe("ActivityService born-read for already-read recipients", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("passes only caught-up recipients to insertBatch as readUserIds", async () => {
+    const service = setupService()
+    const stream = fakeStream()
+    const BEHIND_USER_ID = "usr_behind"
+
+    spyOn(StreamRepository, "findById").mockResolvedValue(stream)
+    spyOn(StreamMemberRepository, "list").mockResolvedValue([
+      { memberId: TARGET_USER_ID },
+      { memberId: BEHIND_USER_ID },
+    ] as any)
+    const resolveModule = await import("../streams")
+    spyOn(resolveModule, "resolveNotificationLevelsForStream").mockResolvedValue([
+      { memberId: TARGET_USER_ID, effectiveLevel: NotificationLevels.ACTIVITY },
+      { memberId: BEHIND_USER_ID, effectiveLevel: NotificationLevels.ACTIVITY },
+    ] as any)
+    spyOn(UserRepository, "findById").mockResolvedValue({ id: USER_ID, name: "Alice" } as any)
+
+    // The message resolves to sequence 50; TARGET has read through it, BEHIND hasn't.
+    ;(StreamEventRepository.findByMessageId as any).mockResolvedValue({ id: "evt_msg", sequence: 50n })
+    ;(StreamMemberRepository.membersReadThrough as any).mockResolvedValue(new Set([TARGET_USER_ID]))
+
+    let captured: { userIds?: string[]; readUserIds?: ReadonlySet<string> } = {}
+    spyOn(ActivityRepository, "insertBatch").mockImplementation(async (_db: any, params: any) => {
+      captured = { userIds: params.userIds, readUserIds: params.readUserIds }
+      return []
+    })
+
+    await service.processMessageNotifications({
+      workspaceId: WORKSPACE_ID,
+      streamId: STREAM_ID,
+      messageId: MESSAGE_ID,
+      actorId: USER_ID,
+      actorType: AuthorTypes.USER,
+      contentMarkdown: "hello",
+      excludeUserIds: new Set(),
+    })
+
+    expect(captured.userIds).toEqual([TARGET_USER_ID, BEHIND_USER_ID])
+    expect(captured.readUserIds && [...captured.readUserIds]).toEqual([TARGET_USER_ID])
+    expect(StreamMemberRepository.membersReadThrough).toHaveBeenCalledWith(
+      {},
+      STREAM_ID,
+      [TARGET_USER_ID, BEHIND_USER_ID],
+      50n
+    )
   })
 })
 

--- a/apps/backend/src/features/activity/service.ts
+++ b/apps/backend/src/features/activity/service.ts
@@ -1,7 +1,13 @@
 import type { Pool, PoolClient } from "pg"
 import { ActivityRepository, type Activity } from "./repository"
 import { UserRepository } from "../workspaces"
-import { StreamRepository, StreamMemberRepository, resolveNotificationLevelsForStream, type Stream } from "../streams"
+import {
+  StreamRepository,
+  StreamMemberRepository,
+  StreamEventRepository,
+  resolveNotificationLevelsForStream,
+  type Stream,
+} from "../streams"
 import { PersonaRepository } from "../agents"
 import { collectMentionSlugs } from "@threa/prosemirror"
 import { BotRepository } from "../public-api"
@@ -98,15 +104,19 @@ export class ActivityService {
       const contentPreview = contentMarkdown.slice(0, 200)
       const authorName = await this.resolveAuthorName(client, workspaceId, actorId, actorType)
 
+      const mentionedUserIds = [...userIds]
+      const readUserIds = await this.resolveAlreadyReadRecipients(client, streamId, messageId, mentionedUserIds)
+
       return ActivityRepository.insertBatch(client, {
         workspaceId,
-        userIds: [...userIds],
+        userIds: mentionedUserIds,
         activityType: ActivityTypes.MENTION,
         streamId,
         messageId,
         actorId,
         actorType,
         context: { contentPreview, authorName, ...streamContext },
+        readUserIds,
       })
     })
   }
@@ -240,6 +250,8 @@ export class ActivityService {
         })
         .map((row) => row.memberId)
 
+      const readUserIds = await this.resolveAlreadyReadRecipients(client, streamId, messageId, eligibleUserIds)
+
       return ActivityRepository.insertBatch(client, {
         workspaceId,
         userIds: eligibleUserIds,
@@ -249,8 +261,29 @@ export class ActivityService {
         actorId,
         actorType,
         context: { contentPreview, authorName, ...streamContext },
+        readUserIds,
       })
     })
+  }
+
+  /**
+   * Of `userIds`, which have already read past this message in the stream? Their
+   * activity rows are born read (see {@link ActivityRepository.insertBatch}) so a
+   * notification for a message the recipient has already read never lands as
+   * unread — closing the race where the read-time clear runs before the async
+   * activity row exists. Returns an empty set when the message has no event row
+   * yet (nothing to compare against), leaving every recipient unread.
+   */
+  private async resolveAlreadyReadRecipients(
+    client: PoolClient,
+    streamId: string,
+    messageId: string,
+    userIds: string[]
+  ): Promise<Set<string>> {
+    if (userIds.length === 0) return new Set()
+    const messageEvent = await StreamEventRepository.findByMessageId(client, streamId, messageId)
+    if (!messageEvent) return new Set()
+    return StreamMemberRepository.membersReadThrough(client, streamId, userIds, messageEvent.sequence)
   }
 
   /**

--- a/apps/backend/src/features/streams/member-repository.test.ts
+++ b/apps/backend/src/features/streams/member-repository.test.ts
@@ -18,3 +18,23 @@ describe("StreamMemberRepository.countMembersNotIn", () => {
     expect(await StreamMemberRepository.countMembersNotIn(db, "stream_target", "stream_source")).toBe(0)
   })
 })
+
+describe("StreamMemberRepository.membersReadThrough", () => {
+  test("returns an empty set without querying when memberIds is empty", async () => {
+    const query = mock(() => Promise.resolve({ rows: [], rowCount: 0 }))
+    const db = { query } as unknown as Querier
+    expect(await StreamMemberRepository.membersReadThrough(db, "stream_1", [], 50n)).toEqual(new Set())
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  test("maps the returned rows to a set of member ids", async () => {
+    const db = makeDb([{ member_id: "usr_caught" }, { member_id: "usr_also" }])
+    const result = await StreamMemberRepository.membersReadThrough(
+      db,
+      "stream_1",
+      ["usr_caught", "usr_also", "usr_behind"],
+      50n
+    )
+    expect(result).toEqual(new Set(["usr_caught", "usr_also"]))
+  })
+})

--- a/apps/backend/src/features/streams/member-repository.ts
+++ b/apps/backend/src/features/streams/member-repository.ts
@@ -217,6 +217,32 @@ export const StreamMemberRepository = {
     return result.rows[0] ? mapRowToMember(result.rows[0]) : null
   },
 
+  /**
+   * Of `memberIds`, which have a read watermark at or past `sequence`? Resolves
+   * each member's last_read_event_id to its event sequence and keeps those that
+   * are >= the target. Members with no watermark (or one that no longer resolves
+   * to an event) are treated as behind and omitted. Used to born-read an activity
+   * whose source message the recipient has already read — closing the race where
+   * the read-time activity clear runs before the async activity row is written.
+   */
+  async membersReadThrough(
+    db: Querier,
+    streamId: string,
+    memberIds: string[],
+    sequence: bigint
+  ): Promise<Set<string>> {
+    if (memberIds.length === 0) return new Set()
+    const result = await db.query<{ member_id: string }>(sql`
+      SELECT sm.member_id
+      FROM stream_members sm
+      JOIN stream_events se ON se.id = sm.last_read_event_id
+      WHERE sm.stream_id = ${streamId}
+        AND sm.member_id = ANY(${memberIds})
+        AND se.sequence >= ${sequence.toString()}
+    `)
+    return new Set(result.rows.map((row) => row.member_id))
+  },
+
   async delete(db: Querier, streamId: string, memberId: string): Promise<boolean> {
     const result = await db.query(sql`
       DELETE FROM stream_members

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -1265,11 +1265,13 @@ describe("StreamService.markAsRead", () => {
   let service: StreamService
   const mockMemberUpdate = spyOn(StreamMemberRepository, "update")
   const mockGetMessageOrdinalForEvent = spyOn(StreamEventRepository, "getMessageOrdinalForEvent")
+  const mockFindByStreamAndMember = spyOn(StreamMemberRepository, "findByStreamAndMember")
 
   beforeEach(() => {
     service = new StreamService({} as never)
     mockMemberUpdate.mockReset()
     mockGetMessageOrdinalForEvent.mockReset()
+    mockFindByStreamAndMember.mockReset()
     mockInsertOutbox.mockReset()
     mockInsertOutbox.mockResolvedValue({} as never)
   })
@@ -1291,20 +1293,26 @@ describe("StreamService.markAsRead", () => {
     })
   })
 
-  test("mirrors the unread query's zero convention when the read event is missing", async () => {
-    mockMemberUpdate.mockResolvedValue({ streamId: "stream_1", memberId: "usr_1" } as never)
+  test("ignores a read pointer that doesn't resolve to a real event — no watermark write, no stream:read", async () => {
+    // An optimistic temp_ id (or any id with no stream_events row) would pin the
+    // unread query's COALESCE(sequence, 0) to 0 and report the whole stream — incl.
+    // the user's own messages — as unread. Resolve first; no-op on a miss.
     mockGetMessageOrdinalForEvent.mockResolvedValue(null)
+    mockFindByStreamAndMember.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "usr_1",
+      lastReadEventId: "evt_real",
+    } as never)
 
-    await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_gone")
+    const result = await service.markAsRead("ws_1", "stream_1", "usr_1", "temp_optimistic")
 
-    expect(mockInsertOutbox).toHaveBeenCalledWith(
-      {},
-      "stream:read",
-      expect.objectContaining({ lastReadSequence: "0", lastReadOrdinal: 0 })
-    )
+    expect(mockMemberUpdate).not.toHaveBeenCalled()
+    expect(mockInsertOutbox).not.toHaveBeenCalled()
+    expect(result?.lastReadEventId).toBe("evt_real")
   })
 
   test("emits nothing for a non-member", async () => {
+    mockGetMessageOrdinalForEvent.mockResolvedValue({ sequence: 42n, messageOrdinal: 7 })
     mockMemberUpdate.mockResolvedValue(null)
 
     await service.markAsRead("ws_1", "stream_1", "usr_1", "evt_9")

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1812,20 +1812,31 @@ export class StreamService {
     eventId: string
   ): Promise<StreamMember | null> {
     return withTransaction(this.pool, async (client) => {
+      // The read pointer must reference a real event in THIS stream. A client can
+      // briefly hold an optimistic event id (temp_…) as its frontier right after a
+      // send, before the server echo swaps it for the persisted id. Persisting an
+      // id with no stream_events row pins last_read_seq to 0 (the unread query's
+      // COALESCE(sequence, 0)), so every message — including the author's own —
+      // reports unread until the watermark is overwritten. Resolve first, no-op on
+      // a miss rather than corrupting the pointer.
+      const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
+      if (!position) {
+        logger.warn({ workspaceId, streamId, memberId, eventId }, "Ignored mark-as-read: event not found in stream")
+        return StreamMemberRepository.findByStreamAndMember(client, streamId, memberId)
+      }
+
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
       if (membership) {
         // Absolute read position (sync phase 2c): clients derive unread as
-        // latestOrdinal - lastReadOrdinal, so the event carries where this
-        // read lands in message-ordinal space. A missing event mirrors the
-        // unread query's COALESCE(sequence, 0) convention.
-        const position = await StreamEventRepository.getMessageOrdinalForEvent(client, streamId, eventId)
+        // latestOrdinal - lastReadOrdinal, so the event carries where this read
+        // lands in message-ordinal space.
         await OutboxRepository.insert(client, "stream:read", {
           workspaceId,
           authorId: memberId,
           streamId,
           lastReadEventId: eventId,
-          lastReadSequence: (position?.sequence ?? 0n).toString(),
-          lastReadOrdinal: position?.messageOrdinal ?? 0,
+          lastReadSequence: position.sequence.toString(),
+          lastReadOrdinal: position.messageOrdinal,
         })
       }
       return membership

--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -594,4 +594,63 @@ describe("Unread Counts", () => {
       expect(await StreamEventRepository.countMessagesThrough(pool, testStreamId, events[1].sequence)).toBe(2)
     })
   })
+
+  describe("membersReadThrough", () => {
+    test("includes members at or past the target sequence, excludes behind / unread / dangling watermarks", async () => {
+      const testStreamId = streamId()
+      const testWorkspaceId = workspaceId()
+      const atTarget = userId()
+      const past = userId()
+      const behind = userId()
+      const unread = userId()
+      const dangling = userId()
+
+      await withTransaction(pool, async (client) => {
+        await client.query(
+          `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+          [testStreamId, testWorkspaceId, atTarget]
+        )
+        for (const m of [atTarget, past, behind, unread, dangling]) {
+          await StreamMemberRepository.insert(client, testStreamId, m)
+        }
+      })
+
+      // Three message events; the middle one is the target whose activity we'd born-read.
+      for (const body of ["first", "target", "third"]) {
+        await eventService.createMessage({
+          workspaceId: testWorkspaceId,
+          streamId: testStreamId,
+          authorId: atTarget,
+          authorType: "user",
+          ...testMessageContent(body),
+        })
+      }
+
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      const [firstEvent, targetEvent, thirdEvent] = events
+
+      await withTransaction(pool, async (client) => {
+        await StreamMemberRepository.update(client, testStreamId, atTarget, { lastReadEventId: targetEvent.id })
+        await StreamMemberRepository.update(client, testStreamId, past, { lastReadEventId: thirdEvent.id })
+        await StreamMemberRepository.update(client, testStreamId, behind, { lastReadEventId: firstEvent.id })
+        await StreamMemberRepository.update(client, testStreamId, dangling, { lastReadEventId: "evt_does_not_exist" })
+        // `unread` keeps its null watermark (never read).
+      })
+
+      const result = await StreamMemberRepository.membersReadThrough(
+        pool,
+        testStreamId,
+        [atTarget, past, behind, unread, dangling],
+        targetEvent.sequence
+      )
+
+      // `atTarget` proves the >= boundary — a `>` would wrongly drop a reader sitting
+      // exactly on the message; behind / unread / dangling are all excluded.
+      expect(result).toEqual(new Set([atTarget, past]))
+    })
+
+    test("returns an empty set for empty memberIds", async () => {
+      expect(await StreamMemberRepository.membersReadThrough(pool, streamId(), [], 1n)).toEqual(new Set())
+    })
+  })
 })

--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -169,7 +169,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
         const activityCount = getActivityCount(stream.id)
         const isMuted = mutedStreamIdSet.has(stream.id)
         const urgency = calculateUrgency(streamWithPreview, unreadCount, mentionCount, isMuted, activityCount)
-        const section = categorizeStream(streamWithPreview, unreadCount, urgency)
+        const section = categorizeStream(streamWithPreview, unreadCount, urgency, activityCount)
         const dmPeerUserId = dmPeerByStreamId.get(stream.id) ?? dmPeerByStreamId.get(stream.rootStreamId ?? "")
 
         // DM names are viewer-specific and can be stale/null in the cached stream

--- a/apps/frontend/src/components/layout/sidebar/utils.test.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.test.ts
@@ -65,6 +65,14 @@ describe("calculateUrgency", () => {
     expect(calculateUrgency(streamWith("user"), 0, 0, false, 2)).toBe("activity")
   })
 
+  it("colors activity-only persona streams gold (ai), not generic blue", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.PERSONA), 0, 0, false, 2)).toBe("ai")
+  })
+
+  it("colors activity-only bot streams green (bot), not generic blue", () => {
+    expect(calculateUrgency(streamWith(AuthorTypes.BOT), 0, 0, false, 2)).toBe("bot")
+  })
+
   it("prefers mentions over the activity fallback", () => {
     expect(calculateUrgency(streamWith("user"), 0, 1, false, 2)).toBe("mentions")
   })
@@ -141,19 +149,21 @@ describe("categorizeStream", () => {
   })
 
   it("promotes activity-only streams to 'recent' even when the cached preview is stale", () => {
-    // A notification arrived via the always-joined user room (urgency "activity")
-    // before the per-stream stream:activity bumped the unread count. The sidebar
-    // row glows, so it must not sink into "other" just because its last cached
-    // message is older than 7 days.
+    // A notification arrived via the always-joined user room before the per-stream
+    // stream:activity bumped the unread count (activityCount > 0, unreadCount 0).
+    // The row glows — now in its actor's color ("ai" for a persona, no longer a
+    // literal "activity") — so it must not sink into "other" just because its last
+    // cached message is older than 7 days. Section placement reads activityCount,
+    // not the color.
     const stream = makeStream({
       lastMessagePreview: {
-        authorId: "user_2",
-        authorType: "user",
+        authorId: "persona_1",
+        authorType: AuthorTypes.PERSONA,
         content: "hello",
         createdAt: "2026-03-01T12:00:00Z", // >7 days ago
       },
     })
-    expect(categorizeStream(stream, 0, "activity")).toBe("recent")
+    expect(categorizeStream(stream, 0, "ai", 2)).toBe("recent")
   })
 
   it("puts streams with no preview and no unread in 'other'", () => {

--- a/apps/frontend/src/components/layout/sidebar/utils.ts
+++ b/apps/frontend/src/components/layout/sidebar/utils.ts
@@ -48,19 +48,19 @@ export function calculateUrgency(
 
   if (mentionCount > 0) return "mentions"
 
-  if (unreadCount > 0) {
+  // Unread messages or unread activity both light the row; color either case by
+  // the last author so a persona reads gold, a bot green, a human (or unknown)
+  // blue. activityCount counts on its own because a notification can reach the
+  // always-joined per-user room (activity:created) before the per-stream
+  // stream:activity that drives unreadCount — e.g. before the stream-room join
+  // lands, or while briefly disconnected — so the row never stays quiet for
+  // something the Activity feed is already showing.
+  if (unreadCount > 0 || activityCount > 0) {
     const authorType = stream.lastMessagePreview?.authorType
     if (authorType === AuthorTypes.PERSONA) return "ai"
     if (authorType === AuthorTypes.BOT) return "bot"
     return "activity"
   }
-
-  // A notification reached the always-joined per-user room (activity:created)
-  // but the per-stream stream:activity that drives unreadCount was missed — e.g.
-  // before the stream-room join lands, or while it's briefly disconnected. Light
-  // the stream so the sidebar never stays quiet for something the Activity feed
-  // is already showing.
-  if (activityCount > 0) return "activity"
 
   return "quiet"
 }
@@ -76,19 +76,25 @@ export function isUnreadStream(stream: { urgency: UrgencyLevel }, unreadCount: n
 }
 
 /** Categorize stream into smart section */
-export function categorizeStream(stream: StreamWithPreview, unreadCount: number, urgency: UrgencyLevel): SectionKey {
+export function categorizeStream(
+  stream: StreamWithPreview,
+  unreadCount: number,
+  urgency: UrgencyLevel,
+  activityCount = 0
+): SectionKey {
   if (urgency === "mentions" || (urgency === "ai" && unreadCount > 0)) {
     return "important"
   }
 
   // A stream the user is still catching up on stays in Recent regardless of age
   // or whether a preview has been cached yet — it should never sink into
-  // "Everything else". This covers unread messages and activity-only streams: a
-  // notification can arrive via the always-joined user room (urgency "activity")
-  // before the per-stream stream:activity bumps the unread count. Muted streams
-  // (urgency "quiet") are excluded — muting is an explicit deprioritization
-  // signal, so unread messages in a muted stream should not resurface.
-  if (urgency !== "quiet" && (unreadCount > 0 || urgency === "activity")) {
+  // "Everything else". This covers unread messages and activity-only streams. The
+  // activity signal is read from activityCount, not urgency: an activity-only row
+  // now carries its actor's color (gold/green/blue), so urgency no longer spells
+  // "activity". Muted streams (urgency "quiet") are excluded — muting is an
+  // explicit deprioritization signal, so unread messages in a muted stream should
+  // not resurface.
+  if (urgency !== "quiet" && (unreadCount > 0 || activityCount > 0)) {
     return "recent"
   }
 

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -242,4 +242,36 @@ describe("useUnreadCounts", () => {
     expect(bootstrap?.unreadCounts.stream_1).toBe(2)
     expect(await db.unreadState.get("ws_1")).toMatchObject({ unreadCounts: { stream_1: 2 } })
   })
+
+  it("skips an optimistic temp_ read pointer but still sends a confirmed event id", async () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_new",
+      lastReadAt: new Date().toISOString(),
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    // A temp_ id is an unconfirmed optimistic event with no server stream_events
+    // row; persisting it would pin the watermark to sequence 0 and report the whole
+    // stream — including the user's own messages — as unread. The mutation is skipped.
+    act(() => {
+      result.current.markAsRead("stream_1", "temp_optimistic")
+    })
+    expect(mockMarkAsRead).not.toHaveBeenCalled()
+
+    // The real event id (after the server echo swaps it in) is sent normally.
+    act(() => {
+      result.current.markAsRead("stream_1", "event_new")
+    })
+    await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalledWith("ws_1", "stream_1", "event_new"))
+  })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -209,6 +209,12 @@ export function useUnreadCounts(workspaceId: string) {
 
   const markAsRead = useCallback(
     (streamId: string, lastEventId: string, opts?: { partial?: boolean }) => {
+      // Never advance the read pointer to an optimistic event: its temp_ id has no
+      // server stream_events row, so persisting it pins the watermark to sequence 0
+      // and reports the whole stream — including the user's own messages — as
+      // unread. The auto-read effect re-fires with the real id once the server echo
+      // swaps it in.
+      if (lastEventId.startsWith("temp_")) return
       markAsReadMutation.mutate({ streamId, lastEventId, partial: opts?.partial })
     },
     [markAsReadMutation]


### PR DESCRIPTION
No Linear ticket — reported from forensics on a live workspace. Invariants cited inline (INV-8, INV-11, INV-20).

## Problem

A real scratchpad was stuck reporting `unread = total` (including the author's own messages), and activity badges lingered after the stream had been read. Three distinct defects, all in the unread/activity path:

1. **A `temp_` read pointer corrupts the watermark.** Right after a send, the client briefly holds an optimistic event id (`temp_…`) as its read frontier, before the server echo swaps in the persisted id. `StreamService.markAsRead` stored that id verbatim. The live `stream:read` ordinal it then emits is harmless (the client max-merges read positions), but the **persisted** `last_read_event_id = temp_…` resurfaces on the next bootstrap: `countUnreadByStreamBatch` resolves the unknown event to sequence 0 (`COALESCE(se.sequence, 0)`), so the stream reports every message — including the user's own — as unread. Forensics found exactly this: a stuck `temp_` watermark pinning a scratchpad at `unread = total`.

2. **Activity-only sidebar rows are always blue.** `calculateUrgency` colored streams with unread *messages* by their last author (persona→gold, bot→green, human→blue), but an *activity-only* stream — lit by an `activity:created` notification that arrived before the per-stream `stream:activity` bumped the unread count — fell through to a hardcoded `"activity"` (blue) regardless of who acted. A persona's or bot's activity read as a generic blue row.

3. **Activity lingers as unread after a read.** Reading a stream clears its activity rows (the read→activity coupling in `markStreamActivityAsRead`), but that clear is point-in-time. Activity rows are written by the async outbox pipeline *after* the message commits, so an activity that lands just after a read survives and stays unread until the next read — the lingering badge observed on the stuck scratchpad.

## Solution

Three independent fixes, each closing its defect at the source.

### 1. Reject optimistic read pointers (`d0b4ea3`)

- **Backend** (`apps/backend/src/features/streams/service.ts`): `markAsRead` resolves the event via `StreamEventRepository.getMessageOrdinalForEvent` *first*. On a miss it logs and no-ops — returns the existing membership via `findByStreamAndMember`, persists nothing, emits no `stream:read` — instead of writing a watermark that resolves to 0. The no-op path is read-only, so nothing in the surrounding transaction mutates. Because `position` is now guaranteed non-null on the write path, the outbox payload's `?? 0n` / `?? 0` fallbacks are dropped.
- **Frontend** (`apps/frontend/src/hooks/use-unread-counts.ts`): the `markAsRead` callback returns early when `lastEventId.startsWith("temp_")`, so the mutation never fires for an optimistic id. The auto-read effect re-fires with the real id once the echo swaps it in (verified end-to-end in `use-unread-counts.test.tsx`).

### 2. Color activity-only rows by actor (`46409ea`)

The palette in `config.ts` (`URGENCY_COLORS`) was already correct (ai=gold, bot=green, activity=blue, mentions=red) — only `calculateUrgency`'s logic was wrong. The unread-message and activity-only branches are merged so **both** color by `lastMessagePreview.authorType`. Mentions and muted still short-circuit first, so mentions stay red and the `mentionCount`-driven mention icon is untouched. Because an activity-only row can now be `"ai"`/`"bot"` instead of the literal `"activity"`, `categorizeStream` no longer infers "activity-only" from the urgency color — it takes `activityCount` and reads it directly, so an actor-colored activity row still lands in **Recent** rather than sinking into Everything Else.

### 3. Born-read activity for already-read recipients (`7523019`)

An activity for a message the recipient has already read is inserted already-read, mirroring how `isSelf` rows are born-read:

- `StreamMemberRepository.membersReadThrough(db, streamId, memberIds, sequence)` returns the recipients whose read watermark already covers the message (join `last_read_event_id` → `stream_events.sequence`, keep `>= message sequence`).
- `ActivityRepository.insertBatch` takes `readUserIds` and sets `read_at` per row (`isSelf || readUserIds.has(user)`), via a new per-row `timestamptz[]` column in the UNNEST.
- `processMessageNotifications` and `processMessageMentions` compute the set from the message's event sequence (`resolveAlreadyReadRecipients`) and pass it through.
- `publishActivityCreated` suppresses the live `activity:created` for born-read recipient rows. This is the load-bearing half: the client holds every non-self event as unread (the payload carries no `read_at`), so emitting one would re-add the row to the badge the read just cleared. Self rows stay emittable (the client skips them via `isSelf`); born-read recipient rows surface as read on the feed's next fetch.

## Key design decisions

**1. No-op the bad watermark rather than coercing it.** Persisting a `temp_` id and "fixing it later" is what caused the bug. The backend now treats an unresolvable event as "not a valid read position" and leaves the existing pointer intact — this *removes* the silent `?? 0` fallback that masked the bad pointer (INV-11). The frontend guard is the primary defense; the backend check is defense-in-depth for any other caller (all optimistic ids are `temp_`-prefixed).

**2. Section placement reads `activityCount`, not the urgency color.** Once activity-only rows are actor-colored, `urgency === "activity"` no longer means "activity-only" — so `categorizeStream` would have mis-sectioned them. Threading the count through keeps color and section orthogonal. The picker `URGENCY_ORDER` sort shifts slightly for activity-only rows (a bot now ranks like a bot, not like generic activity); this is the same actor-ranking unread-message streams already had, applied consistently — confirmed not a regression in review.

**3. Born-read at insert + suppress the emit — both are required.** Born-read alone fixes the bootstrap state (`unreadActivities` excludes read rows) but not the live race: an emitted `activity:created` for a born-read row would re-add it to the client's held set right after the read cleared it. Suppressing the emit for born-read recipient rows (while keeping self rows emittable, since the client already skips them) closes the live path too. The alternative — adding `read_at` to the wire payload and skipping it client-side — was rejected as a larger, cross-package change for no behavioral gain on an already-read activity.

**4. `>=` on the sequence boundary.** A watermark equal to the message's own event sequence means "read through this message", so it born-reads. A watermark that advances/recedes between the read and the insert is self-correcting: the next read's clear catches a straggler, and the window is strictly smaller than the bug it replaces.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/streams/service.ts` | `markAsRead` resolves the event first; no-ops on a miss (Bug 1) |
| `apps/frontend/src/hooks/use-unread-counts.ts` | `markAsRead` callback skips `temp_` ids (Bug 1) |
| `apps/frontend/src/components/layout/sidebar/utils.ts` | `calculateUrgency` colors activity-only by actor; `categorizeStream` takes `activityCount` (Bug 2) |
| `apps/frontend/src/components/layout/sidebar/sidebar.tsx` | pass `activityCount` to `categorizeStream` (Bug 2) |
| `apps/backend/src/features/streams/member-repository.ts` | new `membersReadThrough` (Bug 3) |
| `apps/backend/src/features/activity/repository.ts` | `insertBatch` per-row `read_at` via `readUserIds` (Bug 3) |
| `apps/backend/src/features/activity/service.ts` | `resolveAlreadyReadRecipients`; wire into both creation paths (Bug 3) |
| `apps/backend/src/features/activity/outbox-handler.ts` | suppress `activity:created` for born-read recipient rows (Bug 3) |
| `member-repository.test.ts`, `service.test.ts` (streams + activity), `outbox-handler.test.ts`, `utils.test.ts`, `use-unread-counts.test.tsx` | unit coverage for the new behavior |
| `tests/integration/unread-counts.test.ts` | DB-backed `membersReadThrough` semantics — `>=` boundary, NULL/dangling-watermark exclusion (added in self-review, see below) |

## Out of scope (deliberate)

- **Reactions** (`processReactionAdded`) are not born-read — the reported defect is message/mention activity, and reaction notifications target a single author at lower volume. Left for a follow-up if it proves needed.
- **The `read_at`-on-the-wire approach** (so born-read rows could refresh the Activity feed live) is deliberately not taken — see design decision 3.

## Design evolution (self-review)

The pre-PR review (3 agents, one per commit) confirmed all stated claims and surfaced one real gap: the new `membersReadThrough` raw SQL was exercised only through a mocked stub, so its JOIN semantics, NULL/dangling-watermark exclusion, and `>=` boundary — the parts most likely to be wrong — had no committed coverage. Fixed in commit `26e8bd7`: a DB-backed integration test (run against a local Postgres with the full migration chain) plus mock-based unit tests for the empty-guard and row→Set mapping. One nit (a shared `nowIso` per batch) was dismissed as intentional. The `>=` boundary was independently confirmed to match the canonical unread predicate (`e.sequence > last_read_seq`).

## Test plan

- [x] Backend unit `bun test src/features/activity src/features/streams/service.test.ts src/features/streams/member-repository.test.ts` — 110 pass
- [x] Backend integration `bun test tests/integration/unread-counts.test.ts` (full migration chain on a local Postgres) — 15 pass, incl. the 2 new `membersReadThrough` cases
- [x] Frontend sidebar + quick-switcher — 417 pass
- [x] Frontend `use-unread-counts.test.tsx` (vitest) — 3 pass
- [x] `tsc --noEmit` backend + frontend clean (incl. test tsconfig)
- [x] eslint clean on touched files
- [x] Born-read `insertBatch` per-row `read_at` validated against a real Postgres (6/6 assertions: caught-up→read, behind/no-watermark→unread, isSelf→read, plain→unread); `membersReadThrough` promoted to the committed integration test above
- [x] Pre-PR review (3 agents): all claims confirmed; 1 minor finding fixed (test gap, commit `26e8bd7`); 1 nit dismissed
- [ ] `test:e2e` (needs Docker, daemon unavailable in this sandbox) — CI covers it

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GD4wusCBvzT6fakQyMcwtY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784878027&installation_id=129946197&pr_number=1075&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1075&signature=86a5f56c37889383c657b44dce793d5b2aff4c6392fbea6d0d8cc6ff52d0c58a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->