### PR TITLE
test(activity): cover born-read insert path end-to-end

### DIFF
--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -3,6 +3,7 @@ import { Pool } from "pg"
 import { withTransaction } from "./setup"
 import { StreamService, StreamEventRepository, StreamMemberRepository } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
+import { ActivityService } from "../../src/features/activity"
 import { streamId, userId, workspaceId } from "../../src/lib/id"
 import { setupTestDatabase, testMessageContent } from "./setup"
 
@@ -10,11 +11,13 @@ describe("Unread Counts", () => {
   let pool: Pool
   let streamService: StreamService
   let eventService: EventService
+  let activityService: ActivityService
 
   beforeAll(async () => {
     pool = await setupTestDatabase()
     streamService = new StreamService(pool)
     eventService = new EventService(pool)
+    activityService = new ActivityService({ pool })
   })
 
   afterAll(async () => {
@@ -22,6 +25,7 @@ describe("Unread Counts", () => {
   })
 
   beforeEach(async () => {
+    await pool.query("DELETE FROM user_activity")
     await pool.query("DELETE FROM reactions")
     await pool.query("DELETE FROM messages")
     await pool.query("DELETE FROM stream_events")
@@ -651,6 +655,99 @@ describe("Unread Counts", () => {
 
     test("returns an empty set for empty memberIds", async () => {
       expect(await StreamMemberRepository.membersReadThrough(pool, streamId(), [], 1n)).toEqual(new Set())
+    })
+  })
+
+  // End-to-end coverage for the born-read insert path: a message notification
+  // for a message the recipient has ALREADY read must land already read
+  // (read_at set), so the read-time clear can't race ahead of the async row and
+  // leave it stuck unread. Exercises the real service → repository UNNEST insert.
+  describe("born-read activity insert", () => {
+    async function setupDmWithMembers(): Promise<{
+      testStreamId: string
+      testWorkspaceId: string
+      authorId: string
+      readerId: string
+    }> {
+      const testStreamId = streamId()
+      const testWorkspaceId = workspaceId()
+      const authorId = userId()
+      const readerId = userId()
+
+      await withTransaction(pool, async (client) => {
+        await client.query(
+          `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'dm', 'private', $3)`,
+          [testStreamId, testWorkspaceId, authorId]
+        )
+        await StreamMemberRepository.insert(client, testStreamId, authorId)
+        await StreamMemberRepository.insert(client, testStreamId, readerId)
+      })
+
+      return { testStreamId, testWorkspaceId, authorId, readerId }
+    }
+
+    async function readActivityReadAt(userIdValue: string, messageIdValue: string): Promise<Date | null> {
+      const result = await pool.query<{ read_at: Date | null }>(
+        `SELECT read_at FROM user_activity WHERE user_id = $1 AND message_id = $2 AND activity_type = 'message'`,
+        [userIdValue, messageIdValue]
+      )
+      expect(result.rows).toHaveLength(1)
+      return result.rows[0].read_at
+    }
+
+    test("recipient who already read through the message gets a born-read row", async () => {
+      const { testStreamId, testWorkspaceId, authorId, readerId } = await setupDmWithMembers()
+
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId,
+        authorType: "user",
+        ...testMessageContent("already read"),
+      })
+
+      const events = await StreamEventRepository.list(pool, testStreamId)
+      await streamService.markAsRead(testWorkspaceId, testStreamId, readerId, events[0].id)
+
+      const activities = await activityService.processMessageNotifications({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        messageId: message.id,
+        actorId: authorId,
+        actorType: "user",
+        contentMarkdown: "already read",
+        excludeUserIds: new Set(),
+      })
+
+      const readerRow = activities.find((a) => a.userId === readerId)
+      expect(readerRow?.readAt).not.toBeNull()
+      expect(await readActivityReadAt(readerId, message.id)).not.toBeNull()
+    })
+
+    test("recipient who has not read the message gets an unread row", async () => {
+      const { testStreamId, testWorkspaceId, authorId, readerId } = await setupDmWithMembers()
+
+      const message = await eventService.createMessage({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        authorId,
+        authorType: "user",
+        ...testMessageContent("still unread"),
+      })
+
+      const activities = await activityService.processMessageNotifications({
+        workspaceId: testWorkspaceId,
+        streamId: testStreamId,
+        messageId: message.id,
+        actorId: authorId,
+        actorType: "user",
+        contentMarkdown: "still unread",
+        excludeUserIds: new Set(),
+      })
+
+      const readerRow = activities.find((a) => a.userId === readerId)
+      expect(readerRow?.readAt).toBeNull()
+      expect(await readActivityReadAt(readerId, message.id)).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Problem

The born-read insert path — where an activity row for a message the recipient has **already read** is inserted with `read_at` set, so a read-time clear can't race ahead of the async row and leave it stuck unread — shipped in #1075 (`e81fa57`). At merge it was covered only by **mocked** unit tests. The real SQL (`ActivityRepository.insertBatch`'s per-row `read_at` via the `::timestamptz[]` UNNEST column, fed by `ActivityService.resolveAlreadyReadRecipients` → `StreamMemberRepository.membersReadThrough`) was validated against a live Postgres once in a throwaway script, but nothing committed exercised it end-to-end. The handover flagged this as the one remaining coverage gap.

## Solution

A DB-backed integration test in `unread-counts.test.ts` that drives the real `ActivityService.processMessageNotifications` → `ActivityRepository.insertBatch` path against a live Postgres, asserting `read_at` from both sides:

- **Recipient who already read through the message** → born-read row (`read_at` set). Setup: author sends a message in a DM, the reader marks-read through that message's event, *then* the notification is processed — the order that reproduces the race the born-read fix closes.
- **Recipient who has not read the message** → unread row (`read_at` null).

The two cases pin the behavior from both sides: if born-read were broken (always null) the first fails; if it were always-on (always set) the second fails. The assertions check both the returned `Activity.readAt` and the persisted `user_activity.read_at` row.

A DM stream is used so the recipient reliably receives a `message` activity — `dm` defaults to notification level `everything` (`NOTIFICATION_CONFIG`), where all non-muted members get rows, avoiding the channel default (`mentions`) that would skip a plain message notification.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/tests/integration/unread-counts.test.ts` | New `describe("born-read activity insert")` block (2 tests) + `ActivityService` wiring in `beforeAll` and a `user_activity` cleanup in `beforeEach`. |

## Out of scope (deliberate)

Born-read for **reactions** was the other deferred follow-up. On investigation it's harmful as literally specified and was **dropped** (not deferred): a reaction notification targets the *message author*, who is always auto-advanced to their own message's read watermark on send (`event-service.ts:566`), so `membersReadThrough` would match them every time and suppress every reaction unread. There's no per-reaction read watermark to gate on instead, so the message-sequence predicate is simply the wrong gate. No code change made there.

## Test plan

- [x] `bun test tests/integration/unread-counts.test.ts` (backend, live PG16) — 17 pass (15 prior + 2 new)
- [x] Pre-commit hook clean — full-monorepo lint, `tsc --noEmit` across all workspaces, migration check (175 clean), OpenAPI doc check
- [ ] No new unit/mocked test — this gap was specifically about the *un-mocked* insert path, so the new coverage is integration-only by design

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZpiQzAjMn8SNSVfirwUKe)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784931709&installation_id=129946197&pr_number=1077&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1077&signature=be8ef9e888b37837f793db7f35b20b019fd4fb28d1dbdfd7de0df9e2e1963770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->