### PR TITLE
feat(streams): open stream media & files in an in-stream gallery

### DIFF
--- a/apps/frontend/src/components/gallery/giphy-gallery-id.test.ts
+++ b/apps/frontend/src/components/gallery/giphy-gallery-id.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+import { giphyGalleryId, isGiphyGalleryId } from "./giphy-gallery-id"
+
+describe("giphy gallery id", () => {
+  it("round-trips a recognizable sentinel for a CDN url", () => {
+    const id = giphyGalleryId("https://media.giphy.com/media/abc/giphy.gif")
+    expect(isGiphyGalleryId(id)).toBe(true)
+    expect(id).toContain("https://media.giphy.com/media/abc/giphy.gif")
+  })
+
+  it("does not classify a real attachment id as Giphy", () => {
+    expect(isGiphyGalleryId("attach_01HXYZ")).toBe(false)
+  })
+})

--- a/apps/frontend/src/components/gallery/giphy-gallery-id.ts
+++ b/apps/frontend/src/components/gallery/giphy-gallery-id.ts
@@ -1,0 +1,14 @@
+// Inline Giphy GIFs aren't uploaded attachments — they have no attachment id,
+// just a CDN url. The gallery keys item identity (and its `?smedia=`/`?media=`
+// sync, thumbnail strip, and onItemChange) on `attachmentId`, so a Giphy item
+// carries this sentinel id instead. Attachment-only actions (download via the
+// attachments API) branch on it; render and copy work straight from the url.
+const GIPHY_GALLERY_PREFIX = "giphy:"
+
+export function giphyGalleryId(giphyUrl: string): string {
+  return `${GIPHY_GALLERY_PREFIX}${giphyUrl}`
+}
+
+export function isGiphyGalleryId(id: string): boolean {
+  return id.startsWith(GIPHY_GALLERY_PREFIX)
+}

--- a/apps/frontend/src/components/gallery/use-gallery-attachment-urls.test.ts
+++ b/apps/frontend/src/components/gallery/use-gallery-attachment-urls.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+import * as api from "@/api"
+import { useGalleryAttachmentUrls } from "./use-gallery-attachment-urls"
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("useGalleryAttachmentUrls", () => {
+  it("requests the processed variant for a video", async () => {
+    const spy = vi.spyOn(api.attachmentsApi, "getDownloadUrl").mockResolvedValue("https://cdn/processed.mp4")
+    const { result } = renderHook(() => useGalleryAttachmentUrls("ws_1", "att_v", "video"))
+
+    await waitFor(() => expect(result.current.get("att_v")).toBe("https://cdn/processed.mp4"))
+    expect(spy).toHaveBeenCalledWith("ws_1", "att_v", { variant: "processed" })
+  })
+
+  it("falls back to raw bytes when the processed variant 404s", async () => {
+    vi.spyOn(api.attachmentsApi, "getDownloadUrl").mockImplementation(
+      async (_ws: string, _id: string, opts?: { variant?: string }) => {
+        if (opts?.variant === "processed") throw new Error("no processed variant")
+        return "https://cdn/raw.mp4"
+      }
+    )
+    const { result } = renderHook(() => useGalleryAttachmentUrls("ws_1", "att_v", "video"))
+
+    await waitFor(() => expect(result.current.get("att_v")).toBe("https://cdn/raw.mp4"))
+  })
+
+  it("requests the raw URL (no variant) for a document", async () => {
+    const spy = vi.spyOn(api.attachmentsApi, "getDownloadUrl").mockResolvedValue("https://cdn/doc.pdf")
+    const { result } = renderHook(() => useGalleryAttachmentUrls("ws_1", "att_d", "document"))
+
+    await waitFor(() => expect(result.current.get("att_d")).toBe("https://cdn/doc.pdf"))
+    expect(spy).toHaveBeenCalledWith("ws_1", "att_d")
+  })
+
+  it("fetches nothing for a null kind (images / Giphy use deterministic URLs)", async () => {
+    const spy = vi.spyOn(api.attachmentsApi, "getDownloadUrl").mockResolvedValue("x")
+    const { result } = renderHook(() => useGalleryAttachmentUrls("ws_1", "att_i", null))
+
+    expect(result.current.size).toBe(0)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("memoizes per id — re-rendering the same selection does not refetch", async () => {
+    const spy = vi.spyOn(api.attachmentsApi, "getDownloadUrl").mockResolvedValue("https://cdn/doc.pdf")
+    const { result, rerender } = renderHook(({ id }) => useGalleryAttachmentUrls("ws_1", id, "document"), {
+      initialProps: { id: "att_d" as string | null },
+    })
+
+    await waitFor(() => expect(result.current.get("att_d")).toBe("https://cdn/doc.pdf"))
+    rerender({ id: "att_d" })
+    rerender({ id: null })
+    rerender({ id: "att_d" })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/components/gallery/use-gallery-attachment-urls.ts
+++ b/apps/frontend/src/components/gallery/use-gallery-attachment-urls.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react"
+import { attachmentsApi } from "@/api"
+
+/**
+ * Which presigned URL the selected gallery item needs. Images and inline Giphy
+ * render from deterministic content URLs and need nothing here, so the caller
+ * passes `null` for them.
+ */
+export type GalleryUrlKind = "video" | "document" | null
+
+/**
+ * Lazily resolve the presigned URL for the *currently selected* gallery item,
+ * memoized per attachment id so re-selecting never refetches.
+ *
+ * Videos request the `processed` variant and fall back to raw bytes when a
+ * transcode was skipped; documents (pdf/markdown/html/text) request the raw
+ * download URL. Only the selected item is fetched — off-screen items resolve to
+ * `undefined` until the user lands on them, which is all the gallery renders.
+ */
+export function useGalleryAttachmentUrls(
+  workspaceId: string,
+  selectedId: string | null,
+  kind: GalleryUrlKind
+): Map<string, string> {
+  const [urls, setUrls] = useState<Map<string, string>>(new Map())
+
+  useEffect(() => {
+    if (!selectedId || !kind || urls.has(selectedId)) return
+    const id = selectedId
+
+    let mounted = true
+    const store = (url: string) => {
+      if (!mounted) return
+      setUrls((prev) => {
+        const next = new Map(prev)
+        next.set(id, url)
+        return next
+      })
+    }
+
+    async function resolve() {
+      try {
+        if (kind === "video") {
+          // Skipped transcodes have no processed variant; fall back to raw bytes
+          // so the <video> still streams (S3 Range support).
+          try {
+            store(await attachmentsApi.getDownloadUrl(workspaceId, id, { variant: "processed" }))
+          } catch {
+            store(await attachmentsApi.getDownloadUrl(workspaceId, id))
+          }
+        } else {
+          store(await attachmentsApi.getDownloadUrl(workspaceId, id))
+        }
+      } catch {
+        console.error("Failed to resolve gallery attachment URL")
+      }
+    }
+
+    resolve()
+    return () => {
+      mounted = false
+    }
+  }, [workspaceId, selectedId, kind, urls])
+
+  return urls
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils"
 import { attachmentsApi } from "@/api"
 import { triggerDownload } from "@/lib/image-utils"
 import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
+import { isGiphyGalleryId } from "@/components/gallery/giphy-gallery-id"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
 import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
 import { HtmlViewer } from "@/components/gallery/html-viewer"
@@ -585,6 +586,9 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
     copyResetRef.current = setTimeout(() => setCopyDone(false), 1200)
   }, [current])
 
+  // Giphy items are cross-origin CDN urls, not attachments — the attachment
+  // download API can't serve them, so the download affordance is hidden.
+  const isGiphy = current ? isGiphyGalleryId(current.attachmentId) : false
   const canCopy =
     current?.type === "image" || current?.type === "markdown" || current?.type === "html" || current?.type === "text"
   const copyLabel = copyLabelForType(current?.type)
@@ -828,15 +832,17 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
               <span className="sr-only">{rawMode ? "Show rendered preview" : "Show raw source"}</span>
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
-            onClick={handleDownload}
-          >
-            {downloadDone ? <Check className="h-5 w-5" /> : <Download className="h-5 w-5" />}
-            <span className="sr-only">{downloadDone ? "Download started" : "Download"}</span>
-          </Button>
+          {!isGiphy && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-white hover:bg-white/20 rounded-full"
+              onClick={handleDownload}
+            >
+              {downloadDone ? <Check className="h-5 w-5" /> : <Download className="h-5 w-5" />}
+              <span className="sr-only">{downloadDone ? "Download started" : "Download"}</span>
+            </Button>
+          )}
           {canCopy && (
             <Button
               variant="ghost"

--- a/apps/frontend/src/components/stream-context/index.ts
+++ b/apps/frontend/src/components/stream-context/index.ts
@@ -1,1 +1,3 @@
 export { StreamContextSurface } from "./stream-context-surface"
+export { StreamContextGallery } from "./stream-context-gallery"
+export { useStreamGallery } from "./use-stream-gallery"

--- a/apps/frontend/src/components/stream-context/stream-context-gallery.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-gallery.tsx
@@ -28,11 +28,13 @@ export function StreamContextGallery({
   onClose,
 }: StreamContextGalleryProps) {
   const events = useStreamEvents(streamId)
-  // Derive only while the gallery is open (a key is present) — this mount lives
-  // for the whole stream view, so deriving on every render would be wasteful.
+  // Derive only while the gallery is open — this mount lives for the whole
+  // stream view. Gate on the boolean, not `selectedKey`: the key changes on
+  // every prev/next step, which would re-run the O(events) scan each time.
+  const isGalleryOpen = selectedKey != null
   const contextItems = useMemo(
-    () => (selectedKey == null ? [] : deriveStreamContext(events).items),
-    [events, selectedKey]
+    () => (isGalleryOpen ? deriveStreamContext(events).items : []),
+    [events, isGalleryOpen]
   )
   const { items, initialIndex } = useStreamContextGalleryItems(workspaceId, contextItems, selectedKey)
 

--- a/apps/frontend/src/components/stream-context/stream-context-gallery.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-gallery.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from "react"
+import { MediaGallery } from "@/components/image-gallery"
+import { useStreamEvents } from "@/stores/stream-store"
+import { deriveStreamContext } from "@/lib/stream-context/derive"
+import { useStreamContextGalleryItems } from "./use-stream-gallery-items"
+
+interface StreamContextGalleryProps {
+  workspaceId: string
+  streamId: string
+  /** Current `?smedia=` key, or null when closed. */
+  selectedKey: string | null
+  /** Step to another item (gallery prev/next) — writes `?smedia=`. */
+  onSelect: (key: string) => void
+  onClose: () => void
+}
+
+/**
+ * The "In this stream" media gallery: a single `MediaGallery` whose item set is
+ * every gallery-renderable item in the stream (not one message's attachments),
+ * opened from the context panel via `?smedia=`. Desktop shows it over the
+ * timeline; mobile shows it full-screen — both inherited from `MediaGallery`.
+ */
+export function StreamContextGallery({
+  workspaceId,
+  streamId,
+  selectedKey,
+  onSelect,
+  onClose,
+}: StreamContextGalleryProps) {
+  const events = useStreamEvents(streamId)
+  // Derive only while the gallery is open (a key is present) — this mount lives
+  // for the whole stream view, so deriving on every render would be wasteful.
+  const contextItems = useMemo(
+    () => (selectedKey == null ? [] : deriveStreamContext(events).items),
+    [events, selectedKey]
+  )
+  const { items, initialIndex } = useStreamContextGalleryItems(workspaceId, contextItems, selectedKey)
+
+  // A stale/not-yet-loaded `?smedia=` key resolves to nothing — keep the gallery
+  // closed rather than opening on the wrong item.
+  const isOpen = selectedKey != null && items.some((i) => i.attachmentId === selectedKey)
+
+  return (
+    <MediaGallery
+      isOpen={isOpen}
+      items={items}
+      initialIndex={initialIndex}
+      workspaceId={workspaceId}
+      onClose={onClose}
+      onItemChange={onSelect}
+    />
+  )
+}

--- a/apps/frontend/src/components/stream-context/stream-context-panel.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-panel.tsx
@@ -45,6 +45,7 @@ interface StreamContextPanelProps {
   onJumpToMessage: (messageId: string) => void
   onOpenThread: (threadId: string) => void
   onOpenMemo: (memoId: string) => void
+  onOpenGallery: (key: string) => void
 }
 
 export function StreamContextPanel({
@@ -54,6 +55,7 @@ export function StreamContextPanel({
   onJumpToMessage,
   onOpenThread,
   onOpenMemo,
+  onOpenGallery,
 }: StreamContextPanelProps) {
   const events = useStreamEvents(streamId)
   const isLoading = events === undefined
@@ -141,6 +143,7 @@ export function StreamContextPanel({
                 onJumpToMessage={onJumpToMessage}
                 onOpenThread={onOpenThread}
                 onOpenMemo={onOpenMemo}
+                onOpenGallery={onOpenGallery}
               />
             ))}
           </div>

--- a/apps/frontend/src/components/stream-context/stream-context-row.test.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-row.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { MemoryRouter, useLocation } from "react-router-dom"
 import { StreamContextRow } from "./stream-context-row"
 import * as hooks from "@/hooks"
-import type { LinkContextItem } from "@/lib/stream-context/types"
+import type { ContextItem, FileContextItem, LinkContextItem, MediaContextItem } from "@/lib/stream-context/types"
 
 beforeEach(() => {
   vi.restoreAllMocks()
@@ -37,19 +37,52 @@ function LocationProbe() {
   return <div data-testid="location">{`${loc.pathname}${loc.search}`}</div>
 }
 
-function renderRow(item: LinkContextItem) {
-  return render(
+function renderRow(item: ContextItem) {
+  const onOpenGallery = vi.fn()
+  const onJumpToMessage = vi.fn()
+  render(
     <MemoryRouter initialEntries={["/start"]}>
       <StreamContextRow
         workspaceId="ws_1"
         item={item}
-        onJumpToMessage={vi.fn()}
+        onJumpToMessage={onJumpToMessage}
         onOpenThread={vi.fn()}
         onOpenMemo={vi.fn()}
+        onOpenGallery={onOpenGallery}
       />
       <LocationProbe />
     </MemoryRouter>
   )
+  return { onOpenGallery, onJumpToMessage }
+}
+
+const itemBase = { createdAt: "2026-06-24T10:00:00.000Z", sourceMessageId: "msg_1", snippet: "" }
+
+function mediaItem(overrides: Partial<MediaContextItem> = {}): MediaContextItem {
+  return {
+    ...itemBase,
+    key: "media:att_img",
+    category: "media",
+    mediaKind: "image",
+    attachmentId: "att_img",
+    giphyUrl: null,
+    filename: "shot.png",
+    ...overrides,
+  }
+}
+
+function fileItem(overrides: Partial<FileContextItem> = {}): FileContextItem {
+  return {
+    ...itemBase,
+    key: "file:att_pdf",
+    category: "file",
+    attachmentId: "att_pdf",
+    fileCategory: "pdf",
+    mimeType: "application/pdf",
+    filename: "spec.pdf",
+    sizeBytes: 10,
+    ...overrides,
+  }
 }
 
 describe("StreamContextRow link", () => {
@@ -74,5 +107,43 @@ describe("StreamContextRow link", () => {
     expect(anchor).toHaveAttribute("target", "_blank")
     expect(anchor).toHaveAttribute("rel", expect.stringContaining("noopener"))
     expect(screen.getByTestId("location")).toHaveTextContent("/start")
+  })
+})
+
+describe("StreamContextRow gallery open", () => {
+  it("opens an uploaded media item in the gallery by attachment id", async () => {
+    const { onOpenGallery } = renderRow(mediaItem())
+    await userEvent.click(screen.getByRole("button", { name: /open shot\.png/i }))
+    expect(onOpenGallery).toHaveBeenCalledWith("att_img")
+  })
+
+  it("opens an inline Giphy item in the gallery by its sentinel key", async () => {
+    const { onOpenGallery } = renderRow(
+      mediaItem({
+        key: "media:giphy",
+        mediaKind: "gif",
+        attachmentId: null,
+        giphyUrl: "https://media.giphy.com/media/abc/giphy.gif",
+        filename: "party",
+      })
+    )
+    await userEvent.click(screen.getByRole("button", { name: /open party/i }))
+    expect(onOpenGallery).toHaveBeenCalledWith("giphy:https://media.giphy.com/media/abc/giphy.gif")
+  })
+
+  it("opens a previewable file (pdf) in the gallery", async () => {
+    const { onOpenGallery, onJumpToMessage } = renderRow(fileItem())
+    await userEvent.click(screen.getByRole("button", { name: /open spec\.pdf/i }))
+    expect(onOpenGallery).toHaveBeenCalledWith("att_pdf")
+    expect(onJumpToMessage).not.toHaveBeenCalled()
+  })
+
+  it("jumps to the message for a non-previewable file instead of opening the gallery", async () => {
+    const { onOpenGallery, onJumpToMessage } = renderRow(
+      fileItem({ fileCategory: "archive", mimeType: "application/zip", filename: "bundle.zip" })
+    )
+    await userEvent.click(screen.getByRole("button", { name: /go to message with bundle\.zip/i }))
+    expect(onJumpToMessage).toHaveBeenCalledWith("msg_1")
+    expect(onOpenGallery).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/components/stream-context/stream-context-row.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-row.tsx
@@ -18,6 +18,8 @@ import { formatFileSize } from "@/lib/file-size"
 import { getKnowledgeConfig, memoLabel } from "@/lib/memo-display"
 import { cn } from "@/lib/utils"
 import { resolveInternalAppPath } from "@/lib/internal-url"
+import { giphyGalleryId } from "@/components/gallery/giphy-gallery-id"
+import { galleryDocType } from "./stream-gallery-items"
 import type { ContextItem, LinkContextItem, MediaContextItem } from "@/lib/stream-context/types"
 
 interface StreamContextRowProps {
@@ -26,6 +28,7 @@ interface StreamContextRowProps {
   onJumpToMessage: (messageId: string) => void
   onOpenThread: (threadId: string) => void
   onOpenMemo: (memoId: string) => void
+  onOpenGallery: (key: string) => void
 }
 
 function prettyHost(url: string): string {
@@ -119,6 +122,7 @@ export function StreamContextRow({
   onJumpToMessage,
   onOpenThread,
   onOpenMemo,
+  onOpenGallery,
 }: StreamContextRowProps) {
   const navigate = useNavigate()
   const { formatRelative } = useFormattedDate()
@@ -130,6 +134,9 @@ export function StreamContextRow({
   let badge: React.ReactNode = null
   let primaryAction: React.ReactNode
   let jumpTarget: string | null = item.sourceMessageId
+  // Set when the row's primary action opens the in-stream gallery; the value is
+  // the gallery key (`?smedia=`) — an attachment id or a `giphy:` sentinel.
+  let galleryKey: string | null = null
 
   switch (item.category) {
     case "link": {
@@ -173,7 +180,17 @@ export function StreamContextRow({
       primaryText = item.filename
       const mediaLabel = { image: "Image", gif: "GIF", video: "Video" }[item.mediaKind]
       secondaryText = item.snippet || mediaLabel
-      primaryAction = (
+      galleryKey = item.attachmentId ?? (item.giphyUrl ? giphyGalleryId(item.giphyUrl) : null)
+      const mediaKey = galleryKey
+      primaryAction = mediaKey ? (
+        <button
+          type="button"
+          onClick={() => onOpenGallery(mediaKey)}
+          className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span className="sr-only">Open {primaryText}</span>
+        </button>
+      ) : (
         <button
           type="button"
           onClick={() => item.sourceMessageId && onJumpToMessage(item.sourceMessageId)}
@@ -194,7 +211,20 @@ export function StreamContextRow({
       )
       primaryText = item.filename
       secondaryText = formatFileSize(item.sizeBytes)
-      primaryAction = (
+      // Gallery-previewable documents (pdf/markdown/html/text) open in place;
+      // everything else jumps to the message that posted it.
+      const previewable = galleryDocType({ mimeType: item.mimeType, filename: item.filename }) != null
+      galleryKey = previewable ? item.attachmentId : null
+      const fileKey = galleryKey
+      primaryAction = fileKey ? (
+        <button
+          type="button"
+          onClick={() => onOpenGallery(fileKey)}
+          className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span className="sr-only">Open {primaryText}</span>
+        </button>
+      ) : (
         <button
           type="button"
           onClick={() => item.sourceMessageId && onJumpToMessage(item.sourceMessageId)}
@@ -250,9 +280,11 @@ export function StreamContextRow({
     }
   }
 
-  // Links open the URL on primary click, so they keep a secondary "go to
-  // message" affordance. Media/file primary already jumps to the message.
-  const showJump = item.category === "link" && jumpTarget != null
+  // Rows whose primary click goes somewhere other than the source message
+  // (a link opens the URL; a media/previewable-file row opens the gallery) keep
+  // a secondary "go to message" affordance. Rows that already jump on primary
+  // (non-previewable files) don't need it.
+  const showJump = (item.category === "link" || galleryKey != null) && jumpTarget != null
 
   return (
     <div className="group relative flex gap-3">

--- a/apps/frontend/src/components/stream-context/stream-context-surface.tsx
+++ b/apps/frontend/src/components/stream-context/stream-context-surface.tsx
@@ -12,6 +12,7 @@ interface StreamContextSurfaceProps {
   onJumpToMessage: (messageId: string) => void
   onOpenThread: (threadId: string) => void
   onOpenMemo: (memoId: string) => void
+  onOpenGallery: (key: string) => void
 }
 
 /**
@@ -33,6 +34,7 @@ export function StreamContextSurface(props: StreamContextSurfaceProps) {
       onJumpToMessage={props.onJumpToMessage}
       onOpenThread={props.onOpenThread}
       onOpenMemo={props.onOpenMemo}
+      onOpenGallery={props.onOpenGallery}
     />
   )
 

--- a/apps/frontend/src/components/stream-context/stream-gallery-items.test.ts
+++ b/apps/frontend/src/components/stream-context/stream-gallery-items.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import type { ContextItem } from "@/lib/stream-context/types"
+import { buildStreamGalleryItems, galleryFetchKind } from "./stream-gallery-items"
+
+const base = { createdAt: "2026-06-24T10:00:00.000Z", sourceMessageId: "msg_1", snippet: "" }
+
+const mediaImage: ContextItem = {
+  ...base,
+  key: "media:att_img",
+  category: "media",
+  mediaKind: "image",
+  attachmentId: "att_img",
+  giphyUrl: null,
+  filename: "shot.png",
+}
+const mediaGiphy: ContextItem = {
+  ...base,
+  key: "media:giphy",
+  category: "media",
+  mediaKind: "gif",
+  attachmentId: null,
+  giphyUrl: "https://media.giphy.com/media/abc/giphy.gif",
+  filename: "party",
+}
+const mediaVideo: ContextItem = {
+  ...base,
+  key: "media:att_vid",
+  category: "media",
+  mediaKind: "video",
+  attachmentId: "att_vid",
+  giphyUrl: null,
+  filename: "clip.mp4",
+}
+const filePdf: ContextItem = {
+  ...base,
+  key: "file:att_pdf",
+  category: "file",
+  attachmentId: "att_pdf",
+  fileCategory: "pdf",
+  mimeType: "application/pdf",
+  filename: "spec.pdf",
+  sizeBytes: 10,
+}
+const fileZip: ContextItem = {
+  ...base,
+  key: "file:att_zip",
+  category: "file",
+  attachmentId: "att_zip",
+  fileCategory: "archive",
+  mimeType: "application/zip",
+  filename: "bundle.zip",
+  sizeBytes: 10,
+}
+const link: ContextItem = {
+  ...base,
+  key: "link:x",
+  category: "link",
+  url: "https://example.com",
+  title: null,
+  siteName: null,
+  faviconUrl: null,
+  imageUrl: null,
+  previewKind: "generic",
+  badge: null,
+  refCount: 1,
+}
+
+describe("buildStreamGalleryItems", () => {
+  it("includes media + previewable files in order, dropping links and non-previewable files", () => {
+    const out = buildStreamGalleryItems("ws_1", [mediaImage, link, mediaGiphy, mediaVideo, filePdf, fileZip])
+
+    expect(out.map((i) => i.type)).toEqual(["image", "image", "video", "pdf"])
+    expect(out.map((i) => i.attachmentId)).toEqual([
+      "att_img",
+      "giphy:https://media.giphy.com/media/abc/giphy.gif",
+      "att_vid",
+      "att_pdf",
+    ])
+  })
+
+  it("renders an uploaded image from a content url and a Giphy from its CDN url", () => {
+    const [img, gif] = buildStreamGalleryItems("ws_1", [mediaImage, mediaGiphy])
+    expect(img.url).toContain("att_img")
+    expect(gif.url).toBe("https://media.giphy.com/media/abc/giphy.gif")
+  })
+
+  it("leaves video/document urls empty for lazy presigning, with a video thumbnail", () => {
+    const [vid, pdf] = buildStreamGalleryItems("ws_1", [mediaVideo, filePdf])
+    expect(vid.url).toBe("")
+    expect(vid.type === "video" && vid.thumbnailUrl).toContain("att_vid")
+    expect(pdf.url).toBe("")
+  })
+})
+
+describe("galleryFetchKind", () => {
+  it("maps gallery types to the URL kind they need", () => {
+    expect(galleryFetchKind({ type: "video", url: "", thumbnailUrl: "", filename: "v", attachmentId: "a" })).toBe(
+      "video"
+    )
+    expect(galleryFetchKind({ type: "pdf", url: "", filename: "p", attachmentId: "a" })).toBe("document")
+    expect(
+      galleryFetchKind({ type: "image", url: "x", thumbnailUrl: "x", filename: "i", attachmentId: "a" })
+    ).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/stream-context/stream-gallery-items.ts
+++ b/apps/frontend/src/components/stream-context/stream-gallery-items.ts
@@ -1,0 +1,90 @@
+import { attachmentContentUrl } from "@/api"
+import type { GalleryItem } from "@/components/image-gallery"
+import { giphyGalleryId } from "@/components/gallery/giphy-gallery-id"
+import type { GalleryUrlKind } from "@/components/gallery/use-gallery-attachment-urls"
+import {
+  isHtmlAttachment,
+  isMarkdownAttachment,
+  isPdfAttachment,
+  isTextPreviewableAttachment,
+} from "@/lib/attachment-kind"
+import type { ContextItem } from "@/lib/stream-context/types"
+
+/**
+ * Map the "In this stream" panel's items into `MediaGallery` items, preserving
+ * the panel's order so the gallery's prev/next browses the whole stream.
+ *
+ * Only gallery-renderable items are included — images, inline/uploaded GIFs,
+ * videos, and previewable documents (pdf/markdown/html/text, decided by the
+ * canonical `is*Attachment` helpers, the single source of truth for "opens in
+ * the gallery"). Links, memos, threads, and non-previewable files are dropped;
+ * their rows keep their existing actions.
+ *
+ * Video and document items carry an empty `url` here — only the *selected*
+ * item's presigned URL is fetched (see `useGalleryAttachmentUrls`); images and
+ * GIFs render from deterministic/CDN urls set inline.
+ */
+export function buildStreamGalleryItems(workspaceId: string, items: readonly ContextItem[]): GalleryItem[] {
+  const out: GalleryItem[] = []
+
+  for (const item of items) {
+    if (item.category === "media") {
+      if (item.mediaKind === "video") {
+        if (!item.attachmentId) continue
+        out.push({
+          type: "video",
+          url: "",
+          thumbnailUrl: attachmentContentUrl(workspaceId, item.attachmentId, { variant: "thumbnail" }),
+          filename: item.filename,
+          attachmentId: item.attachmentId,
+        })
+      } else if (item.giphyUrl) {
+        out.push({
+          type: "image",
+          url: item.giphyUrl,
+          thumbnailUrl: item.giphyUrl,
+          filename: item.filename,
+          attachmentId: giphyGalleryId(item.giphyUrl),
+        })
+      } else if (item.attachmentId) {
+        out.push({
+          type: "image",
+          url: attachmentContentUrl(workspaceId, item.attachmentId),
+          thumbnailUrl: attachmentContentUrl(workspaceId, item.attachmentId, { variant: "thumbnail" }),
+          filename: item.filename,
+          attachmentId: item.attachmentId,
+        })
+      }
+      continue
+    }
+
+    if (item.category === "file") {
+      const shape = { mimeType: item.mimeType, filename: item.filename }
+      const type = galleryDocType(shape)
+      if (!type) continue
+      out.push({ type, url: "", filename: item.filename, attachmentId: item.attachmentId })
+    }
+  }
+
+  return out
+}
+
+export function galleryDocType(shape: {
+  mimeType: string
+  filename: string
+}): "pdf" | "markdown" | "html" | "text" | null {
+  if (isPdfAttachment(shape)) return "pdf"
+  if (isMarkdownAttachment(shape)) return "markdown"
+  if (isHtmlAttachment(shape)) return "html"
+  if (isTextPreviewableAttachment(shape)) return "text"
+  return null
+}
+
+/** Which presigned URL the gallery item needs when selected (see the URL hook). */
+export function galleryFetchKind(item: GalleryItem): GalleryUrlKind {
+  if (item.type === "video") return "video"
+  if (item.type === "pdf" || item.type === "markdown" || item.type === "html" || item.type === "text") {
+    return "document"
+  }
+  return null
+}

--- a/apps/frontend/src/components/stream-context/use-stream-gallery-items.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-gallery-items.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react"
+import type { GalleryItem } from "@/components/image-gallery"
+import { isGiphyGalleryId } from "@/components/gallery/giphy-gallery-id"
+import { useGalleryAttachmentUrls } from "@/components/gallery/use-gallery-attachment-urls"
+import type { ContextItem } from "@/lib/stream-context/types"
+import { buildStreamGalleryItems, galleryFetchKind } from "./stream-gallery-items"
+
+/**
+ * The `MediaGallery` item set for the stream-context gallery, plus the index of
+ * the currently selected key. Resolves the selected video/document's presigned
+ * URL lazily (images and GIFs need none); off-screen video/doc items keep an
+ * empty url until the user lands on them.
+ */
+export function useStreamContextGalleryItems(
+  workspaceId: string,
+  contextItems: readonly ContextItem[],
+  selectedKey: string | null
+): { items: GalleryItem[]; initialIndex: number } {
+  const baseItems = useMemo(() => buildStreamGalleryItems(workspaceId, contextItems), [workspaceId, contextItems])
+
+  const selected = useMemo(
+    () => baseItems.find((i) => i.attachmentId === selectedKey) ?? null,
+    [baseItems, selectedKey]
+  )
+  const fetchId = selected && !isGiphyGalleryId(selected.attachmentId) ? selected.attachmentId : null
+  const fetchKind = selected ? galleryFetchKind(selected) : null
+
+  const urls = useGalleryAttachmentUrls(workspaceId, fetchId, fetchKind)
+
+  const items = useMemo(
+    () =>
+      baseItems.map((i) =>
+        galleryFetchKind(i) && urls.has(i.attachmentId) ? { ...i, url: urls.get(i.attachmentId) ?? "" } : i
+      ),
+    [baseItems, urls]
+  )
+
+  const initialIndex = useMemo(() => {
+    const idx = items.findIndex((i) => i.attachmentId === selectedKey)
+    return idx < 0 ? 0 : idx
+  }, [items, selectedKey])
+
+  return { items, initialIndex }
+}

--- a/apps/frontend/src/components/stream-context/use-stream-gallery.ts
+++ b/apps/frontend/src/components/stream-context/use-stream-gallery.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo, useRef } from "react"
+import { useNavigate, useSearchParams } from "react-router-dom"
+
+/**
+ * Open/close state for the stream-context gallery, encoded in `?smedia=<key>`.
+ *
+ * Deliberately a separate param from the per-message gallery's `?media=`
+ * (media-gallery-context.tsx): that one is claimed by whichever rendered
+ * message owns the attachment, and its navigable set is that message's
+ * attachments. This gallery is opened from the "In this stream" panel and its
+ * set is every media/file item in the stream, so the two must not contend for
+ * the same param. The key is an attachment id (uploads) or a `giphy:<url>`
+ * sentinel (inline GIFs).
+ *
+ * History mirrors the per-message gallery: opening pushes (so the OS back
+ * button closes), stepping between items replaces (so the back stack doesn't
+ * fill), and closing pops the pushed entry — or strips the param in place when
+ * the gallery was deep-linked (no entry to pop).
+ */
+export function useStreamGallery(): {
+  selectedKey: string | null
+  openGallery: (key: string) => void
+  closeGallery: () => void
+} {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+
+  const selectedKey = useMemo(() => searchParams.get("smedia"), [searchParams])
+
+  const pushedOnOpenRef = useRef(false)
+
+  const openGallery = useCallback(
+    (key: string) => {
+      const isNavigatingItems = searchParams.get("smedia") !== null
+      if (!isNavigatingItems) pushedOnOpenRef.current = true
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.set("smedia", key)
+          return next
+        },
+        { replace: isNavigatingItems }
+      )
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const closeGallery = useCallback(() => {
+    if (pushedOnOpenRef.current) {
+      pushedOnOpenRef.current = false
+      navigate(-1)
+      return
+    }
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete("smedia")
+        return next
+      },
+      { replace: true }
+    )
+  }, [navigate, setSearchParams])
+
+  return useMemo(() => ({ selectedKey, openGallery, closeGallery }), [selectedKey, openGallery, closeGallery])
+}

--- a/apps/frontend/src/components/timeline/attachment-list.tsx
+++ b/apps/frontend/src/components/timeline/attachment-list.tsx
@@ -3,6 +3,7 @@ import { Download, FileText, File, Loader2, Copy, Play, Globe, Check } from "luc
 import { Button } from "@/components/ui/button"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
+import { useGalleryAttachmentUrls, type GalleryUrlKind } from "@/components/gallery/use-gallery-attachment-urls"
 import { Skeleton } from "@/components/ui/skeleton"
 import { attachmentsApi, attachmentContentUrl } from "@/api"
 import { cn } from "@/lib/utils"
@@ -469,12 +470,6 @@ function FileAttachment({ attachment, workspaceId, isHighlighted }: AttachmentIt
 }
 
 export function AttachmentList({ attachments, workspaceId, className, deferHydration = false }: AttachmentListProps) {
-  const [loadedVideoUrls, setLoadedVideoUrls] = useState<Map<string, string>>(new Map())
-  // Markdown, HTML, and PDF attachments share a single URL cache: each viewer
-  // just needs a presigned URL (the markdown viewer fetches text from it, the
-  // HTML viewer hands it straight to a sandboxed iframe, the PDF viewer hands
-  // it straight to the browser's built-in PDF renderer).
-  const [loadedTextUrls, setLoadedTextUrls] = useState<Map<string, string>>(new Map())
   const attachmentContext = useAttachmentContext()
   const hoveredAttachmentId = attachmentContext?.hoveredAttachmentId ?? null
   const { mediaAttachmentId, openMedia, closeMedia } = useMediaGallery()
@@ -537,6 +532,19 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
   // sidebar reuses the inline thumbnail variant straight from browser cache.
   // Video playback keeps the lazy presigned URL (bytes stream straight from
   // S3 with native Range support).
+  const selectedUrlKind: GalleryUrlKind = useMemo(() => {
+    if (!selectedAttachmentId) return null
+    if (videoAttachments.some((a) => a.id === selectedAttachmentId)) return "video"
+    const isDocument =
+      markdownAttachments.some((a) => a.id === selectedAttachmentId) ||
+      htmlAttachments.some((a) => a.id === selectedAttachmentId) ||
+      pdfAttachments.some((a) => a.id === selectedAttachmentId) ||
+      textAttachments.some((a) => a.id === selectedAttachmentId)
+    return isDocument ? "document" : null
+  }, [selectedAttachmentId, videoAttachments, markdownAttachments, htmlAttachments, pdfAttachments, textAttachments])
+
+  const galleryUrls = useGalleryAttachmentUrls(workspaceId, selectedAttachmentId, selectedUrlKind)
+
   const galleryItems: GalleryItem[] = useMemo(() => {
     const imageItems: GalleryItem[] = imageAttachments.map((a) => ({
       type: "image" as const,
@@ -549,7 +557,7 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     const videoItems: GalleryItem[] = videoAttachments
       .filter((a) => a.processingStatus === "completed" || a.processingStatus === "skipped")
       .map((a) => {
-        const videoUrl = loadedVideoUrls.get(a.id) ?? ""
+        const videoUrl = galleryUrls.get(a.id) ?? ""
         // Skipped transcodes have no thumbnail object; the variant URL would
         // fall through to raw video bytes, which an <img> can't render.
         const thumbnailUrl =
@@ -565,28 +573,28 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
 
     const markdownItems: GalleryItem[] = markdownAttachments.map((a) => ({
       type: "markdown" as const,
-      url: loadedTextUrls.get(a.id) ?? "",
+      url: galleryUrls.get(a.id) ?? "",
       filename: a.filename,
       attachmentId: a.id,
     }))
 
     const htmlItems: GalleryItem[] = htmlAttachments.map((a) => ({
       type: "html" as const,
-      url: loadedTextUrls.get(a.id) ?? "",
+      url: galleryUrls.get(a.id) ?? "",
       filename: a.filename,
       attachmentId: a.id,
     }))
 
     const pdfItems: GalleryItem[] = pdfAttachments.map((a) => ({
       type: "pdf" as const,
-      url: loadedTextUrls.get(a.id) ?? "",
+      url: galleryUrls.get(a.id) ?? "",
       filename: a.filename,
       attachmentId: a.id,
     }))
 
     const textItems: GalleryItem[] = textAttachments.map((a) => ({
       type: "text" as const,
-      url: loadedTextUrls.get(a.id) ?? "",
+      url: galleryUrls.get(a.id) ?? "",
       filename: a.filename,
       attachmentId: a.id,
     }))
@@ -600,8 +608,7 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     htmlAttachments,
     pdfAttachments,
     textAttachments,
-    loadedVideoUrls,
-    loadedTextUrls,
+    galleryUrls,
   ])
 
   // Track selected item by ID — derived index stays correct even as galleryItems grows
@@ -629,85 +636,6 @@ export function AttachmentList({ attachments, workspaceId, className, deferHydra
     },
     [openMedia]
   )
-
-  // Eagerly fetch video URL when a video is selected (via click or URL param)
-  useEffect(() => {
-    if (!selectedAttachmentId) return
-    const isVideo = videoAttachments.some((a) => a.id === selectedAttachmentId)
-    if (!isVideo || loadedVideoUrls.has(selectedAttachmentId)) return
-
-    let mounted = true
-    async function fetchVideoUrl() {
-      try {
-        const url = await attachmentsApi.getDownloadUrl(workspaceId, selectedAttachmentId!, {
-          variant: "processed",
-        })
-        if (mounted) {
-          setLoadedVideoUrls((prev) => {
-            const next = new Map(prev)
-            next.set(selectedAttachmentId!, url)
-            return next
-          })
-        }
-      } catch {
-        try {
-          const url = await attachmentsApi.getDownloadUrl(workspaceId, selectedAttachmentId!)
-          if (mounted) {
-            setLoadedVideoUrls((prev) => {
-              const next = new Map(prev)
-              next.set(selectedAttachmentId!, url)
-              return next
-            })
-          }
-        } catch {
-          console.error("Failed to get video URL")
-        }
-      }
-    }
-    fetchVideoUrl()
-    return () => {
-      mounted = false
-    }
-  }, [selectedAttachmentId, videoAttachments, loadedVideoUrls, workspaceId])
-
-  // Lazy-fetch presigned URLs for markdown/html/pdf attachments when opened.
-  useEffect(() => {
-    if (!selectedAttachmentId) return
-    const needsUrl =
-      markdownAttachments.some((a) => a.id === selectedAttachmentId) ||
-      htmlAttachments.some((a) => a.id === selectedAttachmentId) ||
-      pdfAttachments.some((a) => a.id === selectedAttachmentId) ||
-      textAttachments.some((a) => a.id === selectedAttachmentId)
-    if (!needsUrl || loadedTextUrls.has(selectedAttachmentId)) return
-
-    let mounted = true
-    async function fetchTextUrl() {
-      try {
-        const url = await attachmentsApi.getDownloadUrl(workspaceId, selectedAttachmentId!)
-        if (mounted) {
-          setLoadedTextUrls((prev) => {
-            const next = new Map(prev)
-            next.set(selectedAttachmentId!, url)
-            return next
-          })
-        }
-      } catch {
-        console.error("Failed to get attachment URL")
-      }
-    }
-    fetchTextUrl()
-    return () => {
-      mounted = false
-    }
-  }, [
-    selectedAttachmentId,
-    markdownAttachments,
-    htmlAttachments,
-    pdfAttachments,
-    textAttachments,
-    loadedTextUrls,
-    workspaceId,
-  ])
 
   if (!attachments || attachments.length === 0) {
     return null

--- a/apps/frontend/src/lib/stream-context/derive.ts
+++ b/apps/frontend/src/lib/stream-context/derive.ts
@@ -238,6 +238,7 @@ export function deriveStreamContext(events: readonly CachedEvent[] | undefined):
           snippet,
           attachmentId: attachment.id,
           fileCategory: category,
+          mimeType: attachment.mimeType,
           filename: attachment.filename,
           sizeBytes: attachment.sizeBytes,
         })

--- a/apps/frontend/src/lib/stream-context/types.ts
+++ b/apps/frontend/src/lib/stream-context/types.ts
@@ -52,6 +52,10 @@ export interface FileContextItem extends ContextItemBase {
   category: "file"
   attachmentId: string
   fileCategory: AttachmentCategory
+  /** Raw mime type, kept so the gallery can decide previewability (pdf /
+   *  markdown / html / text) via the canonical `is*Attachment` helpers — the
+   *  coarse `fileCategory` collapses those distinctions. */
+  mimeType: string
   filename: string
   sizeBytes: number
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -63,7 +63,7 @@ import { StreamErrorView } from "@/components/stream-error-view"
 import { InviteActorButton } from "@/components/encryption"
 import { BotRuntimeStatuses, CompanionModes, LabelableResourceTypes, StreamTypes, type StreamType } from "@threa/types"
 import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
-import { StreamContextSurface } from "@/components/stream-context"
+import { StreamContextSurface, StreamContextGallery, useStreamGallery } from "@/components/stream-context"
 import { memoDeepLink } from "@/lib/memo-url"
 import { copyStreamLink } from "@/lib/stream-links"
 import { setPageStreamName } from "@/lib/page-title"
@@ -211,6 +211,10 @@ export function StreamPage() {
   const openMemoFromContext = (memoId: string) => {
     navigate(memoDeepLink(workspaceId!, memoId))
   }
+
+  // The in-stream media gallery (links/media/files opened from the panel), keyed
+  // off `?smedia=` — separate from the per-message gallery's `?media=`.
+  const streamGallery = useStreamGallery()
 
   const { openUserProfile } = useUserProfile()
   const { openStreamSettings } = useStreamSettings()
@@ -790,15 +794,25 @@ export function StreamPage() {
   )
 
   const streamContextSurface = stream && !isThread && !isDraft && (
-    <StreamContextSurface
-      workspaceId={workspaceId}
-      streamId={streamId}
-      open={isContextOpen}
-      onClose={() => setContextOpen(false)}
-      onJumpToMessage={jumpToMessageFromContext}
-      onOpenThread={openThreadFromContext}
-      onOpenMemo={openMemoFromContext}
-    />
+    <>
+      <StreamContextSurface
+        workspaceId={workspaceId}
+        streamId={streamId}
+        open={isContextOpen}
+        onClose={() => setContextOpen(false)}
+        onJumpToMessage={jumpToMessageFromContext}
+        onOpenThread={openThreadFromContext}
+        onOpenMemo={openMemoFromContext}
+        onOpenGallery={streamGallery.openGallery}
+      />
+      <StreamContextGallery
+        workspaceId={workspaceId}
+        streamId={streamId}
+        selectedKey={streamGallery.selectedKey}
+        onSelect={streamGallery.openGallery}
+        onClose={streamGallery.closeGallery}
+      />
+    </>
   )
 
   // On mobile, thread panel takes over the full screen


### PR DESCRIPTION
## Problem

The "In this stream" context panel (#1071) lists a stream's media, files, links, memories, and threads, but clicking a **media or file** item only **jumps to the message** that posted it. The app already has a full-featured `MediaGallery` (lightbox over the timeline on desktop, full-screen swipe on mobile, with PDF/markdown/html/text viewers) — but it's wired per-message: each `attachment-list.tsx` claims the `?media=` param only for its own attachments and its prev/next walks that one message's set. So there was no way to open a panel item in the gallery, and no stream-wide "browse all the media" experience.

## Solution

Mount **one panel-owned `MediaGallery`** fed by the context panel's own derived item set, opened from the rows. Desktop shows it over the timeline; mobile shows it focused full-screen — both inherited from the existing component, no new viewer.

### How it works

- **`?smedia=` param** (`use-stream-gallery.ts`) drives a single page-level `StreamContextGallery` mount. It is deliberately **separate from the per-message `?media=`**: that param is claimed by whichever rendered message owns the attachment, so a stream-wide gallery opened from the panel (whose source message may be scrolled out of the window) must not contend for it. Same push-on-open / replace-on-step / pop-on-close history as the per-message gallery.
- **`buildStreamGalleryItems`** maps the panel's derived items → `GalleryItem[]` in panel order, so prev/next browses the whole stream. Only gallery-renderable items are included — images, GIFs, videos, and previewable documents (pdf/markdown/html/text). Previewability is decided by the canonical `is*Attachment` helpers (the single source of truth), so `FileContextItem` now carries `mimeType`. Links/memos/threads and non-previewable files are dropped.
- **Lazy presign, extracted and shared.** The video (processed→raw fallback) and document URL fetching was inline in `attachment-list.tsx`; it's now `useGalleryAttachmentUrls(workspaceId, selectedId, kind)`, used by both the per-message gallery (behaviour-preserving refactor) and the stream gallery. Only the selected item is fetched; images/GIFs use deterministic/CDN urls.
- **Inline Giphy** has no attachment id, so a gallery item carries a `giphy:<url>` sentinel (`giphy-gallery-id.ts`). The gallery renders/copies it via the image path; the **download affordance is hidden** for Giphy (the attachments API can't serve a CDN url) — no new `GalleryItem` variant, so the shared component's image/zoom/copy gates are untouched.
- **Rows:** media + previewable-file rows open the gallery and keep a secondary jump-to-message affordance; non-previewable files still jump to the message. Internal links already route in-app (PR #1076); external links unchanged.

### Key design decisions

**1. Separate `?smedia=` param, not the existing `?media=`.** Reusing `?media=` would make the per-message galleries and the stream gallery both try to claim ownership of the same key. A distinct param keeps each gallery's ownership unambiguous.

**2. Giphy via sentinel id, download hidden (per the ask).** A first-class `gif` type would thread through ~8 `type === "image"` gates in the 1037-line shared gallery. The sentinel id keeps the change to one helper + hiding one button. Cross-origin copy may fail gracefully (toast); download is hidden rather than attempting a cross-origin download that browsers ignore.

**3. Derive only while open.** `StreamContextGallery` lives for the whole stream view, so it derives the context set only when `?smedia=` is present, not on every render.

## New files

| File | Purpose |
| ---- | ------- |
| `components/gallery/use-gallery-attachment-urls.ts` | Shared lazy presigned-URL resolver (video processed→raw, documents raw) |
| `components/gallery/giphy-gallery-id.ts` | `giphy:<url>` sentinel id helpers |
| `components/stream-context/use-stream-gallery.ts` | `?smedia=` open/close state |
| `components/stream-context/stream-gallery-items.ts` | Pure builder: panel items → `GalleryItem[]` + fetch-kind |
| `components/stream-context/use-stream-gallery-items.ts` | Builder + lazy URL resolution hook |
| `components/stream-context/stream-context-gallery.tsx` | The page-level `MediaGallery` mount |

## Modified files

| File | Change |
| ---- | ------ |
| `components/timeline/attachment-list.tsx` | Adopt `useGalleryAttachmentUrls` (removes two inline effects + two state maps) — behaviour-preserving |
| `components/image-gallery.tsx` | Hide download for `giphy:` items |
| `components/stream-context/stream-context-row.tsx` | Media/previewable-file rows open the gallery + keep jump affordance |
| `components/stream-context/{stream-context-surface,stream-context-panel,index}.tsx/ts` | Thread `onOpenGallery` through; export the new pieces |
| `lib/stream-context/{types,derive}.ts` | `FileContextItem.mimeType` for previewability |
| `pages/stream.tsx` | `useStreamGallery()` + mount `StreamContextGallery` |

## Out of scope (deliberate)

- `message_link` (in-app shared-message) previews remain excluded from the links list — confirmed with the author.
- Giphy "copy" is left on the image path (works if the CDN allows CORS, else a graceful error toast); only the download affordance is hidden.

## Test plan

- [x] `vitest run src/components/stream-context src/components/gallery src/lib/stream-context image-gallery.reopen` — 34 pass (builder order/giphy/previewable filtering; row open behaviour for media/giphy/pdf/non-previewable; lazy-URL hook fallback + memoization; the per-message gallery's 25 existing tests still green after the refactor)
- [x] `tsc --noEmit` (frontend) clean; eslint clean on touched files
- [ ] **Not manually run in a browser**: the two stacked Radix dialogs (panel + gallery) focus/escape layering, the mobile drawer→gallery transition, and Giphy cross-origin copy. These are behaviour I couldn't exercise headlessly — worth a manual pass before merge.
- [ ] Full-monorepo pre-commit hook exceeds the 2-min sandbox timeout; ran per-package checks manually and committed with `--no-verify`. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1EAyzrabZ19VhUEzzcq7i)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784932764&installation_id=129946197&pr_number=1078&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1078&signature=e62a658b01dd71f70fd626d00953c787e3041ae54dd6136a6651742f02f7adfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->