### PR TITLE
fix(link-previews): strip trailing markdown markers from extracted bare URLs

### DIFF
--- a/apps/backend/src/features/link-previews/url-utils.test.ts
+++ b/apps/backend/src/features/link-previews/url-utils.test.ts
@@ -124,10 +124,14 @@ describe("extractUrls", () => {
     expect(extractUrls(md)).toEqual(["https://github.com/threahq/threa/pull/1070"])
   })
 
-  test("strips trailing italic/strikethrough/code markers from a bare URL", () => {
-    expect(extractUrls("_see https://example.com/page_ now")).toEqual(["https://example.com/page"])
+  test("strips trailing strikethrough markers from a bare URL", () => {
     expect(extractUrls("~~see https://example.com/page~~ now")).toEqual(["https://example.com/page"])
-    expect(extractUrls("`see https://example.com/page` now")).toEqual(["https://example.com/page"])
+  })
+
+  test("preserves single trailing markers that are valid URL characters", () => {
+    expect(extractUrls("ref https://example.com/page_ here")).toEqual(["https://example.com/page_"])
+    expect(extractUrls("ref https://example.com/page~ here")).toEqual(["https://example.com/page~"])
+    expect(extractUrls("ref https://example.com/page* here")).toEqual(["https://example.com/page*"])
   })
 
   test("strips trailing emphasis markers around a parenthesized URL", () => {

--- a/apps/backend/src/features/link-previews/url-utils.test.ts
+++ b/apps/backend/src/features/link-previews/url-utils.test.ts
@@ -119,6 +119,22 @@ describe("extractUrls", () => {
     expect(extractUrls(md)).toEqual(["https://en.wikipedia.org/wiki/Foo_(bar_(baz))"])
   })
 
+  test("strips trailing bold markers from a bare URL inside emphasis", () => {
+    const md = "**PR: https://github.com/threahq/threa/pull/1070** — branch docs"
+    expect(extractUrls(md)).toEqual(["https://github.com/threahq/threa/pull/1070"])
+  })
+
+  test("strips trailing italic/strikethrough/code markers from a bare URL", () => {
+    expect(extractUrls("_see https://example.com/page_ now")).toEqual(["https://example.com/page"])
+    expect(extractUrls("~~see https://example.com/page~~ now")).toEqual(["https://example.com/page"])
+    expect(extractUrls("`see https://example.com/page` now")).toEqual(["https://example.com/page"])
+  })
+
+  test("strips trailing emphasis markers around a parenthesized URL", () => {
+    const md = "**ref https://en.wikipedia.org/wiki/Foo_(bar)** here"
+    expect(extractUrls(md)).toEqual(["https://en.wikipedia.org/wiki/Foo_(bar)"])
+  })
+
   test("deduplicates by normalized URL", () => {
     const md = "Check [link](https://example.com/page?utm_source=twitter) and https://example.com/page"
     expect(extractUrls(md)).toEqual(["https://example.com/page?utm_source=twitter"])

--- a/apps/backend/src/features/link-previews/url-utils.ts
+++ b/apps/backend/src/features/link-previews/url-utils.ts
@@ -276,12 +276,13 @@ function stripUnbalancedTrailingParens(url: string): string {
 }
 
 /**
- * Strip trailing markdown emphasis/code markers (`*`, `_`, `~`, `` ` ``) that the bare-URL
+ * Strip trailing doubled emphasis markers (`**` bold, `~~` strikethrough) that the bare-URL
  * match greedily swallowed when the URL sits inside emphasis, e.g. `**PR: https://…/1070**`.
- * The link mark href in the message is clean; only the serialized-markdown scan leaks these.
+ * Restricted to doubled runs: single `*`/`_`/`~`/backtick are valid URL characters (paths and
+ * anchors routinely end in `_`), so trimming them unconditionally would corrupt real links.
  */
 function stripTrailingMarkdownMarkers(url: string): string {
-  return url.replace(/[*_~`]+$/, "")
+  return url.replace(/(?:\*{2,}|~{2,})+$/, "")
 }
 
 const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "ico", "bmp", "avif"])

--- a/apps/backend/src/features/link-previews/url-utils.ts
+++ b/apps/backend/src/features/link-previews/url-utils.ts
@@ -225,9 +225,11 @@ export function extractUrls(markdown: string, appOrigins?: string[]): string[] {
     let url = (match[1] ?? match[2])?.trim()
     if (!url) continue
 
-    // For bare URLs (group 2), strip unbalanced trailing parentheses
+    // For bare URLs (group 2), trim trailing markdown that the greedy match swallowed.
+    // Emphasis markers strip first so a wrapped paren URL (`**…/Foo_(bar)**`) is balanced
+    // again before the paren pass runs.
     if (match[2]) {
-      url = stripUnbalancedTrailingParens(url)
+      url = stripUnbalancedTrailingParens(stripTrailingMarkdownMarkers(url))
     }
 
     // Skip non-http protocols and internal links
@@ -271,6 +273,15 @@ function stripUnbalancedTrailingParens(url: string): string {
     }
   }
   return url
+}
+
+/**
+ * Strip trailing markdown emphasis/code markers (`*`, `_`, `~`, `` ` ``) that the bare-URL
+ * match greedily swallowed when the URL sits inside emphasis, e.g. `**PR: https://…/1070**`.
+ * The link mark href in the message is clean; only the serialized-markdown scan leaks these.
+ */
+function stripTrailingMarkdownMarkers(url: string): string {
+  return url.replace(/[*_~`]+$/, "")
 }
 
 const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "svg", "ico", "bmp", "avif"])


### PR DESCRIPTION
## Problem

Links in the "In this stream" context panel (links/media drawer) were rendered with trailing markdown junk — e.g. `https://github.com/threahq/threa/pull/1070**` instead of `…/pull/1070`. The same link in the message body works fine, because the timeline reads the clean `href` from `contentJson`, not the markdown.

These panel entries are **server-side link previews**. The backend extracts URLs from the message's serialized markdown in `extractUrls` (`apps/backend/src/features/link-previews/url-utils.ts`). For a message like:

```
**PR: https://github.com/threahq/threa/pull/1070** — branch docs/recent-features
```

the bare-URL branch of the extraction regex (`(?:^|\s)(https?:\/\/[^\s<>"]+)`) matches after the space following `PR:`, then `[^\s<>"]+` greedily consumes up to the next whitespace — including the closing `**`. So the stored preview URL is `…/pull/1070**`. (The leading `**` does not break extraction here because the real `PR: ` text sits between it and the URL, giving the regex its whitespace boundary.)

## Solution

Trim trailing **doubled** markdown emphasis markers (`**` bold, `~~` strikethrough) off bare URLs before the existing unbalanced-paren pass, mirroring how `stripUnbalancedTrailingParens` already cleans sentence-trailing `)`.

### How it works

- New `stripTrailingMarkdownMarkers(url)` strips a trailing run of doubled emphasis markers via `replace(/(?:\*{2,}|~{2,})+$/, "")` — only `**`/`~~` (and longer runs like `***`), never single markers.
- Applied only inside the bare-URL branch (`if (match[2])`), so markdown-link URLs (`[text](url)`, group 1) are never touched — their parens-and-emphasis handling is already correct.
- Composed as `stripUnbalancedTrailingParens(stripTrailingMarkdownMarkers(url))`: emphasis strips first so a wrapped parenthesized URL (`**ref https://…/Foo_(bar)**`) re-balances its parens before the paren pass runs.

### Key design decisions

**1. Fix in `extractUrls`, not by switching the backend to `contentJson`.** The frontend's own bare-link path (`collectLinkUrls`) already reads the ProseMirror node tree and is immune (PR #1072). The backend preview pipeline (`LinkPreviewService.extractAndCreatePending` / `replacePreviewsForMessage`) only receives `contentMarkdown` on the wire; rewiring it to carry structured content is a larger change than this defect warrants. Cleaning the greedy match at the source is the minimal correct fix and matches the existing paren-trim precedent.

**2. Doubled markers only — leave single `*`/`_`/`~`/backtick intact.** Single emphasis characters are valid, common URL characters (trailing `_` appears in slugs and anchors), so trimming them unconditionally would silently truncate real links. Restricting to doubled runs (`**`, `~~`) — which never legitimately terminate a URL — fixes the reported bold-wrapped case without false positives. Single-marker italic/code wrapping of a bare URL still leaks its trailing marker; that's a rarer shape and not worth the truncation risk. (Narrowed in self-review + CodeRabbit review; see commit `34f8d9d`. The first version stripped `[*_~`]+$` unconditionally.)

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/link-previews/url-utils.ts` | Add `stripTrailingMarkdownMarkers` (doubled `**`/`~~` only); apply it before `stripUnbalancedTrailingParens` in the bare-URL branch of `extractUrls`. |
| `apps/backend/src/features/link-previews/url-utils.test.ts` | Cover the PR-1070 bold case, the `~~` strikethrough case, the paren-wrapped case, and a regression guard that single trailing `_`/`~`/`*` are preserved. |

## Out of scope (deliberate)

- **Existing stored previews** with trailing `**` are not backfilled — they're rows already written. Re-editing the message re-runs extraction (`replacePreviewsForMessage`) and corrects it; a one-off backfill would be a separate change if the historical rows matter.
- **Single-marker emphasis** (`*…*`, `_…_`, `` `…` ``) wrapping a bare URL still leaks the trailing marker — left alone deliberately to avoid truncating legitimate URLs (see decision 2).
- **Leading-marker cases** (e.g. `` `https://…` `` with the marker directly against the URL and no intervening text) never extract at all — the marker breaks the regex's leading whitespace boundary — so there's nothing to trim. Not a regression; just noting the boundary.

## Test plan

- [x] `bun test apps/backend/src/features/link-previews/url-utils.test.ts` — 77 pass
- [x] `bun test apps/backend/src/features/link-previews/` — 137 pass (full feature suite, pre-narrowing commit)
- [x] Pre-commit hook (full monorepo lint + `tsc --noEmit` + migration/dockerfile/openapi checks) — clean on both commits
- [x] CodeRabbit review: 1 finding (unconditional marker strip truncating `_`/`~`) — fixed by narrowing to doubled markers

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_