### PR TITLE
perf(composer): drop backdrop-blur on the mobile inline composer

### DIFF
--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -1026,11 +1026,16 @@ export function MessageComposer({
             data-composer-card
             className={cn(
               "rounded-[16px] border border-input flex flex-col flex-1 min-h-0",
-              // Glass effect for the floating inline composer so messages show
-              // through the bottom panel; keep the expanded fullscreen sheet opaque.
-              !mobileExpanded
-                ? "bg-card/75 backdrop-blur-md shadow-[inset_0_1px_0_hsl(33_28%_97%),0_8px_24px_-14px_hsl(28_30%_22%/0.18),0_2px_6px_-2px_hsl(28_30%_22%/0.06)] dark:shadow-[0_8px_24px_-14px_rgb(0_0_0/0.35),0_2px_6px_-2px_rgb(0_0_0/0.12)]"
-                : "bg-card",
+              // Floating-composer shadow on the inline (non-expanded) card; the
+              // expanded fullscreen sheet stays flat.
+              !mobileExpanded &&
+                "shadow-[inset_0_1px_0_hsl(33_28%_97%),0_8px_24px_-14px_hsl(28_30%_22%/0.18),0_2px_6px_-2px_hsl(28_30%_22%/0.06)] dark:shadow-[0_8px_24px_-14px_rgb(0_0_0/0.35),0_2px_6px_-2px_rgb(0_0_0/0.12)]",
+              // Glass (translucent + backdrop-blur) lets the timeline show through
+              // the floating composer, but backdrop-filter re-rasterizes the blurred
+              // backdrop on every repaint — cheap on desktop, a frame-killer on
+              // mobile over a long, image-heavy timeline while typing. Opaque on
+              // mobile; keep the glass on desktop where the GPU absorbs it.
+              !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card",
               // Compact padding when mobile-unfocused (single line), normal otherwise
               isMobile && !mobileChromeOpen ? "px-3 py-2" : "p-3 gap-2",
               // When mobile-expanded, let the editor grow and override its internal max-height


### PR DESCRIPTION
## Summary

Typing in the composer is sluggish on **mobile** in long, attachment-heavy DMs (e.g. a long chat with a frequent contact), while staying buttery-smooth on desktop and in small/light chats. This is the first, cheapest experiment from a composer long-chat performance audit.

The inline (non-expanded) composer card painted with `bg-card/75 backdrop-blur-md` so the timeline shows through it. `backdrop-filter: blur()` forces the browser to re-sample and Gaussian-blur the pixels **behind** the element on every repaint of the composer — caret blink, each inserted glyph. On a desktop GPU that's effectively free; on a mobile GPU, over a long image/attachment-heavy timeline, it re-rasterizes an expensive backdrop region on every keystroke and drops frames.

This fits all three observed signals exactly:
- **mobile-only** — backdrop blur is cheap on desktop GPUs, a frame-killer on mobile
- **scales with content behind it** — a long chat full of images/attachments is an expensive backdrop to blur; light chats are cheap
- **fires continuously while typing** — every repaint re-rasterizes the blur

## Change

Keep the glass look on desktop (where the GPU absorbs it); go opaque (`bg-card`) on mobile. The floating-composer shadow is preserved in both cases — only the translucency + blur are dropped on mobile. The expanded fullscreen sheet was already opaque and is unchanged.

```
- !mobileExpanded
-   ? "bg-card/75 backdrop-blur-md shadow-[…]"
-   : "bg-card"
+ !mobileExpanded && "shadow-[…]"            // floating shadow, both surfaces
+ !mobileExpanded && !isMobile ? "bg-card/75 backdrop-blur-md" : "bg-card"
```

## Design decisions

- **Gated on `isMobile` (JS), not a `sm:` CSS breakpoint** — the cost is the device GPU, not viewport width; this matches the existing `isMobile` branching already in the same `cn()` call.
- **Shadow preserved on mobile** — the floating-pill look stays; only the GPU-expensive translucency/blur is removed.
- **One file, fully reversible** — deliberately scoped as an experiment so it can be confirmed or reverted against real production volume.

## Why a PR (not a direct push / staging test)

Staging data isn't large enough to reproduce a "big chat" slowdown, and the reproducing chat is real production data. This PR is sized to merge → auto-deploy → test on device against the actual heavy chat, and trivially revert if it doesn't move the needle.

## Status of the diagnosis

This is a **strong, well-fitted hypothesis, not a measured fact** — GPU raster/compositing cost can't be confirmed by reading source. Merging this is itself the decisive yes/no test: if mobile typing in the heavy chat smooths out, the blur was the dominant cost. If it doesn't, this rules it out cleanly and the audit moves to the next candidates (composer-resize → Virtua re-measure storm; sidebar re-render on every debounced draft save; decrypted-attachment memory pressure / GC).

## Verification

- `apps/frontend` typecheck: clean
- `message-composer.test.tsx`: 24/24 pass
- eslint on the changed file: clean

## Test plan (on device)

1. Open the long, attachment-heavy DM on mobile.
2. Type a few sentences; confirm input keeps up with the keyboard.
3. Compare against a small/light chat (should be unchanged) and desktop (glass look unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwpKuN2t8sHgzRWLBBh1No

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwpKuN2t8sHgzRWLBBh1No)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784979998&installation_id=129946197&pr_number=1082&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1082&signature=815c4968da9b9b08cd3412396772a18fa01801e1154d2e4553ee97fa58c58e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->