### PR TITLE
fix(memos): give memorizer real message ids so memos cite the right messages

### DIFF
--- a/apps/backend/src/features/memos/memorizer.test.ts
+++ b/apps/backend/src/features/memos/memorizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { getMemorizerSystemPrompt, memoSetSchema, MEMO_MAX_PER_CONVERSATION } from "./config"
+import { resolveSourceMessageIds } from "./memorizer"
 
 describe("getMemorizerSystemPrompt", () => {
   it("should inject current date in YYYY-MM-DD format for UTC", () => {
@@ -84,5 +85,31 @@ describe("memoSetSchema", () => {
   it("rejects an unknown knowledge type", () => {
     const result = memoSetSchema.safeParse({ memos: [{ ...validMemo, knowledgeType: "gossip" }] })
     expect(result.success).toBe(false)
+  })
+})
+
+describe("resolveSourceMessageIds", () => {
+  const messages = [
+    { id: "msg_1", createdAt: new Date("2024-01-01T10:00:00Z") },
+    { id: "msg_2", createdAt: new Date("2024-01-01T10:05:00Z") },
+    { id: "msg_3", createdAt: new Date("2024-01-01T10:02:00Z") },
+  ]
+
+  it("keeps only the cited ids that were actually shown to the model", () => {
+    expect(resolveSourceMessageIds(["msg_1", "msg_3"], messages)).toEqual(["msg_1", "msg_3"])
+  })
+
+  it("drops invented ids the model never saw", () => {
+    expect(resolveSourceMessageIds(["msg_2", "msg_hallucinated"], messages)).toEqual(["msg_2"])
+  })
+
+  it("anchors to the single most-recent message (not the whole conversation) when nothing valid is cited", () => {
+    // msg_2 is newest by createdAt even though it isn't last in array order.
+    expect(resolveSourceMessageIds(["msg_nope"], messages)).toEqual(["msg_2"])
+    expect(resolveSourceMessageIds([], messages)).toEqual(["msg_2"])
+  })
+
+  it("returns no anchor when there are no messages", () => {
+    expect(resolveSourceMessageIds(["whatever"], [])).toEqual([])
   })
 })

--- a/apps/backend/src/features/memos/memorizer.ts
+++ b/apps/backend/src/features/memos/memorizer.ts
@@ -13,6 +13,23 @@ import {
   MEMORIZER_EXISTING_TAGS_TEMPLATE,
 } from "./config"
 
+/**
+ * Resolve the model's cited source messages against the messages it was actually
+ * shown. Invented ids are dropped. If nothing valid remains, anchor to the single
+ * most-recent message (by createdAt) rather than the whole conversation: a memo
+ * smeared across every message mis-attributes one topic to an entire multi-topic
+ * exchange, which is the wrong-attribution footgun this guards. `messages` order
+ * is not guaranteed chronological (findByIds returns a Map), so pick by timestamp.
+ */
+export function resolveSourceMessageIds(citedIds: string[], messages: Pick<Message, "id" | "createdAt">[]): string[] {
+  const present = new Set(messages.map((m) => m.id))
+  const valid = citedIds.filter((id) => present.has(id))
+  if (valid.length > 0) return valid
+  if (messages.length === 0) return []
+  const mostRecent = messages.reduce((a, b) => (b.createdAt > a.createdAt ? b : a))
+  return [mostRecent.id]
+}
+
 /** A single single-topic memo whose abstract is self-contained and can stand alone (GAM paper). */
 export interface MemoContent {
   title: string
@@ -107,17 +124,14 @@ export class Memorizer {
       context: { workspaceId: context.workspaceId, origin: "system" },
     })
 
-    return value.memos.map((memo) => {
-      const validSourceIds = memo.sourceMessageIds.filter((id) => messages.some((m) => m.id === id))
-      return {
-        title: memo.title,
-        abstract: memo.abstract,
-        knowledgeType: memo.knowledgeType,
-        keyPoints: memo.keyPoints,
-        tags: memo.tags,
-        sourceMessageIds: validSourceIds.length > 0 ? validSourceIds : messages.map((m) => m.id),
-      }
-    })
+    return value.memos.map((memo) => ({
+      title: memo.title,
+      abstract: memo.abstract,
+      knowledgeType: memo.knowledgeType,
+      keyPoints: memo.keyPoints,
+      tags: memo.tags,
+      sourceMessageIds: resolveSourceMessageIds(memo.sourceMessageIds, messages),
+    }))
   }
 
   private formatMemoryContext(context: MemorizerContext): string {

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -161,12 +161,17 @@ export class MemoService implements MemoServiceLike {
       }
 
       // Pre-format all messages while we have database access (INV-41)
-      // Formatting requires resolving author names from the database
+      // Formatting requires resolving author names from the database.
+      // includeIds: the memorizer and suggestion collector must cite source
+      // message ids; without ids in the prompt the model can't reference them and
+      // every memo falls back to the whole conversation (mis-attribution).
       const formattedConversations = new Map<string, string>()
       for (const [convId, msgs] of conversationMessages) {
         const messagesArray = Array.from(msgs.values()).filter((m): m is Message => m !== null)
         if (messagesArray.length > 0) {
-          const formatted = await this.messageFormatter.formatMessages(client, workspaceId, messagesArray)
+          const formatted = await this.messageFormatter.formatMessages(client, workspaceId, messagesArray, {
+            includeIds: true,
+          })
           formattedConversations.set(convId, formatted)
         }
       }

--- a/apps/backend/src/lib/ai/message-formatter.test.ts
+++ b/apps/backend/src/lib/ai/message-formatter.test.ts
@@ -231,6 +231,24 @@ describe("MessageFormatter", () => {
     expect(result).not.toContain('authorName="Bob "The Builder" Smith"')
   })
 
+  test("omits message ids by default", async () => {
+    const messages = [createMessage({ id: "msg_1", authorId: "usr_123", authorType: "user", contentMarkdown: "Hi" })]
+    mockFindUsersByIds.mockResolvedValue([{ id: "usr_123", name: "Alice" }])
+
+    const result = await formatter.formatMessages(mockClient, "ws_test", messages)
+
+    expect(result).not.toContain("id=")
+  })
+
+  test("includes message ids when includeIds is set (so the model can cite sources)", async () => {
+    const messages = [createMessage({ id: "msg_1", authorId: "usr_123", authorType: "user", contentMarkdown: "Hi" })]
+    mockFindUsersByIds.mockResolvedValue([{ id: "usr_123", name: "Alice" }])
+
+    const result = await formatter.formatMessages(mockClient, "ws_test", messages, { includeIds: true })
+
+    expect(result).toContain('<message id="msg_1" authorType="user"')
+  })
+
   describe("formatMessagesInline", () => {
     test("should return empty string for empty message list", async () => {
       const result = await formatter.formatMessagesInline(mockClient, "ws_test", [])

--- a/apps/backend/src/lib/ai/message-formatter.ts
+++ b/apps/backend/src/lib/ai/message-formatter.ts
@@ -20,19 +20,33 @@ export class MessageFormatter {
    * Format messages with author names resolved from the database.
    * Batch-fetches all unique author IDs to minimize queries (2 max: users + personas).
    *
+   * @param options.includeIds - Prefix each message with its `id` attribute, so
+   *   a model asked to cite source messages (memorizer, suggestion collector) has
+   *   real ids to return. Off by default — callers that don't cite stay unchanged.
+   *
    * @example
    * const formatted = await messageFormatter.formatMessages(client, messages)
    * // <messages>
    * // <message authorType="user" authorId="user_123" authorName="Alice" createdAt="2021-01-01T00:00:00Z">Hello!</message>
    * // <message authorType="persona" authorId="persona_456" authorName="Ariadne" createdAt="2021-01-01T00:00:01Z">Hi there!</message>
    * // </messages>
+   *
+   * @example
+   * // With ids (memorizer / suggestion collector)
+   * const formatted = await messageFormatter.formatMessages(client, ws, messages, { includeIds: true })
+   * // <message id="msg_123" authorType="user" authorId="user_123" authorName="Alice" createdAt="...">Hello!</message>
    */
-  async formatMessages(client: Querier, workspaceId: string, messages: Message[]): Promise<string> {
+  async formatMessages(
+    client: Querier,
+    workspaceId: string,
+    messages: Message[],
+    options?: { includeIds?: boolean }
+  ): Promise<string> {
     if (messages.length === 0) return "<messages></messages>"
 
     const nameById = await this.resolveAuthorNames(client, workspaceId, messages)
 
-    const formatted = messages.map((m) => this.formatSingleMessage(m, nameById))
+    const formatted = messages.map((m) => this.formatSingleMessage(m, nameById, options?.includeIds ?? false))
 
     return `<messages>\n${formatted.join("\n")}\n</messages>`
   }
@@ -66,9 +80,10 @@ export class MessageFormatter {
     return nameById
   }
 
-  private formatSingleMessage(m: Message, nameById: Map<string, string>): string {
+  private formatSingleMessage(m: Message, nameById: Map<string, string>, includeIds: boolean): string {
     const authorName = nameById.get(m.authorId) ?? "Unknown"
-    return `<message authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(authorName)}" createdAt="${m.createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
+    const idAttr = includeIds ? `id="${m.id}" ` : ""
+    return `<message ${idAttr}authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(authorName)}" createdAt="${m.createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
   }
 
   /**

--- a/apps/backend/src/lib/ai/message-formatter.ts
+++ b/apps/backend/src/lib/ai/message-formatter.ts
@@ -25,7 +25,7 @@ export class MessageFormatter {
    *   real ids to return. Off by default — callers that don't cite stay unchanged.
    *
    * @example
-   * const formatted = await messageFormatter.formatMessages(client, messages)
+   * const formatted = await messageFormatter.formatMessages(client, workspaceId, messages)
    * // <messages>
    * // <message authorType="user" authorId="user_123" authorName="Alice" createdAt="2021-01-01T00:00:00Z">Hello!</message>
    * // <message authorType="persona" authorId="persona_456" authorName="Ariadne" createdAt="2021-01-01T00:00:01Z">Hi there!</message>


### PR DESCRIPTION
## Problem

Every GAM memo was being attributed to **all** of its conversation's messages instead of the few it actually drew from. In one real workspace, the memo "Kristoffer är väldigt sugen på semester" and the unrelated memo "Stream description … Topic i Slack" both cited the *identical* 43 of 49 messages — two distinct topics pointing at the same near-complete blob. The `?memo=` deep-link and the `memos:captured` provenance (INV-62) therefore pointed at the whole exchange rather than the source.

Root cause: the memo pipeline pre-formats conversation messages in `MemoService.processBatch` with `MessageFormatter.formatMessages`, the XML variant that emits `authorId`/`createdAt` but **no message `id`**. The memorizer prompt asks the model to "set sourceMessageIds to only the messages that topic draws from," but the model was never shown any ids. Whatever it returned failed the validation filter in `Memorizer.generateMemoSet` (`messages.some((m) => m.id === id)`), so `validSourceIds` was always empty and the fallback `messages.map((m) => m.id)` attributed the memo to every message. The same id-less string is handed to the saved-suggestion collector, whose schema requires `sourceMessageIds` (`.min(1)`), so it had the same blind spot.

`MessageFormatter` already documents a `formatMessagesInline(..., { includeIds: true })` "(for memorizer)" path — the intent was there; the memo pipeline just wired up the id-less method.

## Solution

Give the model real message ids in the prompt, and stop the fallback from smearing a memo across the whole conversation when it cites nothing valid.

### How it works

1. `formatMessages` gains an opt-in `{ includeIds }` (default `false`, mirroring `formatMessagesInline`'s existing flag). When set, each row renders as `<message id="msg_…" authorType="…" …>`. Default-off means the one production caller is the only behavior change — no other `formatMessages` consumer exists (`formatMessagesWithAttachments` powers `naming-service`, untouched).
2. `MemoService.processBatch` formats with `{ includeIds: true }`, so the same string fed to the classifier, the saved-suggestion collector, and the memorizer now carries ids. The classifier ignores them; the memorizer and collector can finally cite.
3. `Memorizer` extracts the id resolution into a pure, exported `resolveSourceMessageIds(citedIds, messages)`: keep cited ids that were actually shown, drop invented ones, and when nothing valid remains anchor to the **single most-recent message** by `createdAt` rather than the entire conversation.

## Key design decisions

**1. Opt-in `includeIds`, not always-on** — `formatMessages` is generic. Defaulting ids on would change every hypothetical future caller and churn the classifier's prompt for no reason. Off-by-default keeps the blast radius to the one call site that needs it, matching the existing `formatMessagesInline` shape.

**2. Anchor to the newest message, not all and not empty** — when the model still cites nothing valid, attributing to all messages is exactly the bug (one topic claims the whole exchange); empty would leave the memo with no provenance and break the `?memo=` deep-link. A single most-recent anchor keeps provenance functional and never over-claims. It's picked by `createdAt` because `MessageRepository.findByIds` returns a `Map` with no ordering guarantee, so array position is not reliably chronological.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/ai/message-formatter.ts` | `formatMessages` + `formatSingleMessage` take opt-in `{ includeIds }`; renders `id="…"` when set |
| `apps/backend/src/features/memos/service.ts` | Pre-format memo-batch messages with `{ includeIds: true }`; load-bearing comment on why |
| `apps/backend/src/features/memos/memorizer.ts` | New exported `resolveSourceMessageIds`; fallback anchors to newest message instead of all |
| `apps/backend/src/lib/ai/message-formatter.test.ts` | `includeIds` on/off coverage |
| `apps/backend/src/features/memos/memorizer.test.ts` | `resolveSourceMessageIds`: keeps valid, drops invented, anchors to newest, no-op on empty |

## Out of scope (deliberate)

- **Existing rows are not backfilled.** The ~30 memos already stored keep their smeared `sourceMessageIds`; this fixes attribution going forward. A repair pass (re-extract or clear the bad arrays) is a separate follow-up.
- **Whether transient lines like "ready for vacation" should be memos at all** — that's the trigger-happy / pseudo-memo question (raise the memorizer's bar, add a per-memo durability floor like saved-suggestions' `SUGGESTION_CONFIDENCE_FLOOR`). Independent of attribution; not touched here.
- **No temporal weighting in boundary extraction.** Considered and rejected for this line of work: conversations legitimately span red days, weekends, and a two-week vacation and are still one conversation; strong recency weighting would fragment exactly that case.

## Test plan

- [x] Backend `bun test src/lib/ai/message-formatter.test.ts src/features/memos/memorizer.test.ts` — 37 pass
- [x] Backend `bun test src/features/memos src/features/saved-suggestions` — 62 pass
- [x] `bunx tsc --noEmit -p apps/backend/tsconfig.json` — clean
- [x] Full pre-commit hook (lint + monorepo typecheck + api-doc check) — clean
- [ ] No live-DB harness for the memo batch worker, so the `includeIds` wiring is exercised via the formatter/memorizer unit tests rather than an end-to-end extraction run

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011dXF3DuvwcXJoYvtwXvukd)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784985745&installation_id=129946197&pr_number=1083&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1083&signature=1c32d2568cd3459aede7a8bd6e2050af006ed8fa05069b8d5b3623d76f487d73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->