### PR TITLE
feat(labels): label messages and surface them on the label page

### DIFF
--- a/apps/backend/src/features/labels/assignment-service.test.ts
+++ b/apps/backend/src/features/labels/assignment-service.test.ts
@@ -5,6 +5,7 @@ import { LabelAssignmentService } from "./assignment-service"
 import { LabelService } from "./service"
 import { LabelRepository, LabelAssignmentRepository } from "./repository"
 import { OutboxRepository } from "../../lib/outbox"
+import { MessageRepository } from "../messaging"
 import * as streamsBarrel from "../streams"
 import * as dbModule from "../../db"
 
@@ -143,6 +144,62 @@ describe("LabelAssignmentService.assign", () => {
     expect(getAccessibleStreamIdsForBot).not.toHaveBeenCalled()
     expect(assignSpy).not.toHaveBeenCalled()
     expect(outboxSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("LabelAssignmentService.assign — message resource", () => {
+  afterEach(() => mock.restore())
+
+  const messageAssignParams = {
+    workspaceId: WORKSPACE_ID,
+    actor: USER_ACTOR,
+    labelId: LABEL_ID,
+    resourceType: LabelableResourceTypes.MESSAGE,
+    resourceId: "msg_1",
+  }
+
+  it("labels a message gated by the message's owning stream", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findById").mockResolvedValue(fakeLabel())
+    spyOn(MessageRepository, "findStreamIdsByIds").mockResolvedValue(new Map([["msg_1", "stream_9"]]))
+    const access = spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set(["stream_9"]))
+    spyOn(LabelAssignmentRepository, "assign").mockResolvedValue(
+      fakeAssignment({ resourceType: LabelableResourceTypes.MESSAGE, resourceId: "msg_1" })
+    )
+    const outboxSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.assign(messageAssignParams)
+
+    expect(result).toMatchObject({ resourceType: LabelableResourceTypes.MESSAGE, resourceId: "msg_1" })
+    // The message inherits its stream's access — the gate resolves the stream id
+    // and reuses the stream-access predicate, not a message-specific one.
+    expect(access).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, USER_ID, ["stream_9"])
+    expect(outboxSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      "label:assigned",
+      expect.objectContaining({ targetUserId: USER_ID })
+    )
+  })
+
+  it("throws 404 when the message does not exist", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findById").mockResolvedValue(fakeLabel())
+    spyOn(MessageRepository, "findStreamIdsByIds").mockResolvedValue(new Map())
+    const assignSpy = spyOn(LabelAssignmentRepository, "assign")
+
+    await expect(service.assign(messageAssignParams)).rejects.toMatchObject({ status: 404 })
+    expect(assignSpy).not.toHaveBeenCalled()
+  })
+
+  it("throws 404 when the message's stream is unreachable", async () => {
+    const service = setupService()
+    spyOn(LabelRepository, "findById").mockResolvedValue(fakeLabel())
+    spyOn(MessageRepository, "findStreamIdsByIds").mockResolvedValue(new Map([["msg_1", "stream_9"]]))
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set())
+    const assignSpy = spyOn(LabelAssignmentRepository, "assign")
+
+    await expect(service.assign(messageAssignParams)).rejects.toMatchObject({ status: 404 })
+    expect(assignSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/labels/assignment-service.ts
+++ b/apps/backend/src/features/labels/assignment-service.ts
@@ -12,6 +12,7 @@ import { withTransaction } from "../../db"
 import { HttpError } from "../../lib/errors"
 import { OutboxRepository } from "../../lib/outbox"
 import { listAccessibleStreamIds } from "../streams"
+import { MessageRepository } from "../messaging"
 import type { BotChannelService } from "../api-keys"
 import { LabelRepository, LabelAssignmentRepository } from "./repository"
 import type { LabelService, UpsertLabelByNameParams } from "./service"
@@ -192,10 +193,12 @@ export class LabelAssignmentService {
 
   /**
    * A member may only label a resource they can reach. Mirrors listForViewer's
-   * access model on the write path. Stream is the only labelable resource type
-   * today; an unreachable stream — or any resource type without an access rule
-   * yet — is reported as not-found rather than leaking whether it exists.
-   * Unassign is intentionally not gated: it only removes the caller's own row.
+   * access model on the write path. Each labelable resource type resolves to a
+   * stream and gates on the actor's reachability of it (a message inherits its
+   * stream's access, threads inherit their root — INV-62); a resource type
+   * without an access rule yet, or an unreachable one, is reported as not-found
+   * rather than leaking whether it exists. Unassign is intentionally not gated:
+   * it only removes the caller's own row.
    */
   private async assertResourceAccess(
     client: PoolClient,
@@ -206,8 +209,26 @@ export class LabelAssignmentService {
   ): Promise<void> {
     if (resourceType === LabelableResourceTypes.STREAM) {
       if (await this.canReachStream(client, actor, workspaceId, resourceId)) return
+    } else if (resourceType === LabelableResourceTypes.MESSAGE) {
+      if (await this.canReachMessage(client, actor, workspaceId, resourceId)) return
     }
     throw new HttpError("Resource not found", { status: 404, code: "RESOURCE_NOT_FOUND" })
+  }
+
+  /**
+   * A message is reachable when its owning stream is — labeling a message is
+   * gated by stream access (thread→root inheritance and public-channel reads
+   * resolve inside {@link canReachStream}).
+   */
+  private async canReachMessage(
+    client: PoolClient,
+    actor: LabelActor,
+    workspaceId: string,
+    messageId: string
+  ): Promise<boolean> {
+    const streamId = (await MessageRepository.findStreamIdsByIds(client, [messageId])).get(messageId)
+    if (!streamId) return false
+    return this.canReachStream(client, actor, workspaceId, streamId)
   }
 
   private async canReachStream(

--- a/apps/backend/src/features/labels/handlers.ts
+++ b/apps/backend/src/features/labels/handlers.ts
@@ -4,6 +4,7 @@ import { LABELABLE_RESOURCE_TYPES, LabelActorTypes } from "@threa/types"
 import { HttpError } from "../../lib/errors"
 import type { LabelService } from "./service"
 import type { LabelAssignmentService } from "./assignment-service"
+import type { LabelMessageService } from "./label-message-service"
 
 const COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/
 
@@ -34,9 +35,10 @@ const updateSchema = z
 interface Dependencies {
   labelService: LabelService
   labelAssignmentService: LabelAssignmentService
+  labelMessageService: LabelMessageService
 }
 
-export function createLabelHandlers({ labelService, labelAssignmentService }: Dependencies) {
+export function createLabelHandlers({ labelService, labelAssignmentService, labelMessageService }: Dependencies) {
   return {
     async list(req: Request, res: Response) {
       const userId = req.user!.id
@@ -46,6 +48,19 @@ export function createLabelHandlers({ labelService, labelAssignmentService }: De
         labelAssignmentService.listForViewer(workspaceId, { type: LabelActorTypes.USER, id: userId }),
       ])
       res.json({ labels, assignments })
+    },
+
+    /** Messages the viewer has filed under a label, hydrated for the label page. */
+    async listMessages(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const labelId = req.params.labelId!
+      const messages = await labelMessageService.listLabeledMessages(
+        workspaceId,
+        { type: LabelActorTypes.USER, id: userId },
+        labelId
+      )
+      res.json({ messages })
     },
 
     async create(req: Request, res: Response) {

--- a/apps/backend/src/features/labels/index.ts
+++ b/apps/backend/src/features/labels/index.ts
@@ -7,4 +7,6 @@ export type { CreateLabelParams, UpsertLabelByNameParams } from "./service"
 export { LabelAssignmentService } from "./assignment-service"
 export type { AssignLabelParams, AssignLabelByNameParams } from "./assignment-service"
 
+export { LabelMessageService } from "./label-message-service"
+
 export { createLabelHandlers } from "./handlers"

--- a/apps/backend/src/features/labels/label-message-service.test.ts
+++ b/apps/backend/src/features/labels/label-message-service.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { LabelActorTypes, LabelableResourceTypes, type LabelAssignment } from "@threa/types"
+import { LabelMessageService } from "./label-message-service"
+import { LabelAssignmentRepository } from "./repository"
+import { MessageRepository, type Message } from "../messaging"
+import { AttachmentRepository } from "../attachments"
+import { LinkPreviewRepository } from "../link-previews"
+import * as streamsBarrel from "../streams"
+
+const WORKSPACE_ID = "ws_1"
+const USER_ID = "usr_1"
+const USER_ACTOR = { type: LabelActorTypes.USER, id: USER_ID } as const
+const LABEL_ID = "label_1"
+const CREATED_AT = "2026-05-28T12:00:00.000Z"
+
+function messageAssignment(resourceId: string): LabelAssignment {
+  return {
+    labelId: LABEL_ID,
+    resourceType: LabelableResourceTypes.MESSAGE,
+    resourceId,
+    actorType: LabelActorTypes.USER,
+    userId: USER_ID,
+    workspaceId: WORKSPACE_ID,
+    assignedAt: CREATED_AT,
+  }
+}
+
+function fakeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg_1",
+    streamId: "stream_a",
+    sequence: 1n,
+    authorId: USER_ID,
+    authorType: "user",
+    contentJson: { type: "doc", content: [] } as unknown as Message["contentJson"],
+    contentMarkdown: "hello",
+    replyCount: 0,
+    clientMessageId: null,
+    sentVia: null,
+    reactions: {},
+    metadata: {},
+    editedAt: null,
+    deletedAt: null,
+    createdAt: new Date(CREATED_AT),
+    ciphertext: null,
+    envelope: null,
+    e2eVersion: null,
+    ...overrides,
+  }
+}
+
+function setupService() {
+  return new LabelMessageService({ pool: {} as any, botChannelService: {} as any })
+}
+
+describe("LabelMessageService.listLabeledMessages", () => {
+  afterEach(() => mock.restore())
+
+  it("returns the actor's labeled messages in stowed order, hydrated with stream + content", async () => {
+    const service = setupService()
+    spyOn(LabelAssignmentRepository, "listForLabelAndResourceType").mockResolvedValue([
+      messageAssignment("msg_2"),
+      messageAssignment("msg_1"),
+    ])
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        ["msg_1", fakeMessage({ id: "msg_1", streamId: "stream_a", contentMarkdown: "first" })],
+        ["msg_2", fakeMessage({ id: "msg_2", streamId: "stream_b", contentMarkdown: "second" })],
+      ])
+    )
+    const access = spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set(["stream_a", "stream_b"]))
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    const result = await service.listLabeledMessages(WORKSPACE_ID, USER_ACTOR, LABEL_ID)
+
+    // Order follows the assignment list (newest stowed first), not message ids.
+    expect(result.map((m) => m.id)).toEqual(["msg_2", "msg_1"])
+    expect(result[0]).toEqual({
+      id: "msg_2",
+      streamId: "stream_b",
+      authorId: USER_ID,
+      authorType: "user",
+      contentMarkdown: "second",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: CREATED_AT,
+    })
+    expect(access).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, USER_ID, ["stream_b", "stream_a"])
+  })
+
+  it("drops a message deleted after it was labeled", async () => {
+    const service = setupService()
+    spyOn(LabelAssignmentRepository, "listForLabelAndResourceType").mockResolvedValue([
+      messageAssignment("msg_1"),
+      messageAssignment("msg_2"),
+    ])
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        ["msg_1", fakeMessage({ id: "msg_1", deletedAt: new Date(CREATED_AT) })],
+        ["msg_2", fakeMessage({ id: "msg_2" })],
+      ])
+    )
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set(["stream_a"]))
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    const result = await service.listLabeledMessages(WORKSPACE_ID, USER_ACTOR, LABEL_ID)
+
+    expect(result.map((m) => m.id)).toEqual(["msg_2"])
+  })
+
+  it("drops a labeled message whose stream the viewer can no longer reach", async () => {
+    const service = setupService()
+    spyOn(LabelAssignmentRepository, "listForLabelAndResourceType").mockResolvedValue([
+      messageAssignment("msg_1"),
+      messageAssignment("msg_2"),
+    ])
+    spyOn(MessageRepository, "findByIds").mockResolvedValue(
+      new Map([
+        ["msg_1", fakeMessage({ id: "msg_1", streamId: "stream_a" })],
+        ["msg_2", fakeMessage({ id: "msg_2", streamId: "stream_private" })],
+      ])
+    )
+    spyOn(streamsBarrel, "listAccessibleStreamIds").mockResolvedValue(new Set(["stream_a"]))
+    spyOn(AttachmentRepository, "findByMessageIds").mockResolvedValue(new Map())
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(new Map())
+
+    const result = await service.listLabeledMessages(WORKSPACE_ID, USER_ACTOR, LABEL_ID)
+
+    expect(result.map((m) => m.id)).toEqual(["msg_1"])
+  })
+
+  it("returns [] without fetching messages when nothing is filed under the label", async () => {
+    const service = setupService()
+    spyOn(LabelAssignmentRepository, "listForLabelAndResourceType").mockResolvedValue([])
+    const findByIds = spyOn(MessageRepository, "findByIds")
+
+    const result = await service.listLabeledMessages(WORKSPACE_ID, USER_ACTOR, LABEL_ID)
+
+    expect(result).toEqual([])
+    expect(findByIds).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/labels/label-message-service.ts
+++ b/apps/backend/src/features/labels/label-message-service.ts
@@ -1,0 +1,106 @@
+import type { Pool } from "pg"
+import {
+  LabelActorTypes,
+  LabelableResourceTypes,
+  type AttachmentSummary,
+  type LabelActor,
+  type LabeledMessage,
+  type LinkPreviewSummary,
+} from "@threa/types"
+import { MessageRepository, type Message } from "../messaging"
+import { AttachmentRepository, toAttachmentSummary } from "../attachments"
+import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
+import { listAccessibleStreamIds } from "../streams"
+import type { BotChannelService } from "../api-keys"
+import { LabelAssignmentRepository } from "./repository"
+
+interface LabelMessageServiceDeps {
+  pool: Pool
+  botChannelService: BotChannelService
+}
+
+/**
+ * Reads the messages an actor has filed under a label, hydrated for the label
+ * landing page's Messages section. Labeled messages span streams, so each row
+ * carries its own `streamId` (to render context + open in place). The read is
+ * re-gated on stream access: a message the actor can no longer reach is dropped,
+ * even though their owner-scoped assignment row still exists.
+ */
+export class LabelMessageService {
+  private readonly pool: Pool
+  private readonly botChannelService: BotChannelService
+
+  constructor(deps: LabelMessageServiceDeps) {
+    this.pool = deps.pool
+    this.botChannelService = deps.botChannelService
+  }
+
+  async listLabeledMessages(workspaceId: string, actor: LabelActor, labelId: string): Promise<LabeledMessage[]> {
+    const assignments = await LabelAssignmentRepository.listForLabelAndResourceType(this.pool, {
+      workspaceId,
+      actorId: actor.id,
+      labelId,
+      resourceType: LabelableResourceTypes.MESSAGE,
+    })
+    const messageIds = assignments.map((a) => a.resourceId)
+    if (messageIds.length === 0) return []
+
+    const byId = await MessageRepository.findByIds(this.pool, messageIds)
+    // Preserve the newest-stowed-first order of the assignments; drop ids that
+    // resolved to nothing and messages deleted after they were labeled.
+    const ordered = messageIds.map((id) => byId.get(id)).filter((m): m is Message => Boolean(m) && !m!.deletedAt)
+    if (ordered.length === 0) return []
+
+    // Re-check reachability: access can change after labeling, and a message
+    // inherits its stream's access (thread→root resolves in the shared helper).
+    const streamIds = [...new Set(ordered.map((m) => m.streamId))]
+    const accessible = await this.accessibleStreamIds(workspaceId, actor, streamIds)
+    const visible = ordered.filter((m) => accessible.has(m.streamId))
+    if (visible.length === 0) return []
+
+    const ids = visible.map((m) => m.id)
+    const [attachmentsByMessage, linkPreviewsByMessage] = await Promise.all([
+      AttachmentRepository.findByMessageIds(this.pool, ids),
+      LinkPreviewRepository.findByMessageIds(this.pool, workspaceId, ids),
+    ])
+
+    return visible.map((message) => {
+      const attachments = (attachmentsByMessage.get(message.id) ?? []).map(toAttachmentSummary)
+      const linkPreviews = (linkPreviewsByMessage.get(message.id) ?? [])
+        .filter((p) => p.status === "completed")
+        .map((p, i) => toLinkPreviewSummary(p, i))
+      return toLabeledMessage(message, attachments, linkPreviews)
+    })
+  }
+
+  private async accessibleStreamIds(
+    workspaceId: string,
+    actor: LabelActor,
+    candidateIds: string[]
+  ): Promise<Set<string>> {
+    if (actor.type === LabelActorTypes.BOT) {
+      const granted = new Set(await this.botChannelService.getAccessibleStreamIdsForBot(workspaceId, actor.id))
+      return new Set(candidateIds.filter((id) => granted.has(id)))
+    }
+    return listAccessibleStreamIds(this.pool, workspaceId, actor.id, candidateIds)
+  }
+}
+
+/** Project a hydrated message down to the label-view rendering shape. */
+function toLabeledMessage(
+  message: Message,
+  attachments: AttachmentSummary[],
+  linkPreviews: LinkPreviewSummary[]
+): LabeledMessage {
+  return {
+    id: message.id,
+    streamId: message.streamId,
+    authorId: message.authorId,
+    authorType: message.authorType,
+    contentMarkdown: message.contentMarkdown,
+    reactions: message.reactions,
+    attachments,
+    linkPreviews,
+    createdAt: message.createdAt.toISOString(),
+  }
+}

--- a/apps/backend/src/features/labels/repository.ts
+++ b/apps/backend/src/features/labels/repository.ts
@@ -322,6 +322,34 @@ export const LabelAssignmentRepository = {
   },
 
   /**
+   * The actor's assignments of one label to one resource type, newest-stowed
+   * first. Backs the label landing page's per-type sections (e.g. its Messages
+   * list); ordering by `assigned_at DESC` surfaces the most recently filed item
+   * on top. Owner-scoped + archived-label filtered, like {@link listForActor}.
+   */
+  async listForLabelAndResourceType(
+    db: Querier,
+    params: { workspaceId: string; actorId: string; labelId: string; resourceType: LabelableResourceType }
+  ): Promise<LabelAssignment[]> {
+    const result = await db.query<LabelAssignmentRow>(sql`
+      SELECT ${sql.raw(
+        ASSIGNMENT_COLUMNS.split(", ")
+          .map((c) => `a.${c}`)
+          .join(", ")
+      )}
+      FROM label_assignments a
+      JOIN labels l ON l.id = a.label_id AND l.workspace_id = a.workspace_id
+      WHERE a.workspace_id = ${params.workspaceId}
+        AND a.user_id = ${params.actorId}
+        AND a.label_id = ${params.labelId}
+        AND a.resource_type = ${params.resourceType}
+        AND l.archived_at IS NULL
+      ORDER BY a.assigned_at DESC
+    `)
+    return result.rows.map(mapAssignmentRow)
+  },
+
+  /**
    * Drop every assignment of a label across all resources. Callers run this
    * inside the label-archive transaction so no chip outlives its label.
    */

--- a/apps/backend/src/features/messaging/repository.ts
+++ b/apps/backend/src/features/messaging/repository.ts
@@ -209,6 +209,19 @@ export const MessageRepository = {
     return map
   },
 
+  /**
+   * Map message ids to their owning stream id — the minimal lookup an access
+   * check needs (resolve the stream, then gate on it) without paying for the
+   * full message + reactions hydration. Unknown ids are simply absent.
+   */
+  async findStreamIdsByIds(db: Querier, ids: string[]): Promise<Map<string, string>> {
+    if (ids.length === 0) return new Map()
+    const result = await db.query<{ id: string; stream_id: string }>(sql`
+      SELECT id, stream_id FROM messages WHERE id = ANY(${ids})
+    `)
+    return new Map(result.rows.map((row) => [row.id, row.stream_id]))
+  },
+
   async findByIdsForUpdate(db: Querier, ids: string[]): Promise<Message[]> {
     if (ids.length === 0) return []
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -80,7 +80,7 @@ import type { SavedMessagesService } from "./features/saved-messages"
 import type { SavedSuggestionsService } from "./features/saved-suggestions"
 import type { ScheduledMessagesService } from "./features/scheduled-messages"
 import type { DraftsService } from "./features/drafts"
-import type { LabelService, LabelAssignmentService } from "./features/labels"
+import type { LabelService, LabelAssignmentService, LabelMessageService } from "./features/labels"
 import type { PushService } from "./features/push"
 import type { S3Config } from "./lib/env"
 import type { StorageProvider } from "./lib/storage/s3-client"
@@ -126,6 +126,7 @@ interface Dependencies {
   draftsService: DraftsService
   labelService: LabelService
   labelAssignmentService: LabelAssignmentService
+  labelMessageService: LabelMessageService
   pushService: PushService
   s3Config: S3Config
   commandRegistry: CommandRegistry
@@ -184,6 +185,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     draftsService,
     labelService,
     labelAssignmentService,
+    labelMessageService,
     pushService,
     s3Config,
     commandRegistry,
@@ -283,7 +285,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const savedSuggestions = createSavedSuggestionsHandlers({ savedSuggestionsService })
   const scheduledMessages = createScheduledMessagesHandlers({ scheduledMessagesService })
   const drafts = createDraftsHandlers({ draftsService })
-  const label = createLabelHandlers({ labelService, labelAssignmentService })
+  const label = createLabelHandlers({ labelService, labelAssignmentService, labelMessageService })
   const agentSession = createAgentSessionHandlers({ pool })
   const contextBag = createContextBagHandlers({ pool, ai })
   const linkPreview = createLinkPreviewHandlers({ linkPreviewService })
@@ -578,6 +580,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   app.post("/api/workspaces/:workspaceId/saved/suggestions/:suggestionId/dismiss", ...authed, savedSuggestions.dismiss)
 
   app.get("/api/workspaces/:workspaceId/labels", ...authed, label.list)
+  app.get("/api/workspaces/:workspaceId/labels/:labelId/messages", ...authed, label.listMessages)
   app.post("/api/workspaces/:workspaceId/labels", ...authed, label.create)
   app.patch("/api/workspaces/:workspaceId/labels/:labelId", ...authed, label.update)
   app.delete("/api/workspaces/:workspaceId/labels/:labelId", ...authed, label.delete)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -122,7 +122,7 @@ import { SavedMessagesService, createSavedReminderWorker } from "./features/save
 import { SavedSuggestionsService, SuggestionExtractor } from "./features/saved-suggestions"
 import { ScheduledMessagesService, createScheduledMessageSendWorker } from "./features/scheduled-messages"
 import { DraftsService } from "./features/drafts"
-import { LabelService, LabelAssignmentService } from "./features/labels"
+import { LabelService, LabelAssignmentService, LabelMessageService } from "./features/labels"
 import { PushService, PushNotificationHandler, createPushSessionCleanup } from "./features/push"
 import { AttachmentUploadedHandler, AttachmentEmbeddingHandler } from "./features/attachments"
 import { AICostService, AIBudgetService } from "./features/ai-usage"
@@ -540,6 +540,7 @@ export async function startServer(): Promise<ServerInstance> {
   // actor's own access model, so the assignment service resolves bot reachability
   // through channel grants (users resolve through stream membership).
   const labelAssignmentService = new LabelAssignmentService({ pool, labelService, botChannelService })
+  const labelMessageService = new LabelMessageService({ pool, botChannelService })
 
   // User-scoped API keys are managed by Threa, not WorkOS.
   const userApiKeyService = new UserApiKeyServiceImpl(pool)
@@ -637,6 +638,7 @@ export async function startServer(): Promise<ServerInstance> {
     draftsService,
     labelService,
     labelAssignmentService,
+    labelMessageService,
     pushService,
     s3Config: config.s3,
     commandRegistry,

--- a/apps/frontend/src/api/labels.ts
+++ b/apps/frontend/src/api/labels.ts
@@ -1,5 +1,12 @@
 import { api } from "./client"
-import type { CreateLabelInput, Label, LabelAssignment, LabelableResourceType, UpdateLabelInput } from "@threa/types"
+import type {
+  CreateLabelInput,
+  Label,
+  LabelAssignment,
+  LabelableResourceType,
+  LabeledMessage,
+  UpdateLabelInput,
+} from "@threa/types"
 
 export type { CreateLabelInput, UpdateLabelInput }
 
@@ -11,6 +18,13 @@ export interface ResourceRef {
 export const labelsApi = {
   async list(workspaceId: string): Promise<{ labels: Label[]; assignments: LabelAssignment[] }> {
     return api.get<{ labels: Label[]; assignments: LabelAssignment[] }>(`/api/workspaces/${workspaceId}/labels`)
+  },
+
+  async listMessages(workspaceId: string, labelId: string): Promise<LabeledMessage[]> {
+    const res = await api.get<{ messages: LabeledMessage[] }>(
+      `/api/workspaces/${workspaceId}/labels/${labelId}/messages`
+    )
+    return res.messages
   },
 
   async create(workspaceId: string, data: CreateLabelInput): Promise<Label> {

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -2,22 +2,13 @@ import { useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
-import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
-import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
-import { LinkPreviewProvider } from "@/lib/markdown/link-preview-context"
-import { AttachmentList } from "@/components/timeline/attachment-list"
-import { LinkPreviewList } from "@/components/timeline/link-preview-list"
-import { MemoPreviewList } from "@/components/timeline/memo-preview-list"
-import { GiphyPreviewList } from "@/components/timeline/giphy-preview-list"
-import { MessageReactions } from "@/components/timeline/message-reactions"
+import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useUserProfile } from "@/components/user-profile"
-import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useConversationService } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
-import type { AttachmentSummary, AuthorType, BoardPost, LinkPreviewSummary } from "@threa/types"
+import type { BoardPost } from "@threa/types"
 
 interface BoardCardProps {
   workspaceId: string
@@ -32,33 +23,6 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
   channel: Hash,
   scratchpad: FileEdit,
   dm: User,
-}
-
-/** Same-author messages within this window collapse into a continuation (no
- * repeated header) — matches the timeline's grouping. */
-const GROUP_WINDOW_MS = 5 * 60_000
-
-/** The fields the post renderer reads — satisfied by both `BoardPostMessage`
- * (feed payload) and a full `Message` (fetched on expand). */
-interface RenderableMessage {
-  id: string
-  authorId: string
-  authorType: AuthorType
-  contentMarkdown: string
-  reactions: Record<string, string[]>
-  createdAt: string | Date
-  // Present on feed messages (BoardPostMessage); absent on messages fetched via
-  // getMessages on expand, which carry no enrichment.
-  attachments?: AttachmentSummary[]
-  linkPreviews?: LinkPreviewSummary[]
-}
-
-function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolean {
-  return (
-    prev.authorId === cur.authorId &&
-    prev.authorType === cur.authorType &&
-    Math.abs(new Date(cur.createdAt).getTime() - new Date(prev.createdAt).getTime()) < GROUP_WINDOW_MS
-  )
 }
 
 /**
@@ -101,7 +65,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const contiguous = (expanded && !!allMessages) || (!expanded && hiddenCount === 0)
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => (
-    <PostMessage
+    <MessageItem
       key={message.id}
       workspaceId={workspaceId}
       streamId={streamId}
@@ -157,125 +121,6 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
             {replies.map((message, i) => renderMessage(message, i > 0 && isContinuation(replies[i - 1], message)))}
           </>
         )}
-      </div>
-    </div>
-  )
-}
-
-interface PostMessageProps {
-  workspaceId: string
-  streamId: string
-  message: RenderableMessage
-  authorName: string
-  currentUserId: string | null
-  /** A same-author follow-up: drop the avatar/header and align the body under
-   * the head row's content (matches the timeline's grouped continuations). */
-  continuation?: boolean
-}
-
-function PostMessage({ workspaceId, streamId, message, authorName, currentUserId, continuation }: PostMessageProps) {
-  const { formatTime, formatFull } = useFormattedDate()
-  const { openUserProfile } = useUserProfile()
-  const hasReactions = Object.keys(message.reactions).length > 0
-  // Users open their profile on click (same as the timeline); other actor types
-  // (persona/bot/system) are non-interactive.
-  const interactiveName = message.authorType === "user" && Boolean(message.authorId)
-  const attachments = message.attachments ?? []
-  const linkPreviews = message.linkPreviews ?? []
-
-  const richBody = (
-    <>
-      <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
-      {attachments.length > 0 && <AttachmentList attachments={attachments} workspaceId={workspaceId} />}
-      {linkPreviews.length > 0 && (
-        <LinkPreviewList
-          messageId={message.id}
-          workspaceId={workspaceId}
-          previews={linkPreviews}
-          hydrateFromApi={false}
-        />
-      )}
-      {/* Memo + giphy embeds are parsed from the markdown, so they render here
-          just like the timeline — no extra payload needed. */}
-      <MemoPreviewList contentMarkdown={message.contentMarkdown} />
-      <GiphyPreviewList contentMarkdown={message.contentMarkdown} />
-    </>
-  )
-  // The body renders real message content (mentions, attachments, link previews),
-  // so it gets the same markdown context wrappers the timeline uses. Attachments
-  // open the media gallery / download via AttachmentList.
-  const body = (
-    <>
-      <LinkPreviewProvider>
-        {attachments.length > 0 ? (
-          <AttachmentProvider workspaceId={workspaceId} attachments={attachments}>
-            {richBody}
-          </AttachmentProvider>
-        ) : (
-          richBody
-        )}
-      </LinkPreviewProvider>
-      {hasReactions && (
-        <MessageReactions
-          reactions={message.reactions}
-          workspaceId={workspaceId}
-          messageId={message.id}
-          currentUserId={currentUserId}
-        />
-      )}
-    </>
-  )
-
-  if (continuation) {
-    const sentAt = new Date(message.createdAt)
-    return (
-      <div className="group mt-0.5 flex gap-3">
-        {/* Gutter reveals the message time on hover (desktop), mirroring the
-            timeline's grouped-continuation micro-time. */}
-        <div
-          className="w-8 shrink-0 pt-0.5 text-right font-mono text-[10px] tabular-nums leading-5 text-transparent transition-colors group-hover:text-muted-foreground/60"
-          title={formatFull(sentAt)}
-        >
-          {formatTime(sentAt)}
-        </div>
-        <div className="min-w-0 flex-1">{body}</div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="mt-3 flex items-start gap-3">
-      <ActorAvatar
-        actorId={message.authorId}
-        actorType={message.authorType}
-        workspaceId={workspaceId}
-        size="md"
-        alt={authorName}
-        showStatus={false}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="mb-0.5 flex items-baseline gap-2">
-          {interactiveName ? (
-            <button
-              type="button"
-              onClick={() => openUserProfile(message.authorId)}
-              className="truncate text-left text-sm font-semibold hover:underline"
-            >
-              {authorName}
-            </button>
-          ) : (
-            <span className="truncate text-sm font-semibold">{authorName}</span>
-          )}
-          {/* Permalink to the message in its stream timeline — the body is
-              interactive, so navigation lives on the timestamp instead. */}
-          <Link
-            to={`/w/${workspaceId}/s/${streamId}?m=${message.id}`}
-            className="shrink-0 text-xs text-muted-foreground hover:underline"
-          >
-            <RelativeTime date={message.createdAt} />
-          </Link>
-        </div>
-        {body}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/labels/label-stack.test.tsx
+++ b/apps/frontend/src/components/labels/label-stack.test.tsx
@@ -8,7 +8,7 @@ import * as authModule from "@/auth"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import * as drawerModule from "@/components/ui/drawer"
-import { StreamLabelStack } from "./stream-label-stack"
+import { LabelStack } from "./label-stack"
 import type { CachedLabel, CachedLabelAssignment } from "@/hooks"
 
 const WORKSPACE_ID = "ws_1"
@@ -60,13 +60,13 @@ function mount() {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter>
-        <StreamLabelStack workspaceId={WORKSPACE_ID} streamId={STREAM_ID} />
+        <LabelStack workspaceId={WORKSPACE_ID} resourceType={LabelableResourceTypes.STREAM} resourceId={STREAM_ID} />
       </MemoryRouter>
     </QueryClientProvider>
   )
 }
 
-describe("StreamLabelStack", () => {
+describe("LabelStack", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("mouse")

--- a/apps/frontend/src/components/labels/label-stack.tsx
+++ b/apps/frontend/src/components/labels/label-stack.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import { LabelableResourceTypes } from "@threa/types"
+import type { LabelableResourceType } from "@threa/types"
 import { cn } from "@/lib/utils"
 import { useResourceLabelAssignments } from "@/hooks"
 import { useInputMode } from "@/hooks/use-input-mode"
@@ -10,24 +10,27 @@ import { LabelChip, LabelGlyph } from "./label-chip"
 /** Collapsed marks shown before the "+N" overflow indicator. */
 const VISIBLE_CAP = 3
 
-interface StreamLabelStackProps {
+interface LabelStackProps {
   workspaceId: string
-  streamId: string
+  /** What carries the labels — a stream (top bar) or a message (message rows). */
+  resourceType: LabelableResourceType
+  resourceId: string
   className?: string
 }
 
 /**
- * Display-only stack of the labels on a stream, for the stream top bar. Shows up
- * to {@link VISIBLE_CAP} overlapping glyphs + a `+N` overflow count; the full set
- * fans out as tinted name-pills on mouse hover (an overlay — no layout
- * shift, INV-21) or in a bottom drawer on touch tap. Editing lives in `LabelPicker`.
+ * Display-only stack of the labels on a resource (a stream's top bar, a message
+ * row). Shows up to {@link VISIBLE_CAP} overlapping glyphs + a `+N` overflow
+ * count; the full set fans out as tinted name-pills on mouse hover (an overlay —
+ * no layout shift, INV-21) or in a bottom drawer on touch tap. Editing lives in
+ * `LabelPicker`.
  *
- * Reads the shared assignment pool (public labels on the stream + the viewer's
- * private ones), already deduped + active-only, and stays live via the
- * `label:assigned`/`label:unassigned` socket handlers.
+ * Resource-generic: `resourceType` + `resourceId` are the only per-resource
+ * inputs. Reads the viewer's active assignments (already deduped + active-only)
+ * and stays live via the `label:assigned`/`label:unassigned` socket handlers.
  */
-export function StreamLabelStack({ workspaceId, streamId, className }: StreamLabelStackProps) {
-  const { labels } = useResourceLabelAssignments(workspaceId, LabelableResourceTypes.STREAM, streamId)
+export function LabelStack({ workspaceId, resourceType, resourceId, className }: LabelStackProps) {
+  const { labels } = useResourceLabelAssignments(workspaceId, resourceType, resourceId)
   // Drawer-vs-hovercard keys off the active input mode: a finger taps for the
   // drawer, a mouse (even on a touchscreen laptop) hovers for the hovercard.
   const isTouch = useInputMode() === "touch"
@@ -44,7 +47,7 @@ export function StreamLabelStack({ workspaceId, streamId, className }: StreamLab
       type="button"
       aria-label={ariaLabel}
       // Negative margin keeps the glyphs visually aligned with neighbouring
-      // header controls while the padding gives a comfortable tap target.
+      // controls while the padding gives a comfortable tap target.
       className={cn(
         "-m-1 flex items-center rounded-md p-1 transition-colors hover:bg-muted/60",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -196,8 +196,14 @@ export function MessageItem({
           currentUserId={currentUserId}
         />
       )}
-      <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.MESSAGE} resourceId={message.id} />
     </>
+  )
+
+  // The message's own labels. On a standalone row they ride in the header next
+  // to the timestamp; a continuation has no header, so they trail the body
+  // there (renders nothing until the message is actually labeled).
+  const labelStack = (
+    <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.MESSAGE} resourceId={message.id} />
   )
 
   const touchHandlers = touchCapable ? longPress.handlers : undefined
@@ -217,7 +223,10 @@ export function MessageItem({
         >
           {formatTime(sentAt)}
         </div>
-        <div className="min-w-0 flex-1 pr-7">{body}</div>
+        <div className="min-w-0 flex-1 pr-7">
+          {body}
+          {labelStack}
+        </div>
         {overflowMenu}
         {overlays}
       </div>
@@ -261,6 +270,7 @@ export function MessageItem({
           >
             <RelativeTime date={message.createdAt} />
           </Link>
+          {labelStack}
           {streamLabel && (
             <MessageStreamByline
               workspaceId={workspaceId}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -1,0 +1,227 @@
+import { useState } from "react"
+import { Link } from "react-router-dom"
+import { LabelableResourceTypes, type AttachmentSummary, type AuthorType, type LinkPreviewSummary } from "@threa/types"
+import { ActorAvatar } from "@/components/actor-avatar"
+import { RelativeTime } from "@/components/relative-time"
+import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
+import { LinkPreviewProvider } from "@/lib/markdown/link-preview-context"
+import { AttachmentList } from "@/components/timeline/attachment-list"
+import { LinkPreviewList } from "@/components/timeline/link-preview-list"
+import { MemoPreviewList } from "@/components/timeline/memo-preview-list"
+import { GiphyPreviewList } from "@/components/timeline/giphy-preview-list"
+import { MessageReactions } from "@/components/timeline/message-reactions"
+import { MessageContextMenu } from "@/components/timeline/message-context-menu"
+import type { MessageActionContext } from "@/components/timeline/message-actions"
+import { LabelStack } from "@/components/labels/label-stack"
+import { LabelPicker } from "@/components/labels/label-picker"
+import { useUserProfile } from "@/components/user-profile"
+import { useFormattedDate } from "@/hooks/use-formatted-date"
+import { useInputMode } from "@/hooks/use-input-mode"
+import { cn } from "@/lib/utils"
+
+/** Same-author messages within this window collapse into a continuation (no
+ * repeated header) — matches the timeline's grouping. */
+export const GROUP_WINDOW_MS = 5 * 60_000
+
+/**
+ * The fields {@link MessageItem} reads. A lean rendering shape satisfied by the
+ * board feed payload (`BoardPostMessage`), a labeled message (`LabeledMessage`),
+ * and a full `Message` alike — anything that can show a message outside the
+ * stream timeline.
+ */
+export interface RenderableMessage {
+  id: string
+  authorId: string
+  authorType: AuthorType
+  contentMarkdown: string
+  reactions: Record<string, string[]>
+  createdAt: string | Date
+  attachments?: AttachmentSummary[]
+  linkPreviews?: LinkPreviewSummary[]
+}
+
+export function isContinuation(prev: RenderableMessage, cur: RenderableMessage): boolean {
+  return (
+    prev.authorId === cur.authorId &&
+    prev.authorType === cur.authorType &&
+    Math.abs(new Date(cur.createdAt).getTime() - new Date(prev.createdAt).getTime()) < GROUP_WINDOW_MS
+  )
+}
+
+interface MessageItemProps {
+  workspaceId: string
+  streamId: string
+  message: RenderableMessage
+  authorName: string
+  currentUserId: string | null
+  /** A same-author follow-up: drop the avatar/header and align the body under
+   * the head row's content (matches the timeline's grouped continuations). */
+  continuation?: boolean
+}
+
+/**
+ * One message rendered outside the stream timeline — the unit shared by the
+ * board feed and the label landing page. Uses the same primitives as the
+ * timeline (`ActorAvatar`, `MarkdownContent`, `MessageReactions`, same
+ * same-author grouping) so a board/label message is indistinguishable from a
+ * real one. Carries its own labels (`LabelStack`, renders nothing until there's
+ * one) and a hover overflow menu to file it under a label or copy a link; the
+ * timestamp permalinks back into the message's own stream context.
+ */
+export function MessageItem({
+  workspaceId,
+  streamId,
+  message,
+  authorName,
+  currentUserId,
+  continuation,
+}: MessageItemProps) {
+  const { formatTime, formatFull } = useFormattedDate()
+  const { openUserProfile } = useUserProfile()
+  const [labelPickerOpen, setLabelPickerOpen] = useState(false)
+  const isTouch = useInputMode() === "touch"
+  const hasReactions = Object.keys(message.reactions).length > 0
+  // Users open their profile on click (same as the timeline); other actor types
+  // (persona/bot/system) are non-interactive.
+  const interactiveName = message.authorType === "user" && Boolean(message.authorId)
+  const attachments = message.attachments ?? []
+  const linkPreviews = message.linkPreviews ?? []
+
+  // A deliberately small menu for surfaces with no thread context: file under a
+  // label, copy the content, copy a link. `isThreadParent: true` suppresses
+  // "Reply in thread" (its only gate) rather than point it at a thread we don't
+  // have here; the timestamp is the way back into the stream.
+  const menuContext: MessageActionContext = {
+    contentMarkdown: message.contentMarkdown,
+    actorType: message.authorType,
+    isThreadParent: true,
+    replyUrl: "",
+    messageId: message.id,
+    workspaceId,
+    streamId,
+    onLabelMessage: () => setLabelPickerOpen(true),
+  }
+
+  const overflowMenu = (
+    <div
+      className={cn(
+        "absolute right-0 top-0 transition-opacity",
+        isTouch ? "opacity-70" : "opacity-0 focus-within:opacity-100 group-hover:opacity-100"
+      )}
+    >
+      <MessageContextMenu context={menuContext} />
+    </div>
+  )
+
+  const labelPicker = labelPickerOpen && (
+    <LabelPicker
+      workspaceId={workspaceId}
+      resourceType={LabelableResourceTypes.MESSAGE}
+      resourceId={message.id}
+      open={labelPickerOpen}
+      onOpenChange={setLabelPickerOpen}
+    />
+  )
+
+  const richBody = (
+    <>
+      <MarkdownContent content={message.contentMarkdown} messageId={message.id} className="text-sm leading-relaxed" />
+      {attachments.length > 0 && <AttachmentList attachments={attachments} workspaceId={workspaceId} />}
+      {linkPreviews.length > 0 && (
+        <LinkPreviewList
+          messageId={message.id}
+          workspaceId={workspaceId}
+          previews={linkPreviews}
+          hydrateFromApi={false}
+        />
+      )}
+      {/* Memo + giphy embeds are parsed from the markdown, so they render here
+          just like the timeline — no extra payload needed. */}
+      <MemoPreviewList contentMarkdown={message.contentMarkdown} />
+      <GiphyPreviewList contentMarkdown={message.contentMarkdown} />
+    </>
+  )
+  // The body renders real message content (mentions, attachments, link previews),
+  // so it gets the same markdown context wrappers the timeline uses. Attachments
+  // open the media gallery / download via AttachmentList.
+  const body = (
+    <>
+      <LinkPreviewProvider>
+        {attachments.length > 0 ? (
+          <AttachmentProvider workspaceId={workspaceId} attachments={attachments}>
+            {richBody}
+          </AttachmentProvider>
+        ) : (
+          richBody
+        )}
+      </LinkPreviewProvider>
+      {hasReactions && (
+        <MessageReactions
+          reactions={message.reactions}
+          workspaceId={workspaceId}
+          messageId={message.id}
+          currentUserId={currentUserId}
+        />
+      )}
+      <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.MESSAGE} resourceId={message.id} />
+    </>
+  )
+
+  if (continuation) {
+    const sentAt = new Date(message.createdAt)
+    return (
+      <div className="group relative mt-0.5 flex gap-3">
+        {/* Gutter reveals the message time on hover (desktop), mirroring the
+            timeline's grouped-continuation micro-time. */}
+        <div
+          className="w-8 shrink-0 pt-0.5 text-right font-mono text-[10px] tabular-nums leading-5 text-transparent transition-colors group-hover:text-muted-foreground/60"
+          title={formatFull(sentAt)}
+        >
+          {formatTime(sentAt)}
+        </div>
+        <div className="min-w-0 flex-1">{body}</div>
+        {overflowMenu}
+        {labelPicker}
+      </div>
+    )
+  }
+
+  return (
+    <div className="group relative mt-3 flex items-start gap-3">
+      <ActorAvatar
+        actorId={message.authorId}
+        actorType={message.authorType}
+        workspaceId={workspaceId}
+        size="md"
+        alt={authorName}
+        showStatus={false}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="mb-0.5 flex items-baseline gap-2">
+          {interactiveName ? (
+            <button
+              type="button"
+              onClick={() => openUserProfile(message.authorId)}
+              className="truncate text-left text-sm font-semibold hover:underline"
+            >
+              {authorName}
+            </button>
+          ) : (
+            <span className="truncate text-sm font-semibold">{authorName}</span>
+          )}
+          {/* Permalink to the message in its stream timeline — the body is
+              interactive, so navigation lives on the timestamp instead. */}
+          <Link
+            to={`/w/${workspaceId}/s/${streamId}?m=${message.id}`}
+            className="shrink-0 text-xs text-muted-foreground hover:underline"
+          >
+            <RelativeTime date={message.createdAt} />
+          </Link>
+        </div>
+        {body}
+      </div>
+      {overflowMenu}
+      {labelPicker}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { Link } from "react-router-dom"
 import { LabelableResourceTypes, type AttachmentSummary, type AuthorType, type LinkPreviewSummary } from "@threa/types"
 import { ActorAvatar } from "@/components/actor-avatar"
@@ -11,12 +11,14 @@ import { MemoPreviewList } from "@/components/timeline/memo-preview-list"
 import { GiphyPreviewList } from "@/components/timeline/giphy-preview-list"
 import { MessageReactions } from "@/components/timeline/message-reactions"
 import { MessageContextMenu } from "@/components/timeline/message-context-menu"
+import { MessageActionDrawer } from "@/components/timeline/message-action-drawer"
 import type { MessageActionContext } from "@/components/timeline/message-actions"
 import { LabelStack } from "@/components/labels/label-stack"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
-import { useInputMode } from "@/hooks/use-input-mode"
+import { useTouchCapable } from "@/hooks/use-touch-capable"
+import { useLongPress } from "@/hooks/use-long-press"
 import { cn } from "@/lib/utils"
 
 /** Same-author messages within this window collapse into a continuation (no
@@ -65,8 +67,9 @@ interface MessageItemProps {
  * timeline (`ActorAvatar`, `MarkdownContent`, `MessageReactions`, same
  * same-author grouping) so a board/label message is indistinguishable from a
  * real one. Carries its own labels (`LabelStack`, renders nothing until there's
- * one) and a hover overflow menu to file it under a label or copy a link; the
- * timestamp permalinks back into the message's own stream context.
+ * one) and the timeline's action surface: a hover overflow menu on desktop and
+ * a long-press action drawer on touch. The timestamp permalinks back into the
+ * message's own stream context.
  */
 export function MessageItem({
   workspaceId,
@@ -79,7 +82,13 @@ export function MessageItem({
   const { formatTime, formatFull } = useFormattedDate()
   const { openUserProfile } = useUserProfile()
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
-  const isTouch = useInputMode() === "touch"
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  // Touch reaches the actions via long-press → the same `MessageActionDrawer`
+  // the timeline uses; the hover overflow button is desktop/keyboard only. This
+  // mirrors `SentMessageEvent` rather than exposing a tap-sized dropdown.
+  const touchCapable = useTouchCapable()
+  const openDrawer = useCallback(() => setDrawerOpen(true), [])
+  const longPress = useLongPress({ onLongPress: openDrawer, enabled: touchCapable, deferToNativeLinks: true })
   const hasReactions = Object.keys(message.reactions).length > 0
   // Users open their profile on click (same as the timeline); other actor types
   // (persona/bot/system) are non-interactive.
@@ -87,13 +96,15 @@ export function MessageItem({
   const attachments = message.attachments ?? []
   const linkPreviews = message.linkPreviews ?? []
 
-  // A deliberately small menu for surfaces with no thread context: file under a
-  // label, copy the content, copy a link. `isThreadParent: true` suppresses
-  // "Reply in thread" (its only gate) rather than point it at a thread we don't
-  // have here; the timestamp is the way back into the stream.
+  // A deliberately small action set for surfaces with no thread context: file
+  // under a label, copy the content, copy a link. `isThreadParent: true`
+  // suppresses "Reply in thread" (its only gate) rather than point it at a
+  // thread we don't have here; the timestamp is the way back into the stream.
+  // No `currentUserId`, so the owner-only edit/delete actions stay hidden.
   const menuContext: MessageActionContext = {
     contentMarkdown: message.contentMarkdown,
     actorType: message.authorType,
+    authorId: message.authorId,
     isThreadParent: true,
     replyUrl: "",
     messageId: message.id,
@@ -102,25 +113,35 @@ export function MessageItem({
     onLabelMessage: () => setLabelPickerOpen(true),
   }
 
+  // Desktop/keyboard only (hover or focus reveals it); touch uses the drawer
+  // below. The body columns carry `pr-7` so this absolute button never overlays
+  // the row's top-right content (INV-21).
   const overflowMenu = (
-    <div
-      className={cn(
-        "absolute right-0 top-0 transition-opacity",
-        isTouch ? "opacity-70" : "opacity-0 focus-within:opacity-100 group-hover:opacity-100"
-      )}
-    >
+    <div className="absolute right-0 top-0 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
       <MessageContextMenu context={menuContext} />
     </div>
   )
 
-  const labelPicker = labelPickerOpen && (
-    <LabelPicker
-      workspaceId={workspaceId}
-      resourceType={LabelableResourceTypes.MESSAGE}
-      resourceId={message.id}
-      open={labelPickerOpen}
-      onOpenChange={setLabelPickerOpen}
-    />
+  const overlays = (
+    <>
+      {labelPickerOpen && (
+        <LabelPicker
+          workspaceId={workspaceId}
+          resourceType={LabelableResourceTypes.MESSAGE}
+          resourceId={message.id}
+          open={labelPickerOpen}
+          onOpenChange={setLabelPickerOpen}
+        />
+      )}
+      {touchCapable && (
+        <MessageActionDrawer
+          open={drawerOpen}
+          onOpenChange={setDrawerOpen}
+          context={menuContext}
+          authorName={authorName}
+        />
+      )}
+    </>
   )
 
   const richBody = (
@@ -167,10 +188,15 @@ export function MessageItem({
     </>
   )
 
+  const touchHandlers = touchCapable ? longPress.handlers : undefined
+
   if (continuation) {
     const sentAt = new Date(message.createdAt)
     return (
-      <div className="group relative mt-0.5 flex gap-3">
+      <div
+        className={cn("group relative mt-0.5 flex gap-3", longPress.isPressed && "opacity-70 transition-opacity")}
+        {...touchHandlers}
+      >
         {/* Gutter reveals the message time on hover (desktop), mirroring the
             timeline's grouped-continuation micro-time. */}
         <div
@@ -179,15 +205,21 @@ export function MessageItem({
         >
           {formatTime(sentAt)}
         </div>
-        <div className="min-w-0 flex-1">{body}</div>
+        <div className="min-w-0 flex-1 pr-7">{body}</div>
         {overflowMenu}
-        {labelPicker}
+        {overlays}
       </div>
     )
   }
 
   return (
-    <div className="group relative mt-3 flex items-start gap-3">
+    <div
+      className={cn(
+        "group relative mt-3 flex items-start gap-3",
+        longPress.isPressed && "opacity-70 transition-opacity"
+      )}
+      {...touchHandlers}
+    >
       <ActorAvatar
         actorId={message.authorId}
         actorType={message.authorType}
@@ -196,7 +228,7 @@ export function MessageItem({
         alt={authorName}
         showStatus={false}
       />
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 pr-7">
         <div className="mb-0.5 flex items-baseline gap-2">
           {interactiveName ? (
             <button
@@ -221,7 +253,7 @@ export function MessageItem({
         {body}
       </div>
       {overflowMenu}
-      {labelPicker}
+      {overlays}
     </div>
   )
 }

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useState } from "react"
 import { Link } from "react-router-dom"
-import { LabelableResourceTypes, type AttachmentSummary, type AuthorType, type LinkPreviewSummary } from "@threa/types"
+import {
+  LabelableResourceTypes,
+  type AttachmentSummary,
+  type AuthorType,
+  type LinkPreviewSummary,
+  type StreamType,
+} from "@threa/types"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { RelativeTime } from "@/components/relative-time"
 import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
@@ -19,6 +25,7 @@ import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { useLongPress } from "@/hooks/use-long-press"
+import { STREAM_ICONS } from "@/lib/streams"
 import { cn } from "@/lib/utils"
 
 /** Same-author messages within this window collapse into a continuation (no
@@ -59,6 +66,10 @@ interface MessageItemProps {
   /** A same-author follow-up: drop the avatar/header and align the body under
    * the head row's content (matches the timeline's grouped continuations). */
   continuation?: boolean
+  /** Opt-in origin-stream chip in the header, right of the timestamp. Set on the
+   * label page (messages span streams, so each row names its origin); the board
+   * leaves it off because it shows the stream at the card level. */
+  streamLabel?: { name: string; type: StreamType }
 }
 
 /**
@@ -78,6 +89,7 @@ export function MessageItem({
   authorName,
   currentUserId,
   continuation,
+  streamLabel,
 }: MessageItemProps) {
   const { formatTime, formatFull } = useFormattedDate()
   const { openUserProfile } = useUserProfile()
@@ -234,12 +246,12 @@ export function MessageItem({
             <button
               type="button"
               onClick={() => openUserProfile(message.authorId)}
-              className="truncate text-left text-sm font-semibold hover:underline"
+              className="min-w-0 truncate text-left text-sm font-semibold hover:underline"
             >
               {authorName}
             </button>
           ) : (
-            <span className="truncate text-sm font-semibold">{authorName}</span>
+            <span className="min-w-0 truncate text-sm font-semibold">{authorName}</span>
           )}
           {/* Permalink to the message in its stream timeline — the body is
               interactive, so navigation lives on the timestamp instead. */}
@@ -249,11 +261,49 @@ export function MessageItem({
           >
             <RelativeTime date={message.createdAt} />
           </Link>
+          {streamLabel && (
+            <MessageStreamByline
+              workspaceId={workspaceId}
+              streamId={streamId}
+              name={streamLabel.name}
+              type={streamLabel.type}
+            />
+          )}
         </div>
         {body}
       </div>
       {overflowMenu}
       {overlays}
     </div>
+  )
+}
+
+/**
+ * Origin-stream chip for the header metadata line — the stream glyph + name,
+ * linking into the stream (INV-40). Sits right of the timestamp and shares its
+ * muted `text-xs` treatment so it reads as metadata, not a heading; the name
+ * truncates so a long stream can't push the row.
+ */
+function MessageStreamByline({
+  workspaceId,
+  streamId,
+  name,
+  type,
+}: {
+  workspaceId: string
+  streamId: string
+  name: string
+  type: StreamType
+}) {
+  const Icon = STREAM_ICONS[type]
+  return (
+    <Link
+      to={`/w/${workspaceId}/s/${streamId}`}
+      title={name}
+      className="flex min-w-0 shrink items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <Icon className="h-3 w-3 shrink-0" aria-hidden />
+      <span className="truncate">{name}</span>
+    </Link>
   )
 }

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -65,7 +65,7 @@ import { streamLabel } from "@/lib/streams"
 import { useDecryptedStreamName } from "@/hooks/use-decrypted-stream-name"
 import { copyStreamLink } from "@/lib/stream-links"
 import { LabelPicker } from "@/components/labels/label-picker"
-import { StreamLabelStack } from "@/components/labels/stream-label-stack"
+import { LabelStack } from "@/components/labels/label-stack"
 
 interface StreamPanelProps {
   workspaceId: string
@@ -507,7 +507,12 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
         )}
         {headerContent}
         {!isDraft && stream && panelId && (
-          <StreamLabelStack workspaceId={workspaceId} streamId={panelId} className="flex-shrink-0" />
+          <LabelStack
+            workspaceId={workspaceId}
+            resourceType={LabelableResourceTypes.STREAM}
+            resourceId={panelId}
+            className="flex-shrink-0"
+          />
         )}
         {!isDraft &&
           stream &&

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -363,6 +363,33 @@ describe("share action (modal)", () => {
   })
 })
 
+describe("label-message action", () => {
+  it("is hidden when onLabelMessage is not supplied", () => {
+    const actions = getVisibleActions(createContext())
+    expect(actions.find((a) => a.id === "label-message")).toBeUndefined()
+  })
+
+  it("is visible when onLabelMessage is supplied", () => {
+    const actions = getVisibleActions(createContext({ onLabelMessage: () => {} }))
+    expect(actions.find((a) => a.id === "label-message")).toBeDefined()
+  })
+
+  it("invokes the onLabelMessage callback when run", () => {
+    const onLabelMessage = vi.fn()
+    const ctx = createContext({ onLabelMessage })
+    const action = getVisibleActions(ctx).find((a) => a.id === "label-message")!
+    action.action!(ctx)
+    expect(onLabelMessage).toHaveBeenCalledOnce()
+  })
+
+  it("renders as a standalone row, not part of the save group", () => {
+    const ctx = createContext({ onToggleSave: () => {}, onRequestReminder: () => {}, onLabelMessage: () => {} })
+    const items = groupVisibleActions(getVisibleActions(ctx))
+    const labelRow = items.find((i) => i.kind === "single" && i.action.id === "label-message")
+    expect(labelRow).toBeDefined()
+  })
+})
+
 describe("mark-read-up-to-here action", () => {
   it("is hidden when onMarkReadUpToHere is not supplied", () => {
     const actions = getVisibleActions(createContext())

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -17,6 +17,7 @@ import {
   Layers,
   CheckCheck,
   CircleDot,
+  Tag,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -101,6 +102,12 @@ export interface MessageActionContext {
   onRequestReminder?: () => void
   /** Whether the message is currently saved by the viewer */
   isSaved?: boolean
+  /**
+   * Open the label picker for this message — file it under one of the viewer's
+   * labels (or a new one). Distinct from Save: labeling is the organizational
+   * axis (stow into a named bucket), Save is the single "for later" inbox.
+   */
+  onLabelMessage?: () => void
   /** Callback to start a private "Discuss with Ariadne" scratchpad seeded with this thread */
   onDiscussWithAriadne?: () => void | Promise<void>
   /**
@@ -328,6 +335,13 @@ export const messageActions: MessageAction[] = [
     icon: BookmarkX,
     when: (ctx) => !!ctx.onToggleSave && !!ctx.isSaved,
     action: (ctx) => ctx.onToggleSave?.(),
+  },
+  {
+    id: "label-message",
+    label: "Label message",
+    icon: Tag,
+    when: (ctx) => !!ctx.onLabelMessage,
+    action: (ctx) => ctx.onLabelMessage?.(),
   },
   {
     // Seed a private scratchpad that has this message's thread pre-loaded as

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useRef, useEffect, useState, useMemo, useCallback } from "react"
 import {
   isSentViaApi,
+  LabelableResourceTypes,
   type StreamEvent,
   type AttachmentSummary,
   type JSONContent,
@@ -64,6 +65,8 @@ import { EditedIndicator } from "./edited-indicator"
 import { MovedFromIndicator } from "./moved-from-indicator"
 import { MovedMessagesDrawer } from "./moved-messages-drawer"
 import { SavedIndicator } from "@/components/saved/saved-indicator"
+import { LabelStack } from "@/components/labels/label-stack"
+import { LabelPicker } from "@/components/labels/label-picker"
 import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
 import { ReactionEmojiPicker } from "./reaction-emoji-picker"
@@ -873,6 +876,7 @@ function SentMessageEvent({
   const [historyOpen, setHistoryOpen] = useState(false)
   const [shareModalOpen, setShareModalOpen] = useState(false)
   const [moveDetailsOpen, setMoveDetailsOpen] = useState(false)
+  const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   // Hydrate the destination tombstone on demand for the per-message
   // "Show move details" action. Reactive — populates as soon as the row
   // lands in IDB (live socket apply or bootstrap).
@@ -1094,6 +1098,7 @@ function SentMessageEvent({
       reactions: payload.reactions,
       isSaved,
       onToggleSave: handleToggleSave,
+      onLabelMessage: () => setLabelPickerOpen(true),
       onRequestReminder: handleRequestReminder,
       onDiscussWithAriadne: handleDiscussWithAriadne,
       onQuoteReply: quoteReplyCtx
@@ -1230,6 +1235,13 @@ function SentMessageEvent({
             currentUserId={currentUserId}
           />
         )}
+        {/* Labels the viewer filed this message under — renders nothing until
+            there's at least one, so unlabeled rows keep their footprint. */}
+        <LabelStack
+          workspaceId={workspaceId}
+          resourceType={LabelableResourceTypes.MESSAGE}
+          resourceId={payload.messageId}
+        />
         {threadSlot}
       </>
     )
@@ -1428,6 +1440,15 @@ function SentMessageEvent({
           onOpenChange={setMoveDetailsOpen}
           event={movedTombstoneEvent}
           workspaceId={workspaceId}
+        />
+      )}
+      {labelPickerOpen && (
+        <LabelPicker
+          workspaceId={workspaceId}
+          resourceType={LabelableResourceTypes.MESSAGE}
+          resourceId={payload.messageId}
+          open={labelPickerOpen}
+          onOpenChange={setLabelPickerOpen}
         />
       )}
       {touchCapable && (

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1235,13 +1235,16 @@ function SentMessageEvent({
             currentUserId={currentUserId}
           />
         )}
-        {/* Labels the viewer filed this message under — renders nothing until
-            there's at least one, so unlabeled rows keep their footprint. */}
-        <LabelStack
-          workspaceId={workspaceId}
-          resourceType={LabelableResourceTypes.MESSAGE}
-          resourceId={payload.messageId}
-        />
+        {/* Grouped continuations have no header row, so their labels trail the
+            footer; standalone rows render them in the header beside the time
+            (see statusIndicator). Renders nothing until the message is labeled. */}
+        {groupContinuation && (
+          <LabelStack
+            workspaceId={workspaceId}
+            resourceType={LabelableResourceTypes.MESSAGE}
+            resourceId={payload.messageId}
+          />
+        )}
         {threadSlot}
       </>
     )
@@ -1272,6 +1275,13 @@ function SentMessageEvent({
               />
             )}
             <SavedIndicator saved={savedForMessage ?? null} />
+            {/* Labels beside the time — standalone rows only; this header isn't
+                rendered for continuations, which keep them in the footer. */}
+            <LabelStack
+              workspaceId={workspaceId}
+              resourceType={LabelableResourceTypes.MESSAGE}
+              resourceId={payload.messageId}
+            />
           </>
         }
         isEditing={isEditing && !editingSurfaceTouch}

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -103,6 +103,7 @@ export interface ScheduledService {
 
 export interface LabelService {
   list: typeof labelsApi.list
+  listMessages: typeof labelsApi.listMessages
   create: typeof labelsApi.create
   update: typeof labelsApi.update
   delete: typeof labelsApi.delete

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -217,6 +217,7 @@ export {
   useDeleteLabel,
   useResourceLabelAssignments,
   useLabelStreams,
+  useLabelMessages,
   selectLabelStreams,
   useAssignLabel,
   useUnassignLabel,

--- a/apps/frontend/src/hooks/use-labels.ts
+++ b/apps/frontend/src/hooks/use-labels.ts
@@ -6,13 +6,21 @@ import { db, type CachedLabel, type CachedLabelAssignment, type CachedStream } f
 import { useWorkspaceLabels, useWorkspaceLabelAssignments, useWorkspaceStreams } from "@/stores/workspace-store"
 import { useCurrentWorkspaceUserId } from "./use-current-workspace-user-id"
 import { LabelableResourceTypes } from "@threa/types"
-import type { CreateLabelInput, Label, LabelAssignment, LabelableResourceType, UpdateLabelInput } from "@threa/types"
+import type {
+  CreateLabelInput,
+  Label,
+  LabelAssignment,
+  LabelableResourceType,
+  LabeledMessage,
+  UpdateLabelInput,
+} from "@threa/types"
 
 export type { CachedLabel, CachedLabelAssignment }
 
 export const labelKeys = {
   all: ["labels"] as const,
   list: (workspaceId: string) => ["labels", workspaceId] as const,
+  messages: (workspaceId: string, labelId: string) => ["labels", workspaceId, labelId, "messages"] as const,
 }
 
 /**
@@ -343,4 +351,23 @@ export function useLabelStreams(workspaceId: string, labelId: string): CachedStr
   const assignments = useWorkspaceLabelAssignments(workspaceId)
   const streams = useWorkspaceStreams(workspaceId)
   return useMemo(() => selectLabelStreams(assignments, streams, labelId), [assignments, streams, labelId])
+}
+
+/**
+ * The messages filed under a label, hydrated server-side (content, reactions,
+ * attachments, link previews) for the label landing page's Messages section.
+ *
+ * Unlike streams, messages aren't fully cached client-side, so this is a real
+ * fetch rather than a cache projection. The assign/unassign mutations invalidate
+ * `["labels", workspaceId]`, which prefix-covers this key — so labeling a message
+ * from anywhere refreshes the list without extra wiring.
+ */
+export function useLabelMessages(workspaceId: string, labelId: string) {
+  const labelService = useLabelService()
+  return useQuery<LabeledMessage[]>({
+    queryKey: labelKeys.messages(workspaceId, labelId),
+    queryFn: () => labelService.listMessages(workspaceId, labelId),
+    enabled: !!workspaceId && !!labelId,
+    staleTime: 30_000,
+  })
 }

--- a/apps/frontend/src/pages/label-detail.tsx
+++ b/apps/frontend/src/pages/label-detail.tsx
@@ -363,53 +363,22 @@ function MessagesSection({
   if (messages.length === 0) return <EmptyMessages />
   return (
     <div className="divide-y overflow-hidden rounded-xl border bg-card">
-      {messages.map((message) => {
-        const stream = resolveMessageStream(message.streamId)
-        return (
-          <div key={message.id} className="px-4 py-3">
-            <StreamByline workspaceId={workspaceId} streamId={message.streamId} name={stream.name} type={stream.type} />
-            {/* Each labeled message is standalone, so zero the item's leading
-                margin (which exists to space stacked messages in a board card)
-                and let the cell padding + byline gap own the rhythm. */}
-            <div className="[&>*]:mt-0">
-              <MessageItem
-                workspaceId={workspaceId}
-                streamId={message.streamId}
-                message={message}
-                authorName={getActorName(message.authorId, message.authorType)}
-                currentUserId={currentUserId}
-              />
-            </div>
-          </div>
-        )
-      })}
+      {messages.map((message) => (
+        // Each labeled message is standalone, so zero the item's leading margin
+        // (which spaces stacked messages in a board card) and let the cell
+        // padding own the rhythm. The origin stream rides in the item's header.
+        <div key={message.id} className="px-4 py-3 [&>*]:mt-0">
+          <MessageItem
+            workspaceId={workspaceId}
+            streamId={message.streamId}
+            message={message}
+            authorName={getActorName(message.authorId, message.authorType)}
+            currentUserId={currentUserId}
+            streamLabel={resolveMessageStream(message.streamId)}
+          />
+        </div>
+      ))}
     </div>
-  )
-}
-
-/** Names the stream a labeled message came from, linking back into it (INV-40).
- * Labeled messages span streams, so the origin is per-row here — the board shows
- * the analogous context at the card level. */
-function StreamByline({
-  workspaceId,
-  streamId,
-  name,
-  type,
-}: {
-  workspaceId: string
-  streamId: string
-  name: string
-  type: StreamType
-}) {
-  const Icon = STREAM_ICONS[type] ?? Tag
-  return (
-    <Link
-      to={`/w/${workspaceId}/s/${streamId}`}
-      className="mb-1.5 flex w-fit max-w-full items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-    >
-      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
-      <span className="truncate font-medium">{name}</span>
-    </Link>
   )
 }
 

--- a/apps/frontend/src/pages/label-detail.tsx
+++ b/apps/frontend/src/pages/label-detail.tsx
@@ -177,6 +177,7 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
 }
 
 function countLabel(count: number, noun: string): string {
+  if (count === 0) return `No ${noun}s yet`
   return `${count} ${count === 1 ? noun : `${noun}s`}`
 }
 

--- a/apps/frontend/src/pages/label-detail.tsx
+++ b/apps/frontend/src/pages/label-detail.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { Link, useParams } from "react-router-dom"
 import { ArrowLeft, ChevronRight, Pencil, Tag } from "lucide-react"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -29,8 +29,14 @@ import {
   useWorkspaceUserId,
   type CachedLabel,
 } from "@/hooks"
-import { useWorkspaceDmPeers, useWorkspaceLabels, useWorkspaceUsers, type CachedStream } from "@/stores/workspace-store"
-import type { LabeledMessage } from "@threa/types"
+import {
+  useWorkspaceDmPeers,
+  useWorkspaceLabels,
+  useWorkspaceStreams,
+  useWorkspaceUsers,
+  type CachedStream,
+} from "@/stores/workspace-store"
+import type { LabeledMessage, StreamType } from "@threa/types"
 
 /**
  * Route is `/w/:workspaceId/labels/:labelId` — a label's landing page. Opens
@@ -56,6 +62,7 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
   const messages = messagesQuery.data ?? []
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
+  const workspaceStreams = useWorkspaceStreams(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const { getActorName } = useActors(workspaceId)
   const [editOpen, setEditOpen] = useState(false)
@@ -66,6 +73,21 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
   const namedStreams = useMemo(
     () => streams.map((stream) => ({ stream, name: resolveStreamName(stream.id, { streams, users, dmPeers }) })),
     [streams, users, dmPeers]
+  )
+
+  // Labeled messages span streams, so each row names its origin. Resolve against
+  // the full workspace streams (not the label's own), since a labeled message
+  // can live in a stream the label doesn't otherwise gather.
+  const resolveMessageStream = useCallback(
+    (messageStreamId: string): { name: string; type: StreamType } => {
+      const stream = workspaceStreams.find((s) => s.id === messageStreamId)
+      const type: StreamType = stream?.type ?? "channel"
+      const name =
+        resolveStreamName(messageStreamId, { streams: workspaceStreams, users, dmPeers }, "breadcrumb") ??
+        streamFallbackLabel(type, "breadcrumb")
+      return { name, type }
+    },
+    [workspaceStreams, users, dmPeers]
   )
 
   // A cold deep-link to this URL lands before bootstrap fills the cache, so an
@@ -137,6 +159,7 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
               isLoading={messagesQuery.isLoading}
               getActorName={getActorName}
               currentUserId={currentUserId}
+              resolveMessageStream={resolveMessageStream}
             />
           </section>
         </div>
@@ -327,32 +350,66 @@ function MessagesSection({
   isLoading,
   getActorName,
   currentUserId,
+  resolveMessageStream,
 }: {
   workspaceId: string
   messages: LabeledMessage[]
   isLoading: boolean
   getActorName: ReturnType<typeof useActors>["getActorName"]
   currentUserId: string | null
+  resolveMessageStream: (streamId: string) => { name: string; type: StreamType }
 }) {
   if (isLoading && messages.length === 0) return <MessagesLoading />
   if (messages.length === 0) return <EmptyMessages />
   return (
     <div className="divide-y overflow-hidden rounded-xl border bg-card">
-      {messages.map((message) => (
-        // Each labeled message is standalone, so zero the item's leading margin
-        // (which exists to space stacked messages in a board card) and let the
-        // cell padding own the rhythm.
-        <div key={message.id} className="px-4 py-3 [&>*]:mt-0">
-          <MessageItem
-            workspaceId={workspaceId}
-            streamId={message.streamId}
-            message={message}
-            authorName={getActorName(message.authorId, message.authorType)}
-            currentUserId={currentUserId}
-          />
-        </div>
-      ))}
+      {messages.map((message) => {
+        const stream = resolveMessageStream(message.streamId)
+        return (
+          <div key={message.id} className="px-4 py-3">
+            <StreamByline workspaceId={workspaceId} streamId={message.streamId} name={stream.name} type={stream.type} />
+            {/* Each labeled message is standalone, so zero the item's leading
+                margin (which exists to space stacked messages in a board card)
+                and let the cell padding + byline gap own the rhythm. */}
+            <div className="[&>*]:mt-0">
+              <MessageItem
+                workspaceId={workspaceId}
+                streamId={message.streamId}
+                message={message}
+                authorName={getActorName(message.authorId, message.authorType)}
+                currentUserId={currentUserId}
+              />
+            </div>
+          </div>
+        )
+      })}
     </div>
+  )
+}
+
+/** Names the stream a labeled message came from, linking back into it (INV-40).
+ * Labeled messages span streams, so the origin is per-row here — the board shows
+ * the analogous context at the card level. */
+function StreamByline({
+  workspaceId,
+  streamId,
+  name,
+  type,
+}: {
+  workspaceId: string
+  streamId: string
+  name: string
+  type: StreamType
+}) {
+  const Icon = STREAM_ICONS[type] ?? Tag
+  return (
+    <Link
+      to={`/w/${workspaceId}/s/${streamId}`}
+      className="mb-1.5 flex w-fit max-w-full items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span className="truncate font-medium">{name}</span>
+    </Link>
   )
 }
 

--- a/apps/frontend/src/pages/label-detail.tsx
+++ b/apps/frontend/src/pages/label-detail.tsx
@@ -14,14 +14,23 @@ import {
 import { SidebarToggle } from "@/components/layout"
 import { LabelGlyph } from "@/components/labels/label-chip"
 import { LabelEditForm } from "@/components/labels/label-edit-form"
+import { MessageItem } from "@/components/message/message-item"
 import { cn } from "@/lib/utils"
 import { hexToRgba } from "@/lib/labels"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { truncateContent } from "@/components/layout/sidebar/utils"
 import { resolveStreamName, streamFallbackLabel, STREAM_ICONS } from "@/lib/streams"
 import { formatRelativeTime } from "@/lib/dates"
-import { useLabelStreams, useLabelsSync, useWorkspaceUserId, type CachedLabel } from "@/hooks"
+import {
+  useActors,
+  useLabelMessages,
+  useLabelStreams,
+  useLabelsSync,
+  useWorkspaceUserId,
+  type CachedLabel,
+} from "@/hooks"
 import { useWorkspaceDmPeers, useWorkspaceLabels, useWorkspaceUsers, type CachedStream } from "@/stores/workspace-store"
+import type { LabeledMessage } from "@threa/types"
 
 /**
  * Route is `/w/:workspaceId/labels/:labelId` — a label's landing page. Opens
@@ -43,9 +52,12 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
   const labels = useWorkspaceLabels(workspaceId)
   const label = useMemo(() => labels.find((l) => l.id === labelId && !l.archivedAt) ?? null, [labels, labelId])
   const streams = useLabelStreams(workspaceId, labelId)
+  const messagesQuery = useLabelMessages(workspaceId, labelId)
+  const messages = messagesQuery.data ?? []
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
+  const { getActorName } = useActors(workspaceId)
   const [editOpen, setEditOpen] = useState(false)
   const canEdit = !!label && label.creatorUserId === currentUserId
 
@@ -68,7 +80,13 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
   } else {
     body = (
       <>
-        <LabelHero label={label} streamCount={namedStreams.length} canEdit={canEdit} onEdit={() => setEditOpen(true)} />
+        <LabelHero
+          label={label}
+          streamCount={namedStreams.length}
+          messageCount={messagesQuery.isFetched ? messages.length : null}
+          canEdit={canEdit}
+          onEdit={() => setEditOpen(true)}
+        />
         {canEdit && (
           <ResponsiveDialog open={editOpen} onOpenChange={setEditOpen} disableSnapPoints>
             <ResponsiveDialogContent
@@ -92,22 +110,36 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
             </ResponsiveDialogContent>
           </ResponsiveDialog>
         )}
-        <section className="mt-8">
-          <h2 className="mb-2.5 px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Streams</h2>
-          {namedStreams.length === 0 ? (
-            <EmptyStreams />
-          ) : (
-            <div className="overflow-hidden rounded-xl border bg-card">
-              <ul className="divide-y">
-                {namedStreams.map(({ stream, name }, i) => (
-                  <li key={stream.id}>
-                    <StreamRow workspaceId={workspaceId} stream={stream} name={name} index={i} />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </section>
+        {/* Streams and messages sit side by side on wide screens and stack on
+            narrow ones — two resource sections of the same label. */}
+        <div className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-2">
+          <section>
+            <SectionHeading>Streams</SectionHeading>
+            {namedStreams.length === 0 ? (
+              <EmptyStreams />
+            ) : (
+              <div className="overflow-hidden rounded-xl border bg-card">
+                <ul className="divide-y">
+                  {namedStreams.map(({ stream, name }, i) => (
+                    <li key={stream.id}>
+                      <StreamRow workspaceId={workspaceId} stream={stream} name={name} index={i} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </section>
+          <section>
+            <SectionHeading>Messages</SectionHeading>
+            <MessagesSection
+              workspaceId={workspaceId}
+              messages={messages}
+              isLoading={messagesQuery.isLoading}
+              getActorName={getActorName}
+              currentUserId={currentUserId}
+            />
+          </section>
+        </div>
       </>
     )
   }
@@ -138,28 +170,36 @@ function LabelDetailPageInner({ workspaceId, labelId }: { workspaceId: string; l
           preview line push the page wider than the screen on mobile. Matches the
           saved/activity pages. */}
       <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
-        <main className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6 sm:py-8">{body}</main>
+        <main className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-8">{body}</main>
       </ScrollArea>
     </div>
   )
 }
 
-function streamCountLabel(count: number): string {
-  if (count === 0) return "No streams yet"
-  return `${count} ${count === 1 ? "stream" : "streams"}`
+function countLabel(count: number, noun: string): string {
+  return `${count} ${count === 1 ? noun : `${noun}s`}`
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return <h2 className="mb-2.5 px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{children}</h2>
 }
 
 function LabelHero({
   label,
   streamCount,
+  messageCount,
   canEdit,
   onEdit,
 }: {
   label: CachedLabel
   streamCount: number
+  /** `null` until the messages query settles, so the hero doesn't flash "0 messages". */
+  messageCount: number | null
   canEdit: boolean
   onEdit: () => void
 }) {
+  const counts = [countLabel(streamCount, "stream")]
+  if (messageCount !== null) counts.push(countLabel(messageCount, "message"))
   return (
     <div
       className="relative overflow-hidden rounded-xl border p-5 sm:p-6"
@@ -178,7 +218,7 @@ function LabelHero({
         <div className="min-w-0 flex-1">
           <h2 className="truncate text-xl font-semibold leading-tight">{label.name}</h2>
           <div className="mt-1.5 flex items-center gap-2 text-xs font-medium text-muted-foreground">
-            <span>{streamCountLabel(streamCount)}</span>
+            <span>{counts.join(" · ")}</span>
           </div>
           {label.description && (
             <p className="mt-3 max-w-prose text-sm leading-relaxed text-foreground/80">
@@ -275,6 +315,71 @@ function EmptyStreams() {
       <h3 className="text-sm font-semibold">Nothing here yet</h3>
       <p className="mt-1 max-w-md text-sm text-muted-foreground">
         Apply this label to a scratchpad, channel, or thread from its “Labels…” menu and it will show up here.
+      </p>
+    </div>
+  )
+}
+
+function MessagesSection({
+  workspaceId,
+  messages,
+  isLoading,
+  getActorName,
+  currentUserId,
+}: {
+  workspaceId: string
+  messages: LabeledMessage[]
+  isLoading: boolean
+  getActorName: ReturnType<typeof useActors>["getActorName"]
+  currentUserId: string | null
+}) {
+  if (isLoading && messages.length === 0) return <MessagesLoading />
+  if (messages.length === 0) return <EmptyMessages />
+  return (
+    <div className="divide-y overflow-hidden rounded-xl border bg-card">
+      {messages.map((message) => (
+        // Each labeled message is standalone, so zero the item's leading margin
+        // (which exists to space stacked messages in a board card) and let the
+        // cell padding own the rhythm.
+        <div key={message.id} className="px-4 py-3 [&>*]:mt-0">
+          <MessageItem
+            workspaceId={workspaceId}
+            streamId={message.streamId}
+            message={message}
+            authorName={getActorName(message.authorId, message.authorType)}
+            currentUserId={currentUserId}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function MessagesLoading() {
+  return (
+    <div className="divide-y overflow-hidden rounded-xl border bg-card">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="flex animate-pulse gap-3 px-4 py-3">
+          <div className="h-8 w-8 shrink-0 rounded-full bg-muted" />
+          <div className="flex-1 space-y-2 pt-0.5">
+            <div className="h-3.5 w-1/3 rounded bg-muted" />
+            <div className="h-3 w-2/3 rounded bg-muted" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function EmptyMessages() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed bg-card/40 px-6 py-12 text-center">
+      <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+        <Tag className="h-5 w-5" />
+      </div>
+      <h3 className="text-sm font-semibold">No messages yet</h3>
+      <p className="mt-1 max-w-md text-sm text-muted-foreground">
+        Pick “Label message” from any message's menu to file it under this label.
       </p>
     </div>
   )

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -48,7 +48,7 @@ import { useStreamSettings } from "@/components/stream-settings/use-stream-setti
 import { useExplorerUrlState } from "@/components/attachment-explorer"
 import { TimelineView } from "@/components/timeline"
 import { LabelPicker } from "@/components/labels/label-picker"
-import { StreamLabelStack } from "@/components/labels/stream-label-stack"
+import { LabelStack } from "@/components/labels/label-stack"
 import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
 import { StreamEncryptionGate } from "@/components/encryption/stream-encryption-gate"
 import { useDecryptedStreamName, useStreamNameDecrypting } from "@/hooks/use-decrypted-stream-name"
@@ -605,7 +605,9 @@ export function StreamPage() {
           <SidebarToggle location="page" />
           {headerTitle}
           {companionModeIndicator}
-          {stream && !isDraft && <StreamLabelStack workspaceId={workspaceId} streamId={streamId} />}
+          {stream && !isDraft && (
+            <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.STREAM} resourceId={streamId} />
+          )}
           {isEncryptedScratchpad && !isDraft && (
             <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
           )}

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -3692,7 +3692,7 @@
                             "type": "object",
                             "properties": {
                               "labelId": { "type": "string" },
-                              "resourceType": { "type": "string", "enum": ["stream"] },
+                              "resourceType": { "type": "string", "enum": ["stream", "message"] },
                               "resourceId": { "type": "string" },
                               "actorType": { "type": "string", "enum": ["user", "bot"] },
                               "actorId": { "type": "string" },
@@ -3883,7 +3883,7 @@
                   "color": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
                   "emoji": { "anyOf": [{ "type": "string", "maxLength": 32 }, { "type": "null" }] },
                   "description": { "anyOf": [{ "type": "string", "maxLength": 500 }, { "type": "null" }] },
-                  "resourceType": { "type": "string", "enum": ["stream"] },
+                  "resourceType": { "type": "string", "enum": ["stream", "message"] },
                   "resourceId": { "type": "string", "minLength": 1, "maxLength": 64 }
                 },
                 "required": ["name", "resourceType", "resourceId"],
@@ -3940,7 +3940,7 @@
                           "type": "object",
                           "properties": {
                             "labelId": { "type": "string" },
-                            "resourceType": { "type": "string", "enum": ["stream"] },
+                            "resourceType": { "type": "string", "enum": ["stream", "message"] },
                             "resourceId": { "type": "string" },
                             "actorType": { "type": "string", "enum": ["user", "bot"] },
                             "actorId": { "type": "string" },
@@ -4019,7 +4019,7 @@
             "name": "resourceType",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "enum": ["stream"] }
+            "schema": { "type": "string", "enum": ["stream", "message"] }
           },
           {
             "name": "resourceId",

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -29,13 +29,15 @@ export const Visibilities = {
 // Labelable resource types — the polymorphic target of a label assignment.
 // Labeling is resource-agnostic: the table, service, events, sync, and UI
 // primitives are identical for every type. This set only gates which targets
-// the API accepts today; adding "message" | "user" | "attachment" later is a
-// one-line change here plus a presentation adapter — no new mechanism.
-export const LABELABLE_RESOURCE_TYPES = ["stream"] as const
+// the API accepts; each type still needs a backend access rule
+// (assertResourceAccess) and a presentation adapter — adding "user" |
+// "attachment" later is a one-line change here plus those two seams.
+export const LABELABLE_RESOURCE_TYPES = ["stream", "message"] as const
 export type LabelableResourceType = (typeof LABELABLE_RESOURCE_TYPES)[number]
 
 export const LabelableResourceTypes = {
   STREAM: "stream",
+  MESSAGE: "message",
 } as const satisfies Record<string, LabelableResourceType>
 
 // The actor that owns/applies a label — a workspace user or a bot. A shared bot

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -656,6 +656,18 @@ export interface BoardPostMessage {
 }
 
 /**
+ * A message gathered under a label, for the label landing page's Messages
+ * section. Same lean rendering projection as {@link BoardPostMessage}, plus the
+ * `streamId` it lives in: labeled messages span streams, so each row carries its
+ * own origin to render the author/context and to open in its own stream
+ * (`/w/:workspaceId/s/:streamId?m=:id`) — the board derives `streamId` from the
+ * post instead.
+ */
+export interface LabeledMessage extends BoardPostMessage {
+  streamId: string
+}
+
+/**
  * One board post: a conversation (the grouping) surfaced as a feed post (the
  * unit). The card renders `openingMessage` as the post body and `recentMessages`
  * as the latest replies beneath it, with a collapsed "N more" gap between — so

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -280,6 +280,7 @@ export type {
   ConversationWithStaleness,
   BoardPost,
   BoardPostMessage,
+  LabeledMessage,
   Memo,
   PendingMemoItem,
   MemoStreamState,


### PR DESCRIPTION
## Problem

Labels could only be applied to streams. The assignment table, service, sync, and frontend primitives were already resource-generic (`LABELABLE_RESOURCE_TYPES`, the `label_assignments` polymorphic `resource_type`/`resource_id`, the `label:assigned`/`label:unassigned` socket handlers), but `"stream"` was the only accepted target — so a user could file a whole channel under "Follow-up" but not a single message in it. The label landing page (`apps/frontend/src/pages/label-detail.tsx`) listed only Streams.

The two seams a new resource type needs were also not generic: the backend write-path access gate (`assertResourceAccess`) handled only streams, and the frontend had a `StreamLabelStack` hard-wired to `LabelableResourceTypes.STREAM` plus a board-only `PostMessage` renderer that couldn't be reused on the label page.

## Solution

Add `"message"` as a labelable resource type and carry it through the two seams. A message inherits its owning stream's access (INV-62), so both the write gate and the read-back resolve the message's `stream_id` and reuse the canonical stream-access predicates — no message-specific access rule. On the frontend, generalize the stream label stack into a resource-generic `LabelStack`, extract the board's per-message renderer into a shared `MessageItem`, and reuse both on a new Messages section of the label page. A message's labels render as a header chip beside the timestamp (timeline + board + label page), not trailing the body.

### How it works

**Write path — labeling a message** (`apps/backend/src/features/labels/assignment-service.ts`). `assertResourceAccess` gains a `MESSAGE` branch → `canReachMessage`, which resolves the message's stream via `MessageRepository.findStreamIdsByIds([id])` and delegates to the existing `canReachStream` → `listAccessibleStreamIds`. Thread→root inheritance and public-channel reads resolve inside that shared predicate; bot actors route through `botChannelService`. A missing message or an unreachable stream is reported as `404 RESOURCE_NOT_FOUND` (INV-32) rather than leaking existence. Unassign stays ungated.

**Read path — the label's messages** (`apps/backend/src/features/labels/label-message-service.ts`, new). `listLabeledMessages`:
1. `LabelAssignmentRepository.listForLabelAndResourceType` — the actor's MESSAGE assignments for this label, `ORDER BY assigned_at DESC` (newest-stowed first), owner-scoped + archived-label filtered.
2. `MessageRepository.findByIds`, preserving the assignment order through the Map lookup and dropping ids that resolved to nothing or were deleted after labeling.
3. Re-gate: collect distinct `streamId`s and re-check reachability via `listAccessibleStreamIds` (or bot channel grants) — access can change after labeling, so a message whose stream the viewer can no longer reach is dropped even though their owner-scoped assignment row survives.
4. Hydrate content + reactions + attachments + link previews via the shared projection helpers, projected to `LabeledMessage` (= `BoardPostMessage` + `streamId`).

New endpoint `GET /api/workspaces/:workspaceId/labels/:labelId/messages`.

**Frontend.**
- `useLabelMessages` (`apps/frontend/src/hooks/use-labels.ts`) — a server fetch under key `["labels", workspaceId, labelId, "messages"]`, `staleTime: 30_000`. The assign/unassign mutations invalidate `["labels", workspaceId]`, which prefix-covers this key.
- `LabelStack` (renamed from `StreamLabelStack`) — `resourceType` + `resourceId` are the only per-resource inputs; same hover-fan / touch-drawer behavior (INV-21). Call sites in `stream.tsx`, `stream-panel.tsx`, `message-event.tsx`.
- `MessageItem` (`apps/frontend/src/components/message/message-item.tsx`, extracted from board-card's `PostMessage`) — one message rendered outside the timeline, same primitives as the timeline. Desktop shows a hover overflow menu; **touch shows the timeline's long-press `MessageActionDrawer`** (via `useLongPress` + `useTouchCapable`), so there's no tap-sized dropdown. Reused by the board card and the label page.
- **A message's labels render in the header** beside the timestamp — `MessageItem`'s header row (board + label page) and the timeline's `statusIndicator` (`message-event.tsx`). Grouped continuations have no header, so they keep the `LabelStack` in the footer. (Earlier the label sat below the reactions and a lone label read as a stray glyph.)
- `message-actions.ts` — new `label-message` action (Tag icon) → the resource-generic `LabelPicker`.
- `label-detail.tsx` — a Messages section beside Streams (two columns on `lg`); each row is a `MessageItem` carrying an origin-stream byline in its header (right of the time, resolved via `resolveStreamName` against the full workspace streams), openable in its own stream. Hero counts read `N streams · N messages` (`No streams yet` / null-until-fetched so it doesn't flash `0`). Width widened to `max-w-5xl`.

### Key design decisions

**1. A message inherits its stream's access — no message-level access rule.** The write gate (`canReachMessage`) and the read-back both resolve `message → stream_id` and run the existing `canReachStream` / `listAccessibleStreamIds` predicate (INV-62): a thread message resolves through `root_stream_id`, a public channel grants reads without a `stream_members` row. Gating on direct `stream_members` rows would silently drop thread content for root-stream members — the recurring footgun INV-62 calls out.

**2. Re-gate the read path, don't trust the assignment row.** A label assignment is owner-scoped and outlives access changes. `listLabeledMessages` re-checks stream reachability on every read and drops what's no longer visible.

**3. Extract one shared `MessageItem` rather than fork board-card.** The board already had a faithful out-of-timeline renderer (`PostMessage`); the label page needs the same thing. One shared component keeps a board/label/timeline message visually identical from one code path. Consequence (deliberate): board messages gain a `LabelStack` + overflow menu, so you can label from the board too.

**4. Labels live in the header, beside the time.** A message's labels are row metadata, like the saved/edited markers — so they sit in the header `statusIndicator` (timeline) / header row (`MessageItem`), not below the reactions where a single label floated as a stray glyph. Continuations (no header) are the one exception and keep them in the footer.

**5. Touch parity with the timeline.** `MessageItem` reuses the timeline's `useLongPress` → `MessageActionDrawer` for touch instead of an always-visible sub-44px dropdown; the overflow menu is hover/focus-gated on desktop (a faithful reuse, not a parallel implementation).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/labels/label-message-service.ts` | Read the viewer's labeled messages for a label, re-gated on stream access and hydrated for the label page |
| `apps/backend/src/features/labels/label-message-service.test.ts` | Order preservation, deleted-after-label drop, unreachable-stream drop, empty-fast-path |
| `apps/frontend/src/components/message/message-item.tsx` | Shared out-of-timeline message renderer (board + label page): header labels + origin-stream chip, desktop hover menu / touch action drawer |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | Add `"message"` to `LABELABLE_RESOURCE_TYPES` + `LabelableResourceTypes.MESSAGE` |
| `packages/types/src/domain.ts`, `src/index.ts` | Add + export `LabeledMessage` (`BoardPostMessage` + `streamId`) |
| `apps/backend/src/features/labels/assignment-service.ts` (+ `.test.ts`) | `assertResourceAccess` MESSAGE branch → `canReachMessage`; message-resource access tests |
| `apps/backend/src/features/labels/repository.ts` | `LabelAssignmentRepository.listForLabelAndResourceType` (owner-scoped, archived-filtered, `assigned_at DESC`) |
| `apps/backend/src/features/labels/handlers.ts`, `index.ts` | `listMessages` handler + `LabelMessageService` wiring/export |
| `apps/backend/src/features/messaging/repository.ts` | `MessageRepository.findStreamIdsByIds` — minimal id→stream lookup for the access check |
| `apps/backend/src/routes.ts`, `server.ts` | Construct + inject `labelMessageService`; register `GET .../labels/:labelId/messages` |
| `apps/frontend/src/components/board/board-card.tsx` | Replace inline `PostMessage`/`isContinuation`/`RenderableMessage` with the shared `MessageItem` |
| `apps/frontend/src/components/labels/label-stack.tsx` (+ `.test.tsx`) | Renamed from `stream-label-stack`; resource-generic (`resourceType`/`resourceId`) |
| `apps/frontend/src/components/timeline/message-actions.ts` (+ `.test.ts`) | New `label-message` action gated on `onLabelMessage` |
| `apps/frontend/src/components/timeline/message-event.tsx` | Wire `onLabelMessage` → message `LabelPicker`; render the message's `LabelStack` in the header (`statusIndicator`), footer for continuations |
| `apps/frontend/src/components/thread/stream-panel.tsx`, `apps/frontend/src/pages/stream.tsx` | `StreamLabelStack` → resource-generic `LabelStack` call sites |
| `apps/frontend/src/api/labels.ts`, `contexts/services-context.tsx`, `hooks/use-labels.ts`, `hooks/index.ts` | `listMessages` API + `useLabelMessages` query hook |
| `apps/frontend/src/pages/label-detail.tsx` | Messages section beside Streams; per-row origin-stream byline in the message header; `No streams yet` empty copy; width → `max-w-5xl` |
| `docs/public-api/openapi.json` | `resourceType` enum `["stream"]` → `["stream", "message"]` (4 sites) |

## Out of scope (deliberate)

- **Cross-device live refresh of the label page** — `useLabelMessages` is a server fetch; only the local mutation invalidates the key, so a label change on another device surfaces after the 30s `staleTime`.
- **No `workspace_id` filter on `MessageRepository.findStreamIdsByIds`** — id-only to match its siblings; the sole caller re-gates the resolved stream through `listAccessibleStreamIds`, whose predicate re-checks `workspace_id`.
- **E2EE message bodies** — `MessageItem` renders `contentMarkdown` exactly as the board already does; same pre-existing contract, no new decrypt wiring.
- **Other resource types** (`user`, `attachment`) — still rejected by `LABELABLE_RESOURCE_TYPES`.

## Test plan

- [x] Backend `bun test src/features/labels` — 29 pass (incl. `label-message-service` ×4, `assignment-service` message-resource ×3)
- [x] Frontend `vitest` — `label-detail` (7), `label-stack`, `message-actions`, and the timeline `message-event` (22) suites pass
- [x] `bun run typecheck` — clean across the monorepo
- [x] Pre-PR review + a focused re-review of the fix commits (sonnet ×4 lenses): no surviving findings; the 3 UX/mobile findings from the first pass were fixed
- [ ] No live-DB harness for the new read/write SQL — covered via stubbed-repo service tests like their siblings, not integration-tested
- [ ] E2E suite (`bun run test:e2e`) not run — covered by unit/integration above; no new cross-app flow

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Extend labeling from streams to individual messages, surface a label's messages on the label landing page, and render a message's labels as header metadata.

**What was built.**
- Types: `"message"` in `LABELABLE_RESOURCE_TYPES`; `LabeledMessage` (`BoardPostMessage` + `streamId`).
- Backend write gate (`assertResourceAccess` → `canReachMessage`) and read service (`LabelMessageService.listLabeledMessages`), both inheriting stream access via `listAccessibleStreamIds`/`canReachStream` (INV-62); new `GET .../labels/:labelId/messages`.
- Frontend: `label-message` action → resource-generic `LabelPicker`; `StreamLabelStack` → `LabelStack`; board's `PostMessage` → shared `MessageItem`; label page Messages section; message labels render in the header beside the time.

**Design evolution.**
- Self-review of the first cut found the empty hero copy regressed (`0 streams` vs `No streams yet`) — restored (`009bc57`).
- A multi-lens review flagged 3 UX/mobile issues on `MessageItem`'s overflow menu — fixed (`295c411`): touch now uses the long-press `MessageActionDrawer`; `pr-7` reserves the hover button's footprint; the label page gained a stream-origin byline.
- Design feedback: the origin-stream byline moved from above the message into the header (`7d17e2b`), and the message's own labels moved from below the reactions into the header beside the time (`0ddc707`) — a single label was reading as a stray glyph at the row bottom.

**Schema changes.** None — `label_assignments` is already polymorphic; `"message"` is an accepted-value change, not a migration.

**What's NOT included.** Cross-device live refresh (30s stale), `user`/`attachment` types, E2EE-body decrypt on these surfaces (renders `contentMarkdown` as the board does).

**Status.** Backend + frontend tests green, monorepo typecheck clean, reviewed (no surviving findings). CI green; staging deployed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_