### PR TITLE
perf(sidebar): derive draft badge from a lightweight summary, not the explorer model

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar.tsx
@@ -9,8 +9,7 @@ import { getE2eSessionState } from "@/stores/e2e-session-store"
 import { useSealedNamePendingResolver } from "@/hooks/use-decrypted-stream-name"
 import {
   useActivityCounts,
-  useAllDrafts,
-  streamIdsWithLoadedDraft,
+  useDraftSummary,
   createDmDraftId,
   useDraftScratchpads,
   useLiveSavedCount,
@@ -93,7 +92,7 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   const { createScratchpad } = useDraftScratchpads(workspaceId)
   const { getUnreadCount } = useUnreadCounts(workspaceId)
   const { getMentionCount, getActivityCount, unreadActivityCount } = useActivityCounts(workspaceId)
-  const { drafts: allDrafts } = useAllDrafts(workspaceId)
+  const { draftCount, loadedDraftStreamIdSignature } = useDraftSummary(workspaceId)
   const { openCreateChannel } = useCreateChannel()
   const { user } = useAuth()
   const assignLabel = useAssignLabel(workspaceId)
@@ -110,7 +109,6 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   // decrypt settles — including a failure, which leaves the overlaid row unchanged.
   const isSealedNamePending = useSealedNamePendingResolver(workspaceId)
 
-  const draftCount = allDrafts.length
   const savedCount = useLiveSavedCount(workspaceId)
   const scheduledCount = useLiveScheduledCount(workspaceId)
   const isDraftsPage = splat === "drafts" || window.location.pathname.endsWith("/drafts")
@@ -147,13 +145,10 @@ export function Sidebar({ workspaceId }: SidebarProps) {
   }, [idbStreams])
 
   // Streams the user stepped away from with an unsent (loaded, non-stashed)
-  // draft, surfaced as a per-row hint. The signature string keeps the derived
-  // Set referentially stable across draft edits that don't change membership, so
-  // the heavy `processedStreams` map below doesn't rebuild on every keystroke.
-  const loadedDraftStreamIdSignature = useMemo(
-    () => [...streamIdsWithLoadedDraft(allDrafts)].sort().join(","),
-    [allDrafts]
-  )
+  // draft, surfaced as a per-row hint. `loadedDraftStreamIdSignature` (from the
+  // lightweight summary) keeps this Set referentially stable across draft edits
+  // that don't change membership, so the heavy `processedStreams` map below
+  // doesn't rebuild on every keystroke.
   const streamsWithLoadedDraft = useMemo(
     () => new Set(loadedDraftStreamIdSignature ? loadedDraftStreamIdSignature.split(",") : []),
     [loadedDraftStreamIdSignature]

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -123,7 +123,14 @@ export {
 } from "./use-mentionables"
 export type { MentionStreamContext } from "./use-mentionables"
 
-export { useAllDrafts, streamIdsWithLoadedDraft, type UnifiedDraft, type DraftType } from "./use-all-drafts"
+export {
+  useAllDrafts,
+  useDraftSummary,
+  streamIdsWithLoadedDraft,
+  type UnifiedDraft,
+  type DraftType,
+  type DraftSummary,
+} from "./use-all-drafts"
 
 export { useFormattedDate } from "./use-formatted-date"
 

--- a/apps/frontend/src/hooks/use-all-drafts.test.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.test.ts
@@ -9,7 +9,13 @@ import { seedDecryption, clearDecryptCache } from "@/lib/crypto/decrypt-cache"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as currentUserHook from "./use-current-workspace-user-id"
 import * as e2eSessionStore from "@/stores/e2e-session-store"
-import { streamIdsWithLoadedDraft, useAllDrafts, type DraftType, type UnifiedDraft } from "./use-all-drafts"
+import {
+  streamIdsWithLoadedDraft,
+  useAllDrafts,
+  useDraftSummary,
+  type DraftType,
+  type UnifiedDraft,
+} from "./use-all-drafts"
 
 const EMPTY_DOC: JSONContent = { type: "doc", content: [{ type: "paragraph" }] }
 const UNLOCKED_SESSION = {
@@ -230,5 +236,37 @@ describe("streamIdsWithLoadedDraft", () => {
   it("ignores rows without a resolved stream id", () => {
     const ids = streamIdsWithLoadedDraft([unifiedDraft({ streamId: null })])
     expect(ids.size).toBe(0)
+  })
+})
+
+describe("useDraftSummary", () => {
+  it("counts unsent drafts and flags loaded-draft streams without building the explorer model", async () => {
+    // A loaded (pointed) stream draft, a stashed stream draft, a thread draft,
+    // and an empty draft that should be dropped.
+    await db.drafts.bulkAdd([
+      syncedDraft({ id: "draft_loaded", scope: "stream:stream_1", contentJson: makeDoc("loaded") }),
+      syncedDraft({ id: "draft_stashed", scope: "stream:stream_2", contentJson: makeDoc("stashed") }),
+      syncedDraft({ id: "draft_thread", scope: "thread:msg_1", contentJson: makeDoc("reply") }),
+      syncedDraft({ id: "draft_empty", scope: "stream:stream_3", contentJson: EMPTY_DOC }),
+    ])
+    await db.composerLoaded.put({ scope: "stream:stream_1", workspaceId, draftId: "draft_loaded" })
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => ({ summary: useDraftSummary(workspaceId), all: useAllDrafts(workspaceId) }), {
+      wrapper,
+    })
+
+    await waitFor(() => expect(result.current.all.drafts.length).toBe(3))
+
+    // Empty draft dropped; loaded/stashed/thread counted; only the loaded
+    // non-thread stream surfaces as a draft hint.
+    expect(result.current.summary.draftCount).toBe(3)
+    expect(result.current.summary.loadedDraftStreamIdSignature).toBe("stream_1")
+
+    // Drift guard: the lightweight summary must agree with the full explorer
+    // model it replaces in the sidebar.
+    expect(result.current.summary.draftCount).toBe(result.current.all.drafts.length)
+    const expectedSignature = [...streamIdsWithLoadedDraft(result.current.all.drafts)].sort().join(",")
+    expect(result.current.summary.loadedDraftStreamIdSignature).toBe(expectedSignature)
   })
 })

--- a/apps/frontend/src/hooks/use-all-drafts.ts
+++ b/apps/frontend/src/hooks/use-all-drafts.ts
@@ -92,6 +92,17 @@ function truncatePreview(content: string, maxLength: number = 80): string {
 }
 
 /**
+ * A draft carries real, unsent payload: a non-empty body, an attachment, or a
+ * sealed E2E body (whose plaintext `contentJson` is the empty placeholder at
+ * rest, so it counts on the strength of its ciphertext). The single
+ * qualification predicate shared by the explorer build and the sidebar summary
+ * so a draft counts identically in both — the badge can't drift from the list.
+ */
+function draftHasPayload(draft: CachedDraft): boolean {
+  return draft.ciphertext != null || !isEmptyContent(draft.contentJson) || (draft.attachments?.length ?? 0) > 0
+}
+
+/**
  * The explorer preview for a draft row. Plaintext rows read `contentJson`
  * directly; E2E rows (ciphertext at rest) read the decrypted body from the shared
  * cache via `previewMap`, falling back to a status label so a sealed draft still
@@ -340,11 +351,7 @@ export function useAllDrafts(workspaceId: string) {
       const loadedId = loadedByScope.get(scope) ?? null
       const loadedDraft = loadedId ? draftsById.get(loadedId) : undefined
 
-      const isE2e = loadedDraft?.ciphertext != null
-      const hasContent = !isEmptyContent(loadedDraft?.contentJson)
-      const hasAttachments = (loadedDraft?.attachments?.length ?? 0) > 0
-
-      if (loadedDraft && (hasContent || hasAttachments || isE2e)) {
+      if (loadedDraft && draftHasPayload(loadedDraft)) {
         const displayName = scratchpad.displayName ?? streamFallbackLabel("scratchpad", "sidebar")
         result.push({
           id: scratchpad.id,
@@ -372,13 +379,7 @@ export function useAllDrafts(workspaceId: string) {
       // supports them.
       if (parsed.type === "stream" && isDraftId(parsed.id)) continue
 
-      // An E2E draft's `contentJson` is the empty placeholder (the body is sealed),
-      // so it counts as content on the strength of its ciphertext — otherwise it
-      // would be dropped from the explorer entirely.
-      const isE2e = draft.ciphertext != null
-      const hasContent = !isEmptyContent(draft.contentJson)
-      const hasAttachments = (draft.attachments?.length ?? 0) > 0
-      if (!isE2e && !hasContent && !hasAttachments) continue
+      if (!draftHasPayload(draft)) continue
 
       const resolved = resolveDraftLocation(parsed, workspaceId, streamMap, messageToStreamMap)
       const isStashed = (loadedByScope.get(draft.scope) ?? null) !== draft.id
@@ -446,4 +447,72 @@ export function useAllDrafts(workspaceId: string) {
     draftCount: drafts.length,
     deleteDraft,
   }
+}
+
+export interface DraftSummary {
+  /** Total unsent drafts for the workspace (matches the drafts-explorer row count). */
+  draftCount: number
+  /**
+   * Comma-joined, sorted stream ids whose composer holds an unsent loaded
+   * (non-stashed) draft. A string, not a Set, so a consumer can memoize on it
+   * by value: it changes only when the *set* of streams-with-a-draft changes,
+   * not when a draft's body changes — keeping the sidebar's per-row map stable
+   * across keystrokes.
+   */
+  loadedDraftStreamIdSignature: string
+}
+
+/**
+ * Lightweight draft rollup for the sidebar — the badge count plus which streams
+ * carry an unsent loaded draft. Derived straight from the raw draft store with
+ * NO preview building, sealed-body decryption, location resolution, or sort, so
+ * a keystroke's debounced draft save doesn't rebuild the full {@link useAllDrafts}
+ * explorer model (which it does on every change) just to read two values off it.
+ * Shares {@link draftHasPayload} with the explorer so the count never drifts.
+ */
+export function useDraftSummary(workspaceId: string): DraftSummary {
+  const draftScratchpads = useDraftScratchpadsFromStore(workspaceId)
+  const allDrafts = useDraftsFromStore(workspaceId)
+  const composerLoaded = useComposerLoadedFromStore(workspaceId)
+
+  const loadedByScope = useMemo(() => {
+    const map = new Map<string, string | null>()
+    for (const row of composerLoaded) map.set(row.scope, row.draftId)
+    return map
+  }, [composerLoaded])
+
+  const draftsById = useMemo(() => {
+    const map = new Map<string, CachedDraft>()
+    for (const draft of allDrafts) map.set(draft.id, draft)
+    return map
+  }, [allDrafts])
+
+  return useMemo(() => {
+    let draftCount = 0
+    const loadedDraftStreamIds = new Set<string>()
+
+    // Scratchpads count via their loaded draft (the `stream:{scratchpadId}` scope).
+    for (const scratchpad of draftScratchpads ?? []) {
+      const loadedId = loadedByScope.get(`stream:${scratchpad.id}`) ?? null
+      const loadedDraft = loadedId ? draftsById.get(loadedId) : undefined
+      if (loadedDraft && draftHasPayload(loadedDraft)) draftCount++
+    }
+
+    for (const draft of allDrafts) {
+      const parsed = parseDraftMessageKey(draft.scope)
+      if (!parsed) continue
+      // Scratchpad-scoped rows are counted above; skip them and their siblings.
+      if (parsed.type === "stream" && isDraftId(parsed.id)) continue
+      if (!draftHasPayload(draft)) continue
+      draftCount++
+      // A non-thread stream draft that is the loaded (not stashed) one for its
+      // scope surfaces as the per-row "unsent draft" hint — mirrors
+      // `streamIdsWithLoadedDraft` over the built explorer list.
+      if (parsed.type === "stream" && loadedByScope.get(draft.scope) === draft.id) {
+        loadedDraftStreamIds.add(parsed.id)
+      }
+    }
+
+    return { draftCount, loadedDraftStreamIdSignature: [...loadedDraftStreamIds].sort().join(",") }
+  }, [draftScratchpads, allDrafts, loadedByScope, draftsById])
 }


### PR DESCRIPTION
## Summary

Second change in the composer long-chat perf audit (follows #1082, the mobile backdrop-blur fix). Targets a periodic main-thread hitch while typing: the sidebar rebuilding the **entire drafts-explorer model** on every debounced draft save.

## The problem

The sidebar consumes exactly two things about drafts — the badge `draftCount` and the set of streams holding an unsent loaded draft (the per-row hint) — but it got them from `useAllDrafts(workspaceId)`, which is the **drafts-explorer model builder**. On every draft-store change — i.e. every ~500ms debounced draft save *while you type* — `useAllDrafts` rebuilds the whole workspace's unified draft list:

- builds truncated preview strings for every draft
- **runs sealed-body decryption for every E2E draft** (`useDecryptedDraftPreviews`)
- resolves display names / locations
- sorts the list

…all of which the sidebar discards. It shows none of it.

The expensive per-row `processedStreams` map was *already* memoized on a signature of "which streams have a draft" (so content-only edits don't rebuild it) — this change removes the remaining upstream waste that fed it.

## The change

- Add `useDraftSummary(workspaceId)` → `{ draftCount, loadedDraftStreamIdSignature }`, derived straight from the raw draft store with **no** preview building, decryption, location resolution, or sort.
- Point the sidebar at it; the drafts **page** (`pages/drafts.tsx`) keeps the full `useAllDrafts`.
- Extract `draftHasPayload(draft)` as the single qualification predicate shared by the explorer build and the summary, so the badge count can never drift from the list (also de-duplicates two inline copies of that check in `useAllDrafts`).

## Design decisions

- **Returns a signature *string*, not a `Set`** — so the sidebar memoizes on it by value. It changes only when the *set* of streams-with-a-draft changes, not when a draft body changes, preserving the existing `processedStreams` stability across keystrokes.
- **Shared predicate over a second derivation** — avoids drift between "what counts as a draft" in the badge vs. the explorer (INV-35/37).
- The drafts explorer is untouched; only the sidebar's data source changed.

## Honest scope note

This removes a recurring **~500ms periodic** stutter (the debounced-save cadence), not necessarily a continuous per-character lag. It's clearly wasted work regardless — the E2E decryption pass for the whole workspace on every keystroke-save is the worst of it — but if typing still feels continuously sluggish after this, the next candidates are the composer-resize → Virtua re-measure path and decrypted-attachment memory/GC pressure.

## Verification

- `apps/frontend` typecheck: clean
- eslint (changed files): clean
- `use-all-drafts.test.ts`: 9/9 pass, including a new drift-guard asserting `useDraftSummary` agrees with `useAllDrafts` (count + loaded-stream-id signature) on the same seeded store
- No sidebar test referenced the old wiring

## Test plan (on device)

1. Open the long DM on mobile, type continuously, and confirm the periodic hitch is reduced/gone.
2. Confirm the sidebar "Drafts" badge count still matches the drafts page, and the per-row "unsent draft" hint still appears on streams with a loaded draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwpKuN2t8sHgzRWLBBh1No

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwpKuN2t8sHgzRWLBBh1No)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785010378&installation_id=129946197&pr_number=1086&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1086&signature=7a964a185afc5d55b84f84b963d2f1154f9c9feb25dc3ecc2a215a0f5915cc26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->