### PR TITLE
fix(timeline): keep auto-follow armed through cold-load reflow (stop "settles 2 pages up")

### DIFF
--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -189,6 +189,26 @@ describe("useTimelineScroll — scroll position", () => {
     expect(harness.current.isFollowingTailRef.current).toBe(false)
   })
 
+  it("keeps following when content reflow lowers scrollTop AND grows scrollHeight (cold-load tail landing)", () => {
+    // The cold-load "settles 2 pages up" bug: as the catch-up tail lands, virtua
+    // re-anchors and LOWERS scrollTop while scrollHeight GROWS. A scrollTop drop
+    // alone read as a scrollbar scroll-up and disarmed follow, so the
+    // ResizeObserver stopped re-pinning and the view stranded above the tail.
+    // A drop that coincides with a height change is content reflow, not the
+    // user — follow must stay armed so the tail re-pins to the true bottom.
+    const harness = renderScrollHook(opts({ itemCount: 50, getFirstKey: () => "e10" }))
+    const el = makeScrollerDiv({ scrollHeight: 4961, clientHeight: 852, scrollTop: 4109 })
+    harness.current.scrollerRef.current = el
+    act(() => harness.current.handleScroll())
+    expect(harness.current.isFollowingTailRef.current).toBe(true)
+    // Catch-up content lands: scrollHeight 4961 → 6420 AND virtua drops scrollTop
+    // 4109 → 3040, with no user gesture.
+    Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 6420 })
+    el.scrollTop = 3040
+    act(() => harness.current.handleScroll())
+    expect(harness.current.isFollowingTailRef.current).toBe(true)
+  })
+
   it("disarms follow when the user scrolls away right after a programmatic pin", () => {
     // A real scroll-away immediately after our own re-pin MUST still disarm —
     // otherwise follow stays wrongly armed and the next composer resize yanks the

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -361,7 +361,18 @@ export function useTimelineScroll({
     // scroll-up, follow disarmed, and the close parked the list a
     // keyboard-height above the tail. Our own programmatic pins update prevTop
     // in the same statement as the write, so they read as no movement here.
-    const scrolledUp = el.scrollTop < prevTop - 1 && el.scrollHeight >= prevHeight - 1 && distanceFromBottom > 1
+    // A device-independent user scroll-up is a scrollTop drop while the content
+    // height is UNCHANGED — the user moved the viewport over stable content
+    // (scrollbar drag fires no gesture event, so this is its only signal). When
+    // scrollHeight ALSO moved, the drop was content reflow, not the user: a
+    // prepend, a display-floor change, or virtua re-anchoring as the cold-load
+    // tail lands all lower scrollTop with no gesture. Treating that as a
+    // scroll-up wrongly disarmed follow mid-cold-load — handleScroll ran before
+    // the ResizeObserver could re-pin — stranding the view pages above the tail
+    // ("settles 2 pages up"). Both browser clamps stay excluded: a shrink
+    // (composer collapse) and a growth (content reflow) are both `!heightStable`.
+    const heightStable = Math.abs(el.scrollHeight - prevHeight) <= 1
+    const scrolledUp = el.scrollTop < prevTop - 1 && heightStable && distanceFromBottom > 1
     // Secondary signal for a touch/wheel gesture that hasn't moved scrollTop yet.
     const now = performance.now()
     const userGestured = now - (userInteractedAtRef?.current ?? 0) < USER_SCROLL_GRACE_MS
@@ -392,8 +403,9 @@ export function useTimelineScroll({
     } else if (scrolledUp || userGestured) {
       // The user scrolled away from the bottom (past the band, or a deliberate
       // nudge inside it). Content growth (new message, link preview, virtua
-      // measuring real heights) does NOT lower scrollTop, so it doesn't land
-      // here — the tail keeps following and the ResizeObserver re-pins it.
+      // measuring real heights) does NOT register as a scroll-up — it changes
+      // scrollHeight, so `scrolledUp` (height-stable only) stays false and the
+      // tail keeps following while the ResizeObserver re-pins it.
       isFollowingTailRef.current = false
     }
     // While following we're effectively at the tail (the observer re-pins), so


### PR DESCRIPTION
## Problem

Opening a stream cold against a stale IndexedDB cache (the *"first load after restarting the app"* case) stranded the timeline **~2 pages above the newest message**, with "Jump to latest" showing — auto-follow had disarmed and the ResizeObserver stopped re-pinning to the tail. After the eager-hydration change in #1085 this spread from "one highly dynamic stream" to **every** stream, because that change causes more content reflow per stream.

## Root cause (reproduced + traced in a real browser)

Reproduced deterministically in headless Chromium against `dev:test` (stale-cache + catch-up scenario), with the scroll engine instrumented:

```
reveal stable@244ms dfb:0 following:true       ← revealed at the bottom, correct
RO-pin following h:3902                          ← catch-up tail growing, re-pinning
RO-pin following h:4961
disarm {top:3040, prevTop:4109, h:6420, prevHeight:4961, scrolledUp:true, userGestured:false}
RO-noFollow dfb:2528                              ← follow disarmed → stranded 2 pages up
```

As the catch-up tail lands, **virtua re-anchors and lowers `scrollTop` while `scrollHeight` grows** (4109→3040 as height 4961→6420). `handleScroll`'s scroll-up detector assumed *"content growth never lowers scrollTop"*, so it read that drop as a desktop-scrollbar scroll-up (which fires no gesture event) and disarmed auto-follow — `handleScroll` ran before the ResizeObserver could re-pin, so the tail was abandoned.

## Fix

A non-gesture `scrollTop` drop only counts as a user scroll-up when **`scrollHeight` is unchanged** (a real scrollbar drag over stable content). When the height also moved, the drop is content reflow — a prepend, a display-floor change, or virtua re-anchoring — so follow stays armed and the ResizeObserver re-pins to the true bottom. One condition change:

```diff
-const scrolledUp = el.scrollTop < prevTop - 1 && el.scrollHeight >= prevHeight - 1 && distanceFromBottom > 1
+const heightStable = Math.abs(el.scrollHeight - prevHeight) <= 1
+const scrolledUp = el.scrollTop < prevTop - 1 && heightStable && distanceFromBottom > 1
```

The shrink case (composer collapse) stays excluded exactly as before — this only *additionally* excludes growth.

## Verification (real browser)

Headless Chromium repro: cache the stream, post messages while "disconnected" to stale the cache, then cold-load and measure where the scroll rests.

- **Before:** stranded at `distanceFromBottom ≈ 4700px` (≈2 pages up).
- **After:** lands at `distanceFromBottom: 0` on the newest message, **3/3 consistent**.

The earlier eager-hydration change (#1085) is kept and now behaves correctly — its extra reflow is absorbed by the now-armed follow, so off-screen previews still lay out eagerly without stranding the view.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | `scrolledUp` requires `scrollHeight` unchanged, so content reflow can't masquerade as a user scroll-up and disarm follow |
| `apps/frontend/src/hooks/use-timeline-scroll.test.tsx` | Regression test: scrollTop drop **with** scrollHeight growth (cold-load tail landing) keeps follow armed |

## Test plan

- [x] `apps/frontend` `use-timeline-scroll.test.tsx` — 21 pass (incl. new regression test; the desktop-scrollbar-drag test still passes since its height is unchanged)
- [x] In-browser repro (headless Chromium, stale-cache + catch-up) — lands at `dfb:0`, 3/3 consistent
- [x] Monorepo lint + typecheck (pre-commit over all apps/packages) — clean
- [ ] Deep-link/search-jump drift — **not addressed here** (separate jump-mode path; flagged as follow-up)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785043722&installation_id=129946197&pr_number=1088&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1088&signature=0953177b7318472d702fdf2e8453137f3845013c04388f33cdf9d0a33e0028b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->