### PR TITLE
feat: session control (steer/stop/model/run) for the Claude Code channel

### DIFF
--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -391,9 +391,11 @@ export class BotRuntimeService {
       instanceId: params.instanceId,
       status: "available",
       acceptingInvocations: true,
-      // Bootstrap capabilities until the runtime's own heartbeat lands. Only Pi
-      // advertises session-control commands; the Claude Code channel can't drive
-      // the host session, so it must not offer /compact, /model, etc.
+      // Bootstrap capabilities until the runtime's own heartbeat lands. Pi gets a
+      // default session-control set here. The Claude Code channel advertises its
+      // own set in `bot:hello` (gated on running inside tmux — see
+      // docs/claude-channel-session-control.md), so we don't presume one for it;
+      // its real capabilities land within a frame of connecting.
       capabilities: {
         runtimeSessionId: params.runtimeSessionId,
         supportsActiveScratchpad: true,

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -24,18 +24,18 @@ import {
 import type { CommandRegistry } from "./registry"
 import {
   listClientActionCommandInfos,
-  listPiSessionControlCommandInfos,
+  listSessionControlCommandInfos,
   listServerCommandInfos,
   listWorkspaceCommandInfos,
-  PI_SESSION_CONTROL_COMMAND_NAMES,
+  SESSION_CONTROL_COMMAND_NAMES,
 } from "./catalog"
 
 export type ResolvedCommand =
   | { info: CommandInfo; executionKind: "server" }
   | { info: CommandInfo; executionKind: "client-action" }
-  | { info: CommandInfo; executionKind: "bot-runtime"; runtime: PiRuntimeCommandTarget }
+  | { info: CommandInfo; executionKind: "bot-runtime"; runtime: RuntimeCommandTarget }
 
-export interface PiRuntimeCommandTarget {
+export interface RuntimeCommandTarget {
   botId: string
   /** The live runtime's kind — drives kind-specific invocation routing (e.g. steer/stop capability). */
   runtimeKind: BotRuntimeKind
@@ -52,7 +52,7 @@ export interface PiRuntimeCommandTarget {
   advertisedModelSuggestions: readonly CommandArgumentSuggestion[]
 }
 
-interface PiRuntimeTargetInternal extends PiRuntimeCommandTarget {
+interface RuntimeTargetInternal extends RuntimeCommandTarget {
   link: BotRuntimeSessionLink
   presence: BotRuntimeInstance
 }
@@ -103,13 +103,13 @@ export class CommandAvailabilityService {
         }
       }
 
-      const runtimeTarget = await resolvePiRuntimeCommandTarget(client, {
+      const runtimeTarget = await resolveRuntimeCommandTarget(client, {
         workspaceId: params.workspaceId,
         userId: params.userId,
         stream,
       })
       if (runtimeTarget) {
-        for (const info of listPiSessionControlCommandInfos()) {
+        for (const info of listSessionControlCommandInfos()) {
           if (!runtimeTarget.advertisedCommandNames.has(info.name.toLowerCase())) continue
           commands.push({
             info: applyAdvertisedSuggestions(info, runtimeTarget),
@@ -137,10 +137,10 @@ function isClientActionAvailableInStream(info: CommandInfo, stream: Stream): boo
   return true
 }
 
-async function resolvePiRuntimeCommandTarget(
+async function resolveRuntimeCommandTarget(
   db: Querier,
   params: { workspaceId: string; userId: string; stream: Stream }
-): Promise<PiRuntimeTargetInternal | null> {
+): Promise<RuntimeTargetInternal | null> {
   const { workspaceId, stream } = params
   const rootStreamId = stream.rootStreamId ?? stream.id
   const rootStream = rootStreamId === stream.id ? stream : await StreamRepository.findById(db, rootStreamId)
@@ -235,7 +235,7 @@ function resolveAdvertisedModelSuggestions(presence: BotRuntimeInstance): readon
   return result
 }
 
-function applyAdvertisedSuggestions(info: CommandInfo, target: PiRuntimeCommandTarget): CommandInfo {
+function applyAdvertisedSuggestions(info: CommandInfo, target: RuntimeCommandTarget): CommandInfo {
   if (info.name === "thinking" && target.advertisedThinkingLevels.length > 0) {
     return withArgSuggestions(
       info,
@@ -274,7 +274,7 @@ function resolveAdvertisedSessionControlCommandNames(presence: BotRuntimeInstanc
   const advertisedLower = new Set(
     advertised.filter((value): value is string => typeof value === "string").map((value) => value.toLowerCase())
   )
-  return new Set(PI_SESSION_CONTROL_COMMAND_NAMES.filter((name) => advertisedLower.has(name.toLowerCase())))
+  return new Set(SESSION_CONTROL_COMMAND_NAMES.filter((name) => advertisedLower.has(name.toLowerCase())))
 }
 
 function dedupeCommands(commands: ResolvedCommand[]): ResolvedCommand[] {

--- a/apps/backend/src/features/commands/availability.ts
+++ b/apps/backend/src/features/commands/availability.ts
@@ -7,6 +7,7 @@ import {
   DISCUSS_WITH_ARIADNE_COMMAND,
   StreamTypes,
   botHasCapability,
+  type BotRuntimeKind,
   type CommandArgumentSuggestion,
   type CommandInfo,
 } from "@threa/types"
@@ -36,6 +37,8 @@ export type ResolvedCommand =
 
 export interface PiRuntimeCommandTarget {
   botId: string
+  /** The live runtime's kind — drives kind-specific invocation routing (e.g. steer/stop capability). */
+  runtimeKind: BotRuntimeKind
   rootStreamId: string
   activeStreamId: string
   responseStreamId: string
@@ -175,7 +178,16 @@ async function resolvePiRuntimeCommandTarget(
     instanceId: link.instanceId,
   })
   if (!presence) return null
-  if (presence.runtimeKind !== BotRuntimeKinds.PI_LOCAL) return null
+  // Session-control is for runtimes that drive a long-lived linked session. Pi
+  // controls its session natively; the Claude Code channel drives the host via
+  // tmux key injection (see docs/claude-channel-session-control.md). Both gate
+  // the surfaced command set on what they advertise in `sessionControlCommands`.
+  if (
+    presence.runtimeKind !== BotRuntimeKinds.PI_LOCAL &&
+    presence.runtimeKind !== BotRuntimeKinds.CLAUDE_CODE_CHANNEL
+  ) {
+    return null
+  }
   if (presence.status !== BotRuntimeStatuses.AVAILABLE && presence.status !== BotRuntimeStatuses.BUSY) return null
 
   const runtimeSessionId =
@@ -187,6 +199,7 @@ async function resolvePiRuntimeCommandTarget(
 
   return {
     botId: bot.id,
+    runtimeKind: presence.runtimeKind,
     rootStreamId: rootStream.id,
     activeStreamId: stream.id,
     responseStreamId: stream.id,

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -1,6 +1,11 @@
 import { CommandKinds, CommandScopes, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo } from "@threa/types"
 import type { CommandRegistry } from "./registry"
 
+// Canonical session-control command names. Shared across runtimes that drive a
+// long-lived linked session (Pi, the Claude Code channel). A runtime only sees
+// the subset it advertises in `capabilities.sessionControlCommands`, so commands
+// one runtime can't actuate (e.g. `run`/`compact` for Claude, `skill`/`reload`
+// for Pi) never surface for the other.
 export const PI_SESSION_CONTROL_COMMAND_NAMES = [
   "compact",
   "model",
@@ -10,6 +15,7 @@ export const PI_SESSION_CONTROL_COMMAND_NAMES = [
   "shell",
   "steer",
   "stop",
+  "run",
 ] as const
 export type PiSessionControlCommandName = (typeof PI_SESSION_CONTROL_COMMAND_NAMES)[number]
 
@@ -45,21 +51,21 @@ export function listPiSessionControlCommandInfos(): CommandInfo[] {
   return [
     {
       name: "compact",
-      description: "Compact the linked Pi session",
+      description: "Compact the linked session",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "instructions", required: false, description: "Optional compaction focus" }],
     },
     {
       name: "model",
-      description: "Set the linked Pi session model",
+      description: "Set the linked session's model",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "model", required: true, description: "Model id or fuzzy model name" }],
     },
     {
       name: "thinking",
-      description: "Set Pi thinking effort",
+      description: "Set the linked session's thinking effort",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       // Level suggestions are model-specific; the resolver fills them in from the
@@ -68,36 +74,43 @@ export function listPiSessionControlCommandInfos(): CommandInfo[] {
     },
     {
       name: "skill",
-      description: "Find and run a Pi skill by fuzzy search",
+      description: "Find and run a skill by fuzzy search",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "query", required: true, description: "Skill name or search terms" }],
     },
     {
       name: "reload",
-      description: "Reload Pi extensions, skills, prompts, and themes",
+      description: "Reload the linked session's extensions, skills, prompts, and themes",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
     },
     {
       name: "shell",
-      description: "Run a shell command in the linked Pi session's working directory",
+      description: "Run a shell command in the linked session's working directory",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "command", required: true, description: "Shell command to run (passed to `$SHELL -c`)" }],
     },
     {
       name: "steer",
-      description: "Steer the linked Pi session with an immediate follow-up",
+      description: "Steer the linked session with an immediate follow-up",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
       args: [{ name: "message", required: false, description: "Optional instruction to inject immediately" }],
     },
     {
       name: "stop",
-      description: "Stop the current linked Pi turn",
+      description: "Stop the current turn in the linked session",
       kind: CommandKinds.BOT_RUNTIME,
       scope: CommandScopes.STREAM,
+    },
+    {
+      name: "run",
+      description: "Run a slash command in the linked session",
+      kind: CommandKinds.BOT_RUNTIME,
+      scope: CommandScopes.STREAM,
+      args: [{ name: "command", required: true, description: "Slash command to run, e.g. /compact" }],
     },
   ]
 }

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -1,11 +1,11 @@
 import { CommandKinds, CommandScopes, DISCUSS_WITH_ARIADNE_COMMAND, type CommandInfo } from "@threa/types"
 import type { CommandRegistry } from "./registry"
 
-// Canonical session-control command names. Shared across runtimes that drive a
-// long-lived linked session (Pi, the Claude Code channel). A runtime only sees
-// the subset it advertises in `capabilities.sessionControlCommands`, so commands
-// one runtime can't actuate (e.g. `run`/`compact` for Claude, `skill`/`reload`
-// for Pi) never surface for the other.
+// Canonical session-control command names, shared across runtimes that drive a
+// long-lived linked session (Pi, the Claude Code channel). Each runtime sees only
+// the subset it advertises in `capabilities.sessionControlCommands`, so a command
+// it doesn't advertise never surfaces for it (e.g. `skill` is Pi-only; `run` is
+// Claude-channel-only; `compact`/`reload` are advertised by both).
 export const SESSION_CONTROL_COMMAND_NAMES = [
   "compact",
   "model",

--- a/apps/backend/src/features/commands/catalog.ts
+++ b/apps/backend/src/features/commands/catalog.ts
@@ -6,7 +6,7 @@ import type { CommandRegistry } from "./registry"
 // the subset it advertises in `capabilities.sessionControlCommands`, so commands
 // one runtime can't actuate (e.g. `run`/`compact` for Claude, `skill`/`reload`
 // for Pi) never surface for the other.
-export const PI_SESSION_CONTROL_COMMAND_NAMES = [
+export const SESSION_CONTROL_COMMAND_NAMES = [
   "compact",
   "model",
   "thinking",
@@ -17,7 +17,7 @@ export const PI_SESSION_CONTROL_COMMAND_NAMES = [
   "stop",
   "run",
 ] as const
-export type PiSessionControlCommandName = (typeof PI_SESSION_CONTROL_COMMAND_NAMES)[number]
+export type SessionControlCommandName = (typeof SESSION_CONTROL_COMMAND_NAMES)[number]
 
 export function listServerCommandInfos(commandRegistry: CommandRegistry): CommandInfo[] {
   return commandRegistry.getCommandNames().map((name) => {
@@ -47,7 +47,7 @@ export function listWorkspaceCommandInfos(commandRegistry: CommandRegistry): Com
   return [...listServerCommandInfos(commandRegistry), ...listClientActionCommandInfos()]
 }
 
-export function listPiSessionControlCommandInfos(): CommandInfo[] {
+export function listSessionControlCommandInfos(): CommandInfo[] {
   return [
     {
       name: "compact",

--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -2,7 +2,8 @@ import { z } from "zod"
 import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import { serializeBigInt } from "@threa/backend-common"
-import { BotInvocationCapabilities, BotInvocationTriggers, CommandKinds } from "@threa/types"
+import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds, CommandKinds } from "@threa/types"
+import type { BotRuntimeKind } from "@threa/types"
 import { withTransaction } from "../../db"
 import { commandId as generateCommandId } from "../../lib/id"
 import { parseCommand } from "./registry"
@@ -21,20 +22,25 @@ interface Dependencies {
   botRuntimeService: BotRuntimeService
 }
 
-function resolveRuntimeInvocationRouting(commandName: string): {
+export function resolveRuntimeInvocationRouting(
+  commandName: string,
+  runtimeKind: BotRuntimeKind
+): {
   trigger: (typeof BotInvocationTriggers)[keyof typeof BotInvocationTriggers]
   requiredCapability: (typeof BotInvocationCapabilities)[keyof typeof BotInvocationCapabilities]
 } {
-  if (commandName === "steer") {
+  if (commandName === "steer" || commandName === "stop") {
+    // steer/stop must reach the runtime mid-turn. Pi advertises `active-scratchpad`
+    // while busy, so it claims them there. The Claude Code channel instead advertises
+    // ONLY `session-control` while busy (so a normal `active-scratchpad` follow-up
+    // stays queued behind the running turn) — route its interrupts there so a busy
+    // channel can still claim them. See docs/claude-channel-session-control.md.
     return {
       trigger: BotInvocationTriggers.SESSION_CONTROL,
-      requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
-    }
-  }
-  if (commandName === "stop") {
-    return {
-      trigger: BotInvocationTriggers.SESSION_CONTROL,
-      requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
+      requiredCapability:
+        runtimeKind === BotRuntimeKinds.CLAUDE_CODE_CHANNEL
+          ? BotInvocationCapabilities.SESSION_CONTROL
+          : BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
     }
   }
   return {
@@ -137,7 +143,7 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
           name: parsed.name,
           args: parsed.args,
         })
-        const routing = resolveRuntimeInvocationRouting(parsed.name)
+        const routing = resolveRuntimeInvocationRouting(parsed.name, resolved.runtime.runtimeKind)
         await botRuntimeService.createInvocationInTransaction(client, {
           workspaceId,
           rootStreamId: resolved.runtime.rootStreamId,

--- a/apps/backend/src/features/commands/index.ts
+++ b/apps/backend/src/features/commands/index.ts
@@ -3,12 +3,8 @@ export { createCommandHandlers } from "./handlers"
 export { CommandRegistry, parseCommand, isCommand } from "./registry"
 export type { Command, CommandContext, CommandResult } from "./registry"
 export { CommandAvailabilityService } from "./availability"
-export type { ResolvedCommand, PiRuntimeCommandTarget } from "./availability"
-export {
-  PI_SESSION_CONTROL_COMMAND_NAMES,
-  listWorkspaceCommandInfos,
-  listPiSessionControlCommandInfos,
-} from "./catalog"
+export type { ResolvedCommand, RuntimeCommandTarget } from "./availability"
+export { SESSION_CONTROL_COMMAND_NAMES, listWorkspaceCommandInfos, listSessionControlCommandInfos } from "./catalog"
 export {
   buildRuntimeCommandInvocationMetadata,
   parseRuntimeCommandInvocationMetadata,

--- a/apps/backend/src/features/commands/routing.test.ts
+++ b/apps/backend/src/features/commands/routing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test"
+import { BotInvocationCapabilities, BotInvocationTriggers, BotRuntimeKinds } from "@threa/types"
+import { resolveRuntimeInvocationRouting } from "./handlers"
+
+describe("resolveRuntimeInvocationRouting", () => {
+  it("routes steer/stop to active-scratchpad for pi-local (claimable by a busy Pi)", () => {
+    for (const name of ["steer", "stop"]) {
+      expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.PI_LOCAL)).toEqual({
+        trigger: BotInvocationTriggers.SESSION_CONTROL,
+        requiredCapability: BotInvocationCapabilities.ACTIVE_SCRATCHPAD,
+      })
+    }
+  })
+
+  it("routes steer/stop to session-control for the Claude Code channel (so a busy channel still claims interrupts)", () => {
+    for (const name of ["steer", "stop"]) {
+      expect(resolveRuntimeInvocationRouting(name, BotRuntimeKinds.CLAUDE_CODE_CHANNEL)).toEqual({
+        trigger: BotInvocationTriggers.SESSION_CONTROL,
+        requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
+      })
+    }
+  })
+
+  it("routes every other command to session-control regardless of runtime kind", () => {
+    for (const name of ["model", "compact", "thinking", "skill", "reload", "shell", "run"]) {
+      for (const kind of [BotRuntimeKinds.PI_LOCAL, BotRuntimeKinds.CLAUDE_CODE_CHANNEL]) {
+        expect(resolveRuntimeInvocationRouting(name, kind)).toEqual({
+          trigger: BotInvocationTriggers.SESSION_CONTROL,
+          requiredCapability: BotInvocationCapabilities.SESSION_CONTROL,
+        })
+      }
+    }
+  })
+})

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -1,0 +1,249 @@
+# Session control for the Claude Code channel (steer / stop / model / run-command)
+
+Status: **implemented** on `feat/harness-steer`, 2026-06-26 (pending live tmux verification — see
+checklist). Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`.
+
+Implemented across: backend (`commands/availability.ts`, `commands/handlers.ts`, `commands/catalog.ts`,
+`bot-runtimes/service.ts` comment), channel (`claude-code-remote/src/tmux-control.ts` +
+`channel-server.ts`), and a harness-CLI bonus (`harness-daemon`: `interrupt`/`steer`/`keys` verbs).
+Tests: backend `commands/routing.test.ts`; channel `tmux-control.test.ts` + `session-control.test.ts`
+(busy-aware claim caps, command parsing, steer-combine). All green; full typechecks clean. Frontend
+unchanged (it was already runtime-agnostic).
+
+## Goal
+
+Give the Claude Code channel runtime the same in-UI session-control slash commands that
+the Pi remote runtime already has — `/stop`, `/steer`, `/model`, and the ability to run
+arbitrary Claude Code slash commands (e.g. `/compact`, `/remote-control`) — driven from the
+Threa composer. Claude Code exposes **no** programmatic control surface to an MCP server, so
+the actuator is the tmux pane: the channel sends keystrokes to the pane Claude Code runs in
+(the "Ctrl-C-lite" mechanism the harness already uses during spawn). `Escape` = interrupt;
+`Escape` + text + `Enter` = steer; `/cmd` + `Enter` = run a slash command.
+
+## What already exists (≈80% of the work is done and runtime-agnostic)
+
+The whole pipeline from composer to a claimed bot-invocation already ships and works for Pi:
+
+- **Frontend is fully generic.** The slash menu (`use-command-suggestion.tsx`), arg picker
+  (`use-command-arg-picker.tsx` / `command-arg-picker.tsx`), dispatch
+  (`POST /api/workspaces/:id/commands/dispatch` via `commandsApi.dispatch`), optimistic
+  `command_dispatched` event, and `/model` value picker all key off `StreamBootstrap.commands`
+  (`CommandInfo[]`) + `args[].suggestions`. **`runtimeKind` is never used to gate commands in
+  the frontend** (only ref is a presence equality check in `stream-sync.ts:1003`). If the
+  backend lists the commands for a stream, the UI lights up automatically. **No frontend change
+  is required.**
+- **Invocation type + claim path exist.** `bot_invocations.trigger = "session-control"` and
+  `requiredCapability` are real columns/enums (`packages/types/src/constants.ts:856-872`). The
+  claim SQL (`bot-runtimes/repository.ts:669-711`) has **no server-side busy gate** — a runtime
+  can claim an invocation while mid-turn; "one turn at a time" is purely a runtime-side
+  convention. Session-control claims skip sealed-context + `agent_session` creation
+  (`public-api/handlers.ts:1040,1048`).
+- **Targeted delivery exists.** Session-control invocations carry `targetInstanceId` /
+  `targetRuntimeSessionId`; the outbox→socket router (`broadcast-handler.ts:209-246`) delivers
+  `bot_invocation:available` to the narrow `…:session:{runtimeSessionId}` room, so it reaches
+  the exact live instance even when it's busy.
+- **The channel already runs in tmux.** `harness-daemon` spawns Claude with
+  `tmux new-window … claude …` (`spawners.ts:84-94`) and already uses `tmux send-keys` for the
+  boot Enter (`spawners.ts:98`). The channel (an MCP stdio child of Claude) inherits `$TMUX_PANE`.
+
+## The three gaps that gate this to Pi today
+
+1. **Backend target resolver is hard-gated to Pi.**
+   `availability.ts:178` — `if (presence.runtimeKind !== BotRuntimeKinds.PI_LOCAL) return null`.
+2. **Catalog + capability injection are Pi-named / Pi-only.**
+   `PI_SESSION_CONTROL_COMMAND_NAMES` (`catalog.ts:4`), `listPiSessionControlCommandInfos()`
+   descriptions say "the linked Pi session", and the bootstrap-default capability injection
+   (`bot-runtimes/service.ts:386-407`) adds `supportsSessionControlCommands` only for `pi-local`
+   ("the Claude Code channel can't drive the host session" — the assumption we're changing).
+3. **The channel neither advertises session-control caps nor has an executor.**
+   `channel-server.ts` hello caps = `{ supportsActiveScratchpad, supportsPersistentSessions }`,
+   `SUPPORTED_CAPABILITIES = ["active-scratchpad","mentionable"]`, and it does strict
+   one-turn-at-a-time (`claimDrain` breaks when `inflight.size > 0`).
+
+## Core mechanism: tmux key injection
+
+The channel resolves its own pane at startup from `process.env.TMUX_PANE` (e.g. `%5`), with an
+optional `THREA_TMUX_TARGET` override for tests. Self-discovery beats harness-injection because
+the harness picks the window _after_ `claude mcp add`, so the pane id isn't known at registration
+time; the env is set by tmux inside the pane and inherited by Claude → the MCP child.
+
+New tiny module `extensions/claude-code-remote/src/tmux-control.ts`:
+
+```ts
+const target = process.env.THREA_TMUX_TARGET ?? process.env.TMUX_PANE
+export const tmuxAvailable = () => Boolean(process.env.TMUX && target)
+
+function sendKeys(args: string[]) {
+  // best-effort; returns ok/err, never throws
+  return Bun.spawnSync(["tmux", "send-keys", "-t", target!, ...args])
+}
+export const interrupt = () => sendKeys(["Escape"])
+export const typeLine = (text: string) => {
+  sendKeys(["-l", text])
+  sendKeys(["Enter"])
+}
+```
+
+Notes:
+
+- `-l` sends **literal** text so `/`, spaces, and punctuation aren't parsed as tmux key names.
+- text then `Enter` are separate, ordered emits (tmux preserves order).
+- `Escape` at an idle prompt is harmless, so commands can always interrupt first without needing
+  to know whether Claude is busy in the TUI (which the channel can't otherwise detect).
+
+## Command semantics
+
+| Command             | Key sequence                                                                                                   | Channel bookkeeping                                                                                                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **stop**            | `Escape`                                                                                                       | Complete every in-flight invocation (interrupted), ack the stop invocation: "Stopped Claude."                                                                                                    |
+| **steer `<text>`**  | `Escape`, ~250 ms, then forward **one combined** payload through the **existing MCP channel path** (not typed) | Drain all pending msgs for the session + the steer text, combine into ONE turn; complete the interrupted turn + all swept msgs `noResponse`; the primary invocation gets Claude's single `reply` |
+| **model `<alias>`** | `typeLine("/model <alias>")`                                                                                   | Ack "Model set to `<alias>`." (best-effort)                                                                                                                                                      |
+| **compact**         | `typeLine("/compact")`                                                                                         | Ack                                                                                                                                                                                              |
+| **run `<cmd>`**     | `typeLine("/<cmd>")` (strip a leading slash if present)                                                        | Ack "Ran `/<cmd>`."                                                                                                                                                                              |
+
+**Steer is the interesting one.** Rather than blind-typing the steer text into the TUI (where the
+result would be orphaned with no invocation to reply to), we use tmux **only** for the `Escape`
+interrupt, then push the steer text through the channel's normal
+`notifications/claude/channel` notification using the steer invocation's own id. Claude treats it
+as a fresh turn and calls `reply(steerId)` → the work round-trips back into the scratchpad. This
+is exactly the user's "stop, then send another message," and it reuses the battle-tested
+reply/idle-timeout/attachment machinery instead of inventing a parallel path. (A plain follow-up
+message with no steer just queues behind the current turn as it does today — steer is the
+_interrupt-and-redirect_ variant.)
+
+**Steer combines all pending messages into one turn (mirrors Pi).** Pi drains up to
+`STEER_DRAIN_LIMIT` (10) pending invocations while busy: the first becomes `pending`, the rest go
+into `steeredInvocations[]`, and on completion the primary gets the final `reply` while **every
+swept invocation closes `noResponse`** (`threa-remote.ts:2365-2404`) — N rapid messages → **one**
+combined response, not N. The channel reproduces this without a native steer queue: on `/steer`,
+after the `Escape`, it drains all currently-pending invocations targeted at the session (plain
+messages the user queued while Claude was busy + the steer's own text), **concatenates them
+oldest→newest into a single `notifications/claude/channel` payload**, and delivers one turn. The
+triggering steer invocation is the primary (registered in `inflight`, receives Claude's `reply`);
+the interrupted turn and every swept message complete `noResponse`. Bounded by a drain limit; the
+existing `claiming` single-flight guard serialises concurrent steer handlers so rapid `/steer`s
+coalesce.
+
+`model` / `compact` / `run` typed mid-turn are buffered by Claude Code's input queue and applied
+after the current turn — acceptable, documented. `/model` and other menu-opening commands are
+**best-effort**: typing `/model sonnet`+`Enter` can race Claude Code's slash autocomplete. This is
+the single biggest live-verify item (see below).
+
+## Concurrency: claiming session-control while a turn is in flight (the crux)
+
+The hard constraint: `/stop` and `/steer` must reach the channel **while it's busy** on a
+forwarded turn, but a normal follow-up message must still _wait its turn_ (preserve today's
+serialization). These can't be separated by capability today because Pi routes steer/stop to
+`active-scratchpad` — the same capability normal scratchpad turns use — specifically so a busy Pi
+(which advertises `active-scratchpad` while busy) can claim them.
+
+**Recommended: make `resolveRuntimeInvocationRouting` runtime-kind-aware.**
+
+- `pi-local`: unchanged — steer/stop → `active-scratchpad`.
+- `claude-code-channel`: steer/stop → `session-control`.
+
+Then the channel advertises capabilities by busy-state (mirroring Pi's `buildClaimInvocationBody`):
+
+- **idle** (`inflight.size === 0`): `["active-scratchpad","mentionable","session-control"]`
+- **busy** (`inflight.size > 0`): `["session-control"]`
+
+Result, with the existing oldest-first claim SQL:
+
+- Busy channel claims **only** session-control invocations (stop/steer/model/…); normal
+  follow-ups (`active-scratchpad`) don't match the advertised caps and correctly wait — **today's
+  behavior is preserved exactly**, no dependency on Claude Code's mid-turn queueing, no local
+  hold-queue.
+- `claimDrain` changes from "break if `inflight > 0`" to: loop, claim with busy-appropriate caps,
+  execute session-control immediately, forward a normal turn then break.
+
+The routing change is ~5 contained lines (`resolved.runtime.presence.runtimeKind` is already in
+scope at the dispatch site, `handlers.ts:140`).
+
+**Alternative (no backend routing change):** keep steer/stop on `active-scratchpad`, have the busy
+channel advertise `["active-scratchpad","session-control"]`, claim-and-inspect, and forward any
+normal follow-up it grabs mid-turn to Claude (relying on Claude Code to queue it). Lower backend
+footprint but changes follow-up serialization and depends on Claude's queueing behavior — not
+"rock solid". Recommend the routing-aware option.
+
+## Capability advertisement + graceful degradation
+
+The channel advertises in its `bot:hello` / presence `capabilities` **only when `tmuxAvailable()`**:
+
+```jsonc
+{
+  "supportsActiveScratchpad": true,
+  "supportsPersistentSessions": true,
+  "supportsSessionControlCommands": true,
+  "sessionControlCommands": ["stop", "steer", "model", "compact", "run"],
+  "modelSuggestions": [{ "value": "sonnet" }, { "value": "opus" }, { "value": "default" }, { "value": "opusplan" }],
+}
+```
+
+`supportedCapabilities` in the hello/claim adds `"session-control"`. If the channel isn't running
+inside tmux (no pane), it advertises none of this, so the UI never shows a command that can't be
+actuated — fail-safe. `resolveAdvertisedSessionControlCommandNames` (`availability.ts:257`)
+already intersects with the canonical name list, so only what the channel advertises shows up.
+
+Commands chosen for v1: **stop, steer, model, compact, run**. Dropped from Pi's set: `thinking`
+(no Claude Code slash equivalent), `reload`, `skill` (needs the skill list the channel doesn't
+have — fold into generic `run`). `shell` could be added later as a direct exec in the channel
+(like Pi's `runShellCommand`), independent of tmux.
+
+`run` is a **new generic command** (arg = slash command to type, e.g. `run /remote-control`). It
+must be added to the canonical name list + catalog. Open UX question for Kris: `run` vs surfacing
+named passthroughs. The canonical list/identifiers should be renamed
+`PI_SESSION_CONTROL_*` → `SESSION_CONTROL_*` (now shared; INV-49 — no deprecated alias) and the
+catalog descriptions made runtime-neutral ("the linked session", not "the linked Pi session", per
+INV-46).
+
+## Precise change list
+
+**Backend** (`apps/backend/src`)
+
+- `features/commands/availability.ts:178` — widen the gate to allow `claude-code-channel`
+  (and rename `resolvePiRuntimeCommandTarget` → `resolveRuntimeCommandTarget`,
+  `PiRuntimeCommandTarget` → `RuntimeCommandTarget`).
+- `features/commands/handlers.ts:24-44` — `resolveRuntimeInvocationRouting(name, runtimeKind)`;
+  claude steer/stop → `session-control`.
+- `features/commands/catalog.ts` — rename `PI_SESSION_CONTROL_COMMAND_NAMES` →
+  `SESSION_CONTROL_COMMAND_NAMES`, add `run`, neutralize descriptions.
+- `features/bot-runtimes/service.ts:386-407` — optional: extend the bootstrap-default capability
+  injection to `claude-code-channel` so commands show before the channel's first presence; update
+  the now-stale comment. (Belt-and-suspenders; the channel's own hello is the primary source.)
+
+**Channel** (`extensions/claude-code-remote/src`)
+
+- new `tmux-control.ts` (above).
+- `config.ts` — read `TMUX_PANE` / `THREA_TMUX_TARGET`; optional `modelSuggestions` config.
+- `channel-server.ts` — advertise session-control caps when `tmuxAvailable()`; busy-aware
+  `claimBody`; relax `claimDrain` to keep draining session-control while busy; add
+  `handleSessionControl(invocation)` dispatching stop/steer/model/compact/run; steer reuses the
+  notification + inflight machinery; stop/steer complete interrupted in-flight turns.
+
+**Frontend** — none.
+
+## Risks & live-verify checklist
+
+1. **`$TMUX_PANE` reaches the MCP child.** Confirm Claude Code doesn't scrub env for MCP servers.
+   Fallback: harness passes `THREA_TMUX_TARGET` via `claude mcp add --env`.
+2. **Single `Escape` interrupts Claude Code** (vs needing double-Esc, which opens history). Tune.
+3. **`/model <alias> + Enter` against the slash autocomplete.** Most fragile path. Try literal
+   string then short delay then `Enter`; possibly a second `Enter`; confirm `/model sonnet` sets
+   directly rather than opening a picker that swallows Enter.
+4. **Steer timing** — Claude accepts a new `notifications/claude/channel` immediately after an
+   `Escape` interrupt; confirm the ~250 ms delay is enough and the interrupted turn completes
+   cleanly.
+5. **Busy-claim** — with routing-aware caps, confirm a busy channel claims `/stop` within a frame
+   (WS push to the session room) and that a normal follow-up still waits.
+
+Verify with the harness-spawned Claude in tmux + a real scratchpad, watching the pane and the
+scratchpad timeline. Unit tests: `tmux-control` (mock `Bun.spawnSync`), `claimDrain` busy-state
+capability selection, `handleSessionControl` dispatch + interrupted-turn completion. Backend:
+routing-by-kind, target resolver accepts `claude-code-channel`, command list for a channel stream.
+
+## Bonus: harness CLI ergonomics (optional)
+
+To "improve the harness" for manual use, add `threa-harnessd stop|steer|keys <ref> [text]` verbs
+that reuse `tmux.ts` against an inventory agent's recorded `tmuxSession:tmuxWindow`. Not on the
+Threa-UI path (the channel sends keys directly via its own pane — no cross-process dependency at
+runtime), but handy from a terminal.

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -224,22 +224,34 @@ descriptions made runtime-neutral ("the linked session", not "the linked Pi sess
 
 ## Risks & live-verify checklist
 
-1. **`$TMUX_PANE` reaches the MCP child.** Confirm Claude Code doesn't scrub env for MCP servers.
-   Fallback: harness passes `THREA_TMUX_TARGET` via `claude mcp add --env`.
-2. **Single `Escape` interrupts Claude Code** (vs needing double-Esc, which opens history). Tune.
-3. **`/model <alias> + Enter` against the slash autocomplete.** Most fragile path. Try literal
-   string then short delay then `Enter`; possibly a second `Enter`; confirm `/model sonnet` sets
-   directly rather than opening a picker that swallows Enter.
-4. **Steer timing** — Claude accepts a new `notifications/claude/channel` immediately after an
-   `Escape` interrupt; confirm the ~250 ms delay is enough and the interrupted turn completes
-   cleanly.
-5. **Busy-claim** — with routing-aware caps, confirm a busy channel claims `/stop` within a frame
-   (WS push to the session room) and that a normal follow-up still waits.
+Live-tested 2026-06-26 against **Claude Code v2.1.193** in tmux (a throwaway session, no Threa
+stack). Results:
 
-Verify with the harness-spawned Claude in tmux + a real scratchpad, watching the pane and the
-scratchpad timeline. Unit tests: `tmux-control` (mock `Bun.spawnSync`), `claimDrain` busy-state
-capability selection, `handleSessionControl` dispatch + interrupted-turn completion. Backend:
-routing-by-kind, target resolver accepts `claude-code-channel`, command list for a channel stream.
+1. **`$TMUX_PANE` reaches the MCP child** — ✅ confirmed. A child shell of the Claude Code host
+   inherits `TMUX_PANE`. (Fallback `THREA_TMUX_TARGET` remains for non-self-discovering launches.)
+2. **Single `Escape` interrupts Claude Code** — ✅ confirmed via a filesystem marker: a
+   `sleep 30 && touch DONE_MARKER` tool call was killed by one `Escape` (marker never appeared).
+3. **`/model <alias>` against the slash autocomplete** — ✅ works (150 ms settle beats the menu),
+   but live testing surfaced **two real bugs, both now fixed**:
+   - **Input-box residue.** An `Escape` interrupt restores the interrupted message into the input
+     box; a typed command then concatenates with it and submits as a plain prompt (silent no-op).
+     Fix: `submitLine` sends `Ctrl-U` to clear the line first.
+   - **Model-switch confirmation modal.** A mid-session switch pops a "Switch model?" dialog
+     (default "Yes") that wedges the session if unanswered. Fix: `/model` sends a confirming
+     `Enter` after a settle (harmless empty submit when no modal appears).
+     `/model sonnet` then `/model opus` both verified end-to-end with residue present.
+4. **Steer timing** — ⏳ not live-tested end-to-end (needs the Threa stack). The `Escape` half is
+   verified; the combined-turn delivery rides the existing notification path. The residue the steer
+   leaves in the box is harmless (steer content goes via MCP, not the keyboard) and the next typed
+   command clears it.
+5. **Busy-claim + full dispatch round-trip** — ⏳ not live-tested (unit-tested only; needs a
+   `bun run dev:test` stack + a linked scratchpad). This is the already-tested claim/dispatch
+   plumbing rather than novel tmux behavior.
+
+Unit tests: `tmux-control` (`tmuxAvailable` env detection), `session-control` (command parse,
+steer-combine, busy-state capability selection), backend `routing` (kind-aware). Backend
+DB-backed paths (resolver accepts `claude-code-channel`, command list for a channel stream) remain
+covered by their feature-folder suites.
 
 ## Bonus: harness CLI ergonomics (optional)
 

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -1,7 +1,10 @@
 # Session control for the Claude Code channel (steer / stop / model / run-command)
 
-Status: **implemented** on `feat/harness-steer`, 2026-06-26 (pending live tmux verification — see
-checklist). Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`.
+Status: **implemented + tmux mechanics live-verified** on `feat/harness-steer`, 2026-06-26.
+Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`. The
+genuinely-novel tmux paths ($TMUX_PANE inheritance, Esc interrupt, `/model`) are verified against
+Claude Code v2.1.193 (and live testing found + fixed two bugs — see the checklist); the full
+dispatch round-trip through a real scratchpad is still only unit-tested.
 
 Implemented across: backend (`commands/availability.ts`, `commands/handlers.ts`, `commands/catalog.ts`,
 `bot-runtimes/service.ts` comment), channel (`claude-code-remote/src/tmux-control.ts` +

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -189,20 +189,20 @@ Commands chosen for v1: **stop, steer, model, compact, run**. Dropped from Pi's 
 have — fold into generic `run`). `shell` could be added later as a direct exec in the channel
 (like Pi's `runShellCommand`), independent of tmux.
 
-`run` is a **new generic command** (arg = slash command to type, e.g. `run /remote-control`). It
-must be added to the canonical name list + catalog. Open UX question for Kris: `run` vs surfacing
-named passthroughs. The canonical list/identifiers should be renamed
-`PI_SESSION_CONTROL_*` → `SESSION_CONTROL_*` (now shared; INV-49 — no deprecated alias) and the
-catalog descriptions made runtime-neutral ("the linked session", not "the linked Pi session", per
-INV-46).
+`run` is a **new generic command** (arg = slash command to type, e.g. `run /remote-control`),
+added to the canonical name list + catalog. Open UX question for Kris: `run` vs surfacing named
+passthroughs. The canonical list/identifiers were renamed `PI_SESSION_CONTROL_*` →
+`SESSION_CONTROL_*` / `resolvePiRuntimeCommandTarget` → `resolveRuntimeCommandTarget` /
+`PiRuntimeCommandTarget` → `RuntimeCommandTarget` (now shared across runtimes), and the catalog
+descriptions made runtime-neutral ("the linked session", not "the linked Pi session").
 
 ## Precise change list
 
 **Backend** (`apps/backend/src`)
 
-- `features/commands/availability.ts:178` — widen the gate to allow `claude-code-channel`
-  (and rename `resolvePiRuntimeCommandTarget` → `resolveRuntimeCommandTarget`,
-  `PiRuntimeCommandTarget` → `RuntimeCommandTarget`).
+- `features/commands/availability.ts` — widened the gate to allow `claude-code-channel`; renamed
+  `resolvePiRuntimeCommandTarget` → `resolveRuntimeCommandTarget`,
+  `PiRuntimeCommandTarget` → `RuntimeCommandTarget`.
 - `features/commands/handlers.ts:24-44` — `resolveRuntimeInvocationRouting(name, runtimeKind)`;
   claude steer/stop → `session-control`.
 - `features/commands/catalog.ts` — rename `PI_SESSION_CONTROL_COMMAND_NAMES` →

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -1,7 +1,7 @@
 # Session control for the Claude Code channel (steer / stop / model / run-command)
 
 Status: **implemented + tmux mechanics live-verified** on `feat/harness-steer`, 2026-06-26.
-Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`. The
+Author: agent session. Command set shipped: `stop`, `steer`, `model`, `compact`, `run`, `reload`. The
 genuinely-novel tmux paths ($TMUX_PANE inheritance, Esc interrupt, `/model`) are verified against
 Claude Code v2.1.193 (and live testing found + fixed two bugs — see the checklist); the full
 dispatch round-trip through a real scratchpad is still only unit-tested.
@@ -187,10 +187,13 @@ inside tmux (no pane), it advertises none of this, so the UI never shows a comma
 actuated — fail-safe. `resolveAdvertisedSessionControlCommandNames` (`availability.ts:257`)
 already intersects with the canonical name list, so only what the channel advertises shows up.
 
-Commands chosen for v1: **stop, steer, model, compact, run**. Dropped from Pi's set: `thinking`
-(no Claude Code slash equivalent), `reload`, `skill` (needs the skill list the channel doesn't
-have — fold into generic `run`). `shell` could be added later as a direct exec in the channel
-(like Pi's `runShellCommand`), independent of tmux.
+Commands chosen for v1: **stop, steer, model, compact, run, reload**. `reload` maps to Claude
+Code's `/reload-skills` (v2.1.152+) — picks up skills + custom commands added on disk mid-session;
+verified live ("16 skills available"). Newly `claude mcp add`'d MCP servers still can't hot-reload
+(Claude Code limitation — restart only); `/reload-plugins` is reachable via the generic `run`.
+Dropped from Pi's set: `thinking` (no Claude Code slash equivalent), `skill` (needs the skill list
+the channel doesn't have — fold into generic `run`). `shell` could be added later as a direct exec
+in the channel (like Pi's `runShellCommand`), independent of tmux.
 
 `run` is a **new generic command** (arg = slash command to type, e.g. `run /remote-control`),
 added to the canonical name list + catalog. Open UX question for Kris: `run` vs surfacing named

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -6,9 +6,22 @@ import { z } from "zod"
 import { downloadInboundAttachments, formatInboundAttachmentManifest, uploadReplyAttachments } from "./attachments"
 import type { ThreaChannelConfig } from "./config"
 import { ThreaClient, type ClaimedInvocation, type RuntimeSessionLink } from "./threa-client"
+import { interrupt, STEER_SETTLE_MS, submitLine, tmuxAvailable } from "./tmux-control"
 
 const RUNTIME_KIND = "claude-code-channel"
 const SUPPORTED_CAPABILITIES = ["active-scratchpad", "mentionable"] as const
+const SESSION_CONTROL_CAPABILITY = "session-control"
+// The session-control slash commands this channel can actuate via tmux. Only
+// advertised when running inside tmux. `run` types an arbitrary slash command
+// (e.g. /remote-control); `compact` is sugar for `run /compact`.
+const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "compact", "run"] as const
+// Claude Code `/model` aliases offered as autocomplete in the composer's arg picker.
+const MODEL_SUGGESTIONS = [{ value: "default" }, { value: "sonnet" }, { value: "opus" }, { value: "opusplan" }]
+// Mirror Pi's STEER_DRAIN_LIMIT: how many queued messages a single /steer folds
+// into one combined turn before stopping (a backstop, not an expected count).
+const STEER_DRAIN_LIMIT = 10
+
+type SessionControlCommand = { name: string; args: string }
 export const CHANNEL_SOURCE = "threa"
 const CLAIM_TTL_SECONDS = 120
 // Renew at a third of the lease so a single transient renew failure can't let
@@ -92,6 +105,69 @@ export function buildInstructions(permissionRelay: boolean): string {
   return lines.join("\n")
 }
 
+/**
+ * Extract the session-control command (name + args) from a claimed invocation.
+ * Prefers the structured `metadata.command` the dispatch endpoint stamps; falls
+ * back to parsing the `/name args` prompt for a session-control invocation.
+ */
+export function parseSessionControlCommand(invocation: ClaimedInvocation): SessionControlCommand | null {
+  const meta = invocation.metadata?.command
+  if (meta && typeof meta === "object") {
+    const value = meta as Record<string, unknown>
+    if (value.executionKind === "bot-runtime" && typeof value.name === "string") {
+      return { name: value.name.toLowerCase(), args: typeof value.args === "string" ? value.args.trim() : "" }
+    }
+  }
+  if (invocation.trigger !== SESSION_CONTROL_CAPABILITY) return null
+  const match = invocation.promptMarkdown.trim().match(/^\/([\w-]+)(?:\s+([\s\S]*))?$/)
+  if (!match) return null
+  return { name: match[1]!.toLowerCase(), args: (match[2] ?? "").trim() }
+}
+
+export function isSessionControlInvocation(invocation: ClaimedInvocation): boolean {
+  return invocation.trigger === SESSION_CONTROL_CAPABILITY && parseSessionControlCommand(invocation) !== null
+}
+
+/** Fold the steer text + any swept queued messages into one prompt (most recent last). */
+export function buildSteerContent(parts: string[]): string {
+  if (parts.length === 1) return parts[0]!
+  return ["Handle all of the following together (most recent last):", "", parts.join("\n\n---\n\n")].join("\n")
+}
+
+/** Capabilities advertised in hello + presence. Session control only when we can drive the TUI. */
+export function supportedCapabilitiesFor(sessionControlEnabled: boolean): string[] {
+  return sessionControlEnabled ? [...SUPPORTED_CAPABILITIES, SESSION_CONTROL_CAPABILITY] : [...SUPPORTED_CAPABILITIES]
+}
+
+/**
+ * Capabilities to claim with. Idle: everything we support. Busy (a turn in
+ * flight): session-control ONLY, so /stop and /steer jump the queue while a
+ * normal active-scratchpad follow-up waits. Empty when busy without TUI control
+ * (callers must not claim in that state).
+ */
+export function claimCapabilitiesFor(busy: boolean, sessionControlEnabled: boolean): string[] {
+  if (!busy) return supportedCapabilitiesFor(sessionControlEnabled)
+  return sessionControlEnabled ? [SESSION_CONTROL_CAPABILITY] : []
+}
+
+export function runtimeCapabilitiesFor(
+  runtimeSessionId: string,
+  sessionControlEnabled: boolean
+): Record<string, unknown> {
+  return {
+    runtimeSessionId,
+    supportsActiveScratchpad: true,
+    supportsPersistentSessions: true,
+    ...(sessionControlEnabled
+      ? {
+          supportsSessionControlCommands: true,
+          sessionControlCommands: [...SESSION_CONTROL_COMMANDS],
+          modelSuggestions: MODEL_SUGGESTIONS,
+        }
+      : {}),
+  }
+}
+
 interface Inflight {
   invocation: ClaimedInvocation
   // Idle-timeout timer; reset on every sign of life (a `send`, a permission
@@ -121,6 +197,9 @@ export class ChannelServer {
   private renewTimer: ReturnType<typeof setInterval> | undefined
   private readonly inflight = new Map<string, Inflight>()
   private readonly openPermissions = new Map<string, { cleanup: ReturnType<typeof setTimeout> }>()
+  // Whether this channel can drive the Claude Code TUI (running inside tmux with a
+  // known pane). Fixed at startup. Gates advertising + claiming session control.
+  private readonly sessionControlEnabled = tmuxAvailable()
   // The invocation whose turn is executing — the stream a relayed permission
   // prompt belongs in. Set when a non-verdict invocation is pushed to Claude;
   // it's the turn that can trigger a tool-approval prompt. Tracking it beats
@@ -157,8 +236,8 @@ export class ChannelServer {
           runtimeKind: RUNTIME_KIND,
           runtimeSessionId: config.runtimeSessionId,
           displayName: config.displayName,
-          supportedCapabilities: [...SUPPORTED_CAPABILITIES],
-          capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
+          supportedCapabilities: supportedCapabilitiesFor(this.sessionControlEnabled),
+          capabilities: runtimeCapabilitiesFor(config.runtimeSessionId, this.sessionControlEnabled),
           manifest: { output: { reply: true, trace: true, sources: false } },
         },
         callbacks: {
@@ -317,15 +396,25 @@ export class ChannelServer {
     this.claiming = true
     try {
       for (let i = 0; i < MAX_CLAIMS_PER_DRAIN; i++) {
-        // One turn at a time: once something is in flight, stop pulling new work
-        // and let the queue wait — unless a permission request is open. Its
-        // verdict arrives as an ordinary message (a claimable invocation) and the
-        // in-flight turn is blocked until we route it, so we keep draining. (A
-        // non-verdict message sent in that window is forwarded too and simply
-        // queues behind the blocked turn in Claude's session.)
-        if (this.inflight.size > 0 && this.openPermissions.size === 0) break
-        const invocation = await this.client.claim(this.claimBody())
+        // One normal turn at a time: once a turn is in flight we claim with
+        // session-control caps ONLY (claimBody(busy)), so /stop and /steer still
+        // reach us mid-turn while a normal active-scratchpad follow-up stays
+        // queued. A permission request is the exception — its verdict arrives as
+        // an ordinary message and the in-flight turn is blocked until we route it,
+        // so we keep draining with full caps. Without tmux control there's nothing
+        // to claim while busy, so preserve strict one-at-a-time.
+        const busy = this.inflight.size > 0 && this.openPermissions.size === 0
+        if (busy && !this.sessionControlEnabled) break
+        const invocation = await this.client.claim(this.claimBody(busy))
         if (!invocation) break
+        if (isSessionControlInvocation(invocation)) {
+          const isStop = parseSessionControlCommand(invocation)?.name === "stop"
+          await this.handleSessionControl(invocation)
+          // After a stop, don't immediately pull the next queued turn — the user
+          // asked for quiet (mirrors Pi's runStopCommand).
+          if (isStop) break
+          continue
+        }
         await this.handleClaimed(invocation)
       }
     } catch (error) {
@@ -362,6 +451,12 @@ export class ChannelServer {
       }
     }
 
+    const content = await this.buildChannelContent(invocation)
+    await this.deliverTurn(invocation, content)
+  }
+
+  /** Register an invocation as the in-flight turn and push its content to Claude Code. */
+  private async deliverTurn(invocation: ClaimedInvocation, content: string): Promise<void> {
     this.inflight.set(invocation.id, {
       invocation,
       deadline: this.scheduleIdleTimeout(invocation.id),
@@ -379,7 +474,6 @@ export class ChannelServer {
         "Working in Claude Code…"
       )
       .catch(() => undefined)
-    const content = await this.buildChannelContent(invocation)
     await this.notify("notifications/claude/channel", {
       content,
       meta: {
@@ -388,6 +482,167 @@ export class ChannelServer {
         source_message_id: invocation.sourceMessageId,
       },
     })
+  }
+
+  // --- Session control (steer / stop / model / run) -------------------------
+
+  private async handleSessionControl(invocation: ClaimedInvocation): Promise<void> {
+    const command = parseSessionControlCommand(invocation)
+    if (!command) {
+      await this.failInvocation(invocation, "Missing session-control command metadata")
+      return
+    }
+    try {
+      switch (command.name) {
+        case "stop":
+          return await this.runStop(invocation)
+        case "steer":
+          return await this.runSteer(invocation, command.args)
+        case "model":
+          return await this.runModelCommand(invocation, command.args)
+        case "compact":
+          return await this.runSlashCommand(invocation, command.args ? `/compact ${command.args}` : "/compact")
+        case "run":
+          return await this.runRunCommand(invocation, command.args)
+        default:
+          await this.failInvocation(invocation, `Unsupported session-control command: ${command.name}`)
+      }
+    } catch (error) {
+      await this.failInvocation(invocation, this.summarize(error))
+    }
+  }
+
+  private async runStop(invocation: ClaimedInvocation): Promise<void> {
+    const hadTurn = this.inflight.size > 0
+    const sent = interrupt()
+    await this.completeInterruptedTurns("Stopped by /stop.")
+    const ack = !sent
+      ? "Could not send the interrupt (no tmux control)."
+      : hadTurn
+        ? "Stopped the current Claude Code turn."
+        : "Sent an interrupt to Claude Code."
+    await this.completeAck(invocation, ack)
+    await this.syncPresence()
+  }
+
+  /**
+   * Interrupt the running turn, then fold the steer text + any messages queued
+   * while Claude was busy into ONE combined turn (mirrors Pi: N messages → 1
+   * response). tmux is used only for the interrupt; the combined content
+   * round-trips through the normal notification path so Claude replies to it.
+   */
+  private async runSteer(invocation: ClaimedInvocation, text: string): Promise<void> {
+    interrupt()
+    await Bun.sleep(STEER_SETTLE_MS)
+    await this.completeInterruptedTurns("Superseded by /steer.")
+
+    const parts: string[] = []
+    const swept: ClaimedInvocation[] = []
+    for (let i = 0; i < STEER_DRAIN_LIMIT; i++) {
+      const extra = await this.client.claim(this.claimBody(false)).catch(() => null)
+      if (!extra) break
+      swept.push(extra)
+      if (isSessionControlInvocation(extra)) {
+        // Fold a queued /steer's text in; other control commands in the sweep are
+        // closed without execution (rare double-command race).
+        const queued = parseSessionControlCommand(extra)
+        if (queued?.name === "steer" && queued.args) parts.push(queued.args)
+      } else {
+        parts.push(extra.promptMarkdown.trim() || "(empty message)")
+      }
+    }
+    if (text) parts.push(text)
+
+    // Close every swept message with no response — its content is folded into the
+    // single combined turn the primary (this steer invocation) will answer.
+    await Promise.all(swept.map((item) => this.completeNoResponse(item)))
+
+    if (parts.length === 0) {
+      await this.completeAck(invocation, "Interrupted Claude Code; nothing pending to steer with.")
+      await this.syncPresence()
+      return
+    }
+
+    await this.deliverTurn(invocation, buildSteerContent(parts))
+  }
+
+  private async runModelCommand(invocation: ClaimedInvocation, args: string): Promise<void> {
+    const alias = args.trim()
+    if (!alias) {
+      await this.completeAck(invocation, "Usage: `/model <name>` (e.g. sonnet, opus, default).")
+      return
+    }
+    const ok = await submitLine(`/model ${alias}`)
+    await this.completeAck(
+      invocation,
+      ok ? `Set Claude Code model to \`${alias}\`.` : "Could not send /model (no tmux control)."
+    )
+  }
+
+  private async runRunCommand(invocation: ClaimedInvocation, args: string): Promise<void> {
+    const raw = args.trim()
+    if (!raw) {
+      await this.completeAck(invocation, "Usage: `/run <slash-command>` (e.g. /run /remote-control).")
+      return
+    }
+    await this.runSlashCommand(invocation, raw.startsWith("/") ? raw : `/${raw}`)
+  }
+
+  private async runSlashCommand(invocation: ClaimedInvocation, slash: string): Promise<void> {
+    const ok = await submitLine(slash)
+    await this.completeAck(
+      invocation,
+      ok ? `Ran \`${slash}\` in Claude Code.` : `Could not send \`${slash}\` (no tmux control).`
+    )
+  }
+
+  private async completeAck(invocation: ClaimedInvocation, markdown: string): Promise<void> {
+    await this.client
+      .complete(invocation.id, {
+        instanceId: this.config.instanceId,
+        claimToken: invocation.claimToken,
+        finalMessageMarkdown: markdown,
+        metadata: { "cc.channel.invocationId": invocation.id, "cc.channel.sessionControl": "true" },
+      })
+      .catch((error) => log(`session-control ack failed: ${this.summarize(error)}`))
+  }
+
+  private async completeNoResponse(invocation: ClaimedInvocation): Promise<void> {
+    await this.client
+      .complete(invocation.id, {
+        instanceId: this.config.instanceId,
+        claimToken: invocation.claimToken,
+        noResponse: true,
+        metadata: { "cc.channel.invocationId": invocation.id, "cc.channel.steered": "true" },
+      })
+      .catch((error) => log(`steered close failed: ${this.summarize(error)}`))
+  }
+
+  private async failInvocation(invocation: ClaimedInvocation, errorMessage: string): Promise<void> {
+    await this.client
+      .fail(invocation.id, {
+        instanceId: this.config.instanceId,
+        claimToken: invocation.claimToken,
+        errorMessage: errorMessage.slice(0, 1000),
+      })
+      .catch((error) => log(`session-control fail failed: ${this.summarize(error)}`))
+  }
+
+  /** Close every in-flight turn that an interrupt just aborted, so none idle-hangs for an hour. */
+  private async completeInterruptedTurns(note: string): Promise<void> {
+    for (const [id, entry] of [...this.inflight]) {
+      this.clearInflight(id)
+      if (this.activeTurnStreamId === entry.invocation.responseStreamId) this.activeTurnStreamId = undefined
+      const body = entry.sentCount > 0 ? { noResponse: true } : { finalMessageMarkdown: `_${note}_` }
+      await this.client
+        .complete(id, {
+          instanceId: this.config.instanceId,
+          claimToken: entry.invocation.claimToken,
+          ...body,
+          metadata: { "cc.channel.invocationId": id, "cc.channel.interrupted": "true" },
+        })
+        .catch((error) => log(`interrupted-turn close failed: ${this.summarize(error)}`))
+    }
   }
 
   /** The prompt + history Claude reads, with any downloaded attachments appended as a manifest. */
@@ -673,17 +928,20 @@ export class ChannelServer {
       displayName: this.config.displayName,
       status,
       acceptingInvocations: status === "available",
-      capabilities: { supportsActiveScratchpad: true, supportsPersistentSessions: true },
+      // Full capabilities on EVERY presence update: the server replaces stored
+      // capabilities on a presence:update (it doesn't merge), so omitting the
+      // session-control keys here would wipe what bot:hello advertised.
+      capabilities: runtimeCapabilitiesFor(this.config.runtimeSessionId, this.sessionControlEnabled),
       ...(statusText ? { statusText } : {}),
     }
   }
 
-  private claimBody(): Record<string, unknown> {
+  private claimBody(busy: boolean): Record<string, unknown> {
     return {
       runtimeKind: RUNTIME_KIND,
       instanceId: this.config.instanceId,
       runtimeSessionId: this.config.runtimeSessionId,
-      supportedCapabilities: [...SUPPORTED_CAPABILITIES],
+      supportedCapabilities: claimCapabilitiesFor(busy, this.sessionControlEnabled),
       claimTtlSeconds: CLAIM_TTL_SECONDS,
     }
   }

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -513,15 +513,18 @@ export class ChannelServer {
   }
 
   private async runStop(invocation: ClaimedInvocation): Promise<void> {
+    // If the interrupt can't be sent (pane gone), Claude is still running — don't
+    // close its in-flight turns as if we stopped them; just report the failure.
+    if (!interrupt()) {
+      await this.completeAck(invocation, "Could not send the interrupt (no tmux control).")
+      return
+    }
     const hadTurn = this.inflight.size > 0
-    const sent = interrupt()
     await this.completeInterruptedTurns("Stopped by /stop.")
-    const ack = !sent
-      ? "Could not send the interrupt (no tmux control)."
-      : hadTurn
-        ? "Stopped the current Claude Code turn."
-        : "Sent an interrupt to Claude Code."
-    await this.completeAck(invocation, ack)
+    await this.completeAck(
+      invocation,
+      hadTurn ? "Stopped the current Claude Code turn." : "Sent an interrupt to Claude Code."
+    )
     await this.syncPresence()
   }
 
@@ -532,7 +535,13 @@ export class ChannelServer {
    * round-trips through the normal notification path so Claude replies to it.
    */
   private async runSteer(invocation: ClaimedInvocation, text: string): Promise<void> {
-    interrupt()
+    // If the interrupt can't be sent (pane gone), bail before any destructive
+    // side-effect — don't close the running turn or deliver the steer as a
+    // second concurrent turn against a Claude we couldn't actually interrupt.
+    if (!interrupt()) {
+      await this.completeAck(invocation, "Could not interrupt Claude Code (no tmux control); steer not delivered.")
+      return
+    }
     await Bun.sleep(STEER_SETTLE_MS)
     await this.completeInterruptedTurns("Superseded by /steer.")
 

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -13,8 +13,10 @@ const SUPPORTED_CAPABILITIES = ["active-scratchpad", "mentionable"] as const
 const SESSION_CONTROL_CAPABILITY = "session-control"
 // The session-control slash commands this channel can actuate via tmux. Only
 // advertised when running inside tmux. `run` types an arbitrary slash command
-// (e.g. /remote-control); `compact` is sugar for `run /compact`.
-const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "compact", "run"] as const
+// (e.g. /remote-control); `compact` is sugar for `run /compact`; `reload` maps
+// to Claude Code's `/reload-skills` (pick up skills + custom commands added on
+// disk this session — `/reload-plugins` is reachable via `run` for the plugin case).
+const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "compact", "run", "reload"] as const
 // Claude Code `/model` aliases offered as autocomplete in the composer's arg picker.
 const MODEL_SUGGESTIONS = [{ value: "default" }, { value: "sonnet" }, { value: "opus" }, { value: "opusplan" }]
 // Mirror Pi's STEER_DRAIN_LIMIT: how many queued messages a single /steer folds
@@ -502,6 +504,11 @@ export class ChannelServer {
           return await this.runModelCommand(invocation, command.args)
         case "compact":
           return await this.runSlashCommand(invocation, command.args ? `/compact ${command.args}` : "/compact")
+        case "reload":
+          // Claude Code has no single "reload everything"; /reload-skills picks up
+          // skills + custom commands added on disk mid-session (newly `claude mcp
+          // add`'d MCP servers still need a restart). /reload-plugins via `run`.
+          return await this.runSlashCommand(invocation, "/reload-skills")
         case "run":
           return await this.runRunCommand(invocation, command.args)
         default:

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -630,19 +630,28 @@ export class ChannelServer {
 
   /** Close every in-flight turn that an interrupt just aborted, so none idle-hangs for an hour. */
   private async completeInterruptedTurns(note: string): Promise<void> {
-    for (const [id, entry] of [...this.inflight]) {
+    // Clear every entry's timer and drop it from the map BEFORE the first await.
+    // If we cleared-and-completed one at a time, a sibling's idle-timeout could
+    // fire at a `complete()` yield point, find itself still in the map, and
+    // complete itself — then this loop double-completes it.
+    const entries = [...this.inflight]
+    for (const [id, entry] of entries) {
       this.clearInflight(id)
       if (this.activeTurnStreamId === entry.invocation.responseStreamId) this.activeTurnStreamId = undefined
-      const body = entry.sentCount > 0 ? { noResponse: true } : { finalMessageMarkdown: `_${note}_` }
-      await this.client
-        .complete(id, {
-          instanceId: this.config.instanceId,
-          claimToken: entry.invocation.claimToken,
-          ...body,
-          metadata: { "cc.channel.invocationId": id, "cc.channel.interrupted": "true" },
-        })
-        .catch((error) => log(`interrupted-turn close failed: ${this.summarize(error)}`))
     }
+    await Promise.all(
+      entries.map(([id, entry]) => {
+        const body = entry.sentCount > 0 ? { noResponse: true } : { finalMessageMarkdown: `_${note}_` }
+        return this.client
+          .complete(id, {
+            instanceId: this.config.instanceId,
+            claimToken: entry.invocation.claimToken,
+            ...body,
+            metadata: { "cc.channel.invocationId": id, "cc.channel.interrupted": "true" },
+          })
+          .catch((error) => log(`interrupted-turn close failed: ${this.summarize(error)}`))
+      })
+    )
   }
 
   /** The prompt + history Claude reads, with any downloaded attachments appended as a manifest. */

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -581,7 +581,9 @@ export class ChannelServer {
       await this.completeAck(invocation, "Usage: `/model <name>` (e.g. sonnet, opus, default).")
       return
     }
-    const ok = await submitLine(`/model ${alias}`)
+    // `confirm`: a mid-session model switch pops a "Switch model?" dialog (default
+    // "Yes") — the second Enter accepts it; harmless no-op when no dialog appears.
+    const ok = await submitLine(`/model ${alias}`, { confirm: true })
     await this.completeAck(
       invocation,
       ok ? `Set Claude Code model to \`${alias}\`.` : "Could not send /model (no tmux control)."

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test"
+import {
+  buildSteerContent,
+  claimCapabilitiesFor,
+  isSessionControlInvocation,
+  parseSessionControlCommand,
+  runtimeCapabilitiesFor,
+  supportedCapabilitiesFor,
+} from "./channel-server"
+import type { ClaimedInvocation } from "./threa-client"
+
+function invocation(overrides: Partial<ClaimedInvocation>): ClaimedInvocation {
+  return {
+    id: "binv_1",
+    workspaceId: "ws_1",
+    rootStreamId: "stream_root",
+    activeStreamId: "stream_root",
+    sourceMessageId: "msg_1",
+    responseStreamId: "stream_root",
+    actor: { type: "bot", id: "bot_1", slug: "claude" },
+    trigger: "active-scratchpad",
+    requiredCapability: "active-scratchpad",
+    promptMarkdown: "hello",
+    authorUserId: "usr_1",
+    mentionedActorSlugs: [],
+    claimToken: "tok",
+    claimExpiresAt: "2026-01-01T00:00:00Z",
+    runtimeSessionId: "ccs_1",
+    metadata: {},
+    ...overrides,
+  }
+}
+
+describe("parseSessionControlCommand", () => {
+  it("reads name + args from structured command metadata", () => {
+    const inv = invocation({
+      trigger: "session-control",
+      promptMarkdown: "/steer focus on the failing test",
+      metadata: {
+        command: { executionKind: "bot-runtime", id: "cmd_1", name: "steer", args: "focus on the failing test" },
+      },
+    })
+    expect(parseSessionControlCommand(inv)).toEqual({ name: "steer", args: "focus on the failing test" })
+  })
+
+  it("falls back to parsing the prompt for a session-control invocation without metadata", () => {
+    const inv = invocation({ trigger: "session-control", promptMarkdown: "/model opus", metadata: {} })
+    expect(parseSessionControlCommand(inv)).toEqual({ name: "model", args: "opus" })
+  })
+
+  it("handles a no-arg command", () => {
+    const inv = invocation({ trigger: "session-control", promptMarkdown: "/stop", metadata: {} })
+    expect(parseSessionControlCommand(inv)).toEqual({ name: "stop", args: "" })
+  })
+
+  it("returns null for a normal (non-session-control) message even if it starts with a slash", () => {
+    const inv = invocation({ trigger: "active-scratchpad", promptMarkdown: "/not-a-command really", metadata: {} })
+    expect(parseSessionControlCommand(inv)).toBeNull()
+    expect(isSessionControlInvocation(inv)).toBe(false)
+  })
+
+  it("recognises a session-control invocation via metadata regardless of trigger text", () => {
+    const inv = invocation({
+      trigger: "session-control",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_2", name: "run", args: "/remote-control" } },
+    })
+    expect(isSessionControlInvocation(inv)).toBe(true)
+    expect(parseSessionControlCommand(inv)).toEqual({ name: "run", args: "/remote-control" })
+  })
+})
+
+describe("buildSteerContent", () => {
+  it("returns the single part verbatim", () => {
+    expect(buildSteerContent(["just this"])).toBe("just this")
+  })
+
+  it("combines multiple parts most-recent-last under one header", () => {
+    const combined = buildSteerContent(["first queued", "second queued", "the steer"])
+    expect(combined).toContain("Handle all of the following together (most recent last):")
+    expect(combined.indexOf("first queued")).toBeLessThan(combined.indexOf("the steer"))
+    expect(combined).toContain("second queued")
+  })
+})
+
+describe("capability selection", () => {
+  it("advertises session-control only when TUI control is available", () => {
+    expect(supportedCapabilitiesFor(true)).toContain("session-control")
+    expect(supportedCapabilitiesFor(false)).not.toContain("session-control")
+    expect(supportedCapabilitiesFor(false)).toEqual(["active-scratchpad", "mentionable"])
+  })
+
+  it("claims everything when idle but session-control only when busy", () => {
+    expect(claimCapabilitiesFor(false, true)).toEqual(["active-scratchpad", "mentionable", "session-control"])
+    expect(claimCapabilitiesFor(true, true)).toEqual(["session-control"])
+  })
+
+  it("claims nothing while busy without TUI control (caller must not claim)", () => {
+    expect(claimCapabilitiesFor(true, false)).toEqual([])
+    expect(claimCapabilitiesFor(false, false)).toEqual(["active-scratchpad", "mentionable"])
+  })
+
+  it("only publishes session-control command capabilities when control is available", () => {
+    const enabled = runtimeCapabilitiesFor("ccs_1", true)
+    expect(enabled.supportsSessionControlCommands).toBe(true)
+    expect(enabled.sessionControlCommands).toEqual(["stop", "steer", "model", "compact", "run"])
+    expect(enabled.runtimeSessionId).toBe("ccs_1")
+
+    const disabled = runtimeCapabilitiesFor("ccs_1", false)
+    expect(disabled.supportsSessionControlCommands).toBeUndefined()
+    expect(disabled.sessionControlCommands).toBeUndefined()
+    expect(disabled.runtimeSessionId).toBe("ccs_1")
+  })
+})

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -102,7 +102,7 @@ describe("capability selection", () => {
   it("only publishes session-control command capabilities when control is available", () => {
     const enabled = runtimeCapabilitiesFor("ccs_1", true)
     expect(enabled.supportsSessionControlCommands).toBe(true)
-    expect(enabled.sessionControlCommands).toEqual(["stop", "steer", "model", "compact", "run"])
+    expect(enabled.sessionControlCommands).toEqual(["stop", "steer", "model", "compact", "run", "reload"])
     expect(enabled.runtimeSessionId).toBe("ccs_1")
 
     const disabled = runtimeCapabilitiesFor("ccs_1", false)

--- a/extensions/claude-code-remote/src/tmux-control.test.ts
+++ b/extensions/claude-code-remote/src/tmux-control.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { tmuxAvailable } from "./tmux-control"
+
+describe("tmuxAvailable", () => {
+  const saved = {
+    TMUX: process.env.TMUX,
+    TMUX_PANE: process.env.TMUX_PANE,
+    THREA_TMUX_TARGET: process.env.THREA_TMUX_TARGET,
+  }
+
+  beforeEach(() => {
+    delete process.env.TMUX
+    delete process.env.TMUX_PANE
+    delete process.env.THREA_TMUX_TARGET
+  })
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
+  it("is false outside tmux", () => {
+    process.env.TMUX_PANE = "%5"
+    expect(tmuxAvailable()).toBe(false)
+  })
+
+  it("is false inside tmux with no pane target", () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    expect(tmuxAvailable()).toBe(false)
+  })
+
+  it("is true inside tmux with a discovered pane", () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.TMUX_PANE = "%5"
+    expect(tmuxAvailable()).toBe(true)
+  })
+
+  it("honours an explicit THREA_TMUX_TARGET override", () => {
+    process.env.TMUX = "/tmp/tmux-501/default,1234,0"
+    process.env.THREA_TMUX_TARGET = "work:claude.0"
+    expect(tmuxAvailable()).toBe(true)
+  })
+})

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -1,0 +1,55 @@
+/**
+ * Drive the Claude Code TUI from outside the process by sending keystrokes to the
+ * tmux pane it runs in. Claude Code exposes no programmatic control to an MCP
+ * server, so the pane is the only actuator: `Escape` interrupts the current turn;
+ * literal text + `Enter` submits a prompt or a slash command (`/model`, `/compact`,
+ * `/remote-control`, …). See docs/claude-channel-session-control.md.
+ *
+ * The target pane is discovered from `$TMUX_PANE`, which tmux sets inside the pane
+ * and Claude Code inherits and passes to this MCP child. `THREA_TMUX_TARGET` is an
+ * explicit override for tests or non-self-discovering launches. Both the env and
+ * the target are read at call time so the value is never stale-captured.
+ */
+
+function paneTarget(): string | undefined {
+  const explicit = process.env.THREA_TMUX_TARGET?.trim()
+  if (explicit) return explicit
+  const pane = process.env.TMUX_PANE?.trim()
+  return pane || undefined
+}
+
+/** True only when we're inside tmux AND know which pane to drive. Gates whether the channel advertises session control at all (fail-safe: no control → no commands offered). */
+export function tmuxAvailable(): boolean {
+  return Boolean(process.env.TMUX && paneTarget())
+}
+
+function sendKeys(args: string[]): boolean {
+  const target = paneTarget()
+  if (!target) return false
+  try {
+    const result = Bun.spawnSync(["tmux", "send-keys", "-t", target, ...args], { stdout: "pipe", stderr: "pipe" })
+    return result.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+/** Interrupt the current Claude Code turn (single Esc). Harmless at an idle prompt. */
+export function interrupt(): boolean {
+  return sendKeys(["Escape"])
+}
+
+/**
+ * Type literal text, then submit with Enter. `-l` sends the text verbatim so `/`,
+ * spaces, and punctuation aren't parsed as tmux key names. A short settle between
+ * the text and Enter lets Claude Code's slash-command autocomplete resolve, so
+ * `/model sonnet` submits instead of the menu swallowing the Enter.
+ */
+export async function submitLine(text: string, settleMs = 150): Promise<boolean> {
+  if (!sendKeys(["-l", text])) return false
+  if (settleMs > 0) await Bun.sleep(settleMs)
+  return sendKeys(["Enter"])
+}
+
+/** Milliseconds to wait after an interrupt before delivering the steer turn, so Claude has returned to idle. */
+export const STEER_SETTLE_MS = 250

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -40,16 +40,37 @@ export function interrupt(): boolean {
 }
 
 /**
- * Type literal text, then submit with Enter. `-l` sends the text verbatim so `/`,
- * spaces, and punctuation aren't parsed as tmux key names. A short settle between
- * the text and Enter lets Claude Code's slash-command autocomplete resolve, so
- * `/model sonnet` submits instead of the menu swallowing the Enter.
+ * Type literal text, then submit with Enter.
+ *
+ * Clears the input line first (Ctrl-U): an Esc-interrupt restores the interrupted
+ * message back into Claude Code's input box, so a stale line would concatenate
+ * with the command and get submitted as a plain prompt (the command silently
+ * doesn't run). Verified live against Claude Code v2.1.193.
+ *
+ * `-l` sends the text verbatim so `/`, spaces, and punctuation aren't parsed as
+ * tmux key names. A short settle between the text and Enter lets the slash-command
+ * autocomplete resolve, so `/model sonnet` submits instead of the menu eating the
+ * Enter.
+ *
+ * With `confirm`, a second Enter is sent after a longer settle to accept a modal
+ * Claude Code may raise — `/model <x>` mid-session pops a "Switch model?" dialog
+ * whose default option is "Yes"; without the confirm the session wedges at the
+ * dialog. The trailing Enter is a harmless empty submit when no modal appears.
  */
-export async function submitLine(text: string, settleMs = 150): Promise<boolean> {
+export async function submitLine(text: string, opts: { settleMs?: number; confirm?: boolean } = {}): Promise<boolean> {
+  const settleMs = opts.settleMs ?? 150
+  if (!sendKeys(["C-u"])) return false
   if (!sendKeys(["-l", text])) return false
   if (settleMs > 0) await Bun.sleep(settleMs)
-  return sendKeys(["Enter"])
+  if (!sendKeys(["Enter"])) return false
+  if (opts.confirm) {
+    await Bun.sleep(CONFIRM_SETTLE_MS)
+    sendKeys(["Enter"])
+  }
+  return true
 }
 
 /** Milliseconds to wait after an interrupt before delivering the steer turn, so Claude has returned to idle. */
 export const STEER_SETTLE_MS = 250
+/** Wait for a modal (e.g. "Switch model?") to render before sending the confirming Enter. */
+const CONFIRM_SETTLE_MS = 350

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -64,8 +64,15 @@ export async function submitLine(text: string, opts: { settleMs?: number; confir
   if (settleMs > 0) await Bun.sleep(settleMs)
   if (!sendKeys(["Enter"])) return false
   if (opts.confirm) {
+    // A modal Claude Code raises (e.g. "/model" mid-session pops "Switch model?")
+    // may render slightly after the first Enter. Send two guarded, spaced Enters
+    // so a late-rendering modal is still confirmed; an Enter on an empty prompt is
+    // a harmless no-op. Guarded (unlike a fire-and-forget Enter) so a pane that
+    // vanished mid-confirm reports failure instead of acking a false success.
     await Bun.sleep(CONFIRM_SETTLE_MS)
-    sendKeys(["Enter"])
+    if (!sendKeys(["Enter"])) return false
+    await Bun.sleep(CONFIRM_SETTLE_MS)
+    if (!sendKeys(["Enter"])) return false
   }
   return true
 }

--- a/extensions/harness-daemon/src/cli.ts
+++ b/extensions/harness-daemon/src/cli.ts
@@ -10,6 +10,9 @@ Usage:
   threa-harnessd do <natural language command>
   threa-harnessd list
   threa-harnessd stop <agent-id-or-name>
+  threa-harnessd interrupt <agent-id-or-name>
+  threa-harnessd steer <agent-id-or-name> [follow-up text]
+  threa-harnessd keys <agent-id-or-name> <tmux send-keys tokens...>
   threa-harnessd attach <agent-id-or-name>
   threa-harnessd doctor
 
@@ -17,6 +20,9 @@ Examples:
   threa-harnessd spawn pi --name explore-long-chat-perf --branch explore/long-chat-perf
   threa-harnessd spawn claude --name fix-sidebar --branch fix/sidebar
   threa-harnessd do spawn a pi agent for long chat performance
+  threa-harnessd interrupt fix-sidebar
+  threa-harnessd steer fix-sidebar "also update the tests"
+  threa-harnessd keys fix-sidebar /compact Enter
 `)
   process.exit(0)
 }

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -4,6 +4,7 @@ import { die } from "./errors"
 import { findAgent, inventoryPath, readInventory, upsertAgent } from "./inventory"
 import { commandExists, commandPath, output } from "./shell"
 import { ClaudeRuntimeSpawner, PiRuntimeSpawner } from "./spawners"
+import { sendKeys } from "./tmux"
 import type { SpawnOptions } from "./types"
 
 function spawnCommand(options: SpawnOptions): string[] {
@@ -79,6 +80,38 @@ export function stopAgent(ref: string): void {
   if (result.exitCode !== 0) die(result.stderr.trim() || `tmux kill-window failed for ${target}`)
   upsertAgent({ ...agent, status: "stopped", updatedAt: now() })
   console.log(`harnessd: stopped ${agent.name} (${target})`)
+}
+
+function tmuxTarget(ref: string): { session: string; window: string } {
+  const agent = findAgent(ref)
+  if (!agent.tmuxSession || !agent.tmuxWindow) die(`${agent.name} has no tmux target recorded`)
+  return { session: agent.tmuxSession, window: agent.tmuxWindow }
+}
+
+/** Send Esc to interrupt the agent's current turn (Claude Code / Pi) without killing the window. */
+export function interruptAgent(ref: string): void {
+  const { session, window } = tmuxTarget(ref)
+  sendKeys(session, window, ["Escape"])
+  console.log(`harnessd: interrupted ${session}:${window}`)
+}
+
+/** Interrupt the current turn, then (if given) type a follow-up and submit it. */
+export function steerAgent(ref: string, text: string): void {
+  const { session, window } = tmuxTarget(ref)
+  sendKeys(session, window, ["Escape"])
+  if (text) {
+    sendKeys(session, window, ["-l", text])
+    sendKeys(session, window, ["Enter"])
+  }
+  console.log(`harnessd: steered ${session}:${window}`)
+}
+
+/** Raw `tmux send-keys` passthrough to the agent's window (tokens follow tmux rules). */
+export function sendKeysToAgent(ref: string, keys: string[]): void {
+  if (keys.length === 0) die("keys requires at least one key or token")
+  const { session, window } = tmuxTarget(ref)
+  sendKeys(session, window, keys)
+  console.log(`harnessd: sent keys to ${session}:${window}`)
 }
 
 export function attachAgent(ref: string): void {

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -100,6 +100,10 @@ export function steerAgent(ref: string, text: string): void {
   const { session, window } = tmuxTarget(ref)
   sendKeys(session, window, ["Escape"])
   if (text) {
+    // Esc restores the interrupted message into the input box; clear it (Ctrl-U)
+    // before typing so the follow-up doesn't concatenate with that residue and
+    // submit as a plain prompt.
+    sendKeys(session, window, ["C-u"])
     sendKeys(session, window, ["-l", text])
     sendKeys(session, window, ["Enter"])
   }

--- a/extensions/harness-daemon/src/index.ts
+++ b/extensions/harness-daemon/src/index.ts
@@ -1,7 +1,17 @@
 #!/usr/bin/env bun
 
 import { parseSpawn, usage } from "./cli"
-import { attachAgent, doctor, inferAndRun, listAgents, spawnAgent, stopAgent } from "./commands"
+import {
+  attachAgent,
+  doctor,
+  inferAndRun,
+  interruptAgent,
+  listAgents,
+  sendKeysToAgent,
+  spawnAgent,
+  steerAgent,
+  stopAgent,
+} from "./commands"
 import { die } from "./errors"
 
 async function main(): Promise<void> {
@@ -10,6 +20,10 @@ async function main(): Promise<void> {
   if (command === "spawn") return spawnAgent(parseSpawn(args))
   if (command === "list") return listAgents()
   if (command === "stop") return stopAgent(args[0] ?? die("stop requires an agent id or name"))
+  if (command === "interrupt") return interruptAgent(args[0] ?? die("interrupt requires an agent id or name"))
+  if (command === "steer")
+    return steerAgent(args[0] ?? die("steer requires an agent id or name"), args.slice(1).join(" "))
+  if (command === "keys") return sendKeysToAgent(args[0] ?? die("keys requires an agent id or name"), args.slice(1))
   if (command === "attach") return attachAgent(args[0] ?? die("attach requires an agent id or name"))
   if (command === "doctor") return doctor()
   if (command === "do") return inferAndRun(args.join(" "))

--- a/extensions/harness-daemon/src/tmux.ts
+++ b/extensions/harness-daemon/src/tmux.ts
@@ -1,5 +1,5 @@
 import { die } from "./errors"
-import { output } from "./shell"
+import { output, run } from "./shell"
 import type { SpawnOptions } from "./types"
 
 export function tmuxSession(options: SpawnOptions): string {
@@ -23,4 +23,9 @@ export function capturePane(session: string, window: string, lines = 30): string
   return output(["tmux", "capture-pane", "-t", `${session}:${window}`, "-p", "-S", `-${lines}`], {
     allowFailure: true,
   }).stdout
+}
+
+/** Send keys/tokens to a window's active program. `tmux send-keys` token rules apply (`Escape`, `Enter`, `-l` for literal text). */
+export function sendKeys(session: string, window: string, keys: string[]): void {
+  run(["tmux", "send-keys", "-t", `${session}:${window}`, ...keys])
 }


### PR DESCRIPTION
**Design doc:** [`docs/claude-channel-session-control.md`](docs/claude-channel-session-control.md) (added in this PR)

## Problem

The Pi remote runtime has in-UI session-control slash commands dispatched from the Threa composer; the Claude Code channel (`extensions/claude-code-remote`) had none — you could talk to a linked Claude session but not interrupt it, steer it, change its model, compact it, or run a slash command from Threa.

The dispatch pipeline (composer → `POST /api/workspaces/:id/commands/dispatch` → a `session-control` `bot_invocation` → claim → targeted delivery) and the frontend slash menu were **already runtime-agnostic** — the frontend never inspects `runtimeKind`, it renders whatever `CommandInfo[]` the stream bootstrap carries. Three things gated session control to Pi: the target resolver returned `null` for non-`pi-local` kinds; the catalog/descriptions were Pi-named; and the channel never advertised session-control capabilities and had no executor — and crucially, **Claude Code exposes no programmatic control surface to an MCP server**, so there was nothing to call.

## Solution

The actuator is the tmux pane Claude Code runs in (the "Ctrl-C-lite" mechanism the harness already uses at spawn). The channel — an MCP stdio child of Claude Code — discovers its own pane from `$TMUX_PANE` and sends keystrokes: `Escape` to interrupt, literal text + `Enter` to submit a prompt or a slash command. The backend is generalized off `pi-local`; the frontend is untouched.

Command set shipped: **`stop` · `steer` · `model` · `compact` · `run <slash-command>` · `reload`**.

### How it works

- **Backend, generalized (no Pi behavior change).** `resolveRuntimeCommandTarget` (`availability.ts`) accepts `claude-code-channel` as well as `pi-local` and exposes `runtimeKind`. `resolveRuntimeInvocationRouting(name, runtimeKind)` (`handlers.ts`) is kind-aware. `catalog.ts` adds a generic `run` command and drops "Pi" from the user-facing descriptions. (The `Pi`-prefixed identifiers were renamed to runtime-neutral — see review fixes.)
- **Channel executor.** New `tmux-control.ts`: `tmuxAvailable()`, `interrupt()` (`Escape`), `submitLine()` (clear line → literal text → settle → Enter, with an optional confirming Enter). `channel-server.ts` gains `handleSessionControl` dispatching the six commands.
- **`/stop`** sends `Escape`, completes every in-flight forwarded turn so none idle-hangs, acks.
- **`/steer`** sends `Escape`, then folds the steer text + every message queued while busy into **one combined turn** (mirrors Pi: N messages → 1 response), closing the swept invocations `noResponse`. tmux is used only for the interrupt; the combined content round-trips through the normal channel notification so Claude `reply`s to it.
- **`/model <alias>` · `/compact [instructions]` · `/run <cmd>` · `/reload`** type the slash command into the TUI. `reload` maps to Claude Code's `/reload-skills` (picks up skills + custom commands added on disk mid-session).
- **Capability advertisement is fail-safe.** The channel advertises `supportsSessionControlCommands` + `sessionControlCommands` + `modelSuggestions` **only when `tmuxAvailable()`**, and on **every** presence body (the server full-replaces stored capabilities on a `bot:presence:update`, so omitting them on a tick would wipe what hello advertised).
- **Harness CLI bonus.** `threa-harnessd` gains `interrupt` / `steer` / `keys` verbs.

### Key design decisions

**1. Runtime-kind-aware routing for `steer`/`stop`.** They must reach the channel *mid-turn*, but a normal follow-up must still wait its turn. For the Claude channel, steer/stop route to the `session-control` capability, and the channel advertises **only** `session-control` while busy (`claimCapabilitiesFor(busy, …)`) — so a busy channel claims interrupts while a normal `active-scratchpad` follow-up stays queued, with no dependency on Claude Code's mid-turn queueing. Pi's routing is unchanged.

**2. tmux pane self-discovery.** `$TMUX_PANE` is set by tmux inside the pane and inherited by Claude → the MCP child (verified live). `THREA_TMUX_TARGET` is a test override. No tmux → no session-control advertised at all.

**3. Steer routes content through the channel, not the keyboard.** Using tmux only for the `Escape` and pushing the combined content through the existing notification path keeps the reply/idle-timeout/attachment machinery and posts the steered work back to Threa.

### Review + live-testing evolution

This branch was reviewed twice and live-tested against **Claude Code v2.1.193**; the fixes are folded in:

- **Review round 1** — renamed the now-cross-runtime `Pi`-prefixed identifiers to neutral names (`resolveRuntimeCommandTarget`, `RuntimeCommandTarget`, `SESSION_CONTROL_COMMAND_NAMES`); made `completeInterruptedTurns` race-safe (clear all timers/entries before the first `await`, then complete in parallel — a sibling idle-timeout could otherwise double-complete).
- **Review round 2** — `runSteer`/`runStop` now bail with a clear ack when `interrupt()` returns false, instead of closing the running turn + delivering a concurrent steer against a Claude that was never interrupted.
- **Live testing found + fixed two bugs the unit tests couldn't:** (a) an `Esc`-interrupt restores the interrupted message into the input box, so a typed command concatenated with the residue and submitted as a plain prompt → `submitLine` now sends `Ctrl-U` first; (b) a mid-session model switch pops a "Switch model?" modal that wedges the session → `/model` sends a confirming Enter after a settle.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/tmux-control.ts` | Pane discovery + `interrupt`/`submitLine` key injection |
| `extensions/claude-code-remote/src/tmux-control.test.ts` | `tmuxAvailable()` env-detection cases |
| `extensions/claude-code-remote/src/session-control.test.ts` | Command parsing, steer-combine, busy-aware capability selection |
| `apps/backend/src/features/commands/routing.test.ts` | Kind-aware `resolveRuntimeInvocationRouting` |
| `docs/claude-channel-session-control.md` | Design doc (mechanism, concurrency, live-verify results) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/commands/availability.ts` | Resolver accepts `claude-code-channel`; exposes `runtimeKind`; identifier rename |
| `apps/backend/src/features/commands/handlers.ts` | `resolveRuntimeInvocationRouting(name, runtimeKind)` exported + kind-aware |
| `apps/backend/src/features/commands/catalog.ts` | Added `run`; neutralized descriptions; identifier rename |
| `apps/backend/src/features/commands/index.ts` | Barrel re-exports updated for the rename |
| `apps/backend/src/features/bot-runtimes/service.ts` | Corrected the now-false bootstrap-capability comment |
| `extensions/claude-code-remote/src/channel-server.ts` | Session-control caps (tmux-gated, every presence body), busy-aware claim, `handleSessionControl`, steer-combine, interrupted-turn close, interrupt-failure guards |
| `extensions/harness-daemon/src/{tmux,commands,index,cli}.ts` | `interrupt` / `steer` / `keys` CLI verbs |

## Out of scope (deliberate)

- **Frontend** — none; it already renders `CommandInfo[]` generically and never gates on `runtimeKind`.
- **`thinking` / `skill` / `shell`** — Pi-only; the channel doesn't advertise them.
- **Hot-reloading newly `claude mcp add`'d MCP servers** — Claude Code has no mid-session MCP-config reload (restart only); `/reload` covers skills/commands, `/reload-plugins` is reachable via `run`.

## Test plan

- [x] `apps/backend` `bun test src/features/commands/routing.test.ts` — 3 pass
- [x] `extensions/claude-code-remote` `bun test` — 71 pass
- [x] `tsc --noEmit` clean: `apps/backend` (src + tests), `extensions/claude-code-remote`, `extensions/harness-daemon`; `eslint` clean on touched backend files
- [x] Two `/code-review` rounds (sonnet ×2 each): round 1 → 2 findings fixed (identifier rename, `completeInterruptedTurns` race); round 2 → 1 finding fixed (`runSteer` interrupt-discard); confidence 6/7
- [x] **Live tmux verification (Claude Code v2.1.193):** `$TMUX_PANE` inheritance ✓; single `Escape` interrupts (filesystem-marker proof) ✓; `/model <alias>` ✓; `/compact` ✓; `/reload` → `/reload-skills` ✓ ("16 skills available"). Found + fixed the input-residue and model-switch-modal bugs.
- [ ] **Full dispatch round-trip through a real scratchpad** (composer → channel claims → executes) and **steer-combine end-to-end** — not live-exercised; covered by unit tests. This is the already-tested claim/dispatch plumbing rather than novel tmux behavior. Would need a `bun run dev:test` stack + a linked scratchpad.
- [ ] Branch is behind `origin/main` (advanced since branch point) — no file overlap with this diff, so no conflicts expected; rebase before merge if desired.

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Session-control slash commands (`stop`/`steer`/`model`/`compact`/`run`/`reload`) for the Claude Code channel, driven from the Threa composer, actuated via tmux key injection (Claude Code exposes no programmatic control to an MCP server).

**What was built.** (1) Backend generalized off `pi-local`: target resolver accepts `claude-code-channel`, exposes `runtimeKind`; kind-aware steer/stop routing; generic `run`; runtime-neutral catalog. (2) Channel executor: `tmux-control.ts` (pane self-discovery + key injection with line-clear and optional confirm), busy-aware claim (session-control-only while busy), `handleSessionControl`, steer = interrupt + drain-all-pending + combine into one turn + close swept `noResponse`. (3) Harness CLI `interrupt`/`steer`/`keys`. `reload` → `/reload-skills`.

**Design decisions.** Kind-aware routing so a busy channel claims interrupts while normal follow-ups wait. Pane self-discovery via `$TMUX_PANE`. Steer content round-trips through the channel (not blind-typed). Caps advertised only inside tmux and on every presence body (server full-replaces caps).

**What's NOT included.** Frontend (already generic). `thinking`/`skill`/`shell`. Hot-reload of newly added MCP servers (Claude Code limitation).

**Status.** Implemented; two review rounds + live tmux verification done (which found + fixed four issues total). Full dispatch round-trip still unit-tested only.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
