### PR TITLE
fix(timeline): scope the sealed-E2E-name reveal gate to the open stream (cached-DM blank)

### DIFF
--- a/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.test.tsx
@@ -628,7 +628,38 @@ describe("CoordinatedLoadingProvider", () => {
     warnSpy.mockRestore()
   })
 
-  it("holds the reveal until an unlocked session's sealed name decrypts, then reveals", async () => {
+  it("reveals an open plaintext stream immediately even when OTHER workspace streams have undecrypted sealed names", async () => {
+    // Multi-second-blank regression: the reveal must scope the sealed-name wait to
+    // the stream being shown, not the whole workspace. Opening a plaintext DM on a
+    // workspace full of E2E scratchpads blanked the cached DM behind decrypting all
+    // those unrelated names (each a network key-wrap fetch, re-run every refresh).
+    // The open stream is plaintext (already has its name) → reveal now; the other
+    // sealed streams resolve in the sidebar via their own per-row loader.
+    makeReadyWorkspaceState()
+    mockSeedCacheFromIdbResult = true
+    mockE2eSessionStatus = "unlocked"
+    mockStreams = [
+      { id: "stream_1" }, // the OPEN stream — plaintext, no sealed name
+      // an unrelated E2E scratchpad whose name has NOT decrypted
+      { id: "stream_sealed", e2eEnabled: true, sealedNameCiphertext: "ct_other", sealedNameEnvelope: { v: 1 } },
+    ]
+
+    render(
+      <CoordinatedLoadingProvider workspaceId="workspace_1" streamIds={["stream_1"]}>
+        <TestConsumer />
+      </CoordinatedLoadingProvider>
+    )
+
+    await flushEffects()
+
+    // The open plaintext stream does not wait on the other workspace stream's name.
+    expect(screen.getByTestId("phase").textContent).toBe("ready")
+  })
+
+  it("holds the reveal until an OPEN sealed stream's own name decrypts, then reveals", async () => {
+    // The scoped wait is kept where it's legitimate: when the stream being opened
+    // is itself sealed, hold briefly so its header paints the real name rather than
+    // flashing the placeholder. Only its ONE name is awaited, never the workspace's.
     makeReadyWorkspaceState()
     mockSeedCacheFromIdbResult = true
     mockE2eSessionStatus = "unlocked"
@@ -642,11 +673,10 @@ describe("CoordinatedLoadingProvider", () => {
 
     await flushEffects()
 
-    // Everything else is ready, but the sealed name hasn't decrypted yet, so the
-    // gate holds rather than flashing the placeholder.
+    // The open stream is sealed and its name hasn't decrypted → hold.
     expect(screen.getByTestId("phase").textContent).not.toBe("ready")
 
-    // The decrypt lands (seeded into the shared cache) → the gate opens.
+    // Its name lands (seeded into the shared cache) → reveal.
     act(() => {
       primeStreamName(streamNameCacheKey("workspace_1", "stream_1", "ct_1"), "Quarterly Plan")
     })
@@ -660,7 +690,7 @@ describe("CoordinatedLoadingProvider", () => {
     expect(screen.getByTestId("phase").textContent).toBe("ready")
   })
 
-  it("does not wait on sealed names while the session is locked (reveals with the placeholder)", async () => {
+  it("does not wait on an open sealed stream while the session is locked (reveals with the placeholder)", async () => {
     makeReadyWorkspaceState()
     mockSeedCacheFromIdbResult = true
     mockE2eSessionStatus = "locked"

--- a/apps/frontend/src/contexts/coordinated-loading-context.tsx
+++ b/apps/frontend/src/contexts/coordinated-loading-context.tsx
@@ -192,16 +192,23 @@ export function CoordinatedLoadingProvider({ workspaceId, streamIds, children }:
   // user's real layout. A row always exists after the first bootstrap (the server
   // seeds the default), so this only ever waits on a genuinely-unloaded config.
   const idbSidebarConfig = useWorkspaceSidebarConfig(workspaceId)
-  // Hold the initial reveal until every sealed E2E stream name has decrypted, so
-  // the first painted render shows real names instead of flashing the placeholder
-  // and popping to the decrypted name a tick later. The resolver (the single
-  // session + name-cache authority) only reports pending while the session is
-  // settling or unlocked-and-decrypting; it returns false for a locked/no-key
-  // session (the placeholder is then the right answer) and once a decrypt settles,
-  // so this can't deadlock the reveal. It re-binds when a decrypt lands.
+  // Wait on a sealed E2E name ONLY when the stream being revealed is itself
+  // sealed — never the whole workspace. The content area shows the OPEN stream(s):
+  // a plaintext stream (the common case, every DM included) already has its name
+  // and must reveal immediately; other streams' sealed names are a sidebar concern
+  // with their own per-row loader. The old `idbStreams.some(...)` here was the
+  // multi-second blank — it held an already-cached plaintext DM behind decrypting
+  // EVERY E2E scratchpad name in the workspace, each a network key-wrap fetch that
+  // re-runs every refresh (the name cache is memory-only). Scoping to the open
+  // streams keeps the legitimate wait — an open sealed scratchpad still resolves
+  // its single name before paint so its header shows the real name, not a
+  // placeholder — without gating unrelated content on unrelated names.
   const isSealedNamePending = useSealedNamePendingResolver(workspaceId)
-  const sealedNamesPending = useMemo(() => idbStreams.some(isSealedNamePending), [idbStreams, isSealedNamePending])
   const streamById = useMemo(() => new Map(idbStreams.map((stream) => [stream.id, stream])), [idbStreams])
+  const sealedNamesPending = useMemo(
+    () => serverStreamIds.some((id) => isSealedNamePending(streamById.get(id))),
+    [serverStreamIds, isSealedNamePending, streamById]
+  )
   const workspaceDataReady =
     hasSeededWorkspaceCache(workspaceId) &&
     !!idbWorkspace &&


### PR DESCRIPTION
## Problem

On a workspace with E2E scratchpads, hard-refreshing a **fully-cached plaintext DM** blanked the timeline for ~1–3s before the cached content reappeared — every message already in IndexedDB, nothing new sent. A screen recording on a real prod account (227 streams, 16 `e2e_streams`) showed ~3s of blank.

This is the content-reveal gate, **not** scroll. `CoordinatedLoadingProvider` holds the whole content area on a `StreamContentSkeleton` (`MainContentGate`, `coordinated-loading-context.tsx`) until `phase === "ready"`, which requires `!isLoading`. `isLoading` included `(!isReady && sealedNamesPending)`, where:

```ts
sealedNamesPending = idbStreams.some(isSealedNamePending) // workspace-global
```

`resolveSealedNamePending` (`use-decrypted-stream-name.ts`) returns `true` while the E2E session is `unknown`/`unlocking`, or while an unlocked stream's name is still decrypting. The decrypted names live only in a memory-only cache (`stream-name-cache.ts`, never persisted), so on every hard refresh the cache is empty and each sealed name re-decrypts — and each decrypt is a network key-wrap fetch (`resolveStreamKey → fetchAndUnwrap → e2eKeyWrapsApi.get`).

Net: opening the **plaintext** Pierre DM waited on the E2E session unlocking and on **every** E2E scratchpad name in the workspace decrypting (9 carry a name) — none of which the DM uses. That `.some()` over all streams is the blank. It never reproduced on a light dev workspace: zero E2E scratchpads → `sealedNamesPending` always false → the gate never engaged.

## Solution

Scope the wait to the stream actually being revealed. The content area shows the **open** stream(s) (`serverStreamIds`), so check only those:

```ts
sealedNamesPending = serverStreamIds.some((id) => isSealedNamePending(streamById.get(id)))
```

- **Plaintext stream** (every DM) → already has a name, nothing to unseal → reveals immediately.
- **Open sealed scratchpad** → still waits for **its one** name (not the workspace's), so its header paints the real name instead of flashing the placeholder — the original no-flash intent, kept.
- **Locked session** → `resolveSealedNamePending` returns false → reveals with the placeholder, no deadlock.

Other streams' sealed names keep resolving in the sidebar through its own per-row loader (`useSealedNamePendingResolver` → `nameDecrypting` in the sidebar builder), unchanged — so nothing flashes there either.

### Key design decision

**Scope, don't remove.** The first cut dropped `sealedNamesPending` from the gate entirely (the sidebar's per-row loaders already prevent a name flash). That fixes the blank but throws away the legitimate case — opening a sealed scratchpad cold should still paint its real name, not a placeholder. Per Kris's call ("if there is nothing to unseal … it should be fine; for a plain text one there is already a name … we can have both"), scoping the term to the open streams keeps the wait exactly where it's earned (the thing you opened, one name) and drops it everywhere it isn't (plaintext, and the other scratchpads).

## How this was found

An exhaustive 74-agent workflow enumerated 63 distinct suspects across the cold-load → first-paint pipeline and adversarially verified each against the real account: **exactly one was real** — this gate. The rest were measured and ruled out (`seedCacheFromIdb` reads ~500 small indexed rows / tens of ms and never touches `db.events`; the `streamsLoading` bootstrap "race" resolves from the local seed; 979/981 drafts are tombstones; the bundle/SW/font floors are account-independent). Independently, the prior session's E2E sub-agent had traced the blank to the same line.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/contexts/coordinated-loading-context.tsx` | `sealedNamesPending` scoped from `idbStreams.some(...)` (workspace-global) to `serverStreamIds.some((id) => isSealedNamePending(streamById.get(id)))` (open streams only) |
| `apps/frontend/src/contexts/coordinated-loading-context.test.tsx` | Three cases for the scoped gate: plaintext-open-with-other-sealed-names-pending reveals instantly; open-sealed holds then reveals on its own name; locked reveals |

## Out of scope (deliberate)

- **PR #1089** (revert #1085 coalescing) is a separate timeline cold-load fix; the workflow ruled the apply-window out for the hard-refresh blank, so this stands alone.
- The ~9 sidebar key-wrap re-fetches per refresh (memory-only cache) are sidebar pop-in, off the first-paint path — separate perf ticket.
- The account-independent ~0.5–1s cold-hard-refresh bundle floor (lazy chunk waterfall + 1.53MB entry parse + render-blocking font) — separate vite `manualChunks` ticket.

## Test plan

- [x] `apps/frontend` `coordinated-loading-context.test.tsx` — 25 pass (incl. the 3 scoped-gate cases)
- [x] Adjacent suites (`sidebar/`, `use-decrypt-stream-names`) — 192 pass
- [x] Monorepo lint + typecheck (pre-commit hook over all apps/packages) — clean
- [ ] No post-fix live first-paint measurement — my local seed has zero E2E scratchpads and can't reproduce. **Verify on staging**: hard-refresh the Pierre DM on the real account and confirm `phase=ready` sub-second (bootstrap-debug log). This PR carries the `staging` label for exactly that.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785058865&installation_id=129946197&pr_number=1092&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1092&signature=2ef5db6deb008eaf8286dbcb365217939739b559ecc32dadc06e71e104003f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->