### PR TITLE
fix(board): keep composer target in sync with the body draft; stop select overflow

### DIFF
--- a/apps/backend/src/features/labels/label-message-service.test.ts
+++ b/apps/backend/src/features/labels/label-message-service.test.ts
@@ -37,6 +37,7 @@ function fakeMessage(overrides: Partial<Message> = {}): Message {
     replyCount: 0,
     clientMessageId: null,
     sentVia: null,
+    conversationIntent: null,
     reactions: {},
     metadata: {},
     editedAt: null,

--- a/apps/frontend/src/components/board/board-composer.tsx
+++ b/apps/frontend/src/components/board/board-composer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { PenSquare, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -30,9 +30,33 @@ const POSTABLE_TYPES = new Set<string>([StreamTypes.CHANNEL, StreamTypes.DM])
 const NEW_SCRATCHPAD = "new:scratchpad"
 const NEW_QUICK_NOTE = "new:quick-note"
 
-// One durable draft for the board's "New post" composer, independent of any
-// target (the target is separate UI state, chosen per post).
+// One durable draft for the board's "New post" composer body.
 const BOARD_DRAFT_KEY = "board:new-post"
+
+// The chosen target is persisted alongside the body draft so reopening the
+// composer (or reloading the page) restores the whole in-progress post, not just
+// the text — a restored body with a silently-cleared target would leave the send
+// disabled with no explanation. Cleared once the post is sent.
+const boardTargetStorageKey = (workspaceId: string) => `board:new-post:target:${workspaceId}`
+
+function readStoredTarget(workspaceId: string): string {
+  try {
+    return localStorage.getItem(boardTargetStorageKey(workspaceId)) ?? ""
+  } catch {
+    return ""
+  }
+}
+
+function writeStoredTarget(workspaceId: string, value: string): void {
+  // Best-effort: localStorage can throw (private mode / quota). The target falls
+  // back to in-memory state, so a failure just means it won't survive a reload.
+  try {
+    if (value) localStorage.setItem(boardTargetStorageKey(workspaceId), value)
+    else localStorage.removeItem(boardTargetStorageKey(workspaceId))
+  } catch {
+    /* ignore */
+  }
+}
 
 /**
  * Existing streams a board post can target: live channels and DMs. Scratchpads
@@ -85,8 +109,29 @@ function BoardComposerForm({ workspaceId, onClose }: { workspaceId: string; onCl
 
   const postableStreams = useMemo(() => streams.filter(isPostableStream), [streams])
 
-  // The selected Select value: a sentinel ("new:…") or a stream id.
-  const [targetValue, setTargetValue] = useState("")
+  // The selected Select value: a sentinel ("new:…") or a stream id. Seeded from
+  // (and written back to) localStorage so it stays in sync with the durable body
+  // draft across reopen/reload.
+  const [targetValue, setTargetValue] = useState(() => readStoredTarget(workspaceId))
+  const handleTargetChange = useCallback(
+    (value: string) => {
+      setTargetValue(value)
+      writeStoredTarget(workspaceId, value)
+    },
+    [workspaceId]
+  )
+
+  // A persisted stream-id target can go stale (archived, left, deleted). Once the
+  // postable list has loaded, drop a target that's no longer selectable so the
+  // composer can't post to a stream the user can't see. Sentinels are always valid.
+  useEffect(() => {
+    if (!targetValue || targetValue === NEW_SCRATCHPAD || targetValue === NEW_QUICK_NOTE) return
+    if (streams.length > 0 && !postableStreams.some((s) => s.id === targetValue)) {
+      setTargetValue("")
+      writeStoredTarget(workspaceId, "")
+    }
+  }, [targetValue, postableStreams, streams.length, workspaceId])
+
   // Only an existing-stream target has a stream object for mention context; a
   // "new scratchpad" target has no stream yet.
   const selectedStream = useMemo<CachedStream | undefined>(
@@ -118,6 +163,7 @@ function BoardComposerForm({ workspaceId, onClose }: { workspaceId: string; onCl
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
+      writeStoredTarget(workspaceId, "")
       onClose()
     } catch {
       toast.error("Couldn't post to the board. Please try again.")
@@ -129,8 +175,8 @@ function BoardComposerForm({ workspaceId, onClose }: { workspaceId: string; onCl
   return (
     <div className="mb-3 rounded-xl border bg-card p-3 sm:p-4">
       <div className="mb-2 flex items-center gap-2">
-        <Select value={targetValue} onValueChange={setTargetValue}>
-          <SelectTrigger className="h-8 w-auto min-w-[180px] text-sm">
+        <Select value={targetValue} onValueChange={handleTargetChange}>
+          <SelectTrigger className="h-8 min-w-0 flex-1 text-sm">
             <SelectValue placeholder="Post to…" />
           </SelectTrigger>
           <SelectContent>


### PR DESCRIPTION
Follow-up polish from the #1080 review (the PR merged before these landed), plus a fix for a semantic merge conflict it left on `main`.

## Changes

**1. Composer target persists in sync with the body draft** (`board-composer.tsx`)

The board "New post" body is a durable draft (`useDraftComposer`, IDB), but the "Post to…" target was plain `useState`. So after closing and reopening the composer (or reloading), the body was restored while the target silently reset — leaving a restored post with a disabled send and no explanation of why. The target now persists in `localStorage` alongside the body: seeded on mount, written on change, cleared on a sent post. A stale persisted stream id (archived/left/deleted) is dropped once the postable list loads, so the composer can never post to a stream the user can't see.

**2. Target select no longer overflows on narrow viewports** (`board-composer.tsx`)

The trigger was `w-auto min-w-[180px]` with no shrink bound; a long channel/DM name grew it past the card width and pushed the cancel button off-screen on a phone. It's now `min-w-0 flex-1`, so it fills the row and truncates instead of overflowing.

**3. Heal red `main`** (`label-message-service.test.ts`)

#1080 made `Message.conversationIntent` non-optional; the labels feature (#1084) merged just before it with a `Message` test fixture that omits the field. Each was green alone, red together — `main`'s `apps/backend` test typecheck currently fails. Adds `conversationIntent: null` to the fixture.

## Test plan

- [x] `apps/frontend` lint + typecheck clean
- [x] `vitest run board-composer.test.tsx use-conversations.test.tsx` (11 tests) pass
- [x] `apps/backend` test typecheck clean (was failing on `main`); labels suite (4 tests) pass
- [x] Full pre-commit suite (all-workspace lint + typecheck + astro + api-doc check) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3o9Z6R5iF8VP8iZeRKmsz)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785071171&installation_id=129946197&pr_number=1094&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1094&signature=f7ea62f7f3f49305dff8ca31c5a4df91e5a9bf59d96d30e22f00a37145e6499b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->