### PR TITLE
fix(pwa): verify the Reload swap landed new code, recover if not

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -249,8 +249,11 @@ describe("reloadForUpdate", () => {
 
       expect(await reconcilePostReload()).toBe(true)
       expect(recoverySpy).toHaveBeenCalledOnce()
-      // Capped, not forced: a genuine recovery loop must still hit the attempt cap.
-      expect(recoverySpy).toHaveBeenCalledWith()
+      // Forced: this recovery only fires from a user Reload click (single-shot
+      // flag), so it can't auto-loop; forcing keeps unrelated chunk-load
+      // recoveries from exhausting the shared attempt cap and silently no-opping
+      // the user's Reload.
+      expect(recoverySpy).toHaveBeenCalledWith({ force: true })
     })
 
     it("wipes nothing when the running build already matches the latest", async () => {

--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { reloadForUpdate, shouldAnnounceWaiting, RELOAD_FALLBACK_TIMEOUT_MS } from "./use-app-update"
+import {
+  currentAppVersion,
+  reconcilePostReload,
+  reloadForUpdate,
+  shouldAnnounceWaiting,
+  shouldRecoverForVersion,
+  RELOAD_FALLBACK_TIMEOUT_MS,
+} from "./use-app-update"
 import * as swRecovery from "@/lib/sw-recovery"
 import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
 
@@ -100,6 +107,7 @@ describe("reloadForUpdate", () => {
   }
 
   beforeEach(() => {
+    sessionStorage.clear()
     reloadSpy = vi.fn()
     // jsdom's location.reload() throws "Not implemented" — replace it with a spy.
     Object.defineProperty(window, "location", {
@@ -201,5 +209,84 @@ describe("reloadForUpdate", () => {
     await vi.advanceTimersByTimeAsync(RELOAD_FALLBACK_TIMEOUT_MS)
     expect(reloadSpy).toHaveBeenCalledOnce()
     expect(recoverySpy).not.toHaveBeenCalled()
+  })
+
+  it("marks a reload attempt so the next load can reconcile it", async () => {
+    setServiceWorker(makeRegistration({ waiting: makeWorker() }))
+    await reloadForUpdate()
+    expect(sessionStorage.getItem("app-update-reload-attempt")).not.toBeNull()
+  })
+
+  describe("reconcilePostReload", () => {
+    const RELOAD_KEY = "app-update-reload-attempt"
+    let fetchSpy: ReturnType<typeof vi.spyOn>
+
+    const mockVersion = (version: string | null, ok = true) => {
+      fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok,
+        json: async () => (version === null ? {} : { version }),
+      } as Response)
+    }
+    const markReload = () => sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+
+    afterEach(() => {
+      fetchSpy?.mockRestore()
+    })
+
+    it("does nothing without a recent Reload click", async () => {
+      mockVersion("anything-newer")
+      expect(await reconcilePostReload()).toBe(false)
+      expect(fetchSpy).not.toHaveBeenCalled()
+      expect(recoverySpy).not.toHaveBeenCalled()
+    })
+
+    it("recovers when the running build differs from the server's latest (swap didn't take)", async () => {
+      // The decisive signal: a successful version fetch proves we're online, and a
+      // mismatch proves the Reload didn't boot us onto new code. Re-announcing
+      // would loop forever, so force a clean boot.
+      markReload()
+      mockVersion(`${currentAppVersion() ?? "x"}-stale`)
+
+      expect(await reconcilePostReload()).toBe(true)
+      expect(recoverySpy).toHaveBeenCalledOnce()
+      // Capped, not forced: a genuine recovery loop must still hit the attempt cap.
+      expect(recoverySpy).toHaveBeenCalledWith()
+    })
+
+    it("wipes nothing when the running build already matches the latest", async () => {
+      markReload()
+      mockVersion(currentAppVersion())
+
+      expect(await reconcilePostReload()).toBe(false)
+      expect(recoverySpy).not.toHaveBeenCalled()
+    })
+
+    it("wipes nothing when the version can't be verified (offline)", async () => {
+      // Offline-first: a failed fetch must never trigger a cache wipe, or we'd
+      // brick a launch that has no network to refetch from.
+      markReload()
+      fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"))
+
+      expect(await reconcilePostReload()).toBe(false)
+      expect(recoverySpy).not.toHaveBeenCalled()
+    })
+
+    it("consumes the flag so a later check doesn't recover again", async () => {
+      markReload()
+      mockVersion(`${currentAppVersion() ?? "x"}-stale`)
+
+      expect(await reconcilePostReload()).toBe(true)
+      expect(await reconcilePostReload()).toBe(false)
+    })
+  })
+
+  describe("shouldRecoverForVersion", () => {
+    it("recovers only on two known, differing versions", () => {
+      expect(shouldRecoverForVersion("a", "b")).toBe(true)
+      expect(shouldRecoverForVersion("a", "a")).toBe(false)
+      expect(shouldRecoverForVersion("a", null)).toBe(false)
+      expect(shouldRecoverForVersion(null, "b")).toBe(false)
+      expect(shouldRecoverForVersion(null, null)).toBe(false)
+    })
   })
 })

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react"
+import { useEffect, useCallback, useRef } from "react"
 import { toast } from "sonner"
 import { usePageActivity } from "./use-page-activity"
 import { useSocketReconnectCount } from "@/contexts"
@@ -275,6 +275,15 @@ export function useAppUpdate(): void {
   const { isVisible } = usePageActivity()
   const reconnectCount = useSocketReconnectCount()
 
+  // Share one in-flight reconciliation across the mount effect and checkForUpdate
+  // (both fire on a visible load). reconcilePostReload clears its single-shot flag
+  // before awaiting the version fetch, so without a shared promise the second
+  // caller sees no flag, skips recovery, and re-announces the waiting worker while
+  // the first is still recovering. A ref (not module state) keeps it per hook
+  // instance, per INV-9; the sessionStorage flag is the across-remount guard.
+  const reconcileRef = useRef<Promise<boolean> | null>(null)
+  const reconcileOnce = useCallback(() => (reconcileRef.current ??= reconcilePostReload()), [])
+
   const checkForUpdate = useCallback(async () => {
     if (IS_DEV) return
     const registration = await navigator.serviceWorker?.getRegistration()
@@ -289,11 +298,10 @@ export function useAppUpdate(): void {
       // Network error — retry on the next trigger.
     }
     // Reconcile before announcing so a Reload that didn't swap in new code
-    // escalates to recovery instead of re-announcing (idempotent with the
-    // mount-effect call; whichever runs first consumes the flag).
-    if (await reconcilePostReload()) return
+    // escalates to recovery instead of re-announcing the same build.
+    if (await reconcileOnce()) return
     announceIfWaiting(registration)
-  }, [])
+  }, [reconcileOnce])
 
   // Announce a build that finishes installing between checks: the browser may
   // park a new worker at any time (another tab's update(), a slow precache
@@ -306,7 +314,7 @@ export function useAppUpdate(): void {
       if (!registration || disposed) return
       // A prior Reload click that didn't swap in new code escalates to recovery
       // here; a reload follows, so don't announce on top of it.
-      if (await reconcilePostReload()) return
+      if (await reconcileOnce()) return
       if (disposed) return
       announceIfWaiting(registration)
       // Track per-install statechange listeners so unmount (workspace switch
@@ -341,7 +349,7 @@ export function useAppUpdate(): void {
       disposed = true
       cleanup?.()
     }
-  }, [])
+  }, [reconcileOnce])
 
   useEffect(() => {
     if (IS_DEV) return

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -12,6 +12,46 @@ const IS_DEV = import.meta.env.DEV
 export const WAITING_WORKER_TIMEOUT_MS = 1500
 export const RELOAD_FALLBACK_TIMEOUT_MS = 3000
 
+// The build version baked into this bundle at build time (vite `define`). The
+// running app otherwise has no idea which build it is, so it can't tell whether a
+// reload actually swapped in new code — see reconcilePostReload.
+declare const __APP_VERSION__: string
+
+// Marks that the user clicked Reload, so the first check after the page comes
+// back can verify the swap actually happened (running build == server's latest)
+// rather than silently re-announcing the same build forever. The window bounds a
+// flag the reload somehow never consumed so it can't trip a spurious recovery
+// much later in the tab session.
+const RELOAD_ATTEMPT_KEY = "app-update-reload-attempt"
+const RELOAD_ATTEMPT_WINDOW_MS = 60_000
+
+function markReloadAttempt(): void {
+  try {
+    sessionStorage.setItem(RELOAD_ATTEMPT_KEY, String(Date.now()))
+  } catch {
+    // Private mode / storage disabled — reconciliation just won't escalate.
+  }
+}
+
+function reloadRecentlyAttempted(): boolean {
+  try {
+    const raw = sessionStorage.getItem(RELOAD_ATTEMPT_KEY)
+    if (!raw) return false
+    const ts = Number.parseInt(raw, 10)
+    return Number.isFinite(ts) && Date.now() - ts < RELOAD_ATTEMPT_WINDOW_MS
+  } catch {
+    return false
+  }
+}
+
+function clearReloadAttempt(): void {
+  try {
+    sessionStorage.removeItem(RELOAD_ATTEMPT_KEY)
+  } catch {
+    // No-op — see markReloadAttempt.
+  }
+}
+
 // The waiting worker we've already announced. Module-level (not a ref, not
 // persisted): it survives the AppUpdateChecker remounts that fire on every
 // workspace switch — so one ready build is announced once, not on every
@@ -81,6 +121,11 @@ async function findWaitingWorker(registration: ServiceWorkerRegistration): Promi
  * which previously tripped that wipe on a worker that had actually activated).
  */
 export async function reloadForUpdate(): Promise<void> {
+  // Record the click so the next page load can verify the swap landed new code
+  // and escalate to recovery if it didn't, rather than re-announcing the same
+  // build forever. See reconcilePostReload.
+  markReloadAttempt()
+
   // A reload lands the new build whenever something can already control the
   // page (the parked worker activated, or another tab already swapped it in).
   // Only when nothing controls us is recovery — unregister + cache wipe + fresh
@@ -159,6 +204,73 @@ function announceIfWaiting(registration: ServiceWorkerRegistration): void {
   })
 }
 
+/** This bundle's build version, or null if the `define` wasn't applied (e.g. some test envs). */
+export function currentAppVersion(): string | null {
+  return typeof __APP_VERSION__ === "string" ? __APP_VERSION__ : null
+}
+
+/**
+ * The latest deployed build version from the server, or null if it can't be read.
+ * `no-store` bypasses the HTTP cache; `/version.json` is excluded from the SW's
+ * navigation handler and matches no other SW route, so this reaches the network.
+ * A null return means "couldn't verify" (offline, server hiccup, or a poisoned
+ * non-JSON response) — never treated as a mismatch.
+ */
+export async function fetchLatestVersion(): Promise<string | null> {
+  try {
+    const res = await fetch("/version.json", { cache: "no-store" })
+    if (!res.ok) return null
+    const body = (await res.json()) as { version?: unknown }
+    return typeof body.version === "string" ? body.version : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Recover only on a CONFIRMED stale build: both versions known and different. A
+ * successful version fetch proves we're online, so the cache wipe + refetch can
+ * actually land the new build. Any unknown (offline, fetch failed, define
+ * missing) returns false — never wipe when we can't verify, or we'd brick an
+ * offline launch (the offline-first constraint the whole SW model exists for).
+ */
+export function shouldRecoverForVersion(current: string | null, latest: string | null): boolean {
+  return Boolean(current && latest && current !== latest)
+}
+
+/**
+ * Decide what a fresh page load owes a prior Reload click. Runs once before any
+ * announce, and is the single thing that breaks the "Reload keeps re-showing the
+ * toast" loop.
+ *
+ * The whole point of Reload is the *swap*: activate the downloaded worker and
+ * boot onto its new code. That swap can silently fail to take — skipWaiting may
+ * not evict a worker that open clients keep parked, controllerchange can be
+ * dropped (iOS) or the platform re-serves the old precached shell — and because
+ * `announcedWaiting` resets on a real page load, the still-current build just
+ * re-announces. The user can then click Reload forever without ever moving builds.
+ *
+ * So after a Reload click, ask the decisive question directly: is the code
+ * running now the latest deployed code? If a successful version fetch says no,
+ * the swap didn't happen — escalate to recovery (unregister + cache wipe + fresh
+ * fetch), which forces a clean boot onto the new build. If the versions match, or
+ * we can't verify (offline), wipe nothing.
+ *
+ * Returns true when recovery was kicked off (a reload will follow, so the caller
+ * should not announce). Recovery is capped: if it's itself broken it falls
+ * through and the toast still surfaces as a manual path.
+ */
+export async function reconcilePostReload(): Promise<boolean> {
+  if (!reloadRecentlyAttempted()) return false
+  // Clear synchronously, before the await: the mount effect and checkForUpdate
+  // can both reach here, and the loser must see the flag already consumed.
+  clearReloadAttempt()
+  const current = currentAppVersion()
+  const latest = await fetchLatestVersion()
+  if (!shouldRecoverForVersion(current, latest)) return false
+  return swRecovery.runSwRecovery()
+}
+
 export function useAppUpdate(): void {
   const { isVisible } = usePageActivity()
   const reconnectCount = useSocketReconnectCount()
@@ -176,6 +288,10 @@ export function useAppUpdate(): void {
     } catch {
       // Network error — retry on the next trigger.
     }
+    // Reconcile before announcing so a Reload that didn't swap in new code
+    // escalates to recovery instead of re-announcing (idempotent with the
+    // mount-effect call; whichever runs first consumes the flag).
+    if (await reconcilePostReload()) return
     announceIfWaiting(registration)
   }, [])
 
@@ -186,8 +302,12 @@ export function useAppUpdate(): void {
     if (IS_DEV) return
     let disposed = false
     let cleanup: (() => void) | null = null
-    void navigator.serviceWorker?.getRegistration().then((registration) => {
+    void navigator.serviceWorker?.getRegistration().then(async (registration) => {
       if (!registration || disposed) return
+      // A prior Reload click that didn't swap in new code escalates to recovery
+      // here; a reload follows, so don't announce on top of it.
+      if (await reconcilePostReload()) return
+      if (disposed) return
       announceIfWaiting(registration)
       // Track per-install statechange listeners so unmount (workspace switch
       // remounts AppUpdateChecker) tears them down too — otherwise a worker

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -257,8 +257,13 @@ export function shouldRecoverForVersion(current: string | null, latest: string |
  * we can't verify (offline), wipe nothing.
  *
  * Returns true when recovery was kicked off (a reload will follow, so the caller
- * should not announce). Recovery is capped: if it's itself broken it falls
- * through and the toast still surfaces as a manual path.
+ * should not announce). Recovery is forced, not capped: it only ever fires as the
+ * direct result of a user Reload click (the flag is set solely by reloadForUpdate
+ * and is single-shot), so it can't auto-loop and the attempt cap buys nothing
+ * here. Leaving it capped would let unrelated chunk-load recoveries exhaust the
+ * shared counter and silently turn the user's Reload into a no-op — the exact bug
+ * this fixes — so this follows runSwRecovery's "user-initiated clicks force"
+ * convention.
  */
 export async function reconcilePostReload(): Promise<boolean> {
   if (!reloadRecentlyAttempted()) return false
@@ -268,7 +273,7 @@ export async function reconcilePostReload(): Promise<boolean> {
   const current = currentAppVersion()
   const latest = await fetchLatestVersion()
   if (!shouldRecoverForVersion(current, latest)) return false
-  return swRecovery.runSwRecovery()
+  return swRecovery.runSwRecovery({ force: true })
 }
 
 export function useAppUpdate(): void {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -120,6 +120,12 @@ export default defineConfig({
       },
     }),
   ],
+  // Bake the build version into the bundle so the running app can tell whether a
+  // reload actually swapped in new code (see use-app-update reconcilePostReload).
+  // Same value as the emitted version.json, so a post-reload mismatch is decisive.
+  define: {
+    __APP_VERSION__: JSON.stringify(buildVersion),
+  },
   resolve: {
     dedupe: ["react", "react-dom"],
     alias: {


### PR DESCRIPTION
## Problem

The PWA "A new version of Threa is available — Reload" toast keeps reappearing, and pressing Reload doesn't actually move the user onto the new build. This is a recurring class of bug: `e188826` (#721, "infinite Updating Threa loop") and `200762e` (#1081, "gate the toast on a downloaded worker") both circled the same drain. Reported again here on Android ("pressed it like 10 times … it keeps showing up").

The update model itself is sound and is what we want: the new build precaches in full in the background while the current worker keeps serving (build-atomic, offline-first), and Reload is the swap signal. The break is in the **swap**. `reloadForUpdate` posts `skipWaiting` and plain-reloads, but that swap can silently fail to take:

- `skipWaiting()` doesn't always evict a worker that open clients keep parked,
- `controllerchange` can be dropped (iOS standalone), so the 3s fallback reloads onto whatever is controlling,
- the platform can re-serve the old precached shell.

When the swap doesn't happen, `announcedWaiting` (the module-level announce dedup in `use-app-update.ts`) resets on the real page load, the unchanged build looks new again, and the toast re-announces. Reload becomes a no-op the user can click forever.

The deeper issue behind all three attempts: **the running bundle had no idea which build it was**, so every fix hung off a *proxy* for "did we update" — CSS present (#721), worker parked (the first cut of this PR), version.json delta as the toast trigger (#1081). None of them answer the actual question.

## Solution

Give the app the one fact it was missing — its own build version — and after a Reload click ask the decisive question directly: *is the code running now the latest deployed code?*

### How it works

1. **Bake the build version into the bundle.** `apps/frontend/vite.config.ts` already computes `buildVersion` (git short hash) and emits it as `version.json`. A new `define: { __APP_VERSION__: JSON.stringify(buildVersion) }` exposes the *same value* to the running bundle, so a post-reload comparison is exact.

2. **Mark the Reload click.** `reloadForUpdate` writes a `sessionStorage` flag (`app-update-reload-attempt`, 60s window) via `markReloadAttempt()`. This scopes the verification to "the user asked to update" — we never wipe a cache just because a tab is old.

3. **Verify on the next load, recover only on a confirmed miss.** `reconcilePostReload()` runs once before any announce (from both the mount effect and `checkForUpdate`):
   - no recent Reload click → return (no network fetch),
   - else fetch `/version.json` (`cache: "no-store"`) and compare to `currentAppVersion()`,
   - `shouldRecoverForVersion(current, latest)` is true only when **both are known and differ** → the swap didn't take → `swRecovery.runSwRecovery()` (unregister + cache wipe + fresh boot),
   - versions match, or the fetch failed (offline / non-JSON / `!ok`) → wipe nothing.

### Key design decisions

**1. Version comparison over a worker-parked heuristic.** The first cut of this PR escalated when a worker was still parked after the reload. On Android `skipWaiting` generally *does* evict the parked worker, so that heuristic would miss the reported case, and reading `registration.waiting` on a fresh load is timing-fragile. A version mismatch tests the actual symptom ("the app didn't update") and is platform-independent. (Design evolution — see below.)

**2. Recover only on a *confirmed* mismatch — never on an unverifiable fetch.** A successful `version.json` fetch proves we're online, which is precisely the condition under which a cache wipe + refetch can land the new build. A failed fetch (offline) returns false: wiping then would brick a launch with no network to refetch from. This preserves the offline-first constraint the whole SW model exists for. Opposite failure modes: false-positive recovery bricks offline; false-negative just leaves the existing (working) toast path.

**3. Verification, not announcement, uses version.json.** #1081 deliberately moved the *toast trigger* off version.json because it changes the instant a deploy starts, before the precache is ready — premature toasts. That reasoning is intact: the announce path is still worker-identity based (`shouldAnnounceWaiting`). version.json is consulted only *after* a Reload click, as a post-hoc check, where the premature-delta problem doesn't apply.

**4. Single-shot flag, cleared before the await.** `reconcilePostReload` clears the flag synchronously before awaiting the fetch, so the mount effect and `checkForUpdate` racing into it can't both recover. Recovery is capped (`runSwRecovery()` without `force`, cap 2/session shared with the index.html watchdog): if recovery is itself broken it falls through and the toast still surfaces as a manual escape.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/vite.config.ts` | `define: { __APP_VERSION__ }` from the existing `buildVersion`, same value as the emitted `version.json`. |
| `apps/frontend/src/hooks/use-app-update.ts` | Add `currentAppVersion`, `fetchLatestVersion`, `shouldRecoverForVersion`, `reconcilePostReload`, and the `app-update-reload-attempt` flag helpers. `reloadForUpdate` marks the click; the mount effect and `checkForUpdate` reconcile before announcing. |
| `apps/frontend/src/hooks/use-app-update.test.ts` | New coverage for the version helpers and reconcile (mismatch→recover, match→no-op, offline→no-op, no-click→no fetch, flag single-shot). |

## Out of scope (deliberate)

- **Users stuck on a pre-fix build.** They can't receive this fix through the broken button — it ships *in* a new build they can't swap to. One manual hard-reload (or PWA reinstall) lands them on a build that contains the guard; thereafter it self-heals. No code path can fix a client that won't run the new code.
- **The `reloadForUpdate` swap mechanism itself** (skipWaiting / controllerchange / 3s fallback) is unchanged — this PR adds verification + recovery around it rather than re-architecting the swap.
- **No `version.json` format or cache-header change**; `public/_headers` already serves it `no-cache`.

## Test plan

- [x] `apps/frontend` `bun run test src/hooks/use-app-update.test.ts` — 17 pass (10 pre-existing + 7 new). The version-mismatch test passing confirms `currentAppVersion()` returns a real value under vitest, i.e. the `define` is applied.
- [x] `apps/frontend` `bun run typecheck` (`tsc --noEmit`) — clean.
- [ ] No device lab — the Android skipWaiting/controllerchange behavior that triggers the miss can't be reproduced in jsdom; the swap-failure path is covered at the unit level (mismatch → `runSwRecovery`) rather than end-to-end on a real PWA.
- [ ] Full production build not run here (~14 MiB precache); the `define` is a standard Vite mechanism and is exercised by the passing tests.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzBG92zCxnsm9mPqFqLF98)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785074427&installation_id=129946197&pr_number=1095&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1095&signature=ac117d6ceda666d250f896000f6d6cc70254147cfd30da9dd8a717cb66f8a262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->