### PR TITLE
fix(timeline): render cold-load timeline ascending from the first frame (oldest-at-bottom flicker)

### DIFF
--- a/apps/frontend/src/stores/stream-store.ts
+++ b/apps/frontend/src/stores/stream-store.ts
@@ -32,20 +32,20 @@ export async function loadStreamEvents(streamId: string, fromSequenceNum: number
     : [streamId, Dexie.minKey]
   const range = db.events.where("[streamId+_sequenceNum]").between(lowerBound, [streamId, Dexie.maxKey], true, true)
 
-  // The compound index already yields rows in `_sequenceNum` order, so the base
-  // window needs no comparison sort:
-  //   - With a floor: scan ASC directly — already in render order.
-  //   - Without a floor: scan DESC + cap to the newest N (memory bound on the
-  //     pre-bootstrap load), then flip to ASC with an O(n) reverse.
-  // This matters because `useLiveQuery` re-runs this on every write to
-  // `db.events`; a deep scrolled-back window must not pay an O(n log n) sort
-  // per incoming message.
+  // With a floor we scan the compound index ASC directly — already in render
+  // order. Without a floor we scan DESC + cap to the newest N as a memory bound
+  // on the pre-bootstrap load, then sort ASC by `_sequenceNum`: the render
+  // contract is ascending (INV-61), and the DESC cursor's materialised direction
+  // can't be assumed, so an explicit comparison sort — not the cursor order — is
+  // what guarantees it. Bounded by `DEFAULT_IDB_EVENT_LIMIT`, and `useLiveQuery`
+  // re-runs the floored (sort-free) branch for every steady-state write, so the
+  // cost lands only on the one pre-bootstrap read.
   let base: CachedEvent[]
   if (hasFloor) {
     base = await range.toArray()
   } else {
     base = await range.reverse().limit(DEFAULT_IDB_EVENT_LIMIT).toArray()
-    base.reverse()
+    base.sort((a, b) => a._sequenceNum - b._sequenceNum)
   }
 
   // Pending/failed optimistic events may have placeholder sequences outside the


### PR DESCRIPTION
## Problem

On a cold load / hard refresh, the stream timeline painted in **descending** order — newest at the top, the **oldest message at the very bottom** — for ~600ms, then flipped to the correct ascending order. This is the "loads the wrong messages first / oldest at the bottom" flicker that's been hounding the timeline. It's a genuine **render-order reversal**, not a scroll-position or virtua-sizing issue (the DB data is correctly ordered: `sequence` monotonic with time, 0 mismatches).

Confirmed with a frame-by-frame probe of render order on a cold load:

```
first paint:  [87, 86, … 72, 71]    ← DESCENDING (oldest #71 at the very bottom)
~600ms later: [74, 75, … 119, 120]  ← ascending (correct)
```

## Root cause

The no-floor (pre-bootstrap) branch of `loadStreamEvents` (`apps/frontend/src/stores/stream-store.ts`) read the newest N events via a Dexie **DESC cursor** and then called a blind `base.reverse()` to "restore" chronological order:

```ts
base = await range.reverse().limit(DEFAULT_IDB_EVENT_LIMIT).toArray()
base.reverse() // ← assumed the cursor materialised newest-first
```

That `reverse()` assumed `range.reverse().limit(N)` materialises newest-first. In this cold-load path it does **not** — Dexie returned the page already ascending — so the compensating `reverse()` flipped an **already-ascending** page into descending. That descending array flowed unchanged through `getEffectiveEvents → effectiveEvents → getRenderableEvents` (filter-only, no sort) → the DOM, so the first painted frame had the oldest row at the bottom. When the bootstrap floor arrived (~600ms), the **floored** branch (`range.toArray()`, no reverse) re-queried ascending and replaced the frame — the visible flip.

`bootstrap.events` was ascending throughout (the backend `listEvents` does `DESC + limit` then `.reverse()` to chronological) and was never the source. The only descending array was this client-side blind reverse.

**Regressed in PR #813** (`93944d82`, "perf(timeline): drop per-write sort from cached-events read"), which replaced the comparison sort with the DESC-cursor read + blind `reverse()`. Matches the "it just worked when we moved to virtua, regressed since" timeline.

## Solution

Keep the DESC `range.reverse().limit(DEFAULT_IDB_EVENT_LIMIT)` purely as a **memory bound** (newest N rows on the pre-bootstrap load), but replace the order-dependent `base.reverse()` with an explicit comparison sort:

```ts
base.sort((a, b) => a._sequenceNum - b._sequenceNum)
```

An explicit sort yields ascending output regardless of which direction Dexie's compound-index cursor materialises — the blind reverse's assumption is removed. Scoped to the pre-bootstrap branch only; the floored read path stays sort-free.

### Why this is safe for search / go-to-message / infinite scroll

In-stream search and go-to-message always supply a target sequence, so they take the **floored** branch (`range.toArray()`, untouched) and run in jump mode (`skipInitialScroll` + their own `scrollToIndex`). Reverse-infinite-scroll prepend (virtua `shift`) and keyboard-follow also run post-bootstrap on the floored branch. The pending/failed optimistic merge keeps its own `merged.sort()`. So only the one pre-bootstrap cold-load read changes; everything else is byte-for-byte the same path.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/stores/stream-store.ts` | No-floor branch: `base.reverse()` → `base.sort((a,b) => a._sequenceNum - b._sequenceNum)`; comment updated to explain why the sort (not a reverse) is load-bearing |

## How this was found

A focused multi-agent workflow instrumented every event source's order per render, pinpointed the descending array to this exact branch (proving Dexie's cursor returned ascending and the `reverse()` corrupted it), git-archaeology'd the regression to PR #813, and verified the one-line fix against the repros.

## Test plan

- [x] `wrongmsg.mjs` (cold-load tail): first painted frame shows `#110–120` at the bottom — zero flicker
- [x] `orderdoc.mjs` (render order): `docOrderAsc:true` from the first painted frame, **zero descending frames** (3/3)
- [x] `gotomsg.mjs` (deep-link to message #85): target lands in viewport — go-to-message preserved
- [x] `apps/frontend` `stream-store.test.ts` — 14/14 pass; `use-timeline-scroll.test.tsx` — 21/21 pass
- [x] Monorepo lint + typecheck (pre-commit, all apps/packages) — clean
- [ ] Live before/after on a real busy account — **verify on staging** (this PR carries the `staging` label); the local repros cover the order + tail + deep-link, but a real hard-refresh on the owner's account is the final confirmation

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785077740&installation_id=129946197&pr_number=1096&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1096&signature=8ff4d3d5ff971022ae34132c05a0ab37e7d2736d88c09e2ef0575ba49b080a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->