### PR TITLE
feat(settings): move voice dictation prefs into their own Dictation tab

### DIFF
--- a/apps/frontend/src/components/settings/ai-settings.test.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { forwardRef, useImperativeHandle } from "react"
 import { AISettings } from "./ai-settings"
-import type { JSONContent, VoicePolishLevel } from "@threa/types"
+import type { JSONContent } from "@threa/types"
 import * as contextsModule from "@/contexts"
 import * as editorModule from "@/components/editor"
 import * as encryptionModule from "@/components/encryption"
@@ -13,14 +13,8 @@ const updatePreferenceMock = vi.fn().mockResolvedValue(undefined)
 
 let mockPreferences: {
   scratchpadCustomPrompt: string | null
-  voiceTranscriptionModel: string | null
-  voicePolishLevel: VoicePolishLevel
-  voiceSteeringWords: string[]
 } = {
   scratchpadCustomPrompt: "Current instructions",
-  voiceTranscriptionModel: null,
-  voicePolishLevel: "opinionated",
-  voiceSteeringWords: [],
 }
 
 function extractText(node: JSONContent | undefined): string {
@@ -41,9 +35,6 @@ describe("AISettings", () => {
     vi.restoreAllMocks()
     mockPreferences = {
       scratchpadCustomPrompt: "Current instructions",
-      voiceTranscriptionModel: null,
-      voicePolishLevel: "opinionated",
-      voiceSteeringWords: [],
     }
     updatePreferenceMock.mockClear()
 
@@ -149,133 +140,5 @@ describe("AISettings", () => {
     await user.click(screen.getByRole("button", { name: "Reset" }))
 
     expect(editor.value).toBe("Current instructions")
-  })
-
-  it("selects 'Use server default' when no voice model preference is set", () => {
-    render(<AISettings />)
-
-    const defaultRadio = screen.getByRole("radio", { name: /Use server default/i }) as HTMLInputElement
-    expect(defaultRadio).toBeChecked()
-  })
-
-  it("saves the chosen voice transcription model", async () => {
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    await user.click(screen.getByRole("radio", { name: /Deepgram Nova-3/i }))
-
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceTranscriptionModel", "deepgram:nova-3")
-  })
-
-  it("clears the voice transcription override when 'Use server default' is picked", async () => {
-    mockPreferences.voiceTranscriptionModel = "deepgram:nova-3"
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    await user.click(screen.getByRole("radio", { name: /Use server default/i }))
-
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceTranscriptionModel", null)
-  })
-
-  it("shows the currently saved voice transcription model as selected", () => {
-    mockPreferences.voiceTranscriptionModel = "elevenlabs:scribe-v2-realtime"
-    render(<AISettings />)
-
-    const elevenLabsRadio = screen.getByRole("radio", { name: /ElevenLabs Scribe v2/i }) as HTMLInputElement
-    expect(elevenLabsRadio).toBeChecked()
-  })
-
-  it("shows Opinionated as the selected polish level by default", () => {
-    render(<AISettings />)
-    const radio = screen.getByRole("radio", { name: /Opinionated/i }) as HTMLInputElement
-    expect(radio).toBeChecked()
-  })
-
-  it("saves the chosen polish level", async () => {
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    await user.click(screen.getByRole("radio", { name: /^Minor$/i }))
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voicePolishLevel", "minor")
-  })
-
-  it("turns polish off when the Off level is selected", async () => {
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    await user.click(screen.getByRole("radio", { name: /^Off$/i }))
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voicePolishLevel", "none")
-  })
-
-  it("reflects a saved 'minor' preference", () => {
-    mockPreferences.voicePolishLevel = "minor"
-    render(<AISettings />)
-    const minorRadio = screen.getByRole("radio", { name: /^Minor$/i }) as HTMLInputElement
-    expect(minorRadio).toBeChecked()
-  })
-
-  it("defaults to Opinionated when the preference is missing", () => {
-    mockPreferences = {
-      scratchpadCustomPrompt: null,
-      voiceTranscriptionModel: null,
-      voicePolishLevel: undefined as unknown as VoicePolishLevel,
-      voiceSteeringWords: [],
-    }
-    render(<AISettings />)
-    const radio = screen.getByRole("radio", { name: /Opinionated/i }) as HTMLInputElement
-    expect(radio).toBeChecked()
-  })
-
-  it("shows the baked-in product terms as always-on, non-removable chips", () => {
-    render(<AISettings />)
-    // The product's own names are biased for everyone; they get no remove button.
-    expect(screen.getByText("Threa")).toBeInTheDocument()
-    expect(screen.getByText("Ariadne")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /Remove Threa/i })).not.toBeInTheDocument()
-  })
-
-  it("adds a typed steering word on Enter", async () => {
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    const input = screen.getByLabelText("Add a dictation steering word")
-    await user.type(input, "Langfuse{Enter}")
-
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceSteeringWords", ["Langfuse"])
-  })
-
-  it("ignores a re-add of a baked-in term and explains why instead of silently clearing", async () => {
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    const input = screen.getByLabelText("Add a dictation steering word")
-    await user.type(input, "threa{Enter}")
-
-    expect(updatePreferenceMock).not.toHaveBeenCalled()
-    // The rejected add surfaces a reason rather than a confusing silent clear.
-    expect(screen.getByText(/already included/i)).toBeInTheDocument()
-  })
-
-  it("disables the steering-word input until preferences have loaded (no clobber from an empty baseline)", () => {
-    // Before IDB hydrates, usePreferences returns null; writing then would
-    // replace the user's saved words with a list built from an empty snapshot.
-    vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
-      preferences: null,
-      updatePreference: updatePreferenceMock,
-      isLoading: false,
-    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
-    render(<AISettings />)
-
-    expect(screen.getByLabelText("Add a dictation steering word")).toBeDisabled()
-  })
-
-  it("removes a saved steering word", async () => {
-    mockPreferences.voiceSteeringWords = ["Langfuse", "pgvector"]
-    const user = userEvent.setup()
-    render(<AISettings />)
-
-    await user.click(screen.getByRole("button", { name: "Remove Langfuse" }))
-
-    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceSteeringWords", ["pgvector"])
   })
 })

--- a/apps/frontend/src/components/settings/ai-settings.tsx
+++ b/apps/frontend/src/components/settings/ai-settings.tsx
@@ -3,38 +3,10 @@ import { serializeToMarkdown, parseMarkdown } from "@/components/editor/editor-m
 import { EditorActionBar, RichEditor, type RichEditorHandle } from "@/components/editor"
 import { EncryptedScratchpadsSection } from "@/components/encryption"
 import { Button } from "@/components/ui/button"
-import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
-import { VoiceSteeringWords } from "./voice-steering-words"
 import { useInputMode } from "@/hooks/use-input-mode"
-import { VOICE_TRANSCRIPTION_MODELS, type JSONContent, type VoicePolishLevel } from "@threa/types"
-
-const VOICE_POLISH_LEVEL_DESCRIPTIONS: ReadonlyArray<{
-  value: VoicePolishLevel
-  label: string
-  description: string
-}> = [
-  {
-    value: "opinionated",
-    label: "Opinionated",
-    description:
-      'Cleans up the most. Drops filler ("uh", "um"), applies self-corrections ("nine, no sorry eight" → "eight"), formats lists, and expands spoken emoji shortcodes.',
-  },
-  {
-    value: "minor",
-    label: "Minor",
-    description: "Just punctuation, capitalization, and obvious typos. Keeps filler and self-corrections intact.",
-  },
-  {
-    value: "none",
-    label: "Off",
-    description: "Commits raw transcripts straight to the editor. No model in the loop.",
-  },
-]
-
-const VOICE_DEFAULT_OPTION_ID = "default"
+import { type JSONContent } from "@threa/types"
 
 const MODIFIER_LABEL =
   typeof navigator !== "undefined" && navigator.platform?.toLowerCase().includes("mac") ? "Cmd" : "Ctrl"
@@ -78,26 +50,6 @@ export function AISettings() {
   const handleReset = () => {
     setContentJson(parsePrompt(savedPrompt))
     setFormatOpen(false)
-  }
-
-  const savedVoiceModel = preferences?.voiceTranscriptionModel ?? null
-  const voiceSelection = savedVoiceModel ?? VOICE_DEFAULT_OPTION_ID
-  const handleVoiceModelChange = (value: string) => {
-    const next = value === VOICE_DEFAULT_OPTION_ID ? null : value
-    if (next === savedVoiceModel) {
-      return
-    }
-    void updatePreference("voiceTranscriptionModel", next)
-  }
-
-  // Default to "opinionated" so a missing preference (new account, in-flight
-  // bootstrap) still reflects the opt-out stance — the user actively dials
-  // polish down rather than discovers it was silently weak.
-  const polishLevel: VoicePolishLevel = preferences?.voicePolishLevel ?? "opinionated"
-  const handlePolishLevelChange = (value: string) => {
-    const next = value as VoicePolishLevel
-    if (next === polishLevel) return
-    void updatePreference("voicePolishLevel", next)
   }
 
   return (
@@ -173,85 +125,6 @@ export function AISettings() {
           <span>{MODIFIER_LABEL}+Enter to save</span>
         </div>
       </section>
-
-      <Separator />
-
-      <section className="space-y-3">
-        <div>
-          <h3 className="text-sm font-medium">Voice Dictation Model</h3>
-          <p className="text-sm text-muted-foreground">
-            Choose which speech-to-text provider Threa uses when you dictate a message.
-          </p>
-        </div>
-        <RadioGroup
-          value={voiceSelection}
-          onValueChange={handleVoiceModelChange}
-          aria-label="Voice dictation model"
-          className="space-y-3"
-        >
-          <div className="flex items-start space-x-3">
-            <RadioGroupItem value={VOICE_DEFAULT_OPTION_ID} id="voice-model-default" className="mt-1" />
-            <div className="grid gap-1">
-              <Label htmlFor="voice-model-default" className="cursor-pointer">
-                Use server default
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Let Threa pick the provider. We currently default to ElevenLabs Scribe v2.
-              </p>
-            </div>
-          </div>
-          {VOICE_TRANSCRIPTION_MODELS.map((option) => (
-            <div key={option.id} className="flex items-start space-x-3">
-              <RadioGroupItem value={option.id} id={`voice-model-${option.id}`} className="mt-1" />
-              <div className="grid gap-1">
-                <Label htmlFor={`voice-model-${option.id}`} className="cursor-pointer">
-                  {option.name}
-                </Label>
-                <p className="text-sm text-muted-foreground">{option.description}</p>
-              </div>
-            </div>
-          ))}
-        </RadioGroup>
-      </section>
-
-      <Separator />
-
-      <section className="space-y-3">
-        <div>
-          <h3 className="text-sm font-medium">Polish dictated text</h3>
-          <p className="text-sm text-muted-foreground">
-            How aggressively a small, fast model rewrites your dictation before it lands in the editor. You can still
-            flip "Show original" on the live session to compare.
-          </p>
-        </div>
-        <RadioGroup
-          value={polishLevel}
-          onValueChange={handlePolishLevelChange}
-          aria-label="Polish dictated text"
-          className="space-y-3"
-        >
-          {VOICE_POLISH_LEVEL_DESCRIPTIONS.map((option) => (
-            <div key={option.value} className="flex items-start space-x-3">
-              <RadioGroupItem
-                value={option.value}
-                id={`voice-polish-${option.value}`}
-                className="mt-1"
-                disabled={isLoading}
-              />
-              <div className="grid gap-1">
-                <Label htmlFor={`voice-polish-${option.value}`} className="cursor-pointer">
-                  {option.label}
-                </Label>
-                <p className="text-sm text-muted-foreground">{option.description}</p>
-              </div>
-            </div>
-          ))}
-        </RadioGroup>
-      </section>
-
-      <Separator />
-
-      <VoiceSteeringWords />
 
       <Separator />
 

--- a/apps/frontend/src/components/settings/dictation-settings.test.tsx
+++ b/apps/frontend/src/components/settings/dictation-settings.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { DictationSettings } from "./dictation-settings"
+import type { VoicePolishLevel } from "@threa/types"
+import * as contextsModule from "@/contexts"
+
+const updatePreferenceMock = vi.fn().mockResolvedValue(undefined)
+
+let mockPreferences: {
+  voiceTranscriptionModel: string | null
+  voicePolishLevel: VoicePolishLevel
+  voiceSteeringWords: string[]
+}
+
+function mockUsePreferences(preferences: unknown) {
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences,
+    updatePreference: updatePreferenceMock,
+    isLoading: false,
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+}
+
+describe("DictationSettings", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockPreferences = {
+      voiceTranscriptionModel: null,
+      voicePolishLevel: "opinionated",
+      voiceSteeringWords: [],
+    }
+    updatePreferenceMock.mockClear()
+    mockUsePreferences(mockPreferences)
+  })
+
+  it("selects 'Use server default' when no voice model preference is set", () => {
+    render(<DictationSettings />)
+
+    const defaultRadio = screen.getByRole("radio", { name: /Use server default/i }) as HTMLInputElement
+    expect(defaultRadio).toBeChecked()
+  })
+
+  it("saves the chosen voice transcription model", async () => {
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.click(screen.getByRole("radio", { name: /Deepgram Nova-3/i }))
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceTranscriptionModel", "deepgram:nova-3")
+  })
+
+  it("clears the voice transcription override when 'Use server default' is picked", async () => {
+    mockPreferences.voiceTranscriptionModel = "deepgram:nova-3"
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.click(screen.getByRole("radio", { name: /Use server default/i }))
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceTranscriptionModel", null)
+  })
+
+  it("shows the currently saved voice transcription model as selected", () => {
+    mockPreferences.voiceTranscriptionModel = "elevenlabs:scribe-v2-realtime"
+    render(<DictationSettings />)
+
+    const elevenLabsRadio = screen.getByRole("radio", { name: /ElevenLabs Scribe v2/i }) as HTMLInputElement
+    expect(elevenLabsRadio).toBeChecked()
+  })
+
+  it("shows Opinionated as the selected polish level by default", () => {
+    render(<DictationSettings />)
+    const radio = screen.getByRole("radio", { name: /Opinionated/i }) as HTMLInputElement
+    expect(radio).toBeChecked()
+  })
+
+  it("saves the chosen polish level", async () => {
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.click(screen.getByRole("radio", { name: /^Minor$/i }))
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voicePolishLevel", "minor")
+  })
+
+  it("turns polish off when the Off level is selected", async () => {
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.click(screen.getByRole("radio", { name: /^Off$/i }))
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voicePolishLevel", "none")
+  })
+
+  it("reflects a saved 'minor' preference", () => {
+    mockPreferences.voicePolishLevel = "minor"
+    render(<DictationSettings />)
+    const minorRadio = screen.getByRole("radio", { name: /^Minor$/i }) as HTMLInputElement
+    expect(minorRadio).toBeChecked()
+  })
+
+  it("defaults to Opinionated when the preference is missing", () => {
+    mockPreferences.voicePolishLevel = undefined as unknown as VoicePolishLevel
+    render(<DictationSettings />)
+    const radio = screen.getByRole("radio", { name: /Opinionated/i }) as HTMLInputElement
+    expect(radio).toBeChecked()
+  })
+
+  it("shows the baked-in product terms as always-on, non-removable chips", () => {
+    render(<DictationSettings />)
+    expect(screen.getByText("Threa")).toBeInTheDocument()
+    expect(screen.getByText("Ariadne")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Remove Threa/i })).not.toBeInTheDocument()
+  })
+
+  it("adds a typed steering word on Enter", async () => {
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.type(screen.getByLabelText("Add a dictation steering word"), "Langfuse{Enter}")
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceSteeringWords", ["Langfuse"])
+  })
+
+  it("ignores a re-add of a baked-in term and explains why instead of silently clearing", async () => {
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.type(screen.getByLabelText("Add a dictation steering word"), "threa{Enter}")
+
+    expect(updatePreferenceMock).not.toHaveBeenCalled()
+    expect(screen.getByText(/already included/i)).toBeInTheDocument()
+  })
+
+  it("disables the steering-word input until preferences have loaded (no clobber from an empty baseline)", () => {
+    mockUsePreferences(null)
+    render(<DictationSettings />)
+
+    expect(screen.getByLabelText("Add a dictation steering word")).toBeDisabled()
+  })
+
+  it("removes a saved steering word", async () => {
+    mockPreferences.voiceSteeringWords = ["Langfuse", "pgvector"]
+    const user = userEvent.setup()
+    render(<DictationSettings />)
+
+    await user.click(screen.getByRole("button", { name: "Remove Langfuse" }))
+
+    expect(updatePreferenceMock).toHaveBeenCalledWith("voiceSteeringWords", ["pgvector"])
+  })
+})

--- a/apps/frontend/src/components/settings/dictation-settings.tsx
+++ b/apps/frontend/src/components/settings/dictation-settings.tsx
@@ -1,0 +1,141 @@
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Separator } from "@/components/ui/separator"
+import { usePreferences } from "@/contexts"
+import { VoiceSteeringWords } from "./voice-steering-words"
+import { VOICE_TRANSCRIPTION_MODELS, type VoicePolishLevel } from "@threa/types"
+
+const VOICE_POLISH_LEVEL_DESCRIPTIONS: ReadonlyArray<{
+  value: VoicePolishLevel
+  label: string
+  description: string
+}> = [
+  {
+    value: "opinionated",
+    label: "Opinionated",
+    description:
+      'Cleans up the most. Drops filler ("uh", "um"), applies self-corrections ("nine, no sorry eight" → "eight"), formats lists, and expands spoken emoji shortcodes.',
+  },
+  {
+    value: "minor",
+    label: "Minor",
+    description: "Just punctuation, capitalization, and obvious typos. Keeps filler and self-corrections intact.",
+  },
+  {
+    value: "none",
+    label: "Off",
+    description: "Commits raw transcripts straight to the editor. No model in the loop.",
+  },
+]
+
+const VOICE_DEFAULT_OPTION_ID = "default"
+
+/**
+ * Voice dictation preferences: which speech-to-text provider runs, how
+ * aggressively transcripts are polished, and the user's steering words. Grouped
+ * in their own settings tab, separate from the scratchpad/AI guidance.
+ */
+export function DictationSettings() {
+  const { preferences, updatePreference, isLoading } = usePreferences()
+
+  const savedVoiceModel = preferences?.voiceTranscriptionModel ?? null
+  const voiceSelection = savedVoiceModel ?? VOICE_DEFAULT_OPTION_ID
+  const handleVoiceModelChange = (value: string) => {
+    const next = value === VOICE_DEFAULT_OPTION_ID ? null : value
+    if (next === savedVoiceModel) {
+      return
+    }
+    void updatePreference("voiceTranscriptionModel", next)
+  }
+
+  // Default to "opinionated" so a missing preference (new account, in-flight
+  // bootstrap) still reflects the opt-out stance — the user actively dials
+  // polish down rather than discovers it was silently weak.
+  const polishLevel: VoicePolishLevel = preferences?.voicePolishLevel ?? "opinionated"
+  const handlePolishLevelChange = (value: string) => {
+    const next = value as VoicePolishLevel
+    if (next === polishLevel) return
+    void updatePreference("voicePolishLevel", next)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Voice Dictation Model</h3>
+          <p className="text-sm text-muted-foreground">
+            Choose which speech-to-text provider Threa uses when you dictate a message.
+          </p>
+        </div>
+        <RadioGroup
+          value={voiceSelection}
+          onValueChange={handleVoiceModelChange}
+          aria-label="Voice dictation model"
+          className="space-y-3"
+        >
+          <div className="flex items-start space-x-3">
+            <RadioGroupItem value={VOICE_DEFAULT_OPTION_ID} id="voice-model-default" className="mt-1" />
+            <div className="grid gap-1">
+              <Label htmlFor="voice-model-default" className="cursor-pointer">
+                Use server default
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                Let Threa pick the provider. We currently default to ElevenLabs Scribe v2.
+              </p>
+            </div>
+          </div>
+          {VOICE_TRANSCRIPTION_MODELS.map((option) => (
+            <div key={option.id} className="flex items-start space-x-3">
+              <RadioGroupItem value={option.id} id={`voice-model-${option.id}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`voice-model-${option.id}`} className="cursor-pointer">
+                  {option.name}
+                </Label>
+                <p className="text-sm text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Polish dictated text</h3>
+          <p className="text-sm text-muted-foreground">
+            How aggressively a small, fast model rewrites your dictation before it lands in the editor. You can still
+            flip "Show original" on the live session to compare.
+          </p>
+        </div>
+        <RadioGroup
+          value={polishLevel}
+          onValueChange={handlePolishLevelChange}
+          aria-label="Polish dictated text"
+          className="space-y-3"
+        >
+          {VOICE_POLISH_LEVEL_DESCRIPTIONS.map((option) => (
+            <div key={option.value} className="flex items-start space-x-3">
+              <RadioGroupItem
+                value={option.value}
+                id={`voice-polish-${option.value}`}
+                className="mt-1"
+                disabled={isLoading}
+              />
+              <div className="grid gap-1">
+                <Label htmlFor={`voice-polish-${option.value}`} className="cursor-pointer">
+                  {option.label}
+                </Label>
+                <p className="text-sm text-muted-foreground">{option.description}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <VoiceSteeringWords />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/settings/settings-dialog.tsx
+++ b/apps/frontend/src/components/settings/settings-dialog.tsx
@@ -12,6 +12,7 @@ import { useSettings } from "@/contexts"
 import { SETTINGS_TABS, type SettingsTab } from "@threa/types"
 import { SETTINGS_TAB_CONFIG } from "./tab-config"
 import { AISettings } from "./ai-settings"
+import { DictationSettings } from "./dictation-settings"
 import { ProfileSettings } from "./profile-settings"
 import { AppearanceSettings } from "./appearance-settings"
 import { DateTimeSettings } from "./datetime-settings"
@@ -71,6 +72,9 @@ export function SettingsDialog() {
               </TabsContent>
               <TabsContent value="ai" className="mt-0">
                 <AISettings />
+              </TabsContent>
+              <TabsContent value="dictation" className="mt-0">
+                <DictationSettings />
               </TabsContent>
               <TabsContent value="appearance" className="mt-0">
                 <AppearanceSettings />

--- a/apps/frontend/src/components/settings/tab-config.ts
+++ b/apps/frontend/src/components/settings/tab-config.ts
@@ -20,8 +20,13 @@ export const SETTINGS_TAB_CONFIG: Record<SettingsTab, SettingsTabConfig> = {
   },
   ai: {
     label: "AI",
-    description: "Scratchpad behavior, guidance, and voice dictation",
-    keywords: ["voice", "dictation", "transcription", "polish", "prompt", "companion"],
+    description: "Scratchpad guidance and behavior",
+    keywords: ["scratchpad", "prompt", "guidance", "companion", "ariadne", "instructions"],
+  },
+  dictation: {
+    label: "Dictation",
+    description: "Voice model, polish, and steering words",
+    keywords: ["voice", "dictation", "transcription", "polish", "steering", "speech", "mic"],
   },
   appearance: {
     label: "Appearance",

--- a/apps/frontend/src/components/settings/voice-steering-words.tsx
+++ b/apps/frontend/src/components/settings/voice-steering-words.tsx
@@ -5,9 +5,9 @@ import { SteeringWordsEditor } from "./steering-words-editor"
 const BAKED_IN_LABEL = VOICE_STEERING_BASE_TERMS.join(", ")
 
 /**
- * The user's personal dictation steering words, edited in the AI settings tab.
- * Unioned at session start with the baked-in product terms and the
- * workspace-shared list.
+ * The user's personal dictation steering words, edited in the Dictation
+ * settings tab. Unioned at session start with the baked-in product terms and
+ * the workspace-shared list.
  */
 export function VoiceSteeringWords() {
   const { preferences, updatePreference, isLoading } = usePreferences()

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -178,6 +178,7 @@ export const VOICE_TRANSCRIPTION_MODELS: readonly VoiceTranscriptionModelOption[
 export const SETTINGS_TAB_OPTIONS = [
   "profile",
   "ai",
+  "dictation",
   "appearance",
   "datetime",
   "schedule",


### PR DESCRIPTION
## Problem

After [#1090](https://github.com/threahq/threa/pull/1090) the user-settings **AI** tab carried two unrelated concerns: scratchpad/companion guidance *and* all the voice-dictation controls (model, polish level, steering words). It had grown crowded, and the workspace settings already have a dedicated **Dictation** tab — the per-user side should match.

## Solution

Give the per-user voice settings their own **Dictation** tab in user settings, mirroring the workspace one. Nothing about behavior or storage changes — this is a UI re-home.

- **New `DictationSettings` component** holds the three voice sections moved verbatim from `AISettings`: Voice Dictation Model, Polish dictated text, and the steering-words editor (`VoiceSteeringWords`).
- **`AISettings` slims down** to what's actually AI/scratchpad: Scratchpad Instructions + Encrypted Scratchpads.
- **`dictation` registered as a tab**: added to `SETTINGS_TAB_OPTIONS` (`@threa/types`), the frontend `SETTINGS_TAB_CONFIG` (own label/description/keywords), and a `TabsContent` in the settings dialog. The command palette picks it up automatically — its settings commands map over `SETTINGS_TABS` — and the URL tab (`?settings=dictation`) is valid via the existing `SETTINGS_TABS.includes(...)` gate (INV-59).
- The **AI tab's keywords** lose voice/dictation/transcription/polish (now on the Dictation tab) and gain scratchpad/guidance terms, so palette search lands on the right tab.

No backend, types-behavior, or preference-key changes — the same `voiceTranscriptionModel` / `voicePolishLevel` / `voiceSteeringWords` preferences, just surfaced under a new tab.

## Files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/settings/dictation-settings.tsx` | **New** — voice model + polish + steering-words sections |
| `apps/frontend/src/components/settings/dictation-settings.test.tsx` | **New** — the voice tests, moved from the AI settings test |
| `apps/frontend/src/components/settings/ai-settings.tsx` | Removed the voice sections; keeps scratchpad + encryption |
| `apps/frontend/src/components/settings/ai-settings.test.tsx` | Dropped the voice tests (now in dictation-settings.test) |
| `apps/frontend/src/components/settings/settings-dialog.tsx` | Render the `dictation` tab |
| `apps/frontend/src/components/settings/tab-config.ts` | Add the `dictation` tab; retune the `ai` tab keywords/description |
| `packages/types/src/preferences.ts` | Add `"dictation"` to `SETTINGS_TAB_OPTIONS` |

## Test plan

- [x] Frontend `vitest run` settings + quick-switcher — 288 pass (new `DictationSettings` suite covers model/polish/steering/hydration; `AISettings` keeps the scratchpad tests; the palette's `it.each(SETTINGS_TABS)` now also covers the dictation command)
- [x] `tsc --noEmit` types + frontend — clean
- [x] Prettier + ESLint — clean on touched files

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785077905&installation_id=129946197&pr_number=1097&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1097&signature=9e3716d83adb48bd01094a8e572ad16714622a0ee1521ca3ef590b2de4f4d50f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->