### PR TITLE
feat(board): reply to a conversation from the board feed

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
 import { RelativeTime } from "@/components/relative-time"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useConversationService } from "@/contexts"
@@ -39,6 +40,11 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const [expanded, setExpanded] = useState(false)
+  // Replies sent from this card, shown in place without a board refetch. They
+  // live only on this card for now — board-wide liveness is a follow-up. A
+  // channel reply lands in a thread off the post, so on the next board refresh
+  // it surfaces as its own post rather than under this card; that's expected.
+  const [localReplies, setLocalReplies] = useState<RenderableMessage[]>([])
 
   const streamId = conversation.streamId
   const hiddenCount = Math.max(0, totalReplies - recentMessages.length)
@@ -59,6 +65,10 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // Collapsed: just the trailing replies the feed already carried.
   const replies: RenderableMessage[] =
     expanded && allMessages ? allMessages.filter((m) => m.id !== openingMessage?.id) : recentMessages
+  // Append this card's own just-sent replies, skipping any a refetch already
+  // carries (the expanded fetch can include them once the server catches up).
+  const seenReplyIds = new Set(replies.map((m) => m.id))
+  const displayedReplies = [...replies, ...localReplies.filter((m) => !seenReplyIds.has(m.id))]
   const loadingMore = expanded && !allMessages && !expandFailed
   // No middle is hidden, so opening + replies form one uninterrupted run that
   // groups across the boundary. Otherwise a gap row sits between them.
@@ -92,7 +102,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
 
       <div className="mt-3 [&>*:first-child]:mt-0">
         {contiguous ? (
-          (openingMessage ? [openingMessage, ...replies] : replies).map((message, i, all) =>
+          (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).map((message, i, all) =>
             renderMessage(message, i > 0 && isContinuation(all[i - 1], message))
           )
         ) : (
@@ -118,10 +128,19 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                 Couldn't load messages. Retry.
               </button>
             )}
-            {replies.map((message, i) => renderMessage(message, i > 0 && isContinuation(replies[i - 1], message)))}
+            {displayedReplies.map((message, i) =>
+              renderMessage(message, i > 0 && isContinuation(displayedReplies[i - 1], message))
+            )}
           </>
         )}
       </div>
+
+      <BoardReplyComposer
+        workspaceId={workspaceId}
+        post={post}
+        hostStreamType={streamType}
+        onReplied={(message) => setLocalReplies((prev) => [...prev, message])}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+import { Reply, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { MessageComposer } from "@/components/composer"
+import { useDraftComposer } from "@/hooks"
+import { usePreferences } from "@/contexts"
+import { useMentionStreamContext } from "@/hooks/use-mentionables"
+import { useReplyToBoardPost } from "@/hooks/use-conversations"
+import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
+import { EMPTY_DOC } from "@/lib/prosemirror-utils"
+import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
+import type { BoardPost, JSONContent, Message } from "@threa/types"
+
+interface BoardReplyComposerProps {
+  workspaceId: string
+  post: BoardPost
+  /** Host stream type of the post's conversation, selecting the reply routing. */
+  hostStreamType: string | undefined
+  /** Called with the created reply so the card can show it in place. */
+  onReplied: (message: Message) => void
+}
+
+/**
+ * Inline reply affordance on a board card. Collapsed to a single line so the
+ * feed stays scannable; clicking expands the full composer in place (the heavy
+ * editor mounts only once a card is activated, so a feed of cards costs one
+ * lightweight button each, not one composer each). Routing — channel → thread,
+ * everything else → the conversation — lives in {@link useReplyToBoardPost}.
+ */
+export function BoardReplyComposer(props: BoardReplyComposerProps) {
+  const [open, setOpen] = useState(false)
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mt-3 flex w-full items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
+      >
+        <Reply className="h-3.5 w-3.5 shrink-0" />
+        Reply…
+      </button>
+    )
+  }
+
+  return <BoardReplyComposerForm {...props} onClose={() => setOpen(false)} />
+}
+
+function BoardReplyComposerForm({
+  workspaceId,
+  post,
+  hostStreamType,
+  onReplied,
+  onClose,
+}: BoardReplyComposerProps & { onClose: () => void }) {
+  const { preferences } = usePreferences()
+  const streams = useWorkspaceStreams(workspaceId)
+  const reply = useReplyToBoardPost(workspaceId)
+
+  const streamId = post.conversation.streamId
+  // The host stream backs mention autocomplete + attachment uploads. A thread
+  // card's host may not be in the workspace stream cache; the composer degrades
+  // gracefully (no mention context) when it isn't.
+  const hostStream = useMemo<CachedStream | undefined>(
+    () => streams.find((s) => s.id === streamId),
+    [streams, streamId]
+  )
+  const streamContext = useMentionStreamContext(workspaceId, hostStream)
+
+  const draftKey = `board:reply:${post.conversation.id}`
+  const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
+
+  const canSubmit = composer.canSend && !reply.isPending
+
+  const handleSubmit = async (editorContent?: JSONContent) => {
+    if (!composer.canSend) return
+
+    const pendingAttachments = composer.getPendingAttachmentsSnapshot()
+    const liveContent = editorContent ?? composer.content
+    const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
+    const attachmentIds = extractUploadedAttachments(normalizedContent).map((a) => a.id)
+
+    composer.setIsSending(true)
+    try {
+      const message = await reply.mutateAsync({
+        conversation: post.conversation,
+        openingMessageId: post.openingMessage?.id ?? null,
+        hostStreamType,
+        contentJson: normalizedContent,
+        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+      })
+      composer.setContent(EMPTY_DOC)
+      await composer.resolveDraft()
+      composer.clearAttachments()
+      onReplied(message)
+      onClose()
+    } catch {
+      toast.error("Couldn't post your reply. Please try again.")
+    } finally {
+      composer.setIsSending(false)
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded-lg border bg-background p-2">
+      <div className="mb-1 flex items-center justify-end">
+        <Button variant="ghost" size="icon" aria-label="Cancel reply" className="h-7 w-7" onClick={onClose}>
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <MessageComposer
+        content={composer.content}
+        onContentChange={composer.handleContentChange}
+        pendingAttachments={composer.pendingAttachments}
+        onRemoveAttachment={composer.handleRemoveAttachment}
+        workspaceId={workspaceId}
+        streamId={hostStream?.id}
+        fileInputRef={composer.fileInputRef}
+        onFileSelect={composer.handleFileSelect}
+        onFileUpload={composer.uploadFile}
+        imageCount={composer.imageCount}
+        onSubmit={handleSubmit}
+        canSubmit={canSubmit}
+        isSubmitting={composer.isSending}
+        hasFailed={composer.hasFailed}
+        placeholder="Write a reply…"
+        messageSendMode={preferences?.messageSendMode ?? "enter"}
+        autoFocus
+        scopeId={draftKey}
+        streamContext={streamContext}
+      />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,16 +1,22 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Reply } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
-import { EMPTY_DOC } from "@/lib/prosemirror-utils"
+import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
 import type { BoardPost, JSONContent, Message } from "@threa/types"
+
+// Focus moving into one of these means a composer popover is open (the inline
+// suggestion lists render as `[role="listbox"]`; emoji/format/link popovers are
+// Radix poppers; the mobile drawer is a dialog) — all portal outside the
+// composer subtree, so blur-to-collapse must treat them as "still editing"
+// rather than a dismissal. Mirrors the guard in document-editor-modal.tsx.
+const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
 
 interface BoardReplyComposerProps {
   workspaceId: string
@@ -73,6 +79,32 @@ function BoardReplyComposerForm({
 
   const canSubmit = composer.canSend && !reply.isPending
 
+  // Collapse back to the one-line affordance when focus leaves an empty reply —
+  // the native composer feel. A draft with content (text or a pending upload)
+  // stays open and persists; abandoning means clearing it. The latest emptiness
+  // is read through a ref so the deferred check sees current state without
+  // re-binding the handler each keystroke.
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isEmptyRef = useRef(true)
+  isEmptyRef.current = isEmptyContent(composer.content) && composer.pendingAttachments.length === 0
+
+  const handleBlur = useCallback(() => {
+    // Defer past the focusout: focus may be landing on a sibling control, or on
+    // a popover that portals out of this subtree (guarded above). Collapse only
+    // once focus has truly left and the draft is empty.
+    requestAnimationFrame(() => {
+      const container = containerRef.current
+      if (!container) return
+      // The page itself lost focus — a native file picker opened or the user
+      // switched tab/app. Keep the draft open; they're mid-action.
+      if (!document.hasFocus()) return
+      const active = document.activeElement
+      if (active && (container.contains(active) || active.closest(COMPOSER_POPOVER_SELECTOR))) return
+      if (!isEmptyRef.current) return
+      onClose()
+    })
+  }, [onClose])
+
   const handleSubmit = async (editorContent?: JSONContent) => {
     if (!composer.canSend) return
 
@@ -105,10 +137,10 @@ function BoardReplyComposerForm({
 
   // The composer carries its own bordered, collapse-on-focus chrome and toolbar,
   // so it sits directly on the card — no wrapper frame, which would double the
-  // border and leave an empty header strip. Cancel is a low-emphasis control
-  // below it rather than a lone button in a header row.
+  // border and leave an empty header strip. An empty reply collapses on blur
+  // (handleBlur) rather than needing an explicit cancel control.
   return (
-    <div className="mt-3">
+    <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
       <MessageComposer
         content={composer.content}
         onContentChange={composer.handleContentChange}
@@ -131,16 +163,6 @@ function BoardReplyComposerForm({
         scopeId={draftKey}
         streamContext={streamContext}
       />
-      <div className="mt-1.5 flex justify-start">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-      </div>
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
@@ -14,7 +14,9 @@ import type { BoardPost, JSONContent, Message } from "@threa/types"
 // suggestion lists render as `[role="listbox"]`; emoji/format/link popovers are
 // Radix poppers; the mobile drawer is a dialog) — all portal outside the
 // composer subtree, so blur-to-collapse must treat them as "still editing"
-// rather than a dismissal. Mirrors the guard in document-editor-modal.tsx.
+// rather than a dismissal. document-editor-modal.tsx guards its suggestion
+// popover the same way (`[role="listbox"]`); this set is broader to also cover
+// the Radix poppers and dialog.
 const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
 
 interface BoardReplyComposerProps {
@@ -39,10 +41,28 @@ interface BoardReplyComposerProps {
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  // Return focus to the resting button after an explicit collapse (Escape /
+  // after-send) so keyboard navigation isn't dropped onto <body> when the form
+  // unmounts. A blur-driven collapse passes refocus=false — the user already
+  // moved focus elsewhere, so we leave it where they put it.
+  const refocusOnCollapseRef = useRef(false)
+  useEffect(() => {
+    if (!open && refocusOnCollapseRef.current) {
+      refocusOnCollapseRef.current = false
+      buttonRef.current?.focus()
+    }
+  }, [open])
+
+  const close = useCallback((opts?: { refocus?: boolean }) => {
+    refocusOnCollapseRef.current = opts?.refocus ?? false
+    setOpen(false)
+  }, [])
 
   if (!open) {
     return (
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen(true)}
         className="mt-3 flex w-full items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -52,7 +72,7 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     )
   }
 
-  return <BoardReplyComposerForm {...props} onClose={() => setOpen(false)} />
+  return <BoardReplyComposerForm {...props} onClose={close} />
 }
 
 function BoardReplyComposerForm({
@@ -61,7 +81,7 @@ function BoardReplyComposerForm({
   hostStreamType,
   onReplied,
   onClose,
-}: BoardReplyComposerProps & { onClose: () => void }) {
+}: BoardReplyComposerProps & { onClose: (opts?: { refocus?: boolean }) => void }) {
   const { preferences } = usePreferences()
   const streams = useWorkspaceStreams(workspaceId)
   const reply = useReplyToBoardPost(workspaceId)
@@ -117,7 +137,7 @@ function BoardReplyComposerForm({
 
     composer.setIsSending(true)
     try {
-      const message = await reply.mutateAsync({
+      const { message, plan } = await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
         hostStreamType,
@@ -128,8 +148,12 @@ function BoardReplyComposerForm({
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
-      onReplied(message)
-      onClose()
+      // Only an `intoConversation` reply belongs under this card; a `newThread`
+      // reply lives in its own thread conversation and surfaces as its own board
+      // post on the next load, so showing it here would render it under the wrong
+      // card with stream-mismatched action links.
+      if (plan.kind === "intoConversation") onReplied(message)
+      onClose({ refocus: true })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")
     } finally {
@@ -139,8 +163,9 @@ function BoardReplyComposerForm({
 
   // The composer carries its own bordered, collapse-on-focus chrome and toolbar,
   // so it sits directly on the card — no wrapper frame, which would double the
-  // border and leave an empty header strip. An empty reply collapses on blur
-  // (handleBlur) rather than needing an explicit cancel control.
+  // border and leave an empty header strip. Dismissal instead of a cancel
+  // control: an empty reply collapses on blur (handleBlur); Escape collapses
+  // even a non-empty draft and returns focus to the trigger (onEscapeBlur).
   return (
     <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
       <MessageComposer
@@ -165,6 +190,10 @@ function BoardReplyComposerForm({
         initialMobileChromeOpen
         scopeId={draftKey}
         streamContext={streamContext}
+        // Escape (when no @/emoji/slash popup is open) collapses the reply and
+        // returns focus to the trigger — a keyboard cancel even with a draft,
+        // which the empty-only blur-collapse doesn't cover.
+        onEscapeBlur={() => onClose({ refocus: true })}
       />
     </div>
   )

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { Reply, X } from "lucide-react"
+import { Reply } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
@@ -103,13 +103,12 @@ function BoardReplyComposerForm({
     }
   }
 
+  // The composer carries its own bordered, collapse-on-focus chrome and toolbar,
+  // so it sits directly on the card — no wrapper frame, which would double the
+  // border and leave an empty header strip. Cancel is a low-emphasis control
+  // below it rather than a lone button in a header row.
   return (
-    <div className="mt-3 rounded-lg border bg-background p-2">
-      <div className="mb-1 flex items-center justify-end">
-        <Button variant="ghost" size="icon" aria-label="Cancel reply" className="h-7 w-7" onClick={onClose}>
-          <X className="h-3.5 w-3.5" />
-        </Button>
-      </div>
+    <div className="mt-3">
       <MessageComposer
         content={composer.content}
         onContentChange={composer.handleContentChange}
@@ -117,6 +116,7 @@ function BoardReplyComposerForm({
         onRemoveAttachment={composer.handleRemoveAttachment}
         workspaceId={workspaceId}
         streamId={hostStream?.id}
+        memoAnchorStreamId={streamId}
         fileInputRef={composer.fileInputRef}
         onFileSelect={composer.handleFileSelect}
         onFileUpload={composer.uploadFile}
@@ -131,6 +131,16 @@ function BoardReplyComposerForm({
         scopeId={draftKey}
         streamContext={streamContext}
       />
+      <div className="mt-1.5 flex justify-start">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -87,6 +87,7 @@ function BoardReplyComposerForm({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
         hostStreamType,
+        messageCount: post.conversation.messageIds.length,
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
       })

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -31,11 +31,11 @@ interface BoardReplyComposerProps {
  * so the feed stays scannable; tapping it mounts the real composer in place (the
  * heavy editor mounts only once a card is activated, so a feed of cards costs one
  * lightweight button each, not one composer each). The button deliberately
- * mirrors the composer's own resting container — same radius, border, surface,
- * padding, and placeholder — so the swap is seamless and the only visible change
- * is the toolbar appearing on focus, exactly like the timeline composer. Routing
- * — channel → thread, everything else → the conversation — lives in
- * {@link useReplyToBoardPost}.
+ * mirrors the composer's own container — same radius, border, surface, padding,
+ * and placeholder — and the composer mounts already open (`initialMobileChromeOpen`)
+ * so the tap lands straight in the toolbar view instead of stepping through the
+ * mobile compacted phase. Routing — channel → thread, everything else → the
+ * conversation — lives in {@link useReplyToBoardPost}.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
@@ -45,7 +45,7 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="mt-3 flex w-full items-center rounded-[16px] border border-input bg-card px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+        className="mt-3 flex w-full items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
         Write a reply…
       </button>
@@ -162,6 +162,7 @@ function BoardReplyComposerForm({
         placeholder="Write a reply…"
         messageSendMode={preferences?.messageSendMode ?? "enter"}
         autoFocus
+        initialMobileChromeOpen
         scopeId={draftKey}
         streamContext={streamContext}
       />

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
+import { Check } from "lucide-react"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
@@ -18,6 +19,21 @@ import type { BoardPost, JSONContent, Message } from "@threa/types"
 // popover the same way (`[role="listbox"]`); this set is broader to also cover
 // the Radix poppers and dialog.
 const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
+
+// Resting-affordance state. `draft` signals a persisted-but-collapsed reply (so
+// the user knows reopening restores it); `posted` is a transient confirmation
+// that a new-thread reply went through — it stands in for the in-place echo a
+// same-conversation reply gets, since a new-thread reply lands in its own
+// conversation and only surfaces on the next board load.
+type RestingState = "idle" | "draft" | "posted"
+const RESTING_LABEL: Record<RestingState, string> = {
+  idle: "Write a reply…",
+  draft: "Continue reply…",
+  posted: "Posted to a new thread",
+}
+// How long the transient "posted" confirmation stays before the affordance
+// returns to its normal invitation.
+const POSTED_NOTE_MS = 4000
 
 interface BoardReplyComposerProps {
   workspaceId: string
@@ -38,9 +54,15 @@ interface BoardReplyComposerProps {
  * so the tap lands straight in the toolbar view instead of stepping through the
  * mobile compacted phase. Routing — channel → thread, everything else → the
  * conversation — lives in {@link useReplyToBoardPost}.
+ *
+ * The resting affordance carries state (best-effort, in-session): it flags a
+ * persisted draft after an Escape ("Continue reply…") and a transient "Posted to
+ * a new thread" confirmation after a new-thread send, so a collapse never reads
+ * as a no-op or an accidental discard.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
+  const [resting, setResting] = useState<RestingState>("idle")
   const buttonRef = useRef<HTMLButtonElement>(null)
   // Return focus to the resting button after an explicit collapse (Escape /
   // after-send) so keyboard navigation isn't dropped onto <body> when the form
@@ -54,8 +76,18 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     }
   }, [open])
 
-  const close = useCallback((opts?: { refocus?: boolean }) => {
+  // Let the transient "posted" confirmation fade back to the normal invitation.
+  useEffect(() => {
+    if (resting !== "posted") return
+    const timer = window.setTimeout(() => setResting("idle"), POSTED_NOTE_MS)
+    return () => window.clearTimeout(timer)
+  }, [resting])
+
+  const close = useCallback((opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => {
     refocusOnCollapseRef.current = opts?.refocus ?? false
+    if (opts?.posted) setResting("posted")
+    else if (opts?.hadContent) setResting("draft")
+    else setResting("idle")
     setOpen(false)
   }, [])
 
@@ -64,10 +96,14 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setOpen(true)}
-        className="mt-3 flex w-full items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+        onClick={() => {
+          setResting("idle")
+          setOpen(true)
+        }}
+        className="mt-3 flex w-full min-w-0 items-center gap-1.5 rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        Write a reply…
+        {resting === "posted" && <Check className="h-3.5 w-3.5 shrink-0 text-primary" />}
+        <span className="truncate">{RESTING_LABEL[resting]}</span>
       </button>
     )
   }
@@ -81,7 +117,9 @@ function BoardReplyComposerForm({
   hostStreamType,
   onReplied,
   onClose,
-}: BoardReplyComposerProps & { onClose: (opts?: { refocus?: boolean }) => void }) {
+}: BoardReplyComposerProps & {
+  onClose: (opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => void
+}) {
   const { preferences } = usePreferences()
   const streams = useWorkspaceStreams(workspaceId)
   const reply = useReplyToBoardPost(workspaceId)
@@ -151,9 +189,11 @@ function BoardReplyComposerForm({
       // Only an `intoConversation` reply belongs under this card; a `newThread`
       // reply lives in its own thread conversation and surfaces as its own board
       // post on the next load, so showing it here would render it under the wrong
-      // card with stream-mismatched action links.
+      // card with stream-mismatched action links. The visible in-place reply IS
+      // the feedback for the former; the latter gets a transient resting note
+      // instead, since nothing changes on this card.
       if (plan.kind === "intoConversation") onReplied(message)
-      onClose({ refocus: true })
+      onClose({ refocus: true, posted: plan.kind === "newThread" })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")
     } finally {
@@ -192,8 +232,9 @@ function BoardReplyComposerForm({
         streamContext={streamContext}
         // Escape (when no @/emoji/slash popup is open) collapses the reply and
         // returns focus to the trigger — a keyboard cancel even with a draft,
-        // which the empty-only blur-collapse doesn't cover.
-        onEscapeBlur={() => onClose({ refocus: true })}
+        // which the empty-only blur-collapse doesn't cover. A non-empty draft
+        // persists, so the resting affordance flags it ("Continue reply…").
+        onEscapeBlur={() => onClose({ refocus: true, hadContent: !isEmptyRef.current })}
       />
     </div>
   )

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
-import { Check } from "lucide-react"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
@@ -100,9 +99,11 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
           setResting("idle")
           setOpen(true)
         }}
-        className="mt-3 flex w-full min-w-0 items-center gap-1.5 rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
+        className="mt-3 flex w-full min-w-0 items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        {resting === "posted" && <Check className="h-3.5 w-3.5 shrink-0 text-primary" />}
+        {/* Label-only confirmation: the text IS the in-place signal. No leading
+            icon — adding one only in the "posted" state would shift the label
+            (INV-21) and misalign the resting text against the open composer's. */}
         <span className="truncate">{RESTING_LABEL[resting]}</span>
       </button>
     )
@@ -232,9 +233,16 @@ function BoardReplyComposerForm({
         streamContext={streamContext}
         // Escape (when no @/emoji/slash popup is open) collapses the reply and
         // returns focus to the trigger — a keyboard cancel even with a draft,
-        // which the empty-only blur-collapse doesn't cover. A non-empty draft
-        // persists, so the resting affordance flags it ("Continue reply…").
-        onEscapeBlur={() => onClose({ refocus: true, hadContent: !isEmptyRef.current })}
+        // which the empty-only blur-collapse doesn't cover. Flush the draft to
+        // IDB FIRST: collapsing unmounts the form, which cancels the in-flight
+        // debounced save, so without this the just-typed draft would live only
+        // in localStorage (reconciled at startup) and a mid-session reopen would
+        // read an empty editor — a false "Continue reply…".
+        onEscapeBlur={() => {
+          const hadContent = !isEmptyRef.current
+          void composer.flushDraft()
+          onClose({ refocus: true, hadContent })
+        }}
       />
     </div>
   )

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
-import { Reply } from "lucide-react"
 import { MessageComposer } from "@/components/composer"
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
@@ -28,11 +27,15 @@ interface BoardReplyComposerProps {
 }
 
 /**
- * Inline reply affordance on a board card. Collapsed to a single line so the
- * feed stays scannable; clicking expands the full composer in place (the heavy
- * editor mounts only once a card is activated, so a feed of cards costs one
- * lightweight button each, not one composer each). Routing — channel → thread,
- * everything else → the conversation — lives in {@link useReplyToBoardPost}.
+ * Inline reply affordance on a board card. Collapsed to a single resting line
+ * so the feed stays scannable; tapping it mounts the real composer in place (the
+ * heavy editor mounts only once a card is activated, so a feed of cards costs one
+ * lightweight button each, not one composer each). The button deliberately
+ * mirrors the composer's own resting container — same radius, border, surface,
+ * padding, and placeholder — so the swap is seamless and the only visible change
+ * is the toolbar appearing on focus, exactly like the timeline composer. Routing
+ * — channel → thread, everything else → the conversation — lives in
+ * {@link useReplyToBoardPost}.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
@@ -42,10 +45,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="mt-3 flex w-full items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-accent/40 hover:text-foreground"
+        className="mt-3 flex w-full items-center rounded-[16px] border border-input bg-card px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        <Reply className="h-3.5 w-3.5 shrink-0" />
-        Reply…
+        Write a reply…
       </button>
     )
   }

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -182,6 +182,16 @@ export interface MessageComposerProps {
   /** Auto-focus the editor when mounted */
   autoFocus?: boolean
 
+  /**
+   * Mount with the mobile chrome (action bar + full editor) already open rather
+   * than the compacted single-line resting state. For tap-to-open inline
+   * composers (e.g. the board reply) the user has explicitly revealed the
+   * composer, so it shouldn't step through the compacted phase before the
+   * toolbar appears. Desktop always shows the chrome, so this is a no-op there.
+   * Default false (the timeline/thread composers rest compacted on mobile).
+   */
+  initialMobileChromeOpen?: boolean
+
   /** Scope identifier — when it changes, re-focus the editor (if autoFocus) */
   scopeId?: string
 
@@ -266,6 +276,7 @@ export function MessageComposer({
   className,
   messageSendMode = "enter",
   autoFocus = false,
+  initialMobileChromeOpen = false,
   scopeId,
   onEditLastMessage,
   onExpandClick,
@@ -291,7 +302,7 @@ export function MessageComposer({
   const [formatOpen, setFormatOpen] = useState(false)
   const [isInTable, setIsInTable] = useState(false)
   const [mobileExpanded, setMobileExpanded] = useState(false)
-  const [mobileFocused, setMobileFocused] = useState(false)
+  const [mobileFocused, setMobileFocused] = useState(initialMobileChromeOpen)
   const [mobileLinkPopoverOpen, setMobileLinkPopoverOpen] = useState(false)
   // True while a dictation take is in flight. Keeps the mobile chrome (and the
   // mic button it lives in) mounted across a tap-outside blur so the session
@@ -388,7 +399,15 @@ export function MessageComposer({
   // Close inline format toolbar and collapse expansion when navigating to a different stream/scope.
   // Clearing voiceActive collapses the mobile chrome; combined with the scopeId-keyed mic below,
   // an in-flight dictation take ends on navigation rather than carrying over into the next stream.
+  // The first run (mount) is skipped so an opt-in initialMobileChromeOpen isn't cleared before it
+  // shows; the reset only matters on a later scope CHANGE. For every existing caller the mount-time
+  // state is already all-closed, so skipping that run is a no-op for them.
+  const didMountScopeResetRef = useRef(false)
   useEffect(() => {
+    if (!didMountScopeResetRef.current) {
+      didMountScopeResetRef.current = true
+      return
+    }
     if (blurTimeoutRef.current) {
       clearTimeout(blurTimeoutRef.current)
       blurTimeoutRef.current = null

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -198,6 +198,13 @@ export interface MessageComposerProps {
   /** Called when ArrowUp is pressed in an empty editor — triggers edit-last-message */
   onEditLastMessage?: () => void
 
+  /**
+   * Called when Escape blurs the editor (only fires when no suggestion popup is
+   * active — the popup consumes Escape first). Lets a host collapse a tap-to-open
+   * inline composer on Escape without fighting the @/emoji/slash popovers.
+   */
+  onEscapeBlur?: () => void
+
   /** Called when the desktop expand button is clicked — opens fullscreen document editor */
   onExpandClick?: () => void
 
@@ -279,6 +286,7 @@ export function MessageComposer({
   initialMobileChromeOpen = false,
   scopeId,
   onEditLastMessage,
+  onEscapeBlur,
   onExpandClick,
   expanded = false,
   onCollapse,
@@ -654,6 +662,7 @@ export function MessageComposer({
       staticToolbarOpen={!isMobile && formatOpen}
       disableSelectionToolbar={disableSelectionToolbar}
       onEditLastMessage={onEditLastMessage}
+      onEscapeBlur={onEscapeBlur}
       ariaLabel="Message input"
       ariaDescribedBy={instructionsId}
       blurOnEscape

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -125,11 +125,15 @@ export function MessageItem({
     onLabelMessage: () => setLabelPickerOpen(true),
   }
 
-  // Desktop/keyboard only (hover or focus reveals it); touch uses the drawer
-  // below. The body columns carry `pr-7` so this absolute button never overlays
-  // the row's top-right content (INV-21).
+  // Desktop/keyboard only via the shared input-mode reveal model: the row is the
+  // `reveal-host`, and `reveal-actions-hover-only` keeps this cluster
+  // opacity-0 + pointer-events-none for touch (so a tap can't trigger the
+  // invisible button — it passes through), revealing it on mouse hover / focus.
+  // Touch reaches the same actions through the long-press drawer below. The body
+  // columns carry `pr-7` so this absolute button never overlays the row's
+  // top-right content (INV-21).
   const overflowMenu = (
-    <div className="absolute right-0 top-0 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+    <div className="reveal-actions-hover-only absolute right-0 top-0">
       <MessageContextMenu context={menuContext} />
     </div>
   )
@@ -212,7 +216,10 @@ export function MessageItem({
     const sentAt = new Date(message.createdAt)
     return (
       <div
-        className={cn("group relative mt-0.5 flex gap-3", longPress.isPressed && "opacity-70 transition-opacity")}
+        className={cn(
+          "group reveal-host relative mt-0.5 flex gap-3",
+          longPress.isPressed && "opacity-70 transition-opacity"
+        )}
         {...touchHandlers}
       >
         {/* Gutter reveals the message time on hover (desktop), mirroring the
@@ -236,7 +243,7 @@ export function MessageItem({
   return (
     <div
       className={cn(
-        "group relative mt-3 flex items-start gap-3",
+        "group reveal-host relative mt-3 flex items-start gap-3",
         longPress.isPressed && "opacity-70 transition-opacity"
       )}
       {...touchHandlers}

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -9,7 +9,7 @@ import * as syncEngineModule from "@/sync/sync-engine"
 import * as draftScratchpadsModule from "./use-draft-scratchpads"
 import * as queueDraftModule from "./use-queue-draft-message"
 import { SocketEventGate } from "@/sync/socket-event-gate"
-import { useConversations, useCreateBoardPost, conversationKeys } from "./use-conversations"
+import { useConversations, useCreateBoardPost, useReplyToBoardPost, conversationKeys } from "./use-conversations"
 
 const WORKSPACE_ID = "ws_1"
 const STREAM_ID = "stream_1"
@@ -236,6 +236,123 @@ describe("useCreateBoardPost", () => {
         draftId: "draft_1",
         streamCreation: { type: StreamTypes.SCRATCHPAD, companionMode: "on" },
       })
+    )
+  })
+})
+
+describe("useReplyToBoardPost", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockReplyDeps() {
+    const create = vi.fn().mockResolvedValue({ id: "msg_new" })
+    vi.spyOn(contextsModule, "useMessageService").mockReturnValue({
+      create,
+    } as unknown as contextsModule.MessageService)
+    const createStream = vi.fn().mockResolvedValue({ id: "thread_1" })
+    vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
+      create: createStream,
+    } as unknown as contextsModule.StreamService)
+    return { create, createStream }
+  }
+
+  const DOC = { type: "doc", content: [] }
+
+  it("threads a channel reply off the opening message, then sends into the thread (no directive)", async () => {
+    const { create, createStream } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_1", streamId: "chan_1" },
+        openingMessageId: "msg_open",
+        hostStreamType: StreamTypes.CHANNEL,
+        contentJson: DOC,
+      })
+    })
+
+    expect(createStream).toHaveBeenCalledWith(WORKSPACE_ID, {
+      type: StreamTypes.THREAD,
+      parentStreamId: "chan_1",
+      parentMessageId: "msg_open",
+    })
+    expect(create).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "thread_1",
+      expect.objectContaining({ streamId: "thread_1", contentJson: DOC, clientMessageId: expect.any(String) })
+    )
+    // The thread is its own context — no existing-conversation directive.
+    expect(create.mock.calls[0][2]).not.toHaveProperty("conversation")
+  })
+
+  it("attaches a DM reply to the conversation via the existing directive (no thread)", async () => {
+    const { create, createStream } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_dm", streamId: "dm_1" },
+        openingMessageId: "msg_open",
+        hostStreamType: StreamTypes.DM,
+        contentJson: DOC,
+      })
+    })
+
+    expect(createStream).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "dm_1",
+      expect.objectContaining({
+        streamId: "dm_1",
+        conversation: { intent: "existing", conversationId: "conv_dm" },
+      })
+    )
+  })
+
+  it("replies straight into a thread card's own stream via the existing directive", async () => {
+    const { create, createStream } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_thread", streamId: "thread_x" },
+        openingMessageId: "msg_open",
+        hostStreamType: StreamTypes.THREAD,
+        contentJson: DOC,
+      })
+    })
+
+    expect(createStream).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "thread_x",
+      expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_thread" } })
+    )
+  })
+
+  it("falls back to a conversation-attached message when a channel post has no opening message", async () => {
+    const { create, createStream } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_1", streamId: "chan_1" },
+        openingMessageId: null,
+        hostStreamType: StreamTypes.CHANNEL,
+        contentJson: DOC,
+      })
+    })
+
+    expect(createStream).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      "chan_1",
+      expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_1" } })
     )
   })
 })

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -9,7 +9,13 @@ import * as syncEngineModule from "@/sync/sync-engine"
 import * as draftScratchpadsModule from "./use-draft-scratchpads"
 import * as queueDraftModule from "./use-queue-draft-message"
 import { SocketEventGate } from "@/sync/socket-event-gate"
-import { useConversations, useCreateBoardPost, useReplyToBoardPost, conversationKeys } from "./use-conversations"
+import {
+  useConversations,
+  useCreateBoardPost,
+  useReplyToBoardPost,
+  planBoardReply,
+  conversationKeys,
+} from "./use-conversations"
 
 const WORKSPACE_ID = "ws_1"
 const STREAM_ID = "stream_1"
@@ -240,6 +246,48 @@ describe("useCreateBoardPost", () => {
   })
 })
 
+describe("planBoardReply", () => {
+  it("threads a lone root message in a channel or DM off the opening message", () => {
+    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 1, openingMessageId: "m1" })).toEqual({
+      kind: "newThread",
+      parentMessageId: "m1",
+    })
+    expect(planBoardReply({ hostStreamType: StreamTypes.DM, messageCount: 1, openingMessageId: "m1" })).toEqual({
+      kind: "newThread",
+      parentMessageId: "m1",
+    })
+  })
+
+  it("keeps a flat conversation with replies flat — no stray thread", () => {
+    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 3, openingMessageId: "m1" })).toEqual({
+      kind: "intoConversation",
+    })
+    expect(planBoardReply({ hostStreamType: StreamTypes.DM, messageCount: 2, openingMessageId: "m1" })).toEqual({
+      kind: "intoConversation",
+    })
+  })
+
+  it("replies into a thread conversation's own stream, even when it holds a single message", () => {
+    expect(planBoardReply({ hostStreamType: StreamTypes.THREAD, messageCount: 1, openingMessageId: "m1" })).toEqual({
+      kind: "intoConversation",
+    })
+  })
+
+  it("never threads a scratchpad, even a lone one", () => {
+    expect(planBoardReply({ hostStreamType: StreamTypes.SCRATCHPAD, messageCount: 1, openingMessageId: "m1" })).toEqual(
+      {
+        kind: "intoConversation",
+      }
+    )
+  })
+
+  it("stays flat when a lone root has been deleted (no anchor to thread off)", () => {
+    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 1, openingMessageId: null })).toEqual({
+      kind: "intoConversation",
+    })
+  })
+})
+
 describe("useReplyToBoardPost", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -259,7 +307,7 @@ describe("useReplyToBoardPost", () => {
 
   const DOC = { type: "doc", content: [] }
 
-  it("threads a channel reply off the opening message, then sends into the thread (no directive)", async () => {
+  it("threads a lone channel root off the opening message, then sends into the thread (no directive)", async () => {
     const { create, createStream } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
@@ -269,6 +317,7 @@ describe("useReplyToBoardPost", () => {
         conversation: { id: "conv_1", streamId: "chan_1" },
         openingMessageId: "msg_open",
         hostStreamType: StreamTypes.CHANNEL,
+        messageCount: 1,
         contentJson: DOC,
       })
     })
@@ -287,16 +336,17 @@ describe("useReplyToBoardPost", () => {
     expect(create.mock.calls[0][2]).not.toHaveProperty("conversation")
   })
 
-  it("attaches a DM reply to the conversation via the existing directive (no thread)", async () => {
+  it("keeps a multi-message channel reply flat, attached to the conversation (no thread)", async () => {
     const { create, createStream } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
     await act(async () => {
       await result.current.mutateAsync({
-        conversation: { id: "conv_dm", streamId: "dm_1" },
+        conversation: { id: "conv_1", streamId: "chan_1" },
         openingMessageId: "msg_open",
-        hostStreamType: StreamTypes.DM,
+        hostStreamType: StreamTypes.CHANNEL,
+        messageCount: 3,
         contentJson: DOC,
       })
     })
@@ -304,10 +354,10 @@ describe("useReplyToBoardPost", () => {
     expect(createStream).not.toHaveBeenCalled()
     expect(create).toHaveBeenCalledWith(
       WORKSPACE_ID,
-      "dm_1",
+      "chan_1",
       expect.objectContaining({
-        streamId: "dm_1",
-        conversation: { intent: "existing", conversationId: "conv_dm" },
+        streamId: "chan_1",
+        conversation: { intent: "existing", conversationId: "conv_1" },
       })
     )
   })
@@ -322,6 +372,7 @@ describe("useReplyToBoardPost", () => {
         conversation: { id: "conv_thread", streamId: "thread_x" },
         openingMessageId: "msg_open",
         hostStreamType: StreamTypes.THREAD,
+        messageCount: 2,
         contentJson: DOC,
       })
     })
@@ -331,28 +382,6 @@ describe("useReplyToBoardPost", () => {
       WORKSPACE_ID,
       "thread_x",
       expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_thread" } })
-    )
-  })
-
-  it("falls back to a conversation-attached message when a channel post has no opening message", async () => {
-    const { create, createStream } = mockReplyDeps()
-    const { wrapper } = createWrapper()
-    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
-
-    await act(async () => {
-      await result.current.mutateAsync({
-        conversation: { id: "conv_1", streamId: "chan_1" },
-        openingMessageId: null,
-        hostStreamType: StreamTypes.CHANNEL,
-        contentJson: DOC,
-      })
-    })
-
-    expect(createStream).not.toHaveBeenCalled()
-    expect(create).toHaveBeenCalledWith(
-      WORKSPACE_ID,
-      "chan_1",
-      expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_1" } })
     )
   })
 })

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -312,8 +312,9 @@ describe("useReplyToBoardPost", () => {
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
+    let res: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined
     await act(async () => {
-      await result.current.mutateAsync({
+      res = await result.current.mutateAsync({
         conversation: { id: "conv_1", streamId: "chan_1" },
         openingMessageId: "msg_open",
         hostStreamType: StreamTypes.CHANNEL,
@@ -334,6 +335,9 @@ describe("useReplyToBoardPost", () => {
     )
     // The thread is its own context — no existing-conversation directive.
     expect(create.mock.calls[0][2]).not.toHaveProperty("conversation")
+    // The plan rides back so the card can refuse to show a reply that landed in
+    // a different (thread) conversation than the one it renders.
+    expect(res).toEqual({ message: { id: "msg_new" }, plan: { kind: "newThread", parentMessageId: "msg_open" } })
   })
 
   it("keeps a multi-message channel reply flat, attached to the conversation (no thread)", async () => {
@@ -341,8 +345,9 @@ describe("useReplyToBoardPost", () => {
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
+    let res: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined
     await act(async () => {
-      await result.current.mutateAsync({
+      res = await result.current.mutateAsync({
         conversation: { id: "conv_1", streamId: "chan_1" },
         openingMessageId: "msg_open",
         hostStreamType: StreamTypes.CHANNEL,
@@ -360,6 +365,8 @@ describe("useReplyToBoardPost", () => {
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
     )
+    // intoConversation → the card may show it in place.
+    expect(res?.plan).toEqual({ kind: "intoConversation" })
   })
 
   it("replies straight into a thread card's own stream via the existing directive", async () => {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -215,7 +215,10 @@ export function planBoardReply(input: {
 
 /**
  * Reply to a board post from the feed, routed by {@link planBoardReply}. Returns
- * the created message so the card can show it in place; board-wide
+ * the created message AND the resolved plan so the caller knows where it landed:
+ * a `newThread` reply lives in a brand-new thread stream (its own conversation),
+ * NOT this card's conversation, so the card must not show it in place — only an
+ * `intoConversation` reply belongs under the card that produced it. Board-wide
  * liveness/optimism across cards is a follow-up (no cache writes here).
  */
 export function useReplyToBoardPost(workspaceId: string) {
@@ -230,7 +233,7 @@ export function useReplyToBoardPost(workspaceId: string) {
       messageCount,
       contentJson,
       attachmentIds,
-    }: ReplyToBoardPostInput): Promise<Message> => {
+    }: ReplyToBoardPostInput): Promise<{ message: Message; plan: BoardReplyPlan }> => {
       const base = {
         contentJson,
         attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
@@ -247,14 +250,16 @@ export function useReplyToBoardPost(workspaceId: string) {
           parentStreamId: conversation.streamId,
           parentMessageId: plan.parentMessageId,
         })
-        return messageService.create(workspaceId, thread.id, { streamId: thread.id, ...base })
+        const message = await messageService.create(workspaceId, thread.id, { streamId: thread.id, ...base })
+        return { message, plan }
       }
 
-      return messageService.create(workspaceId, conversation.streamId, {
+      const message = await messageService.create(workspaceId, conversation.streamId, {
         streamId: conversation.streamId,
         ...base,
         conversation: { intent: "existing", conversationId: conversation.id },
       })
+      return { message, plan }
     },
   })
 }

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -171,32 +171,51 @@ export function useCreateBoardPost(workspaceId: string) {
 export interface ReplyToBoardPostInput {
   /** The post's conversation — supplies the host stream and the attach target. */
   conversation: Pick<ConversationWithStaleness, "id" | "streamId">
-  /** The post's opening message id — the thread parent for a channel reply. */
+  /** The post's opening message id — the thread parent for a lone-message reply. */
   openingMessageId: string | null
   /** Host stream type (`channel` | `dm` | `scratchpad` | `thread` | undefined). */
   hostStreamType: string | undefined
+  /** Count of messages in the conversation, deciding the lone-root case. */
+  messageCount: number
   contentJson: JSONContent
   attachmentIds?: string[]
 }
 
 /**
- * Reply to a board post from the feed. Where the reply lands depends on the
- * conversation's host stream (user ruling):
+ * Where a board reply lands. A conversation owns exactly one stream — its
+ * messages are wholly flat or wholly inside a thread; a thread is always its own
+ * conversation — so "follow where the conversation lives" reduces to the host
+ * stream type plus whether the conversation is still a lone root (user ruling):
  *
- *  - **channel** → a thread reply off the post's opening message, so it stays
- *    scoped to the topic instead of interleaving into the channel's live
- *    timeline. Thread creation is idempotent server-side on
- *    `(parentStreamId, parentMessageId)`, so we create-or-find the thread, then
- *    send into it — its own conversation forms there.
- *  - **dm / scratchpad / thread card** → a message into the conversation's stream
- *    attached to it via the `existing` directive ("the conversation as a whole"),
- *    so the assignment + activity bump happen synchronously in the send txn.
+ *  - **thread conversation** → into the thread (it IS the thread).
+ *  - **flat conversation with replies** (channel/DM) → flat in its stream.
+ *  - **scratchpad** → always flat (scratchpads don't thread).
+ *  - **a lone root message** in a channel/DM → start a thread off it: a single
+ *    message has no established shape, and threading a bare message keeps the
+ *    channel from sprouting a stray top-level reply. Scratchpads stay flat even
+ *    when lone; a deleted root (no opening id) can't be threaded, so it stays flat.
  *
- * A channel post whose opening message was deleted falls through to the second
- * path (a top-level message attached to the conversation) — there's no anchor to
- * thread off.
- *
- * Returns the created message so the card can show it in place; board-wide
+ * "Into the thread" and "flat" are the same send — into the conversation's own
+ * stream, attached via the `existing` directive — so only the lone channel/DM
+ * root diverges into a new thread.
+ */
+export type BoardReplyPlan = { kind: "newThread"; parentMessageId: string } | { kind: "intoConversation" }
+
+export function planBoardReply(input: {
+  hostStreamType: string | undefined
+  messageCount: number
+  openingMessageId: string | null
+}): BoardReplyPlan {
+  const threadable = input.hostStreamType === StreamTypes.CHANNEL || input.hostStreamType === StreamTypes.DM
+  if (threadable && input.messageCount <= 1 && input.openingMessageId) {
+    return { kind: "newThread", parentMessageId: input.openingMessageId }
+  }
+  return { kind: "intoConversation" }
+}
+
+/**
+ * Reply to a board post from the feed, routed by {@link planBoardReply}. Returns
+ * the created message so the card can show it in place; board-wide
  * liveness/optimism across cards is a follow-up (no cache writes here).
  */
 export function useReplyToBoardPost(workspaceId: string) {
@@ -208,6 +227,7 @@ export function useReplyToBoardPost(workspaceId: string) {
       conversation,
       openingMessageId,
       hostStreamType,
+      messageCount,
       contentJson,
       attachmentIds,
     }: ReplyToBoardPostInput): Promise<Message> => {
@@ -217,11 +237,15 @@ export function useReplyToBoardPost(workspaceId: string) {
         clientMessageId: generateClientId(),
       }
 
-      if (hostStreamType === StreamTypes.CHANNEL && openingMessageId) {
+      const plan = planBoardReply({ hostStreamType, messageCount, openingMessageId })
+
+      if (plan.kind === "newThread") {
+        // Create-or-find is idempotent server-side on (parentStreamId,
+        // parentMessageId), so this can't double-create the thread.
         const thread = await streamService.create(workspaceId, {
           type: StreamTypes.THREAD,
           parentStreamId: conversation.streamId,
-          parentMessageId: openingMessageId,
+          parentMessageId: plan.parentMessageId,
         })
         return messageService.create(workspaceId, thread.id, { streamId: thread.id, ...base })
       }

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -1,12 +1,18 @@
 import { useEffect } from "react"
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useConversationService, useMessageService, useSocket, useSocketReconnectCount } from "@/contexts"
+import {
+  useConversationService,
+  useMessageService,
+  useStreamService,
+  useSocket,
+  useSocketReconnectCount,
+} from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
 import { StreamTypes } from "@threa/types"
-import type { CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent } from "@threa/types"
+import type { CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent, Message } from "@threa/types"
 
 /**
  * Where a board post lands: an existing channel/DM the user picked, or a
@@ -158,6 +164,73 @@ export function useCreateBoardPost(workspaceId: string) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...conversationKeys.all, "workspaceList", workspaceId] })
+    },
+  })
+}
+
+export interface ReplyToBoardPostInput {
+  /** The post's conversation — supplies the host stream and the attach target. */
+  conversation: Pick<ConversationWithStaleness, "id" | "streamId">
+  /** The post's opening message id — the thread parent for a channel reply. */
+  openingMessageId: string | null
+  /** Host stream type (`channel` | `dm` | `scratchpad` | `thread` | undefined). */
+  hostStreamType: string | undefined
+  contentJson: JSONContent
+  attachmentIds?: string[]
+}
+
+/**
+ * Reply to a board post from the feed. Where the reply lands depends on the
+ * conversation's host stream (user ruling):
+ *
+ *  - **channel** → a thread reply off the post's opening message, so it stays
+ *    scoped to the topic instead of interleaving into the channel's live
+ *    timeline. Thread creation is idempotent server-side on
+ *    `(parentStreamId, parentMessageId)`, so we create-or-find the thread, then
+ *    send into it — its own conversation forms there.
+ *  - **dm / scratchpad / thread card** → a message into the conversation's stream
+ *    attached to it via the `existing` directive ("the conversation as a whole"),
+ *    so the assignment + activity bump happen synchronously in the send txn.
+ *
+ * A channel post whose opening message was deleted falls through to the second
+ * path (a top-level message attached to the conversation) — there's no anchor to
+ * thread off.
+ *
+ * Returns the created message so the card can show it in place; board-wide
+ * liveness/optimism across cards is a follow-up (no cache writes here).
+ */
+export function useReplyToBoardPost(workspaceId: string) {
+  const messageService = useMessageService()
+  const streamService = useStreamService()
+
+  return useMutation({
+    mutationFn: async ({
+      conversation,
+      openingMessageId,
+      hostStreamType,
+      contentJson,
+      attachmentIds,
+    }: ReplyToBoardPostInput): Promise<Message> => {
+      const base = {
+        contentJson,
+        attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
+        clientMessageId: generateClientId(),
+      }
+
+      if (hostStreamType === StreamTypes.CHANNEL && openingMessageId) {
+        const thread = await streamService.create(workspaceId, {
+          type: StreamTypes.THREAD,
+          parentStreamId: conversation.streamId,
+          parentMessageId: openingMessageId,
+        })
+        return messageService.create(workspaceId, thread.id, { streamId: thread.id, ...base })
+      }
+
+      return messageService.create(workspaceId, conversation.streamId, {
+        streamId: conversation.streamId,
+        ...base,
+        conversation: { intent: "existing", conversationId: conversation.id },
+      })
     },
   })
 }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -144,6 +144,13 @@ describe("BoardPage", () => {
     expect(await screen.findByText("Rotate the tokens before Friday.")).toBeTruthy()
   })
 
+  it("offers an inline reply affordance on each post", async () => {
+    mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
+    await screen.findByText("Rotate the tokens before Friday.")
+    // Collapsed to a single line until activated — the heavy composer mounts only on click.
+    expect(screen.getByRole("button", { name: "Reply…" })).toBeTruthy()
+  })
+
   it("collapses the middle as an 'N more messages' expander, pluralizing the count", async () => {
     // 5 messages: opening + 3 recent shown + 1 hidden in the middle.
     const recent = [

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -147,8 +147,9 @@ describe("BoardPage", () => {
   it("offers an inline reply affordance on each post", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     await screen.findByText("Rotate the tokens before Friday.")
-    // Collapsed to a single line until activated — the heavy composer mounts only on click.
-    expect(screen.getByRole("button", { name: "Reply…" })).toBeTruthy()
+    // Collapsed to a single resting line until activated — the heavy composer
+    // mounts only on click. Mirrors the composer's own placeholder copy.
+    expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
   })
 
   it("collapses the middle as an 'N more messages' expander, pluralizing the count", async () => {


### PR DESCRIPTION
Implements the **board-view design** step 3 ("Reply in place") for authored posts — the first act-from-the-board affordance on top of the read-only/authored board (#1062, #1080).

## Problem

The board (`apps/frontend/src/pages/board.tsx`) renders each conversation as a feed post (`BoardCard`), but there was no way to reply to one from the board — you had to open the source stream. A reply also can't land just anywhere: a conversation lives somewhere specific (flat in a channel/DM, or inside a thread), and a reply needs to follow that shape. Dropping every channel reply into a new thread (or every reply into the top-level stream) is wrong in opposite ways — the former sprouts a stray thread on an otherwise-flat conversation; the latter interleaves a reply into a busy channel where it doesn't belong.

## Solution

An inline reply composer on every board card, plus a placement rule that follows where the conversation already lives.

The composer is collapsed to a single line (`Reply…`) and expands the full `MessageComposer` in place on click, so a feed of N cards costs N lightweight buttons rather than N mounted editors — the heavy editor mounts only once a card is activated.

The routing rule was sharpened by a data-model fact: **a conversation owns exactly one stream.** Its messages are wholly flat or wholly inside a thread, and a thread is always its *own* conversation (`ConversationRepository` keys every conversation to one `streamId`; the boundary extractor assigns a thread message to the thread stream's conversation, not the parent's — `boundary-extraction-service.ts:328-336`). So a conversation can never be "msgs 1–3 flat + msg 4 threaded" — that 4th threaded message is, by construction, a different conversation (a different board card). The "weighted average / center of gravity" the placement intuitively wanted therefore collapses to the host stream type plus whether the conversation is still a lone root — all computable from data already on the card (`hostStreamType` + `conversation.messageIds.length`), so this is frontend-only with no backend or schema change.

### How it works

**Placement — `planBoardReply(...)` (pure, in `use-conversations.ts`):**

- **thread conversation** → into the thread (it IS the thread)
- **flat conversation with replies** (channel/DM, ≥2 messages) → flat in its stream, attached to the conversation
- **scratchpad** → always flat (scratchpads don't thread)
- **a lone root** in a channel/DM (≤1 message, opening message present) → start a thread off the opening message
- a lone root whose opening message was deleted (no anchor) → flat

Everything but the lone-root case is the **same send** — into the conversation's own stream attached via the `existing` conversation directive (added in #1080: `conversation: { intent: "existing", conversationId }`, validated + assigned + activity-bumped synchronously in the send txn by `conversation-assigner.ts`). Only a lone channel/DM root diverges into a new thread.

**Send — `useReplyToBoardPost(workspaceId)`:**

- `newThread` plan → `streamService.create({ type: THREAD, parentStreamId, parentMessageId })`, then `messageService.create` into the returned thread. Thread creation is idempotent server-side on `(parent_stream_id, parent_message_id)` (`StreamRepository.insertThreadOrFind` — `ON CONFLICT … DO NOTHING` then find), so this can't double-create a thread if one already exists off that message.
- `intoConversation` plan → `messageService.create(workspaceId, conversation.streamId, { …, conversation: { intent: "existing", conversationId } })`.
- Both carry a `clientMessageId` (idempotent retry) and return the created `Message`.

**In-place display:** on a successful reply the card appends the returned message to a local `localReplies` list (deduped against what a refetch already carries), so the user sees their reply land without a board refetch. No cross-card/cache writes — board-wide liveness is deferred (see Out of scope).

### Key design decisions

**1. Follow the conversation, not the host type alone.** The first cut threaded *every* channel reply, which dropped a stray thread onto flat channel conversations — exactly the "weird branch" failure called out in review. Corrected to `planBoardReply` after verifying conversations are single-stream (so the placement is fully determined by host type + lone-root). User ruling: "if it's mainly in a thread, post in a thread; if it's mainly flat, post in the top-level stream; if there's just the one message, post it as a thread — except scratchpads."

**2. Lone root → new thread (channel/DM).** A single message has no established shape, and threading a bare message keeps the channel from sprouting a stray top-level reply. Tradeoff (accepted, user's "I foresee some junk… we can get to that later"): that reply forms a *new* thread conversation, so it won't join the original one-message card — it surfaces as its own thread card on the next board load.

**3. Reuse, no parallel impl.** The composer reuses `MessageComposer` + `useDraftComposer` (per-conversation durable draft `board:reply:${conversationId}`); placement reuses #1080's `existing` directive and the existing idempotent thread-create path. Send-mode follows `preferences?.messageSendMode ?? "enter"` like the timeline/thread composer (a reply is conversational), not the new-post composer's hardcoded `cmdEnter`.

**4. Collapsed-until-activated (INV-21-friendly, perf).** Matches the existing `BoardComposer` open/close pattern; avoids mounting a rich editor per card.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Inline collapsed→expand reply composer for a board card; calls `useReplyToBoardPost`, surfaces the sent message via `onReplied`. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-conversations.ts` | Add `planBoardReply` (pure placement rule), `useReplyToBoardPost` (routed send), `ReplyToBoardPostInput`/`BoardReplyPlan` types; import `useStreamService` + `Message`. |
| `apps/frontend/src/components/board/board-card.tsx` | Mount `BoardReplyComposer`; append a sent reply to a local `localReplies` list (deduped) and render it in place. |
| `apps/frontend/src/hooks/use-conversations.test.tsx` | `planBoardReply` unit suite (5 cases) + `useReplyToBoardPost` dispatch suite (3 cases). |
| `apps/frontend/src/pages/board.test.tsx` | Assert each post renders the collapsed `Reply…` affordance. |

## Out of scope (deliberate)

- **Board-wide liveness / cross-card optimism.** A reply shows on its own card only; the board still refreshes on open/reconnect (no socket sub yet — see `docs/board-view-design.md` "Realtime / sync model"). Deferred follow-up; no cache writes here.
- **Lone-root reconciliation.** A lone-root reply starts a new thread conversation and won't fold back into the original card until the next board load (decision 2).
- **E2E streams.** The board's derived conversations exclude E2E streams (extractor runs on non-E2E only), and the composer doesn't seal — same exclusion as the new-post composer.

## Test plan

- [x] `apps/frontend` typecheck (`tsc --noEmit`) clean
- [x] `vitest run use-conversations.test.tsx board.test.tsx components/board` — 33 pass (planBoardReply ×5, useReplyToBoardPost ×3, board page reply affordance ×1, plus prior board/conversation suites)
- [x] Full pre-commit suite on both commits: all-workspace lint + monorepo typecheck (incl. `apps/backend` tsconfig.tests) + astro check + migrations check + OpenAPI `--check` — green
- [x] ESLint on changed files — clean
- [ ] Not run live in-app — no logged-in board harness available this session (flag-gated surface). Behavior covered by the hook/placement unit tests and the page mount test.

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Make it possible to reply to a conversation from the board view, routing the reply to the appropriate place (board-view design step 3, "Reply in place").

**What was built:**
- Inline reply composer per board card, collapsed to one line, expands the real `MessageComposer` on focus/click (user: "just one line without much chrome, then you focus it and it takes space — let's try that first"). Heavy editor mounts only on activation.
- `planBoardReply` placement rule + `useReplyToBoardPost` send hook.
- Sent reply shown in place on the card.

**Design decisions:**
- Reply placement follows where the conversation lives (user ruling), not host type alone.
- Verified via code (boundary-extraction-service, ConversationRepository, StreamRepository) that a conversation owns exactly one stream and threads are always separate conversations → the "weighted-average" rule reduces to host-type + lone-root, computable client-side. No backend change.
- Lone channel/DM root → new thread; flat-with-replies → flat; thread → into thread; scratchpad → flat.
- Reuse `MessageComposer`/`useDraftComposer`, #1080's `existing` directive, and the idempotent `insertThreadOrFind` path. Send-mode = user preference (default Enter).

**Design evolution:**
- First cut routed by host type only (channel → always thread). Corrected mid-PR after the user flagged it would drop a stray thread onto flat channel conversations; replaced with `planBoardReply`.

**Schema changes:** none. Frontend-only.

**What's NOT included:** board-wide realtime/optimism; lone-root reconciliation; E2E reply targets. (See Out of scope.)

**Status:** Complete; two commits on branch, full pre-commit suite green.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGFbPpiXFd5fWrfxdqAxWJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785089209&installation_id=129946197&pr_number=1098&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1098&signature=fcf5b2002248decb1f98d14a27592352fb37381caa66a884509fed3b32ae1147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->