### PR TITLE
fix(timeline): unstick jump-to-message for out-of-window targets (skeleton-forever) + double-render shift

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   classifyDeepLinkScrollTick,
   shouldStartHighlightClear,
+  canActOnDeepLinkNavigation,
   computeScrollEdges,
   shouldPrefetchOlderHistory,
   shouldShowOlderSkeletons,
@@ -156,6 +157,34 @@ describe("shouldStartHighlightClear", () => {
         deepLinkGaveUp: true,
       })
     ).toBe(true)
+  })
+})
+
+describe("canActOnDeepLinkNavigation", () => {
+  const base = { highlightMessageId: "msg_1", isLoading: false, isDraft: false, hasEvents: true }
+
+  it("acts once the event window has hydrated", () => {
+    expect(canActOnDeepLinkNavigation(base)).toBe(true)
+  })
+
+  it("does not act without a highlight target", () => {
+    for (const highlightMessageId of [null, undefined, ""] as const) {
+      expect(canActOnDeepLinkNavigation({ ...base, highlightMessageId })).toBe(false)
+    }
+  })
+
+  it("does not act while loading or on a draft stream", () => {
+    expect(canActOnDeepLinkNavigation({ ...base, isLoading: true })).toBe(false)
+    expect(canActOnDeepLinkNavigation({ ...base, isDraft: true })).toBe(false)
+  })
+
+  it("defers while the window is still empty (regression: out-of-window target stuck behind holdForDeepLink)", () => {
+    // On a cold deep-link `isLoading` can read false before the IDB live-query
+    // resolves. Claiming the navigation then — with no window to scroll within
+    // or jump from — stamped the once-per-key guard and blocked the retry once
+    // events arrived, leaving an out-of-window target blank forever. The effect
+    // must stay re-armed until there is a window to act on.
+    expect(canActOnDeepLinkNavigation({ ...base, hasEvents: false })).toBe(false)
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -173,6 +173,26 @@ export function shouldStartHighlightClear(args: {
   return args.deepLinkTargetLoaded || args.deepLinkGaveUp
 }
 
+/**
+ * Whether the deep-link / search highlight effect may claim a navigation and
+ * act on it this render. The event window must have hydrated first: on a cold
+ * open `isLoading` can read false while `events` is still empty (the IDB
+ * live-query hasn't resolved). Claiming the navigation then — stamping the
+ * once-per-`location.key` guard — with nothing to act on (no window to scroll
+ * within, none to jump from) would block the retry once events arrive, leaving
+ * an out-of-window target stranded behind `holdForDeepLink`. Gating on
+ * `hasEvents` keeps the effect re-armed until there is a window to act on.
+ */
+export function canActOnDeepLinkNavigation<T extends string>(args: {
+  highlightMessageId: T | null | undefined
+  isLoading: boolean
+  isDraft: boolean
+  hasEvents: boolean
+}): args is { highlightMessageId: T; isLoading: boolean; isDraft: boolean; hasEvents: boolean } {
+  if (!args.highlightMessageId || args.isLoading || args.isDraft) return false
+  return args.hasEvents
+}
+
 /** Lead distance (px) from either edge of the scroll range at which the next
  *  page is prefetched, so it lands before a fast scroll reaches the boundary. */
 export const EDGE_PREFETCH_PX = 1500
@@ -1440,8 +1460,13 @@ export function StreamContent({
   // (which produce identical URLs and would otherwise not change any state)
   // still re-trigger — react-router stamps each navigation with a fresh key.
   useEffect(() => {
-    if (!highlightMessageId || isLoading || isDraft) return
+    // Gate on a hydrated window (see canActOnDeepLinkNavigation) BEFORE the
+    // once-per-key claim below, so a cold open with `events` still empty doesn't
+    // claim the navigation and then block its own retry once events arrive.
+    const nav = { highlightMessageId, isLoading, isDraft, hasEvents: events.length > 0 }
+    if (!canActOnDeepLinkNavigation(nav)) return
     if (jumpTriggeredKeyRef.current === location.key) return
+    const targetMessageId = nav.highlightMessageId
     const navigationKey = location.key
     jumpTriggeredKeyRef.current = navigationKey
     // Fresh navigation: re-arm the mount hold for this target and clear any
@@ -1455,37 +1480,36 @@ export function StreamContent({
     // Check if the message is already visible in current events
     const isVisible = events.some((e) => {
       const payload = e.payload as { messageId?: string }
-      return payload?.messageId === highlightMessageId
+      return payload?.messageId === targetMessageId
     })
 
     if (isVisible) {
-      deepLinkDebug("highlight: target already in window, scrolling directly", highlightMessageId)
-      scrollToMessage(highlightMessageId)
+      deepLinkDebug("highlight: target already in window, scrolling directly", targetMessageId)
+      scrollToMessage(targetMessageId)
       return
     }
 
-    if (events.length > 0) {
-      deepLinkDebug("highlight: target out of window, jumping", highlightMessageId)
-      pendingScrollTarget.current = highlightMessageId
-      jumpToEvent(highlightMessageId)
-        .then((success) => {
-          // A newer navigation may have superseded this request while it was
-          // in flight; its stale completion must not clear the new target or
-          // release the new mount hold.
-          if (jumpTriggeredKeyRef.current !== navigationKey) return
-          deepLinkDebug("highlight: jumpToEvent resolved", highlightMessageId, "success=", success)
-          if (!success) {
-            pendingScrollTarget.current = null
-            setDeepLinkGaveUp(true)
-          }
-        })
-        .catch(() => {
-          if (jumpTriggeredKeyRef.current !== navigationKey) return
-          deepLinkDebug("highlight: jumpToEvent rejected", highlightMessageId)
+    // Target is outside the loaded window — fetch a window around it, then scroll.
+    deepLinkDebug("highlight: target out of window, jumping", targetMessageId)
+    pendingScrollTarget.current = targetMessageId
+    jumpToEvent(targetMessageId)
+      .then((success) => {
+        // A newer navigation may have superseded this request while it was
+        // in flight; its stale completion must not clear the new target or
+        // release the new mount hold.
+        if (jumpTriggeredKeyRef.current !== navigationKey) return
+        deepLinkDebug("highlight: jumpToEvent resolved", highlightMessageId, "success=", success)
+        if (!success) {
           pendingScrollTarget.current = null
           setDeepLinkGaveUp(true)
-        })
-    }
+        }
+      })
+      .catch(() => {
+        if (jumpTriggeredKeyRef.current !== navigationKey) return
+        deepLinkDebug("highlight: jumpToEvent rejected", highlightMessageId)
+        pendingScrollTarget.current = null
+        setDeepLinkGaveUp(true)
+      })
   }, [highlightMessageId, location.key, isLoading, isDraft, events, jumpToEvent, disableAutoScroll, scrollToMessage])
 
   // Reset jump and search state when switching streams (component stays mounted).

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1498,7 +1498,7 @@ export function StreamContent({
         // in flight; its stale completion must not clear the new target or
         // release the new mount hold.
         if (jumpTriggeredKeyRef.current !== navigationKey) return
-        deepLinkDebug("highlight: jumpToEvent resolved", highlightMessageId, "success=", success)
+        deepLinkDebug("highlight: jumpToEvent resolved", targetMessageId, "success=", success)
         if (!success) {
           pendingScrollTarget.current = null
           setDeepLinkGaveUp(true)
@@ -1506,7 +1506,7 @@ export function StreamContent({
       })
       .catch(() => {
         if (jumpTriggeredKeyRef.current !== navigationKey) return
-        deepLinkDebug("highlight: jumpToEvent rejected", highlightMessageId)
+        deepLinkDebug("highlight: jumpToEvent rejected", targetMessageId)
         pendingScrollTarget.current = null
         setDeepLinkGaveUp(true)
       })

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest"
+import { StrictMode } from "react"
 import { act, render } from "@testing-library/react"
 import { useTimelineScroll } from "./use-timeline-scroll"
 
@@ -21,6 +22,42 @@ function renderScrollHook(initialOptions: Options): {
       return ref.current
     },
     rerender: (options: Options) => act(() => utils.rerender(<Probe options={options} />)),
+  }
+}
+
+/**
+ * Same as renderScrollHook, but mounted under StrictMode so every render is
+ * double-invoked — the condition that exposed the `shift` regression where
+ * the prepend baseline was tracked with a during-render ref write (the second
+ * pass read the first pass's value and collapsed shift to false).
+ */
+function renderScrollHookStrict(initialOptions: Options): {
+  current: HookApi
+  rerender: (options: Options) => void
+} {
+  const ref: { current: HookApi | undefined } = { current: undefined }
+  function Probe({ options }: { options: Options }) {
+    ref.current = useTimelineScroll(options)
+    return null
+  }
+  const utils = render(
+    <StrictMode>
+      <Probe options={initialOptions} />
+    </StrictMode>
+  )
+  return {
+    get current(): HookApi {
+      if (!ref.current) throw new Error("Probe did not capture the hook return value")
+      return ref.current
+    },
+    rerender: (options: Options) =>
+      act(() =>
+        utils.rerender(
+          <StrictMode>
+            <Probe options={options} />
+          </StrictMode>
+        )
+      ),
   }
 }
 
@@ -58,6 +95,20 @@ describe("useTimelineScroll — shift (prepend) detection", () => {
     // Leave the live tail (reading history).
     act(() => harness.current.disableAutoScroll())
     // Older page lands: the first row's identity changes from e10 to e0.
+    harness.rerender(opts({ itemCount: 60, getFirstKey: () => "e0" }))
+    expect(harness.current.shift).toBe(true)
+  })
+
+  it("still shifts on a prepend under StrictMode double-render", () => {
+    // Regression guard: tracking the prepend baseline with a during-render ref
+    // write made the StrictMode second pass see firstKey === prevFirstKey, so
+    // the committed render carried shift=false and virtua skipped the scroll
+    // compensation — the viewport jumped on every older-page prepend. The
+    // baseline now updates in a layout effect (once per commit), so both passes
+    // compare against the same prior-commit value.
+    const harness = renderScrollHookStrict(opts({ itemCount: 0, getFirstKey: () => null }))
+    harness.rerender(opts({ itemCount: 50, getFirstKey: () => "e10" }))
+    act(() => harness.current.disableAutoScroll())
     harness.rerender(opts({ itemCount: 60, getFirstKey: () => "e0" }))
     expect(harness.current.shift).toBe(true)
   })

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -1,65 +1,40 @@
 import { describe, it, expect, vi } from "vitest"
-import { StrictMode } from "react"
+import { StrictMode, type ReactNode } from "react"
 import { act, render } from "@testing-library/react"
 import { useTimelineScroll } from "./use-timeline-scroll"
 
 type Options = Parameters<typeof useTimelineScroll>[0]
 type HookApi = ReturnType<typeof useTimelineScroll>
 
-function renderScrollHook(initialOptions: Options): {
-  current: HookApi
-  rerender: (options: Options) => void
-} {
+function renderScrollHookWith(
+  initialOptions: Options,
+  wrap: (node: ReactNode) => ReactNode = (node) => node
+): { current: HookApi; rerender: (options: Options) => void } {
   const ref: { current: HookApi | undefined } = { current: undefined }
   function Probe({ options }: { options: Options }) {
     ref.current = useTimelineScroll(options)
     return null
   }
-  const utils = render(<Probe options={initialOptions} />)
+  const utils = render(wrap(<Probe options={initialOptions} />))
   return {
     get current(): HookApi {
       if (!ref.current) throw new Error("Probe did not capture the hook return value")
       return ref.current
     },
-    rerender: (options: Options) => act(() => utils.rerender(<Probe options={options} />)),
+    rerender: (options: Options) => act(() => utils.rerender(wrap(<Probe options={options} />))),
   }
 }
 
+const renderScrollHook = (initialOptions: Options) => renderScrollHookWith(initialOptions)
+
 /**
- * Same as renderScrollHook, but mounted under StrictMode so every render is
- * double-invoked — the condition that exposed the `shift` regression where
- * the prepend baseline was tracked with a during-render ref write (the second
- * pass read the first pass's value and collapsed shift to false).
+ * Mounts the hook under StrictMode so every render is double-invoked — the
+ * condition that exposed the `shift` regression where the prepend baseline was
+ * tracked with a during-render ref write (the second pass read the first pass's
+ * value and collapsed shift to false).
  */
-function renderScrollHookStrict(initialOptions: Options): {
-  current: HookApi
-  rerender: (options: Options) => void
-} {
-  const ref: { current: HookApi | undefined } = { current: undefined }
-  function Probe({ options }: { options: Options }) {
-    ref.current = useTimelineScroll(options)
-    return null
-  }
-  const utils = render(
-    <StrictMode>
-      <Probe options={initialOptions} />
-    </StrictMode>
-  )
-  return {
-    get current(): HookApi {
-      if (!ref.current) throw new Error("Probe did not capture the hook return value")
-      return ref.current
-    },
-    rerender: (options: Options) =>
-      act(() =>
-        utils.rerender(
-          <StrictMode>
-            <Probe options={options} />
-          </StrictMode>
-        )
-      ),
-  }
-}
+const renderScrollHookStrict = (initialOptions: Options) =>
+  renderScrollHookWith(initialOptions, (node) => <StrictMode>{node}</StrictMode>)
 
 /** A div whose scroll metrics are mockable (jsdom has no layout). */
 function makeScrollerDiv(metrics: { scrollHeight: number; clientHeight: number; scrollTop?: number }) {

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -224,8 +224,20 @@ export function useTimelineScroll({
       shift = true
     }
   }
-  prevFirstKeyRef.current = firstKey
-  prevCountRef.current = itemCount
+  // Record the first-key/count baseline in a layout effect (once per commit),
+  // never during render. React can render this component twice before it
+  // commits — StrictMode in dev, a concurrent re-render in prod — and a
+  // during-render write let the second pass read the first pass's value, so
+  // `firstKey === prevFirstKeyRef.current` and `shift` collapsed to false on
+  // the pass that actually committed. virtua then got `shift=false` and skipped
+  // the scroll compensation, so an older-page prepend jumped the viewport. One
+  // commit → one baseline write keeps both passes comparing against the same
+  // prior-commit value. The stream-switch reset above stays in render (it must
+  // zero the baseline before this render's shift check) and is idempotent.
+  useLayoutEffect(() => {
+    prevFirstKeyRef.current = firstKey
+    prevCountRef.current = itemCount
+  })
 
   // The single pin. Go to the absolute bottom: scrollTop = scrollHeight is
   // browser-clamped to the true maximum, which includes the composer footer

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -224,16 +224,15 @@ export function useTimelineScroll({
       shift = true
     }
   }
-  // Record the first-key/count baseline in a layout effect (once per commit),
-  // never during render. React can render this component twice before it
-  // commits — StrictMode in dev, a concurrent re-render in prod — and a
-  // during-render write let the second pass read the first pass's value, so
-  // `firstKey === prevFirstKeyRef.current` and `shift` collapsed to false on
-  // the pass that actually committed. virtua then got `shift=false` and skipped
-  // the scroll compensation, so an older-page prepend jumped the viewport. One
-  // commit → one baseline write keeps both passes comparing against the same
-  // prior-commit value. The stream-switch reset above stays in render (it must
-  // zero the baseline before this render's shift check) and is idempotent.
+  // Record the baseline once per commit, in a layout effect — not during
+  // render. React may render this component twice before committing (StrictMode
+  // in dev, a concurrent re-render in prod); a during-render write would let a
+  // later pass read an earlier pass's value, so `shift` would compare against a
+  // baseline from the same uncommitted render instead of the prior committed
+  // one. A layout effect writes exactly once per commit, so every render's
+  // `shift` is measured against the last COMMITTED first key. The stream-switch
+  // reset above stays in render — it must zero the baseline before this render's
+  // shift check — and is idempotent across the double render.
   useLayoutEffect(() => {
     prevFirstKeyRef.current = firstKey
     prevCountRef.current = itemCount


### PR DESCRIPTION
## Problem

**Jumping to a message that isn't already loaded in the window left the timeline blank — permanently.** This is every "go to a message from way back" affordance: the **Saved** view (`saved-item.tsx`), **push-notification** deep-links (`sw.ts`), the **message timestamp permalink**, the **activity feed**, **trace steps**, and the **attachment explorer** — all navigate to `/w/{ws}/s/{stream}?m=<messageId>`, which drives the deep-link highlight effect in `stream-content.tsx`. In-stream **search** uses the same `?m=` path; it felt fine because search results are usually recent (already in-window), so they never hit the bug — but search to an older result was broken the same way and is fixed here too. This was broken in production and predates the cold-load fix (#1096) — the regression the timeline work kept stepping around.

Two distinct bugs, both reproduced deterministically against the dev:test stack with frame-by-frame DOM + network + per-render instrumentation:

**1. Deep-link claim race (the prod regression — go-to-message + search).**
The highlight effect stamped `jumpTriggeredKeyRef.current = location.key` (the once-per-navigation guard) **before** it checked that the event window had hydrated. On a cold open `isLoading` reads `false` while `events` is still empty (the IDB live-query hasn't resolved yet), so the effect claimed the navigation, found nothing to act on (`isVisible` false, no window to jump from), and then the guard blocked its own retry once `events` populated — `jumpToEvent` never fired and `holdForDeepLink` never released. An **in-window** target still rendered (it's already on screen, `deepLinkTargetLoaded` true → no hold), which is why it looked intermittent; an **out-of-window** target — the common case for "go to message" and search-to-an-older-message — blanked forever.

```
run 1: isLoading:false  guardHit:false  eventsLen:0   ← claims the nav, events still empty, does nothing
run 5: isLoading:false  guardHit:true   eventsLen:50  ← events arrive, but the guard now blocks the retry → blank
```

**2. virtua `shift` dropped under double-render (older-prepend anchoring).**
Scrolling up, or a jump landing near the top of its window, snapped the viewport to much older messages. The prepend detector in `use-timeline-scroll.ts` tracked its first-key/count baseline with a **during-render ref write**. React renders this component twice before committing (StrictMode in dev; a concurrent re-render in prod), so the second pass read the first pass's write, saw `firstKey === prevFirstKeyRef.current`, and committed `shift=false`. virtua then skipped the scroll compensation:

```
before prepend:  scrollTop=92    scrollHeight=3094   top-visible #72
after  prepend:  scrollTop=92    scrollHeight=5969   top-visible #22   ← +2875px added above, scrollTop unchanged
```

This one only bites under a double-render, so a prod (no-StrictMode) build mostly escaped it — but it's an unsafe React pattern and it broke local testing and reverse-infinite-scroll under dev.

## Solution

**Bug 1** — gate the highlight effect on a hydrated window *before* it claims the navigation, via a new pure predicate `canActOnDeepLinkNavigation({ highlightMessageId, isLoading, isDraft, hasEvents })`. With `events` empty the effect returns without stamping `jumpTriggeredKeyRef`, so it stays re-armed (through the `events` dep) and fires `jumpToEvent` the moment there's a window to act on. The predicate is a type guard so the message id narrows to `string` for the rest of the effect.

**Bug 2** — move the first-key/count baseline write out of render into a `useLayoutEffect` (one write per commit). Both render passes now compare against the same prior-commit baseline, so `shift=true` survives to the committed render and virtua anchors the prepend. The stream-switch reset stays in render (it must zero the baseline before this render's shift check) and is idempotent.

### How it works

- `canActOnDeepLinkNavigation` returns false while `events.length === 0`; the effect's existing `events` dependency re-runs it once the IDB window resolves, at which point it claims the key and either `scrollToMessage` (in window) or `jumpToEvent` (out of window). `holdForDeepLink` releases as soon as the target lands in the window.
- The shift baseline (`prevFirstKeyRef`, `prevCountRef`) updates in `useLayoutEffect(() => {…})` — runs once per commit, after all render passes — instead of two assignments in the render body. The `shift` value virtua receives is computed during render against the last committed baseline, identical across both passes.

### Key design decisions

**1. A predicate, not just an inline guard** — the codebase extracts every deep-link decision into a tested pure function (`classifyDeepLinkScrollTick`, `shouldStartHighlightClear`, `shouldPrefetchOlderHistory`). `canActOnDeepLinkNavigation` follows that pattern and carries a unit regression test; making it a type guard keeps the effect body's `string` narrowing.

**2. Layout effect over render-phase ref write** — the prepend detector inherently compares to the previous render, but a render-phase write is unsafe when React renders twice before commit. A layout effect is the safe place to record per-commit state. The reset-on-stream-switch stays in render because it must run *before* this render's shift check, and it is idempotent under double-render.

**3. Scope** — `stream-store.ts` (the #1096 cold-load fix) is untouched; this branch is only the deep-link/scroll-engine changes. Verified the cold-load ascending-order behaviour still holds (no #1096 regression).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Add `canActOnDeepLinkNavigation` type-guard predicate; gate the highlight effect on a hydrated window before claiming the navigation |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | Unit tests for `canActOnDeepLinkNavigation` incl. the empty-window regression |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | Move the shift baseline write from render into a `useLayoutEffect` |
| `apps/frontend/src/hooks/use-timeline-scroll.test.tsx` | StrictMode-wrapped regression test: `shift` survives a prepend under double-render |

## Test plan

- [x] `apps/frontend` — `stream-content.test.ts`, `use-timeline-scroll.test.tsx`, `event-list.test.ts`, `stream-store.test.ts`: **120 pass**
- [x] New StrictMode shift guard **fails against the pre-fix code** (`expected false to be true`), passes after — confirmed it's a real regression guard
- [x] Headless repro — out-of-window jump (`?m=` to msg #5, not in the warm window): **lands and stays on the target** (was blank forever); deterministic ×4
- [x] Headless repro — in-window go-to-message (`?m=` to msg #85): lands and stays, centered; ×5
- [x] Headless repro — passive older-prepend (StrictMode on): viewport **anchors** (top-visible holds, scrollTop compensates the prepended height)
- [x] Cold-load order oracle (#1096): `docOrderAsc:true` from the first frame — no regression
- [x] `tsc --noEmit` + lint across all apps/packages (pre-commit) — clean
- [ ] Live staging confirmation on a real account — **verify on staging** (this PR carries the `staging` label): hard-refresh a deep-link to an old message, and click a search result for a message outside the loaded window

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
