### PR TITLE
feat(board): put conversations on the sync-engine rails for live updates

### DIFF
--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -1,10 +1,10 @@
 import type { PoolClient } from "pg"
-import { StreamTypes } from "@threa/types"
 import { ConversationRepository, type Conversation } from "./repository"
 import { StreamRepository } from "../streams"
-import { MessageRepository, type Message } from "../messaging"
+import { type Message } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields } from "./staleness"
+import { resolveConversationDelivery } from "./conversation-delivery"
 
 /**
  * Emit the conversation aggregate + per-message membership events for a single
@@ -24,19 +24,8 @@ export async function emitAssignmentEvents(
 ): Promise<Conversation> {
   const { workspaceId, message, conversationId, created, reason } = params
 
-  // Resolve the access-root stream's visibility (INV-62): for a thread that's the
-  // parent channel, otherwise the stream itself. It gates workspace-wide board
-  // delivery — public conversations reach the whole workspace, others stay
-  // scoped to the stream's members.
-  let parentStreamId: string | undefined
   const stream = await StreamRepository.findById(client, message.streamId)
-  let rootStream = stream
-  if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
-    const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
-    parentStreamId = parentMessage?.streamId
-    rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
-  }
-  const streamVisibility = rootStream?.visibility
+  const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
 
   const [refreshed] = await ConversationRepository.findByIds(client, workspaceId, [conversationId])
   if (!refreshed) {

--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -24,12 +24,19 @@ export async function emitAssignmentEvents(
 ): Promise<Conversation> {
   const { workspaceId, message, conversationId, created, reason } = params
 
+  // Resolve the access-root stream's visibility (INV-62): for a thread that's the
+  // parent channel, otherwise the stream itself. It gates workspace-wide board
+  // delivery — public conversations reach the whole workspace, others stay
+  // scoped to the stream's members.
   let parentStreamId: string | undefined
   const stream = await StreamRepository.findById(client, message.streamId)
+  let rootStream = stream
   if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
     const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
     parentStreamId = parentMessage?.streamId
+    rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
   }
+  const streamVisibility = rootStream?.visibility
 
   const [refreshed] = await ConversationRepository.findByIds(client, workspaceId, [conversationId])
   if (!refreshed) {
@@ -43,6 +50,7 @@ export async function emitAssignmentEvents(
     conversationId: refreshed.id,
     conversation: addStalenessFields(refreshed),
     parentStreamId,
+    streamVisibility,
   })
   await OutboxRepository.insert(client, "conversation:message_assigned", {
     workspaceId,

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -497,12 +497,17 @@ export class BoundaryExtractionService {
       const touchedIds = Array.from(touchedConversationIds)
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      // For thread conversations, include parent channel's stream ID for discoverability.
+      // For thread conversations, include parent channel's stream ID for
+      // discoverability, and resolve the access-root stream's visibility (INV-62)
+      // — it gates workspace-wide board delivery of the aggregate events below.
       let parentStreamId: string | undefined
+      let rootStream: Stream | null = stream
       if (stream.type === StreamTypes.THREAD && stream.parentMessageId) {
         const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
         parentStreamId = parentMessage?.streamId
+        rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
       }
+      const streamVisibility = rootStream?.visibility
 
       const primaryAssignment = resolvedAssignments.find((a) => a.isPrimary)
       const primaryConvId = primaryAssignment?.conversationId ?? null
@@ -517,6 +522,7 @@ export class BoundaryExtractionService {
           conversationId: conv.id,
           conversation: addStalenessFields(conv),
           parentStreamId,
+          streamVisibility,
         })
       }
 

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -17,6 +17,7 @@ import type {
 } from "./boundary-extraction/types"
 import { collectQuoteReplyMessageIds } from "@threa/prosemirror"
 import { addStalenessFields } from "./staleness"
+import { resolveConversationDelivery } from "./conversation-delivery"
 import { emitAssignmentEvents } from "./assignment-events"
 import { conversationId } from "../../lib/id"
 import { AuthorTypes, ConversationStatuses, StreamTypes } from "@threa/types"
@@ -497,17 +498,9 @@ export class BoundaryExtractionService {
       const touchedIds = Array.from(touchedConversationIds)
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      // For thread conversations, include parent channel's stream ID for
-      // discoverability, and resolve the access-root stream's visibility (INV-62)
-      // — it gates workspace-wide board delivery of the aggregate events below.
-      let parentStreamId: string | undefined
-      let rootStream: Stream | null = stream
-      if (stream.type === StreamTypes.THREAD && stream.parentMessageId) {
-        const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
-        parentStreamId = parentMessage?.streamId
-        rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
-      }
-      const streamVisibility = rootStream?.visibility
+      // Parent channel (thread discoverability) + access-root visibility (INV-62),
+      // which gates workspace-wide board delivery of the aggregate events below.
+      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
 
       const primaryAssignment = resolvedAssignments.find((a) => a.isPrimary)
       const primaryConvId = primaryAssignment?.conversationId ?? null

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -498,9 +498,25 @@ export class BoundaryExtractionService {
       const touchedIds = Array.from(touchedConversationIds)
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      // Parent channel (thread discoverability) + access-root visibility (INV-62),
-      // which gates workspace-wide board delivery of the aggregate events below.
-      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+      // Parent channel (thread discoverability) + access-root visibility (INV-62)
+      // for the new message's stream — used by its per-message events below.
+      const { parentStreamId } = await resolveConversationDelivery(client, stream)
+
+      // A touched conversation can live in a DIFFERENT stream than the triggering
+      // one (a reassigned context-window message from another channel), so each
+      // aggregate event must route by its OWN access root — using the triggering
+      // stream's visibility would broadcast a private conversation to the whole
+      // workspace (INV-62). Resolve per stream, memoized for the common case.
+      const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+      const deliveryFor = async (conversationStreamId: string) => {
+        const cached = deliveryByStreamId.get(conversationStreamId)
+        if (cached) return cached
+        const conversationStream =
+          conversationStreamId === stream.id ? stream : await StreamRepository.findById(client, conversationStreamId)
+        const resolved = await resolveConversationDelivery(client, conversationStream)
+        deliveryByStreamId.set(conversationStreamId, resolved)
+        return resolved
+      }
 
       const primaryAssignment = resolvedAssignments.find((a) => a.isPrimary)
       const primaryConvId = primaryAssignment?.conversationId ?? null
@@ -509,12 +525,13 @@ export class BoundaryExtractionService {
       for (const conv of touchedConversations) {
         const isNewThisCall = newConversation?.id === conv.id
         const eventType = isNewThisCall ? "conversation:created" : "conversation:updated"
+        const { parentStreamId: convParentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
         await OutboxRepository.insert(client, eventType, {
           workspaceId,
           streamId: conv.streamId,
           conversationId: conv.id,
           conversation: addStalenessFields(conv),
-          parentStreamId,
+          parentStreamId: convParentStreamId,
           streamVisibility,
         })
       }

--- a/apps/backend/src/features/conversations/conversation-delivery.ts
+++ b/apps/backend/src/features/conversations/conversation-delivery.ts
@@ -1,0 +1,28 @@
+import type { Querier } from "@threa/backend-common"
+import { StreamTypes, type Visibility } from "@threa/types"
+import { StreamRepository, type Stream } from "../streams"
+import { MessageRepository } from "../messaging"
+
+/**
+ * Resolve the routing dimensions a `conversation:created`/`updated` event needs:
+ * the parent channel's stream id (for thread discoverability) and the
+ * **access-root** stream's visibility (INV-62) — the parent channel for a thread,
+ * the stream itself otherwise. Visibility gates workspace-wide board delivery in
+ * `delivery-groups.ts`: a public root reaches the whole workspace, anything else
+ * stays scoped to the stream's members.
+ *
+ * The single home for the thread→root rule, shared by the synchronous assigner,
+ * the async boundary extractor, and the reassign path so the three can't drift.
+ */
+export async function resolveConversationDelivery(
+  client: Querier,
+  stream: Stream | null
+): Promise<{ parentStreamId: string | undefined; streamVisibility: Visibility | undefined }> {
+  if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
+    const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
+    const parentStreamId = parentMessage?.streamId
+    const parentStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : null
+    return { parentStreamId, streamVisibility: parentStream?.visibility }
+  }
+  return { parentStreamId: undefined, streamVisibility: stream?.visibility }
+}

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -8,6 +8,7 @@ import { AttachmentRepository, toAttachmentSummary } from "../attachments"
 import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
+import { resolveConversationDelivery } from "./conversation-delivery"
 import { conversationFeedbackId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
 import { StreamTypes, type AttachmentSummary, type ConversationStatus, type LinkPreviewSummary } from "@threa/types"
@@ -290,15 +291,8 @@ export class ConversationService {
       // Thread conversations also fan out to the parent channel's subscribers,
       // matching the boundary extractor's event routing; the access-root stream's
       // visibility (INV-62) gates workspace-wide board delivery of the aggregate.
-      let parentStreamId: string | undefined
       const stream = await StreamRepository.findById(client, target.streamId)
-      let rootStream = stream
-      if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
-        const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
-        parentStreamId = parentMessage?.streamId
-        rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
-      }
-      const streamVisibility = rootStream?.visibility
+      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
 
       const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
       for (const conv of touched) {

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -288,13 +288,17 @@ export class ConversationService {
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
       // Thread conversations also fan out to the parent channel's subscribers,
-      // matching the boundary extractor's event routing.
+      // matching the boundary extractor's event routing; the access-root stream's
+      // visibility (INV-62) gates workspace-wide board delivery of the aggregate.
       let parentStreamId: string | undefined
       const stream = await StreamRepository.findById(client, target.streamId)
+      let rootStream = stream
       if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
         const parentMessage = await MessageRepository.findById(client, stream.parentMessageId)
         parentStreamId = parentMessage?.streamId
+        rootStream = parentMessage ? await StreamRepository.findById(client, parentMessage.streamId) : stream
       }
+      const streamVisibility = rootStream?.visibility
 
       const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
       for (const conv of touched) {
@@ -304,6 +308,7 @@ export class ConversationService {
           conversationId: conv.id,
           conversation: addStalenessFields(conv),
           parentStreamId,
+          streamVisibility,
         })
       }
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -288,9 +288,12 @@ export class ConversationService {
       const touchedIds = previous ? [previous.id, target.id] : [target.id]
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      // Thread conversations also fan out to the parent channel's subscribers,
-      // matching the boundary extractor's event routing; the access-root stream's
-      // visibility (INV-62) gates workspace-wide board delivery of the aggregate.
+      // One delivery resolution for every touched conversation is correct here
+      // (unlike the boundary extractor, which spans streams): both `previous` and
+      // `target` live in the message's stream — the guard above pins `target` to
+      // it, and a primary membership is always in the message's own stream — so
+      // they share one access-root visibility (INV-62). Routing `previous` by
+      // `target`'s stream can't leak because they're the same stream.
       const stream = await StreamRepository.findById(client, target.streamId)
       const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
 

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test"
-import { WORKSPACE_PERMISSION_SCOPES, LabelableResourceTypes } from "@threa/types"
+import { WORKSPACE_PERMISSION_SCOPES, LabelableResourceTypes, Visibilities } from "@threa/types"
 import {
   resolveDeliveryGroups,
   permissionGroupsForRole,
   permissionGroup,
   streamGroup,
   userGroup,
+  WORKSPACE_GROUP,
 } from "./delivery-groups"
 import type { OutboxEvent, OutboxEventType } from "./repository"
 
@@ -86,6 +87,62 @@ describe("resolveDeliveryGroups — label assignments", () => {
       })
     )
     expect(groups).toEqual([userGroup("usr_1")])
+  })
+})
+
+describe("resolveDeliveryGroups — conversation events (board liveness)", () => {
+  it("delivers a public-channel conversation:created to the whole workspace so the board sees it live", () => {
+    const groups = resolveDeliveryGroups(
+      event("conversation:created", {
+        workspaceId: "ws_1",
+        streamId: "stream_pub",
+        conversationId: "conv_1",
+        streamVisibility: Visibilities.PUBLIC,
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_pub"), WORKSPACE_GROUP])
+  })
+
+  it("keeps a private-channel conversation:updated scoped to the stream's members (INV-62)", () => {
+    const groups = resolveDeliveryGroups(
+      event("conversation:updated", {
+        workspaceId: "ws_1",
+        streamId: "stream_priv",
+        conversationId: "conv_1",
+        streamVisibility: Visibilities.PRIVATE,
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_priv")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
+  })
+
+  it("fans a public thread conversation to the thread, its parent channel, and the workspace", () => {
+    const groups = resolveDeliveryGroups(
+      event("conversation:updated", {
+        workspaceId: "ws_1",
+        streamId: "stream_thread",
+        parentStreamId: "stream_pub",
+        conversationId: "conv_1",
+        streamVisibility: Visibilities.PUBLIC,
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_thread"), streamGroup("stream_pub"), WORKSPACE_GROUP])
+  })
+
+  it("never broadcasts conversation:message_assigned to the workspace — it carries no board aggregate", () => {
+    const groups = resolveDeliveryGroups(
+      event("conversation:message_assigned", {
+        workspaceId: "ws_1",
+        streamId: "stream_thread",
+        parentStreamId: "stream_pub",
+        messageId: "msg_1",
+        conversationId: "conv_1",
+        isPrimary: true,
+        reason: "declared",
+      })
+    )
+    expect(groups).toEqual([streamGroup("stream_thread"), streamGroup("stream_pub")])
+    expect(groups).not.toContain(WORKSPACE_GROUP)
   })
 })
 

--- a/apps/backend/src/lib/outbox/delivery-groups.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.ts
@@ -25,6 +25,8 @@ import {
   type AttachmentTranscodedOutboxPayload,
   type AttachmentThumbnailedOutboxPayload,
   type MessagesMovedOutboxPayload,
+  type ConversationCreatedOutboxPayload,
+  type ConversationUpdatedOutboxPayload,
   type LabelUpsertedOutboxPayload,
   type LabelDeletedOutboxPayload,
   type LabelAssignedOutboxPayload,
@@ -193,12 +195,28 @@ export function resolveDeliveryGroups(event: OutboxEvent): string[] | null {
     return [streamGroup(streamId), userGroup(memberId)]
   }
 
-  // Conversation events reach the stream + optionally its parent for
-  // discoverability. `conversation:message_reassigned` has no parent dimension
-  // and falls through to the generic stream-scoped branch below.
-  if (
-    isOneOfOutboxEventType(event, ["conversation:created", "conversation:updated", "conversation:message_assigned"])
-  ) {
+  // Conversation aggregate events reach the stream + optionally its parent for
+  // discoverability, AND the whole workspace when the access-root stream is a
+  // public channel — so the workspace board (which sits in the workspace room,
+  // not in every stream room) sees public-channel activity live. Private/DM/
+  // scratchpad conversations stay scoped to their stream's members (INV-62);
+  // the board picks those up via its bootstrap/reconnect fetch.
+  if (isOneOfOutboxEventType(event, ["conversation:created", "conversation:updated"])) {
+    const payload = event.payload as ConversationCreatedOutboxPayload | ConversationUpdatedOutboxPayload
+    const groups = [streamGroup(payload.streamId)]
+    if (payload.parentStreamId) {
+      groups.push(streamGroup(payload.parentStreamId))
+    }
+    if (payload.streamVisibility === Visibilities.PUBLIC) {
+      groups.push(WORKSPACE_GROUP)
+    }
+    return groups
+  }
+
+  // Per-message membership (no board aggregate) — stays stream-scoped (+ parent);
+  // the board doesn't consume it. `conversation:message_reassigned` has no parent
+  // dimension and falls through to the generic stream-scoped branch below.
+  if (isOutboxEventType(event, "conversation:message_assigned")) {
     const payload = event.payload as { streamId: string; parentStreamId?: string }
     const groups = [streamGroup(payload.streamId)]
     if (payload.parentStreamId) {

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -22,6 +22,7 @@ import type {
   Draft as WireDraft,
   WorkspaceInvitableRole,
   AuthorType,
+  Visibility,
   NotificationLevel,
 } from "@threa/types"
 
@@ -382,6 +383,11 @@ export interface ConversationCreatedOutboxPayload extends StreamScopedPayload {
   conversation: ConversationWithStaleness
   /** For thread conversations, the parent channel's stream ID (for discoverability) */
   parentStreamId?: string
+  /** Visibility of the conversation's access-root stream (the parent channel for
+   *  a thread). Drives workspace-wide board delivery: `public` → the whole
+   *  workspace receives it (the board can show it); otherwise only the stream's
+   *  own members do, via the stream room (INV-62). */
+  streamVisibility?: Visibility
 }
 
 export interface ConversationUpdatedOutboxPayload extends StreamScopedPayload {
@@ -389,6 +395,8 @@ export interface ConversationUpdatedOutboxPayload extends StreamScopedPayload {
   conversation: ConversationWithStaleness
   /** For thread conversations, the parent channel's stream ID (for discoverability) */
   parentStreamId?: string
+  /** See {@link ConversationCreatedOutboxPayload.streamVisibility}. */
+  streamVisibility?: Visibility
 }
 
 /**

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -2,6 +2,7 @@ import Dexie, { type EntityTable } from "dexie"
 import type {
   Activity,
   AuthorType,
+  BoardPost,
   CompanionMode,
   E2eActor,
   EventType,
@@ -778,6 +779,26 @@ export interface CachedWorkspaceMetadata {
   _cachedAt: number
 }
 
+/**
+ * A board post (a conversation surfaced as a feed card) on the sync-engine
+ * rails. Mirrors how messages live in `events`: seeded by the board bootstrap
+ * fetch, then kept live by the gate-applied `conversation:*` workspace handlers
+ * and optimistic local writes — so the board re-sorts the instant a row's
+ * activity changes instead of refetching on open.
+ *
+ * `id` is the conversation id (one card per conversation). `_lastActivityMs`
+ * mirrors `conversation.lastActivityAt` as the numeric the board orders on.
+ * `_status: "pending"` marks an optimistic local write awaiting its
+ * authoritative `conversation:*` echo, swapped in place on arrival.
+ */
+export interface CachedBoardPost extends BoardPost {
+  id: string
+  workspaceId: string
+  _lastActivityMs: number
+  _cachedAt: number
+  _status?: "pending"
+}
+
 export class ThreaDatabase extends Dexie {
   workspaces!: EntityTable<CachedWorkspace, "id">
   workspaceUsers!: EntityTable<CachedWorkspaceUser, "id">
@@ -805,6 +826,7 @@ export class ThreaDatabase extends Dexie {
   labelAssignments!: EntityTable<CachedLabelAssignment, "id">
   e2eDeviceKeys!: EntityTable<CachedE2eDeviceKey, "id">
   sidebarConfigs!: EntityTable<CachedSidebarConfig, "id">
+  conversations!: EntityTable<CachedBoardPost, "id">
 
   constructor(name: string) {
     super(name)
@@ -1187,6 +1209,14 @@ export class ThreaDatabase extends Dexie {
         return tx.table("labels").clear()
       })
 
+    // v36: conversations get their own store so the board rides the sync engine
+    // (IDB + gate-applied events + optimistic writes) like the timeline, rather
+    // than being a refetch-on-open React-Query list. Seeded from the board
+    // bootstrap; never holds anything the server can't refill.
+    this.version(36).stores({
+      conversations: "id, workspaceId, [workspaceId+_lastActivityMs], _cachedAt",
+    })
+
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }
 }
@@ -1254,6 +1284,7 @@ export async function clearAllCachedData(): Promise<void> {
       db.labels.clear(),
       db.labelAssignments.clear(),
       db.sidebarConfigs.clear(),
+      db.conversations.clear(),
       // The persisted device key seals this identity's private key for
       // auto-resume — sign-out must drop it so the next account can't resume
       // this identity's unlocked session.

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -33,5 +33,6 @@ export type {
   CachedLabel,
   CachedLabelAssignment,
   CachedE2eDeviceKey,
+  CachedBoardPost,
 } from "./database"
 export type { EventType } from "@threa/types"

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -8,6 +8,7 @@ import {
   useSocketReconnectCount,
 } from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
+import { seedBoardPosts, optimisticBoardReply } from "@/stores/board-store"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
@@ -86,12 +87,15 @@ interface UseConversationsOptions {
 
 /**
  * Cross-stream conversation feed for the workspace board, keyset-paginated.
- * Read-only bootstrap (the activity-feed pattern): `staleTime: Infinity` +
- * `refetchOnMount` so the list is fresh on open. Unlike the activity feed (which
- * gets live updates via workspace-room socket handlers) the board has no socket
- * subscription yet — conversation events are delivered only to per-stream rooms
- * today (see board-view design doc) — so `refetchOnReconnect` is left ON: a
- * reconnect is the board's only refresh path until cross-stream events land.
+ *
+ * This is the board's FETCH/SEED engine, not its read authority: every fetched
+ * page is written into the `conversations` IDB store (subscribe-then-fetch,
+ * INV-53), and the board renders reactively from IDB via `useBoardPosts` — the
+ * same rails the timeline rides. Live `conversation:*` events (gate-applied in
+ * `registerWorkspaceSocketHandlers`) and optimistic writes re-sort the IDB feed
+ * in place without a refetch; this query just keeps the head fresh on open and
+ * pages older cards in. `refetchOnReconnect` is left ON as the catch-up backstop
+ * for the unsynced board surface.
  */
 export function useWorkspaceConversations(
   workspaceId: string,
@@ -100,7 +104,7 @@ export function useWorkspaceConversations(
   const conversationService = useConversationService()
   const { status, limit } = options ?? {}
 
-  return useInfiniteQuery({
+  const query = useInfiniteQuery({
     queryKey: conversationKeys.workspaceList(workspaceId, { status, limit }),
     queryFn: ({ pageParam }) => conversationService.listByWorkspace(workspaceId, { status, limit, cursor: pageParam }),
     initialPageParam: undefined as string | undefined,
@@ -111,6 +115,20 @@ export function useWorkspaceConversations(
     refetchOnReconnect: true,
     enabled: !!workspaceId,
   })
+
+  // Seed IDB from whatever pages are loaded so the reactive board reflects the
+  // server snapshot. `bulkPut` reconciles cards in place — it never clears rows
+  // a page omits, so live/optimistic rows outside the fetched window survive.
+  const { data } = query
+  useEffect(() => {
+    if (!data) return
+    void seedBoardPosts(
+      workspaceId,
+      data.pages.flatMap((page) => page.posts)
+    )
+  }, [data, workspaceId])
+
+  return query
 }
 
 /**
@@ -259,6 +277,24 @@ export function useReplyToBoardPost(workspaceId: string) {
         ...base,
         conversation: { intent: "existing", conversationId: conversation.id },
       })
+      // Optimistically reflect the reply on the board's IDB feed: the card jumps
+      // to the top and shows the reply before the round-trip's `conversation:updated`
+      // echo merges over it (clearing pending). Link previews/attachments fill in
+      // on that reconciliation; an empty preview here is correct for a text reply.
+      void optimisticBoardReply(
+        conversation.id,
+        {
+          id: message.id,
+          authorId: message.authorId,
+          authorType: message.authorType,
+          contentMarkdown: message.contentMarkdown,
+          reactions: message.reactions,
+          attachments: [],
+          linkPreviews: [],
+          createdAt: message.createdAt,
+        },
+        Date.parse(message.createdAt) || Date.now()
+      )
       return { message, plan }
     },
   })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -242,6 +242,7 @@ export function planBoardReply(input: {
 export function useReplyToBoardPost(workspaceId: string) {
   const messageService = useMessageService()
   const streamService = useStreamService()
+  const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async ({
@@ -279,8 +280,9 @@ export function useReplyToBoardPost(workspaceId: string) {
       })
       // Optimistically reflect the reply on the board's IDB feed: the card jumps
       // to the top and shows the reply before the round-trip's `conversation:updated`
-      // echo merges over it (clearing pending). Link previews/attachments fill in
-      // on that reconciliation; an empty preview here is correct for a text reply.
+      // echo merges over it (clearing pending). The echo carries only the
+      // aggregate, so this preview is the lasting one until the next seed —
+      // correct for a text reply, but it can't show attachments/previews.
       void optimisticBoardReply(
         conversation.id,
         {
@@ -295,6 +297,15 @@ export function useReplyToBoardPost(workspaceId: string) {
         },
         Date.parse(message.createdAt) || Date.now()
       )
+      // A reply with attachments can't be previewed fully from the optimistic
+      // row (the message wire shape carries no attachment summaries), so refetch
+      // the board head to backfill them; the text/bump still showed instantly.
+      if (base.attachmentIds) {
+        void queryClient.invalidateQueries({
+          queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
+          refetchType: "active",
+        })
+      }
       return { message, plan }
     },
   })

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
+import * as boardStoreModule from "@/stores/board-store"
 import { ServicesProvider, SidebarProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { workspaceKeys } from "@/hooks/use-workspaces"
@@ -83,6 +84,11 @@ function mountBoard(
     if (failMessages) throw new Error("boom")
     return []
   })
+  // The board reads its feed reactively from the conversations IDB store; mock
+  // that store hook to return the test's posts (the IDB read/sort/merge path is
+  // covered directly in board-store.test). The query still seeds IDB and drives
+  // pagination/loading/error, so `listByWorkspace` is exercised as before.
+  vi.spyOn(boardStoreModule, "useBoardPosts").mockReturnValue(posts as never)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   // The board is gated behind the board-view flag, read from the bootstrap cache.
   queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), { featureFlags: { "board-view": boardFlag } })
@@ -225,7 +231,9 @@ describe("BoardPage", () => {
   it("offers Load more when there is another page", async () => {
     mountBoard([makePost()], { nextCursor: "2026-06-22T12:00:00.000Z|conv_1" })
     expect(await screen.findByText("Opening message body.")).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy()
+    // Load more is driven by the query's async `hasNextPage` (the feed itself
+    // renders synchronously from the store), so wait for it to resolve.
+    expect(await screen.findByRole("button", { name: "Load more" })).toBeTruthy()
   })
 
   it("does not render the board when the board-view flag is off", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -9,6 +9,7 @@ import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
 import { localStartOfDayMs } from "@/lib/dates"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
+import { useBoardPosts } from "@/stores/board-store"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardComposer } from "@/components/board/board-composer"
@@ -74,9 +75,12 @@ function BoardPageGate({ workspaceId }: { workspaceId: string }) {
 }
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
-  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
+  // The query is the fetch/seed engine; the board reads reactively from IDB so
+  // live events and optimistic writes re-sort it without a refetch.
+  const { isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { limit: 50 })
-  const posts = useMemo(() => data?.pages.flatMap((page) => page.posts) ?? [], [data])
+  const boardPosts = useBoardPosts(workspaceId)
+  const posts = boardPosts ?? []
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -101,47 +105,11 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   if (isFetchingNextPage) loadMoreLabel = "Loading…"
   else if (isFetchNextPageError) loadMoreLabel = "Retry"
 
+  // Prefer cached/live content: a transient refetch error never hides a feed we
+  // already have. Skeleton only before the first IDB read resolves AND nothing
+  // is cached; empty state only once IDB has resolved to genuinely nothing.
   let content
-  if (isLoading) {
-    content = (
-      <div className="flex flex-col gap-3">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="rounded-xl border bg-card p-4">
-            <Skeleton className="h-3 w-1/3" />
-            <div className="mt-3 flex items-start gap-2">
-              <Skeleton className="h-8 w-8 shrink-0 rounded-[8px]" />
-              <div className="min-w-0 flex-1 space-y-2">
-                <Skeleton className="h-3.5 w-1/4" />
-                <Skeleton className="h-3 w-4/5" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    )
-  } else if (isError) {
-    // A failed fetch must read as a failure, not as the empty state's upbeat copy.
-    content = (
-      <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
-        <AlertCircle className="h-8 w-8 text-destructive" />
-        <p className="text-sm font-medium">Couldn't load the board</p>
-        <p className="max-w-sm text-sm text-muted-foreground">Something went wrong fetching your conversations.</p>
-        <Button variant="outline" onClick={() => refetch()} className="min-h-11">
-          Try again
-        </Button>
-      </div>
-    )
-  } else if (posts.length === 0) {
-    content = (
-      <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
-        <LayoutGrid className="h-8 w-8 text-muted-foreground" />
-        <p className="text-sm font-medium">Nothing on the board yet</p>
-        <p className="max-w-sm text-sm text-muted-foreground">
-          As your conversations build up, the topics worth returning to surface here, newest activity first.
-        </p>
-      </div>
-    )
-  } else {
+  if (posts.length > 0) {
     content = (
       <div className="flex flex-col">
         {sections.map((section) => (
@@ -178,6 +146,45 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
             </Button>
           </div>
         )}
+      </div>
+    )
+  } else if (isError) {
+    // A failed fetch must read as a failure, not as the empty state's upbeat copy.
+    content = (
+      <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <p className="text-sm font-medium">Couldn't load the board</p>
+        <p className="max-w-sm text-sm text-muted-foreground">Something went wrong fetching your conversations.</p>
+        <Button variant="outline" onClick={() => refetch()} className="min-h-11">
+          Try again
+        </Button>
+      </div>
+    )
+  } else if (isLoading || boardPosts === undefined) {
+    content = (
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="rounded-xl border bg-card p-4">
+            <Skeleton className="h-3 w-1/3" />
+            <div className="mt-3 flex items-start gap-2">
+              <Skeleton className="h-8 w-8 shrink-0 rounded-[8px]" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-3.5 w-1/4" />
+                <Skeleton className="h-3 w-4/5" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  } else {
+    content = (
+      <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">
+        <LayoutGrid className="h-8 w-8 text-muted-foreground" />
+        <p className="text-sm font-medium">Nothing on the board yet</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          As your conversations build up, the topics worth returning to surface here, newest activity first.
+        </p>
       </div>
     )
   }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -77,10 +77,15 @@ function BoardPageGate({ workspaceId }: { workspaceId: string }) {
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   // The query is the fetch/seed engine; the board reads reactively from IDB so
   // live events and optimistic writes re-sort it without a refetch.
-  const { isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
+  const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { limit: 50 })
   const boardPosts = useBoardPosts(workspaceId)
   const posts = boardPosts ?? []
+  // After a refetch settles, `isLoading` is already false but the seed effect
+  // writes IDB on the next tick, so `useBoardPosts` can be momentarily empty
+  // while the query already holds posts. Treat that window as loading so the
+  // feed doesn't flash the empty state before the seed lands.
+  const seedPending = (data?.pages.some((page) => page.posts.length > 0) ?? false) && posts.length === 0
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -160,7 +165,7 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         </Button>
       </div>
     )
-  } else if (isLoading || boardPosts === undefined) {
+  } else if (isLoading || boardPosts === undefined || seedPending) {
     content = (
       <div className="flex flex-col gap-3">
         {Array.from({ length: 5 }).map((_, i) => (

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import Dexie from "dexie"
+import { db } from "@/db"
+import { seedBoardPosts, mergeBoardConversation, optimisticBoardReply } from "./board-store"
+import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+
+const WORKSPACE_ID = "ws_1"
+
+function makeConversation(id: string, lastActivityAt: string): ConversationWithStaleness {
+  return {
+    id,
+    streamId: "stream_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["m1"],
+    participantIds: ["usr_1"],
+    secondaryMessageIds: [],
+    topicSummary: id,
+    completenessScore: 4,
+    confidence: 0.8,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt,
+    createdAt: lastActivityAt,
+    updatedAt: lastActivityAt,
+    temporalStaleness: 0,
+    effectiveCompleteness: 4,
+  }
+}
+
+function makeMessage(id: string): BoardPostMessage {
+  return {
+    id,
+    authorId: "usr_1",
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-06-22T12:00:00.000Z",
+  }
+}
+
+function makePost(id: string, lastActivityAt: string, recentMessages: BoardPostMessage[] = []): BoardPost {
+  return {
+    conversation: makeConversation(id, lastActivityAt),
+    openingMessage: makeMessage("m1"),
+    recentMessages,
+    totalReplies: recentMessages.length,
+  }
+}
+
+async function readBoard() {
+  return db.conversations
+    .where("[workspaceId+_lastActivityMs]")
+    .between([WORKSPACE_ID, Dexie.minKey], [WORKSPACE_ID, Dexie.maxKey])
+    .reverse()
+    .toArray()
+}
+
+beforeEach(async () => {
+  await db.conversations.clear()
+})
+
+describe("seedBoardPosts", () => {
+  it("orders the feed by last activity, newest first", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_old", "2026-06-20T12:00:00.000Z"),
+      makePost("conv_new", "2026-06-22T12:00:00.000Z"),
+      makePost("conv_mid", "2026-06-21T12:00:00.000Z"),
+    ])
+    expect((await readBoard()).map((p) => p.id)).toEqual(["conv_new", "conv_mid", "conv_old"])
+  })
+
+  it("upserts in place without dropping rows a later page omits", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_a", "2026-06-20T12:00:00.000Z")])
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_b", "2026-06-21T12:00:00.000Z")])
+    expect((await readBoard()).map((p) => p.id)).toEqual(["conv_b", "conv_a"])
+  })
+})
+
+describe("mergeBoardConversation", () => {
+  it("merges the aggregate, re-sorts on activity, and keeps the cached preview", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1")]),
+      makePost("conv_2", "2026-06-21T12:00:00.000Z"),
+    ])
+    const merged = await mergeBoardConversation("conv_1", makeConversation("conv_1", "2026-06-22T12:00:00.000Z"))
+    expect(merged).toBe(true)
+    const board = await readBoard()
+    expect(board.map((p) => p.id)).toEqual(["conv_1", "conv_2"])
+    // The event carries the aggregate, not message bodies — preview is preserved.
+    expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r1"])
+  })
+
+  it("returns false when the card isn't cached (caller hydrates instead)", async () => {
+    const merged = await mergeBoardConversation(
+      "conv_absent",
+      makeConversation("conv_absent", "2026-06-22T12:00:00.000Z")
+    )
+    expect(merged).toBe(false)
+    expect(await readBoard()).toHaveLength(0)
+  })
+
+  it("clears the optimistic pending flag when the authoritative echo merges over it", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_1", "2026-06-20T12:00:00.000Z")])
+    await optimisticBoardReply("conv_1", makeMessage("r1"), Date.parse("2026-06-21T12:00:00.000Z"))
+    expect((await db.conversations.get("conv_1"))?._status).toBe("pending")
+    await mergeBoardConversation("conv_1", makeConversation("conv_1", "2026-06-21T12:00:05.000Z"))
+    expect((await db.conversations.get("conv_1"))?._status).toBeUndefined()
+  })
+})
+
+describe("optimisticBoardReply", () => {
+  it("appends the reply, bumps activity to the top, and marks the row pending", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z"),
+      makePost("conv_2", "2026-06-21T12:00:00.000Z"),
+    ])
+    await optimisticBoardReply("conv_1", makeMessage("r1"), Date.parse("2026-06-22T12:00:00.000Z"))
+    const board = await readBoard()
+    expect(board.map((p) => p.id)).toEqual(["conv_1", "conv_2"])
+    expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r1"])
+    expect(board[0]?.totalReplies).toBe(1)
+    expect(board[0]?._status).toBe("pending")
+  })
+
+  it("caps the preview at the latest three replies", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1"), makeMessage("r2"), makeMessage("r3")]),
+    ])
+    await optimisticBoardReply("conv_1", makeMessage("r4"), Date.parse("2026-06-22T12:00:00.000Z"))
+    const row = await db.conversations.get("conv_1")
+    expect(row?.recentMessages.map((m) => m.id)).toEqual(["r2", "r3", "r4"])
+  })
+
+  it("is a no-op when the conversation isn't cached", async () => {
+    await optimisticBoardReply("conv_absent", makeMessage("r1"), Date.now())
+    expect(await readBoard()).toHaveLength(0)
+  })
+})

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -68,16 +68,20 @@ export async function mergeBoardConversation(
   conversationId: string,
   conversation: ConversationWithStaleness
 ): Promise<boolean> {
-  const existing = await db.conversations.get(conversationId)
-  if (!existing) return false
-  await db.conversations.put({
-    ...existing,
-    conversation,
-    _lastActivityMs: lastActivityMs(conversation),
-    _cachedAt: Date.now(),
-    _status: undefined,
+  // Read-modify-write in one rw transaction so a concurrent optimistic write or
+  // a second echo can't merge over a stale read of this row.
+  return db.transaction("rw", db.conversations, async () => {
+    const existing = await db.conversations.get(conversationId)
+    if (!existing) return false
+    await db.conversations.put({
+      ...existing,
+      conversation,
+      _lastActivityMs: lastActivityMs(conversation),
+      _cachedAt: Date.now(),
+      _status: undefined,
+    })
+    return true
   })
-  return true
 }
 
 /**
@@ -92,16 +96,21 @@ export async function optimisticBoardReply(
   message: BoardPostMessage,
   atMs: number
 ): Promise<void> {
-  const existing = await db.conversations.get(conversationId)
-  if (!existing) return
-  const recentMessages = [...existing.recentMessages, message].slice(-RECENT_PREVIEW_CAP)
-  await db.conversations.put({
-    ...existing,
-    conversation: { ...existing.conversation, lastActivityAt: new Date(atMs).toISOString() },
-    recentMessages,
-    totalReplies: existing.totalReplies + 1,
-    _lastActivityMs: atMs,
-    _cachedAt: Date.now(),
-    _status: "pending",
+  // Read-modify-write in one rw transaction so it can't race the authoritative
+  // echo's merge through a stale read. Dedup by id so a retry can't double-append.
+  await db.transaction("rw", db.conversations, async () => {
+    const existing = await db.conversations.get(conversationId)
+    if (!existing) return
+    if (existing.recentMessages.some((m) => m.id === message.id)) return
+    const recentMessages = [...existing.recentMessages, message].slice(-RECENT_PREVIEW_CAP)
+    await db.conversations.put({
+      ...existing,
+      conversation: { ...existing.conversation, lastActivityAt: new Date(atMs).toISOString() },
+      recentMessages,
+      totalReplies: existing.totalReplies + 1,
+      _lastActivityMs: atMs,
+      _cachedAt: Date.now(),
+      _status: "pending",
+    })
   })
 }

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -1,0 +1,107 @@
+import Dexie from "dexie"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db, type CachedBoardPost } from "@/db"
+import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+
+/**
+ * How many trailing replies a board card previews. Mirrors the backend's
+ * `listByWorkspace` projection (service.ts), so an optimistic append caps the
+ * same way a refetch would.
+ */
+const RECENT_PREVIEW_CAP = 3
+
+function lastActivityMs(conversation: { lastActivityAt: string }): number {
+  const ms = Date.parse(conversation.lastActivityAt)
+  return Number.isNaN(ms) ? 0 : ms
+}
+
+function toCached(workspaceId: string, post: BoardPost, status?: "pending"): CachedBoardPost {
+  return {
+    ...post,
+    id: post.conversation.id,
+    workspaceId,
+    _lastActivityMs: lastActivityMs(post.conversation),
+    _cachedAt: Date.now(),
+    _status: status,
+  }
+}
+
+/**
+ * Reactive board feed for a workspace, newest activity first — the board's read
+ * authority, mirroring how the timeline reads `events` from IDB. A live
+ * `conversation:*` merge or an optimistic write re-sorts the feed in place
+ * without a refetch. Returns `undefined` until the first IDB read resolves
+ * (loading), `[]` when the store is genuinely empty.
+ */
+export function useBoardPosts(workspaceId: string): CachedBoardPost[] | undefined {
+  return useLiveQuery(
+    () =>
+      db.conversations
+        .where("[workspaceId+_lastActivityMs]")
+        .between([workspaceId, Dexie.minKey], [workspaceId, Dexie.maxKey])
+        .reverse()
+        .toArray(),
+    [workspaceId]
+  )
+}
+
+/**
+ * Seed the board store from a bootstrap/page fetch (subscribe-then-fetch,
+ * INV-53). `bulkPut` upserts the fetched cards without touching rows the page
+ * didn't return, so optimistic-pending rows not yet visible to the server
+ * survive, and a card the server now returns is reconciled (its `_status`
+ * cleared) over any optimistic copy.
+ */
+export async function seedBoardPosts(workspaceId: string, posts: BoardPost[]): Promise<void> {
+  if (posts.length === 0) return
+  await db.conversations.bulkPut(posts.map((post) => toCached(workspaceId, post)))
+}
+
+/**
+ * Apply a conversation aggregate from a `conversation:*` event onto the board's
+ * IDB row: merge the new aggregate (re-sorting on `lastActivityAt`) while
+ * keeping the cached preview messages — the event carries the aggregate, not the
+ * message bodies. Returns `false` when no row exists yet, so the caller can
+ * hydrate a card it cannot render from the event alone.
+ */
+export async function mergeBoardConversation(
+  conversationId: string,
+  conversation: ConversationWithStaleness
+): Promise<boolean> {
+  const existing = await db.conversations.get(conversationId)
+  if (!existing) return false
+  await db.conversations.put({
+    ...existing,
+    conversation,
+    _lastActivityMs: lastActivityMs(conversation),
+    _cachedAt: Date.now(),
+    _status: undefined,
+  })
+  return true
+}
+
+/**
+ * Optimistically reflect the viewer's own reply into a visible card: append the
+ * message to the preview, bump activity to `atMs` (so the card jumps to the top
+ * like a real bump would), and mark the row pending until the authoritative
+ * `conversation:updated` echo merges over it. No-op when the card isn't cached
+ * (a reply into a not-yet-seen conversation surfaces via the event path).
+ */
+export async function optimisticBoardReply(
+  conversationId: string,
+  message: BoardPostMessage,
+  atMs: number
+): Promise<void> {
+  const existing = await db.conversations.get(conversationId)
+  if (!existing) return
+  const recentMessages = [...existing.recentMessages, message].slice(-RECENT_PREVIEW_CAP)
+  await db.conversations.put({
+    ...existing,
+    conversation: { ...existing.conversation, lastActivityAt: new Date(atMs).toISOString() },
+    recentMessages,
+    totalReplies: existing.totalReplies + 1,
+    _lastActivityMs: atMs,
+    _cachedAt: Date.now(),
+    _status: "pending",
+  })
+}

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -12,6 +12,7 @@ import { SocketEventGate } from "./socket-event-gate"
 import { savedKeys } from "@/hooks/use-saved"
 import { scheduledKeys } from "@/hooks/use-scheduled"
 import { memoKeys } from "@/hooks/use-memos"
+import { conversationKeys } from "@/hooks/use-conversations"
 import { invitationKeys } from "@/api/invitations"
 import {
   DEFAULT_SIDEBAR_CONFIG,
@@ -954,6 +955,78 @@ describe("registerWorkspaceSocketHandlers", () => {
 
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_other") })
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: memoKeys.searches("ws_1") })
+    cleanup()
+  })
+
+  it("merges a conversation:updated for a cached card into the board IDB store (re-sorts live)", async () => {
+    await db.conversations.clear()
+    await db.conversations.put({
+      id: "conv_1",
+      workspaceId: "ws_1",
+      conversation: { id: "conv_1", lastActivityAt: "2026-06-20T12:00:00.000Z" },
+      openingMessage: null,
+      recentMessages: [],
+      totalReplies: 0,
+      _lastActivityMs: Date.parse("2026-06-20T12:00:00.000Z"),
+      _cachedAt: Date.now(),
+    } as never)
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("conversation:updated", {
+      workspaceId: "ws_1",
+      conversation: { id: "conv_1", lastActivityAt: "2026-06-22T12:00:00.000Z" },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const row = await db.conversations.get("conv_1")
+    expect(row?._lastActivityMs).toBe(Date.parse("2026-06-22T12:00:00.000Z"))
+    // A cached card merges in place — no refetch of the board head.
+    expect(invalidate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [...conversationKeys.all, "workspaceList", "ws_1"] })
+    )
+    cleanup()
+  })
+
+  it("refreshes the board head when a conversation:created arrives for an uncached card", async () => {
+    await db.conversations.clear()
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("conversation:created", {
+      workspaceId: "ws_1",
+      conversation: { id: "conv_new", lastActivityAt: "2026-06-22T12:00:00.000Z" },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // The event carries the aggregate but not the message bodies, so a card we
+    // don't have cached is hydrated by refetching the (active) board head.
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [...conversationKeys.all, "workspaceList", "ws_1"],
+      type: "active",
+    })
+    cleanup()
+  })
+
+  it("ignores conversation events from other workspaces", async () => {
+    await db.conversations.clear()
+    const queryClient = new QueryClient()
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("conversation:created", {
+      workspaceId: "ws_other",
+      conversation: { id: "conv_x", lastActivityAt: "2026-06-22T12:00:00.000Z" },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(await db.conversations.get("conv_x")).toBeUndefined()
+    expect(invalidate).not.toHaveBeenCalled()
     cleanup()
   })
 

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1004,10 +1004,11 @@ describe("registerWorkspaceSocketHandlers", () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     // The event carries the aggregate but not the message bodies, so a card we
-    // don't have cached is hydrated by refetching the (active) board head.
+    // don't have cached is hydrated by refetching the board head (stale-mark all,
+    // refetch only active observers).
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [...conversationKeys.all, "workspaceList", "ws_1"],
-      type: "active",
+      refetchType: "active",
     })
     cleanup()
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -27,6 +27,7 @@ import type {
   ScheduledMessageUpsertedPayload,
   ScheduledMessageSentPayload,
   ScheduledMessageCancelledPayload,
+  ConversationWithStaleness,
   LabelUpsertedPayload,
   LabelDeletedPayload,
   LabelAssignedPayload,
@@ -35,6 +36,8 @@ import type {
   DraftDeletedPayload,
 } from "@threa/types"
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
+import { conversationKeys } from "@/hooks/use-conversations"
+import { mergeBoardConversation } from "@/stores/board-store"
 import { activityKeys } from "@/hooks/use-activity"
 import { memoKeys } from "@/hooks/use-memos"
 import { invitationKeys } from "@/api/invitations"
@@ -1655,6 +1658,27 @@ export function registerWorkspaceSocketHandlers(
     void applyDraftDeleted(payload, workspaceId)
   }
 
+  // Conversation events feed the board's IDB store, the board's read authority
+  // (it reads reactively from it, like the timeline reads `events`). The
+  // created/updated events carry the conversation aggregate for every touched
+  // conversation, so merging them re-sorts the board in place on
+  // `lastActivityAt` without a refetch — the live half of the board's rails.
+  // A card we don't have cached can't be rendered from the aggregate alone (the
+  // message bodies aren't in the event), so refresh the board head to hydrate it
+  // (active-only: nobody's watching a closed board). The viewer's own sends are
+  // already reflected optimistically, and reconcile when their echo merges here.
+  const handleConversationUpserted = (payload: { workspaceId: string; conversation: ConversationWithStaleness }) => {
+    if (payload.workspaceId !== workspaceId) return
+    void mergeBoardConversation(payload.conversation.id, payload.conversation).then((merged) => {
+      if (!merged) {
+        queryClient.invalidateQueries({
+          queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
+          type: "active",
+        })
+      }
+    })
+  }
+
   socket.on("stream:created", handleStreamCreated)
   socket.on("stream:updated", handleStreamUpdated)
   socket.on("stream:archived", handleStreamArchived)
@@ -1699,6 +1723,8 @@ export function registerWorkspaceSocketHandlers(
   socket.on("label:unassigned", handleLabelUnassigned)
   socket.on("draft:upserted", handleDraftUpserted)
   socket.on("draft:deleted", handleDraftDeleted)
+  socket.on("conversation:created", handleConversationUpserted)
+  socket.on("conversation:updated", handleConversationUpserted)
 
   return () => {
     abortController.abort()
@@ -1748,6 +1774,8 @@ export function registerWorkspaceSocketHandlers(
     socket.off("label:unassigned", handleLabelUnassigned)
     socket.off("draft:upserted", handleDraftUpserted)
     socket.off("draft:deleted", handleDraftDeleted)
+    socket.off("conversation:created", handleConversationUpserted)
+    socket.off("conversation:updated", handleConversationUpserted)
   }
 }
 

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -1664,16 +1664,18 @@ export function registerWorkspaceSocketHandlers(
   // conversation, so merging them re-sorts the board in place on
   // `lastActivityAt` without a refetch — the live half of the board's rails.
   // A card we don't have cached can't be rendered from the aggregate alone (the
-  // message bodies aren't in the event), so refresh the board head to hydrate it
-  // (active-only: nobody's watching a closed board). The viewer's own sends are
-  // already reflected optimistically, and reconcile when their echo merges here.
+  // message bodies aren't in the event), so refresh the board head to hydrate it.
+  // Mark every matching board-list query stale (so a closed board refetches on
+  // reopen) but only refetch the ones with active observers now. The viewer's own
+  // sends are already reflected optimistically, and reconcile when their echo
+  // merges here.
   const handleConversationUpserted = (payload: { workspaceId: string; conversation: ConversationWithStaleness }) => {
     if (payload.workspaceId !== workspaceId) return
     void mergeBoardConversation(payload.conversation.id, payload.conversation).then((merged) => {
       if (!merged) {
         queryClient.invalidateQueries({
           queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
-          type: "active",
+          refetchType: "active",
         })
       }
     })

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -310,6 +310,97 @@ Keep the **conversation as the single board card and make its bump synchronous**
 conversation row as pure async enrichment** (more faithful to "the thread is the
 synchronous backbone," but two card-fueling paths). Lean: C.
 
+## Stable view + pending updates — the reactivity model (Kris's "don't move shit on me")
+
+Status: design, 2026-06-27. **Supersedes the live re-sort behavior shipped in the
+realtime slice (PR #1100).** That slice put conversations on the sync engine and
+made the board re-sort live on activity. Dogfooding the consequence: a card you're
+half-way through reading jumps out of view the moment it (or anything above it)
+gets activity. For a surface whose whole job is "get an overview," motion-under-
+the-eye is the wrong default. The fix is the X / Slack / iMessage pattern: **hold
+the view you're looking at perfectly still, accumulate changes out of band, and
+reveal them on demand.** This is the same instinct as INV-61 (off-screen content
+must never shift on-screen content), extended from the timeline's _insertion_ rule
+to the board's _ordering_.
+
+### One truth, two orderings
+
+- **Authoritative order** — the `conversations` IDB store, always live and
+  activity-sorted. Unchanged; the sync engine keeps it true.
+- **Committed view** — a _snapshot_ of order the viewer is currently looking at,
+  deliberately frozen. Render walks the committed order; each card still reads its
+  _content_ reactively from IDB (a reply body can fill in place), but its
+  _position_ never moves while committed.
+
+Live changes accumulate against the committed view as a **buffer**, surfaced as an
+X-style "N new" pill at the top. The pill — or scrolling to the top, or a remount
+(navigate away/back) — is the only thing that commits a fresh snapshot.
+
+This **removes the optimistic bump-to-top** the realtime slice added
+(`optimisticBoardReply` raising `_lastActivityMs` for the rendered order). The IDB
+bump stays as truth; the view layer simply doesn't reorder a committed card. Net,
+optimism gets simpler: the viewer's own reply updates in place, it doesn't chase a
+moving card.
+
+### Behavior per update type
+
+| Update                                      | Treatment                                                                                |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| A **seen card** gets activity (would bump)  | Stay put. Optional in-place "updated" dot so the change is legible without motion.       |
+| A **brand-new conversation**                | Buffer → pill count. On commit it lands at top with a **New** marker.                    |
+| Reorder/insert **fully above** the viewport | Allowed _iff_ scroll-compensated — reordering off-screen rows nets zero on-screen shift. |
+| The **viewer's own reply**                  | Updates in place; **no** bump-to-top (IDB bumps as truth; committed order ignores it).   |
+
+### The scroll-anchor rule
+
+Formalize INV-61 for the board: **the topmost visible card keeps its exact screen
+offset across any mutation.** Measure the above-anchor height delta in a layout
+effect and add it to `scrollTop`.
+
+- The timeline gets its version of this from the **`virtua` virtualizer's `shift`
+  prop on prepend** (`use-timeline-scroll.ts`), in a bottom-pinned chat model. The
+  board is a top-anchored, non-virtualized feed, so it can't reuse that directly:
+  either build a board anchor, or adopt `virtua` for the board and lean on `shift`
+  (likely where it lands at scale anyway).
+- **The hard part is async reflow:** avatars / link previews / images _above_ the
+  viewport loading after the initial compensation and growing the region again. You
+  must re-anchor on those, not only on the data mutation. This is the timeline's
+  recurring cold-load pain (#1085/#1088/#1096); the board will hit the same.
+
+### Edge cases (agreed open items)
+
+1. **Pagination vs. frozen order — the sharp one.** Keyset paging by
+   `(last_activity_at, id)` is incompatible with a frozen view: a bumped card moves
+   its own cursor boundary, so "load older" can re-return or skip rows. A committed
+   view needs a **stable paging key** (snapshot position, or `created_at`) with
+   activity affecting only the buffer.
+2. **Deletions / lost-access / resolved-and-removed.** A _visible_ seen card that
+   disappears is the worst case for a stable list (removal shifts everything below).
+   Tombstone in place until commit, or remove with anchor compensation. Above-
+   viewport removals are absorbed by the anchor.
+3. **Count semantics.** Pill = new conversations. Seen-card activity = in-place dot,
+   not the pill (else "12 new" when nothing is actually new to look at). Decide
+   whether a seen card bumping past the current top counts as "new."
+4. **Reconnect re-seed.** The reconnect bootstrap updates IDB (truth) but must NOT
+   mutate the committed view — it only grows the buffer/pill. Big post-disconnect
+   counts are expected.
+5. **At-the-top behavior.** When already scrolled to top, buffer + pill anyway (match
+   X) and let a click scroll+commit, rather than auto-flowing items in.
+6. **Definition of "seen."** v1 = the whole committed snapshot is frozen (matches X).
+   Intersection-observer "only what scrolled past" is more faithful but much harder;
+   defer.
+7. **Virtualization.** At scale the board virtualizes; the anchor math and stable
+   order must be designed with the virtualizer (`virtua` `shift`), not retrofitted.
+
+### Foundation reuse
+
+None of the realtime slice is wasted: the IDB store + sync-engine delivery +
+visibility routing is exactly the data plane this sits on. What changes is the
+**projection layer** (insert the committed-view/buffer between IDB and render) and
+**dropping the optimistic bump-to-top**. It is a clean follow-up, not a rework, and
+it partly subsumes the "reply bodies on the next seed" gap — a frozen view isn't
+chasing a moving card, so body lag matters less.
+
 ## Phasing
 
 The inversion changes the order. Two candidate entry points:


### PR DESCRIPTION
**Design:** [`docs/board-view-design.md`](https://github.com/threahq/threa/blob/main/docs/board-view-design.md) — "Realtime / sync model — the board must ride the sync engine, not React-Query"

## Problem

The board (PR #1080/#1098) was a refetch-on-open React-Query list with **no socket subscription**. `useWorkspaceConversations` was pure `useInfiniteQuery` with `refetchOnMount`/`refetchOnReconnect` and nothing else — so a reply only surfaced after a manual refresh. The design doc names the exact dogfooding failure:

> Kris typed a direct reply in a stream, opened the board, and his activity wasn't there — a refresh fixed it. For a surface meant to be a co-equal way to interact (not just a read-only digest), seconds-late is disqualifying.

Two stacked causes, both confirmed in code: conversations lived on a different data-plane than messages (not in IDB at all, so no optimism and no live updates), and `conversation:*` events were delivered to per-stream rooms only (`delivery-groups.ts`), so the workspace board never received them.

## Solution

Put conversations on the same rails the timeline rides — IDB store + gate-applied events + optimistic writes — instead of a parallel React-Query path.

### How it works

1. **`conversations` IDB store (Dexie v36).** `apps/frontend/src/db/database.ts` adds `CachedBoardPost` (the wire `BoardPost` + `id` = conversation id, `workspaceId`, `_lastActivityMs`, `_cachedAt`, `_status?`) and the store `"id, workspaceId, [workspaceId+_lastActivityMs], _cachedAt"`. Cleared by `clearAllCachedData`.
2. **The board reads reactively from IDB.** `board-store.ts`'s `useBoardPosts` runs a `[workspaceId+_lastActivityMs]` range scan in `.reverse()` (newest activity first) via `useLiveQuery`, so the feed re-sorts in place the instant a row changes — no refetch.
3. **The query becomes the fetch/seed engine.** `useWorkspaceConversations` keeps the keyset `useInfiniteQuery` but an effect writes every loaded page into IDB via `seedBoardPosts` (`bulkPut`, reconciles in place, never drops rows a page omits). `board.tsx` renders from `useBoardPosts` and uses the query only for pagination / loading / error.
4. **Live updates are gate-applied.** `registerWorkspaceSocketHandlers` (`workspace-sync.ts`) registers `conversation:created`/`updated` through the same `SocketEventGate` as `message:created`, so they ride catch-up replay too (INV-53). `mergeBoardConversation` merges the aggregate onto the cached card (live re-sort, clears `_status`); a card we can't render from the aggregate alone refreshes the active board head.
5. **Optimism = a local pending IDB write.** An `intoConversation` board reply calls `optimisticBoardReply`: append the reply to the preview (capped at 3), bump `lastActivityAt`, mark `_status: "pending"` — reconciled when the authoritative `conversation:updated` echo merges over it.
6. **Backend delivers public conversations to the workspace room (visibility-gated).** `conversation:created`/`updated` carry `streamVisibility` (the access-**root** stream's visibility — the parent channel for a thread, INV-62), resolved by the shared `resolveConversationDelivery` helper at all three emit sites. `delivery-groups.ts` routes those to `WORKSPACE_GROUP` when public; private/DM/scratchpad conversations stay scoped to their stream's members. `conversation:message_assigned` stays stream+parent only.

### Key design decisions

**1. Mirror the timeline, don't extend React-Query.** Per the user ("it should work how stream works tbh") and the design doc, conversations get a first-class IDB store applied by the gate in `syncId` order and read reactively — the exact shape `events` uses.

**2. Visibility-gated delivery over per-member fan-out.** Public channel → `WORKSPACE_GROUP`; private/DM/scratchpad → stream members via the existing stream room. Mirrors `stream:created`'s visibility branch and keeps the resolver pure. INV-62: the gate keys on the access-root stream's visibility, never a raw `stream_members` filter.

**3. Live re-sort always; others' reply *bodies* on the next seed.** A `conversation:*` event carries the aggregate, not message bodies, so another user's reply into an existing card re-sorts it to the top instantly but its body lands on the next seed fetch. The viewer's own actions (optimism) and brand-new cards (created → head refresh) are fully covered. _(Note: a follow-up design — "Stable view + pending updates" in the design doc — will replace this live re-sort with a frozen view + an X-style "new" pill + scroll anchoring; that's deliberately out of this PR.)_

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/stores/board-store.ts` | IDB read authority (`useBoardPosts`) + write helpers (`seedBoardPosts`, `mergeBoardConversation`, `optimisticBoardReply`) |
| `apps/frontend/src/stores/board-store.test.ts` | Unit cover: ordering, in-place upsert, merge/return-false, pending-clear, optimistic append + 3-cap + no-op |
| `apps/backend/src/features/conversations/conversation-delivery.ts` | Shared `resolveConversationDelivery` — the single home for the thread→access-root visibility + parentStreamId rule (INV-35/37, INV-62) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/db/database.ts` | `CachedBoardPost` + `conversations` store + Dexie v36 + clear entry |
| `apps/frontend/src/db/index.ts` | Re-export `CachedBoardPost` |
| `apps/frontend/src/hooks/use-conversations.ts` | `useWorkspaceConversations` seeds IDB; `useReplyToBoardPost` writes optimistic board row + refetches the head when a reply carries attachments |
| `apps/frontend/src/pages/board.tsx` | Render from `useBoardPosts`; query drives only pagination/loading/error; prefer cached content over transient error; `seedPending` guard against empty-state flash |
| `apps/frontend/src/pages/board.test.tsx` | Mock the store hook (page tests don't touch IDB, INV-15); await async `hasNextPage` |
| `apps/frontend/src/sync/workspace-sync.ts` | Gate-register `conversation:created`/`updated` → merge to IDB or refresh head (`refetchType: "active"`) |
| `apps/frontend/src/sync/workspace-sync.test.ts` | 3 cases: merge cached card, refresh head for uncached, ignore other workspace |
| `apps/backend/src/lib/outbox/repository.ts` | `streamVisibility?` on conversation created/updated payloads |
| `apps/backend/src/lib/outbox/delivery-groups.ts` | Route created/updated to `WORKSPACE_GROUP` when public; split `message_assigned` to its own stream-scoped branch |
| `apps/backend/src/lib/outbox/delivery-groups.test.ts` | 4 cases: public→workspace, private→members, public thread fan-out, message_assigned never workspace |
| `apps/backend/src/features/conversations/assignment-events.ts` | Emit access-root `streamVisibility` via the shared helper |
| `apps/backend/src/features/conversations/boundary-extraction-service.ts` | Emit `streamVisibility` **per touched conversation's own stream** (memoized) so a private conv can't inherit a public visibility (INV-62) |
| `apps/backend/src/features/conversations/service.ts` | Emit `streamVisibility` on reassign; comment documenting why one resolution is safe here (same-stream invariant) |
| `docs/board-view-design.md` | New section: "Stable view + pending updates — the reactivity model" (the next-iteration follow-up + edge cases) |

## Review hardening (post-open)

Driven to a clean **7/7** by the multi-agent `/code-review` loop and CodeRabbit's ASSERTIVE pass:

- **INV-62 (important):** the boundary extractor now resolves delivery per touched conversation's own access-root stream — a private conversation touched during a public-channel extraction no longer inherits the public visibility and broadcasts to the workspace.
- Shared `resolveConversationDelivery` helper (was triplicated across the 3 emit sites — INV-35/37).
- `board-store` merge/optimistic writes wrapped in `rw` transactions + dedup by message id (atomic against a concurrent echo).
- `refetchType: "active"` so a closed board refetches on reopen; `seedPending` guard against the empty-state flash; attachment-carrying replies refetch the head.
- Reassign cross-stream concern reviewed → false positive (same-stream invariant), documented in a comment.

## Out of scope (deliberate)

- **Live reply *bodies* for other users into existing cards** — re-sort is live; body lands on the next seed (decision 3). Event-payload enrichment is a follow-up.
- **Per-member fan-out for private streams not joined this session** — covered by the board's bootstrap/reconnect fetch, not live delivery (decision 2).
- **The "stable view + pending pill + scroll anchor" reactivity model** — designed in `docs/board-view-design.md`, a follow-up that reshapes the projection layer (and removes the optimistic bump-to-top).
- **No schema change, no backend route change** — frontend rails + one optional payload field + delivery routing only.

## Test plan

- [x] `apps/frontend` `bunx vitest run src/stores src/sync src/db` — 354 pass (IDB v36 migration touches all store/sync suites)
- [x] `apps/frontend` board suites (`board-store`, `board`, `use-conversations`, `workspace-sync`, `components/board`) — pass
- [x] `apps/backend` `bun test src/features/conversations src/lib/outbox` — 99 pass
- [x] `apps/backend` `bun test src/features/messaging` — 101 pass (event-service drives the assigner)
- [x] `tsc --noEmit` clean for frontend + backend (incl. `tsconfig.tests`)
- [x] Pre-commit hook on every commit: full lint across all apps + monorepo typecheck + astro check + OpenAPI `--check` — clean
- [ ] `test:e2e` not run — unit-level change, fully covered above; the Playwright suite wasn't exercised this session

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Make the board feel live, like the timeline — the design doc's "Realtime / sync model" section.

**What was built.**
1. `conversations` IDB store (Dexie v36) holding `BoardPost` rows.
2. `board-store.ts`: reactive `useBoardPosts` + seed/merge/optimistic helpers.
3. `useWorkspaceConversations` seeds IDB; `board.tsx` reads from IDB.
4. Gate-registered `conversation:created`/`updated` handlers → merge-in-place or refresh-head.
5. Optimistic IDB write for `intoConversation` board replies.
6. Visibility-gated workspace delivery of conversation aggregate events (INV-62), via the shared `resolveConversationDelivery` helper resolved per touched conversation.

**Design evolution.** First sketch considered enriching every `conversation:*` event with the full board projection so others' reply bodies appear live. Dropped: it adds reads to the hot send path and couples the async extractor + worker payloads to a board concern. Settled on live re-sort + body-on-next-seed. Post-open review then (a) extracted the triplicated access-root resolver into one helper, (b) fixed the boundary extractor to resolve delivery per touched conversation (INV-62), (c) hardened the optimistic/echo path with rw transactions, and (d) added the `seedPending`/`refetchType`/attachment-refetch UX fixes. A larger follow-up ("stable view + pending pill") is captured in the design doc and will supersede the live re-sort.

**Schema changes.** None (DB). Frontend IDB Dexie 35 → 36 (additive store).

**What's NOT included.** Live reply bodies for others into existing cards; per-member private-stream live fan-out; payload enrichment; the stable-view reactivity model. All noted in "Out of scope".

**Status.** Complete; typecheck + lint + affected suites green; review at 7/7; pushed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_