### PR TITLE
fix(timeline): reliable auto-read on open-at-bottom + clear push on every read-advance

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1536,7 +1536,19 @@ export function StreamContent({
   // through from where they left off (see useLastSeenEvent), so the unread above
   // the fold stays unread until they go up to it (or press Escape). A not-at-tail
   // mark is partial — the badge keeps the remaining unread (markAsRead partial).
-  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode
+  //
+  // Hold off arming the read-frontier scan until the cold-load settle has parked
+  // the virtualized list at the live bottom. The scan reads row geometry; while
+  // the settle is still pinning to the tail across frames, the last row sits
+  // below the composer band and is excluded from the visible range, and once the
+  // settle converges there's no guaranteed scroll/resize to re-scan — so arming
+  // mid-settle can leave the trailing unread row stuck out of the frontier and it
+  // never auto-reads (opened-fresh-at-bottom, intermittent). Gating on
+  // settle-complete makes the attach scan run once the tail is actually on
+  // screen. Only the virtualized timeline settles; the plain thread scroller has
+  // no settle phase (`isInitialSettling` would never clear there), so exempt it.
+  const settledAtBottom = !useVirtualized || !virtualIsInitialSettling
+  const autoMarkEnabled = !isDraft && !isLoading && !isJumpMode && settledAtBottom
   const { lastSeenEventId, atLastRow, unreadAboveViewport } = useLastSeenEvent({
     scrollContainerRef,
     // The virtualized scroller late-mounts via a ref callback, AFTER

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import { useAutoMarkAsRead } from "./use-auto-mark-as-read"
-import { SW_MSG_CLEAR_NOTIFICATIONS } from "../lib/sw-messages"
 import * as useUnreadCountsModule from "./use-unread-counts"
 import * as useActivityCountsModule from "./use-activity-counts"
 import * as useMobileModule from "./use-mobile"
@@ -9,7 +8,6 @@ import * as useMobileModule from "./use-mobile"
 const mockMarkAsRead = vi.fn()
 const mockGetUnreadCount = vi.fn()
 const mockGetActivityCount = vi.fn()
-const mockPostMessage = vi.fn()
 
 let unreadCount = 1
 let activityCount = 0
@@ -21,7 +19,6 @@ let isMobileViewport = false
 let isCoarsePointer = false
 
 const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState")
-const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
 
 function restoreProperty(target: object, key: PropertyKey, descriptor?: PropertyDescriptor) {
   if (descriptor) {
@@ -37,7 +34,6 @@ describe("useAutoMarkAsRead", () => {
     mockMarkAsRead.mockReset()
     mockGetUnreadCount.mockReset()
     mockGetActivityCount.mockReset()
-    mockPostMessage.mockReset()
     vi.useFakeTimers()
 
     unreadCount = 1
@@ -67,15 +63,6 @@ describe("useAutoMarkAsRead", () => {
       configurable: true,
       get: () => visibilityState,
     })
-
-    Object.defineProperty(navigator, "serviceWorker", {
-      configurable: true,
-      value: {
-        controller: {
-          postMessage: mockPostMessage,
-        },
-      },
-    })
   })
 
   afterEach(() => {
@@ -84,7 +71,6 @@ describe("useAutoMarkAsRead", () => {
     vi.restoreAllMocks()
 
     restoreProperty(document, "visibilityState", originalVisibilityState)
-    restoreProperty(navigator, "serviceWorker", originalServiceWorker)
   })
 
   it("marks the stream as read when the page is visible and focused", () => {
@@ -95,10 +81,6 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: SW_MSG_CLEAR_NOTIFICATIONS,
-      streamId: "stream_123",
-    })
   })
 
   it("does not mark the stream as read while the tab is hidden and unfocused", () => {
@@ -112,7 +94,6 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).not.toHaveBeenCalled()
-    expect(mockPostMessage).not.toHaveBeenCalled()
   })
 
   it("does not mark the stream as read while the tab is visible but the window is unfocused", () => {
@@ -125,7 +106,6 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).not.toHaveBeenCalled()
-    expect(mockPostMessage).not.toHaveBeenCalled()
   })
 
   it("marks read on a phone-like device (coarse + narrow) that is visible but reports no focus", () => {
@@ -222,10 +202,6 @@ describe("useAutoMarkAsRead", () => {
     })
 
     expect(mockMarkAsRead).toHaveBeenCalledWith("stream_123", "event_123", { partial: false })
-    expect(mockPostMessage).toHaveBeenCalledWith({
-      type: SW_MSG_CLEAR_NOTIFICATIONS,
-      streamId: "stream_123",
-    })
   })
 
   it("passes partial through so a mid-window read does not zero the badge", () => {

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -3,7 +3,6 @@ import { useUnreadCounts } from "./use-unread-counts"
 import { useActivityCounts } from "./use-activity-counts"
 import { usePageActivity } from "./use-page-activity"
 import { useIsMobile, useIsCoarsePointer } from "./use-mobile"
-import { SW_MSG_CLEAR_NOTIFICATIONS } from "../lib/sw-messages"
 
 interface UseAutoMarkAsReadOptions {
   enabled?: boolean
@@ -112,11 +111,6 @@ export function useAutoMarkAsRead(
         markAsRead(currentStreamId, currentLastEventId, { partial: partialRef.current })
         lastMarkedRef.current = currentLastEventId
         lastMarkedPartialRef.current = partialRef.current
-        // Dismiss any push notification for this stream — the user is reading it
-        navigator.serviceWorker?.controller?.postMessage({
-          type: SW_MSG_CLEAR_NOTIFICATIONS,
-          streamId: currentStreamId,
-        })
       }
     }, debounceMs)
 

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -261,6 +261,54 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.atLastRow).toBe(true)
   })
 
+  it("advances to the trailing unread row when armed after the cold-load settle parks the tail", () => {
+    // The opened-fresh-at-bottom bug: the virtualized list parks at the live
+    // bottom over several settle frames. If read-tracking arms mid-settle the
+    // scan reads a not-yet-parked viewport and, with no guaranteed re-scan once
+    // the settle converges, the trailing unread row stays out of the frontier and
+    // never auto-reads. The component now holds `enabled` false until the settle
+    // completes; this pins the contract that scope relies on — arming with the
+    // tail already on screen advances the frontier to the last row so auto-read
+    // fires (and the push/divider clear). e0 is the viewer's read pointer, e1 the
+    // single trailing unread (mirrors "oh, nice").
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: 35, bottom: 65 }, // read pointer, visible above the tail
+      e1: { top: 65, bottom: 95 }, // the trailing unread row, parked above the composer
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [
+      { id: "e0", sequence: "0" },
+      { id: "e1", sequence: "1" },
+    ] as unknown as StreamEvent[]
+    const scrollContainerRef = { current: container }
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useLastSeenEvent({ scrollContainerRef, events, streamId: "stream_1", lastReadEventId: "e0", enabled }),
+      { initialProps: { enabled: false } }
+    )
+
+    // Still settling → not armed, frontier can't advance.
+    expect(result.current.lastSeenEventId).toBeUndefined()
+    expect(result.current.atLastRow).toBe(false)
+
+    // Settle complete: the tail is parked on screen and tracking arms.
+    act(() => rerender({ enabled: true }))
+
+    // The frontier advances to the trailing row, so auto-read fires for it.
+    expect(result.current.lastSeenEventId).toBe("e1")
+    expect(result.current.atLastRow).toBe(true)
+  })
+
   it("does not re-read a still-visible row when the read pointer moves backward (mark-as-unread), until a scroll", () => {
     // A short, fully-read stream: every row is on screen and the pointer is at
     // the tail (e3). Marking e2 unread moves the pointer back to e1 while e2 is

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook, waitFor, act } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ServicesProvider, type StreamService } from "@/contexts"
 import { clearAllCachedData, db } from "@/db"
 import {
@@ -11,10 +11,13 @@ import {
   type StreamMember,
   type WorkspaceBootstrap,
 } from "@threa/types"
+import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
 import { workspaceKeys } from "./use-workspaces"
 import { useUnreadCounts } from "./use-unread-counts"
 
 const mockMarkAsRead = vi.fn<(workspaceId: string, streamId: string, lastEventId: string) => Promise<StreamMember>>()
+const mockPostMessage = vi.fn()
+const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, "serviceWorker")
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -116,7 +119,20 @@ function makeBootstrap(): WorkspaceBootstrap {
 describe("useUnreadCounts", () => {
   beforeEach(async () => {
     mockMarkAsRead.mockReset()
+    mockPostMessage.mockReset()
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { controller: { postMessage: mockPostMessage } },
+    })
     await clearAllCachedData()
+  })
+
+  afterEach(() => {
+    if (originalServiceWorker) {
+      Object.defineProperty(navigator, "serviceWorker", originalServiceWorker)
+    } else {
+      Reflect.deleteProperty(navigator, "serviceWorker")
+    }
   })
 
   it("updates the membership read pointer in IndexedDB when marking a stream as read", async () => {
@@ -268,11 +284,40 @@ describe("useUnreadCounts", () => {
       result.current.markAsRead("stream_1", "temp_optimistic")
     })
     expect(mockMarkAsRead).not.toHaveBeenCalled()
+    // No read advanced, so no notification is dismissed for the optimistic id.
+    expect(mockPostMessage).not.toHaveBeenCalled()
 
     // The real event id (after the server echo swaps it in) is sent normally.
     act(() => {
       result.current.markAsRead("stream_1", "event_new")
     })
     await waitFor(() => expect(mockMarkAsRead).toHaveBeenCalledWith("ws_1", "stream_1", "event_new"))
+  })
+
+  it("dismisses the stream's push notification when advancing the read pointer", async () => {
+    // Centralized clear: every read-advance funnels through markAsRead (auto-read,
+    // manual "Mark as read", Escape), so reading a stream dismisses its push banner
+    // locally on this device — not just on the auto-read path.
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), makeBootstrap())
+
+    mockMarkAsRead.mockResolvedValue({
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: "everything",
+      lastReadEventId: "event_new",
+      lastReadAt: new Date().toISOString(),
+      joinedAt: new Date().toISOString(),
+    })
+
+    const { result } = renderHook(() => useUnreadCounts("ws_1"), {
+      wrapper: createWrapper(queryClient),
+    })
+
+    act(() => {
+      result.current.markAsRead("stream_1", "event_new")
+    })
+
+    expect(mockPostMessage).toHaveBeenCalledWith({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId: "stream_1" })
   })
 })

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -6,6 +6,7 @@ import { streamKeys } from "./use-streams"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { db } from "@/db"
 import { deriveActivityCounts } from "@/sync/unread-counters"
+import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
 import type { WorkspaceBootstrap } from "@threa/types"
 
 export function useUnreadCounts(workspaceId: string) {
@@ -216,6 +217,12 @@ export function useUnreadCounts(workspaceId: string) {
       // swaps it in.
       if (lastEventId.startsWith("temp_")) return
       markAsReadMutation.mutate({ streamId, lastEventId, partial: opts?.partial })
+      // Dismiss any push notification for this stream — advancing the read pointer
+      // (auto-read, manual "Mark as read", or Escape) means the user is here, so
+      // the banner is noise. Centralized on this single read-advance funnel so
+      // every caller clears locally, not just auto-read; the backend stream:read
+      // round-trip also fans a clear out to the user's other devices.
+      navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })
     },
     [markAsReadMutation]
   )

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -219,9 +219,10 @@ export function useUnreadCounts(workspaceId: string) {
       markAsReadMutation.mutate({ streamId, lastEventId, partial: opts?.partial })
       // Dismiss any push notification for this stream — advancing the read pointer
       // (auto-read, manual "Mark as read", or Escape) means the user is here, so
-      // the banner is noise. Centralized on this single read-advance funnel so
-      // every caller clears locally, not just auto-read; the backend stream:read
-      // round-trip also fans a clear out to the user's other devices.
+      // the banner is noise. Centralized on this single-stream read-advance funnel
+      // so each of those paths clears locally, not just auto-read; mark-all-read is
+      // a separate path that clears via its own stream:read_all round-trip. The
+      // backend stream:read round-trip also fans a clear out to the user's other devices.
       navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })
     },
     [markAsReadMutation]


### PR DESCRIPTION
## Problem

Auto-read intermittently failed to mark the **last** message on a fresh open-at-bottom — most visibly a mobile DM where the bottom message sat under a red "New" divider and the push notification never cleared, even though the message was on screen. Reproduces on both mobile and desktop, and "not always."

Forensics on the reported DM (`stream_01KJMS77…`) showed the backend read pointer was *already* on the latest message — the read had registered (via manual marking). So this was never a stuck server pointer; it was a client-side auto-read reliability bug, with the stuck "New" divider and lingering push as downstream symptoms (no `stream:read` ever fired on its own).

Two distinct defects:

1. **Cold-load settle race.** The virtualized timeline parks at the live bottom over several settle frames (`useTimelineScroll`'s `isInitialSettling`, hard-capped at 2000ms). `useLastSeenEvent` armed the instant `isLoading` cleared — *before* the settle finished — so its frontier scan read a viewport not yet parked at the tail (the last row still sits below the composer band and is excluded from `pickVisibleRange`). Once the settle converged there was no guaranteed scroll/resize to re-scan, so the trailing unread row never entered the seen frontier, `lastSeenEventId` stayed `undefined`, `useAutoMarkAsRead` never fired, and no `stream:read` was emitted. Whether the single initial scan happened to catch the settled frame was a race — hence "not always," and it's the shared virtualized path, hence both platforms.

2. **Push clear only on the auto-read path.** Manual "Mark as read" (the message action) and the Escape-to-read shortcut advanced the read pointer but never posted `CLEAR_NOTIFICATIONS` to the service worker — only `useAutoMarkAsRead` did. So reading a stream by hand left the OS banner on the device until the slower backend `stream:read` round-trip fanned a clear back.

## Solution

Arm read-tracking only **after** the settle parks the tail, and move the notification clear to the single read-advance funnel so every path clears consistently.

### How it works

- **Settle gate** (`stream-content.tsx`): `autoMarkEnabled` now also requires `settledAtBottom = !useVirtualized || !virtualIsInitialSettling`. `virtualIsInitialSettling` comes from `useTimelineScroll`; it starts `!skipInitialScroll` (true on a normal cold open, false for deep-link opens) and clears when the settle converges or hits its 2000ms cap. When the gate flips false→true post-settle, `useLastSeenEvent`'s attach effect re-runs (`enabled` is a dep) and re-scans at the now-parked bottom, so the trailing row reliably enters the frontier and `useAutoMarkAsRead` fires once. The plain (non-virtualized) thread scroller has no settle phase, so it's exempted via `!useVirtualized`.
- **Centralized clear** (`use-unread-counts.ts`): the `navigator.serviceWorker?.controller?.postMessage({ type: SW_MSG_CLEAR_NOTIFICATIONS, streamId })` post moved into `markAsRead` (the single funnel for auto-read, manual mark, and Escape), after the `temp_` optimistic-id guard. Removed the now-duplicated post and its import from `useAutoMarkAsRead`.

### Key design decisions

**1. Gate `enabled`, don't add a re-scan signal.** Turning tracking off during the ~80ms settle and letting the attach effect re-run on enable is deterministic — the scan is guaranteed to run after the scroller is parked — and reuses the existing enable→attach→scan path rather than threading a new settle event into the hook.

**2. Exempt the non-virtualized scroller.** `isInitialSettling` would never clear for the plain thread scroller (its settle layout effect early-returns on `itemCount === 0`), so gating it there would permanently disable auto-read. Threads load small and are covered by the existing scroll/resize re-scan, so `!useVirtualized` short-circuits the gate.

**3. Clear on every read-advance, including partial.** This matches the pre-existing auto-read behavior (the old `useAutoMarkAsRead` posted the clear unconditionally, including `partial: true`). The push banner is per-stream ("stream X has activity"); being actively in the stream dismisses it, while the in-app unread divider/badge remain the signal for unread-above. Mark-all-read is a separate funnel and clears via its own `stream:read_all` round-trip.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Gate `autoMarkEnabled` on `settledAtBottom` (virtualized-only) |
| `apps/frontend/src/hooks/use-unread-counts.ts` | Post `CLEAR_NOTIFICATIONS` in `markAsRead` (after the `temp_` guard) |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | Remove the now-duplicated SW post + unused import |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | New case: arming after the settle parks the tail advances the frontier to the trailing unread row |
| `apps/frontend/src/hooks/use-unread-counts.test.tsx` | New: `markAsRead` posts the clear; no post for `temp_` ids |
| `apps/frontend/src/hooks/use-auto-mark-as-read.test.ts` | Drop SW-clear assertions (responsibility moved to `markAsRead`) |

## Out of scope (deliberate)

- **Manual-mark cross-device clear** already worked via the backend `stream:read` → `deliverClearForStream` push; this PR only adds the *local* same-device dismissal so the banner clears instantly instead of waiting on the round-trip.
- **No backend change.** The server read-pointer/outbox path was correct (verified in prod for the reported DM).

## Test plan

- [x] `bun test src/hooks/use-last-seen-event` — 21 pass (incl. new settle-arm case)
- [x] `bun test src/hooks/use-unread-counts` — 4 pass (incl. new clear + temp_ cases)
- [x] `bun test src/hooks/use-auto-mark-as-read` — pass (SW assertions relocated)
- [x] `tsc -p apps/frontend/tsconfig.json --noEmit` clean
- [x] Pre-PR review (4 reviewer agents: spec+design, correctness, UX, mobile): 2 findings (both 80) — 1 fixed (comment accuracy re mark-all-read), 1 kept as deliberate (partial-read clear matches prior auto-read behavior)
- [ ] Not device-reproduced — the settle race is timing-dependent; the fix is reasoned against the code + the user's repro and pinned by the new unit test, not observed green on a physical phone

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgH6e9MYdq5H4omQ4XicuY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785181890&installation_id=129946197&pr_number=1102&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1102&signature=90c1424267182abd5b986f66114e25e20d880936630f085767e647e7fc66bbb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->