### PR TITLE
feat(board): stable view with pending-update pill, not live re-sort

### DIFF
--- a/apps/frontend/src/components/board/board-composer.tsx
+++ b/apps/frontend/src/components/board/board-composer.tsx
@@ -82,7 +82,7 @@ function targetForValue(value: string): BoardPostTarget | null {
  * composer. The composer closes on a successful post and the feed refreshes to
  * show it, so the result is visible without a success toast (INV-63).
  */
-export function BoardComposer({ workspaceId }: { workspaceId: string }) {
+export function BoardComposer({ workspaceId, onPosted }: { workspaceId: string; onPosted?: () => void }) {
   const [open, setOpen] = useState(false)
 
   if (!open) {
@@ -98,10 +98,18 @@ export function BoardComposer({ workspaceId }: { workspaceId: string }) {
     )
   }
 
-  return <BoardComposerForm workspaceId={workspaceId} onClose={() => setOpen(false)} />
+  return <BoardComposerForm workspaceId={workspaceId} onClose={() => setOpen(false)} onPosted={onPosted} />
 }
 
-function BoardComposerForm({ workspaceId, onClose }: { workspaceId: string; onClose: () => void }) {
+function BoardComposerForm({
+  workspaceId,
+  onClose,
+  onPosted,
+}: {
+  workspaceId: string
+  onClose: () => void
+  onPosted?: () => void
+}) {
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -165,6 +173,9 @@ function BoardComposerForm({ workspaceId, onClose }: { workspaceId: string; onCl
       composer.clearAttachments()
       writeStoredTarget(workspaceId, "")
       onClose()
+      // Reveal the just-posted card rather than letting it wait behind its own
+      // "N new" pill — the viewer's own action should surface immediately.
+      onPosted?.()
     } catch {
       toast.error("Couldn't post to the board. Please try again.")
     } finally {

--- a/apps/frontend/src/hooks/use-board-scroll-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-scroll-anchor.ts
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react"
+
+/** Below this scrollTop the anchor is disabled, so prepended cards flow in at the
+ *  top (the pill-click reveal) instead of being held off-screen above the fold. */
+const ANCHOR_DISABLE_PX = 4
+/** Sub-pixel layout jitter shouldn't trigger a scroll correction. */
+const MIN_COMPENSATION_PX = 0.5
+
+/** Attribute carrying a card's conversation id, read to re-find the anchor card. */
+export const BOARD_CARD_ATTR = "data-board-card"
+
+interface Anchor {
+  id: string
+  /** The card's top offset within the viewport at the moment it was measured. */
+  offset: number
+}
+
+/** The topmost card still touching the viewport, and its offset within it. */
+function measureAnchor(viewport: HTMLElement): Anchor | null {
+  const cards = viewport.querySelectorAll<HTMLElement>(`[${BOARD_CARD_ATTR}]`)
+  const viewportTop = viewport.getBoundingClientRect().top
+  for (const card of cards) {
+    const top = card.getBoundingClientRect().top - viewportTop
+    if (top + card.offsetHeight > 0) {
+      const id = card.getAttribute(BOARD_CARD_ATTR)
+      return id ? { id, offset: top } : null
+    }
+  }
+  return null
+}
+
+/**
+ * Formalize INV-61 for the top-anchored board feed: the topmost visible card
+ * keeps its exact screen offset across any mutation. The hard case is async
+ * reflow — avatars, link previews and images *above* the viewport loading after
+ * the initial layout and growing the region — which would push the card the
+ * viewer is reading downward. A `ResizeObserver` on the content catches every
+ * such growth (the timeline gets the same guarantee from `virtua`'s `shift`; a
+ * non-virtualized board hand-rolls it) and re-pins the anchor card by adding the
+ * above-anchor height delta to `scrollTop`.
+ *
+ * Disabled near the top so a pill-click reveal (scroll to top, then commit) lets
+ * the new cards flow in rather than holding the old first card in place.
+ */
+export function useBoardScrollAnchor(viewport: HTMLElement | null): void {
+  const anchorRef = useRef<Anchor | null>(null)
+
+  useEffect(() => {
+    if (!viewport) return
+
+    // Re-measure the anchor on every user scroll; our own corrections write
+    // scrollTop and re-measure to the same offset, so they don't drift it.
+    const onScroll = () => {
+      anchorRef.current = measureAnchor(viewport)
+    }
+    onScroll()
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+
+    const content = viewport.firstElementChild
+    const observer = new ResizeObserver(() => {
+      if (viewport.scrollTop <= ANCHOR_DISABLE_PX) return
+      const anchor = anchorRef.current
+      if (!anchor) return
+      const card = viewport.querySelector<HTMLElement>(`[${BOARD_CARD_ATTR}="${CSS.escape(anchor.id)}"]`)
+      if (!card) return
+      const top = card.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+      const delta = top - anchor.offset
+      if (Math.abs(delta) > MIN_COMPENSATION_PX) viewport.scrollTop += delta
+    })
+    if (content) observer.observe(content)
+
+    return () => {
+      viewport.removeEventListener("scroll", onScroll)
+      observer.disconnect()
+    }
+  }, [viewport])
+}

--- a/apps/frontend/src/hooks/use-board-scroll-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-scroll-anchor.ts
@@ -5,6 +5,11 @@ import { useEffect, useRef } from "react"
 const ANCHOR_DISABLE_PX = 4
 /** Sub-pixel layout jitter shouldn't trigger a scroll correction. */
 const MIN_COMPENSATION_PX = 0.5
+/** While a touch scroll is active — and for this long after the finger lifts,
+ *  covering the kinetic-momentum phase — a `scrollTop` write fights iOS Safari's
+ *  native momentum engine and judders. Defer the correction and re-pin once the
+ *  scroll settles instead. */
+const MOMENTUM_SETTLE_MS = 450
 
 /** Attribute carrying a card's conversation id, read to re-find the anchor card. */
 export const BOARD_CARD_ATTR = "data-board-card"
@@ -48,16 +53,21 @@ export function useBoardScrollAnchor(viewport: HTMLElement | null): void {
   useEffect(() => {
     if (!viewport) return
 
+    // A touch scroll holds off compensation until its momentum settles, so we
+    // never write scrollTop mid-flick. Desktop (no touch events) keeps the
+    // immediate path — a programmatic scrollTop write there is invisible.
+    let touching = false
+    let momentumUntil = 0
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+
     // Re-measure the anchor on every user scroll; our own corrections write
     // scrollTop and re-measure to the same offset, so they don't drift it.
     const onScroll = () => {
       anchorRef.current = measureAnchor(viewport)
     }
     onScroll()
-    viewport.addEventListener("scroll", onScroll, { passive: true })
 
-    const content = viewport.firstElementChild
-    const observer = new ResizeObserver(() => {
+    const compensate = () => {
       if (viewport.scrollTop <= ANCHOR_DISABLE_PX) return
       const anchor = anchorRef.current
       if (!anchor) return
@@ -66,12 +76,52 @@ export function useBoardScrollAnchor(viewport: HTMLElement | null): void {
       const top = card.getBoundingClientRect().top - viewport.getBoundingClientRect().top
       const delta = top - anchor.offset
       if (Math.abs(delta) > MIN_COMPENSATION_PX) viewport.scrollTop += delta
-    })
+    }
+
+    // After the active scroll/momentum window passes, re-pin once so above-fold
+    // reflow that landed mid-scroll is corrected without having fought momentum.
+    const scheduleSettle = () => {
+      if (settleTimer) clearTimeout(settleTimer)
+      const wait = Math.max(0, momentumUntil - performance.now()) || MOMENTUM_SETTLE_MS
+      settleTimer = setTimeout(() => {
+        settleTimer = null
+        if (!touching && performance.now() >= momentumUntil) compensate()
+      }, wait)
+    }
+
+    const onResize = () => {
+      if (touching || performance.now() < momentumUntil) {
+        scheduleSettle()
+        return
+      }
+      compensate()
+    }
+
+    const onTouchStart = () => {
+      touching = true
+    }
+    const onTouchEnd = () => {
+      touching = false
+      momentumUntil = performance.now() + MOMENTUM_SETTLE_MS
+      scheduleSettle()
+    }
+
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+    viewport.addEventListener("touchstart", onTouchStart, { passive: true })
+    viewport.addEventListener("touchend", onTouchEnd, { passive: true })
+    viewport.addEventListener("touchcancel", onTouchEnd, { passive: true })
+
+    const content = viewport.firstElementChild
+    const observer = new ResizeObserver(onResize)
     if (content) observer.observe(content)
 
     return () => {
       viewport.removeEventListener("scroll", onScroll)
+      viewport.removeEventListener("touchstart", onTouchStart)
+      viewport.removeEventListener("touchend", onTouchEnd)
+      viewport.removeEventListener("touchcancel", onTouchEnd)
       observer.disconnect()
+      if (settleTimer) clearTimeout(settleTimer)
     }
   }, [viewport])
 }

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -126,6 +126,24 @@ describe("useStableBoardView", () => {
     expect(result.current.newCount).toBe(0)
   })
 
+  it("disarms revealNext after its window, so a later unrelated arrival buffers", () => {
+    vi.useFakeTimers()
+    try {
+      mockLive(feed(post("a", 300)))
+      const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))
+      act(() => result.current.revealNext())
+      // Nothing arrived within the window; the arm expires.
+      act(() => vi.advanceTimersByTime(8001))
+      act(() => mockLive(feed(post("late", 600), post("a", 300))))
+      rerender()
+      // The stale arm did not fire — the late arrival waits behind the pill.
+      expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+      expect(result.current.newCount).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("keeps a vanished committed card rendering in place until the next commit", () => {
     mockLive(feed(post("a", 300), post("b", 200)))
     const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import * as boardStoreModule from "@/stores/board-store"
+import type { CachedBoardPost } from "@/db"
+import { reconcileStableView, useStableBoardView, type CommittedView } from "./use-stable-board-view"
+
+function post(id: string, activityMs: number): CachedBoardPost {
+  return {
+    id,
+    workspaceId: "ws_1",
+    _lastActivityMs: activityMs,
+    _cachedAt: activityMs,
+    conversation: { id, lastActivityAt: new Date(activityMs).toISOString() },
+    openingMessage: null,
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as CachedBoardPost
+}
+
+/** Newest-first feed, matching what `useBoardPosts` returns. */
+function feed(...posts: CachedBoardPost[]): CachedBoardPost[] {
+  return [...posts].sort((a, b) => b._lastActivityMs - a._lastActivityMs)
+}
+
+function committedOf(...posts: CachedBoardPost[]): CommittedView {
+  return {
+    order: posts.map((p) => p.id),
+    activityById: new Map(posts.map((p) => [p.id, p._lastActivityMs])),
+  }
+}
+
+const EMPTY: CommittedView = { order: [], activityById: new Map() }
+
+describe("reconcileStableView", () => {
+  it("commits the live order wholesale on the first non-empty snapshot", () => {
+    const live = feed(post("a", 300), post("b", 200))
+    const { committed, buffered } = reconcileStableView(EMPTY, live)
+    expect(committed.order).toEqual(["a", "b"])
+    expect(buffered).toEqual([])
+  })
+
+  it("keeps the same empty reference for an empty feed (no churn)", () => {
+    const result = reconcileStableView(EMPTY, [])
+    expect(result.committed).toBe(EMPTY)
+    expect(result.buffered).toEqual([])
+  })
+
+  it("buffers a fresh arrival above the floor instead of reordering", () => {
+    const committed = committedOf(post("a", 300), post("b", 200))
+    const live = feed(post("new", 500), post("a", 300), post("b", 200))
+    const result = reconcileStableView(committed, live)
+    // Order is frozen — the new card does NOT appear in it.
+    expect(result.committed.order).toEqual(["a", "b"])
+    expect(result.buffered).toEqual(["new"])
+  })
+
+  it("leaves a bumped seen card in place and out of the buffer", () => {
+    const committed = committedOf(post("a", 300), post("b", 200))
+    // "b" got bumped above "a" in the live feed, but it is already committed.
+    const live = feed(post("b", 900), post("a", 300))
+    const result = reconcileStableView(committed, live)
+    expect(result.committed.order).toEqual(["a", "b"])
+    expect(result.buffered).toEqual([])
+  })
+
+  it("appends older rows paged in below the floor without a pill", () => {
+    const committed = committedOf(post("a", 300), post("b", 200))
+    const live = feed(post("a", 300), post("b", 200), post("old1", 150), post("old2", 100))
+    const result = reconcileStableView(committed, live)
+    expect(result.committed.order).toEqual(["a", "b", "old1", "old2"])
+    expect(result.buffered).toEqual([])
+    expect(result.committed.activityById.get("old1")).toBe(150)
+  })
+
+  it("splits a mixed update into buffer (new) and append (older)", () => {
+    const committed = committedOf(post("a", 300), post("b", 200))
+    const live = feed(post("new", 500), post("a", 300), post("b", 200), post("old", 100))
+    const result = reconcileStableView(committed, live)
+    expect(result.committed.order).toEqual(["a", "b", "old"])
+    expect(result.buffered).toEqual(["new"])
+  })
+})
+
+describe("useStableBoardView", () => {
+  let liveValue: CachedBoardPost[] | undefined
+  function mockLive(value: CachedBoardPost[] | undefined) {
+    liveValue = value
+    vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
+  }
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it("reports loading until the IDB read resolves, then the empty state", () => {
+    mockLive(undefined)
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))
+    expect(result.current.isLoading).toBe(true)
+    act(() => mockLive([]))
+    rerender()
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.posts).toEqual([])
+  })
+
+  it("holds order frozen and surfaces a fresh arrival as the new count", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    act(() => mockLive(feed(post("new", 500), post("a", 300), post("b", 200))))
+    rerender()
+    // The card stays out of view; only the count moves.
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+    expect(result.current.newCount).toBe(1)
+
+    act(() => result.current.commit())
+    expect(result.current.posts.map((p) => p.id)).toEqual(["new", "a", "b"])
+    expect(result.current.newCount).toBe(0)
+  })
+
+  it("auto-reveals on the next arrival when revealNext is armed (the viewer's own post)", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))
+    act(() => result.current.revealNext())
+    act(() => mockLive(feed(post("mine", 600), post("a", 300))))
+    rerender()
+    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
+    expect(result.current.newCount).toBe(0)
+  })
+
+  it("keeps a vanished committed card rendering in place until the next commit", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1"))
+    // "b" loses access / is deleted — it drops out of the live feed.
+    act(() => mockLive(feed(post("a", 300))))
+    rerender()
+    // Still rendered (last-known content), so nothing below it shifts.
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+    // A commit drops it.
+    act(() => result.current.commit())
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+
+  it("resets the committed view when the workspace changes", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(({ ws }) => useStableBoardView(ws), {
+      initialProps: { ws: "ws_1" },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+    act(() => mockLive(feed(post("z", 900))))
+    rerender({ ws: "ws_2" })
+    // Fresh snapshot for the new workspace, not the old order.
+    expect(result.current.posts.map((p) => p.id)).toEqual(["z"])
+  })
+})

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -1,6 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useBoardPosts } from "@/stores/board-store"
 import type { CachedBoardPost } from "@/db"
+
+/** How long `revealNext` stays armed after the viewer posts. Bounds the auto-
+ *  reveal to the window right after their own action, so a stale arm can't later
+ *  fire on an unrelated incoming conversation. */
+const REVEAL_ARM_MS = 8000
 
 /** A board post in the stable view — re-exported so UI (which can't import `@/db`
  *  directly, INV-15) shares the exact shape the hook renders from. */
@@ -134,8 +139,19 @@ export function useStableBoardView(workspaceId: string): StableBoardView {
   const liveRef = useRef<CachedBoardPost[]>([])
   // One-shot: when armed, the next live change with fresh arrivals commits
   // instead of buffering — so the viewer's own just-posted card is revealed, not
-  // hidden behind its own pill.
+  // hidden behind its own pill. Auto-disarms after REVEAL_ARM_MS so a post that
+  // never lands a visible conversation can't leave it armed to fire on an
+  // unrelated arrival minutes later.
   const revealNextRef = useRef(false)
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const disarmReveal = useCallback(() => {
+    revealNextRef.current = false
+    if (revealTimerRef.current) {
+      clearTimeout(revealTimerRef.current)
+      revealTimerRef.current = null
+    }
+  }, [])
+  useEffect(() => disarmReveal, [disarmReveal])
 
   // Reset the view when the workspace changes in place (the board route keeps the
   // same component instance across `:workspaceId`). React-blessed render-time
@@ -161,7 +177,7 @@ export function useStableBoardView(workspaceId: string): StableBoardView {
     const next = reconcileStableView(committed, live)
     if (next.committed !== committed) setCommitted(next.committed)
     if (revealNextRef.current && next.buffered.length > 0) {
-      revealNextRef.current = false
+      disarmReveal()
       const snap = snapshot(live)
       if (!sameIds(snap.order, committed.order)) setCommitted(snap)
       if (buffered.length > 0) setBuffered([])
@@ -180,6 +196,11 @@ export function useStableBoardView(workspaceId: string): StableBoardView {
 
   const revealNext = useCallback(() => {
     revealNextRef.current = true
+    if (revealTimerRef.current) clearTimeout(revealTimerRef.current)
+    revealTimerRef.current = setTimeout(() => {
+      revealNextRef.current = false
+      revealTimerRef.current = null
+    }, REVEAL_ARM_MS)
   }, [])
 
   const posts = useMemo(() => {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -1,0 +1,203 @@
+import { useCallback, useMemo, useRef, useState } from "react"
+import { useBoardPosts } from "@/stores/board-store"
+import type { CachedBoardPost } from "@/db"
+
+/** A board post in the stable view — re-exported so UI (which can't import `@/db`
+ *  directly, INV-15) shares the exact shape the hook renders from. */
+export type BoardViewPost = CachedBoardPost
+
+/**
+ * A frozen snapshot of the board's order. The `conversations` IDB store stays
+ * live and activity-sorted (the sync engine keeps it true); this is the order
+ * the viewer is currently looking at, deliberately held still so a card never
+ * jumps out from under the eye. Cards still read their *content* reactively from
+ * IDB — a reply body fills in place — but their *position* is this snapshot's,
+ * not the live order's, until the viewer commits a fresh one. See
+ * `docs/board-view-design.md` § "Stable view + pending updates".
+ */
+export interface CommittedView {
+  /** Conversation ids in frozen display order (activity-desc at commit time). */
+  order: string[]
+  /**
+   * `lastActivityAt` (ms) captured at commit, keyed by id. The stable grouping
+   * key — recency sections read this, not the live activity, so a bumped card
+   * keeps its section as well as its position until commit.
+   */
+  activityById: Map<string, number>
+}
+
+const EMPTY_VIEW: CommittedView = { order: [], activityById: new Map() }
+
+function postId(post: CachedBoardPost): string {
+  return post.conversation.id
+}
+
+function postMs(post: CachedBoardPost): number {
+  const ms = Date.parse(post.conversation.lastActivityAt)
+  return Number.isNaN(ms) ? 0 : ms
+}
+
+function snapshot(live: CachedBoardPost[]): CommittedView {
+  return {
+    order: live.map(postId),
+    activityById: new Map(live.map((post) => [postId(post), postMs(post)])),
+  }
+}
+
+function sameIds(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}
+
+/**
+ * Fold the live IDB feed into the committed view. Two kinds of "not yet
+ * committed" rows are told apart by the committed window's frozen lower bound:
+ *
+ *  - **Below the floor** — older content paged in by "Load more". It lands below
+ *    the viewport, so appending it to the frozen order shifts nothing on-screen;
+ *    fold it in immediately (no pill).
+ *  - **At or above the floor** — a fresh arrival (new conversation, or a card
+ *    bumped up past where it was). Revealing it would reorder the view, so it
+ *    waits in the buffer and is surfaced as the "N new" pill count instead.
+ *
+ * Returns the same `committed` reference when nothing pages in, so the caller can
+ * skip a state write.
+ */
+export function reconcileStableView(
+  committed: CommittedView,
+  live: CachedBoardPost[]
+): { committed: CommittedView; buffered: string[] } {
+  // First snapshot (initial load, or after a workspace reset): commit wholesale.
+  // An empty feed has nothing to commit — keep the (empty) committed reference so
+  // the caller doesn't churn fresh empty snapshots and loop.
+  if (committed.order.length === 0) {
+    return live.length === 0 ? { committed, buffered: [] } : { committed: snapshot(live), buffered: [] }
+  }
+
+  const committedSet = new Set(committed.order)
+  let floor = Infinity
+  for (const ms of committed.activityById.values()) if (ms < floor) floor = ms
+
+  const paged: CachedBoardPost[] = []
+  const buffered: string[] = []
+  for (const post of live) {
+    if (committedSet.has(postId(post))) continue
+    if (postMs(post) < floor) paged.push(post)
+    else buffered.push(postId(post))
+  }
+
+  if (paged.length === 0) {
+    return { committed, buffered }
+  }
+
+  // Append paged-in older rows below the frozen window, activity-desc.
+  paged.sort((a, b) => postMs(b) - postMs(a))
+  const activityById = new Map(committed.activityById)
+  for (const post of paged) activityById.set(postId(post), postMs(post))
+  return {
+    committed: { order: [...committed.order, ...paged.map(postId)], activityById },
+    buffered,
+  }
+}
+
+export interface StableBoardView {
+  /** Frozen-order posts to render — position is the committed snapshot's, content is live. */
+  posts: CachedBoardPost[]
+  /** Commit-time activity (ms) per id, for monotonic recency grouping. */
+  activityById: Map<string, number>
+  /** Count of buffered new conversations behind the "N new" pill. */
+  newCount: number
+  /** Reveal buffered changes: re-snapshot the live order as the committed view. */
+  commit: () => void
+  /** Arm a one-shot auto-commit on the next live change (the viewer's own post). */
+  revealNext: () => void
+  /** True until the underlying IDB read first resolves. */
+  isLoading: boolean
+}
+
+/**
+ * The board's stable-view projection: holds the order the viewer is looking at
+ * frozen while live changes accumulate behind a pill, instead of re-sorting cards
+ * under the eye. Wraps the live IDB feed (`useBoardPosts`); the committed snapshot
+ * is React state, re-derived from the live feed without ever reordering a
+ * committed card.
+ */
+export function useStableBoardView(workspaceId: string): StableBoardView {
+  const live = useBoardPosts(workspaceId)
+  const [committed, setCommitted] = useState<CommittedView>(EMPTY_VIEW)
+  const [buffered, setBuffered] = useState<string[]>([])
+  // Last-known content for committed cards, so one that vanishes from the live
+  // feed (deleted / lost access) keeps rendering in place until the next commit
+  // drops it — a removal never shifts the rows below it.
+  const retainedRef = useRef<Map<string, CachedBoardPost>>(new Map())
+  const liveRef = useRef<CachedBoardPost[]>([])
+  // One-shot: when armed, the next live change with fresh arrivals commits
+  // instead of buffering — so the viewer's own just-posted card is revealed, not
+  // hidden behind its own pill.
+  const revealNextRef = useRef(false)
+
+  // Reset the view when the workspace changes in place (the board route keeps the
+  // same component instance across `:workspaceId`). React-blessed render-time
+  // reset; the ref writes are idempotent and gated by the changed key.
+  const wsRef = useRef(workspaceId)
+  if (wsRef.current !== workspaceId) {
+    wsRef.current = workspaceId
+    retainedRef.current = new Map()
+    liveRef.current = []
+    revealNextRef.current = false
+    setCommitted(EMPTY_VIEW)
+    setBuffered([])
+  }
+
+  // Fold the live feed into the committed view during render (deriving state from
+  // props/inputs, not an effect — the render reads `committed`/`buffered` below,
+  // so an effect would paint one frame stale). `setState` during render bails out
+  // and re-renders synchronously; the equality guards keep it from looping once
+  // converged.
+  if (live) {
+    liveRef.current = live
+    for (const post of live) retainedRef.current.set(postId(post), post)
+    const next = reconcileStableView(committed, live)
+    if (next.committed !== committed) setCommitted(next.committed)
+    if (revealNextRef.current && next.buffered.length > 0) {
+      revealNextRef.current = false
+      const snap = snapshot(live)
+      if (!sameIds(snap.order, committed.order)) setCommitted(snap)
+      if (buffered.length > 0) setBuffered([])
+    } else if (!sameIds(buffered, next.buffered)) {
+      setBuffered(next.buffered)
+    }
+  }
+
+  const commit = useCallback(() => {
+    const snap = snapshot(liveRef.current)
+    setCommitted(snap)
+    setBuffered([])
+    const keep = new Set(snap.order)
+    for (const id of [...retainedRef.current.keys()]) if (!keep.has(id)) retainedRef.current.delete(id)
+  }, [])
+
+  const revealNext = useCallback(() => {
+    revealNextRef.current = true
+  }, [])
+
+  const posts = useMemo(() => {
+    const liveById = new Map((live ?? []).map((post) => [postId(post), post]))
+    const out: CachedBoardPost[] = []
+    for (const id of committed.order) {
+      const post = liveById.get(id) ?? retainedRef.current.get(id)
+      if (post) out.push(post)
+    }
+    return out
+  }, [committed, live])
+
+  return {
+    posts,
+    activityById: committed.activityById,
+    newCount: buffered.length,
+    commit,
+    revealNext,
+    isLoading: live === undefined,
+  }
+}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -34,10 +34,6 @@ function recencyBucket(activityMs: number, nowMs: number): string {
   return "Older"
 }
 
-/** Scroll depth (px) past which the "N new" pill may show — clears the composer
- *  at the top of the feed so the pill never overlaps it. */
-const PILL_REVEAL_SCROLL_PX = 80
-
 interface BoardSection {
   label: string
   posts: BoardViewPost[]
@@ -114,20 +110,6 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     setViewport(scrollRootRef.current?.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]") ?? null)
   }, [])
   useBoardScrollAnchor(viewport)
-
-  // The "N new" pill only shows once scrolled into the feed, past the composer —
-  // the composer sits at the top of the scroll content, and a pill floating over
-  // it would intercept taps on the page's primary action. New arrivals while at
-  // the top stay buffered (the newest committed cards are already in view) and
-  // surface the moment the reader scrolls in.
-  const [scrolledIntoFeed, setScrolledIntoFeed] = useState(false)
-  useEffect(() => {
-    if (!viewport) return
-    const onScroll = () => setScrolledIntoFeed(viewport.scrollTop > PILL_REVEAL_SCROLL_PX)
-    onScroll()
-    viewport.addEventListener("scroll", onScroll, { passive: true })
-    return () => viewport.removeEventListener("scroll", onScroll)
-  }, [viewport])
 
   const revealNew = () => {
     // Jump to the top first so the freshly-committed cards flow in where the
@@ -248,23 +230,31 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         value="all"
         tabs={[{ value: "all", label: "All", href: `/w/${workspaceId}/board` }]}
       />
+      <span className="sr-only" role="status" aria-live="polite">
+        {newCount > 0 ? `${newCount} new ${newCount === 1 ? "post" : "posts"} available` : ""}
+      </span>
       <div className="relative flex-1 overflow-hidden">
-        {newCount > 0 && scrolledIntoFeed && (
-          <div className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
-            <Button
-              size="sm"
-              onClick={revealNew}
-              aria-label={`Show ${newCount} new ${newCount === 1 ? "post" : "posts"}`}
-              className="pointer-events-auto min-h-11 gap-1.5 rounded-full px-4 shadow-md"
-            >
-              <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
-              {newCount} new
-            </Button>
-          </div>
-        )}
         <ScrollArea ref={scrollRootRef} className="h-full [&>div>div]:!block [&>div>div]:!w-full">
           <main className="mx-auto w-full max-w-[800px] px-2 py-3 sm:px-4">
             <BoardComposer workspaceId={workspaceId} onPosted={revealNext} />
+            {/* Sticky zero-height row: the pill sits just below the composer at the
+                top (never over it) and sticks to the top edge once scrolled in, so
+                it's always reachable without shifting the feed (h-0 = no layout
+                cost). It hangs DOWN over the feed (items-start), clear of the
+                composer above. */}
+            {newCount > 0 && (
+              <div className="pointer-events-none sticky top-2 z-10 flex h-0 items-start justify-center">
+                <Button
+                  size="sm"
+                  onClick={revealNew}
+                  aria-label={`Show ${newCount} new ${newCount === 1 ? "post" : "posts"}`}
+                  className="pointer-events-auto min-h-11 gap-1.5 rounded-full px-4 shadow-md"
+                >
+                  <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+                  {newCount} new
+                </Button>
+              </div>
+            )}
             {content}
           </main>
         </ScrollArea>

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react"
-import { AlertCircle, LayoutGrid } from "lucide-react"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { AlertCircle, ArrowUp, LayoutGrid } from "lucide-react"
 import { Navigate, useParams } from "react-router-dom"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -9,11 +9,12 @@ import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
 import { localStartOfDayMs } from "@/lib/dates"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
-import { useBoardPosts } from "@/stores/board-store"
+import { useStableBoardView, type BoardViewPost } from "@/hooks/use-stable-board-view"
+import { BOARD_CARD_ATTR, useBoardScrollAnchor } from "@/hooks/use-board-scroll-anchor"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardComposer } from "@/components/board/board-composer"
-import type { BoardPost, ConversationWithStaleness } from "@threa/types"
+import type { ConversationWithStaleness } from "@threa/types"
 
 /**
  * Coarse recency bucket for a post's last activity, in device-local time
@@ -22,8 +23,10 @@ import type { BoardPost, ConversationWithStaleness } from "@threa/types"
  * the recency order. Day boundaries, not 24h windows, so "Yesterday" matches the
  * user's calendar.
  */
-function recencyBucket(date: Date | string, nowMs: number): string {
-  const daysAgo = Math.round((localStartOfDayMs(new Date(nowMs)) - localStartOfDayMs(new Date(date))) / 86_400_000)
+function recencyBucket(activityMs: number, nowMs: number): string {
+  const daysAgo = Math.round(
+    (localStartOfDayMs(new Date(nowMs)) - localStartOfDayMs(new Date(activityMs))) / 86_400_000
+  )
   if (daysAgo <= 0) return "Today"
   if (daysAgo === 1) return "Yesterday"
   if (daysAgo <= 6) return "Earlier this week"
@@ -33,14 +36,20 @@ function recencyBucket(date: Date | string, nowMs: number): string {
 
 interface BoardSection {
   label: string
-  posts: BoardPost[]
+  posts: BoardViewPost[]
 }
 
-/** Fold the recency-sorted feed into consecutive buckets, preserving order. */
-function groupByRecency(posts: BoardPost[], nowMs: number): BoardSection[] {
+/**
+ * Fold the frozen feed into consecutive buckets, preserving order. Grouping reads
+ * the commit-time activity (`activityById`), not the live `lastActivityAt`, so a
+ * card bumped while the view is held keeps its section as well as its position —
+ * the sections stay monotonic with the frozen order.
+ */
+function groupByRecency(posts: BoardViewPost[], activityById: Map<string, number>, nowMs: number): BoardSection[] {
   const sections: BoardSection[] = []
   for (const post of posts) {
-    const label = recencyBucket(post.conversation.lastActivityAt, nowMs)
+    const ms = activityById.get(post.conversation.id) ?? Date.parse(post.conversation.lastActivityAt)
+    const label = recencyBucket(ms, nowMs)
     const last = sections[sections.length - 1]
     if (last?.label === label) last.posts.push(post)
     else sections.push({ label, posts: [post] })
@@ -75,22 +84,39 @@ function BoardPageGate({ workspaceId }: { workspaceId: string }) {
 }
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
-  // The query is the fetch/seed engine; the board reads reactively from IDB so
-  // live events and optimistic writes re-sort it without a refetch.
+  // The query is the fetch/seed engine; the board reads reactively from IDB. The
+  // stable-view projection holds the order the viewer is looking at frozen and
+  // accumulates live changes behind the "N new" pill (INV-61, extended from the
+  // timeline's insertion rule to the board's ordering).
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { limit: 50 })
-  const boardPosts = useBoardPosts(workspaceId)
-  const posts = boardPosts ?? []
+  const { posts, activityById, newCount, commit, revealNext, isLoading: viewLoading } = useStableBoardView(workspaceId)
   // After a refetch settles, `isLoading` is already false but the seed effect
-  // writes IDB on the next tick, so `useBoardPosts` can be momentarily empty
-  // while the query already holds posts. Treat that window as loading so the
-  // feed doesn't flash the empty state before the seed lands.
+  // writes IDB on the next tick, so the IDB feed can be momentarily empty while
+  // the query already holds posts. Treat that window as loading so the feed
+  // doesn't flash the empty state before the seed lands.
   const seedPending = (data?.pages.some((page) => page.posts.length > 0) ?? false) && posts.length === 0
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
-  const sections = useMemo(() => groupByRecency(posts, Date.now()), [posts])
+  const sections = useMemo(() => groupByRecency(posts, activityById, Date.now()), [posts, activityById])
+
+  // Resolve the Radix scroll viewport (the scroller) once it mounts, for the
+  // scroll anchor and the pill's scroll-to-top reveal.
+  const scrollRootRef = useRef<HTMLDivElement>(null)
+  const [viewport, setViewport] = useState<HTMLElement | null>(null)
+  useEffect(() => {
+    setViewport(scrollRootRef.current?.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]") ?? null)
+  }, [])
+  useBoardScrollAnchor(viewport)
+
+  const revealNew = () => {
+    // Jump to the top first so the freshly-committed cards flow in where the
+    // viewer can see them; the anchor stays out of the way near the top.
+    if (viewport) viewport.scrollTop = 0
+    commit()
+  }
 
   // Where the post lives — the stream's own name (channel #slug, DM peer,
   // scratchpad name), used as the card's locator. The glyph follows the type.
@@ -126,13 +152,14 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
               {section.posts.map((post) => {
                 const { contextLabel, streamType } = labelsFor(post.conversation)
                 return (
-                  <BoardCard
-                    key={post.conversation.id}
-                    workspaceId={workspaceId}
-                    post={post}
-                    contextLabel={contextLabel}
-                    streamType={streamType}
-                  />
+                  <div key={post.conversation.id} {...{ [BOARD_CARD_ATTR]: post.conversation.id }}>
+                    <BoardCard
+                      workspaceId={workspaceId}
+                      post={post}
+                      contextLabel={contextLabel}
+                      streamType={streamType}
+                    />
+                  </div>
                 )
               })}
             </div>
@@ -165,7 +192,7 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         </Button>
       </div>
     )
-  } else if (isLoading || boardPosts === undefined || seedPending) {
+  } else if (isLoading || viewLoading || seedPending) {
     content = (
       <div className="flex flex-col gap-3">
         {Array.from({ length: 5 }).map((_, i) => (
@@ -203,12 +230,26 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         value="all"
         tabs={[{ value: "all", label: "All", href: `/w/${workspaceId}/board` }]}
       />
-      <ScrollArea className="flex-1 [&>div>div]:!block [&>div>div]:!w-full">
-        <main className="mx-auto w-full max-w-[800px] px-2 py-3 sm:px-4">
-          <BoardComposer workspaceId={workspaceId} />
-          {content}
-        </main>
-      </ScrollArea>
+      <div className="relative flex-1 overflow-hidden">
+        {newCount > 0 && (
+          <div className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
+            <Button
+              size="sm"
+              onClick={revealNew}
+              className="pointer-events-auto h-8 gap-1.5 rounded-full px-3 shadow-md"
+            >
+              <ArrowUp className="h-3.5 w-3.5" />
+              {newCount} new
+            </Button>
+          </div>
+        )}
+        <ScrollArea ref={scrollRootRef} className="h-full [&>div>div]:!block [&>div>div]:!w-full">
+          <main className="mx-auto w-full max-w-[800px] px-2 py-3 sm:px-4">
+            <BoardComposer workspaceId={workspaceId} onPosted={revealNext} />
+            {content}
+          </main>
+        </ScrollArea>
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -237,13 +237,13 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         <ScrollArea ref={scrollRootRef} className="h-full [&>div>div]:!block [&>div>div]:!w-full">
           <main className="mx-auto w-full max-w-[800px] px-2 py-3 sm:px-4">
             <BoardComposer workspaceId={workspaceId} onPosted={revealNext} />
-            {/* Sticky zero-height row: the pill sits just below the composer at the
-                top (never over it) and sticks to the top edge once scrolled in, so
-                it's always reachable without shifting the feed (h-0 = no layout
-                cost). It hangs DOWN over the feed (items-start), clear of the
-                composer above. */}
+            {/* Sticky banner row between the composer and the feed: an in-flow
+                row (its own height, so it never overlaps the first card's tap
+                targets) that sticks to the top edge once scrolled in, keeping the
+                reveal reachable. The transparent row lets the feed scroll behind
+                it; only the centered button takes taps. */}
             {newCount > 0 && (
-              <div className="pointer-events-none sticky top-2 z-10 flex h-0 items-start justify-center">
+              <div className="pointer-events-none sticky top-2 z-10 mb-1 flex min-h-11 items-center justify-center">
                 <Button
                   size="sm"
                   onClick={revealNew}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -34,6 +34,10 @@ function recencyBucket(activityMs: number, nowMs: number): string {
   return "Older"
 }
 
+/** Scroll depth (px) past which the "N new" pill may show — clears the composer
+ *  at the top of the feed so the pill never overlaps it. */
+const PILL_REVEAL_SCROLL_PX = 80
+
 interface BoardSection {
   label: string
   posts: BoardViewPost[]
@@ -110,6 +114,20 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     setViewport(scrollRootRef.current?.querySelector<HTMLElement>("[data-radix-scroll-area-viewport]") ?? null)
   }, [])
   useBoardScrollAnchor(viewport)
+
+  // The "N new" pill only shows once scrolled into the feed, past the composer —
+  // the composer sits at the top of the scroll content, and a pill floating over
+  // it would intercept taps on the page's primary action. New arrivals while at
+  // the top stay buffered (the newest committed cards are already in view) and
+  // surface the moment the reader scrolls in.
+  const [scrolledIntoFeed, setScrolledIntoFeed] = useState(false)
+  useEffect(() => {
+    if (!viewport) return
+    const onScroll = () => setScrolledIntoFeed(viewport.scrollTop > PILL_REVEAL_SCROLL_PX)
+    onScroll()
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+    return () => viewport.removeEventListener("scroll", onScroll)
+  }, [viewport])
 
   const revealNew = () => {
     // Jump to the top first so the freshly-committed cards flow in where the
@@ -231,14 +249,15 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
         tabs={[{ value: "all", label: "All", href: `/w/${workspaceId}/board` }]}
       />
       <div className="relative flex-1 overflow-hidden">
-        {newCount > 0 && (
+        {newCount > 0 && scrolledIntoFeed && (
           <div className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
             <Button
               size="sm"
               onClick={revealNew}
-              className="pointer-events-auto h-8 gap-1.5 rounded-full px-3 shadow-md"
+              aria-label={`Show ${newCount} new ${newCount === 1 ? "post" : "posts"}`}
+              className="pointer-events-auto min-h-11 gap-1.5 rounded-full px-4 shadow-md"
             >
-              <ArrowUp className="h-3.5 w-3.5" />
+              <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
               {newCount} new
             </Button>
           </div>

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -86,10 +86,15 @@ export async function mergeBoardConversation(
 
 /**
  * Optimistically reflect the viewer's own reply into a visible card: append the
- * message to the preview, bump activity to `atMs` (so the card jumps to the top
- * like a real bump would), and mark the row pending until the authoritative
- * `conversation:updated` echo merges over it. No-op when the card isn't cached
- * (a reply into a not-yet-seen conversation surfaces via the event path).
+ * message to the preview, bump activity to `atMs`, and mark the row pending until
+ * the authoritative `conversation:updated` echo merges over it. No-op when the
+ * card isn't cached (a reply into a not-yet-seen conversation surfaces via the
+ * event path).
+ *
+ * The `_lastActivityMs` bump is IDB truth (it re-sorts the live feed and a fresh
+ * snapshot lands the card at the top), but the stable view holds a committed
+ * card's position frozen, so the reply shows in place — it does not yank the card
+ * to the top under the reader (`use-stable-board-view`, INV-61).
  */
 export async function optimisticBoardReply(
   conversationId: string,

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -1001,7 +1001,12 @@ describe("registerWorkspaceSocketHandlers", () => {
       workspaceId: "ws_1",
       conversation: { id: "conv_new", lastActivityAt: "2026-06-22T12:00:00.000Z" },
     })
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    // The handler awaits the (async) IDB merge before deciding to invalidate, so
+    // poll for the call rather than a single tick — one macrotask isn't enough
+    // for the Dexie transaction to settle.
+    for (let i = 0; i < 50 && invalidate.mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
 
     // The event carries the aggregate but not the message bodies, so a card we
     // don't have cached is hydrated by refetching the board head (stale-mark all,

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -312,7 +312,10 @@ synchronous backbone," but two card-fueling paths). Lean: C.
 
 ## Stable view + pending updates — the reactivity model (Kris's "don't move shit on me")
 
-Status: design, 2026-06-27. **Supersedes the live re-sort behavior shipped in the
+Status: **v1 shipped 2026-06-28** (committed-view projection + "N new" pill +
+commit triggers + top scroll-anchor); `virtua` adoption and the backend
+stable-paging-key are deferred follow-ups (see "What shipped" below).
+**Supersedes the live re-sort behavior shipped in the
 realtime slice (PR #1100).** That slice put conversations on the sync engine and
 made the board re-sort live on activity. Dogfooding the consequence: a card you're
 half-way through reading jumps out of view the moment it (or anything above it)
@@ -400,6 +403,38 @@ visibility routing is exactly the data plane this sits on. What changes is the
 **dropping the optimistic bump-to-top**. It is a clean follow-up, not a rework, and
 it partly subsumes the "reply bodies on the next seed" gap — a frozen view isn't
 chasing a moving card, so body lag matters less.
+
+### What shipped (v1, 2026-06-28)
+
+The projection layer landed as `useStableBoardView`
+(`apps/frontend/src/hooks/use-stable-board-view.ts`), wrapping the live
+`useBoardPosts` IDB feed:
+
+- **Committed snapshot** — a frozen ordered list of conversation ids. Render walks
+  it; each card reads content reactively (a reply fills in place) but never moves
+  while committed. A card that vanishes from the live feed (delete / lost access)
+  keeps rendering from last-known content until the next commit (tombstone-in-
+  place, edge 2), so a removal never shifts the rows below it.
+- **Buffer + "N new" pill** — a live id newer than the committed floor that isn't
+  committed → buffered, counted in the pill; an id below the floor is older content
+  paged in by "Load more" → appended below the frozen window with no pill (the
+  `reconcileStableView` split, edge 1's pragmatic v1 take — the client cursor is
+  captured per page so re-return/skip is rare and self-heals via socket→IDB).
+- **Commit triggers** — pill click (scroll to top, then commit) and remount; the
+  viewer's own authored post arms a one-shot `revealNext` so it surfaces instead of
+  hiding behind its own pill. At-top still buffers (edge 5).
+- **Dropped the rendered bump-to-top** — `optimisticBoardReply` still bumps
+  `_lastActivityMs` as IDB truth, but the committed view ignores it, so the
+  viewer's own reply updates in place.
+- **Top scroll-anchor** — `useBoardScrollAnchor` keeps the topmost visible card's
+  screen offset stable across above-fold async reflow via a `ResizeObserver` on the
+  content (the board's hand-rolled equivalent of the timeline's `virtua` `shift`).
+
+**Deferred (not in v1):** `virtua` adoption for the board (stays non-virtualized —
+the floor measurement is ~430 active cards); the backend stable-paging-key (edge 1's
+full fix); the intersection-observer "only what scrolled past is seen" (v1 freezes
+the whole snapshot per edge 6); and the optional per-card "updated" dot for seen-card
+activity (edge 3).
 
 ## Phasing
 


### PR DESCRIPTION
## Problem

PR #1100 put the board's conversations on the sync-engine rails (IDB + gate-applied events + optimistic writes) so cards update live. Dogfooding the consequence: a card you're half-way through reading **jumps out of view** the moment it — or anything above it — gets activity, because the feed re-sorts on every `lastActivityAt` bump. For a surface whose whole job is "get an overview," motion-under-the-eye is the wrong default ("don't move shit on me").

This is the same class of defect INV-61 forbids in the timeline (off-screen content must never shift on-screen content), one projection over: the timeline's rule is about *insertion*; the board needs it for *ordering*.

`docs/board-view-design.md` § "Stable view + pending updates" designed the fix; this PR builds the v1.

## Solution

Hold the order the viewer is looking at **frozen**, accumulate live changes out of band, and reveal them on demand via an X-style "N new" pill — the X / Slack / iMessage pattern. The `conversations` IDB store stays live and activity-sorted (the sync engine keeps it true); a new projection layer sits between it and render. None of #1100's data plane changes — only the projection and the dropped optimistic bump-to-top.

### How it works

1. **`useStableBoardView`** (`hooks/use-stable-board-view.ts`) wraps the live `useBoardPosts` feed and holds a **committed snapshot** — a frozen ordered list of conversation ids plus each id's commit-time activity (`activityById`). Render walks the committed order; each card reads its *content* reactively from IDB (a reply body fills in place) but its *position* never moves while committed.

2. **`reconcileStableView`** (pure, unit-tested) folds the live feed into the committed view by the committed window's frozen lower bound (`floor` = min `activityById`):
   - a live id **at/above the floor** that isn't committed is a fresh arrival → **buffered**, surfaced as the pill count;
   - a live id **below the floor** is older content paged in by "Load more" → **appended below the frozen window**, no pill (it lands below the viewport, shifting nothing on-screen).

3. **Commit triggers** — the pill (`revealNew`: set `scrollTop = 0`, then `commit()` so the new cards flow in where the viewer can see them) and remount (navigating away/back resets to a fresh snapshot). The committed snapshot re-snapshots the live order and prunes retained content to the new set.

4. **The viewer's own post** arms a one-shot `revealNext`; the next live change carrying a fresh arrival commits instead of buffering, so your own authored post surfaces rather than hiding behind its own "1 new" pill. Wired through `BoardComposer`'s new `onPosted` callback.

5. **Dropped the rendered bump-to-top** — `optimisticBoardReply` still raises `_lastActivityMs` as IDB truth (a fresh snapshot lands the card at the top, and the live feed re-sorts), but the committed view ignores it, so the viewer's own reply updates **in place** instead of chasing a moving card. Only the doc comment changed; the write is unchanged.

6. **`useBoardScrollAnchor`** (`hooks/use-board-scroll-anchor.ts`) keeps the topmost visible card's exact screen offset stable across above-fold async reflow — avatars / link previews / images *above* the viewport loading after layout and growing the region. A `ResizeObserver` on the content re-pins the anchor card by adding the above-anchor height delta to `scrollTop`; disabled within `ANCHOR_DISABLE_PX` (4px) of the top so a pill-click reveal lets new cards flow in rather than holding the old first card. This is the board's hand-rolled equivalent of the timeline's `virtua` `shift` (`use-timeline-scroll.ts`); the board is top-anchored and non-virtualized, so it can't reuse `shift` directly.

A vanished committed card (delete / lost access) keeps rendering from last-known content (a retained map) until the next commit drops it — a removal never shifts the rows below it (edge case 2). Recency-section grouping reads `activityById` (commit-time), not live `lastActivityAt`, so a bumped card keeps its section as well as its position and the sections stay monotonic with the frozen order.

### Key design decisions

**1. Focused v1; virtua and the backend paging-key deferred.** The doc's full model is large. This ships the committed-view projection + pill + commit triggers + a hand-rolled top scroll-anchor, and defers (a) adopting `virtua` for the board — it stays non-virtualized, justified by the floor measurement of ~430 active cards; (b) a backend stable-paging-key (edge 1's full fix). The client keyset cursor is captured per page at fetch time, so the re-return/skip window is narrow and self-heals via socket→IDB; the `reconcileStableView` floor-split handles "Load more" correctly without it. (The AskUserQuestion to confirm this scope couldn't be delivered — permission stream closed — so I took the recommended option, which matches the doc's own v1 decisions.)

**2. Snapshot order frozen; content reactive.** Two orderings, one truth: the IDB store is the live activity-sorted truth; the committed view is a deliberately-frozen projection of it. A card's *position* is the snapshot's, its *content* is live. This is what lets a reply body fill in place without the card moving.

**3. Pill counts new conversations only; seen-card bumps stay silent (edge 3).** A seen card getting activity stays put with no pill increment — otherwise "12 new" when nothing is actually new to look at. The optional in-place "updated" dot for seen-card activity is deferred.

**4. v1 freezes the whole snapshot as "seen" (edge 6).** The faithful intersection-observer "only what scrolled past is seen" is deferred as much harder; freezing the whole committed snapshot matches X and is the doc's own v1 call.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | The committed-view projection over the live IDB feed: `reconcileStableView` (pure fold), `useStableBoardView` (frozen order + buffer/pill + commit/revealNext), `BoardViewPost` (re-exported post type so the page need not import `@/db`, INV-15). |
| `apps/frontend/src/hooks/use-board-scroll-anchor.ts` | `ResizeObserver` top scroll-anchor: holds the topmost visible card's offset across above-fold reflow; disabled near the top. |
| `apps/frontend/src/hooks/use-stable-board-view.test.tsx` | 11 tests — `reconcileStableView` (commit, buffer, bump-stays-put, paginate-append, mixed split) and the hook (loading→empty, freeze+pill+commit, revealNext, vanished-card retention, workspace reset). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/board.tsx` | Render from `useStableBoardView` instead of raw `useBoardPosts`; "N new" pill over the feed; resolve the Radix viewport and attach the anchor; `data-board-card` per card; group by `activityById`; wire `revealNext` to the composer. |
| `apps/frontend/src/components/board/board-composer.tsx` | Optional `onPosted` callback, fired after a successful post (reveals the viewer's own card instead of pilling it). |
| `apps/frontend/src/stores/board-store.ts` | `optimisticBoardReply` doc comment only — the `_lastActivityMs` bump is now IDB truth that the committed view ignores; the write is unchanged. |
| `apps/frontend/src/sync/workspace-sync.test.ts` | Make a pre-existing flaky test deterministic: poll for the async IDB-merge `invalidateQueries` instead of a single `setTimeout(0)` (the handler awaits a Dexie transaction before invalidating). |
| `docs/board-view-design.md` | Mark the stable-view section v1-shipped; add a "What shipped" subsection and the deferred follow-ups. |

## Out of scope (deliberate)

- **`virtua` adoption / board virtualization** — deferred; board stays non-virtualized (~430 active cards per the floor measurement).
- **Backend stable-paging-key** (edge 1's full fix) — client keyset cursors are good enough for v1; re-return/skip self-heals via socket→IDB.
- **Intersection-observer "only what scrolled past is seen"** (edge 6) and the **per-card "updated" dot** (edge 3) — both deferred per the doc.
- **No schema / migration change** — frontend-only projection layer over the existing `conversations` IDB store from #1100.

## Test plan

- [x] `src/hooks/use-stable-board-view.test.tsx` — 11 pass
- [x] `src/pages/board.test.tsx`, `src/stores/board-store.test.ts`, `src/components/board`, `src/sync/workspace-sync.test.ts` — 77 pass together (incl. the de-flaked sync test)
- [x] `tsc --noEmit` (frontend) clean; eslint clean on all touched files (incl. INV-15 `@/db`-in-page check, resolved via the `BoardViewPost` re-export)
- [ ] **Scroll-anchor async-reflow compensation not integration-tested** — it's DOM-layout behavior jsdom can't exercise (`ResizeObserver` is a no-op polyfill, `getBoundingClientRect` returns zeros). The hard case (above-fold avatar/link-preview load while reading) needs a real device; flagged for manual `/verify` before merge.
- [ ] **Multi-agent `/code-review` loop** — running post-create (requested); findings will be pushed as follow-up commits and tallied here.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJf9rGx2FN1tRxCiN3f38f)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785218258&installation_id=129946197&pr_number=1104&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1104&signature=dc7a087edfc81ba4fba9dbb401d81d56b953bc761a89037ddc74bf72b4ae5a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->