### PR TITLE
fix(sidebar): keep mobile sidebar open while the theme dropdown is open

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-header.tsx
@@ -19,7 +19,7 @@ interface SidebarHeaderProps {
 export function SidebarHeader({ workspaceName, onEditLayout, hideViewToggle }: SidebarHeaderProps) {
   const { openSwitcher } = useQuickSwitcher()
   const { openSearch } = useSearchPanel()
-  const { collapseOnMobile } = useSidebar()
+  const { collapseOnMobile, setMenuOpen } = useSidebar()
   const { preferences } = usePreferences()
   const customBindings = preferences?.keyboardShortcuts ?? {}
   const streamBinding = getEffectiveKeyBinding("openQuickSwitcher", customBindings)
@@ -46,7 +46,7 @@ export function SidebarHeader({ workspaceName, onEditLayout, hideViewToggle }: S
           <span className="truncate text-sm font-semibold">{workspaceName}</span>
         </Link>
         <div className="ml-auto flex items-center">
-          <ThemeDropdown />
+          <ThemeDropdown onOpenChange={setMenuOpen} />
         </div>
       </div>
 

--- a/apps/frontend/src/components/theme-dropdown.test.tsx
+++ b/apps/frontend/src/components/theme-dropdown.test.tsx
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, userEvent } from "@/test"
+import { ThemeDropdown } from "./theme-dropdown"
+import * as preferencesModule from "@/contexts/preferences-context"
+import * as settingsModule from "@/contexts/settings-context"
+
+describe("ThemeDropdown", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    vi.spyOn(preferencesModule, "usePreferences").mockReturnValue({
+      preferences: { theme: "system" },
+      resolvedTheme: "light",
+      updatePreference: vi.fn(),
+    } as unknown as ReturnType<typeof preferencesModule.usePreferences>)
+
+    vi.spyOn(settingsModule, "useSettings").mockReturnValue({
+      openSettings: vi.fn(),
+    } as unknown as ReturnType<typeof settingsModule.useSettings>)
+  })
+
+  // The sidebar host wires onOpenChange to setMenuOpen so the menu opening can't
+  // collapse the mobile hover-preview sidebar out from under the open dropdown.
+  it("reports open state through onOpenChange", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(<ThemeDropdown onOpenChange={onOpenChange} />)
+
+    await user.click(screen.getByRole("button", { name: "Theme & Settings" }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/apps/frontend/src/components/theme-dropdown.test.tsx
+++ b/apps/frontend/src/components/theme-dropdown.test.tsx
@@ -21,14 +21,18 @@ describe("ThemeDropdown", () => {
 
   // The sidebar host wires onOpenChange to setMenuOpen so the menu opening can't
   // collapse the mobile hover-preview sidebar out from under the open dropdown.
-  it("reports open state through onOpenChange", async () => {
+  // Both edges matter: the close report is what lets the sidebar resume
+  // collapsing, so a regression that stopped forwarding `false` would strand it.
+  it("reports both open and close transitions through onOpenChange", async () => {
     const user = userEvent.setup()
     const onOpenChange = vi.fn()
 
     render(<ThemeDropdown onOpenChange={onOpenChange} />)
 
     await user.click(screen.getByRole("button", { name: "Theme & Settings" }))
-
     expect(onOpenChange).toHaveBeenCalledWith(true)
+
+    await user.keyboard("{Escape}")
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 })

--- a/apps/frontend/src/components/theme-dropdown.tsx
+++ b/apps/frontend/src/components/theme-dropdown.tsx
@@ -10,7 +10,18 @@ import {
 import { usePreferences, useSettings } from "@/contexts"
 import type { Theme } from "@threa/types"
 
-export function ThemeDropdown() {
+interface ThemeDropdownProps {
+  /**
+   * Notified when the menu opens/closes. The sidebar host wires this to
+   * `setMenuOpen` so the menu opening (a Radix modal portal that flips
+   * `pointer-events` under the cursor, firing a stray `mouseleave` on the
+   * sidebar) doesn't collapse the hover-preview sidebar out from under the
+   * still-open dropdown — same guard the other sidebar menus use.
+   */
+  onOpenChange?: (open: boolean) => void
+}
+
+export function ThemeDropdown({ onOpenChange }: ThemeDropdownProps) {
   const { preferences, resolvedTheme, updatePreference } = usePreferences()
   const { openSettings } = useSettings()
 
@@ -28,7 +39,7 @@ export function ThemeDropdown() {
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon" className="h-8 w-8" title="Theme & Settings">
           <ThemeIcon className="h-4 w-4" />


### PR DESCRIPTION
## Problem

On mobile, tapping the theme button in the sidebar header opened the theme dropdown and then immediately collapsed the sidebar, dragging the dropdown off-screen and dismissing it before a theme could be picked.

Root cause: the mobile sidebar opens in `preview` state (the hover-driven mode in `apps/frontend/src/contexts/sidebar-context.tsx`). `ThemeDropdown` rendered a Radix **modal** `DropdownMenu`. When the modal portal opens it flips `pointer-events` under the cursor, so the browser fires a stray `mouseleave` on the sidebar `<aside>` (`apps/frontend/src/components/layout/app-shell.tsx`). That calls `setHovering(false)` → `hidePreview()`, which collapses the `preview` sidebar after the 150ms hide delay. The trigger button then slides off-screen, Popper repositions the now-orphaned dropdown, and Radix dismisses it.

Every other sidebar menu already guards against exactly this. `setMenuOpen` (sidebar context) increments a ref counter that suppresses `hidePreview()` while a menu is open, and `sidebar-actions.tsx` / `sidebar-footer.tsx` call it from their dropdown `onOpenChange`. `ThemeDropdown` was the one sidebar menu that never reported its open state — so it was the one that collapsed the sidebar out from under itself.

## Solution

Thread an optional `onOpenChange` prop through `ThemeDropdown` and wire it to `setMenuOpen` from `SidebarHeader` — the same guard the other sidebar menus use. While the dropdown is open the menu-open counter is non-zero, so the stray `mouseleave` no longer triggers `hidePreview()` and the sidebar stays put. On close, the counter returns to zero and normal collapse behavior resumes, matching the other menus exactly.

The prop is optional so `ThemeDropdown` stays decoupled from the sidebar context (it doesn't call `useSidebar` itself); the host supplies the guard.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/theme-dropdown.tsx` | Added optional `onOpenChange?: (open: boolean) => void` prop, forwarded to the `DropdownMenu`. JSDoc records why the host wires it. |
| `apps/frontend/src/components/layout/sidebar/sidebar-header.tsx` | Pulled `setMenuOpen` from `useSidebar()` and passed it: `<ThemeDropdown onOpenChange={setMenuOpen} />`. |
| `apps/frontend/src/components/theme-dropdown.test.tsx` | New test: opening the dropdown reports open state through `onOpenChange`. |

## Test plan

- [x] `apps/frontend` `bun run test src/components/theme-dropdown.test.tsx` — 1 pass
- [x] `apps/frontend` `bun run test .../sidebar-actions.test.tsx theme-dropdown.test.tsx` — 11 pass (no regression in the shared `setMenuOpen` guard)
- [x] `tsc --noEmit -p tsconfig.app.json` (frontend) clean
- [x] Self-review via `/code-review` (1 combined Sonnet agent, all lenses): no issues >=80; confirmed the `setMenuOpen` counter stays balanced, the JSDoc is load-bearing, and close-collapse matches the other sidebar menus
- [ ] Not manually verified on a physical device — the collapse path is reproduced and reasoned from the code; the unit test covers the wiring, not the live touch `mouseleave`

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYQbwzHckx14UMU3G5YAch)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785221461&installation_id=129946197&pr_number=1105&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1105&signature=e4f4e894a367344f72307b162f3b2e326347ecb3960ef59d05ea52074f32fcf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->