### PR TITLE
refactor(composer): drop below-row chip for in-app stream/message links

### DIFF
--- a/apps/frontend/src/components/composer/composer-link-chip.tsx
+++ b/apps/frontend/src/components/composer/composer-link-chip.tsx
@@ -2,18 +2,15 @@ import { type ComponentType } from "react"
 import { Brain, Lock, Globe, Link2 } from "lucide-react"
 import { AttachmentPill } from "./attachment-pill"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
-import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
-import type { DraftLinkRef } from "@/lib/in-app-links"
+import type { BelowRowDraftLink } from "@/lib/in-app-links"
 
 /**
- * One compact chip for a link in the draft. Stealing the attachment-pill
- * semantics keeps several links from eating the screen (a full preview card per
- * link buries the composer on mobile). In-app stream/message links resolve their
- * name and icon from the local workspace cache — the canonical name source
- * (frontend CLAUDE.md) — which also renders correctly for any stream the viewer
- * can see without a round-trip; the access-tiered backend resolve is the
- * fallback only when the stream isn't cached (no access / cross-workspace /
- * thread). Memo links resolve via the backend; web links chip their host.
+ * One compact chip for a below-row draft link — web or memo only. Stream/message
+ * in-app links never reach here: they render as an inline chip in the draft body
+ * (`ComposerLinkPreviews` filters them via `isBelowRowDraftLink`), matching the
+ * posted message (#1103). Stealing the attachment-pill semantics keeps several
+ * links from eating the screen (a full preview card per link buries the composer
+ * on mobile). Memo links resolve via the backend; web links chip their host.
  *
  * Non-navigable on purpose: clicking must not abandon the draft mid-compose.
  */
@@ -22,53 +19,17 @@ export function ComposerLinkChip({
   workspaceId,
   onDismiss,
 }: {
-  link: DraftLinkRef
+  link: BelowRowDraftLink
   workspaceId: string
   onDismiss: (url: string) => void
 }) {
   const remove = () => onDismiss(link.url)
 
-  if (link.kind === "web") {
-    return (
-      <AttachmentPill icon={Globe} label={link.host} tooltip={link.url} onRemove={remove} removeLabel="Hide link" />
-    )
-  }
-
   if (link.kind === "memo") {
     return <MemoChip workspaceId={workspaceId} url={link.url} onRemove={remove} />
   }
 
-  return (
-    <StreamChip
-      workspaceId={workspaceId}
-      streamId={link.streamId}
-      url={link.url}
-      isMessage={link.kind === "message"}
-      onRemove={remove}
-    />
-  )
-}
-
-function StreamChip({
-  workspaceId,
-  streamId,
-  url,
-  isMessage,
-  onRemove,
-}: {
-  workspaceId: string
-  streamId: string
-  url: string
-  isMessage: boolean
-  onRemove: () => void
-}) {
-  const state = useInAppLinkChip({ workspaceId, streamId, isMessage, url })
-
-  if (state.status === "pending") return <PendingChip onRemove={onRemove} />
-  if (state.status === "restricted") {
-    return <RestrictedChip icon={state.icon} label={state.label} onRemove={onRemove} />
-  }
-  return <AttachmentPill icon={state.icon} label={state.label} onRemove={onRemove} removeLabel="Hide link" />
+  return <AttachmentPill icon={Globe} label={link.host} tooltip={link.url} onRemove={remove} removeLabel="Hide link" />
 }
 
 function MemoChip({ workspaceId, url, onRemove }: { workspaceId: string; url: string; onRemove: () => void }) {

--- a/apps/frontend/src/components/composer/composer-link-previews.test.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.test.tsx
@@ -62,7 +62,7 @@ describe("ComposerLinkPreviews", () => {
 
   it("chips a memo link by its resolved title", async () => {
     const url = `${origin}/w/ws_1/memos/memo_1`
-    const resolve = vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
       kind: "memo",
       accessTier: "full",
       title: "Onboarding notes",
@@ -75,7 +75,6 @@ describe("ComposerLinkPreviews", () => {
     )
 
     await waitFor(() => expect(screen.getByText("Onboarding notes")).toBeInTheDocument())
-    expect(resolve).toHaveBeenCalledWith("ws_1", url)
   })
 
   it("forgets a dismissal once the link leaves and re-enters the draft", async () => {

--- a/apps/frontend/src/components/composer/composer-link-previews.test.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.test.tsx
@@ -36,8 +36,9 @@ describe("ComposerLinkPreviews", () => {
     expect(resolve).not.toHaveBeenCalled()
   })
 
-  it("chips an in-app stream link by its resolved name when not cached locally", async () => {
-    // Empty workspace store in tests → local name is null → backend resolve fallback.
+  it("does not chip in-app stream/message links — they render inline in the draft", async () => {
+    // Stream/message links convert to an inline chip in the body (#1103), so the
+    // below-row chip is suppressed and no resolve round-trip fires for them.
     const resolve = vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
       kind: "stream",
       accessTier: "full",
@@ -46,27 +47,35 @@ describe("ComposerLinkPreviews", () => {
       visibility: "public",
     })
 
-    const url = `${origin}/w/ws_1/s/stream_1`
-    render(
+    const streamUrl = `${origin}/w/ws_1/s/stream_1`
+    const messageUrl = `${origin}/w/ws_1/s/stream_1?m=msg_1`
+    const { container } = render(
       <MemoryRouter>
-        <ComposerLinkPreviews content={draft(link("chan", url))} workspaceId="ws_1" />
+        <ComposerLinkPreviews content={draft(link("chan", streamUrl), link("msg", messageUrl))} workspaceId="ws_1" />
       </MemoryRouter>
     )
 
-    await waitFor(() => expect(screen.getByText("design")).toBeInTheDocument())
-    expect(resolve).toHaveBeenCalledWith("ws_1", url)
+    // Nothing renders for an all-in-app draft, and the resolve is never called.
+    await waitFor(() => expect(container).toBeEmptyDOMElement())
+    expect(resolve).not.toHaveBeenCalled()
   })
 
-  it("chips a restricted in-app link as private without leaking a name", async () => {
-    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({ kind: "stream", accessTier: "private" })
+  it("chips a memo link by its resolved title", async () => {
+    const url = `${origin}/w/ws_1/memos/memo_1`
+    const resolve = vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "memo",
+      accessTier: "full",
+      title: "Onboarding notes",
+    })
 
     render(
       <MemoryRouter>
-        <ComposerLinkPreviews content={draft(link("x", `${origin}/w/ws_1/s/secret_1`))} workspaceId="ws_1" />
+        <ComposerLinkPreviews content={draft(link("memo", url))} workspaceId="ws_1" />
       </MemoryRouter>
     )
 
-    await waitFor(() => expect(screen.getByText("Private conversation")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Onboarding notes")).toBeInTheDocument())
+    expect(resolve).toHaveBeenCalledWith("ws_1", url)
   })
 
   it("forgets a dismissal once the link leaves and re-enters the draft", async () => {

--- a/apps/frontend/src/components/composer/composer-link-previews.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react"
 import type { JSONContent } from "@threa/types"
-import { classifyDraftLink, extractDraftLinkUrls } from "@/lib/in-app-links"
+import {
+  classifyDraftLink,
+  extractDraftLinkUrls,
+  isBelowRowDraftLink,
+  type BelowRowDraftLink,
+} from "@/lib/in-app-links"
 import { ComposerLinkChip } from "./composer-link-chip"
 import { cn } from "@/lib/utils"
 
@@ -43,8 +48,17 @@ export function ComposerLinkPreviews({ content, workspaceId, className }: Compos
     })
   }, [urls])
 
-  const links = useMemo(() => urls.filter((u) => !dismissed.has(u)).map((u) => classifyDraftLink(u)), [urls, dismissed])
-  const visible = links.filter((l) => l !== null)
+  // Stream/message in-app links render as an inline chip in the draft body, not
+  // a below-row chip (`isBelowRowDraftLink`) — so this row carries only web and
+  // memo links, matching the timeline's inline-chip card suppression (#1103).
+  const visible = useMemo(
+    () =>
+      urls
+        .filter((u) => !dismissed.has(u))
+        .map((u) => classifyDraftLink(u))
+        .filter((l): l is BelowRowDraftLink => l !== null && isBelowRowDraftLink(l)),
+    [urls, dismissed]
+  )
   if (visible.length === 0) return null
 
   const dismiss = (url: string) => setDismissed((prev) => new Set(prev).add(url))

--- a/apps/frontend/src/lib/in-app-links.ts
+++ b/apps/frontend/src/lib/in-app-links.ts
@@ -23,6 +23,20 @@ export type DraftLinkRef =
   | { kind: "message"; url: string; workspaceId: string; streamId: string; messageId: string }
   | { kind: "memo"; url: string; workspaceId: string; memoId: string }
 
+/**
+ * Draft link kinds that earn a below-composer chip. Stream/message in-app links
+ * are excluded: like a posted message (#1103), they render as an inline chip in
+ * the draft body (a pasted one becomes an atom node; a typed one converts on
+ * send), so a below-row chip would double the surface. This mirrors the
+ * timeline's `isInlineChipContentType` card suppression — web and memo links
+ * keep their below-row chip exactly as they keep their card.
+ */
+export type BelowRowDraftLink = Extract<DraftLinkRef, { kind: "web" | "memo" }>
+
+export function isBelowRowDraftLink(link: DraftLinkRef): link is BelowRowDraftLink {
+  return link.kind === "web" || link.kind === "memo"
+}
+
 function currentOrigin(): string | null {
   return typeof window === "undefined" ? null : window.location.origin
 }


### PR DESCRIPTION
## Problem

Since #1103, an in-app stream/message link in a draft renders as an inline chip inside the composer body (a pasted URL becomes an `inAppLink` atom node; a typed one converts on send). But the below-composer chip row (`ComposerLinkPreviews` → `ComposerLinkChip`) still classified and resolved those same links into a second chip, so a single in-app link could surface twice in the composer. It also fired a permission-checked `resolveInAppLinkByUrl` round-trip (`StreamChip` → `useInAppLinkChip`) for links the inline chip already names from the local workspace cache.

The timeline already drops the below-message card for these kinds (`link-preview-list.tsx` filters on `isInlineChipContentType`); the composer was the inconsistent surface.

## Solution

Filter the inline-chip kinds out of the below-row, so the composer matches the timeline: in-app stream/message links live only as the inline chip, while **web and memo** links keep their below-row chip exactly as they keep their card.

- New `isBelowRowDraftLink` / `BelowRowDraftLink` in `lib/in-app-links.ts` — the predicate is `kind === "web" || "memo"` (i.e. `DraftLinkRef` minus the `stream`/`message` inline-chip kinds). This is the draft-side mirror of `isInlineChipContentType`.
- `ComposerLinkPreviews` applies it as a typed filter, narrowing `visible` to `BelowRowDraftLink[]`.
- `ComposerLinkChip`'s prop narrows to `BelowRowDraftLink`, which makes its `StreamChip` branch (and the `useInAppLinkChip` import) dead code — deleted (INV-38). `MemoChip`, `RestrictedChip`, `PendingChip`, and the web branch are untouched.

Behavioral effect: a typed-not-yet-converted in-app stream/message URL no longer shows a below-row chip (it chips in the body on send); pasted ones were already inline. No backend or wire change — purely which draft links the composer row renders.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/in-app-links.ts` | Add `BelowRowDraftLink` type + `isBelowRowDraftLink` predicate (web/memo only) |
| `apps/frontend/src/components/composer/composer-link-previews.tsx` | Filter draft links through `isBelowRowDraftLink`; fold classify+filter into one memo |
| `apps/frontend/src/components/composer/composer-link-chip.tsx` | Narrow prop to `BelowRowDraftLink`; delete dead `StreamChip` + `useInAppLinkChip` import |
| `apps/frontend/src/components/composer/composer-link-previews.test.tsx` | Replace the two in-app stream/restricted chip tests with a suppression test (no chip, no resolve call); add a memo-keeps-its-chip test |

## Out of scope (deliberate)

These parked follow-ups from the #1103 handover are **not** in this PR:

- **Access-tier "Private conversation" false-negative.** `checkStreamAccess` (`features/streams/access.ts`) already implements INV-62 correctly (public root reads without a membership row; threads inherit from root) and the resolve handler routes through it, so I found no concrete repro. Won't touch a canonical security predicate without a reproducing case.
- **DM chip tone** (muted vs. blue user-mention) — reverses a deliberate prior decision; needs a product call.
- **Autolink-on-type → inline chip** — explicit non-goal (live-editor caret-reset risk).

## Test plan

- [x] `apps/frontend` — `vitest run` over composer + in-app-link + `link-preview-list.test.tsx`: 77 pass (8 files), including the new suppression + memo tests
- [x] `apps/frontend` `tsc --noEmit` — clean
- [x] `eslint` + `prettier` on the four changed files — clean
- [ ] No manual browser pass — change is a render-filter covered by the component test; not exercised in a live app this session

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014XNCr9nMrTwm2WgTmswqN7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785259463&installation_id=129946197&pr_number=1107&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1107&signature=53db2cb846d6bb2c0003cca17702d6e518ff2e269e6aca6fe576fa4ba4c84d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->