### PR TITLE
feat(link-previews): name the message link chip by author + location

### DIFF
--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -6,6 +6,7 @@ import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
 import { SearchRepository } from "../search"
 import type { StreamService } from "../streams"
+import { StreamMemberRepository } from "../streams"
 import type { MemoExplorerService } from "../memos"
 
 /** The exact shape `tryAccess` resolves to, so a drift in the contract breaks here. */
@@ -205,6 +206,75 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       authorName: "Author",
       contentPreview: "Hello there",
       streamName: "general",
+      streamType: "channel",
+      authorIsSelf: false,
+    })
+  })
+
+  test("a message the viewer authored is flagged self so the chip can render 'You'", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({
+        contentType: "message_link",
+        targetMessageId: "msg_1",
+        url: "https://app.threa.io/w/ws_self/s/stream_1?m=msg_1",
+      })
+    )
+    spyOn(MessageRepository, "findById").mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_1",
+      authorType: "user",
+      authorId: VIEWER_ID,
+      contentMarkdown: "my own message",
+      deletedAt: null,
+    } as never)
+    spyOn(UserRepository, "findById").mockResolvedValue({ name: "Me", avatarUrl: null } as never)
+    const service = makeService({ tryAccess: async () => makeStream({ slug: "general" }) }, {})
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toMatchObject({ kind: "message", accessTier: "full", authorIsSelf: true, streamType: "channel" })
+  })
+
+  test("a DM message resolves the non-author participant as the recipient", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({
+        contentType: "message_link",
+        targetStreamId: "stream_dm",
+        targetMessageId: "msg_1",
+        url: "https://app.threa.io/w/ws_self/s/stream_dm?m=msg_1",
+      })
+    )
+    spyOn(MessageRepository, "findById").mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_dm",
+      authorType: "user",
+      authorId: "user_pierre",
+      contentMarkdown: "hey",
+      deletedAt: null,
+    } as never)
+    spyOn(StreamMemberRepository, "list").mockResolvedValue([
+      { streamId: "stream_dm", memberId: "user_pierre" },
+      { streamId: "stream_dm", memberId: VIEWER_ID },
+    ] as never)
+    spyOn(UserRepository, "findById").mockImplementation((async (_pool: unknown, _ws: unknown, id: string) =>
+      id === "user_pierre"
+        ? { name: "Pierre Boberg", avatarUrl: null }
+        : { name: "Kristoffer Remback", avatarUrl: null }) as never)
+    const service = makeService(
+      { tryAccess: async () => makeStream({ id: "stream_dm", type: "dm", slug: null, displayName: null }) },
+      {}
+    )
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toMatchObject({
+      kind: "message",
+      accessTier: "full",
+      authorName: "Pierre Boberg",
+      authorIsSelf: false,
+      streamType: "dm",
+      recipientName: "Kristoffer Remback",
+      recipientIsSelf: true,
     })
   })
 })

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -207,32 +207,7 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       contentPreview: "Hello there",
       streamName: "general",
       streamType: "channel",
-      authorIsSelf: false,
     })
-  })
-
-  test("a message the viewer authored is flagged self so the chip can render 'You'", async () => {
-    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
-      makePreview({
-        contentType: "message_link",
-        targetMessageId: "msg_1",
-        url: "https://app.threa.io/w/ws_self/s/stream_1?m=msg_1",
-      })
-    )
-    spyOn(MessageRepository, "findById").mockResolvedValue({
-      id: "msg_1",
-      streamId: "stream_1",
-      authorType: "user",
-      authorId: VIEWER_ID,
-      contentMarkdown: "my own message",
-      deletedAt: null,
-    } as never)
-    spyOn(UserRepository, "findById").mockResolvedValue({ name: "Me", avatarUrl: null } as never)
-    const service = makeService({ tryAccess: async () => makeStream({ slug: "general" }) }, {})
-
-    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
-
-    expect(result).toMatchObject({ kind: "message", accessTier: "full", authorIsSelf: true, streamType: "channel" })
   })
 
   test("a DM message resolves the non-author participant as the recipient", async () => {
@@ -271,10 +246,8 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       kind: "message",
       accessTier: "full",
       authorName: "Pierre Boberg",
-      authorIsSelf: false,
       streamType: "dm",
       recipientName: "Kristoffer Remback",
-      recipientIsSelf: true,
     })
   })
 
@@ -315,7 +288,6 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       accessTier: "full",
       streamType: "dm",
       recipientName: "Pierre Boberg",
-      recipientIsSelf: false,
     })
   })
 })

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -277,6 +277,47 @@ describe("LinkPreviewService.resolveInAppLink", () => {
       recipientIsSelf: true,
     })
   })
+
+  test("a persona-authored DM names the other participant, not the viewer", async () => {
+    // The author isn't a DM member, so the recipient must skip the viewer and
+    // name the real other participant rather than resolving to "You".
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({
+        contentType: "message_link",
+        targetStreamId: "stream_dm",
+        targetMessageId: "msg_1",
+        url: "https://app.threa.io/w/ws_self/s/stream_dm?m=msg_1",
+      })
+    )
+    spyOn(MessageRepository, "findById").mockResolvedValue({
+      id: "msg_1",
+      streamId: "stream_dm",
+      authorType: "persona",
+      authorId: "persona_assistant",
+      contentMarkdown: "drafted for you",
+      deletedAt: null,
+    } as never)
+    spyOn(StreamMemberRepository, "list").mockResolvedValue([
+      { streamId: "stream_dm", memberId: VIEWER_ID },
+      { streamId: "stream_dm", memberId: "user_pierre" },
+    ] as never)
+    spyOn(UserRepository, "findById").mockImplementation((async (_pool: unknown, _ws: unknown, id: string) =>
+      id === "user_pierre" ? { name: "Pierre Boberg", avatarUrl: null } : null) as never)
+    const service = makeService(
+      { tryAccess: async () => makeStream({ id: "stream_dm", type: "dm", slug: null, displayName: null }) },
+      {}
+    )
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toMatchObject({
+      kind: "message",
+      accessTier: "full",
+      streamType: "dm",
+      recipientName: "Pierre Boberg",
+      recipientIsSelf: false,
+    })
+  })
 })
 
 describe("LinkPreviewService.resolveInAppLinkByUrl", () => {

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -389,6 +389,8 @@ export class LinkPreviewService {
       streamName: stream.displayName ?? stream.slug ?? undefined,
       streamType: stream.type,
       recipientName,
+      authorId: message.authorId,
+      authorType: message.authorType,
     }
   }
 

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -361,15 +361,16 @@ export class LinkPreviewService {
 
     // A DM message reads "{author} to {recipient}", so resolve the non-author
     // participant. DMs are 1:1 in the display model (display-name.ts collapses to
-    // "the other participant"); falling back to the non-viewer member keeps the
-    // phrasing sensible when the author isn't a member (e.g. a persona).
+    // "the other participant"). Prefer the member who is neither the author nor
+    // the viewer so a non-member author (e.g. a persona) still names the other
+    // person; only then fall back to any non-author member.
     let recipientName: string | undefined
     let recipientIsSelf: boolean | undefined
     if (stream.type === "dm") {
       const members = await StreamMemberRepository.list(this.deps.pool, { streamId: targetStreamId })
       const recipientId =
-        members.find((m) => m.memberId !== message.authorId)?.memberId ??
-        members.find((m) => m.memberId !== userId)?.memberId
+        members.find((m) => m.memberId !== message.authorId && m.memberId !== userId)?.memberId ??
+        members.find((m) => m.memberId !== message.authorId)?.memberId
       if (recipientId) {
         recipientIsSelf = recipientId === userId
         recipientName = (await UserRepository.findById(this.deps.pool, workspaceId, recipientId))?.name

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -365,14 +365,12 @@ export class LinkPreviewService {
     // the viewer so a non-member author (e.g. a persona) still names the other
     // person; only then fall back to any non-author member.
     let recipientName: string | undefined
-    let recipientIsSelf: boolean | undefined
     if (stream.type === "dm") {
       const members = await StreamMemberRepository.list(this.deps.pool, { streamId: targetStreamId })
       const recipientId =
         members.find((m) => m.memberId !== message.authorId && m.memberId !== userId)?.memberId ??
         members.find((m) => m.memberId !== message.authorId)?.memberId
       if (recipientId) {
-        recipientIsSelf = recipientId === userId
         recipientName = (await UserRepository.findById(this.deps.pool, workspaceId, recipientId))?.name
       }
     }
@@ -391,8 +389,6 @@ export class LinkPreviewService {
       streamName: stream.displayName ?? stream.slug ?? undefined,
       streamType: stream.type,
       recipientName,
-      recipientIsSelf,
-      authorIsSelf: message.authorType === "user" && message.authorId === userId,
     }
   }
 

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -12,6 +12,7 @@ import { LinkPreviewRepository, type LinkPreview, type UpdateLinkPreviewParams }
 import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
 import type { StreamService } from "../streams"
+import { StreamMemberRepository } from "../streams"
 import type { MemoExplorerService } from "../memos"
 import { resolveUserAccessibleStreamIds } from "../search"
 import { OutboxRepository } from "../../lib/outbox"
@@ -358,6 +359,23 @@ export class LinkPreviewService {
       }
     }
 
+    // A DM message reads "{author} to {recipient}", so resolve the non-author
+    // participant. DMs are 1:1 in the display model (display-name.ts collapses to
+    // "the other participant"); falling back to the non-viewer member keeps the
+    // phrasing sensible when the author isn't a member (e.g. a persona).
+    let recipientName: string | undefined
+    let recipientIsSelf: boolean | undefined
+    if (stream.type === "dm") {
+      const members = await StreamMemberRepository.list(this.deps.pool, { streamId: targetStreamId })
+      const recipientId =
+        members.find((m) => m.memberId !== message.authorId)?.memberId ??
+        members.find((m) => m.memberId !== userId)?.memberId
+      if (recipientId) {
+        recipientIsSelf = recipientId === userId
+        recipientName = (await UserRepository.findById(this.deps.pool, workspaceId, recipientId))?.name
+      }
+    }
+
     const contentPreview =
       message.contentMarkdown.length > CONTENT_PREVIEW_MAX_LENGTH
         ? message.contentMarkdown.slice(0, CONTENT_PREVIEW_MAX_LENGTH) + "…"
@@ -370,6 +388,10 @@ export class LinkPreviewService {
       authorAvatarUrl,
       contentPreview,
       streamName: stream.displayName ?? stream.slug ?? undefined,
+      streamType: stream.type,
+      recipientName,
+      recipientIsSelf,
+      authorIsSelf: message.authorType === "user" && message.authorId === userId,
     }
   }
 

--- a/apps/frontend/src/components/composer/composer-link-previews.test.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.test.tsx
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { type ReactNode } from "react"
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import { ComposerLinkPreviews } from "./composer-link-previews"
 import type { JSONContent } from "@threa/types"
 
 const origin = window.location.origin
+
+/** Memo chips resolve through the shared query-cached `useResolvedInAppLink`. */
+function withQueryClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+}
 
 function draft(...inline: JSONContent[]): JSONContent {
   return { type: "doc", content: [{ type: "paragraph", content: inline }] }
@@ -69,9 +77,11 @@ describe("ComposerLinkPreviews", () => {
     })
 
     render(
-      <MemoryRouter>
-        <ComposerLinkPreviews content={draft(link("memo", url))} workspaceId="ws_1" />
-      </MemoryRouter>
+      withQueryClient(
+        <MemoryRouter>
+          <ComposerLinkPreviews content={draft(link("memo", url))} workspaceId="ws_1" />
+        </MemoryRouter>
+      )
     )
 
     await waitFor(() => expect(screen.getByText("Onboarding notes")).toBeInTheDocument())

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -63,6 +63,9 @@ function getPreviewText(doc: JSONContent): string {
     if (node.type === "mention") return `@${node.attrs?.label ?? ""}`
     if (node.type === "emoji") return String(node.attrs?.emoji ?? node.attrs?.shortcode ?? "")
     if (node.type === "hardBreak") return null
+    // Atom node: no child text, so surface its baked label or it reads as empty.
+    if (node.type === "inAppLink")
+      return typeof node.attrs?.name === "string" && node.attrs.name ? node.attrs.name : "Link"
 
     if (node.type === "quoteReply") {
       const author = typeof node.attrs?.authorName === "string" ? node.attrs.authorName : ""

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -18,6 +18,7 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const state = useInAppLinkChip({
     workspaceId: workspaceId ?? "",
     streamId: attrs.streamId,
+    messageId: attrs.messageId,
     isMessage: Boolean(attrs.messageId),
     url: attrs.url,
   })

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -39,11 +39,10 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const icon = state.status === "pending" ? pendingIcon : state.icon
   const label = state.status === "pending" ? attrs.name || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
-  const messageParts = state.status === "resolved" ? state.messageParts : undefined
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
-      <InAppLinkChip icon={icon} prefix={prefix} label={label} messageParts={messageParts} />
+      <InAppLinkChip icon={icon} prefix={prefix} label={label} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -36,10 +36,11 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const icon = state.status === "pending" ? undefined : state.icon
   const label = state.status === "pending" ? attrs.name || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
+  const avatar = state.status === "resolved" ? state.avatar : undefined
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
-      <InAppLinkChip icon={icon} prefix={prefix} label={label} />
+      <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -37,10 +37,11 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const label = state.status === "pending" ? attrs.name || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
   const avatar = state.status === "resolved" ? state.avatar : undefined
+  const messageParts = state.status === "resolved" ? state.messageParts : undefined
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
-      <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} />
+      <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} messageParts={messageParts} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { MessageSquare } from "lucide-react"
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
 import { useParams } from "react-router-dom"
 import { InAppLinkChip } from "@/components/in-app-link/in-app-link-chip"
@@ -34,23 +35,15 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
     }
   }, [resolvedName, attrs.name, updateAttributes])
 
-  const icon = state.status === "pending" ? undefined : state.icon
+  const pendingIcon = attrs.messageId ? MessageSquare : undefined
+  const icon = state.status === "pending" ? pendingIcon : state.icon
   const label = state.status === "pending" ? attrs.name || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
-  const avatar = state.status === "resolved" ? state.avatar : undefined
   const messageParts = state.status === "resolved" ? state.messageParts : undefined
-  const avatarSkeleton = state.status === "pending" && Boolean(attrs.messageId)
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
-      <InAppLinkChip
-        icon={icon}
-        prefix={prefix}
-        label={label}
-        avatar={avatar}
-        messageParts={messageParts}
-        avatarSkeleton={avatarSkeleton}
-      />
+      <InAppLinkChip icon={icon} prefix={prefix} label={label} messageParts={messageParts} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -38,10 +38,18 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const prefix = state.status === "resolved" ? state.prefix : undefined
   const avatar = state.status === "resolved" ? state.avatar : undefined
   const messageParts = state.status === "resolved" ? state.messageParts : undefined
+  const avatarSkeleton = state.status === "pending" && Boolean(attrs.messageId)
 
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
-      <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} messageParts={messageParts} />
+      <InAppLinkChip
+        icon={icon}
+        prefix={prefix}
+        label={label}
+        avatar={avatar}
+        messageParts={messageParts}
+        avatarSkeleton={avatarSkeleton}
+      />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -48,13 +48,20 @@ export function InAppLinkChip({
   if (avatarSkeleton && !avatar) {
     // A message resolves to "{author} to/in {where}", but the in-flight fallback
     // label is the link's baked markdown text, which can be stale (e.g. an older
-    // viewer-relative "… to You"). Showing it would flash the wrong words before
-    // the resolve corrects them, so render a neutral skeleton instead — the chip
-    // goes loading → final, never wrong-text → final.
+    // viewer-relative "… to You"). Render it transparently under a shimmer: the
+    // text is hidden so wrong words never flash, but it still reserves the baked
+    // label's width — which for a current-generation chip equals the resolved
+    // label — so the chip doesn't reflow surrounding text when it settles
+    // (INV-21). Goes loading → final, never wrong-text → final.
     return (
       <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
         <span className="h-4 w-4 shrink-0 animate-pulse rounded-[4px] bg-foreground/10" aria-hidden="true" />
-        <span className="h-3 w-24 animate-pulse rounded bg-foreground/10" aria-hidden="true" />
+        <span
+          className="inline-flex h-3 min-w-0 max-w-full animate-pulse items-center truncate rounded bg-foreground/10 text-transparent"
+          aria-hidden="true"
+        >
+          {label}
+        </span>
       </span>
     )
   }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -2,7 +2,6 @@ import { type ComponentType, type ReactNode } from "react"
 import { Link2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { chipBase, triggerStyles } from "@/lib/markdown/mention-renderer"
-import type { ChipMessageParts } from "@/hooks/use-in-app-link-chip"
 
 const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
 
@@ -12,21 +11,20 @@ const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
  * same split `MemoChip` uses. Speaks the mention vocabulary (`chipBase` shape +
  * the channel `triggerStyles` palette): a channel shows its `#` as a text prefix,
  * reading exactly like a `#channel` mention; a message reads "{author} in
- * #channel" behind a leading glyph. The rich preview (author face, snippet) lives
- * in the below-message card, not here — the chip is a compact text reference, so
- * it resolves synchronously from the baked label and never flickers or reflows.
+ * #channel" behind a leading glyph. A single end-truncated `label` (no internal
+ * split) so the baked-label pending state and the resolved state truncate the
+ * same way and never re-align. The rich preview (author face, snippet) lives in
+ * the below-message card; the chip is a compact text reference.
  */
 export function InAppLinkChip({
   icon: Icon,
   prefix,
   label,
-  messageParts,
   className,
 }: {
   icon?: ComponentType<{ className?: string }>
   prefix?: string
   label: ReactNode
-  messageParts?: ChipMessageParts
   className?: string
 }) {
   if (prefix) {
@@ -44,16 +42,7 @@ export function InAppLinkChip({
       <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
         <ChipIcon className="h-3 w-3" aria-hidden="true" />
       </span>
-      {messageParts ? (
-        // Author truncates; the location suffix stays pinned so it survives
-        // truncation — its own leading space separates it from the author.
-        <span className="inline-flex min-w-0 items-center">
-          <span className="min-w-0 truncate">{messageParts.lead}</span>
-          {messageParts.tail && <span className="shrink-0 whitespace-nowrap">{messageParts.tail}</span>}
-        </span>
-      ) : (
-        <span className="truncate">{label}</span>
-      )}
+      <span className="truncate">{label}</span>
     </span>
   )
 }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -14,9 +14,10 @@ const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
  * the channel `triggerStyles` palette): a channel shows its `#` as a text
  * prefix, reading exactly like a `#channel` mention. A message leads with its
  * author's face (`avatar`) and a "{author} in #channel" label; kinds with no
- * face or sigil (restricted/pending, uncached message) fall back to a glyph. The
- * leading face/glyph occupies the same 16px slot in every variant so the chip
- * never changes height as it resolves (INV-21).
+ * face or sigil (restricted, uncached message) fall back to a glyph, and a
+ * pending message shows a neutral placeholder in the same slot. The leading
+ * face/glyph/placeholder occupies the same 16px slot in every variant so the
+ * chip never changes height as it resolves (INV-21).
  */
 export function InAppLinkChip({
   icon: Icon,
@@ -32,7 +33,7 @@ export function InAppLinkChip({
   label: ReactNode
   avatar?: ChipAvatar
   messageParts?: ChipMessageParts
-  /** Pending message chip: reserve the resolved avatar's footprint with a skeleton. */
+  /** Pending message chip: show the baked label with a neutral avatar placeholder. */
   avatarSkeleton?: boolean
   className?: string
 }) {
@@ -46,22 +47,17 @@ export function InAppLinkChip({
   }
 
   if (avatarSkeleton && !avatar) {
-    // A message resolves to "{author} to/in {where}", but the in-flight fallback
-    // label is the link's baked markdown text, which can be stale (e.g. an older
-    // viewer-relative "… to You"). Render it transparently under a shimmer: the
-    // text is hidden so wrong words never flash, but it still reserves the baked
-    // label's width — which for a current-generation chip equals the resolved
-    // label — so the chip doesn't reflow surrounding text when it settles
-    // (INV-21). Goes loading → final, never wrong-text → final.
+    // Pending message chip: render the baked label as real text behind a neutral,
+    // gently-pulsing avatar placeholder — the exact footprint the resolved chip
+    // occupies. For a current-generation link the baked label already equals the
+    // resolved "{author} … {where}", so resolving only swaps the placeholder for
+    // the avatar image; the text doesn't move and the chip never reflows (INV-21).
+    // Deliberately not a shimmer bar: a grey bar collapsing into taller, colored
+    // text is itself the layout shift this is meant to avoid.
     return (
       <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
         <span className="h-4 w-4 shrink-0 animate-pulse rounded-[4px] bg-foreground/10" aria-hidden="true" />
-        <span
-          className="inline-flex h-3 min-w-0 max-w-full animate-pulse items-center truncate rounded bg-foreground/10 text-transparent"
-          aria-hidden="true"
-        >
-          {label}
-        </span>
+        <span className="truncate">{label}</span>
       </span>
     )
   }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -76,11 +76,14 @@ export function InAppLinkChip({
           </AvatarFallback>
         </Avatar>
         {messageParts ? (
-          <>
-            {/* Author truncates; the location suffix stays pinned so it survives. */}
+          // One text child, so the chip has a single avatar↔text gap that matches
+          // the pending skeleton's footprint and doesn't reflow when it settles
+          // (INV-21). Author truncates; the location suffix stays pinned so it
+          // survives — its own leading space separates it from the author.
+          <span className="inline-flex min-w-0 items-center">
             <span className="min-w-0 truncate">{messageParts.lead}</span>
             {messageParts.tail && <span className="shrink-0 whitespace-nowrap">{messageParts.tail}</span>}
-          </>
+          </span>
         ) : (
           <span className="truncate">{label}</span>
         )}

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -46,10 +46,15 @@ export function InAppLinkChip({
   }
 
   if (avatarSkeleton && !avatar) {
+    // A message resolves to "{author} to/in {where}", but the in-flight fallback
+    // label is the link's baked markdown text, which can be stale (e.g. an older
+    // viewer-relative "… to You"). Showing it would flash the wrong words before
+    // the resolve corrects them, so render a neutral skeleton instead — the chip
+    // goes loading → final, never wrong-text → final.
     return (
       <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
         <span className="h-4 w-4 shrink-0 animate-pulse rounded-[4px] bg-foreground/10" aria-hidden="true" />
-        <span className="truncate">{label}</span>
+        <span className="h-3 w-24 animate-pulse rounded bg-foreground/10" aria-hidden="true" />
       </span>
     )
   }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -3,7 +3,7 @@ import { Link2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { chipBase, triggerStyles } from "@/lib/markdown/mention-renderer"
-import type { ChipAvatar } from "@/hooks/use-in-app-link-chip"
+import type { ChipAvatar, ChipMessageParts } from "@/hooks/use-in-app-link-chip"
 
 const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
 
@@ -13,20 +13,24 @@ const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
  * same split `MemoChip` uses. Speaks the mention vocabulary (`chipBase` shape +
  * the channel `triggerStyles` palette): a channel shows its `#` as a text
  * prefix, reading exactly like a `#channel` mention. A message leads with its
- * author's face (`avatar`), reading like "{author} in #channel"; kinds with no
- * face or sigil (restricted/pending, uncached message) fall back to a glyph.
+ * author's face (`avatar`) and a "{author} in #channel" label; kinds with no
+ * face or sigil (restricted/pending, uncached message) fall back to a glyph. The
+ * leading face/glyph occupies the same 16px slot in every variant so the chip
+ * never changes height as it resolves (INV-21).
  */
 export function InAppLinkChip({
   icon: Icon,
   prefix,
   label,
   avatar,
+  messageParts,
   className,
 }: {
   icon?: ComponentType<{ className?: string }>
   prefix?: string
   label: ReactNode
   avatar?: ChipAvatar
+  messageParts?: ChipMessageParts
   className?: string
 }) {
   if (prefix) {
@@ -47,7 +51,15 @@ export function InAppLinkChip({
             {avatar.name.charAt(0).toUpperCase()}
           </AvatarFallback>
         </Avatar>
-        <span className="truncate">{label}</span>
+        {messageParts ? (
+          <>
+            {/* Author truncates; the location suffix stays pinned so it survives. */}
+            <span className="min-w-0 truncate">{messageParts.lead}</span>
+            {messageParts.tail && <span className="shrink-0 whitespace-nowrap">{messageParts.tail}</span>}
+          </>
+        ) : (
+          <span className="truncate">{label}</span>
+        )}
       </span>
     )
   }
@@ -55,7 +67,9 @@ export function InAppLinkChip({
   const ChipIcon = Icon ?? Link2
   return (
     <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
-      <ChipIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
+      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
+        <ChipIcon className="h-3 w-3" aria-hidden="true" />
+      </span>
       <span className="truncate">{label}</span>
     </span>
   )

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -1,25 +1,32 @@
 import { type ComponentType, type ReactNode } from "react"
 import { Link2 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { chipBase, triggerStyles } from "@/lib/markdown/mention-renderer"
+import type { ChipAvatar } from "@/hooks/use-in-app-link-chip"
+
+const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
 
 /**
  * Inline chip for an in-app stream/message link, shared by the composer NodeView
  * (`InAppLinkView`) and the timeline markdown renderer (`MarkdownLink`) — the
  * same split `MemoChip` uses. Speaks the mention vocabulary (`chipBase` shape +
  * the channel `triggerStyles` palette): a channel shows its `#` as a text
- * prefix, reading exactly like a `#channel` mention; kinds with no sigil (DM,
- * message, restricted/pending) show a small leading glyph instead.
+ * prefix, reading exactly like a `#channel` mention. A message leads with its
+ * author's face (`avatar`), reading like "{author} in #channel"; kinds with no
+ * face or sigil (restricted/pending, uncached message) fall back to a glyph.
  */
 export function InAppLinkChip({
   icon: Icon,
   prefix,
   label,
+  avatar,
   className,
 }: {
   icon?: ComponentType<{ className?: string }>
   prefix?: string
   label: ReactNode
+  avatar?: ChipAvatar
   className?: string
 }) {
   if (prefix) {
@@ -31,17 +38,23 @@ export function InAppLinkChip({
     )
   }
 
+  if (avatar) {
+    return (
+      <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
+        <Avatar className="h-4 w-4 shrink-0 rounded-[4px]">
+          {avatar.url && <AvatarImage src={avatar.url} alt={avatar.name} />}
+          <AvatarFallback className="rounded-[4px] bg-foreground/10 text-[8px] font-semibold">
+            {avatar.name.charAt(0).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <span className="truncate">{label}</span>
+      </span>
+    )
+  }
+
   const ChipIcon = Icon ?? Link2
   return (
-    <span
-      className={cn(
-        chipBase,
-        "inline-flex max-w-[14rem] items-center gap-1 align-bottom",
-        triggerStyles.channel,
-        className
-      )}
-      data-type="in-app-link-chip"
-    >
+    <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
       <ChipIcon className="h-3 w-3 shrink-0" aria-hidden="true" />
       <span className="truncate">{label}</span>
     </span>

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -24,6 +24,7 @@ export function InAppLinkChip({
   label,
   avatar,
   messageParts,
+  avatarSkeleton,
   className,
 }: {
   icon?: ComponentType<{ className?: string }>
@@ -31,6 +32,8 @@ export function InAppLinkChip({
   label: ReactNode
   avatar?: ChipAvatar
   messageParts?: ChipMessageParts
+  /** Pending message chip: reserve the resolved avatar's footprint with a skeleton. */
+  avatarSkeleton?: boolean
   className?: string
 }) {
   if (prefix) {
@@ -38,6 +41,15 @@ export function InAppLinkChip({
       <span className={cn(chipBase, triggerStyles.channel, className)} data-type="in-app-link-chip">
         {prefix}
         {label}
+      </span>
+    )
+  }
+
+  if (avatarSkeleton && !avatar) {
+    return (
+      <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
+        <span className="h-4 w-4 shrink-0 animate-pulse rounded-[4px] bg-foreground/10" aria-hidden="true" />
+        <span className="truncate">{label}</span>
       </span>
     )
   }

--- a/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-chip.tsx
@@ -1,9 +1,8 @@
 import { type ComponentType, type ReactNode } from "react"
 import { Link2 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { chipBase, triggerStyles } from "@/lib/markdown/mention-renderer"
-import type { ChipAvatar, ChipMessageParts } from "@/hooks/use-in-app-link-chip"
+import type { ChipMessageParts } from "@/hooks/use-in-app-link-chip"
 
 const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
 
@@ -11,30 +10,23 @@ const inlineChip = "inline-flex max-w-[16rem] items-center gap-1 align-bottom"
  * Inline chip for an in-app stream/message link, shared by the composer NodeView
  * (`InAppLinkView`) and the timeline markdown renderer (`MarkdownLink`) — the
  * same split `MemoChip` uses. Speaks the mention vocabulary (`chipBase` shape +
- * the channel `triggerStyles` palette): a channel shows its `#` as a text
- * prefix, reading exactly like a `#channel` mention. A message leads with its
- * author's face (`avatar`) and a "{author} in #channel" label; kinds with no
- * face or sigil (restricted, uncached message) fall back to a glyph, and a
- * pending message shows a neutral placeholder in the same slot. The leading
- * face/glyph/placeholder occupies the same 16px slot in every variant so the
- * chip never changes height as it resolves (INV-21).
+ * the channel `triggerStyles` palette): a channel shows its `#` as a text prefix,
+ * reading exactly like a `#channel` mention; a message reads "{author} in
+ * #channel" behind a leading glyph. The rich preview (author face, snippet) lives
+ * in the below-message card, not here — the chip is a compact text reference, so
+ * it resolves synchronously from the baked label and never flickers or reflows.
  */
 export function InAppLinkChip({
   icon: Icon,
   prefix,
   label,
-  avatar,
   messageParts,
-  avatarSkeleton,
   className,
 }: {
   icon?: ComponentType<{ className?: string }>
   prefix?: string
   label: ReactNode
-  avatar?: ChipAvatar
   messageParts?: ChipMessageParts
-  /** Pending message chip: show the baked label with a neutral avatar placeholder. */
-  avatarSkeleton?: boolean
   className?: string
 }) {
   if (prefix) {
@@ -46,54 +38,22 @@ export function InAppLinkChip({
     )
   }
 
-  if (avatarSkeleton && !avatar) {
-    // Pending message chip: render the baked label as real text behind a neutral,
-    // gently-pulsing avatar placeholder — the exact footprint the resolved chip
-    // occupies. For a current-generation link the baked label already equals the
-    // resolved "{author} … {where}", so resolving only swaps the placeholder for
-    // the avatar image; the text doesn't move and the chip never reflows (INV-21).
-    // Deliberately not a shimmer bar: a grey bar collapsing into taller, colored
-    // text is itself the layout shift this is meant to avoid.
-    return (
-      <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
-        <span className="h-4 w-4 shrink-0 animate-pulse rounded-[4px] bg-foreground/10" aria-hidden="true" />
-        <span className="truncate">{label}</span>
-      </span>
-    )
-  }
-
-  if (avatar) {
-    return (
-      <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
-        <Avatar className="h-4 w-4 shrink-0 rounded-[4px]">
-          {avatar.url && <AvatarImage src={avatar.url} alt={avatar.name} />}
-          <AvatarFallback className="rounded-[4px] bg-foreground/10 text-[8px] font-semibold">
-            {avatar.name.charAt(0).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
-        {messageParts ? (
-          // One text child, so the chip has a single avatar↔text gap that matches
-          // the pending skeleton's footprint and doesn't reflow when it settles
-          // (INV-21). Author truncates; the location suffix stays pinned so it
-          // survives — its own leading space separates it from the author.
-          <span className="inline-flex min-w-0 items-center">
-            <span className="min-w-0 truncate">{messageParts.lead}</span>
-            {messageParts.tail && <span className="shrink-0 whitespace-nowrap">{messageParts.tail}</span>}
-          </span>
-        ) : (
-          <span className="truncate">{label}</span>
-        )}
-      </span>
-    )
-  }
-
   const ChipIcon = Icon ?? Link2
   return (
     <span className={cn(chipBase, inlineChip, triggerStyles.channel, className)} data-type="in-app-link-chip">
       <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center">
         <ChipIcon className="h-3 w-3" aria-hidden="true" />
       </span>
-      <span className="truncate">{label}</span>
+      {messageParts ? (
+        // Author truncates; the location suffix stays pinned so it survives
+        // truncation — its own leading space separates it from the author.
+        <span className="inline-flex min-w-0 items-center">
+          <span className="min-w-0 truncate">{messageParts.lead}</span>
+          {messageParts.tail && <span className="shrink-0 whitespace-nowrap">{messageParts.tail}</span>}
+        </span>
+      ) : (
+        <span className="truncate">{label}</span>
+      )}
     </span>
   )
 }

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import * as workspaceStore from "@/stores/workspace-store"
+import * as currentUserModule from "@/hooks/use-current-workspace-user-id"
 import { InAppLinkInline } from "./in-app-link-inline"
 
 const origin = window.location.origin
@@ -23,6 +24,10 @@ function renderMessageLink(streamId: string) {
 describe("InAppLinkInline (message chip)", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The chip resolves the viewer via auth; stub it so the component tree
+    // doesn't require an AuthProvider. The backend-resolve tests below seed no
+    // local event, so the message falls through to the mocked backend resolve.
+    vi.spyOn(currentUserModule, "useCurrentWorkspaceUserId").mockReturnValue("user_viewer")
   })
 
   it("renders a DM message as '{author} to {recipient}' with full names", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { linkPreviewsApi } from "@/api"
+import { InAppLinkInline } from "./in-app-link-inline"
+
+const origin = window.location.origin
+
+function renderMessageLink(streamId: string) {
+  const href = `${origin}/w/ws_1/s/${streamId}?m=msg_1`
+  return render(
+    <MemoryRouter>
+      <InAppLinkInline href={href} workspaceId="ws_1" streamId={streamId} messageId="msg_1" fallbackLabel="" />
+    </MemoryRouter>
+  )
+}
+
+describe("InAppLinkInline (message chip)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders a DM message as '{author} to {recipient}', collapsing the viewer to 'You'", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "message",
+      accessTier: "full",
+      authorName: "Pierre Boberg",
+      streamType: "dm",
+      recipientName: "Kristoffer Remback",
+      recipientIsSelf: true,
+    })
+
+    renderMessageLink("stream_dm")
+
+    const chip = await screen.findByText("Pierre Boberg to You")
+    expect(chip.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
+  })
+
+  it("renders a channel message as '{author} in #slug'", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "message",
+      accessTier: "full",
+      authorName: "Kristoffer Remback",
+      streamType: "channel",
+      streamName: "tech-big-new-prop",
+    })
+
+    renderMessageLink("stream_1")
+
+    await waitFor(() => expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument())
+  })
+
+  it("shows a deleted-message placeholder instead of a live chip", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "message",
+      accessTier: "full",
+      deleted: true,
+    })
+
+    renderMessageLink("stream_1")
+
+    await waitFor(() => expect(screen.getByText("Deleted message")).toBeInTheDocument())
+  })
+})

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -41,10 +41,9 @@ describe("InAppLinkInline (message chip)", () => {
 
     renderMessageLink("stream_dm")
 
-    // Author leads (truncatable); the recipient is the pinned suffix.
-    const lead = await screen.findByText("Pierre Boberg")
-    expect(screen.getByText("to Kristoffer Remback")).toBeInTheDocument()
-    expect(lead.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
+    // One end-truncated label so pending and resolved truncate identically.
+    const chip = await screen.findByText("Pierre Boberg to Kristoffer Remback")
+    expect(chip.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
   })
 
   it("renders a channel message as '{author} in #slug'", async () => {
@@ -58,8 +57,9 @@ describe("InAppLinkInline (message chip)", () => {
 
     renderMessageLink("stream_1")
 
-    await waitFor(() => expect(screen.getByText("Kristoffer Remback")).toBeInTheDocument())
-    expect(screen.getByText("in #tech-big-new-prop")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument()
+    )
   })
 
   it("settles a fully-resolved but unnamed (bot/persona) message to 'Message', not the parent stream name", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import * as workspaceStore from "@/stores/workspace-store"
 import { InAppLinkInline } from "./in-app-link-inline"
@@ -9,10 +10,13 @@ const origin = window.location.origin
 
 function renderMessageLink(streamId: string) {
   const href = `${origin}/w/ws_1/s/${streamId}?m=msg_1`
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <MemoryRouter>
-      <InAppLinkInline href={href} workspaceId="ws_1" streamId={streamId} messageId="msg_1" fallbackLabel="" />
-    </MemoryRouter>
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <InAppLinkInline href={href} workspaceId="ws_1" streamId={streamId} messageId="msg_1" fallbackLabel="" />
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
 
@@ -21,20 +25,21 @@ describe("InAppLinkInline (message chip)", () => {
     vi.restoreAllMocks()
   })
 
-  it("renders a DM message as '{author} to {recipient}', collapsing the viewer to 'You'", async () => {
+  it("renders a DM message as '{author} to {recipient}' with full names", async () => {
     vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
       kind: "message",
       accessTier: "full",
       authorName: "Pierre Boberg",
       streamType: "dm",
       recipientName: "Kristoffer Remback",
-      recipientIsSelf: true,
     })
 
     renderMessageLink("stream_dm")
 
-    const chip = await screen.findByText("Pierre Boberg to You")
-    expect(chip.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
+    // Author leads (truncatable); the recipient is the pinned suffix.
+    const lead = await screen.findByText("Pierre Boberg")
+    expect(screen.getByText("to Kristoffer Remback")).toBeInTheDocument()
+    expect(lead.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
     // Author face leads the chip; with no avatar URL it shows the initial fallback.
     expect(screen.getByText("P")).toBeInTheDocument()
   })
@@ -50,7 +55,8 @@ describe("InAppLinkInline (message chip)", () => {
 
     renderMessageLink("stream_1")
 
-    await waitFor(() => expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText("Kristoffer Remback")).toBeInTheDocument())
+    expect(screen.getByText("in #tech-big-new-prop")).toBeInTheDocument()
   })
 
   it("settles a fully-resolved but unnamed (bot/persona) message to 'Message', not the parent stream name", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { linkPreviewsApi } from "@/api"
+import * as workspaceStore from "@/stores/workspace-store"
 import { InAppLinkInline } from "./in-app-link-inline"
 
 const origin = window.location.origin
@@ -50,6 +51,25 @@ describe("InAppLinkInline (message chip)", () => {
     renderMessageLink("stream_1")
 
     await waitFor(() => expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument())
+  })
+
+  it("settles a fully-resolved but unnamed (bot/persona) message to 'Message', not the parent stream name", async () => {
+    // Cached parent stream would resolve to "#general"; the rich label is null
+    // (no author), so the chip must settle on "Message" rather than the stream name.
+    vi.spyOn(workspaceStore, "useWorkspaceStreams").mockReturnValue([
+      { id: "stream_1", type: "channel", slug: "general", displayName: null },
+    ] as never)
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "message",
+      accessTier: "full",
+      streamType: "channel",
+      streamName: "general",
+    })
+
+    renderMessageLink("stream_1")
+
+    await waitFor(() => expect(screen.getByText("Message")).toBeInTheDocument())
+    expect(screen.queryByText("#general")).not.toBeInTheDocument()
   })
 
   it("shows a deleted-message placeholder instead of a live chip", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -45,8 +45,6 @@ describe("InAppLinkInline (message chip)", () => {
     const lead = await screen.findByText("Pierre Boberg")
     expect(screen.getByText("to Kristoffer Remback")).toBeInTheDocument()
     expect(lead.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
-    // Author face leads the chip; with no avatar URL it shows the initial fallback.
-    expect(screen.getByText("P")).toBeInTheDocument()
   })
 
   it("renders a channel message as '{author} in #slug'", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -34,6 +34,8 @@ describe("InAppLinkInline (message chip)", () => {
 
     const chip = await screen.findByText("Pierre Boberg to You")
     expect(chip.closest("a")).toHaveAttribute("href", `${origin}/w/ws_1/s/stream_dm?m=msg_1`)
+    // Author face leads the chip; with no avatar URL it shows the initial fallback.
+    expect(screen.getByText("P")).toBeInTheDocument()
   })
 
   it("renders a channel message as '{author} in #slug'", async () => {

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -34,7 +34,17 @@ export function InAppLinkInline({
   const prefix = state.status === "resolved" ? state.prefix : undefined
   const avatar = state.status === "resolved" ? state.avatar : undefined
   const messageParts = state.status === "resolved" ? state.messageParts : undefined
-  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} messageParts={messageParts} />
+  const avatarSkeleton = state.status === "pending" && Boolean(messageId)
+  const chip = (
+    <InAppLinkChip
+      icon={icon}
+      prefix={prefix}
+      label={label}
+      avatar={avatar}
+      messageParts={messageParts}
+      avatarSkeleton={avatarSkeleton}
+    />
+  )
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -27,7 +27,7 @@ export function InAppLinkInline({
   fallbackLabel: string
 }) {
   const navigate = useNavigate()
-  const state = useInAppLinkChip({ workspaceId, streamId, isMessage: Boolean(messageId), url: href })
+  const state = useInAppLinkChip({ workspaceId, streamId, messageId, isMessage: Boolean(messageId), url: href })
 
   const icon = state.status === "pending" ? undefined : state.icon
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -33,7 +33,8 @@ export function InAppLinkInline({
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
   const avatar = state.status === "resolved" ? state.avatar : undefined
-  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} />
+  const messageParts = state.status === "resolved" ? state.messageParts : undefined
+  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} messageParts={messageParts} />
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -37,8 +37,7 @@ export function InAppLinkInline({
   const icon = state.status === "pending" ? pendingIcon : state.icon
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
-  const messageParts = state.status === "resolved" ? state.messageParts : undefined
-  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} messageParts={messageParts} />
+  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} />
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -32,7 +32,8 @@ export function InAppLinkInline({
   const icon = state.status === "pending" ? undefined : state.icon
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
-  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} />
+  const avatar = state.status === "resolved" ? state.avatar : undefined
+  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} avatar={avatar} />
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -1,4 +1,5 @@
 import { type MouseEvent } from "react"
+import { MessageSquare } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 import { resolveInternalAppPath } from "@/lib/internal-url"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
@@ -8,10 +9,10 @@ import { InAppLinkChip } from "./in-app-link-chip"
  * Posted-message rendering of an in-app stream/message link: the same chip the
  * composer shows, but navigable. Swapped in for the plain underlined link by
  * `MarkdownLink` when the href classifies as an in-app stream/message URL, so
- * old and new messages alike render the link as a compact named chip instead of
- * a raw URL. Resolution goes through the shared `useInAppLinkChip` (local cache
- * → access-tiered backend), and the below-message preview card is suppressed
- * (`link-preview-list`), making this the single surface for the link.
+ * old and new messages alike render the link as a compact named text chip
+ * instead of a raw URL. Resolution goes through the shared `useInAppLinkChip`
+ * (local cache → access-tiered backend); a message link's rich preview (author
+ * face, snippet) renders in the below-message card, not here.
  */
 export function InAppLinkInline({
   href,
@@ -29,22 +30,15 @@ export function InAppLinkInline({
   const navigate = useNavigate()
   const state = useInAppLinkChip({ workspaceId, streamId, messageId, isMessage: Boolean(messageId), url: href })
 
-  const icon = state.status === "pending" ? undefined : state.icon
+  // A message keeps its glyph while pending (the label is the baked text, already
+  // correct) so resolving never swaps the leading icon; a stream pending stays
+  // glyphless and resolves its name synchronously from cache.
+  const pendingIcon = messageId ? MessageSquare : undefined
+  const icon = state.status === "pending" ? pendingIcon : state.icon
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
-  const avatar = state.status === "resolved" ? state.avatar : undefined
   const messageParts = state.status === "resolved" ? state.messageParts : undefined
-  const avatarSkeleton = state.status === "pending" && Boolean(messageId)
-  const chip = (
-    <InAppLinkChip
-      icon={icon}
-      prefix={prefix}
-      label={label}
-      avatar={avatar}
-      messageParts={messageParts}
-      avatarSkeleton={avatarSkeleton}
-    />
-  )
+  const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} messageParts={messageParts} />
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import { InAppLinkPreviewCard } from "./in-app-link-preview-card"
@@ -34,10 +35,13 @@ describe("InAppLinkPreviewCard", () => {
 
   function renderWith(data: InAppLinkPreviewData, preview: LinkPreviewSummary) {
     mockResolveInAppLink.mockResolvedValue(data)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     render(
-      <MemoryRouter>
-        <InAppLinkPreviewCard preview={preview} workspaceId={workspaceId} />
-      </MemoryRouter>
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <InAppLinkPreviewCard preview={preview} workspaceId={workspaceId} />
+        </MemoryRouter>
+      </QueryClientProvider>
     )
   }
 

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -4,12 +4,10 @@ import { Link } from "react-router-dom"
 import { MessageSquare, Hash, Brain, Lock, Globe, NotebookPen, ArrowUpRight, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ActorAvatar } from "@/components/actor-avatar"
-import { MarkdownContent } from "@/components/ui/markdown-content"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { linkPreviewsApi } from "@/api"
-import { LinkPreviewBody } from "./link-preview-body"
 import type {
   InAppLinkPreviewData,
   LinkPreviewSummary,
@@ -57,22 +55,11 @@ export function useResolvedInAppLink(
 interface InAppLinkPreviewCardProps {
   preview: LinkPreviewSummary
   workspaceId: string
-  /**
-   * Scopes the per-preview "Show more" persistence key. Optional so tests and
-   * transient previews without a host message still render.
-   */
-  messageId?: string
   onDismiss?: (previewId: string) => void
   hydrate?: boolean
 }
 
-export function InAppLinkPreviewCard({
-  preview,
-  workspaceId,
-  messageId,
-  onDismiss,
-  hydrate = true,
-}: InAppLinkPreviewCardProps) {
+export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate = true }: InAppLinkPreviewCardProps) {
   const { data, loading } = useResolvedInAppLink(workspaceId, preview.id, undefined, hydrate)
 
   if (loading) return <CardSkeleton />
@@ -83,8 +70,6 @@ export function InAppLinkPreviewCard({
       data={data}
       url={preview.url}
       workspaceId={workspaceId}
-      previewKey={preview.id}
-      messageId={messageId}
       onDismiss={onDismiss ? () => onDismiss(preview.id) : undefined}
     />
   )
@@ -101,45 +86,28 @@ function ResolvedInAppLink({
   data,
   url,
   workspaceId,
-  previewKey,
-  messageId,
   onDismiss,
 }: {
   data: InAppLinkPreviewData
   url: string
   workspaceId: string
-  previewKey: string
-  messageId?: string
   onDismiss?: () => void
 }) {
   if (data.kind === "stream")
     return <StreamLinkCard data={data} url={url} workspaceId={workspaceId} onDismiss={onDismiss} />
   if (data.kind === "memo") return <MemoLinkCard data={data} url={url} onDismiss={onDismiss} />
-  return (
-    <MessageLinkCard
-      data={data}
-      url={url}
-      workspaceId={workspaceId}
-      previewKey={previewKey}
-      messageId={messageId}
-      onDismiss={onDismiss}
-    />
-  )
+  return <MessageLinkCard data={data} url={url} workspaceId={workspaceId} onDismiss={onDismiss} />
 }
 
 function MessageLinkCard({
   data,
   url,
   workspaceId,
-  previewKey,
-  messageId,
   onDismiss,
 }: {
   data: MessageLinkPreviewData
   url: string
   workspaceId: string
-  previewKey: string
-  messageId?: string
   onDismiss?: () => void
 }) {
   // A DM/stream name is per-viewer and absent from the backend resolve, so
@@ -197,12 +165,9 @@ function MessageLinkCard({
         <div className="min-w-0 flex-1">
           {data.authorName && <span className="text-xs font-semibold text-foreground">{data.authorName}</span>}
           {data.contentPreview && (
-            <div className="mt-0.5">
-              <MarkdownContent
-                content={data.contentPreview}
-                className="text-xs leading-relaxed text-muted-foreground"
-              />
-            </div>
+            <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground line-clamp-2">
+              {stripMarkdownToInline(data.contentPreview)}
+            </p>
           )}
         </div>
       </div>
@@ -217,9 +182,7 @@ function MessageLinkCard({
   else if (data.streamName) headerLabel = `#${data.streamName}`
   return (
     <CardShell header={<CardHeader label={headerLabel} onDismiss={onDismiss} />}>
-      <LinkPreviewBody messageId={messageId} previewId={previewKey}>
-        <InternalLink path={internalPath}>{body}</InternalLink>
-      </LinkPreviewBody>
+      <InternalLink path={internalPath}>{body}</InternalLink>
     </CardShell>
   )
 }
@@ -436,8 +399,9 @@ function CardShell({ header, children }: { header: ReactNode; children: ReactNod
 }
 
 /**
- * Loading placeholder. Mirrors the resolved card's header bar + tile + two text
- * lines so resolving doesn't shift following timeline rows (INV-21).
+ * Loading placeholder. Mirrors the resolved card's header bar + tile/avatar +
+ * the title line and the `line-clamp-2` body every in-app card commits to, so
+ * resolving doesn't shift following timeline rows (INV-21).
  */
 function CardSkeleton() {
   return (

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useMemo, type ReactNode } from "react"
+import { useMemo, type ReactNode } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
 import { MessageSquare, Hash, Brain, Lock, Globe, NotebookPen, ArrowUpRight, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -23,8 +24,12 @@ import type {
  * persisted preview row (`previewId`, the posted-message timeline) or a raw
  * `url` (a draft chip with no persisted row). Both hit the same access-tiered
  * resolver; only the lookup key differs. Pass both undefined to no-op (a chip
- * that resolved its name locally and needs no fetch). Deps are primitives so a
- * settled resolve doesn't re-fire on unrelated re-renders.
+ * that resolved its name locally and needs no fetch).
+ *
+ * Backed by a shared query cache keyed on the lookup id, so a link the composer
+ * already resolved renders resolved the instant the sent message re-mounts on
+ * the timeline — no second round-trip and no pending-glyph flash between the two
+ * surfaces (offline-first; INV-21). `loading` is only true on a cold miss.
  */
 export function useResolvedInAppLink(
   workspaceId: string,
@@ -32,50 +37,21 @@ export function useResolvedInAppLink(
   url: string | undefined,
   hydrate: boolean
 ): { data: InAppLinkPreviewData | null; loading: boolean } {
-  const [data, setData] = useState<InAppLinkPreviewData | null>(null)
-  const [loading, setLoading] = useState(hydrate)
+  const key = previewId ?? url ?? null
+  const query = useQuery({
+    queryKey: ["inAppLinkResolve", workspaceId, key],
+    queryFn: () =>
+      previewId
+        ? linkPreviewsApi.resolveInAppLink(workspaceId, previewId)
+        : linkPreviewsApi.resolveInAppLinkByUrl(workspaceId, url!),
+    enabled: hydrate && key !== null,
+    staleTime: 5 * 60_000,
+    // Previews are non-critical; a failed resolve collapses to no card/chip
+    // rather than retrying and holding a skeleton.
+    retry: false,
+  })
 
-  useEffect(() => {
-    if (!hydrate) {
-      // Hydration deferred (e.g. board feed): don't fetch and don't sit on a
-      // perpetual skeleton — collapse until a caller flips hydrate on.
-      setData(null)
-      setLoading(false)
-      return
-    }
-
-    let request: Promise<InAppLinkPreviewData> | null = null
-    if (previewId) request = linkPreviewsApi.resolveInAppLink(workspaceId, previewId)
-    else if (url) request = linkPreviewsApi.resolveInAppLinkByUrl(workspaceId, url)
-    if (!request) {
-      // Neither key (e.g. a chip that resolved its name locally) — collapse to
-      // no data rather than leaving a prior resolve's result on screen.
-      setData(null)
-      setLoading(false)
-      return
-    }
-
-    let mounted = true
-    // Clear any prior target's data so a failed re-resolve (silently caught
-    // below) can't leave the previous link's card showing for the new one.
-    setData(null)
-    setLoading(true)
-    request
-      .then((result) => {
-        if (mounted) setData(result)
-      })
-      .catch(() => {
-        // Silently fail — previews are non-critical
-      })
-      .finally(() => {
-        if (mounted) setLoading(false)
-      })
-    return () => {
-      mounted = false
-    }
-  }, [workspaceId, previewId, url, hydrate])
-
-  return { data, loading }
+  return { data: query.data ?? null, loading: query.isLoading }
 }
 
 interface InAppLinkPreviewCardProps {

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
 import { MessageSquare, Hash, Brain, Lock, Globe, NotebookPen, ArrowUpRight, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
@@ -62,7 +63,7 @@ interface InAppLinkPreviewCardProps {
 export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate = true }: InAppLinkPreviewCardProps) {
   const { data, loading } = useResolvedInAppLink(workspaceId, preview.id, undefined, hydrate)
 
-  if (loading) return <CardSkeleton />
+  if (loading) return <CardSkeleton variant={preview.contentType === "memo_link" ? "memo" : "message"} />
   if (!data) return null
 
   return (
@@ -74,6 +75,19 @@ export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate 
     />
   )
 }
+
+// The timeline does not compensate a row that grows after its first paint — its
+// scroll anchor no-ops content resizes while reading history (use-timeline-scroll)
+// and `overflow-anchor` is off — so the skeleton and EVERY resolved tier must
+// commit the same height or the list jumps (INV-21). These reserve a fixed header
+// and body footprint that content can't exceed (single-line title via `truncate`,
+// body via `line-clamp-2`); the skeleton and the minimal tier mirror them. Two
+// body sizes because the memo card carries an extra source-stream line.
+const CARD_HEADER_H = "min-h-[2.0625rem]" // text/icon line + py-1.5 + border, fits the h-5 dismiss button
+const CARD_BODY_MESSAGE = "min-h-[5.5rem]" // avatar + author line + 2-line clamp
+const CARD_BODY_MEMO = "min-h-[7rem]" // tile + title + 2-line clamp + source line
+
+type CardVariant = "message" | "memo"
 
 /** Stream id of an in-app stream/message link, for client-side name resolution. */
 function streamIdFromUrl(url: string): string | null {
@@ -152,7 +166,7 @@ function MessageLinkCard({
 
   const internalPath = getInternalPath(url)
   const body = (
-    <CardBody>
+    <CardBody className={CARD_BODY_MESSAGE}>
       <div className="flex gap-3">
         <ActorAvatar
           actorId={data.authorId ?? null}
@@ -163,7 +177,9 @@ function MessageLinkCard({
           showStatus={false}
         />
         <div className="min-w-0 flex-1">
-          {data.authorName && <span className="text-xs font-semibold text-foreground">{data.authorName}</span>}
+          {data.authorName && (
+            <span className="block truncate text-xs font-semibold text-foreground">{data.authorName}</span>
+          )}
           {data.contentPreview && (
             <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground line-clamp-2">
               {stripMarkdownToInline(data.contentPreview)}
@@ -275,7 +291,15 @@ function StreamLinkCard({
 
 function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url: string; onDismiss?: () => void }) {
   if (data.accessTier === "cross_workspace") {
-    return <MinimalCard kindIcon={<Brain />} kindLabel="Memory" label="In another workspace" onDismiss={onDismiss} />
+    return (
+      <MinimalCard
+        kindIcon={<Brain />}
+        kindLabel="Memory"
+        label="In another workspace"
+        variant="memo"
+        onDismiss={onDismiss}
+      />
+    )
   }
 
   if (data.accessTier === "private") {
@@ -285,6 +309,7 @@ function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url
         kindLabel="Memory"
         bodyIcon={<Lock />}
         label="From a private conversation"
+        variant="memo"
         onDismiss={onDismiss}
       />
     )
@@ -292,7 +317,7 @@ function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url
 
   const internalPath = getInternalPath(url)
   const body = (
-    <CardBody>
+    <CardBody className={CARD_BODY_MEMO}>
       <div className="flex items-start gap-3">
         <IconTile>
           <Brain />
@@ -371,9 +396,9 @@ function CardHeader({ label, onDismiss }: { label: string; onDismiss?: () => voi
   )
 }
 
-function CardBody({ children }: { children: ReactNode }) {
+function CardBody({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <div className="relative overflow-hidden px-3.5 py-3">
+    <div className={cn("relative overflow-hidden px-3.5 py-3", className)}>
       <CardGlow />
       <div className="relative">{children}</div>
     </div>
@@ -392,24 +417,27 @@ function InternalLink({ path, children }: { path: string | null; children: React
 function CardShell({ header, children }: { header: ReactNode; children: ReactNode }) {
   return (
     <div className="group/preview reveal-host relative max-w-md overflow-hidden rounded-lg border bg-card transition-all hover:border-primary/50 hover:shadow-sm">
-      <div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5">{header}</div>
+      <div className={cn("flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5", CARD_HEADER_H)}>{header}</div>
       {children}
     </div>
   )
 }
 
 /**
- * Loading placeholder. Mirrors the resolved card's header bar + tile/avatar +
- * the title line and the `line-clamp-2` body every in-app card commits to, so
- * resolving doesn't shift following timeline rows (INV-21).
+ * Loading placeholder. Reserves the SAME header + body footprint the resolved
+ * card commits to (`CARD_HEADER_H` + the variant's `CARD_BODY_*`), so resolving
+ * never changes the row height (INV-21). The variant comes from the preview's
+ * content type, known before the resolve, so a memo card gets the taller body.
  */
-function CardSkeleton() {
+function CardSkeleton({ variant }: { variant: CardVariant }) {
   return (
     <div className="max-w-md animate-pulse overflow-hidden rounded-lg border bg-card">
-      <div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5">
+      <div className={cn("flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5", CARD_HEADER_H)}>
         <div className="h-3 w-20 rounded bg-muted" />
       </div>
-      <div className="flex items-start gap-3 px-3.5 py-3">
+      <div
+        className={cn("flex items-start gap-3 px-3.5 py-3", variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE)}
+      >
         <div className="h-9 w-9 shrink-0 rounded-lg bg-muted" />
         <div className="flex-1 space-y-1.5 pt-0.5">
           <div className="h-3.5 w-32 rounded bg-muted" />
@@ -432,6 +460,7 @@ function MinimalCard({
   bodyIcon,
   label,
   italic,
+  variant = "message",
   onDismiss,
 }: {
   kindIcon: ReactNode
@@ -439,16 +468,25 @@ function MinimalCard({
   bodyIcon?: ReactNode
   label: string
   italic?: boolean
+  /** Match the skeleton/full-card footprint of the link's kind so the tier swap doesn't shift. */
+  variant?: CardVariant
   onDismiss?: () => void
 }) {
   return (
     <div className="group/preview reveal-host relative max-w-md overflow-hidden rounded-lg border bg-card">
-      <div className="flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5 text-muted-foreground">
+      <div
+        className={cn("flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5 text-muted-foreground", CARD_HEADER_H)}
+      >
         <span className="shrink-0 [&>svg]:h-3.5 [&>svg]:w-3.5">{kindIcon}</span>
         <span className="text-xs font-medium">{kindLabel}</span>
         <DismissButton onDismiss={onDismiss} />
       </div>
-      <div className="flex items-center gap-3 px-3.5 py-3 text-muted-foreground">
+      <div
+        className={cn(
+          "flex items-center gap-3 px-3.5 py-3 text-muted-foreground",
+          variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE
+        )}
+      >
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40 [&>svg]:h-[18px] [&>svg]:w-[18px]">
           {bodyIcon ?? kindIcon}
         </div>

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -26,10 +26,10 @@ import type {
  * resolver; only the lookup key differs. Pass both undefined to no-op (a chip
  * that resolved its name locally and needs no fetch).
  *
- * Backed by a shared query cache keyed on the lookup id, so a link the composer
- * already resolved renders resolved the instant the sent message re-mounts on
- * the timeline — no second round-trip and no pending-glyph flash between the two
- * surfaces (offline-first; INV-21). `loading` is only true on a cold miss.
+ * Backed by a shared (in-memory, 5-min) query cache keyed on the lookup id, so a
+ * link the composer already resolved renders resolved the instant the sent
+ * message re-mounts on the timeline — no second round-trip and no pending-glyph
+ * flash between the two surfaces (INV-21). `loading` is only true on a cold miss.
  */
 export function useResolvedInAppLink(
   workspaceId: string,

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
 import { MessageSquare, Hash, Brain, Lock, Globe, NotebookPen, ArrowUpRight, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
+import { ActorAvatar } from "@/components/actor-avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
@@ -186,7 +186,14 @@ function MessageLinkCard({
   const body = (
     <CardBody>
       <div className="flex gap-3">
-        <AuthorAvatar avatarUrl={data.authorAvatarUrl} authorName={data.authorName} />
+        <ActorAvatar
+          actorId={data.authorId ?? null}
+          actorType={data.authorType ?? "user"}
+          workspaceId={workspaceId}
+          size="lg"
+          alt={data.authorName ?? ""}
+          showStatus={false}
+        />
         <div className="min-w-0 flex-1">
           {data.authorName && <span className="text-xs font-semibold text-foreground">{data.authorName}</span>}
           {data.contentPreview && (
@@ -494,27 +501,6 @@ function getInternalPath(url: string): string | null {
   } catch {
     return null
   }
-}
-
-function AuthorAvatar({ avatarUrl, authorName }: { avatarUrl?: string; authorName?: string }) {
-  if (avatarUrl) {
-    return (
-      <Avatar className="h-9 w-9 shrink-0 rounded-lg">
-        <AvatarImage src={avatarUrl} alt={authorName ?? ""} />
-        <AvatarFallback className="rounded-lg text-xs">{authorName?.charAt(0)?.toUpperCase() ?? "?"}</AvatarFallback>
-      </Avatar>
-    )
-  }
-
-  if (authorName) {
-    return (
-      <Avatar className="h-9 w-9 shrink-0 rounded-lg">
-        <AvatarFallback className="rounded-lg text-xs">{authorName.charAt(0).toUpperCase()}</AvatarFallback>
-      </Avatar>
-    )
-  }
-
-  return null
 }
 
 function DismissButton({ onDismiss }: { onDismiss?: () => void }) {

--- a/apps/frontend/src/components/timeline/link-preview-list.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.test.tsx
@@ -1,9 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import * as contextsModule from "@/contexts"
 import { LinkPreviewList } from "./link-preview-list"
 import type { LinkPreviewSummary } from "@threa/types"
+
+function renderList(previews: LinkPreviewSummary[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <LinkPreviewList workspaceId="ws_123" messageId="msg_123" previews={previews} />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
 
 const mockGetForMessage = vi.fn()
 const mockDismiss = vi.fn()
@@ -46,18 +59,28 @@ describe("LinkPreviewList", () => {
     expect(mockGetForMessage).not.toHaveBeenCalled()
   })
 
-  it("suppresses stream_link / message_link cards (they render as inline chips instead)", () => {
+  it("suppresses a stream_link card (it renders as an inline chip instead) but keeps web previews", () => {
     const streamPreview: LinkPreviewSummary = { ...preview, id: "p_stream", contentType: "stream_link" }
-    const messagePreview: LinkPreviewSummary = { ...preview, id: "p_msg", contentType: "message_link" }
-    render(<LinkPreviewList workspaceId="ws_123" messageId="msg_123" previews={[streamPreview, messagePreview]} />)
+    renderList([streamPreview, preview])
 
-    expect(screen.queryByText("Preview title")).not.toBeInTheDocument()
+    // The stream link has no card; the web preview in the same message still does.
+    expect(screen.getByText("Preview title")).toBeInTheDocument()
   })
 
-  it("keeps web previews while suppressing an in-app stream link in the same message", () => {
-    const streamPreview: LinkPreviewSummary = { ...preview, id: "p_stream", contentType: "stream_link" }
-    render(<LinkPreviewList workspaceId="ws_123" messageId="msg_123" previews={[streamPreview, preview]} />)
+  it("keeps a message_link card — the inline chip is the body reference, the card is the preview below", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLink").mockResolvedValue({
+      kind: "message",
+      accessTier: "full",
+      deleted: true,
+    })
+    const messagePreview: LinkPreviewSummary = {
+      ...preview,
+      id: "p_msg",
+      contentType: "message_link",
+      url: "https://app.threa.io/w/ws_123/s/stream_1?m=msg_9",
+    }
+    renderList([messagePreview])
 
-    expect(screen.getByText("Preview title")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("This message was deleted")).toBeInTheDocument())
   })
 })

--- a/apps/frontend/src/components/timeline/link-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.tsx
@@ -7,7 +7,7 @@ import { usePreferences } from "@/contexts"
 import { useLinkPreviewDismissal } from "@/hooks/use-link-preview-dismissals"
 import { LinkPreviewCard } from "./link-preview-card"
 import { InAppLinkPreviewCard } from "./in-app-link-preview-card"
-import { isInAppLinkContentType, isInlineChipContentType, type LinkPreviewSummary } from "@threa/types"
+import { isInAppLinkContentType, LinkPreviewContentTypes, type LinkPreviewSummary } from "@threa/types"
 
 const DEFAULT_VISIBLE_COUNT = 3
 
@@ -86,11 +86,12 @@ export function LinkPreviewList({
     [workspaceId, messageId]
   )
 
-  // Stream/message links render as an inline chip inside the message body, so
-  // their card is suppressed here (the chip is the single surface). Memo and
-  // web previews keep their card.
+  // A stream link is a bare "#channel" reference, fully said by its inline chip,
+  // so its card is suppressed. A message link keeps its card: the inline chip is
+  // a compact named reference in the body, and the card carries the rich preview
+  // (author face, snippet) below. Memo and web previews keep their card too.
   const visiblePreviews = useMemo(
-    () => previews.filter((p) => !dismissedIds.has(p.id) && !isInlineChipContentType(p.contentType)),
+    () => previews.filter((p) => !dismissedIds.has(p.id) && p.contentType !== LinkPreviewContentTypes.STREAM_LINK),
     [previews, dismissedIds]
   )
 

--- a/apps/frontend/src/components/timeline/link-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.tsx
@@ -111,7 +111,6 @@ export function LinkPreviewList({
               <InAppLinkPreviewCard
                 preview={preview}
                 workspaceId={workspaceId}
-                messageId={messageId}
                 onDismiss={handleDismiss}
                 hydrate={hydrateFromApi}
               />

--- a/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
@@ -7,21 +7,18 @@ function messageData(overrides: Partial<MessageLinkPreviewData>): MessageLinkPre
 }
 
 describe("buildMessageChipLabel", () => {
-  it("phrases a DM as '{author} to {recipient}', collapsing the viewer to 'You'", () => {
+  it("phrases a DM as '{author} to {recipient}' with full names", () => {
     expect(
       buildMessageChipLabel(
-        messageData({
-          streamType: "dm",
-          authorName: "Pierre Boberg",
-          recipientName: "Kristoffer Remback",
-          recipientIsSelf: true,
-        })
+        messageData({ streamType: "dm", authorName: "Pierre Boberg", recipientName: "Kristoffer Remback" })
       )
-    ).toBe("Pierre Boberg to You")
+    ).toBe("Pierre Boberg to Kristoffer Remback")
 
     expect(
-      buildMessageChipLabel(messageData({ streamType: "dm", authorIsSelf: true, recipientName: "Pierre Boberg" }))
-    ).toBe("You to Pierre Boberg")
+      buildMessageChipLabel(
+        messageData({ streamType: "dm", authorName: "Kristoffer Remback", recipientName: "Pierre Boberg" })
+      )
+    ).toBe("Kristoffer Remback to Pierre Boberg")
   })
 
   it("phrases a channel message as '{author} in #slug'", () => {

--- a/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import type { MessageLinkPreviewData } from "@threa/types"
+import { buildMessageChipLabel } from "./use-in-app-link-chip"
+
+function messageData(overrides: Partial<MessageLinkPreviewData>): MessageLinkPreviewData {
+  return { kind: "message", accessTier: "full", ...overrides }
+}
+
+describe("buildMessageChipLabel", () => {
+  it("phrases a DM as '{author} to {recipient}', collapsing the viewer to 'You'", () => {
+    expect(
+      buildMessageChipLabel(
+        messageData({
+          streamType: "dm",
+          authorName: "Pierre Boberg",
+          recipientName: "Kristoffer Remback",
+          recipientIsSelf: true,
+        })
+      )
+    ).toBe("Pierre Boberg to You")
+
+    expect(
+      buildMessageChipLabel(messageData({ streamType: "dm", authorIsSelf: true, recipientName: "Pierre Boberg" }))
+    ).toBe("You to Pierre Boberg")
+  })
+
+  it("phrases a channel message as '{author} in #slug'", () => {
+    expect(
+      buildMessageChipLabel(
+        messageData({ streamType: "channel", authorName: "Kristoffer Remback", streamName: "tech-big-new-prop" })
+      )
+    ).toBe("Kristoffer Remback in #tech-big-new-prop")
+  })
+
+  it("does not double the '#' when the stream name already carries one", () => {
+    expect(
+      buildMessageChipLabel(messageData({ streamType: "channel", authorName: "Kris", streamName: "#general" }))
+    ).toBe("Kris in #general")
+  })
+
+  it("phrases a scratchpad/thread message as '{author} in {name}' without a sigil", () => {
+    expect(
+      buildMessageChipLabel(messageData({ streamType: "scratchpad", authorName: "Kris", streamName: "My notes" }))
+    ).toBe("Kris in My notes")
+  })
+
+  it("returns null when the author could not be resolved, so the caller falls back", () => {
+    expect(buildMessageChipLabel(messageData({ streamType: "channel", streamName: "general" }))).toBeNull()
+  })
+
+  it("falls back to just the author when a DM recipient could not be resolved", () => {
+    expect(buildMessageChipLabel(messageData({ streamType: "dm", authorName: "Pierre" }))).toBe("Pierre")
+  })
+})

--- a/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import type { MessageLinkPreviewData } from "@threa/types"
-import { buildMessageChipLabel } from "./use-in-app-link-chip"
+import { buildMessageChipLabel, buildLocalMessageParts } from "./use-in-app-link-chip"
 
 function messageData(overrides: Partial<MessageLinkPreviewData>): MessageLinkPreviewData {
   return { kind: "message", accessTier: "full", ...overrides }
@@ -47,5 +47,69 @@ describe("buildMessageChipLabel", () => {
 
   it("falls back to just the author when a DM recipient could not be resolved", () => {
     expect(buildMessageChipLabel(messageData({ streamType: "dm", authorName: "Pierre" }))).toBe("Pierre")
+  })
+})
+
+describe("buildLocalMessageParts", () => {
+  const names: Record<string, string> = {
+    user_pierre: "Pierre Boberg",
+    user_viewer: "Kristoffer Remback",
+  }
+  const resolveName = (id: string) => names[id] ?? id
+
+  it("names a channel message as '{author} in {streamLabel}'", () => {
+    expect(
+      buildLocalMessageParts({
+        authorId: "user_pierre",
+        authorName: "Pierre Boberg",
+        streamId: "stream_1",
+        localName: "#general",
+        dmPeers: [],
+        currentUserId: "user_viewer",
+        resolveName,
+      })
+    ).toEqual({ lead: "Pierre Boberg", tail: " in #general" })
+  })
+
+  it("names a DM the peer authored as '{author} to {viewer}'", () => {
+    expect(
+      buildLocalMessageParts({
+        authorId: "user_pierre",
+        authorName: "Pierre Boberg",
+        streamId: "stream_dm",
+        localName: "Pierre Boberg",
+        dmPeers: [{ streamId: "stream_dm", userId: "user_pierre" }],
+        currentUserId: "user_viewer",
+        resolveName,
+      })
+    ).toEqual({ lead: "Pierre Boberg", tail: " to Kristoffer Remback" })
+  })
+
+  it("names a DM the viewer authored as '{author} to {peer}'", () => {
+    expect(
+      buildLocalMessageParts({
+        authorId: "user_viewer",
+        authorName: "Kristoffer Remback",
+        streamId: "stream_dm",
+        localName: "Pierre Boberg",
+        dmPeers: [{ streamId: "stream_dm", userId: "user_pierre" }],
+        currentUserId: "user_viewer",
+        resolveName,
+      })
+    ).toEqual({ lead: "Kristoffer Remback", tail: " to Pierre Boberg" })
+  })
+
+  it("drops the location tail when neither a DM peer nor a stream label is known", () => {
+    expect(
+      buildLocalMessageParts({
+        authorId: "user_pierre",
+        authorName: "Pierre Boberg",
+        streamId: "stream_x",
+        localName: null,
+        dmPeers: [],
+        currentUserId: "user_viewer",
+        resolveName,
+      })
+    ).toEqual({ lead: "Pierre Boberg", tail: "" })
   })
 })

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -20,9 +20,19 @@ type ChipIcon = ComponentType<{ className?: string }>
  * name (no sigil) so neither surface doubles the `#`.
  */
 export type InAppLinkChipState =
-  | { status: "resolved"; icon: ChipIcon; label: string; prefix?: string }
+  | { status: "resolved"; icon: ChipIcon; label: string; prefix?: string; avatar?: ChipAvatar }
   | { status: "restricted"; icon: ChipIcon; label: string }
   | { status: "pending" }
+
+/**
+ * Leading author face for a message chip — the avatar image when the author has
+ * one, with `name` driving the alt text and the initial fallback. Absent for
+ * stream chips and unnamed (bot/persona) authors, which keep their type glyph.
+ */
+export interface ChipAvatar {
+  url?: string
+  name: string
+}
 
 function streamTypeIcon(streamType: StreamType | undefined): ChipIcon {
   switch (streamType) {
@@ -115,7 +125,10 @@ export function useInAppLinkChip({
     if (isMessage) {
       if (data?.kind === "message" && data.accessTier === "full") {
         const label = buildMessageChipLabel(data)
-        if (label) return { status: "resolved", icon: MessageSquare, label }
+        if (label) {
+          const avatar = data.authorName ? { url: data.authorAvatarUrl, name: data.authorName } : undefined
+          return { status: "resolved", icon: MessageSquare, label, avatar }
+        }
       }
       if (loading) return { status: "pending" }
       return { status: "resolved", icon: MessageSquare, label: localName ?? "Message" }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -1,6 +1,6 @@
 import { useMemo, type ComponentType } from "react"
 import { Hash, NotebookPen, MessageSquare, Lock, Globe } from "lucide-react"
-import type { StreamType } from "@threa/types"
+import type { StreamType, MessageLinkPreviewData } from "@threa/types"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import { resolveStreamName } from "@/lib/streams"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
@@ -33,6 +33,27 @@ function streamTypeIcon(streamType: StreamType | undefined): ChipIcon {
     default:
       return MessageSquare
   }
+}
+
+/**
+ * Phrase a resolved message link the way the surrounding chat reads it:
+ * "{author} to {recipient}" for a DM, "{author} in #channel" or "{author} in
+ * {name}" otherwise. Either side collapses to "You" when it's the viewer. Returns
+ * null when the author couldn't be resolved (e.g. a bot/persona author the
+ * backend doesn't name yet) so the caller falls back to the parent-stream name.
+ */
+export function buildMessageChipLabel(data: MessageLinkPreviewData): string | null {
+  const author = data.authorIsSelf ? "You" : data.authorName
+  if (!author) return null
+  if (data.streamType === "dm") {
+    const recipient = data.recipientIsSelf ? "You" : data.recipientName
+    return recipient ? `${author} to ${recipient}` : author
+  }
+  if (data.streamName) {
+    const name = data.streamType === "channel" ? `#${data.streamName.replace(/^#/, "")}` : data.streamName
+    return `${author} in ${name}`
+  }
+  return author
 }
 
 /**
@@ -86,29 +107,37 @@ export function useInAppLinkChip({
     if (data?.kind === "message" && data.deleted) {
       return { status: "restricted", icon: MessageSquare, label: "Deleted message" }
     }
-    if (localName) {
-      // A channel renders its `#` as a text prefix (mention-style), so strip it
-      // from the bare label; the chip's `prefix` adds it back. Message links keep
-      // a message glyph instead of a sigil.
-      const isChannelChip = !isMessage && cachedType === "channel"
-      const label = isChannelChip && localName.startsWith("#") ? localName.slice(1) : localName
-      return {
-        status: "resolved",
-        icon: isMessage ? MessageSquare : streamTypeIcon(cachedType),
-        label,
-        prefix: isChannelChip ? "#" : undefined,
+
+    // A message reads as "{author} in #channel" / "{author} to {peer}" — that
+    // rich backend label is the whole point, so it wins over the cached
+    // parent-stream name; the parent name (or a generic word) is only a fallback
+    // while the resolve is in flight or the author couldn't be named.
+    if (isMessage) {
+      if (data?.kind === "message" && data.accessTier === "full") {
+        const label = buildMessageChipLabel(data)
+        if (label) return { status: "resolved", icon: MessageSquare, label }
       }
+      if (loading) return { status: "pending" }
+      return { status: "resolved", icon: MessageSquare, label: localName ?? "Message" }
+    }
+
+    // Stream links: a channel renders its `#` as a text prefix (mention-style),
+    // so strip it from the bare label and let the chip's `prefix` add it back.
+    if (localName) {
+      const isChannelChip = cachedType === "channel"
+      const label = isChannelChip && localName.startsWith("#") ? localName.slice(1) : localName
+      return { status: "resolved", icon: streamTypeIcon(cachedType), label, prefix: isChannelChip ? "#" : undefined }
     }
     if (loading) return { status: "pending" }
     if (data?.kind === "stream" && data.streamName) {
       const isChannel = data.streamType === "channel"
       return {
         status: "resolved",
-        icon: isMessage ? MessageSquare : streamTypeIcon(data.streamType),
+        icon: streamTypeIcon(data.streamType),
         label: data.streamName,
-        prefix: !isMessage && isChannel ? "#" : undefined,
+        prefix: isChannel ? "#" : undefined,
       }
     }
-    return { status: "resolved", icon: isMessage ? MessageSquare : Hash, label: isMessage ? "Message" : "Conversation" }
+    return { status: "resolved", icon: Hash, label: "Conversation" }
   }, [localName, loading, data, cachedType, isMessage])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -177,9 +177,20 @@ export function useInAppLinkChip({
     undefined
   )
 
+  // A DM chip names the other participant, which needs the viewer id + the peer
+  // row. When the local stores can't supply them, the backend resolve is
+  // authoritative for the recipient — fall back to it rather than flash an
+  // author-only label or wedge on a permanently-missing peer.
+  const dmPeerEntry = dmPeers.find((p) => p.streamId === streamId)
+  const dmRecipientUnresolved =
+    (cachedType === "dm" || Boolean(dmPeerEntry)) && (currentUserId === null || !dmPeerEntry)
+
   // Hit the access-tiered backend resolve only when the target isn't already
-  // local: a message that isn't cached here, or an uncached stream link.
-  const needsResolve = isMessage ? cachedMessageEvent === null : !localName
+  // local: a message that isn't cached here (or whose DM recipient the local
+  // stores can't name), or an uncached stream link.
+  const needsResolve = isMessage
+    ? cachedMessageEvent === null || (Boolean(cachedMessageEvent) && dmRecipientUnresolved)
+    : !localName
   const { data, loading } = useResolvedInAppLink(workspaceId, undefined, needsResolve ? url : undefined, true)
 
   return useMemo<InAppLinkChipState>(() => {
@@ -211,17 +222,12 @@ export function useInAppLinkChip({
       //    timeline event. A locally-cached message is by definition one the
       //    viewer can read, so no access tier or round-trip is needed.
       const authorId = cachedMessageEvent?.actorId
-      if (authorId) {
+      // Resolve locally only when the chip is fully nameable from the stores: any
+      // message except a DM whose recipient the local stores can't supply yet
+      // (`dmRecipientUnresolved`), which falls through to the backend resolve
+      // rather than rendering an author-only / wrong-preposition label.
+      if (authorId && !dmRecipientUnresolved) {
         const authorType = cachedMessageEvent.actorType ?? "user"
-        const dmPeer = dmPeers.find((p) => p.streamId === streamId)
-        const isDmStream = cachedType === "dm" || Boolean(dmPeer)
-        // A DM chip names the other participant, which needs both the viewer id
-        // and the peer row; either can lag the cached event during cold load, so
-        // hold at the skeleton rather than flash an author-only or wrong-
-        // preposition ("… in {peer}") label (INV-21).
-        if (isDmStream && (currentUserId === null || !dmPeer)) {
-          return { status: "pending" }
-        }
         const lead = actors.getActorName(authorId, authorType)
         const parts = buildLocalMessageParts({
           authorId,
@@ -267,8 +273,6 @@ export function useInAppLinkChip({
         return { status: "resolved", icon: MessageSquare, label: "Message" }
       }
       if (cachedMessageEvent === undefined || loading) return { status: "pending" }
-      // A message link never settles on the parent-stream name — that would
-      // mislabel the message node InAppLinkView serializes into attrs.name.
       return { status: "resolved", icon: MessageSquare, label: "Message" }
     }
 
@@ -290,5 +294,17 @@ export function useInAppLinkChip({
       }
     }
     return { status: "resolved", icon: Hash, label: "Conversation" }
-  }, [localName, loading, data, cachedType, isMessage, cachedMessageEvent, actors, dmPeers, streamId, currentUserId])
+  }, [
+    localName,
+    loading,
+    data,
+    cachedType,
+    isMessage,
+    cachedMessageEvent,
+    actors,
+    dmPeers,
+    streamId,
+    currentUserId,
+    dmRecipientUnresolved,
+  ])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -213,6 +213,15 @@ export function useInAppLinkChip({
       const authorId = cachedMessageEvent?.actorId
       if (authorId) {
         const authorType = cachedMessageEvent.actorType ?? "user"
+        const dmPeer = dmPeers.find((p) => p.streamId === streamId)
+        const isDmStream = cachedType === "dm" || Boolean(dmPeer)
+        // A DM chip names the other participant, which needs both the viewer id
+        // and the peer row; either can lag the cached event during cold load, so
+        // hold at the skeleton rather than flash an author-only or wrong-
+        // preposition ("… in {peer}") label (INV-21).
+        if (isDmStream && (currentUserId === null || !dmPeer)) {
+          return { status: "pending" }
+        }
         const lead = actors.getActorName(authorId, authorType)
         const parts = buildLocalMessageParts({
           authorId,
@@ -258,7 +267,9 @@ export function useInAppLinkChip({
         return { status: "resolved", icon: MessageSquare, label: "Message" }
       }
       if (cachedMessageEvent === undefined || loading) return { status: "pending" }
-      return { status: "resolved", icon: MessageSquare, label: localName ?? "Message" }
+      // A message link never settles on the parent-stream name — that would
+      // mislabel the message node InAppLinkView serializes into attrs.name.
+      return { status: "resolved", icon: MessageSquare, label: "Message" }
     }
 
     // Stream links: a channel renders its `#` as a text prefix (mention-style),

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -24,21 +24,14 @@ type ChipIcon = ComponentType<{ className?: string }>
  * name (no sigil) so neither surface doubles the `#`.
  */
 export type InAppLinkChipState =
-  | {
-      status: "resolved"
-      icon: ChipIcon
-      label: string
-      prefix?: string
-      messageParts?: ChipMessageParts
-    }
+  | { status: "resolved"; icon: ChipIcon; label: string; prefix?: string }
   | { status: "restricted"; icon: ChipIcon; label: string }
   | { status: "pending" }
 
 /**
- * A message chip split into the author (`lead`) and the location suffix
- * (`tail`, e.g. " in #channel" / " to Pierre"). The chip truncates `lead` and
- * pins `tail`, so the destination — the part that disambiguates two messages by
- * the same author — survives truncation. `label` joins them for serialization.
+ * A message chip's author (`lead`) and location suffix (`tail`, e.g. " in
+ * #channel" / " to Pierre"); `buildMessageChipLabel` joins them into the single
+ * label string the inline chip renders and the link node serializes.
  */
 export interface ChipMessageParts {
   lead: string
@@ -221,24 +214,14 @@ export function useInAppLinkChip({
           currentUserId,
           resolveName: (id) => actors.getActorName(id, "user"),
         })
-        return {
-          status: "resolved",
-          icon: MessageSquare,
-          label: `${parts.lead}${parts.tail}`,
-          messageParts: parts,
-        }
+        return { status: "resolved", icon: MessageSquare, label: `${parts.lead}${parts.tail}` }
       }
 
       // 2) Backend fallback (message not in the local cache).
       if (data?.kind === "message" && data.accessTier === "full") {
         const parts = buildMessageChipParts(data)
         if (parts) {
-          return {
-            status: "resolved",
-            icon: MessageSquare,
-            label: `${parts.lead}${parts.tail}`,
-            messageParts: parts,
-          }
+          return { status: "resolved", icon: MessageSquare, label: `${parts.lead}${parts.tail}` }
         }
         // Fully resolved but the author can't be named — settle on the generic
         // word, not the cached parent-stream name (a stream label would mislabel

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -177,20 +177,9 @@ export function useInAppLinkChip({
     undefined
   )
 
-  // A DM chip names the other participant, which needs the viewer id + the peer
-  // row. When the local stores can't supply them, the backend resolve is
-  // authoritative for the recipient — fall back to it rather than flash an
-  // author-only label or wedge on a permanently-missing peer.
-  const dmPeerEntry = dmPeers.find((p) => p.streamId === streamId)
-  const dmRecipientUnresolved =
-    (cachedType === "dm" || Boolean(dmPeerEntry)) && (currentUserId === null || !dmPeerEntry)
-
   // Hit the access-tiered backend resolve only when the target isn't already
-  // local: a message that isn't cached here (or whose DM recipient the local
-  // stores can't name), or an uncached stream link.
-  const needsResolve = isMessage
-    ? cachedMessageEvent === null || (Boolean(cachedMessageEvent) && dmRecipientUnresolved)
-    : !localName
+  // local: a message that isn't cached here, or an uncached stream link.
+  const needsResolve = isMessage ? cachedMessageEvent === null : !localName
   const { data, loading } = useResolvedInAppLink(workspaceId, undefined, needsResolve ? url : undefined, true)
 
   return useMemo<InAppLinkChipState>(() => {
@@ -222,12 +211,17 @@ export function useInAppLinkChip({
       //    timeline event. A locally-cached message is by definition one the
       //    viewer can read, so no access tier or round-trip is needed.
       const authorId = cachedMessageEvent?.actorId
-      // Resolve locally only when the chip is fully nameable from the stores: any
-      // message except a DM whose recipient the local stores can't supply yet
-      // (`dmRecipientUnresolved`), which falls through to the backend resolve
-      // rather than rendering an author-only / wrong-preposition label.
-      if (authorId && !dmRecipientUnresolved) {
+      if (authorId) {
         const authorType = cachedMessageEvent.actorType ?? "user"
+        const dmPeer = dmPeers.find((p) => p.streamId === streamId)
+        const isDmStream = cachedType === "dm" || Boolean(dmPeer)
+        // A DM chip names the other participant (viewer id + peer row). Until both
+        // load, stay pending — which renders the baked label, not a skeleton — so
+        // a half-resolved "author only" / "… in {peer}" label never flashes. No
+        // wedge: a permanently-missing peer just keeps showing the baked label.
+        if (isDmStream && (currentUserId === null || !dmPeer)) {
+          return { status: "pending" }
+        }
         const lead = actors.getActorName(authorId, authorType)
         const parts = buildLocalMessageParts({
           authorId,
@@ -305,6 +299,5 @@ export function useInAppLinkChip({
     dmPeers,
     streamId,
     currentUserId,
-    dmRecipientUnresolved,
   ])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -1,6 +1,6 @@
 import { useMemo, type ComponentType } from "react"
 import { Hash, NotebookPen, MessageSquare, Lock, Globe } from "lucide-react"
-import type { StreamType, MessageLinkPreviewData } from "@threa/types"
+import { getAvatarUrl, type StreamType, type MessageLinkPreviewData } from "@threa/types"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import { resolveStreamName } from "@/lib/streams"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
@@ -69,8 +69,8 @@ function streamTypeIcon(streamType: StreamType | undefined): ChipIcon {
  * or " in {name}" otherwise. Full names on both sides (no viewer-relative "You"),
  * so the label is identical for every reader — it's also what gets serialized
  * back into the link's markdown. Returns null when the author couldn't be
- * resolved (e.g. a bot/persona author the backend doesn't name yet) so the
- * caller falls back to the parent-stream name.
+ * resolved (e.g. a bot/persona author the backend doesn't name yet); the caller
+ * then settles the fully-resolved chip on the generic "Message".
  */
 export function buildMessageChipParts(data: MessageLinkPreviewData): ChipMessageParts | null {
   const lead = data.authorName
@@ -152,7 +152,15 @@ export function useInAppLinkChip({
         const parts = buildMessageChipParts(data)
         if (parts) {
           const label = `${parts.lead}${parts.tail}`
-          const avatar = data.authorName ? { url: data.authorAvatarUrl, name: data.authorName } : undefined
+          // Prefer the author's live avatar from the workspace store (reactive to
+          // avatar changes, like the rest of the app); fall back to the resolve's
+          // point-in-time snapshot for an author not in the local cache.
+          const liveUser =
+            data.authorType === "user" && data.authorId ? users.find((u) => u.id === data.authorId) : undefined
+          const avatarUrl = liveUser
+            ? (getAvatarUrl(workspaceId, liveUser.avatarUrl, 64) ?? undefined)
+            : data.authorAvatarUrl
+          const avatar = data.authorName ? { url: avatarUrl, name: data.authorName } : undefined
           return { status: "resolved", icon: MessageSquare, label, avatar, messageParts: parts }
         }
         // Fully resolved but the author can't be named (bot/persona) — settle on
@@ -183,5 +191,5 @@ export function useInAppLinkChip({
       }
     }
     return { status: "resolved", icon: Hash, label: "Conversation" }
-  }, [localName, loading, data, cachedType, isMessage])
+  }, [localName, loading, data, cachedType, isMessage, users, workspaceId])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -177,8 +177,7 @@ export function useInAppLinkChip({
       return { status: "restricted", icon: MessageSquare, label: "Deleted message" }
     }
 
-    // A message reads as "{author} in #channel" / "{author} to {peer}", with the
-    // author's live avatar leading the chip.
+    // A message reads as "{author} in #channel" / "{author} to {peer}".
     if (isMessage) {
       // A delete is a patch-style event that stamps `deletedAt` onto the cached
       // create row (see stream-sync `handleMessageDeleted`), so the tombstone is

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -1,7 +1,11 @@
 import { useMemo, type ComponentType } from "react"
 import { Hash, NotebookPen, MessageSquare, Lock, Globe } from "lucide-react"
-import { getAvatarUrl, type StreamType, type MessageLinkPreviewData } from "@threa/types"
+import { useLiveQuery } from "dexie-react-hooks"
+import type { StreamType, MessageLinkPreviewData } from "@threa/types"
+import { db } from "@/db"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
+import { useActors } from "@/hooks/use-actors"
+import { useCurrentWorkspaceUserId } from "@/hooks/use-current-workspace-user-id"
 import { resolveStreamName } from "@/lib/streams"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 
@@ -92,6 +96,32 @@ export function buildMessageChipLabel(data: MessageLinkPreviewData): string | nu
 }
 
 /**
+ * Build a message chip's parts from locally-known data (the cached timeline
+ * event + workspace stores), so a link to a message in a stream the viewer can
+ * see resolves with no backend round-trip. DM → "{author} to {recipient}" (the
+ * other participant — the peer, or the viewer when the viewer authored it);
+ * otherwise "{author} in {streamLabel}". `resolveName` maps a user id to its
+ * display name (the live actor resolver).
+ */
+export function buildLocalMessageParts(params: {
+  authorId: string
+  authorName: string
+  streamId: string
+  localName: string | null
+  dmPeers: ReadonlyArray<{ streamId: string; userId: string }>
+  currentUserId: string | null
+  resolveName: (userId: string) => string
+}): ChipMessageParts {
+  const { authorId, authorName, streamId, localName, dmPeers, currentUserId, resolveName } = params
+  const dmPeer = dmPeers.find((p) => p.streamId === streamId)
+  if (dmPeer) {
+    const recipientId = authorId === currentUserId ? dmPeer.userId : currentUserId
+    return { lead: authorName, tail: recipientId ? ` to ${resolveName(recipientId)}` : "" }
+  }
+  return { lead: authorName, tail: localName ? ` in ${localName}` : "" }
+}
+
+/**
  * Resolve a stream/message in-app link to a chip icon + label. Local workspace
  * cache first (the canonical name source — handles channels, scratchpads, DM
  * peers, decrypted E2E names, and any stream the viewer can see without a
@@ -103,11 +133,13 @@ export function buildMessageChipLabel(data: MessageLinkPreviewData): string | nu
 export function useInAppLinkChip({
   workspaceId,
   streamId,
+  messageId,
   isMessage,
   url,
 }: {
   workspaceId: string
   streamId: string
+  messageId: string | null
   isMessage: boolean
   url: string
 }): InAppLinkChipState {
@@ -117,17 +149,37 @@ export function useInAppLinkChip({
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
+  const currentUserId = useCurrentWorkspaceUserId(workspaceId)
+  const actors = useActors(workspaceId)
   const localName = useMemo(
     () => resolveStreamName(streamId, { streams, users, dmPeers }),
     [streamId, streams, users, dmPeers]
   )
   const cachedType = useMemo(() => streams.find((s) => s.id === streamId)?.type, [streams, streamId])
 
-  // A local name covers a stream link outright, but a message link still needs
-  // the backend resolve to learn the message is deleted/restricted — the local
-  // cache only names the parent stream. So message links always resolve; stream
-  // links resolve only when uncached.
-  const needsResolve = isMessage || !localName
+  // Message links resolve local-first: the target message is almost always
+  // already in the timeline cache (it's a message in a stream the viewer can
+  // see), so its author and context resolve with no round-trip and stay behind
+  // the same coordinated-loading gate as the rest of the surface. `undefined`
+  // means the IDB read is still in flight; `null` is a genuine miss (a message
+  // in another stream / not synced) that falls back to the backend resolve.
+  const cachedMessageEvent = useLiveQuery(
+    async () => {
+      if (!isMessage || !streamId || !messageId) return null
+      const event = await db.events
+        .where("[streamId+eventType]")
+        .equals([streamId, "message_created"])
+        .filter((e) => (e.payload as { messageId?: string } | null)?.messageId === messageId)
+        .first()
+      return event ?? null
+    },
+    [isMessage, streamId, messageId],
+    undefined
+  )
+
+  // Hit the access-tiered backend resolve only when the target isn't already
+  // local: a message that isn't cached here, or an uncached stream link.
+  const needsResolve = isMessage ? cachedMessageEvent === null : !localName
   const { data, loading } = useResolvedInAppLink(workspaceId, undefined, needsResolve ? url : undefined, true)
 
   return useMemo<InAppLinkChipState>(() => {
@@ -143,32 +195,60 @@ export function useInAppLinkChip({
       return { status: "restricted", icon: MessageSquare, label: "Deleted message" }
     }
 
-    // A message reads as "{author} in #channel" / "{author} to {peer}" — that
-    // rich backend label is the whole point, so it wins over the cached
-    // parent-stream name; the parent name (or a generic word) is only a fallback
-    // while the resolve is in flight or the author couldn't be named.
+    // A message reads as "{author} in #channel" / "{author} to {peer}", with the
+    // author's live avatar leading the chip.
     if (isMessage) {
+      // 1) Local-first: name the author + context straight from the cached
+      //    timeline event. A locally-cached message is by definition one the
+      //    viewer can read, so no access tier or round-trip is needed.
+      const authorId = cachedMessageEvent?.actorId
+      if (authorId) {
+        const authorType = cachedMessageEvent.actorType ?? "user"
+        const lead = actors.getActorName(authorId, authorType)
+        const parts = buildLocalMessageParts({
+          authorId,
+          authorName: lead,
+          streamId,
+          localName,
+          dmPeers,
+          currentUserId,
+          resolveName: (id) => actors.getActorName(id, "user"),
+        })
+        const avatar = { url: actors.getActorAvatar(authorId, authorType).avatarUrl, name: lead }
+        return {
+          status: "resolved",
+          icon: MessageSquare,
+          label: `${parts.lead}${parts.tail}`,
+          avatar,
+          messageParts: parts,
+        }
+      }
+
+      // 2) Backend fallback (message not in the local cache).
       if (data?.kind === "message" && data.accessTier === "full") {
         const parts = buildMessageChipParts(data)
         if (parts) {
-          const label = `${parts.lead}${parts.tail}`
-          // Prefer the author's live avatar from the workspace store (reactive to
-          // avatar changes, like the rest of the app); fall back to the resolve's
-          // point-in-time snapshot for an author not in the local cache.
-          const liveUser =
-            data.authorType === "user" && data.authorId ? users.find((u) => u.id === data.authorId) : undefined
-          const liveAvatarUrl = liveUser ? getAvatarUrl(workspaceId, liveUser.avatarUrl, 64) : undefined
+          // Prefer the author's live avatar from the workspace store; fall back to
+          // the resolve's point-in-time snapshot for an author not cached locally.
+          const liveAvatarUrl = data.authorId
+            ? actors.getActorAvatar(data.authorId, data.authorType ?? "user").avatarUrl
+            : undefined
           const avatarUrl = liveAvatarUrl ?? data.authorAvatarUrl
           const avatar = data.authorName ? { url: avatarUrl, name: data.authorName } : undefined
-          return { status: "resolved", icon: MessageSquare, label, avatar, messageParts: parts }
+          return {
+            status: "resolved",
+            icon: MessageSquare,
+            label: `${parts.lead}${parts.tail}`,
+            avatar,
+            messageParts: parts,
+          }
         }
-        // Fully resolved but the author can't be named (bot/persona) — settle on
-        // the generic word, not the cached parent-stream name. The parent name is
-        // a stream label; stamping it onto a message node (InAppLinkView writes
-        // the resolved label into attrs.name) would mislabel the link.
+        // Fully resolved but the author can't be named — settle on the generic
+        // word, not the cached parent-stream name (a stream label would mislabel
+        // the message node InAppLinkView serializes into attrs.name).
         return { status: "resolved", icon: MessageSquare, label: "Message" }
       }
-      if (loading) return { status: "pending" }
+      if (cachedMessageEvent === undefined || loading) return { status: "pending" }
       return { status: "resolved", icon: MessageSquare, label: localName ?? "Message" }
     }
 
@@ -190,5 +270,5 @@ export function useInAppLinkChip({
       }
     }
     return { status: "resolved", icon: Hash, label: "Conversation" }
-  }, [localName, loading, data, cachedType, isMessage, users, workspaceId])
+  }, [localName, loading, data, cachedType, isMessage, cachedMessageEvent, actors, dmPeers, streamId, currentUserId])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -198,6 +198,15 @@ export function useInAppLinkChip({
     // A message reads as "{author} in #channel" / "{author} to {peer}", with the
     // author's live avatar leading the chip.
     if (isMessage) {
+      // A delete is a patch-style event that stamps `deletedAt` onto the cached
+      // create row (see stream-sync `handleMessageDeleted`), so the tombstone is
+      // local too — gate on it before the live chip, matching the backend
+      // `data.deleted` branch above, so a cached-then-deleted message never
+      // renders as a normal, navigable chip.
+      if ((cachedMessageEvent?.payload as { deletedAt?: string } | null)?.deletedAt) {
+        return { status: "restricted", icon: MessageSquare, label: "Deleted message" }
+      }
+
       // 1) Local-first: name the author + context straight from the cached
       //    timeline event. A locally-cached message is by definition one the
       //    viewer can read, so no access tier or round-trip is needed.

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -157,9 +157,8 @@ export function useInAppLinkChip({
           // point-in-time snapshot for an author not in the local cache.
           const liveUser =
             data.authorType === "user" && data.authorId ? users.find((u) => u.id === data.authorId) : undefined
-          const avatarUrl = liveUser
-            ? (getAvatarUrl(workspaceId, liveUser.avatarUrl, 64) ?? undefined)
-            : data.authorAvatarUrl
+          const liveAvatarUrl = liveUser ? getAvatarUrl(workspaceId, liveUser.avatarUrl, 64) : undefined
+          const avatarUrl = liveAvatarUrl ?? data.authorAvatarUrl
           const avatar = data.authorName ? { url: avatarUrl, name: data.authorName } : undefined
           return { status: "resolved", icon: MessageSquare, label, avatar, messageParts: parts }
         }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -20,7 +20,14 @@ type ChipIcon = ComponentType<{ className?: string }>
  * name (no sigil) so neither surface doubles the `#`.
  */
 export type InAppLinkChipState =
-  | { status: "resolved"; icon: ChipIcon; label: string; prefix?: string; avatar?: ChipAvatar }
+  | {
+      status: "resolved"
+      icon: ChipIcon
+      label: string
+      prefix?: string
+      avatar?: ChipAvatar
+      messageParts?: ChipMessageParts
+    }
   | { status: "restricted"; icon: ChipIcon; label: string }
   | { status: "pending" }
 
@@ -32,6 +39,17 @@ export type InAppLinkChipState =
 export interface ChipAvatar {
   url?: string
   name: string
+}
+
+/**
+ * A message chip split into the author (`lead`) and the location suffix
+ * (`tail`, e.g. " in #channel" / " to Pierre"). The chip truncates `lead` and
+ * pins `tail`, so the destination — the part that disambiguates two messages by
+ * the same author — survives truncation. `label` joins them for serialization.
+ */
+export interface ChipMessageParts {
+  lead: string
+  tail: string
 }
 
 function streamTypeIcon(streamType: StreamType | undefined): ChipIcon {
@@ -46,24 +64,31 @@ function streamTypeIcon(streamType: StreamType | undefined): ChipIcon {
 }
 
 /**
- * Phrase a resolved message link the way the surrounding chat reads it:
- * "{author} to {recipient}" for a DM, "{author} in #channel" or "{author} in
- * {name}" otherwise. Either side collapses to "You" when it's the viewer. Returns
- * null when the author couldn't be resolved (e.g. a bot/persona author the
- * backend doesn't name yet) so the caller falls back to the parent-stream name.
+ * Split a resolved message link into author (`lead`) and location (`tail`) the
+ * way the surrounding chat reads it: " to {recipient}" for a DM, " in #channel"
+ * or " in {name}" otherwise. Full names on both sides (no viewer-relative "You"),
+ * so the label is identical for every reader — it's also what gets serialized
+ * back into the link's markdown. Returns null when the author couldn't be
+ * resolved (e.g. a bot/persona author the backend doesn't name yet) so the
+ * caller falls back to the parent-stream name.
  */
-export function buildMessageChipLabel(data: MessageLinkPreviewData): string | null {
-  const author = data.authorIsSelf ? "You" : data.authorName
-  if (!author) return null
+export function buildMessageChipParts(data: MessageLinkPreviewData): ChipMessageParts | null {
+  const lead = data.authorName
+  if (!lead) return null
   if (data.streamType === "dm") {
-    const recipient = data.recipientIsSelf ? "You" : data.recipientName
-    return recipient ? `${author} to ${recipient}` : author
+    return { lead, tail: data.recipientName ? ` to ${data.recipientName}` : "" }
   }
   if (data.streamName) {
     const name = data.streamType === "channel" ? `#${data.streamName.replace(/^#/, "")}` : data.streamName
-    return `${author} in ${name}`
+    return { lead, tail: ` in ${name}` }
   }
-  return author
+  return { lead, tail: "" }
+}
+
+/** The joined message label, for serialization and the pending fallback. */
+export function buildMessageChipLabel(data: MessageLinkPreviewData): string | null {
+  const parts = buildMessageChipParts(data)
+  return parts ? `${parts.lead}${parts.tail}` : null
 }
 
 /**
@@ -124,10 +149,11 @@ export function useInAppLinkChip({
     // while the resolve is in flight or the author couldn't be named.
     if (isMessage) {
       if (data?.kind === "message" && data.accessTier === "full") {
-        const label = buildMessageChipLabel(data)
-        if (label) {
+        const parts = buildMessageChipParts(data)
+        if (parts) {
+          const label = `${parts.lead}${parts.tail}`
           const avatar = data.authorName ? { url: data.authorAvatarUrl, name: data.authorName } : undefined
-          return { status: "resolved", icon: MessageSquare, label, avatar }
+          return { status: "resolved", icon: MessageSquare, label, avatar, messageParts: parts }
         }
         // Fully resolved but the author can't be named (bot/persona) — settle on
         // the generic word, not the cached parent-stream name. The parent name is

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -29,21 +29,10 @@ export type InAppLinkChipState =
       icon: ChipIcon
       label: string
       prefix?: string
-      avatar?: ChipAvatar
       messageParts?: ChipMessageParts
     }
   | { status: "restricted"; icon: ChipIcon; label: string }
   | { status: "pending" }
-
-/**
- * Leading author face for a message chip — the avatar image when the author has
- * one, with `name` driving the alt text and the initial fallback. Absent for
- * stream chips and unnamed (bot/persona) authors, which keep their type glyph.
- */
-export interface ChipAvatar {
-  url?: string
-  name: string
-}
 
 /**
  * A message chip split into the author (`lead`) and the location suffix
@@ -232,12 +221,10 @@ export function useInAppLinkChip({
           currentUserId,
           resolveName: (id) => actors.getActorName(id, "user"),
         })
-        const avatar = { url: actors.getActorAvatar(authorId, authorType).avatarUrl, name: lead }
         return {
           status: "resolved",
           icon: MessageSquare,
           label: `${parts.lead}${parts.tail}`,
-          avatar,
           messageParts: parts,
         }
       }
@@ -246,18 +233,10 @@ export function useInAppLinkChip({
       if (data?.kind === "message" && data.accessTier === "full") {
         const parts = buildMessageChipParts(data)
         if (parts) {
-          // Prefer the author's live avatar from the workspace store; fall back to
-          // the resolve's point-in-time snapshot for an author not cached locally.
-          const liveAvatarUrl = data.authorId
-            ? actors.getActorAvatar(data.authorId, data.authorType ?? "user").avatarUrl
-            : undefined
-          const avatarUrl = liveAvatarUrl ?? data.authorAvatarUrl
-          const avatar = data.authorName ? { url: avatarUrl, name: data.authorName } : undefined
           return {
             status: "resolved",
             icon: MessageSquare,
             label: `${parts.lead}${parts.tail}`,
-            avatar,
             messageParts: parts,
           }
         }
@@ -288,16 +267,5 @@ export function useInAppLinkChip({
       }
     }
     return { status: "resolved", icon: Hash, label: "Conversation" }
-  }, [
-    localName,
-    loading,
-    data,
-    cachedType,
-    isMessage,
-    cachedMessageEvent,
-    actors,
-    dmPeers,
-    streamId,
-    currentUserId,
-  ])
+  }, [localName, loading, data, cachedType, isMessage, cachedMessageEvent, actors, dmPeers, streamId, currentUserId])
 }

--- a/apps/frontend/src/hooks/use-in-app-link-chip.ts
+++ b/apps/frontend/src/hooks/use-in-app-link-chip.ts
@@ -129,6 +129,11 @@ export function useInAppLinkChip({
           const avatar = data.authorName ? { url: data.authorAvatarUrl, name: data.authorName } : undefined
           return { status: "resolved", icon: MessageSquare, label, avatar }
         }
+        // Fully resolved but the author can't be named (bot/persona) — settle on
+        // the generic word, not the cached parent-stream name. The parent name is
+        // a stream label; stamping it onto a message node (InAppLinkView writes
+        // the resolved label into attrs.name) would mislabel the link.
+        return { status: "resolved", icon: MessageSquare, label: "Message" }
       }
       if (loading) return { status: "pending" }
       return { status: "resolved", icon: MessageSquare, label: localName ?? "Message" }

--- a/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { linkPreviewsApi } from "@/api"
+import { db } from "@/db"
 import * as workspaceStore from "@/stores/workspace-store"
+import * as currentUserModule from "@/hooks/use-current-workspace-user-id"
 
 const origin = window.location.origin
 
@@ -32,6 +34,13 @@ function renderMarkdown(content: string) {
 describe("MarkdownContent — inline in-app link chip", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    // The chip resolves the viewer via auth; stub it so the markdown tree
+    // doesn't require an AuthProvider.
+    vi.spyOn(currentUserModule, "useCurrentWorkspaceUserId").mockReturnValue("user_viewer")
+  })
+
+  afterEach(async () => {
+    await db.events.clear()
   })
 
   it("renders an in-app stream link as an inline chip named by the local cache, not the link text", () => {
@@ -61,6 +70,30 @@ describe("MarkdownContent — inline in-app link chip", () => {
     await waitFor(() => expect(screen.getByText("Deleted message")).toBeInTheDocument())
     expect(resolve).toHaveBeenCalledWith("ws_1", url)
     expect(screen.queryByText("#design")).not.toBeInTheDocument()
+  })
+
+  it("shows a locally-deleted message as restricted from its tombstone, without a backend resolve", async () => {
+    // A delete stamps `deletedAt` onto the cached create row, so the tombstone is
+    // local — the chip must read it rather than render a live chip or round-trip.
+    seedStreams([{ id: "stream_1", type: "channel", slug: "design", displayName: null }])
+    const resolve = vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl")
+    await db.events.add({
+      id: "evt_del",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      eventType: "message_created",
+      actorId: "user_pierre",
+      actorType: "user",
+      sequence: 1,
+      payload: { messageId: "msg_9", contentMarkdown: "hi", deletedAt: "2026-06-29T00:00:00.000Z" },
+      _cachedAt: 0,
+    } as never)
+
+    const url = `${origin}/w/ws_1/s/stream_1?m=msg_9`
+    renderMarkdown(`see [whatever](${url})`)
+
+    await waitFor(() => expect(screen.getByText("Deleted message")).toBeInTheDocument())
+    expect(resolve).not.toHaveBeenCalled()
   })
 
   it("leaves a plain web link as an anchor showing its own link text", () => {

--- a/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
@@ -98,8 +98,7 @@ describe("MarkdownContent — inline in-app link chip", () => {
 
     // Author + location resolve straight from the cached event; the
     // permission-checked backend resolver is never called.
-    await waitFor(() => expect(screen.getByText("Pierre Boberg")).toBeInTheDocument())
-    expect(screen.getByText("in #design")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("Pierre Boberg in #design")).toBeInTheDocument())
     expect(resolve).not.toHaveBeenCalled()
   })
 

--- a/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
@@ -72,6 +72,37 @@ describe("MarkdownContent — inline in-app link chip", () => {
     expect(screen.queryByText("#design")).not.toBeInTheDocument()
   })
 
+  it("resolves a cached channel message from the local timeline, naming author + location, without a backend resolve", async () => {
+    vi.spyOn(workspaceStore, "useWorkspaceStreams").mockReturnValue([
+      { id: "stream_1", type: "channel", slug: "design", displayName: null },
+    ] as unknown as ReturnType<typeof workspaceStore.useWorkspaceStreams>)
+    vi.spyOn(workspaceStore, "useWorkspaceUsers").mockReturnValue([
+      { id: "user_pierre", name: "Pierre Boberg", workosUserId: "wos_pierre", avatarUrl: null },
+    ] as never)
+    vi.spyOn(workspaceStore, "useWorkspaceDmPeers").mockReturnValue([])
+    const resolve = vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl")
+    await db.events.add({
+      id: "evt_live",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      eventType: "message_created",
+      actorId: "user_pierre",
+      actorType: "user",
+      sequence: 1,
+      payload: { messageId: "msg_2", contentMarkdown: "hi" },
+      _cachedAt: 0,
+    } as never)
+
+    const url = `${origin}/w/ws_1/s/stream_1?m=msg_2`
+    renderMarkdown(`see [whatever](${url})`)
+
+    // Author + location resolve straight from the cached event; the
+    // permission-checked backend resolver is never called.
+    await waitFor(() => expect(screen.getByText("Pierre Boberg")).toBeInTheDocument())
+    expect(screen.getByText("in #design")).toBeInTheDocument()
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
   it("shows a locally-deleted message as restricted from its tombstone, without a backend resolve", async () => {
     // A delete stamps `deletedAt` onto the cached create row, so the tombstone is
     // local — the chip must read it rather than render a live chip or round-trip.

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1324,6 +1324,13 @@ export interface MessageLinkPreviewData {
   streamType?: StreamType
   /** DM recipient (the non-author participant) display name (full tier, DMs only) */
   recipientName?: string
+  /**
+   * Author identity, so the chip can render the author's avatar live from the
+   * workspace store (reactive to avatar changes) rather than the point-in-time
+   * `authorAvatarUrl` snapshot. Full tier only.
+   */
+  authorId?: string
+  authorType?: AuthorType
   /** Whether the target message has been deleted */
   deleted?: boolean
 }

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1320,6 +1320,14 @@ export interface MessageLinkPreviewData {
   contentPreview?: string
   /** Stream display name (full tier only) */
   streamName?: string
+  /** Source stream type — lets the chip phrase "in #channel" vs "to {peer}" (full tier only) */
+  streamType?: StreamType
+  /** DM recipient (the non-author participant) display name (full tier, DMs only) */
+  recipientName?: string
+  /** Viewer authored the message — the chip renders the author as "You" (full tier only) */
+  authorIsSelf?: boolean
+  /** Viewer is the DM recipient — the chip renders the recipient as "You" (full tier, DMs only) */
+  recipientIsSelf?: boolean
   /** Whether the target message has been deleted */
   deleted?: boolean
 }

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1324,10 +1324,6 @@ export interface MessageLinkPreviewData {
   streamType?: StreamType
   /** DM recipient (the non-author participant) display name (full tier, DMs only) */
   recipientName?: string
-  /** Viewer authored the message — the chip renders the author as "You" (full tier only) */
-  authorIsSelf?: boolean
-  /** Viewer is the DM recipient — the chip renders the recipient as "You" (full tier, DMs only) */
-  recipientIsSelf?: boolean
   /** Whether the target message has been deleted */
   deleted?: boolean
 }


### PR DESCRIPTION
## Problem

In #1103 an in-app message link became an inline chip, but a message chip showed only `[message icon] "Message"` (or, at best, the bare parent-stream name) — `useInAppLinkChip` short-circuited a message to its cached parent stream and otherwise fell through to the literal word "Message". A message's identity is *who said what and where*, and the chip showed neither author nor avatar. It was the weakest of the three ways to reference a message: quote-reply (`quote-reply-block.tsx`) and shared-message (`shared-message-block.tsx`) both name the author and content; the link chip didn't.

The backend already resolved the rich data for these links — `MessageLinkPreviewData` carries `authorName`, `authorAvatarUrl`, `contentPreview`, `streamName` — but the chip threw it away.

## Solution

Name the message chip the way the surrounding chat reads it, and lead it with the author's face:

- DM → `[avatar] Pierre Boberg to You`
- channel → `[avatar] Kristoffer Remback in #tech-big-new-prop`
- scratchpad / thread → `[avatar] {author} in {name}`

The viewer collapses to **You** on either side. Stream-link chips are unchanged (a stream reads like a `#channel` mention, so it stays a bare inline chip).

### How it works

- **Backend** (`resolveMessageTarget`, `link-previews/service.ts`): adds `streamType`, plus the DM `recipientName` and `authorIsSelf`/`recipientIsSelf` flags to `MessageLinkPreviewData`. The recipient is the non-author DM participant — `StreamMemberRepository.list({ streamId })` then `members.find(m ⇒ m !== authorId)`, falling back to the non-viewer member when the author isn't a member (e.g. a persona DM). Names are resolved through the workspace-scoped `UserRepository.findById`. The extra member + user reads run only for DM messages.
- **Display text stays on the frontend** (INV-46): `buildMessageChipLabel` (`use-in-app-link-chip.ts`) composes the `#`, the "in"/"to" wording, and the `You` substitution from those structured fields.
- **Rich label wins over the cached parent name.** `useInAppLinkChip` now has a dedicated message branch: a full-tier resolve → the author-context label; otherwise it falls back to the cached parent-stream name (in-flight) or "Message" (unnamed author). Previously the cached parent name short-circuited first.
- **Avatar** (`in-app-link-chip.tsx`): the chip leads with the shared `Avatar` primitive at the quote-reply inline size (`h-4 w-4 rounded-[4px]`), image when present, name-initial fallback (`bg-foreground/10` for contrast on the `bg-muted` chip) otherwise. Threaded through both surfaces — timeline `InAppLinkInline` and composer `InAppLinkView`.

### Key design decisions

**1. Inline chip, not a below-message card.** Considered restoring the suppressed preview card (Slack-style) and a shared-message block; the call (Kris) was to keep it inline and just make it informative — "what I hated was just the [bare] chip." Stream chips stay inline too, so the model is simple: streams read like mentions, messages read like "{author} in/to {where}".

**2. Recipient resolved server-side, not on the frontend.** A DM peer is viewer-specific and message links can target uncached DMs/threads, so the frontend can't reliably name the non-author participant. The backend already has the members and the author, and the viewer is a DM participant (gated by `tryAccess`), so returning `recipientName` is no leak.

**3. `You` is a frontend concern.** The backend returns `authorIsSelf`/`recipientIsSelf` booleans (it knows the viewer); the frontend turns them into "You" so no display string crosses the wire (INV-46). `authorName` is still returned even when self, so the avatar fallback uses the real initial.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/domain.ts` | `MessageLinkPreviewData` gains `streamType`, `recipientName`, `authorIsSelf`, `recipientIsSelf` |
| `apps/backend/src/features/link-previews/service.ts` | `resolveMessageTarget` resolves the DM recipient + self flags + stream type |
| `apps/frontend/src/hooks/use-in-app-link-chip.ts` | `buildMessageChipLabel` + a message branch that prefers the rich label; `ChipAvatar` on the resolved state |
| `apps/frontend/src/components/in-app-link/in-app-link-chip.tsx` | avatar-leading variant (shared `Avatar`, initial fallback) |
| `apps/frontend/src/components/in-app-link/in-app-link-inline.tsx` | passes `avatar` through (timeline) |
| `apps/frontend/src/components/editor/in-app-link-view.tsx` | passes `avatar` through (composer) |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-in-app-link-chip.test.ts` | `buildMessageChipLabel` phrasing units (DM/channel/scratchpad, `You`, `#` de-dup, fallbacks) |
| `apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx` | timeline render: DM/channel labels, avatar initial, deleted placeholder |

## Out of scope (deliberate)

- **Bot/persona-authored messages** have no resolved author name in this path yet, so they fall back to the parent-stream name / glyph. Extending author resolution to non-user actors is a follow-up.
- **No content snippet / hover preview** on the chip — author + location only, per the "keep it inline" call.
- **Stream, memo, web chips** untouched.

## Test plan

- [x] `apps/backend` `bun test src/features/link-previews/service.test.ts` — 14 pass (added: viewer-authored self flag, DM recipient resolution)
- [x] `apps/frontend` `vitest run` — `use-in-app-link-chip` (6) + `in-app-link-inline` (3) new; broad in-app-link/composer/editor/timeline sweep 458 pass
- [x] `tsc --noEmit` clean across types / backend / frontend
- [x] `eslint` + `prettier` clean on changed files
- [x] Self-review: correctness + claim-verification passes over the diff (workspace scoping, INV-46, no-leak recipient, no dead code) — no findings
- [ ] No manual browser pass this session — avatar sizing/contrast matched to the existing quote-reply treatment and covered by the render test, not eyeballed live

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014XNCr9nMrTwm2WgTmswqN7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785268375&installation_id=129946197&pr_number=1108&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1108&signature=090d6f95939e6db12d57cd1bfb4a4b951a437b989958706574c8b4450ced626f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->