### PR TITLE
feat(board): live + offline-first sync for on-screen card streams (threads & public channels)

### DIFF
--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -148,8 +148,9 @@ export interface BoardCardMessages {
  * When the card's stream hasn't synced into IDB yet (a never-opened public channel
  * on a cold device), it falls back to the cached server projection on the
  * conversation row so the card always shows something immediately. The board
- * subscribing those streams (so their events flow in) is the coverage follow-up;
- * the fallback keeps the card correct until then.
+ * declares its on-screen card streams to the SyncEngine (useBoardStreamSubscriptions),
+ * which catches them up + joins their rooms, so the fallback resolves to the live
+ * rail once that sync lands — the projection just covers the cold-open window.
  */
 export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
   const streamId = post.conversation.streamId

--- a/apps/frontend/src/hooks/use-board-stream-subscriptions.test.tsx
+++ b/apps/frontend/src/hooks/use-board-stream-subscriptions.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import type { ConversationWithStaleness } from "@threa/types"
+import { SyncEngineContext, type SyncEngine } from "@/sync/sync-engine"
+import { useBoardStreamSubscriptions } from "./use-board-stream-subscriptions"
+import type { BoardViewPost } from "./use-stable-board-view"
+
+function makePost(conversationId: string, streamId: string): BoardViewPost {
+  return {
+    conversation: { id: conversationId, streamId, messageIds: [] } as unknown as ConversationWithStaleness,
+    openingMessage: null,
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as BoardViewPost
+}
+
+function harness() {
+  const setBoardStreamIds = vi.fn()
+  const engine = { setBoardStreamIds } as unknown as SyncEngine
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SyncEngineContext.Provider value={engine}>{children}</SyncEngineContext.Provider>
+  )
+  return { setBoardStreamIds, wrapper }
+}
+
+describe("useBoardStreamSubscriptions", () => {
+  it("declares each on-screen card's stream to the engine, deduped", () => {
+    const { setBoardStreamIds, wrapper } = harness()
+    const posts = [makePost("conv_1", "stream_a"), makePost("conv_2", "stream_b"), makePost("conv_3", "stream_a")]
+
+    renderHook(() => useBoardStreamSubscriptions(posts), { wrapper })
+
+    expect(setBoardStreamIds).toHaveBeenCalledWith(["stream_a", "stream_b"])
+  })
+
+  it("re-declares only when the visible stream set changes, not on every commit", () => {
+    const { setBoardStreamIds, wrapper } = harness()
+    const initial = [makePost("conv_1", "stream_a")]
+    const { rerender } = renderHook(({ posts }) => useBoardStreamSubscriptions(posts), {
+      wrapper,
+      initialProps: { posts: initial },
+    })
+    expect(setBoardStreamIds).toHaveBeenCalledTimes(1)
+
+    // A fresh array of the same streams (a frozen-view re-commit) — no re-declare.
+    rerender({ posts: [makePost("conv_1", "stream_a")] })
+    expect(setBoardStreamIds).toHaveBeenCalledTimes(1)
+
+    // A genuinely new stream on screen — re-declare with the wider set.
+    rerender({ posts: [makePost("conv_1", "stream_a"), makePost("conv_2", "stream_c")] })
+    expect(setBoardStreamIds).toHaveBeenLastCalledWith(["stream_a", "stream_c"])
+  })
+
+  it("clears the declaration on unmount so a closed board doesn't widen the reconnect set", () => {
+    const { setBoardStreamIds, wrapper } = harness()
+    const { unmount } = renderHook(() => useBoardStreamSubscriptions([makePost("conv_1", "stream_a")]), { wrapper })
+
+    setBoardStreamIds.mockClear()
+    unmount()
+
+    expect(setBoardStreamIds).toHaveBeenCalledWith([])
+  })
+})

--- a/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
+++ b/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from "react"
+import { useSyncEngine } from "@/sync/sync-engine"
+import type { BoardViewPost } from "./use-stable-board-view"
+
+/**
+ * Keep every on-screen board card's stream live + offline-first. Board card
+ * bodies ride the `db.events` rail (see use-board-card-messages), so a card is
+ * only fully reactive once its stream's history is in IDB and its room is joined.
+ * Declaring the cards' stream ids drives the SyncEngine to catch up + bootstrap
+ * the ones that aren't already subscribed — threads and public channels the
+ * viewer never joined — while member streams (already subscribed at bootstrap)
+ * skip through as no-ops.
+ *
+ * The declaration is cleared on unmount so a closed board doesn't widen the
+ * reconnect catch-up set; the engine never tears the subscriptions down (see
+ * SyncEngine.setBoardStreamIds for why per-card teardown would be unsafe).
+ */
+export function useBoardStreamSubscriptions(posts: BoardViewPost[]): void {
+  const syncEngine = useSyncEngine()
+
+  const streamIds = useMemo(() => {
+    const seen = new Set<string>()
+    const ids: string[] = []
+    for (const post of posts) {
+      const streamId = post.conversation.streamId
+      if (seen.has(streamId)) continue
+      seen.add(streamId)
+      ids.push(streamId)
+    }
+    return ids
+  }, [posts])
+
+  // The frozen board view hands back a fresh array on every commit even when the
+  // same streams are on screen; key the declaration on the stream set itself so
+  // it only re-fires when which streams are visible actually changes.
+  const streamSetKey = streamIds.join(",")
+
+  useEffect(() => {
+    syncEngine.setBoardStreamIds(streamIds)
+  }, [syncEngine, streamSetKey])
+
+  useEffect(() => {
+    return () => syncEngine.setBoardStreamIds([])
+  }, [syncEngine])
+}

--- a/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
+++ b/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
@@ -18,7 +18,12 @@ import type { BoardViewPost } from "./use-stable-board-view"
 export function useBoardStreamSubscriptions(posts: BoardViewPost[]): void {
   const syncEngine = useSyncEngine()
 
-  const streamIds = useMemo(() => {
+  // The frozen board view hands back a fresh array on every commit even when the
+  // same streams are on screen. Derive a stable key for the deduped stream set,
+  // then derive the array FROM that key so its identity only changes when which
+  // streams are visible changes — the declaration effect can then depend on the
+  // array directly instead of a proxy it closes over (no stale-closure shape).
+  const streamSetKey = useMemo(() => {
     const seen = new Set<string>()
     const ids: string[] = []
     for (const post of posts) {
@@ -27,17 +32,15 @@ export function useBoardStreamSubscriptions(posts: BoardViewPost[]): void {
       seen.add(streamId)
       ids.push(streamId)
     }
-    return ids
+    return ids.join(",")
+    // Stream ids are prefixed ULIDs (no commas), so join/split round-trips cleanly.
   }, [posts])
 
-  // The frozen board view hands back a fresh array on every commit even when the
-  // same streams are on screen; key the declaration on the stream set itself so
-  // it only re-fires when which streams are visible actually changes.
-  const streamSetKey = streamIds.join(",")
+  const streamIds = useMemo(() => (streamSetKey ? streamSetKey.split(",") : []), [streamSetKey])
 
   useEffect(() => {
     syncEngine.setBoardStreamIds(streamIds)
-  }, [syncEngine, streamSetKey])
+  }, [syncEngine, streamIds])
 
   useEffect(() => {
     return () => syncEngine.setBoardStreamIds([])

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -11,6 +11,7 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as syncEngineModule from "@/sync/sync-engine"
 import * as userProfileModule from "@/components/user-profile"
 import * as contextsModule from "@/contexts"
 
@@ -129,6 +130,11 @@ beforeEach(() => {
     toggleReaction: vi.fn(),
     toggleByEmoji: vi.fn(),
   } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  // The board declares its on-screen card streams to the SyncEngine to keep them
+  // live; the engine isn't wired in this harness, so stub the hook.
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
   // Author names open the profile via UserProfileProvider, not mounted here.
   vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
   // RelativeTime reads timezone/locale from the preferences context.

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -10,6 +10,7 @@ import { resolveStreamName } from "@/lib/streams"
 import { localStartOfDayMs } from "@/lib/dates"
 import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useStableBoardView, type BoardViewPost } from "@/hooks/use-stable-board-view"
+import { useBoardStreamSubscriptions } from "@/hooks/use-board-stream-subscriptions"
 import { BOARD_CARD_ATTR, useBoardScrollAnchor } from "@/hooks/use-board-scroll-anchor"
 import { useWorkspaceConversations } from "@/hooks/use-conversations"
 import { BoardCard } from "@/components/board/board-card"
@@ -96,6 +97,9 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
   // the query already holds posts. Treat that window as loading so the feed
   // doesn't flash the empty state before the seed lands.
   const seedPending = (data?.pages.some((page) => page.posts.length > 0) ?? false) && posts.length === 0
+  // Keep the streams behind on-screen cards live + offline-first (threads and
+  // public channels the viewer never joined aren't subscribed at bootstrap).
+  useBoardStreamSubscriptions(posts)
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -761,6 +761,101 @@ describe("SyncEngine reconnect catch-up cursor (INV-53 gap safety)", () => {
   })
 })
 
+describe("SyncEngine.setBoardStreamIds", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([db.workspaces.clear(), db.events.clear(), db.streams.clear(), db.streamMemberships.clear()])
+  })
+
+  it("catches up + bootstraps a board card stream that isn't already subscribed", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+    deps.streamService.bootstrap.mockClear()
+
+    engine.setBoardStreamIds(["thread_1"])
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "thread_1", undefined)
+    })
+  })
+
+  it("skips a stream already subscribed (member / currently open) — no duplicate bootstrap", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    engine.setCurrentStreamId("stream_open")
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_open", undefined)
+    })
+    deps.streamService.bootstrap.mockClear()
+
+    engine.setBoardStreamIds(["stream_open"])
+
+    // Give any errant async sync a chance to fire before asserting it didn't.
+    await Promise.resolve()
+    expect(deps.streamService.bootstrap).not.toHaveBeenCalled()
+  })
+
+  it("only syncs newly-declared streams when the on-screen set grows", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    engine.setBoardStreamIds(["thread_a"])
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "thread_a", undefined)
+    })
+    deps.streamService.bootstrap.mockClear()
+
+    engine.setBoardStreamIds(["thread_a", "thread_b"])
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "thread_b", undefined)
+    })
+    expect(deps.streamService.bootstrap.mock.calls.filter((call) => call[1] === "thread_a")).toHaveLength(0)
+  })
+
+  it("syncs board streams declared before the first connect (offline-cold board open that comes online)", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+
+    // Board mounted + declared while still disconnected — no socket yet, so the
+    // immediate sync no-ops.
+    engine.setBoardStreamIds(["thread_cold"])
+    expect(deps.streamService.bootstrap).not.toHaveBeenCalledWith("ws_1", "thread_cold", undefined)
+
+    await primeConnectedEngine(engine, socket) // first connect
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap.mock.calls.some((call) => call[1] === "thread_cold")).toBe(true)
+    })
+  })
+
+  it("re-asserts board streams on reconnect so their cards stay live across a drop", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    engine.setBoardStreamIds(["thread_live"])
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "thread_live", undefined)
+    })
+    deps.streamService.bootstrap.mockClear()
+
+    await engine.onConnect(asSocket(socket)) // reconnect wipes + re-subscribes
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap.mock.calls.some((call) => call[1] === "thread_live")).toBe(true)
+    })
+  })
+})
+
 describe("SyncEngine.backfillStreamGap", () => {
   beforeEach(async () => {
     resetRevealGate()

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -83,6 +83,10 @@ interface SyncEngineDeps {
 const MAX_CATCHUP_PAGES = 20
 const CATCHUP_PAGE_LIMIT = 500
 
+/** Max in-flight board card stream catch-ups. Bounds the bootstrap-fetch burst
+ *  when the board opens onto many unsynced thread/public streams at once. */
+const BOARD_SYNC_CONCURRENCY = 6
+
 /**
  * Above this many missed entries on the first catch-up page, heal the whole
  * workspace with one atomic snapshot instead of replaying the gap entry by
@@ -175,6 +179,11 @@ export class SyncEngine {
   // Ref-like state updated by the React layer
   private currentStreamId: string | undefined = undefined
   private visibleStreamIds: string[] = []
+  /** Streams whose board cards are on screen — declared by the board page, kept
+   *  separate from `visibleStreamIds` (the sidebar's, replaced wholesale). Their
+   *  bodies ride `db.events`, so the board joins + catches them up like any opened
+   *  stream and re-asserts them across reconnects (see setBoardStreamIds). */
+  private boardStreamIds = new Set<string>()
   private currentUser: { id: string } | null = null
   /** Last workspace bootstrap error, if any. Consumers can check this for 404/403 handling. */
   lastWorkspaceError: unknown = null
@@ -201,6 +210,41 @@ export class SyncEngine {
 
   setVisibleStreamIds(ids: string[]): void {
     this.visibleStreamIds = ids
+  }
+
+  /**
+   * Declare the streams whose board cards are currently on screen. The board
+   * renders message bodies OFFLINE-FIRST off the `db.events` rail, so a card is
+   * only fully live + reactive once its stream's history is in IDB and its room
+   * is joined — which is exactly what opening the stream does. This drives that
+   * for every board card, including threads and public channels the viewer never
+   * joined (member streams are already subscribed at bootstrap).
+   *
+   * It is additive and must NEVER route through setVisibleStreamIds — that set is
+   * the sidebar's and is replaced wholesale (clobbering it would drop the
+   * sidebar's reconnect catch-up). Newly-declared streams not already subscribed
+   * are caught up + bootstrapped here, concurrency-capped so opening the board
+   * doesn't fire a fetch burst across dozens of unsynced streams. Board streams
+   * join the reconnect / connectivity-resume re-sync set (getVisibleServerStreamIds)
+   * so they stay live across drops while the board is open.
+   *
+   * Subscriptions are NOT torn down per card: clearing on unmount only shrinks the
+   * reconnect set (so a closed board doesn't re-fetch on reconnect), while the
+   * already-subscribed skip below means reopening the board re-syncs nothing. We
+   * never unsubscribe a board stream — that would race a card click that navigates
+   * into the very stream being torn down.
+   */
+  setBoardStreamIds(ids: string[]): void {
+    const next = new Set(ids)
+    const toSync: string[] = []
+    for (const streamId of next) {
+      if (this.boardStreamIds.has(streamId)) continue
+      if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
+      if (this.subscribedStreams.has(streamId)) continue
+      toSync.push(streamId)
+    }
+    this.boardStreamIds = next
+    if (toSync.length > 0) void this.syncBoardStreams(toSync)
   }
 
   /** Update the current auth user (called from React when auth state settles). */
@@ -258,6 +302,19 @@ export class SyncEngine {
     )
 
     await this.runBootstrap(isReconnect)
+
+    // A reconnect catches up the visible + board streams inside runBootstrap (via
+    // getVisibleServerStreamIds); a first connect deliberately does not. But the
+    // board may already be mounted from cache (a deep-link or warm-but-offline
+    // open that just came online), so sync any declared board streams whose rooms
+    // the fresh bootstrap didn't join — otherwise their cards wouldn't go live
+    // until the next reconnect.
+    if (!isReconnect && this.boardStreamIds.size > 0) {
+      const pending = [...this.boardStreamIds].filter(
+        (id) => !this.subscribedStreams.has(id) && !id.startsWith("draft_") && !id.startsWith("draft:")
+      )
+      if (pending.length > 0) void this.syncBoardStreams(pending)
+    }
 
     // Process pending offline operations (edits, deletes, reactions, drafts)
     this.kickOperationQueue()
@@ -817,7 +874,11 @@ export class SyncEngine {
   }
 
   private getVisibleServerStreamIds(): string[] {
-    const streamIds = this.currentStreamId ? [this.currentStreamId, ...this.visibleStreamIds] : this.visibleStreamIds
+    const streamIds = [
+      ...(this.currentStreamId ? [this.currentStreamId] : []),
+      ...this.visibleStreamIds,
+      ...this.boardStreamIds,
+    ]
     return Array.from(
       new Set(streamIds.filter((streamId) => !streamId.startsWith("draft_") && !streamId.startsWith("draft:")))
     )
@@ -837,6 +898,26 @@ export class SyncEngine {
         await this.ensureStreamSubscription(streamId)
       }
     }
+  }
+
+  /**
+   * Full catch-up + bootstrap for board card streams, in feed order (the viewer
+   * sees the top first) and bounded to BOARD_SYNC_CONCURRENCY in-flight so a
+   * board open across dozens of unsynced streams doesn't saturate the network on
+   * a spotty connection. Reuses refreshStreamAfterNavigation — the same
+   * cursor-before-join → bootstrap → applyStreamBootstrap path opening a stream
+   * runs — which dedupes in-flight refreshes and no-ops while offline.
+   */
+  private async syncBoardStreams(streamIds: string[]): Promise<void> {
+    let cursor = 0
+    const worker = async (): Promise<void> => {
+      while (cursor < streamIds.length && !this.isDestroyed) {
+        const streamId = streamIds[cursor++]
+        await this.refreshStreamAfterNavigation(streamId)
+      }
+    }
+    const lanes = Math.min(BOARD_SYNC_CONCURRENCY, streamIds.length)
+    await Promise.all(Array.from({ length: lanes }, () => worker()))
   }
 
   /** Member stream ids from the offline cache, for the bootstrap-failure path. */


### PR DESCRIPTION
## Problem

Board card bodies ride the `db.events` sync rail (shipped in #1106): a card is rendered offline-first from whatever `message_created` events are in IndexedDB, falling back to the cached server projection on the conversation row when the stream hasn't synced. A card is therefore only *fully live + reactive* once its stream's history is in IDB **and** its room is joined.

`SyncEngine.subscribeMemberStreams` subscribes the streams the viewer belongs to at bootstrap, so those cards are already live. But **threads and public channels the viewer never joined are not subscribed** — their `message_created` events are stream-room-scoped (`delivery-groups.ts:resolveDeliveryGroups` routes them to `stream:<threadId>` only, never the parent/workspace room; only the lightweight `conversation:*` aggregate fans out wider). So those cards only went live once the user opened the stream; until then they sat on the static projection and never updated in place.

## Solution

The board declares the streams of its on-screen cards to the SyncEngine, which catches up + joins the rooms of the ones that aren't already subscribed — the same path opening a stream runs. No new server delivery semantics; the client just subscribes the streams it's showing, the way the reconnect catch-up already fans out per-stream joins.

### How it works

1. `useBoardStreamSubscriptions(posts)` (new hook) derives the deduped set of `post.conversation.streamId` for the rendered feed and calls `syncEngine.setBoardStreamIds(ids)` in an effect keyed on the stream set (not the array identity — the frozen board view hands back a fresh array on every commit). It clears the declaration (`setBoardStreamIds([])`) on unmount.
2. `SyncEngine.setBoardStreamIds` stores the set in a new `boardStreamIds` field and, for each newly-declared id that isn't a draft and isn't already in `subscribedStreams`, kicks `syncBoardStreams`.
3. `syncBoardStreams` runs `refreshStreamAfterNavigation` per stream — the existing `joinStreamForCatchUp` (cursor-before-join, INV-53/61) → `bootstrap` → `applyStreamBootstrap` path that writes events into `db.events` — bounded to `BOARD_SYNC_CONCURRENCY` (6) in-flight via a shared-cursor worker pool, in feed order so the top cards sync first.
4. `boardStreamIds` is folded into `getVisibleServerStreamIds`, so the reconnect catch-up and `refreshAfterConnectivityResume` re-sync board streams (they're wiped by `cleanupStreamHandlers` on reconnect) — cards stay live across drops while the board is open.
5. A first-connect branch in `onConnect` syncs declared-but-unsubscribed board streams after the initial bootstrap (the reconnect path covers them via `getVisibleServerStreamIds`, but a first connect deliberately keeps that set empty — this covers a board mounted from cache before the socket connects).

### Key design decisions

**1. Additive set, never `setVisibleStreamIds`.** `visibleStreamIds` is the sidebar's and is *replaced* wholesale (`workspace-layout.tsx` owns it; read by the reconnect catch-up). Routing board streams through it would clobber the sidebar's reconnect set. `boardStreamIds` is a separate field unioned into `getVisibleServerStreamIds`.

**2. Subscriptions are never torn down per card.** Clearing on unmount only shrinks the reconnect set (so a *closed* board doesn't re-fetch its old cards on reconnect); the rooms stay subscribed for the session, consistent with the rest of the app (`unsubscribeStream` is never called from React today). Per-card teardown was rejected: navigating into a card unmounts the board, and tearing down that stream would race the stream view subscribing the very stream the user just opened. The `subscribedStreams.has(id)` skip also means reopening the board re-syncs nothing.

**3. Concurrency cap, not all-at-once.** A 50-card feed can touch dozens of unsynced thread/public streams; firing every bootstrap at once would saturate the network (against the offline-first "spotty connection" goal). Capped at 6, feed-ordered. Member streams skip through as no-ops.

**4. Client-side fan-out over server-side broadcast.** The alternative — fanning thread bodies to the parent/workspace room in `delivery-groups.ts` like `conversation:*` does — would give zero-join live cards but only for *public*-rooted threads (private/DM threads must stay room-scoped per INV-62, so they'd still need client joins) and at the cost of broadcasting every thread message body to every workspace socket. Client join covers all thread types uniformly and adds no broadcast amplification.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-board-stream-subscriptions.ts` | Derives the board's on-screen stream set and declares it to the SyncEngine; clears on unmount. |
| `apps/frontend/src/hooks/use-board-stream-subscriptions.test.tsx` | Dedup, re-declare-only-on-change, clear-on-unmount. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sync/sync-engine.ts` | `boardStreamIds` field + `setBoardStreamIds` + `syncBoardStreams` (capped runner); board streams folded into `getVisibleServerStreamIds`; first-connect sync of declared board streams in `onConnect`. |
| `apps/frontend/src/sync/sync-engine.test.ts` | 5 tests for `setBoardStreamIds` (sync-new, skip-subscribed, only-new-on-grow, first-connect, reconnect re-assert). |
| `apps/frontend/src/pages/board.tsx` | Calls `useBoardStreamSubscriptions(posts)`. |
| `apps/frontend/src/pages/board.test.tsx` | Stubs `useSyncEngine` (engine not wired in this harness). |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | Refreshed the now-stale "coverage is a follow-up" doc comment. |

## Out of scope (deliberate)

- **Strict viewport gating.** Without board virtualization (deferred, see #1104 follow-ups) all feed cards are mounted, so "on screen" = all rendered posts. The concurrency cap bounds the burst and the feed paginates on manual "load more"; an IntersectionObserver gate is a small follow-on if the fetch volume proves to matter.
- **No server delivery changes.** `delivery-groups.ts` is untouched (see design decision 4).
- **Device verification** on a real phone (airplane-mode reopen, throttled live-update) is still pending — the IDB-store tests use fake-indexeddb and don't exercise a real-device render.

## Test plan

- [x] `apps/frontend` vitest — sync-engine (60, incl. 5 new), board page, `use-board-stream-subscriptions` (3), `use-board-card-messages` — 86 pass across the affected suites
- [x] `bun run --cwd apps/frontend typecheck` clean
- [x] eslint on all changed files clean
- [x] pre-commit hook (monorepo lint + typecheck incl. tests tsconfig + astro + OpenAPI `--check` + prettier) passed on commit
- [ ] Real-device airplane-mode / throttled-live-update verification — not done (no real-device harness; logic covered by fake-indexeddb tests)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTLGeTrRapBG5M9pd31QEh)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785270867&installation_id=129946197&pr_number=1109&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1109&signature=e4586b921dfc839943bb42e221c315a4bb3a3c82114bce9285d75ab3c6646eb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->