### PR TITLE
feat(board): eager optimistic board replies through the durable send queue

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -80,10 +80,14 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   else if (incompleteLocally && allMessages)
     replies = (allMessages as RenderableMessage[]).filter((m) => m.id !== openingMessage?.id)
   else replies = railReplies
-  // Append this card's own just-sent replies, skipping any the rail or a backfill
-  // already carries.
+  // Merge this card's own just-sent replies with the confirmed set, skipping any
+  // the rail or a backfill already carries, then sort by time: a pending reply
+  // can be OLDER than a confirmed one (someone else's reply lands while yours is
+  // still in flight), so appending blindly would render it out of order.
   const seenReplyIds = new Set(replies.map((m) => m.id))
-  const displayedReplies = [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))]
+  const displayedReplies = [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  )
   const hiddenCount = expanded ? 0 : Math.max(0, totalReplies - replies.length)
   const loadingMore = expanded && incompleteLocally && !allMessages && !expandFailed
   // No middle is hidden, so opening + replies form one uninterrupted run that

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -42,16 +42,13 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const [expanded, setExpanded] = useState(false)
-  // Replies sent from this card, shown in place immediately. The events rail
-  // carries the authoritative copy once the send round-trips (and any foreign
-  // reply), so these are deduped by id against the rail below. A channel reply
-  // lands in a thread off the post, so it surfaces as its own post on the next
-  // board refresh rather than under this card; that's expected.
-  const [localReplies, setLocalReplies] = useState<RenderableMessage[]>([])
 
   // Bodies ride the same `db.events` rail the timeline does — live and
   // offline-first — with the cached server projection as the cold-start fallback.
-  const { openingMessage, replies: railReplies, totalReplies, source } = useBoardCardMessages(post)
+  // `pendingReplies` are the viewer's own just-sent replies awaiting their echo:
+  // they aren't in the conversation's `messageIds` yet, so the card appends them
+  // in place (deduped by id below) until the echo swaps each for the real row.
+  const { openingMessage, replies: railReplies, totalReplies, pendingReplies, source } = useBoardCardMessages(post)
 
   const streamId = conversation.streamId
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
@@ -86,7 +83,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // Append this card's own just-sent replies, skipping any the rail or a backfill
   // already carries.
   const seenReplyIds = new Set(replies.map((m) => m.id))
-  const displayedReplies = [...replies, ...localReplies.filter((m) => !seenReplyIds.has(m.id))]
+  const displayedReplies = [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))]
   const hiddenCount = expanded ? 0 : Math.max(0, totalReplies - replies.length)
   const loadingMore = expanded && incompleteLocally && !allMessages && !expandFailed
   // No middle is hidden, so opening + replies form one uninterrupted run that
@@ -157,12 +154,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         )}
       </div>
 
-      <BoardReplyComposer
-        workspaceId={workspaceId}
-        post={post}
-        hostStreamType={streamType}
-        onReplied={(message) => setLocalReplies((prev) => [...prev, message])}
-      />
+      <BoardReplyComposer workspaceId={workspaceId} post={post} hostStreamType={streamType} />
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -8,7 +8,7 @@ import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
-import type { BoardPost, JSONContent, Message } from "@threa/types"
+import type { BoardPost, JSONContent } from "@threa/types"
 
 // Focus moving into one of these means a composer popover is open (the inline
 // suggestion lists render as `[role="listbox"]`; emoji/format/link popovers are
@@ -39,8 +39,6 @@ interface BoardReplyComposerProps {
   post: BoardPost
   /** Host stream type of the post's conversation, selecting the reply routing. */
   hostStreamType: string | undefined
-  /** Called with the created reply so the card can show it in place. */
-  onReplied: (message: Message) => void
 }
 
 /**
@@ -116,7 +114,6 @@ function BoardReplyComposerForm({
   workspaceId,
   post,
   hostStreamType,
-  onReplied,
   onClose,
 }: BoardReplyComposerProps & {
   onClose: (opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => void
@@ -169,31 +166,44 @@ function BoardReplyComposerForm({
   const handleSubmit = async (editorContent?: JSONContent) => {
     if (!composer.canSend) return
 
+    // Board replies into an end-to-end-encrypted host aren't supported: the send
+    // path here is plaintext (a sealed send is rejected by INV-E1), and the
+    // boundary extractor skips E2E streams so the reply couldn't be assigned to
+    // this conversation anyway. Surface it instead of queuing a doomed send —
+    // E2E board replies belong to the encrypted-streams workstream. The draft is
+    // kept so nothing the user typed is lost.
+    if (hostStream?.e2eEnabled) {
+      toast.error("Replying from the board isn't available for encrypted notes yet.")
+      return
+    }
+
     const pendingAttachments = composer.getPendingAttachmentsSnapshot()
     const liveContent = editorContent ?? composer.content
     const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
-    const attachmentIds = extractUploadedAttachments(normalizedContent).map((a) => a.id)
+    const attachments = extractUploadedAttachments(normalizedContent)
+    const attachmentIds = attachments.map((a) => a.id)
 
     composer.setIsSending(true)
     try {
-      const { message, plan } = await reply.mutateAsync({
+      // Eager + offline-first: the reply is enqueued as an optimistic event and
+      // shows in place immediately (an `intoConversation` reply rides the card's
+      // own rail; a `newThread` reply lands in its own thread, surfacing as its
+      // own board post on the next load). The send drains in the background, so
+      // there's no created message to await here — only the resolved plan, which
+      // selects the resting note: the visible in-place reply is the feedback for
+      // the former, the transient "Posted to a new thread" note for the latter.
+      const { plan } = await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
         hostStreamType,
         messageCount: post.conversation.messageIds.length,
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        attachments: attachments.length > 0 ? attachments : undefined,
       })
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
-      // Only an `intoConversation` reply belongs under this card; a `newThread`
-      // reply lives in its own thread conversation and surfaces as its own board
-      // post on the next load, so showing it here would render it under the wrong
-      // card with stream-mismatched action links. The visible in-place reply IS
-      // the feedback for the former; the latter gets a transient resting note
-      // instead, since nothing changes on this card.
-      if (plan.kind === "intoConversation") onReplied(message)
       onClose({ refocus: true, posted: plan.kind === "newThread" })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -6,6 +6,7 @@ import { usePreferences } from "@/contexts"
 import { useMentionStreamContext } from "@/hooks/use-mentionables"
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
 import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
+import { useStreamFromStore } from "@/stores/stream-store"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
 import type { BoardPost, JSONContent } from "@threa/types"
@@ -132,6 +133,16 @@ function BoardReplyComposerForm({
   )
   const streamContext = useMentionStreamContext(workspaceId, hostStream)
 
+  // Whether the host is end-to-end-encrypted. Read from the synced IDB stream row
+  // (`useStreamFromStore`) as the authority, NOT just the workspace cache: a
+  // thread card's host is absent from `useWorkspaceStreams` (it holds sidebar
+  // streams) but the board syncs every on-screen card's host into `db.streams`
+  // (useBoardStreamSubscriptions), so the IDB row carries `e2eEnabled` where the
+  // workspace cache has no row. Falling back to the cache alone would skip the
+  // block below for thread hosts.
+  const idbHostStream = useStreamFromStore(streamId)
+  const hostIsE2e = hostStream?.e2eEnabled === true || idbHostStream?.e2eEnabled === true
+
   const draftKey = `board:reply:${post.conversation.id}`
   const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
 
@@ -172,7 +183,7 @@ function BoardReplyComposerForm({
     // this conversation anyway. Surface it instead of queuing a doomed send —
     // E2E board replies belong to the encrypted-streams workstream. The draft is
     // kept so nothing the user typed is lost.
-    if (hostStream?.e2eEnabled) {
+    if (hostIsE2e) {
       toast.error("Encrypted notes can't be replied to from the board yet — open the note to reply there.")
       return
     }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -173,7 +173,7 @@ function BoardReplyComposerForm({
     // E2E board replies belong to the encrypted-streams workstream. The draft is
     // kept so nothing the user typed is lost.
     if (hostStream?.e2eEnabled) {
-      toast.error("Replying from the board isn't available for encrypted notes yet.")
+      toast.error("Encrypted notes can't be replied to from the board yet — open the note to reply there.")
       return
     }
 

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -4,6 +4,7 @@ import type {
   AuthorType,
   BoardPost,
   CompanionMode,
+  ConversationDirective,
   E2eActor,
   EventType,
   JSONContent,
@@ -287,6 +288,12 @@ export interface PendingMessage {
   confirmedPrivacyWarning?: boolean
   /** When set, the queue creates this stream before sending the message */
   streamCreation?: PendingStreamCreation
+  /**
+   * Conversation directive forwarded on send so a board reply attaches to the
+   * declared conversation synchronously (see {@link ConversationDirective}).
+   * Omitted on ordinary stream sends, which let the async extractor infer.
+   */
+  conversation?: ConversationDirective
   /** The draft ID to clean up after successful stream creation + message send */
   draftId?: string
   /** Set by the queue after stream creation succeeds — prevents duplicate creation on retry */

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -112,6 +112,30 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
   })
 
+  it("keeps a failed (mid-backoff) optimistic reply visible instead of blinking it out", async () => {
+    await db.events.put({
+      id: "temp_y",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "2",
+      _sequenceNum: 2,
+      eventType: "message_created",
+      payload: { messageId: "temp_y", contentMarkdown: "retrying reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(2).toISOString(),
+      _cachedAt: 2,
+      // The queue marks the row `failed` between retry-backoff attempts; the reply
+      // must stay on the card across that window, not vanish until the retry lands.
+      _status: "failed",
+    } as CachedEvent)
+
+    const post = makePost({ messageIds: ["m1"], openingId: "m1" })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.pendingReplies.map((m) => m.id)).toEqual(["temp_y"]))
+  })
+
   it("falls back to the cached projection when the stream isn't in IDB (cold/offline)", async () => {
     const post = makePost({
       messageIds: ["m1", "r1"],

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -84,6 +84,34 @@ describe("useBoardCardMessages", () => {
     expect(result.current.totalReplies).toBe(2)
   })
 
+  it("surfaces a pending optimistic reply tagged with its conversation, before the id lands in messageIds", async () => {
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "first reply", 2)])
+    // The viewer's just-sent reply: an optimistic pending event tagged with the
+    // target conversation, not yet a member of the conversation's messageIds.
+    await db.events.put({
+      id: "temp_x",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "3",
+      _sequenceNum: 3,
+      eventType: "message_created",
+      payload: { messageId: "temp_x", contentMarkdown: "my pending reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+
+    const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1" })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.pendingReplies.map((m) => m.id)).toEqual(["temp_x"]))
+    expect(result.current.pendingReplies[0]?.contentMarkdown).toBe("my pending reply")
+    // Optimistic, so it doesn't inflate the rail replies (not yet in messageIds).
+    expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
+  })
+
   it("falls back to the cached projection when the stream isn't in IDB (cold/offline)", async () => {
     const post = makePost({
       messageIds: ["m1", "r1"],

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -112,6 +112,60 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
   })
 
+  it("keeps a reply continuously visible across the optimistic→echo→messageIds hand-off (no blink-out)", async () => {
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "first reply", 2)])
+    const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1" })
+    const { result, rerender } = renderHook((p: typeof post) => useBoardCardMessages(p), { initialProps: post })
+    const shown = () => [...result.current.replies, ...result.current.pendingReplies].map((m) => m.id)
+
+    // 1) Optimistic insert: the reply (tagged with its conversation, not yet in
+    //    messageIds) shows immediately.
+    await db.events.put({
+      id: "temp_z",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "1700000000000",
+      _sequenceNum: 1700000000000,
+      eventType: "message_created",
+      payload: { messageId: "temp_z", contentMarkdown: "my reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+    await waitFor(() => expect(shown()).toContain("temp_z"))
+
+    // 2) Server echo (stream-sync swap): the real event replaces the optimistic
+    //    one, carrying the conversationId tag forward. messageIds hasn't updated
+    //    yet — the reply must NOT disappear in this window.
+    await db.transaction("rw", db.events, async () => {
+      await db.events.put({
+        id: "msg_real",
+        workspaceId: WS,
+        streamId: STREAM,
+        sequence: "3",
+        _sequenceNum: 3,
+        eventType: "message_created",
+        payload: { messageId: "msg_real", contentMarkdown: "my reply", reactions: {}, conversationId: "conv_1" },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: new Date(3).toISOString(),
+        _cachedAt: 4,
+      } as CachedEvent)
+      await db.events.delete("temp_z")
+    })
+    await waitFor(() => expect(shown()).toContain("msg_real"))
+    expect(shown()).not.toContain("temp_z")
+
+    // 3) conversation:updated lands: messageIds now lists the real id. The reply
+    //    renders via `replies` and is deduped out of `pendingReplies` (shown once).
+    rerender(makePost({ messageIds: ["m1", "r1", "msg_real"], openingId: "m1" }))
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["r1", "msg_real"]))
+    expect(result.current.pendingReplies).toEqual([])
+    expect(shown().filter((id) => id === "msg_real")).toHaveLength(1)
+  })
+
   it("keeps a failed (mid-backoff) optimistic reply visible instead of blinking it out", async () => {
     await db.events.put({
       id: "temp_y",

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -40,11 +40,15 @@ interface StreamRail {
   /** Every message id the stream has synced — INCLUDING soft-deleted tombstones,
    *  which are absent from `messages`. Lets a card tell "deleted" from "unsynced". */
   seen: Set<string>
-  /** Pending optimistic replies the viewer just sent, grouped by their target
-   *  conversation id, chronological. These aren't yet in the conversation's
-   *  `messageIds`, so a card appends them to whatever it already shows; the
-   *  server echo swaps each for the real row (in `messages`, via `messageIds`). */
-  pendingByConversation: Map<string, RenderableMessage[]>
+  /** Renderable rows that carry a `conversationId`, grouped by it, chronological.
+   *  A board reply tags its optimistic event with the conversation it attaches to,
+   *  and the swap carries that tag onto the real event (stream-sync), so this holds
+   *  the reply continuously from optimistic insert through the server echo. The
+   *  card unions this with the conversation's server `messageIds`: the tag covers
+   *  the reply BEFORE the id lands in `messageIds` (no blink-out at the echo
+   *  hand-off); once it's in `messageIds` the card dedups it. Only board replies
+   *  carry the tag, so this stays proportional to the stream's reply count. */
+  taggedByConversation: Map<string, RenderableMessage[]>
   /** False until the first IDB read resolves — distinguishes loading from empty. */
   resolved: boolean
 }
@@ -52,36 +56,34 @@ interface StreamRail {
 const LOADING_RAIL: StreamRail = {
   messages: new Map(),
   seen: new Set(),
-  pendingByConversation: new Map(),
+  taggedByConversation: new Map(),
   resolved: false,
 }
 
 function buildRail(events: CachedEvent[]): StreamRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
-  const pendingByConversation = new Map<string, RenderableMessage[]>()
+  const taggedByConversation = new Map<string, RenderableMessage[]>()
   for (const event of events) {
     const payload = (event.payload ?? {}) as MessageCreatedPayloadShape
     if (payload.messageId) seen.add(payload.messageId)
     const message = eventToRenderable(event)
     if (!message) continue
     messages.set(message.id, message)
-    // An optimistic reply carries its target conversation so the card can show
-    // it before the id lands in `messageIds`. Keep it visible while it's still
-    // in flight — `pending` AND `failed`, since the queue cycles a reply through
-    // `failed` between retry-backoff attempts; gating on `pending` alone would
-    // make a reply blink out for the whole backoff window, then reappear. The
-    // server echo deletes the optimistic row, so this set stays bounded.
-    if ((event._status === "pending" || event._status === "failed") && payload.conversationId) {
-      const list = pendingByConversation.get(payload.conversationId)
+    // Group every conversation-tagged row (optimistic OR the swapped real one,
+    // any `_status`) so the card can show the reply continuously across the echo
+    // hand-off — gating on `_status` would drop the real row the instant the
+    // swap clears `pending`, blinking the reply out until `messageIds` catches up.
+    if (payload.conversationId) {
+      const list = taggedByConversation.get(payload.conversationId)
       if (list) list.push(message)
-      else pendingByConversation.set(payload.conversationId, [message])
+      else taggedByConversation.set(payload.conversationId, [message])
     }
   }
-  for (const list of pendingByConversation.values()) {
+  for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, pendingByConversation, resolved: true }
+  return { messages, seen, taggedByConversation, resolved: true }
 }
 
 interface StreamRailEntry {
@@ -163,9 +165,11 @@ export interface BoardCardMessages {
    *  reply can't inflate the gap); otherwise the server count, since older replies
    *  aren't in IDB yet. */
   totalReplies: number
-  /** The viewer's own just-sent replies awaiting their server echo, chronological.
-   *  Not yet in `messageIds` (so absent from `replies`); the card appends them in
-   *  place. Empties as each echo swaps the optimistic row for the real one. */
+  /** Replies known from the rail but not yet in the conversation's server
+   *  `messageIds` — the optimistic row, and the swapped real row in the window
+   *  before `conversation:updated` lands — chronological. The card appends these
+   *  in place so a just-sent reply shows immediately and stays put across the
+   *  echo hand-off; each empties once its id appears in `messageIds`. */
   pendingReplies: RenderableMessage[]
   /** Where the bodies came from: the live `db.events` rail, or the cached server
    *  projection (a stream not yet synced into IDB — a cold/offline first open). */
@@ -204,7 +208,14 @@ export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
   const conversationId = post.conversation.id
 
   return useMemo(() => {
-    const pendingReplies = rail.pendingByConversation.get(conversationId) ?? NO_PENDING
+    // Replies for this conversation the card knows from the rail but the server
+    // `messageIds` doesn't list yet — the optimistic row, and the swapped real
+    // row in the window before `conversation:updated` lands. Exclude ids already
+    // in `replyIds` so a confirmed reply renders once (via `replies`), not twice.
+    const replyIdSet = new Set(replyIds)
+    const tagged = rail.taggedByConversation.get(conversationId)
+    const unconfirmed = tagged ? tagged.filter((m) => !replyIdSet.has(m.id)) : NO_PENDING
+    const pendingReplies = unconfirmed.length > 0 ? unconfirmed : NO_PENDING
 
     // The server's count excludes `messageIds[0]` for a flat conversation even
     // when that opening was deleted, so trust it when the flat relationship is

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -12,6 +12,9 @@ interface MessageCreatedPayloadShape {
   attachments?: RenderableMessage["attachments"]
   linkPreviews?: RenderableMessage["linkPreviews"]
   deletedAt?: string | null
+  /** Set only on an optimistic board reply, naming the conversation it attaches
+   *  to so a card can surface the pending row before the server echo lands. */
+  conversationId?: string
 }
 
 /** Project a `message_created` event row into the shared render shape the timeline
@@ -37,22 +40,44 @@ interface StreamRail {
   /** Every message id the stream has synced — INCLUDING soft-deleted tombstones,
    *  which are absent from `messages`. Lets a card tell "deleted" from "unsynced". */
   seen: Set<string>
+  /** Pending optimistic replies the viewer just sent, grouped by their target
+   *  conversation id, chronological. These aren't yet in the conversation's
+   *  `messageIds`, so a card appends them to whatever it already shows; the
+   *  server echo swaps each for the real row (in `messages`, via `messageIds`). */
+  pendingByConversation: Map<string, RenderableMessage[]>
   /** False until the first IDB read resolves — distinguishes loading from empty. */
   resolved: boolean
 }
 
-const LOADING_RAIL: StreamRail = { messages: new Map(), seen: new Set(), resolved: false }
+const LOADING_RAIL: StreamRail = {
+  messages: new Map(),
+  seen: new Set(),
+  pendingByConversation: new Map(),
+  resolved: false,
+}
 
 function buildRail(events: CachedEvent[]): StreamRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
+  const pendingByConversation = new Map<string, RenderableMessage[]>()
   for (const event of events) {
     const payload = (event.payload ?? {}) as MessageCreatedPayloadShape
     if (payload.messageId) seen.add(payload.messageId)
     const message = eventToRenderable(event)
-    if (message) messages.set(message.id, message)
+    if (!message) continue
+    messages.set(message.id, message)
+    // An optimistic reply (pending, not yet echoed) carries its target
+    // conversation so the card can show it before the id lands in `messageIds`.
+    if (event._status === "pending" && payload.conversationId) {
+      const list = pendingByConversation.get(payload.conversationId)
+      if (list) list.push(message)
+      else pendingByConversation.set(payload.conversationId, [message])
+    }
   }
-  return { messages, seen, resolved: true }
+  for (const list of pendingByConversation.values()) {
+    list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+  }
+  return { messages, seen, pendingByConversation, resolved: true }
 }
 
 interface StreamRailEntry {
@@ -134,10 +159,16 @@ export interface BoardCardMessages {
    *  reply can't inflate the gap); otherwise the server count, since older replies
    *  aren't in IDB yet. */
   totalReplies: number
+  /** The viewer's own just-sent replies awaiting their server echo, chronological.
+   *  Not yet in `messageIds` (so absent from `replies`); the card appends them in
+   *  place. Empties as each echo swaps the optimistic row for the real one. */
+  pendingReplies: RenderableMessage[]
   /** Where the bodies came from: the live `db.events` rail, or the cached server
    *  projection (a stream not yet synced into IDB — a cold/offline first open). */
   source: "events" | "projection"
 }
+
+const NO_PENDING: RenderableMessage[] = []
 
 /**
  * A board card's messages, read OFFLINE-FIRST from the same `db.events` store the
@@ -166,8 +197,11 @@ export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
   )
 
   const rail = useStreamRail(streamId)
+  const conversationId = post.conversation.id
 
   return useMemo(() => {
+    const pendingReplies = rail.pendingByConversation.get(conversationId) ?? NO_PENDING
+
     // The server's count excludes `messageIds[0]` for a flat conversation even
     // when that opening was deleted, so trust it when the flat relationship is
     // unknown (deleted opening → `openingId` null).
@@ -189,6 +223,7 @@ export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
         openingMessage,
         replies: post.recentMessages as RenderableMessage[],
         totalReplies: serverTotal,
+        pendingReplies,
         source: "projection",
       }
     }
@@ -207,6 +242,6 @@ export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
     const fullySynced = replyIds.every((id) => rail.seen.has(id))
     const totalReplies = fullySynced ? liveReplies.length : serverTotal
 
-    return { openingMessage, replies: liveReplies, totalReplies, source: "events" }
-  }, [rail, replyIds, openingId, messageIds, post])
+    return { openingMessage, replies: liveReplies, totalReplies, pendingReplies, source: "events" }
+  }, [rail, replyIds, openingId, messageIds, post, conversationId])
 }

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -66,9 +66,13 @@ function buildRail(events: CachedEvent[]): StreamRail {
     const message = eventToRenderable(event)
     if (!message) continue
     messages.set(message.id, message)
-    // An optimistic reply (pending, not yet echoed) carries its target
-    // conversation so the card can show it before the id lands in `messageIds`.
-    if (event._status === "pending" && payload.conversationId) {
+    // An optimistic reply carries its target conversation so the card can show
+    // it before the id lands in `messageIds`. Keep it visible while it's still
+    // in flight — `pending` AND `failed`, since the queue cycles a reply through
+    // `failed` between retry-backoff attempts; gating on `pending` alone would
+    // make a reply blink out for the whole backoff window, then reappear. The
+    // server echo deletes the optimistic row, so this set stays bounded.
+    if ((event._status === "pending" || event._status === "failed") && payload.conversationId) {
       const list = pendingByConversation.get(payload.conversationId)
       if (list) list.push(message)
       else pendingByConversation.set(payload.conversationId, [message])

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -294,21 +294,18 @@ describe("useReplyToBoardPost", () => {
   })
 
   function mockReplyDeps() {
-    const create = vi.fn().mockResolvedValue({ id: "msg_new" })
-    vi.spyOn(contextsModule, "useMessageService").mockReturnValue({
-      create,
-    } as unknown as contextsModule.MessageService)
-    const createStream = vi.fn().mockResolvedValue({ id: "thread_1" })
-    vi.spyOn(contextsModule, "useStreamService").mockReturnValue({
-      create: createStream,
-    } as unknown as contextsModule.StreamService)
-    return { create, createStream }
+    const queueDraftMessage = vi.fn().mockResolvedValue({ clientId: "temp_abc" })
+    vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+      queueDraftMessage,
+      currentUserId: "user_1",
+    } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+    return { queueDraftMessage }
   }
 
   const DOC = { type: "doc", content: [] }
 
-  it("threads a lone channel root off the opening message, then sends into the thread (no directive)", async () => {
-    const { create, createStream } = mockReplyDeps()
+  it("threads a lone channel root off the opening message, promoting a draft thread (no directive)", async () => {
+    const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
@@ -323,25 +320,25 @@ describe("useReplyToBoardPost", () => {
       })
     })
 
-    expect(createStream).toHaveBeenCalledWith(WORKSPACE_ID, {
-      type: StreamTypes.THREAD,
-      parentStreamId: "chan_1",
-      parentMessageId: "msg_open",
-    })
-    expect(create).toHaveBeenCalledWith(
-      WORKSPACE_ID,
-      "thread_1",
-      expect.objectContaining({ streamId: "thread_1", contentJson: DOC, clientMessageId: expect.any(String) })
+    // The reply rides the durable queue with THREAD stream-creation, keyed on the
+    // draft panel id; no existing-conversation directive (a fresh thread is its
+    // own conversation).
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contentJson: DOC }),
+      expect.objectContaining({
+        workspaceId: WORKSPACE_ID,
+        streamId: "draft:chan_1:msg_open",
+        draftId: "draft:chan_1:msg_open",
+        streamCreation: { type: StreamTypes.THREAD, parentStreamId: "chan_1", parentMessageId: "msg_open" },
+      })
     )
-    // The thread is its own context — no existing-conversation directive.
-    expect(create.mock.calls[0][2]).not.toHaveProperty("conversation")
-    // The plan rides back so the card can refuse to show a reply that landed in
-    // a different (thread) conversation than the one it renders.
-    expect(res).toEqual({ message: { id: "msg_new" }, plan: { kind: "newThread", parentMessageId: "msg_open" } })
+    expect(queueDraftMessage.mock.calls[0][1]).not.toHaveProperty("conversation")
+    // The plan rides back so the composer shows the "posted to a new thread" note.
+    expect(res).toEqual({ plan: { kind: "newThread", parentMessageId: "msg_open" } })
   })
 
-  it("keeps a multi-message channel reply flat, attached to the conversation (no thread)", async () => {
-    const { create, createStream } = mockReplyDeps()
+  it("keeps a multi-message channel reply flat, attached to the conversation via the existing directive", async () => {
+    const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
@@ -356,21 +353,21 @@ describe("useReplyToBoardPost", () => {
       })
     })
 
-    expect(createStream).not.toHaveBeenCalled()
-    expect(create).toHaveBeenCalledWith(
-      WORKSPACE_ID,
-      "chan_1",
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contentJson: DOC }),
       expect.objectContaining({
         streamId: "chan_1",
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
     )
-    // intoConversation → the card may show it in place.
+    // No stream creation — it attaches to the existing conversation in place.
+    expect(queueDraftMessage.mock.calls[0][1]).not.toHaveProperty("streamCreation")
+    // intoConversation → the card shows it in place.
     expect(res?.plan).toEqual({ kind: "intoConversation" })
   })
 
   it("replies straight into a thread card's own stream via the existing directive", async () => {
-    const { create, createStream } = mockReplyDeps()
+    const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
@@ -384,11 +381,12 @@ describe("useReplyToBoardPost", () => {
       })
     })
 
-    expect(createStream).not.toHaveBeenCalled()
-    expect(create).toHaveBeenCalledWith(
-      WORKSPACE_ID,
-      "thread_x",
-      expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_thread" } })
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contentJson: DOC }),
+      expect.objectContaining({
+        streamId: "thread_x",
+        conversation: { intent: "existing", conversationId: "conv_thread" },
+      })
     )
   })
 })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -3,17 +3,18 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tansta
 import {
   useConversationService,
   useMessageService,
-  useStreamService,
   useSocket,
   useSocketReconnectCount,
+  createDraftPanelId,
 } from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import { seedBoardPosts, optimisticBoardReply } from "@/stores/board-store"
+import { seedBoardPosts } from "@/stores/board-store"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
+import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import { StreamTypes } from "@threa/types"
-import type { CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent, Message } from "@threa/types"
+import type { CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent } from "@threa/types"
 
 /**
  * Where a board post lands: an existing channel/DM the user picked, or a
@@ -197,6 +198,8 @@ export interface ReplyToBoardPostInput {
   messageCount: number
   contentJson: JSONContent
   attachmentIds?: string[]
+  /** Full attachment info for the optimistic event so files render in place. */
+  attachments?: AttachmentSummary[]
 }
 
 /**
@@ -232,17 +235,19 @@ export function planBoardReply(input: {
 }
 
 /**
- * Reply to a board post from the feed, routed by {@link planBoardReply}. Returns
- * the created message AND the resolved plan so the caller knows where it landed:
- * a `newThread` reply lives in a brand-new thread stream (its own conversation),
- * NOT this card's conversation, so the card must not show it in place — only an
- * `intoConversation` reply belongs under the card that produced it. Board-wide
- * liveness/optimism across cards is a follow-up (no cache writes here).
+ * Reply to a board post from the feed, routed by {@link planBoardReply}. Eager
+ * and offline-first: the reply is written as an optimistic `message_created`
+ * event into the same `db.events` rail the card reads (and a durable pending row
+ * the background queue drains), so it shows the instant the user sends — no
+ * round-trip — exactly like a stream send. The server echo swaps the optimistic
+ * event for the real one. Returns only the resolved plan: a `newThread` reply
+ * lives in a brand-new thread stream (its own conversation), surfacing as its
+ * own board post, NOT under this card; an `intoConversation` reply is tagged
+ * with the target conversation so it renders in place under the card that
+ * produced it (see `useQueueDraftMessage` / `useBoardCardMessages`).
  */
 export function useReplyToBoardPost(workspaceId: string) {
-  const messageService = useMessageService()
-  const streamService = useStreamService()
-  const queryClient = useQueryClient()
+  const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
 
   return useMutation({
     mutationFn: async ({
@@ -252,61 +257,41 @@ export function useReplyToBoardPost(workspaceId: string) {
       messageCount,
       contentJson,
       attachmentIds,
-    }: ReplyToBoardPostInput): Promise<{ message: Message; plan: BoardReplyPlan }> => {
-      const base = {
+      attachments,
+    }: ReplyToBoardPostInput): Promise<{ plan: BoardReplyPlan }> => {
+      const input = {
         contentJson,
         attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
-        clientMessageId: generateClientId(),
+        attachments: attachments && attachments.length > 0 ? attachments : undefined,
       }
 
       const plan = planBoardReply({ hostStreamType, messageCount, openingMessageId })
 
       if (plan.kind === "newThread") {
-        // Create-or-find is idempotent server-side on (parentStreamId,
-        // parentMessageId), so this can't double-create the thread.
-        const thread = await streamService.create(workspaceId, {
-          type: StreamTypes.THREAD,
-          parentStreamId: conversation.streamId,
-          parentMessageId: plan.parentMessageId,
+        // Promote a draft thread off the opening message, mirroring the timeline's
+        // thread-reply path (`stream-panel.tsx`): the queue create-or-finds the
+        // thread (idempotent server-side on (parentStreamId, parentMessageId))
+        // then sends into it. A lone channel/DM root is never E2E, so no sealing.
+        const panelId = createDraftPanelId(conversation.streamId, plan.parentMessageId)
+        await queueDraftMessage(input, {
+          workspaceId,
+          streamId: panelId,
+          streamCreation: {
+            type: StreamTypes.THREAD,
+            parentStreamId: conversation.streamId,
+            parentMessageId: plan.parentMessageId,
+          },
+          draftId: panelId,
         })
-        const message = await messageService.create(workspaceId, thread.id, { streamId: thread.id, ...base })
-        return { message, plan }
+        return { plan }
       }
 
-      const message = await messageService.create(workspaceId, conversation.streamId, {
+      await queueDraftMessage(input, {
+        workspaceId,
         streamId: conversation.streamId,
-        ...base,
         conversation: { intent: "existing", conversationId: conversation.id },
       })
-      // Optimistically reflect the reply on the board's IDB feed: the card jumps
-      // to the top and shows the reply before the round-trip's `conversation:updated`
-      // echo merges over it (clearing pending). The echo carries only the
-      // aggregate, so this preview is the lasting one until the next seed —
-      // correct for a text reply, but it can't show attachments/previews.
-      void optimisticBoardReply(
-        conversation.id,
-        {
-          id: message.id,
-          authorId: message.authorId,
-          authorType: message.authorType,
-          contentMarkdown: message.contentMarkdown,
-          reactions: message.reactions,
-          attachments: [],
-          linkPreviews: [],
-          createdAt: message.createdAt,
-        },
-        Date.parse(message.createdAt) || Date.now()
-      )
-      // A reply with attachments can't be previewed fully from the optimistic
-      // row (the message wire shape carries no attachment summaries), so refetch
-      // the board head to backfill them; the text/bump still showed instantly.
-      if (base.attachmentIds) {
-        void queryClient.invalidateQueries({
-          queryKey: [...conversationKeys.all, "workspaceList", workspaceId],
-          refetchType: "active",
-        })
-      }
-      return { message, plan }
+      return { plan }
     },
   })
 }

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -242,6 +242,10 @@ export function useMessageQueue(): void {
             attachmentIds: next.attachmentIds,
             clientMessageId: next.clientId,
             confirmedPrivacyWarning: next.confirmedPrivacyWarning,
+            // A board reply declares its conversation so the send attaches it
+            // synchronously (in the message's transaction) instead of waiting on
+            // the async extractor; omitted on ordinary sends.
+            conversation: next.conversation,
           })
         }
 

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -4,7 +4,7 @@ import { useUser } from "@/auth"
 import { useWorkspaceUsers } from "@/stores/workspace-store"
 import { db, sequenceToNum, type CachedStream, type PendingStreamCreation } from "@/db"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import { StreamTypes, Visibilities, type JSONContent, type StreamEvent } from "@threa/types"
+import { StreamTypes, Visibilities, type ConversationDirective, type JSONContent, type StreamEvent } from "@threa/types"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { optimisticReplyCountUpdate } from "@/sync/stream-sync"
 import { sealOutgoingMessage, type SealOutgoingMessageResult } from "@/lib/crypto/seal-send"
@@ -20,12 +20,23 @@ export interface QueueDraftMessageInput {
 
 export interface QueueDraftMessageParams {
   workspaceId: string
-  /** The draft/synthetic streamId used for the optimistic event */
+  /** The streamId the optimistic event is written under — a draft/synthetic id
+   *  when `streamCreation` is set, or a real stream id for a send into one that
+   *  already exists (a board reply attaching to an existing conversation). */
   streamId: string
-  /** Stream creation metadata for the background queue */
-  streamCreation: PendingStreamCreation
-  /** The draft ID to clean up after promotion (may differ from streamId for threads) */
-  draftId: string
+  /** Stream creation metadata for the background queue. Omit to send into the
+   *  existing `streamId` (no promotion). */
+  streamCreation?: PendingStreamCreation
+  /**
+   * Conversation directive forwarded on send (see {@link ConversationDirective}).
+   * `existing` also tags the optimistic event's payload with `conversationId` so
+   * a board card can surface the pending reply under the right conversation
+   * before the server echo lands. Omit to let the async extractor infer.
+   */
+  conversation?: ConversationDirective
+  /** The draft ID to clean up after promotion (may differ from streamId for
+   *  threads). Omit when there is no draft to clean up (an existing-stream send). */
+  draftId?: string
   /**
    * Set when this draft lives under an end-to-end-encrypted root (a thread reply
    * in an encrypted scratchpad). The promoted stream inherits the root's SSK
@@ -40,8 +51,12 @@ export interface QueueDraftMessageParams {
 }
 
 /**
- * Writes an optimistic event to IDB and enqueues the message + stream creation
- * for the background queue, so components don't import @/db directly.
+ * Writes an optimistic event to IDB and enqueues the message for the background
+ * queue, so components don't import @/db directly. Handles both the
+ * stream-creation path (a scratchpad/thread draft promoted on first send) and a
+ * plain send into an existing stream (a board reply, via the `conversation`
+ * directive) — the queue drain forwards whichever fields are set. Returns the
+ * generated `clientId` so the caller can correlate the optimistic event.
  */
 export function useQueueDraftMessage(workspaceId: string) {
   const user = useUser()
@@ -50,7 +65,7 @@ export function useQueueDraftMessage(workspaceId: string) {
   const { markPending, notifyQueue } = usePendingMessages()
 
   const queueDraftMessage = useCallback(
-    async (input: QueueDraftMessageInput, params: QueueDraftMessageParams) => {
+    async (input: QueueDraftMessageInput, params: QueueDraftMessageParams): Promise<{ clientId: string }> => {
       if (!currentUserId) {
         throw new Error("Cannot send message: user identity not resolved yet")
       }
@@ -73,6 +88,11 @@ export function useQueueDraftMessage(workspaceId: string) {
           // contentMarkdown + contentJson) — without it an encrypted thread reply
           // would flash the opaque placeholder for its own author.
           contentJson: input.contentJson,
+          // Tag the optimistic reply with its target conversation so a board card
+          // surfaces it under the right card before the server echo (which carries
+          // the real id in the conversation aggregate) lands. Read-side only; the
+          // timeline ignores it, and the row is swapped for the real event on echo.
+          ...(params.conversation?.intent === "existing" ? { conversationId: params.conversation.conversationId } : {}),
           ...(input.attachments && input.attachments.length > 0 ? { attachments: input.attachments } : {}),
         },
         actorId: currentUserId,
@@ -133,6 +153,7 @@ export function useQueueDraftMessage(workspaceId: string) {
         createdAt: Date.now(),
         retryCount: 0,
         streamCreation: params.streamCreation,
+        conversation: params.conversation,
         draftId: params.draftId,
         ...(e2eFields
           ? { ciphertext: e2eFields.ciphertext, envelope: e2eFields.envelope, e2eVersion: e2eFields.e2eVersion }
@@ -151,8 +172,8 @@ export function useQueueDraftMessage(workspaceId: string) {
       // Surface the committed draft in the sidebar and quick switcher so the
       // user can navigate back to it even before the real stream exists. The
       // promotion step will replace this entry with the server-assigned one.
-      if (params.streamCreation.type === StreamTypes.SCRATCHPAD) {
-        const draftScratchpad = await db.draftScratchpads.get(params.draftId)
+      if (params.streamCreation?.type === StreamTypes.SCRATCHPAD) {
+        const draftScratchpad = params.draftId ? await db.draftScratchpads.get(params.draftId) : undefined
         const optimisticStream: CachedStream = {
           id: params.streamId,
           workspaceId: params.workspaceId,
@@ -186,7 +207,7 @@ export function useQueueDraftMessage(workspaceId: string) {
       // bumping its replyCount. The promotion step swaps the threadId to the
       // real thread stream without re-incrementing.
       if (
-        params.streamCreation.type === StreamTypes.THREAD &&
+        params.streamCreation?.type === StreamTypes.THREAD &&
         params.streamCreation.parentStreamId &&
         params.streamCreation.parentMessageId
       ) {
@@ -202,6 +223,8 @@ export function useQueueDraftMessage(workspaceId: string) {
       }
 
       notifyQueue()
+
+      return { clientId }
     },
     [currentUserId, markPending, notifyQueue]
   )

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { seedBoardPosts, mergeBoardConversation, optimisticBoardReply } from "./board-store"
+import { seedBoardPosts, mergeBoardConversation } from "./board-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 
 const WORKSPACE_ID = "ws_1"
@@ -101,40 +101,13 @@ describe("mergeBoardConversation", () => {
     expect(await readBoard()).toHaveLength(0)
   })
 
-  it("clears the optimistic pending flag when the authoritative echo merges over it", async () => {
+  it("clears a pending flag when the authoritative echo merges over it", async () => {
     await seedBoardPosts(WORKSPACE_ID, [makePost("conv_1", "2026-06-20T12:00:00.000Z")])
-    await optimisticBoardReply("conv_1", makeMessage("r1"), Date.parse("2026-06-21T12:00:00.000Z"))
-    expect((await db.conversations.get("conv_1"))?._status).toBe("pending")
+    // A row left pending by an in-flight optimistic write (the reply rides the
+    // events rail now; the projection row can still be flagged pending elsewhere).
+    const seeded = await db.conversations.get("conv_1")
+    await db.conversations.put({ ...seeded!, _status: "pending" })
     await mergeBoardConversation("conv_1", makeConversation("conv_1", "2026-06-21T12:00:05.000Z"))
     expect((await db.conversations.get("conv_1"))?._status).toBeUndefined()
-  })
-})
-
-describe("optimisticBoardReply", () => {
-  it("appends the reply, bumps activity to the top, and marks the row pending", async () => {
-    await seedBoardPosts(WORKSPACE_ID, [
-      makePost("conv_1", "2026-06-20T12:00:00.000Z"),
-      makePost("conv_2", "2026-06-21T12:00:00.000Z"),
-    ])
-    await optimisticBoardReply("conv_1", makeMessage("r1"), Date.parse("2026-06-22T12:00:00.000Z"))
-    const board = await readBoard()
-    expect(board.map((p) => p.id)).toEqual(["conv_1", "conv_2"])
-    expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r1"])
-    expect(board[0]?.totalReplies).toBe(1)
-    expect(board[0]?._status).toBe("pending")
-  })
-
-  it("caps the preview at the latest three replies", async () => {
-    await seedBoardPosts(WORKSPACE_ID, [
-      makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1"), makeMessage("r2"), makeMessage("r3")]),
-    ])
-    await optimisticBoardReply("conv_1", makeMessage("r4"), Date.parse("2026-06-22T12:00:00.000Z"))
-    const row = await db.conversations.get("conv_1")
-    expect(row?.recentMessages.map((m) => m.id)).toEqual(["r2", "r3", "r4"])
-  })
-
-  it("is a no-op when the conversation isn't cached", async () => {
-    await optimisticBoardReply("conv_absent", makeMessage("r1"), Date.now())
-    expect(await readBoard()).toHaveLength(0)
   })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedBoardPost } from "@/db"
-import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+import type { BoardPost, ConversationWithStaleness } from "@threa/types"
 
 /**
  * How many trailing replies a board card previews. Mirrors the backend's
@@ -82,41 +82,5 @@ export async function mergeBoardConversation(
       _status: undefined,
     })
     return true
-  })
-}
-
-/**
- * Optimistically reflect the viewer's own reply into a visible card: append the
- * message to the preview, bump activity to `atMs`, and mark the row pending until
- * the authoritative `conversation:updated` echo merges over it. No-op when the
- * card isn't cached (a reply into a not-yet-seen conversation surfaces via the
- * event path).
- *
- * The `_lastActivityMs` bump is IDB truth (it re-sorts the live feed and a fresh
- * snapshot lands the card at the top), but the stable view holds a committed
- * card's position frozen, so the reply shows in place — it does not yank the card
- * to the top under the reader (`use-stable-board-view`, INV-61).
- */
-export async function optimisticBoardReply(
-  conversationId: string,
-  message: BoardPostMessage,
-  atMs: number
-): Promise<void> {
-  // Read-modify-write in one rw transaction so it can't race the authoritative
-  // echo's merge through a stale read. Dedup by id so a retry can't double-append.
-  await db.transaction("rw", db.conversations, async () => {
-    const existing = await db.conversations.get(conversationId)
-    if (!existing) return
-    if (existing.recentMessages.some((m) => m.id === message.id)) return
-    const recentMessages = [...existing.recentMessages, message].slice(-RECENT_PREVIEW_CAP)
-    await db.conversations.put({
-      ...existing,
-      conversation: { ...existing.conversation, lastActivityAt: new Date(atMs).toISOString() },
-      recentMessages,
-      totalReplies: existing.totalReplies + 1,
-      _lastActivityMs: atMs,
-      _cachedAt: Date.now(),
-      _status: "pending",
-    })
   })
 }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1102,6 +1102,142 @@ describe("registerStreamSocketHandlers — E2E send reconciliation seeds the dec
 })
 
 // ---------------------------------------------------------------------------
+// Board reply: the swap carries the optimistic conversationId onto the real event
+// ---------------------------------------------------------------------------
+
+describe("registerStreamSocketHandlers — board reply conversationId carry-forward", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.pendingMessages.clear()
+  })
+
+  it("carries the optimistic event's conversationId onto the real event so the board card doesn't blink the reply out", async () => {
+    const streamId = "stream_board_reply"
+
+    // The optimistic board reply tags its event with the target conversation.
+    await db.events.put({
+      id: "temp_reply",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "1700000000000",
+      _sequenceNum: 1700000000000,
+      eventType: "message_created",
+      payload: {
+        messageId: "temp_reply",
+        contentMarkdown: "my reply",
+        contentJson: { type: "doc", content: [] },
+        conversationId: "conv_42",
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    // The server echo carries clientMessageId but NOT conversationId (that rides a
+    // separate conversation:updated). The swap must carry it forward.
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: "msg_real",
+        streamId,
+        sequence: "5",
+        eventType: "message_created",
+        payload: {
+          messageId: "msg_real",
+          clientMessageId: "temp_reply",
+          contentMarkdown: "my reply",
+          contentJson: { type: "doc", content: [] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    expect(await db.events.get("temp_reply")).toBeUndefined()
+    const real = await db.events.get("msg_real")
+    expect((real?.payload as { conversationId?: string }).conversationId).toBe("conv_42")
+
+    cleanup()
+  })
+
+  it("leaves an ordinary send (no optimistic conversationId) untagged", async () => {
+    const streamId = "stream_plain_send"
+
+    await db.events.put({
+      id: "temp_plain",
+      workspaceId: "ws_1",
+      streamId,
+      sequence: "1700000000001",
+      _sequenceNum: 1700000000001,
+      eventType: "message_created",
+      payload: { messageId: "temp_plain", contentMarkdown: "hi", contentJson: { type: "doc", content: [] } },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _status: "pending",
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    await emit("message:created", {
+      workspaceId: "ws_1",
+      streamId,
+      event: {
+        id: "msg_plain",
+        streamId,
+        sequence: "6",
+        eventType: "message_created",
+        payload: {
+          messageId: "msg_plain",
+          clientMessageId: "temp_plain",
+          contentMarkdown: "hi",
+          contentJson: { type: "doc", content: [] },
+        },
+        actorId: "user_1",
+        actorType: "user",
+        createdAt: new Date().toISOString(),
+      },
+    })
+
+    const real = await db.events.get("msg_plain")
+    expect((real?.payload as { conversationId?: string }).conversationId).toBeUndefined()
+
+    cleanup()
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Sequence gap detection — live events that skip past the cached tail
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -667,14 +667,40 @@ export function registerStreamSocketHandlers(
         gapAfterSequence = detectSequenceGap(await getPersistedTail(streamId), newEvent)
       }
 
-      // Add the real event BEFORE deleting the optimistic one so that
-      // Dexie live-query observers never see a frame with neither event.
-      await db.events.put({ ...newEvent, workspaceId, _sequenceNum: sequenceToNum(newEvent.sequence), _cachedAt: now })
-
-      // Now remove the optimistic event, keyed by the client id the server echoes back.
+      // Read the optimistic row (keyed by the client id the server echoes back)
+      // BEFORE writing the real event, so we can carry forward state the server
+      // event doesn't itself carry.
+      let carriedConversationId: string | undefined
       if (newPayload.clientMessageId) {
         const optimistic = await db.events.get(newPayload.clientMessageId)
         optimisticPlaintext = readPlaintextContent(optimistic?.payload)
+        // A board reply tags its optimistic event with the conversation it
+        // attaches to; the server `message:created` does NOT carry that (the
+        // conversation aggregate rides a separate `conversation:updated`). Carry
+        // it onto the real event so the board card keeps showing the reply in the
+        // window between this swap and the aggregate update — otherwise the row
+        // would blink out (its id isn't in `conversation.messageIds` yet, and the
+        // optimistic copy is about to be deleted). Read-side only; ignored by the
+        // timeline. See `useBoardCardMessages`.
+        carriedConversationId = (optimistic?.payload as { conversationId?: string } | undefined)?.conversationId
+      }
+
+      // Add the real event BEFORE deleting the optimistic one so that
+      // Dexie live-query observers never see a frame with neither event.
+      const eventToStore = carriedConversationId
+        ? {
+            ...newEvent,
+            payload: { ...(newEvent.payload as Record<string, unknown>), conversationId: carriedConversationId },
+          }
+        : newEvent
+      await db.events.put({
+        ...eventToStore,
+        workspaceId,
+        _sequenceNum: sequenceToNum(newEvent.sequence),
+        _cachedAt: now,
+      })
+
+      if (newPayload.clientMessageId) {
         await db.events.delete(newPayload.clientMessageId).catch(() => {})
         await db.pendingMessages.delete(newPayload.clientMessageId).catch(() => {})
       }


### PR DESCRIPTION
**Tracking:** board live/offline-first follow-up #1 (eager optimistic sends) — builds on #1106 (`f72a564`) and #1109 (`83bc1d0`). No Linear ticket.

## Problem

Replying to a board card needed a network round-trip before anything showed. `useReplyToBoardPost` **awaited** `messageService.create(...)` (`apps/frontend/src/hooks/use-conversations.ts`), and only then ran two post-hoc mechanisms to reflect the reply:

- `optimisticBoardReply` (`stores/board-store.ts`) — a projection re-sort that appended the *server's* message to `recentMessages` and bumped `lastActivityAt`, keyed by the real id (so it couldn't run before the round-trip).
- the card's `onReplied(message)` → `localReplies` React state (`components/board/board-card.tsx`), deduped against the rail by id.

So a reply visibly lagged the send by a round-trip — the opposite of a stream send, where the composer writes an optimistic `message_created` event to `db.events` *before* the POST and the message appears instantly. The user's words: "when I send, it should immediately show up, like streams do — not a round trip." It was also two parallel optimistic implementations (`localReplies` + `optimisticBoardReply`) layered on top of the rail the card already reads, against INV-35/37 (one path).

## Solution

Route board replies through the **same optimistic-event send queue** stream messages use. The reply is written as an optimistic `message_created` event into the `db.events` rail (and a durable pending row the background queue drains) before the request; the server echo swaps it for the real event. Since threads *are* streams, "same as a stream send" is free.

### How it works

1. **`useReplyToBoardPost` enqueues, doesn't await a POST.** It computes the plan (`planBoardReply`, unchanged) and calls `useQueueDraftMessage`, returning only `{ plan }`:
   - `intoConversation` → `queueDraftMessage(input, { streamId: conversation.streamId, conversation: { intent: "existing", conversationId } })`. The optimistic event is tagged with `payload.conversationId`.
   - `newThread` → `queueDraftMessage(input, { streamId: draftPanelId, streamCreation: { type: THREAD, parentStreamId, parentMessageId }, draftId: draftPanelId })`, mirroring the timeline thread-reply path in `components/thread/stream-panel.tsx`. The queue create-or-finds the thread (idempotent server-side) then sends; it surfaces as its own board post.
2. **`useQueueDraftMessage` generalized** (was scratchpad/thread-draft only): `streamCreation` and `draftId` are now optional, and it accepts a `conversation` directive for a send into an existing stream. When `conversation.intent === "existing"` it tags the optimistic event payload with `conversationId`. The scratchpad/thread side-effects are guarded behind `params.streamCreation?.`. Returns the generated `clientId`.
3. **`PendingMessage` carries the directive.** `db/database.ts` adds `conversation?: ConversationDirective`; the queue drain (`use-message-queue.ts`) forwards `conversation: next.conversation` on the plaintext `messageService.create`, so a declared reply attaches to its conversation synchronously in the message's transaction (the backend's `conversationAssigner` runs in the same txn, emitting `conversation:updated` in the same outbox batch as `message:created`).
4. **The card reads the pending reply off the rail.** `useBoardCardMessages` builds `rail.pendingByConversation` — in-flight events (`_status` `pending` or `failed`) carrying `payload.conversationId`, grouped by conversation — and returns `pendingReplies` for the card. `board-card.tsx` appends them in place (`[...replies, ...pendingReplies]`, deduped by id), exactly where `localReplies` used to go. On echo, `handleMessageCreated` swaps the optimistic event for the real one (keyed by `clientMessageId`) and `mergeBoardConversation` lands the real id in `messageIds`, so the reply renders via `replyIds` and `pendingByConversation` empties — no duplicate.
5. **Deleted the parallel machinery:** `optimisticBoardReply` and the `localReplies`/`onReplied` state are gone (INV-35/37).

### Key design decisions

**1. Tag the optimistic event with `conversationId` rather than inserting the clientId into `messageIds`.** The card derives `replyIds` from `post.conversation.messageIds`; if the optimistic clientId were added there, `conversationSeen` would flip to the events source on a cold card and the previously-shown projection replies (whose ids aren't in the rail yet) would collapse into a "N more" gap the moment the user replies — a visible regression. Tagging via `pendingByConversation` keeps the optimistic reply additive (the exact semantics the deleted `localReplies` had), so it layers on top of either the projection or the events view without disturbing the count or the contiguity model (INV-61).

**2. E2E hosts are blocked, not sealed.** A board reply into an end-to-end-encrypted host is refused up front in `board-reply-composer.tsx` with a `toast.error` pointing the user to open the note to reply there, keeping the draft. Reason, verified in the code: the send path here is plaintext (a sealed send is rejected by INV-E1), and even if sealed, the boundary extractor *skips E2E streams* (`apps/backend/src/features/conversations/boundary-extraction-outbox-handler.ts:40`) and the E2E send schema (`createMessageE2eToStreamSchema`, `apps/backend/src/features/messaging/handlers.ts`) has no `conversation` field — so an E2E reply could never be assigned to the card's conversation and would silently vanish after the echo. Blocking matches the prior behavior (E2E board replies always errored) without queuing a doomed, stuck-pending send. E2E board replies belong to the separate encrypted-streams workstream.

**3. Reuse `useQueueDraftMessage` instead of a third optimistic-event builder.** The optimistic-event + pending-row construction already existed in two places (`useRealStream.sendMessage` and `useQueueDraftMessage`). Generalizing the latter (which exists "so components don't import `@/db` directly") to also cover the no-creation case keeps one builder rather than adding a third copy (INV-35/37).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-conversations.ts` | `useReplyToBoardPost` rewritten: eager enqueue via `useQueueDraftMessage`, returns `{ plan }`; drops the awaited POST + `optimisticBoardReply` + attachment refetch. `ReplyToBoardPostInput` gains `attachments?`. |
| `apps/frontend/src/hooks/use-queue-draft-message.ts` | Generalized: optional `streamCreation`/`draftId`, new `conversation` directive (tags optimistic `payload.conversationId`), returns `{ clientId }`; side-effects guarded behind `streamCreation?.`. |
| `apps/frontend/src/db/database.ts` | `PendingMessage.conversation?: ConversationDirective`. |
| `apps/frontend/src/hooks/use-message-queue.ts` | Drain forwards `conversation: next.conversation` on the plaintext create. |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | Rail builds `pendingByConversation`; hook returns `pendingReplies` (both projection + events branches). |
| `apps/frontend/src/components/board/board-card.tsx` | Removed `localReplies` state + `onReplied`; appends `pendingReplies` in place. |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Removed `onReplied`; routes by plan synchronously; blocks E2E hosts with a toast; passes `attachments` through. |
| `apps/frontend/src/stores/board-store.ts` | Deleted `optimisticBoardReply` (+ its `BoardPostMessage` import). |

## Out of scope (deliberate)

- **E2E board replies** — blocked, not implemented (see decision 2); belongs to the encrypted-streams workstream.
- **`newThread` eager-in-card display** — a new thread is its own conversation and surfaces as its own board post (unchanged); the composer's "Posted to a new thread" resting note remains its feedback.
- **Soft-delete projection divergence** (handover #3), **strict viewport gating** (#4), **device verification** (#5) — untouched.

## Known residuals (honest)

- **Sub-frame echo seam.** `intoConversation` reply: between `message:created` (swaps the optimistic event → real, dropping it from `pendingByConversation`) and `conversation:updated` (lands the real id in `messageIds` so it renders via `replyIds`), there's a window where the real reply is in neither set. Both events ride the same outbox batch, so it's sub-frame at idle. The old `localReplies` avoided it by holding the *real* id in React state post-round-trip — but that's exactly the parallel machinery this PR removes, and a bounded rail-only bridge isn't possible without accumulating every historical board reply. Accepted as the cost of the one-path design.
- **No permanent-failure UI on the board card.** A reply that fails *permanently* (rare now that E2E is blocked; transient failures self-heal via the queue's retry/backoff, and the reply stays visible across that window — see the follow-up commit) shows as a normal reply with no error/retry affordance. The board card has never rendered send-status; threading that in is a separate concern.

## Test plan

- [x] `apps/frontend` vitest, 8 affected suites — 112 pass (`use-conversations`, `use-board-card-messages`, `use-queue-draft-message`, `use-message-queue`, `stream-sync`, `board-store`, `pages/board`, `components/board`)
- [x] Rewrote `useReplyToBoardPost` tests for the eager-queue behavior; added `pendingByConversation` tests in `use-board-card-messages` (incl. the failed/mid-backoff case); updated `board-store` tests (removed `optimisticBoardReply`)
- [x] Full monorepo lint + `tsc --noEmit` (all apps/packages) clean via the pre-commit hook (twice)
- [x] Pre-PR review (3 Sonnet agents: spec+design, correctness+data-flow, UX; Mobile skipped — no layout/CSS/touch surface). No correctness or security findings. 2 fixes applied (reply stays visible across retry-backoff; actionable E2E toast); 3 dismissed (the `hiddenCount`/gap formula is byte-identical to pre-merge — pre-existing, not introduced; the sub-frame echo seam is the documented one-path tradeoff; permanent-failure UI is out of scope as above)
- [ ] Not device-verified on a real phone — no live backend in this session; the optimistic→real echo handoff is exercised by `stream-sync` unit tests, not an end-to-end run

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Make board replies eager + offline-first — appear the instant they're sent, like stream sends — by routing them through the optimistic-event send queue, and delete the parallel post-hoc optimistic machinery (INV-35/37).

**What was built:**
- `useReplyToBoardPost` enqueues via `useQueueDraftMessage` (no awaited POST); returns `{ plan }`. `intoConversation` tags the optimistic event with the target conversation; `newThread` promotes a draft thread like `stream-panel.tsx`.
- `useQueueDraftMessage` generalized to also send into an existing stream with a `conversation` directive; returns `clientId`.
- `PendingMessage.conversation` directive forwarded by the queue drain so the reply attaches synchronously server-side.
- `useBoardCardMessages` surfaces optimistic pending replies by conversation (`pendingByConversation`); `board-card` appends them in place, replacing `localReplies`.
- Deleted `optimisticBoardReply`; deleted `localReplies`/`onReplied`.
- E2E hosts blocked at the composer (extractor skips E2E; E2E schema has no conversation field).

**Design decisions:**
1. Tag optimistic event with `conversationId` instead of mutating `messageIds` — avoids a cold-card regression where prior projection replies collapse into a gap; keeps the reply additive (INV-61 undisturbed).
2. Block E2E rather than seal — a sealed reply could never be conversation-assigned (extractor skip + schema gap) and would vanish after echo; blocking matches prior behavior without a stuck-pending send.
3. Reuse `useQueueDraftMessage` rather than a third optimistic-event builder (INV-35/37).

**Design evolution (self-review):** First cut wired full E2E sealing for board replies (threading `e2e` params through). On verifying the backend, found the boundary extractor skips E2E streams and the E2E send schema omits `conversation` — so a sealed reply would send but never be assigned to the card's conversation, then silently vanish after the echo. Reverted the sealing and replaced it with an explicit composer-level block, which matches the prior (always-errored) behavior without introducing a stuck-pending send. A second self-review pass also kept a reply visible across retry-backoff (the rail groups in-flight `pending` *and* `failed` events) and made the E2E toast actionable.

**Schema changes:** none (IDB `PendingMessage` gains an optional field; no DB migration).

**What's NOT included:** E2E board replies (blocked), `newThread` eager-in-card display, soft-delete projection divergence, viewport gating, device verification.

**Status:** complete; committed and pushed.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9y1fHRs87jd4S8saGR2nk)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785300472&installation_id=129946197&pr_number=1111&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1111&signature=367f2e2dd5d46d81984bf88de96e80cd4c4cdc2092ac2ca7f917e7a06fa8636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->