### PR TITLE
fix(board): board replies always land flat in the conversation

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -158,7 +158,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         )}
       </div>
 
-      <BoardReplyComposer workspaceId={workspaceId} post={post} hostStreamType={streamType} />
+      <BoardReplyComposer workspaceId={workspaceId} post={post} />
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -21,25 +21,17 @@ import type { BoardPost, JSONContent } from "@threa/types"
 const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
 
 // Resting-affordance state. `draft` signals a persisted-but-collapsed reply (so
-// the user knows reopening restores it); `posted` is a transient confirmation
-// that a new-thread reply went through — it stands in for the in-place echo a
-// same-conversation reply gets, since a new-thread reply lands in its own
-// conversation and only surfaces on the next board load.
-type RestingState = "idle" | "draft" | "posted"
+// the user knows reopening restores it). A sent reply needs no resting note: it
+// lands in place under the card, so the visible echo is the confirmation.
+type RestingState = "idle" | "draft"
 const RESTING_LABEL: Record<RestingState, string> = {
   idle: "Write a reply…",
   draft: "Continue reply…",
-  posted: "Posted to a new thread",
 }
-// How long the transient "posted" confirmation stays before the affordance
-// returns to its normal invitation.
-const POSTED_NOTE_MS = 4000
 
 interface BoardReplyComposerProps {
   workspaceId: string
   post: BoardPost
-  /** Host stream type of the post's conversation, selecting the reply routing. */
-  hostStreamType: string | undefined
 }
 
 /**
@@ -50,12 +42,11 @@ interface BoardReplyComposerProps {
  * mirrors the composer's own container — same radius, border, surface, padding,
  * and placeholder — and the composer mounts already open (`initialMobileChromeOpen`)
  * so the tap lands straight in the toolbar view instead of stepping through the
- * mobile compacted phase. Routing — channel → thread, everything else → the
- * conversation — lives in {@link useReplyToBoardPost}.
+ * mobile compacted phase. The send always lands flat in the conversation (see
+ * {@link useReplyToBoardPost}), so the reply shows in place under this card.
  *
  * The resting affordance carries state (best-effort, in-session): it flags a
- * persisted draft after an Escape ("Continue reply…") and a transient "Posted to
- * a new thread" confirmation after a new-thread send, so a collapse never reads
+ * persisted draft after an Escape ("Continue reply…") so a collapse never reads
  * as a no-op or an accidental discard.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
@@ -74,17 +65,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     }
   }, [open])
 
-  // Let the transient "posted" confirmation fade back to the normal invitation.
-  useEffect(() => {
-    if (resting !== "posted") return
-    const timer = window.setTimeout(() => setResting("idle"), POSTED_NOTE_MS)
-    return () => window.clearTimeout(timer)
-  }, [resting])
-
-  const close = useCallback((opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => {
+  const close = useCallback((opts?: { refocus?: boolean; hadContent?: boolean }) => {
     refocusOnCollapseRef.current = opts?.refocus ?? false
-    if (opts?.posted) setResting("posted")
-    else if (opts?.hadContent) setResting("draft")
+    if (opts?.hadContent) setResting("draft")
     else setResting("idle")
     setOpen(false)
   }, [])
@@ -100,9 +83,6 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
         }}
         className="mt-3 flex w-full min-w-0 items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        {/* Label-only confirmation: the text IS the in-place signal. No leading
-            icon — adding one only in the "posted" state would shift the label
-            (INV-21) and misalign the resting text against the open composer's. */}
         <span className="truncate">{RESTING_LABEL[resting]}</span>
       </button>
     )
@@ -114,10 +94,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
 function BoardReplyComposerForm({
   workspaceId,
   post,
-  hostStreamType,
   onClose,
 }: BoardReplyComposerProps & {
-  onClose: (opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => void
+  onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
 }) {
   const { preferences } = usePreferences()
   const streams = useWorkspaceStreams(workspaceId)
@@ -197,17 +176,11 @@ function BoardReplyComposerForm({
     composer.setIsSending(true)
     try {
       // Eager + offline-first: the reply is enqueued as an optimistic event and
-      // shows in place immediately (an `intoConversation` reply rides the card's
-      // own rail; a `newThread` reply lands in its own thread, surfacing as its
-      // own board post on the next load). The send drains in the background, so
-      // there's no created message to await here — only the resolved plan, which
-      // selects the resting note: the visible in-place reply is the feedback for
-      // the former, the transient "Posted to a new thread" note for the latter.
-      const { plan } = await reply.mutateAsync({
+      // shows in place immediately, riding the card's own rail. The send drains
+      // in the background, so there's no created message to await here — the
+      // visible in-place reply is the feedback.
+      await reply.mutateAsync({
         conversation: post.conversation,
-        openingMessageId: post.openingMessage?.id ?? null,
-        hostStreamType,
-        messageCount: post.conversation.messageIds.length,
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
         attachments: attachments.length > 0 ? attachments : undefined,
@@ -215,7 +188,7 @@ function BoardReplyComposerForm({
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: true, posted: plan.kind === "newThread" })
+      onClose({ refocus: true })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")
     } finally {

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -9,13 +9,7 @@ import * as syncEngineModule from "@/sync/sync-engine"
 import * as draftScratchpadsModule from "./use-draft-scratchpads"
 import * as queueDraftModule from "./use-queue-draft-message"
 import { SocketEventGate } from "@/sync/socket-event-gate"
-import {
-  useConversations,
-  useCreateBoardPost,
-  useReplyToBoardPost,
-  planBoardReply,
-  conversationKeys,
-} from "./use-conversations"
+import { useConversations, useCreateBoardPost, useReplyToBoardPost, conversationKeys } from "./use-conversations"
 
 const WORKSPACE_ID = "ws_1"
 const STREAM_ID = "stream_1"
@@ -246,48 +240,6 @@ describe("useCreateBoardPost", () => {
   })
 })
 
-describe("planBoardReply", () => {
-  it("threads a lone root message in a channel or DM off the opening message", () => {
-    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 1, openingMessageId: "m1" })).toEqual({
-      kind: "newThread",
-      parentMessageId: "m1",
-    })
-    expect(planBoardReply({ hostStreamType: StreamTypes.DM, messageCount: 1, openingMessageId: "m1" })).toEqual({
-      kind: "newThread",
-      parentMessageId: "m1",
-    })
-  })
-
-  it("keeps a flat conversation with replies flat — no stray thread", () => {
-    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 3, openingMessageId: "m1" })).toEqual({
-      kind: "intoConversation",
-    })
-    expect(planBoardReply({ hostStreamType: StreamTypes.DM, messageCount: 2, openingMessageId: "m1" })).toEqual({
-      kind: "intoConversation",
-    })
-  })
-
-  it("replies into a thread conversation's own stream, even when it holds a single message", () => {
-    expect(planBoardReply({ hostStreamType: StreamTypes.THREAD, messageCount: 1, openingMessageId: "m1" })).toEqual({
-      kind: "intoConversation",
-    })
-  })
-
-  it("never threads a scratchpad, even a lone one", () => {
-    expect(planBoardReply({ hostStreamType: StreamTypes.SCRATCHPAD, messageCount: 1, openingMessageId: "m1" })).toEqual(
-      {
-        kind: "intoConversation",
-      }
-    )
-  })
-
-  it("stays flat when a lone root has been deleted (no anchor to thread off)", () => {
-    expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 1, openingMessageId: null })).toEqual({
-      kind: "intoConversation",
-    })
-  })
-})
-
 describe("useReplyToBoardPost", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -304,66 +256,30 @@ describe("useReplyToBoardPost", () => {
 
   const DOC = { type: "doc", content: [] }
 
-  it("threads a lone channel root off the opening message, promoting a draft thread (no directive)", async () => {
+  it("replies flat into a lone channel root's own stream via the existing directive (no new thread)", async () => {
     const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
 
-    let res: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined
     await act(async () => {
-      res = await result.current.mutateAsync({
+      await result.current.mutateAsync({
         conversation: { id: "conv_1", streamId: "chan_1" },
-        openingMessageId: "msg_open",
-        hostStreamType: StreamTypes.CHANNEL,
-        messageCount: 1,
         contentJson: DOC,
       })
     })
 
-    // The reply rides the durable queue with THREAD stream-creation, keyed on the
-    // draft panel id; no existing-conversation directive (a fresh thread is its
-    // own conversation).
+    // A board reply always joins the conversation in place — even a lone root
+    // attaches via the existing directive rather than promoting a draft thread,
+    // so the reply renders under the card it came from.
     expect(queueDraftMessage).toHaveBeenCalledWith(
       expect.objectContaining({ contentJson: DOC }),
       expect.objectContaining({
         workspaceId: WORKSPACE_ID,
-        streamId: "draft:chan_1:msg_open",
-        draftId: "draft:chan_1:msg_open",
-        streamCreation: { type: StreamTypes.THREAD, parentStreamId: "chan_1", parentMessageId: "msg_open" },
-      })
-    )
-    expect(queueDraftMessage.mock.calls[0][1]).not.toHaveProperty("conversation")
-    // The plan rides back so the composer shows the "posted to a new thread" note.
-    expect(res).toEqual({ plan: { kind: "newThread", parentMessageId: "msg_open" } })
-  })
-
-  it("keeps a multi-message channel reply flat, attached to the conversation via the existing directive", async () => {
-    const { queueDraftMessage } = mockReplyDeps()
-    const { wrapper } = createWrapper()
-    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
-
-    let res: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined
-    await act(async () => {
-      res = await result.current.mutateAsync({
-        conversation: { id: "conv_1", streamId: "chan_1" },
-        openingMessageId: "msg_open",
-        hostStreamType: StreamTypes.CHANNEL,
-        messageCount: 3,
-        contentJson: DOC,
-      })
-    })
-
-    expect(queueDraftMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ contentJson: DOC }),
-      expect.objectContaining({
         streamId: "chan_1",
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
     )
-    // No stream creation — it attaches to the existing conversation in place.
     expect(queueDraftMessage.mock.calls[0][1]).not.toHaveProperty("streamCreation")
-    // intoConversation → the card shows it in place.
-    expect(res?.plan).toEqual({ kind: "intoConversation" })
   })
 
   it("replies straight into a thread card's own stream via the existing directive", async () => {
@@ -374,9 +290,6 @@ describe("useReplyToBoardPost", () => {
     await act(async () => {
       await result.current.mutateAsync({
         conversation: { id: "conv_thread", streamId: "thread_x" },
-        openingMessageId: "msg_open",
-        hostStreamType: StreamTypes.THREAD,
-        messageCount: 2,
         contentJson: DOC,
       })
     })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -1,12 +1,6 @@
 import { useEffect } from "react"
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import {
-  useConversationService,
-  useMessageService,
-  useSocket,
-  useSocketReconnectCount,
-  createDraftPanelId,
-} from "@/contexts"
+import { useConversationService, useMessageService, useSocket, useSocketReconnectCount } from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { seedBoardPosts } from "@/stores/board-store"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
@@ -190,12 +184,6 @@ export function useCreateBoardPost(workspaceId: string) {
 export interface ReplyToBoardPostInput {
   /** The post's conversation — supplies the host stream and the attach target. */
   conversation: Pick<ConversationWithStaleness, "id" | "streamId">
-  /** The post's opening message id — the thread parent for a lone-message reply. */
-  openingMessageId: string | null
-  /** Host stream type (`channel` | `dm` | `scratchpad` | `thread` | undefined). */
-  hostStreamType: string | undefined
-  /** Count of messages in the conversation, deciding the lone-root case. */
-  messageCount: number
   contentJson: JSONContent
   attachmentIds?: string[]
   /** Full attachment info for the optimistic event so files render in place. */
@@ -203,48 +191,20 @@ export interface ReplyToBoardPostInput {
 }
 
 /**
- * Where a board reply lands. A conversation owns exactly one stream — its
- * messages are wholly flat or wholly inside a thread; a thread is always its own
- * conversation — so "follow where the conversation lives" reduces to the host
- * stream type plus whether the conversation is still a lone root (user ruling):
+ * Reply to a board post from the feed. Eager and offline-first: the reply is
+ * written as an optimistic `message_created` event into the same `db.events`
+ * rail the card reads (and a durable pending row the background queue drains),
+ * so it shows the instant the user sends — no round-trip — exactly like a stream
+ * send. The server echo swaps the optimistic event for the real one.
  *
- *  - **thread conversation** → into the thread (it IS the thread).
- *  - **flat conversation with replies** (channel/DM) → flat in its stream.
- *  - **scratchpad** → always flat (scratchpads don't thread).
- *  - **a lone root message** in a channel/DM → start a thread off it: a single
- *    message has no established shape, and threading a bare message keeps the
- *    channel from sprouting a stray top-level reply. Scratchpads stay flat even
- *    when lone; a deleted root (no opening id) can't be threaded, so it stays flat.
- *
- * "Into the thread" and "flat" are the same send — into the conversation's own
- * stream, attached via the `existing` directive — so only the lone channel/DM
- * root diverges into a new thread.
- */
-export type BoardReplyPlan = { kind: "newThread"; parentMessageId: string } | { kind: "intoConversation" }
-
-export function planBoardReply(input: {
-  hostStreamType: string | undefined
-  messageCount: number
-  openingMessageId: string | null
-}): BoardReplyPlan {
-  const threadable = input.hostStreamType === StreamTypes.CHANNEL || input.hostStreamType === StreamTypes.DM
-  if (threadable && input.messageCount <= 1 && input.openingMessageId) {
-    return { kind: "newThread", parentMessageId: input.openingMessageId }
-  }
-  return { kind: "intoConversation" }
-}
-
-/**
- * Reply to a board post from the feed, routed by {@link planBoardReply}. Eager
- * and offline-first: the reply is written as an optimistic `message_created`
- * event into the same `db.events` rail the card reads (and a durable pending row
- * the background queue drains), so it shows the instant the user sends — no
- * round-trip — exactly like a stream send. The server echo swaps the optimistic
- * event for the real one. Returns only the resolved plan: a `newThread` reply
- * lives in a brand-new thread stream (its own conversation), surfacing as its
- * own board post, NOT under this card; an `intoConversation` reply is tagged
- * with the target conversation so it renders in place under the card that
- * produced it (see `useQueueDraftMessage` / `useBoardCardMessages`).
+ * A board reply always lands flat in the conversation's own stream, attached via
+ * the `existing` directive, so it renders in place under the card that produced
+ * it (see `useQueueDraftMessage` / `useBoardCardMessages`). Threading is the
+ * timeline's gesture, not the board's: replying from the board joins the
+ * conversation — itself a soft thread — while the timeline's explicit
+ * thread-reply affordance (`stream-panel.tsx`) is what starts a strict thread.
+ * A lone channel/DM root therefore gains an in-place reply here rather than
+ * sprouting a separate thread card.
  */
 export function useReplyToBoardPost(workspaceId: string) {
   const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
@@ -252,46 +212,22 @@ export function useReplyToBoardPost(workspaceId: string) {
   return useMutation({
     mutationFn: async ({
       conversation,
-      openingMessageId,
-      hostStreamType,
-      messageCount,
       contentJson,
       attachmentIds,
       attachments,
-    }: ReplyToBoardPostInput): Promise<{ plan: BoardReplyPlan }> => {
-      const input = {
-        contentJson,
-        attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
-        attachments: attachments && attachments.length > 0 ? attachments : undefined,
-      }
-
-      const plan = planBoardReply({ hostStreamType, messageCount, openingMessageId })
-
-      if (plan.kind === "newThread") {
-        // Promote a draft thread off the opening message, mirroring the timeline's
-        // thread-reply path (`stream-panel.tsx`): the queue create-or-finds the
-        // thread (idempotent server-side on (parentStreamId, parentMessageId))
-        // then sends into it. A lone channel/DM root is never E2E, so no sealing.
-        const panelId = createDraftPanelId(conversation.streamId, plan.parentMessageId)
-        await queueDraftMessage(input, {
+    }: ReplyToBoardPostInput): Promise<void> => {
+      await queueDraftMessage(
+        {
+          contentJson,
+          attachmentIds: attachmentIds && attachmentIds.length > 0 ? attachmentIds : undefined,
+          attachments: attachments && attachments.length > 0 ? attachments : undefined,
+        },
+        {
           workspaceId,
-          streamId: panelId,
-          streamCreation: {
-            type: StreamTypes.THREAD,
-            parentStreamId: conversation.streamId,
-            parentMessageId: plan.parentMessageId,
-          },
-          draftId: panelId,
-        })
-        return { plan }
-      }
-
-      await queueDraftMessage(input, {
-        workspaceId,
-        streamId: conversation.streamId,
-        conversation: { intent: "existing", conversationId: conversation.id },
-      })
-      return { plan }
+          streamId: conversation.streamId,
+          conversation: { intent: "existing", conversationId: conversation.id },
+        }
+      )
     },
   })
 }


### PR DESCRIPTION
## Problem

Replying to a board card whose conversation was a **single message in a channel or DM** didn't show the reply under that card. `planBoardReply` (in `apps/frontend/src/hooks/use-conversations.ts`) routed a lone channel/DM root to a brand-new thread (`{ kind: "newThread" }`): the send promoted a draft thread off the opening message, so the reply landed in its own conversation and surfaced as a *separate* board card (initially a collapsed "1 more message") rather than in place. On device this read as a dropped send — you replied, and nothing appeared on the card you replied from. The eager-optimistic work in #1111 made every other board reply appear instantly in place; the lone-root case was the one path that didn't.

## Solution

Board replies always join the conversation flat. A reply from the board feed is a reply *into the conversation* — which #1110 framed as a soft thread — while starting a strict thread stays the timeline's gesture (`stream-panel.tsx`), not the board's. Concretely, `useReplyToBoardPost` now always sends with `conversation: { intent: "existing", conversationId }` into the conversation's own stream, so the eager optimistic event renders under the card that produced it. A lone channel/DM root now gains an in-place reply instead of sprouting a thread card.

This removes the only branch in the board reply path, so the routing helper and its supporting state collapse out:

- Deleted `planBoardReply` / `BoardReplyPlan` and the `newThread` queue branch (the `createDraftPanelId` + `streamCreation: { type: THREAD, … }` send). `useReplyToBoardPost` now returns `void` instead of `{ plan }`.
- Dropped the now-unused inputs `openingMessageId`, `hostStreamType`, `messageCount` from `ReplyToBoardPostInput`, and the `hostStreamType` prop threaded `board-card.tsx → BoardReplyComposer`.
- Removed the composer's transient `"Posted to a new thread"` resting note (the `"posted"` `RestingState`, its 4s fade timer, and the `posted` plumbing through `close`). It existed only because a new-thread reply had no in-place echo; every reply now has one, so the visible reply is the confirmation (INV-63 — success is silent).

### Key design decision

**Board joins the conversation; the timeline threads** — chosen over keeping the lone-root→thread split (Kris's call this session). The two reply surfaces map to the two shapes: replying from the timeline opens a thread via `stream-panel.tsx`; replying from the board joins the conversation. This reverses the earlier "a bare channel/DM root should thread, not sprout a top-level reply" ruling — the accepted tradeoff is that a reply to a lone channel/DM root card now appears as a top-level message in that channel's timeline. The board surface stays direct (reply lands where you replied), which is the behavior the device test demanded.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-conversations.ts` | `useReplyToBoardPost` always sends `intoConversation`; removed `planBoardReply`/`BoardReplyPlan`, the `newThread` branch, the `createDraftPanelId` import, and three now-dead `ReplyToBoardPostInput` fields. |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Removed the `"posted"` resting state, its label, its fade timer, and the `hostStreamType` prop; `handleSubmit` no longer reads a `plan`. |
| `apps/frontend/src/components/board/board-card.tsx` | Stopped passing `hostStreamType` to `BoardReplyComposer`. |
| `apps/frontend/src/hooks/use-conversations.test.tsx` | Dropped the `planBoardReply` suite; `useReplyToBoardPost` tests now assert flat routing, including the lone-channel-root → `intoConversation` (no thread) case. |

## Out of scope (deliberate)

- The timeline thread-reply path (`stream-panel.tsx`) is untouched — threading from the timeline still works exactly as before.
- Bounding/collapsing tall board cards and making E2E scratchpads first-class on the board are separate follow-ups, not in this PR.

## Test plan

- [x] `apps/frontend` `vitest run` over the affected files — `use-conversations.test.tsx`, `board.test.tsx`, `use-board-card-messages.test.tsx`, `board-composer.test.tsx`: 39 pass
- [x] Full pre-commit suite on commit: all-app ESLint, monorepo `tsc --noEmit` (incl. frontend app + test tsconfigs), `check:migrations`, OpenAPI `--check`, astro check — all clean
- [ ] Not manually re-verified on device this session — the behavior change (lone-root reply now lands in place) is the exact fix requested from the prior device test; covered by the hook unit test rather than a fresh device run

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bL9QBbQjeSr9p4JzwvwbF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785332947&installation_id=129946197&pr_number=1112&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1112&signature=3ef59b7e2023f34f6242e4d68149e734396308ecaa4ac946ad26ebbc92343e7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->