### PR TITLE
feat(board): convert a lone channel/DM post into a thread on reply

### DIFF
--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -71,7 +71,12 @@ export async function emitConversationRetired(
   const stream = await StreamRepository.findById(client, streamId)
   const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
   const [refreshed] = await ConversationRepository.findByIds(client, workspaceId, [conversationId])
-  if (!refreshed) return
+  if (!refreshed) {
+    // The row we just locked + emptied in this same transaction is gone — an
+    // invariant break (INV-11). Throwing rolls back the whole send rather than
+    // silently dropping the board-removal event and leaving a stale source card.
+    throw new Error(`Conversation ${conversationId} vanished during retirement`)
+  }
   await OutboxRepository.insert(client, "conversation:updated", {
     workspaceId,
     streamId,

--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -53,3 +53,31 @@ export async function emitAssignmentEvents(
 
   return refreshed
 }
+
+/**
+ * Emit the aggregate update for a conversation that just lost its last message
+ * (e.g. a lone source conversation retired when its message was threaded off).
+ * Mirrors the reassignment path's emptied-source emit (`service.ts`): the board
+ * drops a now-empty conversation (its `cardinality > 0` filter on the server,
+ * the delete-on-empty merge on the client), so this is the signal that retires
+ * the card. Routed by the conversation's OWN stream (INV-62) — `streamId` here
+ * is the source's parent stream, not the thread the reply landed in.
+ */
+export async function emitConversationRetired(
+  client: PoolClient,
+  params: { workspaceId: string; conversationId: string; streamId: string }
+): Promise<void> {
+  const { workspaceId, conversationId, streamId } = params
+  const stream = await StreamRepository.findById(client, streamId)
+  const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+  const [refreshed] = await ConversationRepository.findByIds(client, workspaceId, [conversationId])
+  if (!refreshed) return
+  await OutboxRepository.insert(client, "conversation:updated", {
+    workspaceId,
+    streamId,
+    conversationId,
+    conversation: addStalenessFields(refreshed),
+    parentStreamId,
+    streamVisibility,
+  })
+}

--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -43,6 +43,13 @@ describe("conversationAssigner — threadFromMessage", () => {
     removePrimaryMessage = spyOn(ConversationRepository, "removePrimaryMessage").mockResolvedValue(undefined as never)
     resolveIfEmpty = spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never)
     emitRetired = spyOn(assignmentEvents, "emitConversationRetired").mockResolvedValue(undefined as never)
+    // The thread (the reply's stream `thr_1`) hangs off `msg_open` in `chan_1` —
+    // so the only retire-able source is the lone conversation owning that message.
+    spyOn(streams.StreamRepository, "findById").mockResolvedValue({
+      id: "thr_1",
+      parentStreamId: "chan_1",
+      parentMessageId: "msg_open",
+    } as never)
     // Default: the actor can reach the source stream (the legit board-reply case).
     checkStreamAccess = spyOn(streams, "checkStreamAccess").mockResolvedValue({ id: "chan_1" } as never)
   })
@@ -123,6 +130,20 @@ describe("conversationAssigner — threadFromMessage", () => {
     // a lone conversation in a stream the actor can't see — is left untouched.
     expect(insert).toHaveBeenCalledTimes(1)
     expect(checkStreamAccess).toHaveBeenCalledWith(CLIENT, "chan_1", WORKSPACE_ID, "usr_1")
+    expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(resolveIfEmpty).not.toHaveBeenCalled()
+    expect(emitRetired).not.toHaveBeenCalled()
+  })
+
+  test("only retires the thread's actual parent — not an unrelated accessible lone source", async () => {
+    // A crafted id pointing at a different lone conversation the actor CAN see:
+    // it's in the parent stream and accessible, but its message isn't the thread's
+    // parent (`msg_open`), so it must be left intact.
+    findByIdForUpdate.mockResolvedValue(makeSource({ id: "conv_other", messageIds: ["msg_unrelated"] }))
+
+    await thread("conv_other")
+
+    expect(insert).toHaveBeenCalledTimes(1)
     expect(removePrimaryMessage).not.toHaveBeenCalled()
     expect(resolveIfEmpty).not.toHaveBeenCalled()
     expect(emitRetired).not.toHaveBeenCalled()

--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, spyOn, mock, beforeEach, afterEach } from "bun:test"
+import { conversationAssigner } from "./conversation-assigner"
+import { ConversationRepository, type Conversation } from "./repository"
+import * as assignmentEvents from "./assignment-events"
+import type { Message } from "../messaging"
+
+// The assigner only passes `client` through to the (spied) repositories, so a
+// dummy stands in for a real PoolClient.
+const CLIENT = {} as never
+const WORKSPACE_ID = "ws_1"
+
+function makeReply(): Message {
+  // The thread's first reply, sent into the (already promoted) thread stream.
+  return { id: "msg_reply", streamId: "thr_1", authorId: "usr_1" } as unknown as Message
+}
+
+function makeSource(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_src",
+    streamId: "chan_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["msg_open"],
+    ...overrides,
+  } as unknown as Conversation
+}
+
+describe("conversationAssigner — threadFromMessage", () => {
+  let insert: ReturnType<typeof spyOn>
+  let emitAssignmentEvents: ReturnType<typeof spyOn>
+  let findByIdForUpdate: ReturnType<typeof spyOn>
+  let removePrimaryMessage: ReturnType<typeof spyOn>
+  let resolveIfEmpty: ReturnType<typeof spyOn>
+  let emitRetired: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    insert = spyOn(ConversationRepository, "insert").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+    emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
+    findByIdForUpdate = spyOn(ConversationRepository, "findByIdForUpdate")
+    removePrimaryMessage = spyOn(ConversationRepository, "removePrimaryMessage").mockResolvedValue(undefined as never)
+    resolveIfEmpty = spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never)
+    emitRetired = spyOn(assignmentEvents, "emitConversationRetired").mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  async function thread(sourceConversationId: string): Promise<void> {
+    await conversationAssigner.assignInTransaction(CLIENT, {
+      workspaceId: WORKSPACE_ID,
+      message: makeReply(),
+      directive: { intent: "threadFromMessage", sourceConversationId },
+    })
+  }
+
+  test("mints the thread's conversation seeded with the reply, then empties + retires the lone source", async () => {
+    findByIdForUpdate.mockResolvedValue(makeSource())
+
+    await thread("conv_src")
+
+    // Mint: a fresh conversation in the thread stream, seeded with the reply,
+    // announced as created.
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
+    expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
+      message: expect.objectContaining({ id: "msg_reply" }),
+      created: true,
+    })
+
+    // Retire: the source's sole message (the thread's parent) is removed so the
+    // source empties and drops off the board; one retire event is emitted.
+    expect(removePrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src", "msg_open")
+    expect(resolveIfEmpty).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src")
+    expect(emitRetired).toHaveBeenCalledWith(CLIENT, {
+      workspaceId: WORKSPACE_ID,
+      conversationId: "conv_src",
+      streamId: "chan_1",
+    })
+  })
+
+  test("leaves a non-lone source intact (only empties a single-message source)", async () => {
+    findByIdForUpdate.mockResolvedValue(makeSource({ messageIds: ["msg_open", "msg_other"] }))
+
+    await thread("conv_src")
+
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(resolveIfEmpty).not.toHaveBeenCalled()
+    expect(emitRetired).not.toHaveBeenCalled()
+  })
+
+  test("is idempotent on a missing/foreign source — no throw, no retire", async () => {
+    findByIdForUpdate.mockResolvedValue(null)
+
+    await thread("conv_gone")
+
+    expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(emitRetired).not.toHaveBeenCalled()
+  })
+
+  test("does not gut a source that lives in the reply's own stream (sanity guard)", async () => {
+    findByIdForUpdate.mockResolvedValue(makeSource({ streamId: "thr_1" }))
+
+    await thread("conv_src")
+
+    expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(emitRetired).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, spyOn, mock, beforeEach, afterEach } from "bun:
 import { conversationAssigner } from "./conversation-assigner"
 import { ConversationRepository, type Conversation } from "./repository"
 import * as assignmentEvents from "./assignment-events"
+import * as streams from "../streams"
 import type { Message } from "../messaging"
 
 // The assigner only passes `client` through to the (spied) repositories, so a
@@ -31,6 +32,7 @@ describe("conversationAssigner — threadFromMessage", () => {
   let removePrimaryMessage: ReturnType<typeof spyOn>
   let resolveIfEmpty: ReturnType<typeof spyOn>
   let emitRetired: ReturnType<typeof spyOn>
+  let checkStreamAccess: ReturnType<typeof spyOn>
 
   beforeEach(() => {
     insert = spyOn(ConversationRepository, "insert").mockResolvedValue(undefined as never)
@@ -41,6 +43,8 @@ describe("conversationAssigner — threadFromMessage", () => {
     removePrimaryMessage = spyOn(ConversationRepository, "removePrimaryMessage").mockResolvedValue(undefined as never)
     resolveIfEmpty = spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never)
     emitRetired = spyOn(assignmentEvents, "emitConversationRetired").mockResolvedValue(undefined as never)
+    // Default: the actor can reach the source stream (the legit board-reply case).
+    checkStreamAccess = spyOn(streams, "checkStreamAccess").mockResolvedValue({ id: "chan_1" } as never)
   })
 
   afterEach(() => {
@@ -106,6 +110,21 @@ describe("conversationAssigner — threadFromMessage", () => {
     await thread("conv_src")
 
     expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(emitRetired).not.toHaveBeenCalled()
+  })
+
+  test("does not retire a source the actor cannot access (crafted sourceConversationId)", async () => {
+    findByIdForUpdate.mockResolvedValue(makeSource())
+    checkStreamAccess.mockResolvedValue(null)
+
+    await thread("conv_src")
+
+    // The thread is still minted (the reply is the actor's own), but the source —
+    // a lone conversation in a stream the actor can't see — is left untouched.
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(checkStreamAccess).toHaveBeenCalledWith(CLIENT, "chan_1", WORKSPACE_ID, "usr_1")
+    expect(removePrimaryMessage).not.toHaveBeenCalled()
+    expect(resolveIfEmpty).not.toHaveBeenCalled()
     expect(emitRetired).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -1,6 +1,6 @@
 import { ConversationRepository } from "./repository"
 import type { ConversationAssigner } from "../messaging"
-import { checkStreamAccess } from "../streams"
+import { checkStreamAccess, StreamRepository } from "../streams"
 import { emitAssignmentEvents, emitConversationRetired } from "./assignment-events"
 import { conversationId } from "../../lib/id"
 import { ConversationIntents, ConversationStatuses } from "@threa/types"
@@ -48,31 +48,30 @@ export const conversationAssigner: ConversationAssigner = {
       })
 
       if (directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
-        // Retire the source. Lock + workspace-scope (INV-8/20); only empty a
-        // source that is still lone and lives in a DIFFERENT stream than this
-        // reply (the parent stream, not the thread) — a non-lone source is a real
-        // conversation we must not gut, and a missing/foreign id is a no-op
-        // (retirement is idempotent, unlike `existing`'s 400).
+        // Retire the source — but ONLY the lone conversation this thread was
+        // actually created off, never an arbitrary id the client supplied. The
+        // thread (this reply's stream) carries its parent message/stream, so the
+        // source is bound to that identity: it must live in the parent stream and
+        // its single message must BE the thread's parent message. Lock +
+        // workspace-scope (INV-8/20); gate on the actor's access to the source
+        // stream (INV-62). Any mismatch — foreign/non-lone/wrong-parent/no-access —
+        // is a silent no-op, so retirement stays idempotent (never a 400).
+        const thread = await StreamRepository.findById(client, message.streamId)
         const source = await ConversationRepository.findByIdForUpdate(
           client,
           workspaceId,
           directive.sourceConversationId
         )
-        // Gate the retire on the actor's access to the SOURCE stream (INV-62),
-        // not just the thread they're writing to: the legit board reply targets a
-        // card on the actor's own board (access always holds), so this only blocks
-        // a crafted `sourceConversationId` from emptying a lone conversation in a
-        // stream the actor can't see. A denied/missing/non-lone/same-stream source
-        // is a silent no-op — retirement stays idempotent (never a 400).
         if (
+          thread?.parentStreamId &&
+          thread.parentMessageId &&
           source &&
-          source.streamId !== message.streamId &&
-          source.messageIds.length <= 1 &&
+          source.streamId === thread.parentStreamId &&
+          source.messageIds.length === 1 &&
+          source.messageIds[0] === thread.parentMessageId &&
           (await checkStreamAccess(client, source.streamId, workspaceId, message.authorId))
         ) {
-          for (const sourceMessageId of source.messageIds) {
-            await ConversationRepository.removePrimaryMessage(client, workspaceId, source.id, sourceMessageId)
-          }
+          await ConversationRepository.removePrimaryMessage(client, workspaceId, source.id, thread.parentMessageId)
           await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
           await emitConversationRetired(client, { workspaceId, conversationId: source.id, streamId: source.streamId })
         }

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -1,5 +1,6 @@
 import { ConversationRepository } from "./repository"
 import type { ConversationAssigner } from "../messaging"
+import { checkStreamAccess } from "../streams"
 import { emitAssignmentEvents, emitConversationRetired } from "./assignment-events"
 import { conversationId } from "../../lib/id"
 import { ConversationIntents, ConversationStatuses } from "@threa/types"
@@ -57,7 +58,18 @@ export const conversationAssigner: ConversationAssigner = {
           workspaceId,
           directive.sourceConversationId
         )
-        if (source && source.streamId !== message.streamId && source.messageIds.length <= 1) {
+        // Gate the retire on the actor's access to the SOURCE stream (INV-62),
+        // not just the thread they're writing to: the legit board reply targets a
+        // card on the actor's own board (access always holds), so this only blocks
+        // a crafted `sourceConversationId` from emptying a lone conversation in a
+        // stream the actor can't see. A denied/missing/non-lone/same-stream source
+        // is a silent no-op — retirement stays idempotent (never a 400).
+        if (
+          source &&
+          source.streamId !== message.streamId &&
+          source.messageIds.length <= 1 &&
+          (await checkStreamAccess(client, source.streamId, workspaceId, message.authorId))
+        ) {
           for (const sourceMessageId of source.messageIds) {
             await ConversationRepository.removePrimaryMessage(client, workspaceId, source.id, sourceMessageId)
           }

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -1,6 +1,6 @@
 import { ConversationRepository } from "./repository"
 import type { ConversationAssigner } from "../messaging"
-import { emitAssignmentEvents } from "./assignment-events"
+import { emitAssignmentEvents, emitConversationRetired } from "./assignment-events"
 import { conversationId } from "../../lib/id"
 import { ConversationIntents, ConversationStatuses } from "@threa/types"
 import { HttpError } from "../../lib/errors"
@@ -18,10 +18,16 @@ import { HttpError } from "../../lib/errors"
  *  - `existing`: attach the message to the named conversation, which must live in
  *    the same stream + workspace (conversations are per-stream); a stale/foreign
  *    id is rejected (400) rather than silently mis-assigned.
+ *  - `threadFromMessage`: mint the thread's conversation seeded with this reply
+ *    (the thread's first message), then retire the lone `sourceConversationId`
+ *    it threaded off — its only message is now the thread's parent (in the parent
+ *    stream, referenced not moved), so emptying it drops the duplicate board
+ *    card, leaving just the thread. Retirement is idempotent (a retried send
+ *    must not 400) and defensive: a non-lone/foreign source is left intact.
  */
 export const conversationAssigner: ConversationAssigner = {
   async assignInTransaction(client, { workspaceId, message, directive }) {
-    if (directive.intent === ConversationIntents.NEW) {
+    if (directive.intent === ConversationIntents.NEW || directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
       const newId = conversationId()
       await ConversationRepository.insert(client, {
         id: newId,
@@ -39,6 +45,26 @@ export const conversationAssigner: ConversationAssigner = {
         created: true,
         reason: "declared",
       })
+
+      if (directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
+        // Retire the source. Lock + workspace-scope (INV-8/20); only empty a
+        // source that is still lone and lives in a DIFFERENT stream than this
+        // reply (the parent stream, not the thread) — a non-lone source is a real
+        // conversation we must not gut, and a missing/foreign id is a no-op
+        // (retirement is idempotent, unlike `existing`'s 400).
+        const source = await ConversationRepository.findByIdForUpdate(
+          client,
+          workspaceId,
+          directive.sourceConversationId
+        )
+        if (source && source.streamId !== message.streamId && source.messageIds.length <= 1) {
+          for (const sourceMessageId of source.messageIds) {
+            await ConversationRepository.removePrimaryMessage(client, workspaceId, source.id, sourceMessageId)
+          }
+          await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
+          await emitConversationRetired(client, { workspaceId, conversationId: source.id, streamId: source.streamId })
+        }
+      }
       return
     }
 

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -34,6 +34,7 @@ import { messageMetadataSchema } from "./metadata-schema"
 const conversationDirectiveSchema = z.discriminatedUnion("intent", [
   z.object({ intent: z.literal("new") }),
   z.object({ intent: z.literal("existing"), conversationId: z.string().min(1) }),
+  z.object({ intent: z.literal("threadFromMessage"), sourceConversationId: z.string().min(1) }),
 ])
 
 // INV-31: this runtime schema is the wire guard; `ConversationDirective` in

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -197,12 +197,12 @@ function BoardReplyComposerForm({
     composer.setIsSending(true)
     try {
       // Eager + offline-first: the reply is enqueued as an optimistic event and
-      // shows in place immediately (an `intoConversation` reply rides the card's
-      // own rail; a `newThread` reply lands in its own thread, surfacing as its
-      // own board post on the next load). The send drains in the background, so
-      // there's no created message to await here — only the resolved plan, which
-      // selects the resting note: the visible in-place reply is the feedback for
-      // the former, the transient "Posted to a new thread" note for the latter.
+      // the send drains in the background, so there's no created message to await
+      // here — only the resolved plan, which selects the resting note. An
+      // `intoConversation` reply rides the card's own rail and shows in place; a
+      // `convertToThread` reply lands in a thread off the opener (and retires this
+      // lone card, which swaps to the thread on echo), so the transient "Posted to
+      // a new thread" note bridges the brief swap.
       const { plan } = await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
@@ -215,7 +215,7 @@ function BoardReplyComposerForm({
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: true, posted: plan.kind === "newThread" })
+      onClose({ refocus: true, posted: plan.kind === "convertToThread" })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")
     } finally {

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -22,9 +22,9 @@ const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-w
 
 // Resting-affordance state. `draft` signals a persisted-but-collapsed reply (so
 // the user knows reopening restores it); `posted` is a transient confirmation
-// that a new-thread reply went through — it stands in for the in-place echo a
-// same-conversation reply gets, since a new-thread reply lands in its own
-// conversation and only surfaces on the next board load.
+// that a convert-to-thread reply went through — it bridges the brief swap where
+// this lone card retires and the thread card takes its place on the server echo,
+// since (unlike a same-conversation reply) the reply isn't shown in place here.
 type RestingState = "idle" | "draft" | "posted"
 const RESTING_LABEL: Record<RestingState, string> = {
   idle: "Write a reply…",
@@ -50,13 +50,14 @@ interface BoardReplyComposerProps {
  * mirrors the composer's own container — same radius, border, surface, padding,
  * and placeholder — and the composer mounts already open (`initialMobileChromeOpen`)
  * so the tap lands straight in the toolbar view instead of stepping through the
- * mobile compacted phase. Routing — channel → thread, everything else → the
- * conversation — lives in {@link useReplyToBoardPost}.
+ * mobile compacted phase. Routing — a lone channel/DM post converts to a thread,
+ * everything else replies flat into the conversation — lives in
+ * {@link useReplyToBoardPost}.
  *
  * The resting affordance carries state (best-effort, in-session): it flags a
  * persisted draft after an Escape ("Continue reply…") and a transient "Posted to
- * a new thread" confirmation after a new-thread send, so a collapse never reads
- * as a no-op or an accidental discard.
+ * a new thread" confirmation after a convert-to-thread send, so a collapse never
+ * reads as a no-op or an accidental discard.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -247,13 +247,13 @@ describe("useCreateBoardPost", () => {
 })
 
 describe("planBoardReply", () => {
-  it("threads a lone root message in a channel or DM off the opening message", () => {
+  it("converts a lone message in a channel or DM into a thread off the opener", () => {
     expect(planBoardReply({ hostStreamType: StreamTypes.CHANNEL, messageCount: 1, openingMessageId: "m1" })).toEqual({
-      kind: "newThread",
+      kind: "convertToThread",
       parentMessageId: "m1",
     })
     expect(planBoardReply({ hostStreamType: StreamTypes.DM, messageCount: 1, openingMessageId: "m1" })).toEqual({
-      kind: "newThread",
+      kind: "convertToThread",
       parentMessageId: "m1",
     })
   })
@@ -304,7 +304,7 @@ describe("useReplyToBoardPost", () => {
 
   const DOC = { type: "doc", content: [] }
 
-  it("threads a lone channel root off the opening message, promoting a draft thread (no directive)", async () => {
+  it("converts a lone channel post into a thread, retiring the source via the threadFromMessage directive", async () => {
     const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
@@ -320,9 +320,9 @@ describe("useReplyToBoardPost", () => {
       })
     })
 
-    // The reply rides the durable queue with THREAD stream-creation, keyed on the
-    // draft panel id; no existing-conversation directive (a fresh thread is its
-    // own conversation).
+    // The reply rides the durable queue with THREAD stream-creation (keyed on the
+    // draft panel id) AND the threadFromMessage directive, which mints the thread's
+    // conversation and retires the lone source `conv_1`.
     expect(queueDraftMessage).toHaveBeenCalledWith(
       expect.objectContaining({ contentJson: DOC }),
       expect.objectContaining({
@@ -330,11 +330,35 @@ describe("useReplyToBoardPost", () => {
         streamId: "draft:chan_1:msg_open",
         draftId: "draft:chan_1:msg_open",
         streamCreation: { type: StreamTypes.THREAD, parentStreamId: "chan_1", parentMessageId: "msg_open" },
+        conversation: { intent: "threadFromMessage", sourceConversationId: "conv_1" },
       })
     )
-    expect(queueDraftMessage.mock.calls[0][1]).not.toHaveProperty("conversation")
-    // The plan rides back so the composer shows the "posted to a new thread" note.
-    expect(res).toEqual({ plan: { kind: "newThread", parentMessageId: "msg_open" } })
+    expect(res).toEqual({ plan: { kind: "convertToThread", parentMessageId: "msg_open" } })
+  })
+
+  it("converts a lone DM post into a thread the same way a channel does", async () => {
+    const { queueDraftMessage } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_dm", streamId: "dm_1" },
+        openingMessageId: "msg_open",
+        hostStreamType: StreamTypes.DM,
+        messageCount: 1,
+        contentJson: DOC,
+      })
+    })
+
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contentJson: DOC }),
+      expect.objectContaining({
+        streamId: "draft:dm_1:msg_open",
+        streamCreation: { type: StreamTypes.THREAD, parentStreamId: "dm_1", parentMessageId: "msg_open" },
+        conversation: { intent: "threadFromMessage", sourceConversationId: "conv_dm" },
+      })
+    )
   })
 
   it("keeps a multi-message channel reply flat, attached to the conversation via the existing directive", async () => {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -203,24 +203,22 @@ export interface ReplyToBoardPostInput {
 }
 
 /**
- * Where a board reply lands. A conversation owns exactly one stream — its
- * messages are wholly flat or wholly inside a thread; a thread is always its own
- * conversation — so "follow where the conversation lives" reduces to the host
- * stream type plus whether the conversation is still a lone root (user ruling):
+ * Where a board reply lands. Replying from the board joins the conversation, but
+ * a conversation that is still a lone message (a fresh post, no back-and-forth)
+ * in a channel or DM has no established shape — so the reply converts it into a
+ * thread, keeping the parent stream's top level clean (one opener, the exchange
+ * underneath) instead of sprouting interleaved flat replies (user ruling):
  *
- *  - **thread conversation** → into the thread (it IS the thread).
- *  - **flat conversation with replies** (channel/DM) → flat in its stream.
- *  - **scratchpad** → always flat (scratchpads don't thread).
- *  - **a lone root message** in a channel/DM → start a thread off it: a single
- *    message has no established shape, and threading a bare message keeps the
- *    channel from sprouting a stray top-level reply. Scratchpads stay flat even
- *    when lone; a deleted root (no opening id) can't be threaded, so it stays flat.
- *
- * "Into the thread" and "flat" are the same send — into the conversation's own
- * stream, attached via the `existing` directive — so only the lone channel/DM
- * root diverges into a new thread.
+ *  - **lone message in a channel or DM** (≤1 message, has an opening id) →
+ *    `convertToThread`: thread off the opener (it stays in the parent stream as
+ *    the thread's root) and retire the now-empty source conversation, so the
+ *    board shows one card — the thread — not the post plus the thread.
+ *  - **everything else** → flat into the conversation's own stream via the
+ *    `existing` directive: an established channel/DM conversation stays where it
+ *    is, a thread card replies into its thread, a scratchpad stays flat. A
+ *    deleted opener (no id) can't be threaded, so it stays flat too.
  */
-export type BoardReplyPlan = { kind: "newThread"; parentMessageId: string } | { kind: "intoConversation" }
+export type BoardReplyPlan = { kind: "convertToThread"; parentMessageId: string } | { kind: "intoConversation" }
 
 export function planBoardReply(input: {
   hostStreamType: string | undefined
@@ -229,7 +227,7 @@ export function planBoardReply(input: {
 }): BoardReplyPlan {
   const threadable = input.hostStreamType === StreamTypes.CHANNEL || input.hostStreamType === StreamTypes.DM
   if (threadable && input.messageCount <= 1 && input.openingMessageId) {
-    return { kind: "newThread", parentMessageId: input.openingMessageId }
+    return { kind: "convertToThread", parentMessageId: input.openingMessageId }
   }
   return { kind: "intoConversation" }
 }
@@ -240,11 +238,12 @@ export function planBoardReply(input: {
  * event into the same `db.events` rail the card reads (and a durable pending row
  * the background queue drains), so it shows the instant the user sends — no
  * round-trip — exactly like a stream send. The server echo swaps the optimistic
- * event for the real one. Returns only the resolved plan: a `newThread` reply
- * lives in a brand-new thread stream (its own conversation), surfacing as its
- * own board post, NOT under this card; an `intoConversation` reply is tagged
- * with the target conversation so it renders in place under the card that
- * produced it (see `useQueueDraftMessage` / `useBoardCardMessages`).
+ * event for the real one. Returns the resolved plan so the composer can confirm
+ * a conversion: a `convertToThread` reply lands in a thread off the opener and
+ * retires the lone source (the board card becomes the thread); an
+ * `intoConversation` reply is tagged with the target conversation so it renders
+ * in place under the card that produced it (see `useQueueDraftMessage` /
+ * `useBoardCardMessages`).
  */
 export function useReplyToBoardPost(workspaceId: string) {
   const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
@@ -267,11 +266,14 @@ export function useReplyToBoardPost(workspaceId: string) {
 
       const plan = planBoardReply({ hostStreamType, messageCount, openingMessageId })
 
-      if (plan.kind === "newThread") {
-        // Promote a draft thread off the opening message, mirroring the timeline's
+      if (plan.kind === "convertToThread") {
+        // Promote a draft thread off the opener, mirroring the timeline's
         // thread-reply path (`stream-panel.tsx`): the queue create-or-finds the
         // thread (idempotent server-side on (parentStreamId, parentMessageId))
-        // then sends into it. A lone channel/DM root is never E2E, so no sealing.
+        // then sends into it. The `threadFromMessage` directive mints the thread's
+        // conversation seeded with this reply AND retires the lone source so the
+        // board shows one card (the thread), not the post plus the thread. A lone
+        // channel/DM root is never E2E, so no sealing.
         const panelId = createDraftPanelId(conversation.streamId, plan.parentMessageId)
         await queueDraftMessage(input, {
           workspaceId,
@@ -282,6 +284,7 @@ export function useReplyToBoardPost(workspaceId: string) {
             parentMessageId: plan.parentMessageId,
           },
           draftId: panelId,
+          conversation: { intent: "threadFromMessage", sourceConversationId: conversation.id },
         })
         return { plan }
       }

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -110,4 +110,22 @@ describe("mergeBoardConversation", () => {
     await mergeBoardConversation("conv_1", makeConversation("conv_1", "2026-06-21T12:00:05.000Z"))
     expect((await db.conversations.get("conv_1"))?._status).toBeUndefined()
   })
+
+  it("drops the card when the conversation is emptied (its last message threaded off / reassigned)", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z"),
+      makePost("conv_2", "2026-06-21T12:00:00.000Z"),
+    ])
+    const emptied = { ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"), messageIds: [] }
+    const merged = await mergeBoardConversation("conv_1", emptied)
+    expect(merged).toBe(true)
+    expect((await readBoard()).map((p) => p.id)).toEqual(["conv_2"])
+  })
+
+  it("reports an emptied conversation handled even when uncached, so the caller doesn't hydrate it", async () => {
+    const emptied = { ...makeConversation("conv_absent", "2026-06-22T12:00:00.000Z"), messageIds: [] }
+    const merged = await mergeBoardConversation("conv_absent", emptied)
+    expect(merged).toBe(true)
+    expect(await readBoard()).toHaveLength(0)
+  })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -77,7 +77,9 @@ export async function mergeBoardConversation(
     // message was reassigned or threaded off (the source of a `threadFromMessage`
     // reply) drops here rather than lingering as a stale card. Report it handled
     // even with no row so the caller doesn't hydrate a card that shouldn't exist.
-    if (conversation.messageIds.length === 0) {
+    // Guard on an EXPLICIT empty array: a payload that omits `messageIds` (a
+    // partial/aggregate-only event) is not "known empty" — fall through to upsert.
+    if (Array.isArray(conversation.messageIds) && conversation.messageIds.length === 0) {
       await db.conversations.delete(conversationId)
       return true
     }

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -72,6 +72,15 @@ export async function mergeBoardConversation(
   // Read-modify-write in one rw transaction so a concurrent optimistic write or
   // a second echo can't merge over a stale read of this row.
   return db.transaction("rw", db.conversations, async () => {
+    // An emptied conversation is no longer a board card — it mirrors the server's
+    // `cardinality(message_ids) > 0` board filter, so a conversation whose last
+    // message was reassigned or threaded off (the source of a `threadFromMessage`
+    // reply) drops here rather than lingering as a stale card. Report it handled
+    // even with no row so the caller doesn't hydrate a card that shouldn't exist.
+    if (conversation.messageIds.length === 0) {
+      await db.conversations.delete(conversationId)
+      return true
+    }
     const existing = await db.conversations.get(conversationId)
     if (!existing) return false
     await db.conversations.put({

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -337,11 +337,17 @@ export interface SyncHeartbeatPayload {
  * boundary-extractor infers the conversation (default). Present → the sender
  * declares it, and the send assigns it synchronously in the message's
  * transaction: `new` mints a fresh conversation seeded with the message;
- * `existing` attaches to `conversationId`. The id is a sibling of the
- * discriminant (not folded into one field) so a missing/garbage id on
- * `existing` is a validation error, distinct from `new`.
+ * `existing` attaches to `conversationId`; `threadFromMessage` mints the
+ * conversation for this message (a thread's first reply) and retires the lone
+ * `sourceConversationId` it threaded off, so the board shows one card — the
+ * thread — instead of the source post plus the thread. The id is a sibling of
+ * the discriminant (not folded into one field) so a missing/garbage id on
+ * `existing`/`threadFromMessage` is a validation error, distinct from `new`.
  */
-export type ConversationDirective = { intent: "new" } | { intent: "existing"; conversationId: string }
+export type ConversationDirective =
+  | { intent: "new" }
+  | { intent: "existing"; conversationId: string }
+  | { intent: "threadFromMessage"; sourceConversationId: string }
 
 /**
  * JSON input format - used by rich clients sending ProseMirror JSON directly.

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -333,13 +333,16 @@ export const ConversationStatuses = {
 // async boundary-extractor inferred (clustered) it — the default. A set value
 // records that the sender DECLARED the conversation at send time, so the
 // extractor must not re-cluster it: 'new' minted a fresh conversation seeded
-// with the message; 'existing' attached it to a caller-named conversation.
-export const CONVERSATION_INTENTS = ["new", "existing"] as const
+// with the message; 'existing' attached it to a caller-named conversation;
+// 'threadFromMessage' minted the thread's conversation seeded with this reply
+// and retired the lone source conversation it threaded off (board reply path).
+export const CONVERSATION_INTENTS = ["new", "existing", "threadFromMessage"] as const
 export type ConversationIntent = (typeof CONVERSATION_INTENTS)[number]
 
 export const ConversationIntents = {
   NEW: "new",
   EXISTING: "existing",
+  THREAD_FROM_MESSAGE: "threadFromMessage",
 } as const satisfies Record<string, ConversationIntent>
 
 // Memo types (GAM)


### PR DESCRIPTION
## Problem

Replying to a board post from the feed should keep the parent stream's top level clean. The earlier behavior (`planBoardReply`'s `newThread` branch, since reverted) threaded a lone channel/DM post but left the original one-message conversation behind, so the board showed **two cards** — the post and the thread — and the reply landed on the second, reading as a dropped send. Making board replies flat instead (PR #1112, closed) avoided the duplicate but flattened lone posts into the channel timeline, interleaving unrelated conversations (`conv-1, conv-1, conv-2, conv-1…`) — the "Slack where information dies" mess Threa exists to avoid.

The right shape (Kris's call): a board reply joins the conversation, but a **lone** post (a single message, no back-and-forth yet) in a channel or DM has no established shape, so the reply should **convert it into a thread** — opener stays in the parent stream as the thread's root, the exchange lives in the thread, the parent stream's top level stays one-opener-per-post. The blocker was the conversation model: a thread is a new stream, so the reply's conversation is necessarily a *different* row from the source, and there was **no mechanism to retire the source** so the board wouldn't double-card.

## Solution

A new `threadFromMessage` conversation directive that, in the reply's send transaction, mints the thread's conversation seeded with the reply **and retires the lone source** — by emptying it, not by inventing a new "hidden" status. An empty conversation already drops off the board (`findByWorkspaceForViewer` filters `cardinality(message_ids) > 0`), so emptying the source is the retirement.

### How it works

1. **Routing** (`apps/frontend/src/hooks/use-conversations.ts`, `planBoardReply`): a lone (`messageCount <= 1`, has an opener) post in a `CHANNEL` or `DM` → `{ kind: "convertToThread" }`; everything else → `intoConversation`. DMs and channels route identically (a fresh DM exchange started from the board threads too); established conversations, thread cards, and scratchpads reply flat.
2. **Send** (`useReplyToBoardPost`): the `convertToThread` branch promotes a draft thread off the opener (`createDraftPanelId` + `streamCreation: { type: THREAD, parentStreamId, parentMessageId }`, the same path as the timeline's thread reply) and carries `conversation: { intent: "threadFromMessage", sourceConversationId }`. The durable queue's post-promotion plaintext send already forwards `conversation` (`use-message-queue.ts:248`), so no queue change was needed.
3. **Assign + retire** (`apps/backend/src/features/conversations/conversation-assigner.ts`): the `threadFromMessage` branch shares the `new` mint+seed (a fresh conversation in the thread stream, seeded with the reply, `conversation:created`), then locks the source (`findByIdForUpdate`, INV-8/20) and — only if it's still lone and lives in a different stream than the reply — removes its message(s) (`removePrimaryMessage`), `resolveIfEmpty`, and emits `conversation:updated` for it via `emitConversationRetired` (routed by the source's own stream, INV-62). The opener is **not moved** — it stays in the parent stream as the thread's `parentMessageId`, referenced not relocated, so no channel broadcast slot is vacated (simpler than `moveMessagesToThread`, INV-61).
4. **Board drop** (`apps/frontend/src/stores/board-store.ts`, `mergeBoardConversation`): an incoming aggregate with `messageIds.length === 0` deletes the row instead of upserting, mirroring the server filter. Returns `true` even with no cached row so the `conversation:updated` handler doesn't try to hydrate a card that shouldn't exist. This also fixes a latent gap: reassignment already emits `conversation:updated` for an emptied source (`service.ts:300-310`) but the board kept the stale card.

### Key design decisions

**1. Retire by emptying, not by a new status.** Conversation `status` is `active | stalled | resolved`; `resolved` already means agent-invisible + "not a current topic" (`conversation-highlight.ts`, `cross-surface-stitch.ts`), and the board shows all statuses — so overloading `resolved` would both pollute that meaning and fail to hide the card. There is no soft-delete on conversations. Emptiness is the existing, proven board-retirement mechanism (it's how reassignment retires a conversation), so the directive reuses it.

**2. A new directive variant, not `moveMessagesToThread` or a second REST call.** `moveMessagesToThread` *relocates* messages out of the channel (vacates broadcast slots, needs a validation lease, moves the root) — wrong shape, since the opener must stay as the thread parent. A separate resolve call after the send isn't atomic: a thread-created-but-source-not-retired crash re-introduces the duplicate. Folding the retire into the assigner (which already runs in the send transaction) makes the conversion all-or-nothing (INV-20).

**3. Retirement is idempotent and defensive.** Unlike `existing` (which 400s on a stale id), a missing/foreign `sourceConversationId` is a no-op so a retried send can't fail; a non-lone source (gained a message in a race) or a source in the reply's own stream is left intact rather than gutted.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | Add `threadFromMessage` to `CONVERSATION_INTENTS` / `ConversationIntents`. |
| `packages/types/src/api.ts` | Add the `{ intent: "threadFromMessage"; sourceConversationId }` variant to `ConversationDirective`. |
| `apps/backend/src/features/messaging/handlers.ts` | Add the variant to the Zod directive union (the compile-time type↔schema lock enforces parity). |
| `apps/backend/src/features/conversations/conversation-assigner.ts` | `threadFromMessage` branch: mint+seed the thread conversation, then empty + retire the lone source. |
| `apps/backend/src/features/conversations/assignment-events.ts` | New `emitConversationRetired` — `conversation:updated` for the emptied source, routed by its own stream. |
| `apps/frontend/src/hooks/use-conversations.ts` | `planBoardReply` → `convertToThread`; `useReplyToBoardPost` carries the `threadFromMessage` directive. |
| `apps/frontend/src/stores/board-store.ts` | `mergeBoardConversation` deletes an emptied conversation instead of upserting. |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Rename the plan kind in the resting-note selector (`convertToThread`). |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/conversations/conversation-assigner.test.ts` | Unit-tests the `threadFromMessage` mint+retire, non-lone/foreign/same-stream guards (scoped `spyOn`, INV-48). |

## Out of scope (deliberate)

- **Seamless optimistic swap.** Between send and echo, the reply lands in the thread (not shown under the source card yet); the card swaps to the thread on echo, bridged by the "Posted to a new thread" note. No dropped-send feel (the card never vanishes), but optimistically tagging the reply onto the source so the card content is unchanged through the swap is a fast follow, not this cut — it's the exact reconciliation spot prior optimistic-swap bugs lived in.
- **Private-source live retirement for non-members.** A public-channel source retires live for other board viewers (`conversation:updated` reaches the workspace room); a private channel/DM source relies on the members' own stream-scoped echo + board refetch. Matches how board conversation events already deliver.
- **Established conversations are not retroactively threaded** — only lone posts convert; an established channel/DM conversation replies flat where it lives.

## Test plan

- [x] Backend `bun test src/features/conversations src/features/messaging` — 147 pass (incl. 4 new assigner tests: mint+retire, non-lone intact, idempotent-missing, same-stream guard)
- [x] Frontend `vitest run` — `use-conversations.test.tsx` (routing: lone channel→thread, lone DM→thread, established→flat, thread/scratchpad→flat, deleted-opener→flat), `board-store.test.ts` (delete-on-empty + uncached-empty handled), board render suites
- [x] Full pre-commit suite: all-app ESLint, monorepo `tsc --noEmit` (incl. frontend app + test tsconfigs), `check:migrations`, OpenAPI `--check`, astro check — clean
- [ ] Not device-tested this session — staging label added for manual verification of the card swap on a real board

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bL9QBbQjeSr9p4JzwvwbF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785343970&installation_id=129946197&pr_number=1113&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1113&signature=3581a3c3f526b956ef7bda4bb1160b7f3ab2a7e67aaae4f479cee354a689d49c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->