### PR TITLE
docs(board): record the one-root multi-stream conversation model

### DIFF
--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -545,6 +545,88 @@ stops being load-bearing for the surfaces people actually drive.
    an expandable "re: Pizza, this morning" card that makes a revived reply self-
    contained for someone (or GAM) who wasn't there? _Same node, more rendering._
 
+## Conversations span streams within one root — the model, made precise (2026-06-30)
+
+This doc has said from the start that a conversation "spans a root message and its
+thread replies" (see "The post = a conversation" above). The implementation drifted
+from it, and dogfooding surfaced the gap: a DM top-level message rendered as missing
+from the board because its conversation also held a thread reply, and the board card
+reads only one stream. Three places assume one-stream-per-conversation:
+
+- **Boundary extraction** scopes assignment to a single stream
+  (`boundary-extraction-service.ts`), and the synchronous `existing` assigner
+  rejects any cross-stream attach (`conversation-assigner.ts`,
+  `streamId !== message.streamId` → `CONVERSATION_NOT_IN_STREAM`).
+- **The board card** reads one stream's event rail
+  (`useBoardCardMessages` → `useStreamRail(conversation.streamId)`), so a member
+  message in another stream of the same conversation never draws.
+- **Convert-to-thread** (#1113): a board reply to a lone post **retires** the source
+  conversation and **mints a new** thread conversation, rather than letting one
+  conversation span both. #1114 then built optimistic-swap machinery
+  (`usePendingThreadConversions`, a pending-row bridge, `revealNext`-on-convert) to
+  mask the cross-row card swap that retire+mint creates. **#1114 is closed**; this
+  section is the corrected model.
+
+**The invariant: a conversation is confined to exactly one root stream.** It may span
+that root and any of its threads (equal `root_stream_id` across every member message);
+it may **never** hold messages from two different roots. This matches the access model
+exactly — access is **root-stream membership only**; thread membership is participation,
+not access (INV-62, `core-concepts.md:42-45,261`). So a single access check on the
+conversation's root (`streamAccessPredicateSql` on `conversation.stream_id`, whose
+effective root `COALESCE(root_stream_id, id)` is that one root) gates **every** member,
+with **no per-message-stream gating**. The per-message-access worry only exists in a
+cross-root world, which this invariant forbids.
+
+**Why span streams at all** (rather than forcing one): the real cases require it —
+a **top-level discussion that continues in a thread**, and a **thread answered at the
+top level** (the Slack case — a thread holds the topic, a less thread-savvy person
+replies in the channel). Both are _the same conversation_ split across the root and a
+thread; forcing one stream either loses half of it or shoves unrelated content together.
+Moving messages to "fix" alignment is rejected for the same reason it always is here
+(never mutate a stream's order automatically — see "soft threads" above).
+
+**Convert-to-thread, corrected.** A board reply to a lone post still creates the thread
+(keeps the channel/DM top level clean — Kris's ruling), but the reply joins the **same**
+conversation as a cross-stream member (root opener + thread reply, one root). No retire,
+no new conversation, **stable conversation id**. The board card never swaps — it renders
+in place across the root + thread. The seamless behavior #1114 chased with optimistic
+gymnastics falls out for free: the reply is an ordinary optimistic message tagged to the
+conversation, shown via the existing rail tagging (#1111).
+
+**Continuation is recency-biased.** Once a conversation spans streams, "where does the
+next message go?" is answered by **where the conversation is currently live**, not its
+anchor. A board reply / continuation targets the conversation's most-recently-active
+stream (the thread, if it moved there) — posting into the anchor root would re-interleave
+the channel, the exact mess convert-to-thread avoids. Both `planBoardReply` and the
+extractor's continuation need this; lone-post→thread stays the one special case.
+
+**Board rendering.** The card renders a conversation's messages **flattened-chronological
+across the root + its threads, live** — it subscribes to the rails of the streams its
+members span (a bounded set under one root) and merges by time. A thread-anchored
+conversation (legacy, below) still shows its thread parent as the opener; a root-anchored
+multi-stream conversation's opener is just its earliest member.
+
+**Boundary extraction needs no tightening.** Same-root thread conversations appearing as
+assignment candidates (`findByMessageIds` over thread-context messages,
+`boundary-extraction-service.ts:120-131`) is **correct** under this model — they share
+the root. The misclassification that surfaced all this (a DM-root message clustered into
+a same-root thread conversation) was a **quality** error, not a structural one; it's
+addressed by recency-biased continuation and the eval loop, not by forbidding the shape.
+The one structural rule to enforce: assignment never crosses roots — relax the
+synchronous `existing` guard from same-**stream** to same-**root**, and reject cross-root.
+
+**Follow-ups / constraints.**
+
+1. **Legacy data.** Conversations converted under #1113 are thread-anchored with the
+   source retired (empty). They render fine via the thread-anchored path; the empty
+   sources stay filtered by `cardinality(message_ids) > 0`. An optional backfill could
+   re-anchor them to the root and re-absorb the opener, but it isn't required.
+2. **Move-message** must respect one-root: moving a member message to a different root
+   removes/reassigns it from its conversation, or the invariant breaks.
+3. **Access stays a single root check** everywhere a conversation's messages are read
+   (board list, expand, rails). Do **not** add per-message-stream gating — it's redundant
+   under the invariant and only invites drift.
+
 ## Phasing
 
 The inversion changes the order. Two candidate entry points:


### PR DESCRIPTION
## Problem

`docs/board-view-design.md` has said since v3 that a conversation "spans a root message and its thread replies" (`findByStreamIncludingThreads`), but the implementation drifted to one-stream-per-conversation, and dogfooding exposed the gap: a top-level DM message rendered as missing from the board because its conversation also held a thread reply, and the board card reads only one stream's rail. Three places encode the false assumption:

- Boundary extraction scopes assignment to a single stream (`boundary-extraction-service.ts`), and the synchronous `existing` assigner rejects any cross-stream attach (`conversation-assigner.ts` → `CONVERSATION_NOT_IN_STREAM`).
- The board card reads one stream's events (`useBoardCardMessages` → `useStreamRail(conversation.streamId)`).
- Convert-to-thread (#1113) retires the lone source conversation and mints a new thread conversation; #1114 then built optimistic-swap machinery to mask the resulting cross-row card swap.

The discussion concluded that the assumption is wrong (conversations genuinely span a root and its threads) and that the fix is a model correction, not more swap machinery — so #1114 was closed and the outcome is this doc update, not a feature PR.

## Solution

Adds a dated section — **"Conversations span streams within one root — the model, made precise (2026-06-30)"** — that pins down the model the doc always implied and records the convert-to-thread correction:

- **The invariant:** a conversation is confined to exactly one root stream — it may span that root and any of its threads (equal `root_stream_id`), never two roots. This matches the access model (root-membership only; threads inherit, INV-62), so a single access check on the conversation's root (`streamAccessPredicateSql` on `conversation.stream_id`) gates every member, with **no per-message-stream gating** — that worry only exists in a cross-root world the invariant forbids.
- **Why span at all:** top-level→thread continuation and thread-answered-at-the-top-level are the same conversation; forcing one stream breaks them.
- **Convert-to-thread corrected:** keep one conversation (stable id, no retire/mint, no card swap); the seamless behavior #1114 chased falls out for free. Records that #1114 is closed and why.
- **Recency-biased continuation:** the next message targets where the conversation is currently live (the thread), not the anchor — both `planBoardReply` and the extractor need it.
- **Board rendering:** flattened-chronological across the root's streams, live.
- **Extraction needs no tightening:** same-root thread candidates are correct; the misclassification that surfaced this was a quality error, not structural. The one rule to enforce: assignment never crosses roots (relax `existing` from same-stream to same-root).
- **Follow-ups/constraints:** legacy converted data renders via the thread-anchored path; move-message must respect one-root; access stays a single root check everywhere a conversation's messages are read.

This is design documentation only — no code, schema, or behavior changes. The implementation (one-root assignment + multi-stream board rendering + dropping the retire/mint) is the follow-on work the section scopes.

## Files changed

| File | Change |
| ---- | ------ |
| `docs/board-view-design.md` | New dated section (+82 lines) recording the one-root multi-stream conversation model, the convert-to-thread correction, recency-biased continuation, and multi-stream board rendering. |

## Test plan

- [x] Pre-commit hook (full monorepo typecheck + OpenAPI `--check` + prettier) passed on the commit — docs-only, no code touched.
- [ ] No automated tests — documentation change; nothing executable to verify.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBw6m1RdSddjY4oMN6zFmv)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785387145&installation_id=129946197&pr_number=1115&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1115&signature=7681d36d8d5aa9b986c37ab2fa9b72ed1bb693ebf76ee63b66ffe1418143ce90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->