### PR TITLE
feat(link-previews): sync-render the in-app message preview card from baked per-viewer data

### DIFF
--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -405,6 +405,28 @@ describe("LinkPreviewService.getPreviewsForMessages", () => {
     expect(previews.every((p) => p.inAppData?.kind === "memo")).toBe(true)
     expect(accessibleSpy).toHaveBeenCalledTimes(1)
   })
+
+  test("a failed memo-access lookup leaves memo previews unbaked without failing the page", async () => {
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_1",
+          [
+            makePreview({ id: "lp_memo", contentType: "memo_link", targetStreamId: null, targetMemoId: "memo_a" }),
+            makePreview({ id: "lp_stream", contentType: "stream_link", targetStreamId: "stream_ok" }),
+          ],
+        ],
+      ]) as never
+    )
+    spyOn(SearchRepository, "getAccessibleStreamsWithMembers").mockRejectedValue(new Error("db down"))
+    const service = makeService({ tryAccess: async () => makeStream({ id: "stream_ok", slug: "general" }) }, {})
+
+    const previews = (await service.getPreviewsForMessages(WORKSPACE_ID, VIEWER_ID, ["msg_1"])).get("msg_1")!
+
+    // The non-memo preview still bakes; the memo one is left unbaked, no throw.
+    expect(previews.find((p) => p.id === "lp_stream")!.inAppData).toMatchObject({ kind: "stream", accessTier: "full" })
+    expect(previews.find((p) => p.id === "lp_memo")!.inAppData).toBeUndefined()
+  })
 })
 
 describe("LinkPreviewService.resolveInAppLinkByUrl", () => {

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -348,6 +348,63 @@ describe("LinkPreviewService.getPreviewsForMessages", () => {
 
     expect(result.get("msg_1")![0].inAppData).toEqual({ kind: "stream", accessTier: "private" })
   })
+
+  test("a single resolve failure leaves that preview unbaked without failing the page", async () => {
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_1",
+          [
+            makePreview({ id: "lp_ok", contentType: "stream_link", targetStreamId: "stream_ok" }),
+            makePreview({ id: "lp_bad", contentType: "stream_link", targetStreamId: "stream_err" }),
+          ],
+        ],
+      ]) as never
+    )
+    const service = makeService(
+      {
+        tryAccess: (async (streamId: string) => {
+          if (streamId === "stream_err") throw new Error("boom")
+          return makeStream({ id: "stream_ok", slug: "general" })
+        }) as never,
+      },
+      {}
+    )
+
+    const previews = (await service.getPreviewsForMessages(WORKSPACE_ID, VIEWER_ID, ["msg_1"])).get("msg_1")!
+
+    expect(previews.find((p) => p.id === "lp_ok")!.inAppData).toMatchObject({ kind: "stream", accessTier: "full" })
+    expect(previews.find((p) => p.id === "lp_bad")!.inAppData).toBeUndefined()
+  })
+
+  test("resolves the viewer's accessible streams once for multiple memo previews", async () => {
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        [
+          "msg_1",
+          [
+            makePreview({ id: "lp_a", contentType: "memo_link", targetStreamId: null, targetMemoId: "memo_a" }),
+            makePreview({ id: "lp_b", contentType: "memo_link", targetStreamId: null, targetMemoId: "memo_b" }),
+          ],
+        ],
+      ]) as never
+    )
+    const accessibleSpy = spyOn(SearchRepository, "getAccessibleStreamsWithMembers").mockResolvedValue(["stream_1"])
+    const service = makeService(
+      {},
+      {
+        getById: (async (_ws: string, memoId: string) => ({
+          memo: { title: memoId, abstract: "abstract", knowledgeType: "decision" },
+          sourceStream: { id: "stream_1", type: "channel", name: "eng" },
+        })) as never,
+      }
+    )
+
+    const previews = (await service.getPreviewsForMessages(WORKSPACE_ID, VIEWER_ID, ["msg_1"])).get("msg_1")!
+
+    expect(previews.every((p) => p.inAppData?.kind === "memo")).toBe(true)
+    expect(accessibleSpy).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("LinkPreviewService.resolveInAppLinkByUrl", () => {

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -292,6 +292,64 @@ describe("LinkPreviewService.resolveInAppLink", () => {
   })
 })
 
+describe("LinkPreviewService.getPreviewsForMessages", () => {
+  test("bakes per-viewer in-app data onto in-app previews but not web previews", async () => {
+    const messagePreview = makePreview({
+      id: "lp_inapp",
+      contentType: "message_link",
+      targetStreamId: "stream_1",
+      targetMessageId: "msg_target",
+      url: "https://app.threa.io/w/ws_self/s/stream_1?m=msg_target",
+    })
+    const webPreview = makePreview({
+      id: "lp_web",
+      contentType: "website",
+      targetWorkspaceId: null,
+      targetStreamId: null,
+      url: "https://example.com/blog",
+    })
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(
+      new Map([["msg_1", [messagePreview, webPreview]]]) as never
+    )
+    spyOn(MessageRepository, "findById").mockResolvedValue({
+      id: "msg_target",
+      streamId: "stream_1",
+      authorType: "user",
+      authorId: "user_author",
+      contentMarkdown: "Hello there",
+      deletedAt: null,
+    } as never)
+    spyOn(UserRepository, "findById").mockResolvedValue({ name: "Author", avatarUrl: null } as never)
+    const service = makeService({ tryAccess: async () => makeStream({ slug: "general" }) }, {})
+
+    const result = await service.getPreviewsForMessages(WORKSPACE_ID, VIEWER_ID, ["msg_1"])
+
+    const previews = result.get("msg_1")!
+    expect(previews.find((p) => p.id === "lp_inapp")!.inAppData).toMatchObject({
+      kind: "message",
+      accessTier: "full",
+      authorName: "Author",
+      contentPreview: "Hello there",
+      streamType: "channel",
+    })
+    // A plain web preview carries no in-app resolve.
+    expect(previews.find((p) => p.id === "lp_web")!.inAppData).toBeUndefined()
+  })
+
+  test("bakes the per-viewer private tier when the viewer cannot access the target", async () => {
+    spyOn(LinkPreviewRepository, "findByMessageIds").mockResolvedValue(
+      new Map([
+        ["msg_1", [makePreview({ id: "lp_inapp", contentType: "stream_link", targetStreamId: "stream_secret" })]],
+      ]) as never
+    )
+    const service = makeService({ tryAccess: async () => null }, {})
+
+    const result = await service.getPreviewsForMessages(WORKSPACE_ID, VIEWER_ID, ["msg_1"])
+
+    expect(result.get("msg_1")![0].inAppData).toEqual({ kind: "stream", accessTier: "private" })
+  })
+})
+
 describe("LinkPreviewService.resolveInAppLinkByUrl", () => {
   const previousOrigins = process.env.CORS_ALLOWED_ORIGINS
   beforeAll(() => {

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -264,8 +264,9 @@ export class LinkPreviewService {
     const previewMap = await LinkPreviewRepository.findByMessageIds(this.deps.pool, workspaceId, messageIds)
     const result = new Map<string, LinkPreviewSummary[]>()
 
-    // Build the summaries up front, collecting the in-app ones that still need a
-    // per-viewer resolve so the whole page resolves under one bounded fan-out.
+    // Each pending entry holds the SAME summary object that goes into `result`,
+    // so the fan-out below writes `inAppData` through the shared reference and the
+    // returned map sees it with no second pass. (Breaks if this ever stores copies.)
     const pending: Array<{ summary: LinkPreviewSummary; row: LinkPreview }> = []
     for (const [msgId, previews] of previewMap) {
       const completedRows = previews.filter((p) => p.status === "completed")

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -282,20 +282,32 @@ export class LinkPreviewService {
 
     // A memo's tier is gated by the viewer's accessible streams — the same list
     // for every memo on the page — so resolve it once and share it instead of
-    // re-running that query per memo preview.
-    const accessibleStreamIds = pending.some((p) => p.row.contentType === "memo_link")
-      ? await resolveUserAccessibleStreamIds(this.deps.pool, workspaceId, userId, {
+    // re-running that query per memo preview. A failure here must only skip the
+    // memo bakes (below), never reject the page — baking is optional (the card
+    // falls back to an async resolve when `inAppData` is absent).
+    let accessibleStreamIds: string[] | undefined
+    let memoAccessResolved = true
+    if (pending.some((p) => p.row.contentType === "memo_link")) {
+      try {
+        accessibleStreamIds = await resolveUserAccessibleStreamIds(this.deps.pool, workspaceId, userId, {
           archiveStatus: ["active", "archived"],
         })
-      : undefined
+      } catch (err) {
+        memoAccessResolved = false
+        logger.warn(
+          { err, workspaceId, userId },
+          "Failed to resolve memo preview access; leaving memo previews unbaked"
+        )
+      }
+    }
 
-    // Baking is an optional enhancement — the card falls back to an async resolve
-    // when `inAppData` is absent — so a single resolve failure must leave that one
-    // preview unbaked, never reject the whole history/catch-up enrichment.
+    // Likewise a single resolve failure leaves that one preview unbaked rather
+    // than rejecting the whole history/catch-up enrichment.
     const limit = pLimit(IN_APP_RESOLVE_CONCURRENCY)
     await Promise.all(
       pending.map(({ summary, row }) =>
         limit(async () => {
+          if (row.contentType === "memo_link" && !memoAccessResolved) return
           try {
             const data = await this.resolveInAppTarget(workspaceId, userId, row.contentType, row, {
               accessibleStreamIds,

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -7,7 +7,7 @@ import type {
   LinkPreviewSummary,
   MessageLinkPreviewData,
 } from "@threa/types"
-import { getAvatarUrl } from "@threa/types"
+import { getAvatarUrl, isInAppLinkContentType } from "@threa/types"
 import { LinkPreviewRepository, type LinkPreview, type UpdateLinkPreviewParams } from "./repository"
 import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
@@ -242,17 +242,41 @@ export class LinkPreviewService {
     return previews.filter((p) => p.status === "completed").map((p, i) => toLinkPreviewSummary(p, i))
   }
 
-  async getPreviewsForMessages(workspaceId: string, messageIds: string[]): Promise<Map<string, LinkPreviewSummary[]>> {
+  /**
+   * Assembles previews for a viewer's history/catch-up fetch. In-app previews are
+   * resolved per-viewer here (access tier, DM recipient) and baked onto
+   * `inAppData` so the card renders synchronously — the live broadcast can't carry
+   * this because it has no single viewer to resolve against (see `LinkPreviewSummary`).
+   */
+  async getPreviewsForMessages(
+    workspaceId: string,
+    userId: string,
+    messageIds: string[]
+  ): Promise<Map<string, LinkPreviewSummary[]>> {
     const previewMap = await LinkPreviewRepository.findByMessageIds(this.deps.pool, workspaceId, messageIds)
     const result = new Map<string, LinkPreviewSummary[]>()
 
+    // Collect every in-app resolve across the page so they run concurrently
+    // rather than serializing one message at a time (INV-56 in spirit).
+    const inAppResolves: Array<Promise<void>> = []
+
     for (const [msgId, previews] of previewMap) {
-      const completed = previews.filter((p) => p.status === "completed").map((p, i) => toLinkPreviewSummary(p, i))
-      if (completed.length > 0) {
-        result.set(msgId, completed)
-      }
+      const completedRows = previews.filter((p) => p.status === "completed")
+      if (completedRows.length === 0) continue
+
+      const summaries = completedRows.map((p, i) => toLinkPreviewSummary(p, i))
+      completedRows.forEach((row, i) => {
+        if (!isInAppLinkContentType(row.contentType)) return
+        inAppResolves.push(
+          this.resolveInAppTarget(workspaceId, userId, row.contentType, row).then((data) => {
+            if (data) summaries[i].inAppData = data
+          })
+        )
+      })
+      result.set(msgId, summaries)
     }
 
+    await Promise.all(inAppResolves)
     return result
   }
 

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -1,4 +1,6 @@
 import type { Pool } from "pg"
+import pLimit from "p-limit"
+import { logger } from "@threa/backend-common"
 import { withTransaction } from "../../db"
 import { linkPreviewId } from "../../lib/id"
 import type {
@@ -20,6 +22,12 @@ import { extractUrls, normalizeUrl, detectContentType, parseInAppLink, type InAp
 import { MAX_PREVIEWS_PER_MESSAGE, getAppOrigins } from "./config"
 
 const CONTENT_PREVIEW_MAX_LENGTH = 200
+
+// Cap concurrent per-viewer in-app resolves when assembling a history page. Each
+// resolve runs several sequential queries and holds a pool connection for its
+// duration; a large page of in-app links would otherwise fan out far past the
+// pool size (main pool is 30) and queue unrelated transactional work behind it.
+const IN_APP_RESOLVE_CONCURRENCY = 8
 
 export interface LinkPreviewServiceDeps {
   pool: Pool
@@ -256,27 +264,48 @@ export class LinkPreviewService {
     const previewMap = await LinkPreviewRepository.findByMessageIds(this.deps.pool, workspaceId, messageIds)
     const result = new Map<string, LinkPreviewSummary[]>()
 
-    // Collect every in-app resolve across the page so they run concurrently
-    // rather than serializing one message at a time (INV-56 in spirit).
-    const inAppResolves: Array<Promise<void>> = []
-
+    // Build the summaries up front, collecting the in-app ones that still need a
+    // per-viewer resolve so the whole page resolves under one bounded fan-out.
+    const pending: Array<{ summary: LinkPreviewSummary; row: LinkPreview }> = []
     for (const [msgId, previews] of previewMap) {
       const completedRows = previews.filter((p) => p.status === "completed")
       if (completedRows.length === 0) continue
 
       const summaries = completedRows.map((p, i) => toLinkPreviewSummary(p, i))
       completedRows.forEach((row, i) => {
-        if (!isInAppLinkContentType(row.contentType)) return
-        inAppResolves.push(
-          this.resolveInAppTarget(workspaceId, userId, row.contentType, row).then((data) => {
-            if (data) summaries[i].inAppData = data
-          })
-        )
+        if (isInAppLinkContentType(row.contentType)) pending.push({ summary: summaries[i], row })
       })
       result.set(msgId, summaries)
     }
+    if (pending.length === 0) return result
 
-    await Promise.all(inAppResolves)
+    // A memo's tier is gated by the viewer's accessible streams — the same list
+    // for every memo on the page — so resolve it once and share it instead of
+    // re-running that query per memo preview.
+    const accessibleStreamIds = pending.some((p) => p.row.contentType === "memo_link")
+      ? await resolveUserAccessibleStreamIds(this.deps.pool, workspaceId, userId, {
+          archiveStatus: ["active", "archived"],
+        })
+      : undefined
+
+    // Baking is an optional enhancement — the card falls back to an async resolve
+    // when `inAppData` is absent — so a single resolve failure must leave that one
+    // preview unbaked, never reject the whole history/catch-up enrichment.
+    const limit = pLimit(IN_APP_RESOLVE_CONCURRENCY)
+    await Promise.all(
+      pending.map(({ summary, row }) =>
+        limit(async () => {
+          try {
+            const data = await this.resolveInAppTarget(workspaceId, userId, row.contentType, row, {
+              accessibleStreamIds,
+            })
+            if (data) summary.inAppData = data
+          } catch (err) {
+            logger.warn({ err, workspaceId, previewId: row.id }, "Failed to bake in-app preview data; leaving unbaked")
+          }
+        })
+      )
+    )
     return result
   }
 
@@ -334,7 +363,8 @@ export class LinkPreviewService {
     workspaceId: string,
     userId: string,
     contentType: LinkPreviewContentType,
-    target: InAppLinkTarget
+    target: InAppLinkTarget,
+    opts?: { accessibleStreamIds?: string[] }
   ): Promise<InAppLinkPreviewData | null> {
     switch (contentType) {
       case "message_link":
@@ -342,7 +372,7 @@ export class LinkPreviewService {
       case "stream_link":
         return this.resolveStreamTarget(workspaceId, userId, target)
       case "memo_link":
-        return this.resolveMemoTarget(workspaceId, userId, target)
+        return this.resolveMemoTarget(workspaceId, userId, target, opts?.accessibleStreamIds)
       default:
         return Promise.resolve(null)
     }
@@ -453,7 +483,9 @@ export class LinkPreviewService {
   private async resolveMemoTarget(
     workspaceId: string,
     userId: string,
-    target: InAppLinkTarget
+    target: InAppLinkTarget,
+    /** Precomputed once by the batch path so memos on a page don't each re-query it. */
+    sharedAccessibleStreamIds?: string[]
   ): Promise<InAppLinkPreviewData | null> {
     const { targetWorkspaceId, targetMemoId } = target
     if (!targetWorkspaceId || !targetMemoId) return null
@@ -463,9 +495,11 @@ export class LinkPreviewService {
     }
 
     // A memo's visibility is inherited from the streams its source messages live in.
-    const accessibleStreamIds = await resolveUserAccessibleStreamIds(this.deps.pool, workspaceId, userId, {
-      archiveStatus: ["active", "archived"],
-    })
+    const accessibleStreamIds =
+      sharedAccessibleStreamIds ??
+      (await resolveUserAccessibleStreamIds(this.deps.pool, workspaceId, userId, {
+        archiveStatus: ["active", "archived"],
+      }))
     // No accessible streams means no memo is reachable — return the private tier
     // without reading the memo row, matching how the message/stream paths collapse
     // "not found" and "no access" into one response (no existence side-channel).

--- a/apps/backend/src/features/streams/handlers.test.ts
+++ b/apps/backend/src/features/streams/handlers.test.ts
@@ -78,6 +78,32 @@ describe("applyLinkPreviewStateToEvents", () => {
 
     expect((event.payload as { linkPreviews?: LinkPreviewSummary[] }).linkPreviews).toEqual([visiblePreview])
   })
+
+  it("applies the enriched preview when only the per-viewer inAppData differs", () => {
+    // The stored event payload carries the same preview with no inAppData; the map
+    // version adds it. The override must win or the card loses its synchronous data.
+    const basePreview: LinkPreviewSummary = {
+      id: "preview_msg",
+      url: "https://app.threa.io/w/ws_1/s/stream_1?m=msg_target",
+      title: null,
+      description: null,
+      imageUrl: null,
+      faviconUrl: null,
+      siteName: null,
+      contentType: "message_link",
+      position: 0,
+    }
+    const stored = createMessageEvent("msg_1")
+    ;(stored.payload as { linkPreviews?: LinkPreviewSummary[] }).linkPreviews = [basePreview]
+    const enriched: LinkPreviewSummary = {
+      ...basePreview,
+      inAppData: { kind: "message", accessTier: "full", authorName: "Author", contentPreview: "hi" },
+    }
+
+    const [event] = applyLinkPreviewStateToEvents([stored], new Map([["msg_1", [enriched]]]), new Set())
+
+    expect((event.payload as { linkPreviews?: LinkPreviewSummary[] }).linkPreviews).toEqual([enriched])
+  })
 })
 
 describe("createStreamHandlers.updateToolPolicy", () => {

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -398,9 +398,19 @@ function areLinkPreviewArraysEqual(current: LinkPreviewSummary[] | undefined, ne
       preview.faviconUrl === nextPreview.faviconUrl &&
       preview.siteName === nextPreview.siteName &&
       preview.contentType === nextPreview.contentType &&
-      preview.position === nextPreview.position
+      preview.position === nextPreview.position &&
+      // The stored payload carries no per-viewer `inAppData`; the enriched copy
+      // does, so this difference must register or the override is skipped and the
+      // card loses its synchronous data.
+      isInAppDataEqual(preview.inAppData, nextPreview.inAppData)
     )
   })
+}
+
+function isInAppDataEqual(current: LinkPreviewSummary["inAppData"], next: LinkPreviewSummary["inAppData"]): boolean {
+  if (current === next) return true
+  if (!current || !next) return false
+  return JSON.stringify(current) === JSON.stringify(next)
 }
 
 export function applyLinkPreviewStateToEvents(
@@ -452,7 +462,7 @@ async function enrichEventsWithLinkPreviews(
   if (messageIds.length === 0) return events
 
   const [previewMap, dismissals] = await Promise.all([
-    linkPreviewService.getPreviewsForMessages(workspaceId, messageIds),
+    linkPreviewService.getPreviewsForMessages(workspaceId, userId, messageIds),
     linkPreviewService.getDismissals(workspaceId, userId, messageIds),
   ])
 

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
@@ -158,4 +158,34 @@ describe("InAppLinkPreviewCard", () => {
     await waitFor(() => expect(screen.getByText("In another workspace")).toBeInTheDocument())
     expect(screen.getByText("Memory")).toBeInTheDocument()
   })
+
+  it("renders synchronously from baked inAppData without an async resolve", () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <InAppLinkPreviewCard
+            preview={makePreview({
+              contentType: "message_link",
+              url: "not a valid url",
+              inAppData: {
+                kind: "message",
+                accessTier: "full",
+                deleted: false,
+                streamName: "general",
+                authorName: "Baked Author",
+                contentPreview: "Baked snippet",
+              },
+            })}
+            workspaceId={workspaceId}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    // Content is present on first paint (no waitFor) and the resolve endpoint is never hit.
+    expect(screen.getByText("Baked Author")).toBeInTheDocument()
+    expect(screen.getByText("Baked snippet")).toBeInTheDocument()
+    expect(mockResolveInAppLink).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -61,19 +61,29 @@ interface InAppLinkPreviewCardProps {
 }
 
 export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate = true }: InAppLinkPreviewCardProps) {
-  const { data, loading } = useResolvedInAppLink(workspaceId, preview.id, undefined, hydrate)
+  // When the message was assembled for this viewer (history/catch-up fetch), the
+  // backend bakes the resolved, access-tiered data onto the preview. Render it
+  // synchronously — no skeleton, no second round-trip, and no reserved fixed
+  // footprint, so a short card sizes to its content. Only fall back to the async
+  // per-viewer resolve when the data is absent (the shared live broadcast).
+  const baked = preview.inAppData
+  const { data, loading } = useResolvedInAppLink(workspaceId, preview.id, undefined, hydrate && !baked)
+  const resolved = baked ?? data
+
+  if (resolved) {
+    return (
+      <ResolvedInAppLink
+        data={resolved}
+        url={preview.url}
+        workspaceId={workspaceId}
+        reserve={!baked}
+        onDismiss={onDismiss ? () => onDismiss(preview.id) : undefined}
+      />
+    )
+  }
 
   if (loading) return <CardSkeleton variant={preview.contentType === "memo_link" ? "memo" : "message"} />
-  if (!data) return null
-
-  return (
-    <ResolvedInAppLink
-      data={data}
-      url={preview.url}
-      workspaceId={workspaceId}
-      onDismiss={onDismiss ? () => onDismiss(preview.id) : undefined}
-    />
-  )
+  return null
 }
 
 // The timeline does not compensate a row that grows after its first paint — its
@@ -95,33 +105,43 @@ function streamIdFromUrl(url: string): string | null {
   return ref && (ref.kind === "stream" || ref.kind === "message") ? ref.streamId : null
 }
 
-/** Dispatches resolved data to the matching card. `onDismiss` is already bound. */
+/**
+ * Dispatches resolved data to the matching card. `onDismiss` is already bound.
+ * `reserve` is true on the async path (a skeleton preceded this card, so the body
+ * must commit the same fixed footprint to avoid an INV-21 jump) and false when the
+ * data was baked into the payload (rendered synchronously — no skeleton, so the
+ * card sizes to its content with no reserved padding).
+ */
 function ResolvedInAppLink({
   data,
   url,
   workspaceId,
+  reserve,
   onDismiss,
 }: {
   data: InAppLinkPreviewData
   url: string
   workspaceId: string
+  reserve: boolean
   onDismiss?: () => void
 }) {
   if (data.kind === "stream")
     return <StreamLinkCard data={data} url={url} workspaceId={workspaceId} onDismiss={onDismiss} />
-  if (data.kind === "memo") return <MemoLinkCard data={data} url={url} onDismiss={onDismiss} />
-  return <MessageLinkCard data={data} url={url} workspaceId={workspaceId} onDismiss={onDismiss} />
+  if (data.kind === "memo") return <MemoLinkCard data={data} url={url} reserve={reserve} onDismiss={onDismiss} />
+  return <MessageLinkCard data={data} url={url} workspaceId={workspaceId} reserve={reserve} onDismiss={onDismiss} />
 }
 
 function MessageLinkCard({
   data,
   url,
   workspaceId,
+  reserve,
   onDismiss,
 }: {
   data: MessageLinkPreviewData
   url: string
   workspaceId: string
+  reserve: boolean
   onDismiss?: () => void
 }) {
   // A DM/stream name is per-viewer and absent from the backend resolve, so
@@ -135,6 +155,7 @@ function MessageLinkCard({
         kindIcon={<MessageSquare />}
         kindLabel="Message"
         label="In another workspace"
+        reserve={reserve}
         onDismiss={onDismiss}
       />
     )
@@ -147,6 +168,7 @@ function MessageLinkCard({
         kindLabel="Message"
         bodyIcon={<Lock />}
         label="In a private conversation"
+        reserve={reserve}
         onDismiss={onDismiss}
       />
     )
@@ -159,6 +181,7 @@ function MessageLinkCard({
         kindLabel="Message"
         label="This message was deleted"
         italic
+        reserve={reserve}
         onDismiss={onDismiss}
       />
     )
@@ -166,7 +189,7 @@ function MessageLinkCard({
 
   const internalPath = getInternalPath(url)
   const body = (
-    <CardBody className={CARD_BODY_MESSAGE}>
+    <CardBody className={reserve ? CARD_BODY_MESSAGE : undefined}>
       <div className="flex gap-3">
         <ActorAvatar
           actorId={data.authorId ?? null}
@@ -289,7 +312,17 @@ function StreamLinkCard({
   )
 }
 
-function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url: string; onDismiss?: () => void }) {
+function MemoLinkCard({
+  data,
+  url,
+  reserve,
+  onDismiss,
+}: {
+  data: MemoLinkPreviewData
+  url: string
+  reserve: boolean
+  onDismiss?: () => void
+}) {
   if (data.accessTier === "cross_workspace") {
     return (
       <MinimalCard
@@ -297,6 +330,7 @@ function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url
         kindLabel="Memory"
         label="In another workspace"
         variant="memo"
+        reserve={reserve}
         onDismiss={onDismiss}
       />
     )
@@ -310,6 +344,7 @@ function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url
         bodyIcon={<Lock />}
         label="From a private conversation"
         variant="memo"
+        reserve={reserve}
         onDismiss={onDismiss}
       />
     )
@@ -317,7 +352,7 @@ function MemoLinkCard({ data, url, onDismiss }: { data: MemoLinkPreviewData; url
 
   const internalPath = getInternalPath(url)
   const body = (
-    <CardBody className={CARD_BODY_MEMO}>
+    <CardBody className={reserve ? CARD_BODY_MEMO : undefined}>
       <div className="flex items-start gap-3">
         <IconTile>
           <Brain />
@@ -461,6 +496,7 @@ function MinimalCard({
   label,
   italic,
   variant = "message",
+  reserve = true,
   onDismiss,
 }: {
   kindIcon: ReactNode
@@ -470,6 +506,8 @@ function MinimalCard({
   italic?: boolean
   /** Match the skeleton/full-card footprint of the link's kind so the tier swap doesn't shift. */
   variant?: CardVariant
+  /** False when rendered synchronously from baked data — no skeleton preceded it, so no fixed footprint. */
+  reserve?: boolean
   onDismiss?: () => void
 }) {
   return (
@@ -484,7 +522,7 @@ function MinimalCard({
       <div
         className={cn(
           "flex items-center gap-3 px-3.5 py-3 text-muted-foreground",
-          variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE
+          reserve && (variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE)
         )}
       >
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40 [&>svg]:h-[18px] [&>svg]:w-[18px]">

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -7,6 +7,7 @@ import {
   detectSequenceGap,
   getLatestPersistedSequence,
   getPersistedTail,
+  preserveBakedInAppData,
   registerStreamSocketHandlers,
   toCachedStreamBootstrap,
   updateMessageEvent,
@@ -14,7 +15,7 @@ import {
 } from "./stream-sync"
 import { streamKeys } from "@/hooks/use-streams"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
-import type { BotRuntimePresenceSummary, StreamBootstrap, StreamEvent } from "@threa/types"
+import type { BotRuntimePresenceSummary, LinkPreviewSummary, StreamBootstrap, StreamEvent } from "@threa/types"
 
 // With fake-indexeddb loaded in test setup, Dexie works against a real
 // in-memory IndexedDB. No mocks needed — tests exercise actual queries.
@@ -1651,5 +1652,64 @@ describe("bootstrap no-op rewrite skip (perceived-perf: silence spurious liveQue
 
     expect(second).toEqual(first)
     expect(second?._cachedAt).toBe(12345)
+  })
+})
+
+describe("preserveBakedInAppData", () => {
+  const inAppData: LinkPreviewSummary["inAppData"] = {
+    kind: "message",
+    accessTier: "full",
+    authorName: "Author",
+    contentPreview: "hi",
+  }
+
+  function preview(overrides: Partial<LinkPreviewSummary> & { id: string }): LinkPreviewSummary {
+    return {
+      url: `https://app.threa.io/p/${overrides.id}`,
+      title: null,
+      description: null,
+      imageUrl: null,
+      faviconUrl: null,
+      siteName: null,
+      contentType: "message_link",
+      position: 0,
+      ...overrides,
+    }
+  }
+
+  it("carries baked inAppData forward by id when the broadcast lacks it", () => {
+    const existing = [preview({ id: "lp_1", inAppData })]
+    const incoming = [preview({ id: "lp_1" })]
+
+    const merged = preserveBakedInAppData(incoming, existing)
+
+    expect(merged[0].inAppData).toEqual(inAppData)
+  })
+
+  it("does not carry to a re-extracted preview with a fresh id", () => {
+    const existing = [preview({ id: "lp_old", inAppData })]
+    const incoming = [preview({ id: "lp_new" })]
+
+    const merged = preserveBakedInAppData(incoming, existing)
+
+    expect(merged[0].inAppData).toBeUndefined()
+  })
+
+  it("keeps the incoming inAppData when it already carries one", () => {
+    const fresh = { ...inAppData, authorName: "Fresh" }
+    const existing = [preview({ id: "lp_1", inAppData })]
+    const incoming = [preview({ id: "lp_1", inAppData: fresh })]
+
+    const merged = preserveBakedInAppData(incoming, existing)
+
+    expect(merged[0].inAppData).toEqual(fresh)
+  })
+
+  it("returns the incoming array unchanged when nothing was baked", () => {
+    const incoming = [preview({ id: "lp_1" })]
+
+    const merged = preserveBakedInAppData(incoming, [preview({ id: "lp_1" })])
+
+    expect(merged).toBe(incoming)
   })
 })

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -469,6 +469,23 @@ interface LinkPreviewReadyPayload {
   previews: LinkPreviewSummary[]
 }
 
+/**
+ * The live `link_preview:ready` broadcast can't carry per-viewer `inAppData` (no
+ * single viewer to resolve against), so it would wipe data the history fetch
+ * already baked onto the cached event. Carry that `inAppData` forward by preview
+ * id when the incoming copy lacks it, so an in-app card keeps rendering
+ * synchronously instead of dropping back to the async resolve. A re-extracted
+ * preview (message edit) gets a fresh id and so is correctly not matched.
+ */
+export function preserveBakedInAppData(
+  incoming: LinkPreviewSummary[],
+  existing: LinkPreviewSummary[] | undefined
+): LinkPreviewSummary[] {
+  const baked = new Map(existing?.filter((p) => p.inAppData).map((p) => [p.id, p.inAppData]))
+  if (baked.size === 0) return incoming
+  return incoming.map((p) => (p.inAppData || !baked.has(p.id) ? p : { ...p, inAppData: baked.get(p.id) }))
+}
+
 // ============================================================================
 // Helper: find and update a message_created event in IndexedDB
 // ============================================================================
@@ -981,7 +998,7 @@ export function registerStreamSocketHandlers(
     if (payload.streamId !== streamId) return
     await updateMessageEvent(streamId, payload.messageId, (p) => ({
       ...p,
-      linkPreviews: payload.previews,
+      linkPreviews: preserveBakedInAppData(payload.previews, p.linkPreviews as LinkPreviewSummary[] | undefined),
     }))
   }
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -474,8 +474,10 @@ interface LinkPreviewReadyPayload {
  * single viewer to resolve against), so it would wipe data the history fetch
  * already baked onto the cached event. Carry that `inAppData` forward by preview
  * id when the incoming copy lacks it, so an in-app card keeps rendering
- * synchronously instead of dropping back to the async resolve. A re-extracted
- * preview (message edit) gets a fresh id and so is correctly not matched.
+ * synchronously instead of dropping back to the async resolve. Matching on id is
+ * safe because a preview row is keyed by normalized url: the same id always means
+ * the same link target, so the carried tier still applies; a preview pointing at a
+ * different target carries a different id and is correctly left to resolve async.
  */
 export function preserveBakedInAppData(
   incoming: LinkPreviewSummary[],

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1021,6 +1021,16 @@ export interface LinkPreviewSummary {
   previewType?: GitHubPreviewType | LinearPreviewType | null
   previewData?: GitHubPreview | LinearPreview | null
   position: number
+  /**
+   * Resolved, access-tiered in-app link data (message/stream/memo), populated
+   * per-viewer when a message is assembled for a specific user (the history /
+   * catch-up REST fetch, which carries a `userId`). When present, the in-app
+   * preview card renders synchronously without a second permission-checked
+   * round-trip, so it never flashes a skeleton or reserves a fixed footprint.
+   * Absent on the shared live broadcast, where there is no single viewer to
+   * resolve against — there the card falls back to an async per-viewer resolve.
+   */
+  inAppData?: InAppLinkPreviewData
 }
 
 export interface WorkspaceIntegration {


### PR DESCRIPTION
## Problem

The in-app **message** link preview card (`InAppLinkPreviewCard`) resolves its data asynchronously through `useResolvedInAppLink` — a permission-checked round-trip per card. To avoid a layout jump when the skeleton swaps for the resolved card, #1108 reserved a fixed footprint (`CARD_BODY_MESSAGE="min-h-[5.5rem]"`, `CARD_BODY_MEMO="min-h-[7rem]"`) on every tier. The timeline's scroll anchor no-ops a mid-list row that grows after first paint (`use-timeline-scroll`, `overflow-anchor: none`), so the reserve is load-bearing for INV-21.

The cost the user flagged: a short (1-line) message card carries reserved bottom padding it doesn't use. That was accepted in #1108 as a deliberate zero-shift trade-off, with sync-rendering noted as the follow-up that removes it.

## Solution

Bake the resolved, access-tiered in-app data into the message payload so the card paints once at its natural height — the way web (GitHub/Linear) cards already ship their `previewData`. The card then renders synchronously: no skeleton, no second round-trip, no reserve.

The constraint that shapes where this can happen: the resolve is **per-viewer**. `accessTier` (`full`/`private`) depends on the viewer's access to the linked stream, and a DM's `recipientName` excludes the viewer. The shared live `link_preview:ready` broadcast has no single viewer to resolve against — baking `full` content there would leak a private linked message's content to a recipient who can't see it. So data is baked **only where a `userId` is in hand**: the history / catch-up REST assembly. That is exactly the surface where the mid-list INV-21 shift mattered; live messages (received at the bottom) keep the async resolve and its reserve.

### How it works

1. **Type** — `LinkPreviewSummary` gains optional `inAppData?: InAppLinkPreviewData` (`packages/types/src/domain.ts`), the resolved access-tiered payload.
2. **Backend resolve (per-viewer)** — `LinkPreviewService.getPreviewsForMessages` takes a `userId` and, for each completed in-app preview row, calls the existing `resolveInAppTarget(workspaceId, userId, contentType, row)` and assigns the result to `summary.inAppData`. Resolves across the page are collected and run under one `Promise.all` rather than serializing per message. Non-in-app (web) previews get no `inAppData`. Only caller is `enrichEventsWithLinkPreviews` (`streams/handlers.ts`), which already has the viewer's `userId`.
3. **Override propagation** — `applyLinkPreviewStateToEvents` overrides a `message_created` event's `payload.linkPreviews` with the enriched map version only when it differs from the stored payload. The stored payload has no `inAppData`, so without comparing it the enriched copy looked equal and the override was skipped. `areLinkPreviewArraysEqual` now compares `inAppData` (`isInAppDataEqual`, reference-equal fast path then `JSON.stringify`), so the difference registers and the baked data survives.
4. **Frontend sync render** — `InAppLinkPreviewCard` reads `preview.inAppData`. When present it renders `ResolvedInAppLink` directly and disables the resolve query (`hydrate && !baked`); when absent it keeps the async path (skeleton → card). A `reserve` boolean threads down to `MessageLinkCard` / `MemoLinkCard` / `MinimalCard`: `true` on the async path (skeleton preceded it — keep the fixed footprint), `false` on the baked path (sizes to content). The body class becomes `reserve ? CARD_BODY_MESSAGE : undefined`.

### Key design decisions

**1. Bake only at the per-viewer boundary, never on the broadcast.** The resolve is access-tiered per viewer; the live `link_preview:ready` event is shared. Putting resolved `full` content on the broadcast would leak private linked-message content to non-members (INV-8 ownership / the resolve's whole reason for being permission-checked). History/catch-up fetches carry a `userId` and assemble per-viewer, so that is the only safe place to bake. Live messages stay async — no regression, and they land at the bottom where the mid-list anchor problem doesn't apply.

**2. Keep the reserve on the async path; drop it only when baked.** A given card mount is either baked (history) or async (live) and never switches in place, so there's no in-session reserve→natural transition to cause a shift. Dropping the reserve unconditionally would reintroduce the skeleton→card jump on the live path that #1108's reserve exists to prevent. Threading a `reserve` flag keeps INV-21 intact on the async path and removes the padding everywhere the data is known up front.

**3. Compare `inAppData` in the array-equality check.** The alternative — always override when the map has an entry — would defeat the no-op short-circuit that keeps `enrichEventsWithLinkPreviews` from rebuilding unchanged events. Comparing the field is the minimal change that lets the baked data through without weakening the existing guard.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/domain.ts` | Add `inAppData?: InAppLinkPreviewData` to `LinkPreviewSummary` with a docblock on the per-viewer baking contract |
| `apps/backend/src/features/link-previews/service.ts` | `getPreviewsForMessages(workspaceId, userId, messageIds)` resolves in-app previews per viewer (concurrent across the page) and bakes `inAppData`; import `isInAppLinkContentType` |
| `apps/backend/src/features/streams/handlers.ts` | Pass `userId` to `getPreviewsForMessages`; `areLinkPreviewArraysEqual` compares `inAppData` via new `isInAppDataEqual` |
| `apps/frontend/src/components/timeline/in-app-link-preview-card.tsx` | Render synchronously when `preview.inAppData` is present (no skeleton, query disabled); thread a `reserve` flag so baked cards use natural height while the async path keeps the fixed footprint |
| `apps/backend/src/features/link-previews/service.test.ts` | Tests: per-viewer `inAppData` baked on in-app previews but not web; private tier baked when the viewer lacks access |
| `apps/backend/src/features/streams/handlers.test.ts` | Test: override applies when only `inAppData` differs (equality-propagation guard) |
| `apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx` | Test: baked `inAppData` renders on first paint with no resolve call |

## Out of scope (deliberate)

- **The singular `GET .../link-previews` endpoint** (`getForMessage` → `getPreviewsForMessage`) is unchanged. It feeds dismiss-state hydration, not the card's data (the card reads `inAppData` off the event-payload previews), so it doesn't need the per-viewer resolve.
- **Live broadcast messages** keep the async resolve + reserve by design (see decision 1). On reload they're re-fetched through the history path and become baked.
- **Backend `contentPreview` mid-markdown-link truncation** (a separate observed bug where the snippet is cut inside `[label](url)`) is not addressed here.

## Test plan

- [x] Backend `bun test src/features/link-previews` — 154 pass
- [x] Backend `bun test src/features/streams/handlers.test.ts` — 11 pass
- [x] Frontend `vitest run` over `components/timeline`, `components/message`, `sync/stream-sync` — 389 pass (incl. the new card test)
- [x] Frontend `vitest run` over `link-preview-list`, `composer-link-previews`, `in-app-link-inline`, `in-app-link-block` — 17 pass
- [x] `tsc --noEmit` across `packages/types`, `apps/backend`, `apps/frontend` — clean
- [x] ESLint clean on all touched files; Prettier applied
- [ ] No browser/visual harness run here — the zero-shift behavior on the async path is unchanged (same reserve constants) and asserted only structurally, not pixel-measured in this PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0135TgSPHM4BoyZpPMfBHTQK)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785390077&installation_id=129946197&pr_number=1116&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1116&signature=5c5872a23a4e44430a41c43ccc9b986dea5ad0d98aab04cf63695213f687868a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->