### PR TITLE
feat(board): let a conversation span its root + threads (one root)

### DIFF
--- a/apps/backend/src/features/conversations/assignment-events.ts
+++ b/apps/backend/src/features/conversations/assignment-events.ts
@@ -53,36 +53,3 @@ export async function emitAssignmentEvents(
 
   return refreshed
 }
-
-/**
- * Emit the aggregate update for a conversation that just lost its last message
- * (e.g. a lone source conversation retired when its message was threaded off).
- * Mirrors the reassignment path's emptied-source emit (`service.ts`): the board
- * drops a now-empty conversation (its `cardinality > 0` filter on the server,
- * the delete-on-empty merge on the client), so this is the signal that retires
- * the card. Routed by the conversation's OWN stream (INV-62) — `streamId` here
- * is the source's parent stream, not the thread the reply landed in.
- */
-export async function emitConversationRetired(
-  client: PoolClient,
-  params: { workspaceId: string; conversationId: string; streamId: string }
-): Promise<void> {
-  const { workspaceId, conversationId, streamId } = params
-  const stream = await StreamRepository.findById(client, streamId)
-  const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
-  const [refreshed] = await ConversationRepository.findByIds(client, workspaceId, [conversationId])
-  if (!refreshed) {
-    // The row we just locked + emptied in this same transaction is gone — an
-    // invariant break (INV-11). Throwing rolls back the whole send rather than
-    // silently dropping the board-removal event and leaving a stale source card.
-    throw new Error(`Conversation ${conversationId} vanished during retirement`)
-  }
-  await OutboxRepository.insert(client, "conversation:updated", {
-    workspaceId,
-    streamId,
-    conversationId,
-    conversation: addStalenessFields(refreshed),
-    parentStreamId,
-    streamVisibility,
-  })
-}

--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -10,9 +10,16 @@ import type { Message } from "../messaging"
 const CLIENT = {} as never
 const WORKSPACE_ID = "ws_1"
 
-function makeReply(): Message {
-  // The thread's first reply, sent into the (already promoted) thread stream.
-  return { id: "msg_reply", streamId: "thr_1", authorId: "usr_1" } as unknown as Message
+// The thread (`thr_1`) hangs off `msg_open` in `chan_1`; `chan_1`/`chan_2` are
+// top-level roots; `thr_1`'s effective root is `chan_1`.
+const STREAMS: Record<string, unknown> = {
+  thr_1: { id: "thr_1", parentStreamId: "chan_1", parentMessageId: "msg_open", rootStreamId: "chan_1" },
+  chan_1: { id: "chan_1", parentStreamId: null, parentMessageId: null, rootStreamId: null },
+  chan_2: { id: "chan_2", parentStreamId: null, parentMessageId: null, rootStreamId: null },
+}
+
+function makeReply(streamId = "thr_1"): Message {
+  return { id: "msg_reply", streamId, authorId: "usr_1" } as unknown as Message
 }
 
 function makeSource(overrides: Partial<Conversation> = {}): Conversation {
@@ -27,30 +34,21 @@ function makeSource(overrides: Partial<Conversation> = {}): Conversation {
 
 describe("conversationAssigner — threadFromMessage", () => {
   let insert: ReturnType<typeof spyOn>
+  let addPrimaryMessage: ReturnType<typeof spyOn>
   let emitAssignmentEvents: ReturnType<typeof spyOn>
   let findByIdForUpdate: ReturnType<typeof spyOn>
-  let removePrimaryMessage: ReturnType<typeof spyOn>
-  let resolveIfEmpty: ReturnType<typeof spyOn>
-  let emitRetired: ReturnType<typeof spyOn>
   let checkStreamAccess: ReturnType<typeof spyOn>
 
   beforeEach(() => {
-    insert = spyOn(ConversationRepository, "insert").mockResolvedValue(undefined as never)
-    spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    insert = spyOn(ConversationRepository, "insert").mockResolvedValue({ id: "conv_new" } as never)
+    addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "reactivateIfResolved").mockResolvedValue(undefined as never)
     spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
     emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
     findByIdForUpdate = spyOn(ConversationRepository, "findByIdForUpdate")
-    removePrimaryMessage = spyOn(ConversationRepository, "removePrimaryMessage").mockResolvedValue(undefined as never)
-    resolveIfEmpty = spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never)
-    emitRetired = spyOn(assignmentEvents, "emitConversationRetired").mockResolvedValue(undefined as never)
-    // The thread (the reply's stream `thr_1`) hangs off `msg_open` in `chan_1` —
-    // so the only retire-able source is the lone conversation owning that message.
-    spyOn(streams.StreamRepository, "findById").mockResolvedValue({
-      id: "thr_1",
-      parentStreamId: "chan_1",
-      parentMessageId: "msg_open",
-    } as never)
-    // Default: the actor can reach the source stream (the legit board-reply case).
+    spyOn(streams.StreamRepository, "findById").mockImplementation(
+      async (_client: unknown, id: string) => (STREAMS[id] ?? null) as never
+    )
     checkStreamAccess = spyOn(streams, "checkStreamAccess").mockResolvedValue({ id: "chan_1" } as never)
   })
 
@@ -58,94 +56,128 @@ describe("conversationAssigner — threadFromMessage", () => {
     mock.restore()
   })
 
-  async function thread(sourceConversationId: string): Promise<void> {
+  async function thread(sourceConversationId: string, reply = makeReply()): Promise<void> {
     await conversationAssigner.assignInTransaction(CLIENT, {
       workspaceId: WORKSPACE_ID,
-      message: makeReply(),
+      message: reply,
       directive: { intent: "threadFromMessage", sourceConversationId },
     })
   }
 
-  test("mints the thread's conversation seeded with the reply, then empties + retires the lone source", async () => {
+  test("attaches the reply to the SAME source conversation — one conversation, no mint", async () => {
     findByIdForUpdate.mockResolvedValue(makeSource())
 
     await thread("conv_src")
 
-    // Mint: a fresh conversation in the thread stream, seeded with the reply,
-    // announced as created.
-    expect(insert).toHaveBeenCalledTimes(1)
-    expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
+    // The reply joins the source as a cross-stream member; nothing is minted.
+    expect(insert).not.toHaveBeenCalled()
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src", "msg_reply", "usr_1")
     expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
-      message: expect.objectContaining({ id: "msg_reply" }),
-      created: true,
-    })
-
-    // Retire: the source's sole message (the thread's parent) is removed so the
-    // source empties and drops off the board; one retire event is emitted.
-    expect(removePrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src", "msg_open")
-    expect(resolveIfEmpty).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src")
-    expect(emitRetired).toHaveBeenCalledWith(CLIENT, {
-      workspaceId: WORKSPACE_ID,
       conversationId: "conv_src",
-      streamId: "chan_1",
+      created: false,
+      message: expect.objectContaining({ id: "msg_reply" }),
     })
   })
 
-  test("leaves a non-lone source intact (only empties a single-message source)", async () => {
+  test("attaches even when the source already spans messages (relaxed from lone-only)", async () => {
     findByIdForUpdate.mockResolvedValue(makeSource({ messageIds: ["msg_open", "msg_other"] }))
 
     await thread("conv_src")
 
-    expect(insert).toHaveBeenCalledTimes(1)
-    expect(removePrimaryMessage).not.toHaveBeenCalled()
-    expect(resolveIfEmpty).not.toHaveBeenCalled()
-    expect(emitRetired).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src", "msg_reply", "usr_1")
   })
 
-  test("is idempotent on a missing/foreign source — no throw, no retire", async () => {
+  test("falls back to minting a conversation when the source is missing/foreign (reply never orphaned)", async () => {
     findByIdForUpdate.mockResolvedValue(null)
 
     await thread("conv_gone")
 
-    expect(removePrimaryMessage).not.toHaveBeenCalled()
-    expect(emitRetired).not.toHaveBeenCalled()
+    // No source to attach to → mint a fresh conversation in the thread stream.
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
+    expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({ created: true })
   })
 
-  test("does not gut a source that lives in the reply's own stream (sanity guard)", async () => {
-    findByIdForUpdate.mockResolvedValue(makeSource({ streamId: "thr_1" }))
-
-    await thread("conv_src")
-
-    expect(removePrimaryMessage).not.toHaveBeenCalled()
-    expect(emitRetired).not.toHaveBeenCalled()
-  })
-
-  test("does not retire a source the actor cannot access (crafted sourceConversationId)", async () => {
+  test("falls back to minting when the actor cannot access the source (crafted id)", async () => {
     findByIdForUpdate.mockResolvedValue(makeSource())
     checkStreamAccess.mockResolvedValue(null)
 
     await thread("conv_src")
 
-    // The thread is still minted (the reply is the actor's own), but the source —
-    // a lone conversation in a stream the actor can't see — is left untouched.
-    expect(insert).toHaveBeenCalledTimes(1)
     expect(checkStreamAccess).toHaveBeenCalledWith(CLIENT, "chan_1", WORKSPACE_ID, "usr_1")
-    expect(removePrimaryMessage).not.toHaveBeenCalled()
-    expect(resolveIfEmpty).not.toHaveBeenCalled()
-    expect(emitRetired).not.toHaveBeenCalled()
+    expect(addPrimaryMessage).not.toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_src", "msg_reply", "usr_1")
+    expect(insert).toHaveBeenCalledTimes(1)
   })
 
-  test("only retires the thread's actual parent — not an unrelated accessible lone source", async () => {
-    // A crafted id pointing at a different lone conversation the actor CAN see:
-    // it's in the parent stream and accessible, but its message isn't the thread's
-    // parent (`msg_open`), so it must be left intact.
+  test("falls back to minting when the source isn't anchored at the thread's parent", async () => {
+    // Accessible, but its message isn't the thread's parent (`msg_open`).
     findByIdForUpdate.mockResolvedValue(makeSource({ id: "conv_other", messageIds: ["msg_unrelated"] }))
 
     await thread("conv_other")
 
+    expect(addPrimaryMessage).not.toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_other", "msg_reply", "usr_1")
     expect(insert).toHaveBeenCalledTimes(1)
-    expect(removePrimaryMessage).not.toHaveBeenCalled()
-    expect(resolveIfEmpty).not.toHaveBeenCalled()
-    expect(emitRetired).not.toHaveBeenCalled()
+  })
+})
+
+describe("conversationAssigner — existing (same-root guard)", () => {
+  let addPrimaryMessage: ReturnType<typeof spyOn>
+  let emitAssignmentEvents: ReturnType<typeof spyOn>
+  let findByIdForUpdate: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "reactivateIfResolved").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+    emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
+    findByIdForUpdate = spyOn(ConversationRepository, "findByIdForUpdate")
+    spyOn(streams.StreamRepository, "findById").mockImplementation(
+      async (_client: unknown, id: string) => (STREAMS[id] ?? null) as never
+    )
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  async function existing(target: Conversation, reply: Message): Promise<void> {
+    findByIdForUpdate.mockResolvedValue(target)
+    await conversationAssigner.assignInTransaction(CLIENT, {
+      workspaceId: WORKSPACE_ID,
+      message: reply,
+      directive: { intent: "existing", conversationId: target.id },
+    })
+  }
+
+  test("attaches a same-stream reply", async () => {
+    await existing(makeSource({ id: "conv_a", streamId: "chan_1" }), makeReply("chan_1"))
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_a", "msg_reply", "usr_1")
+  })
+
+  test("attaches a reply from a thread under the conversation's root (cross-stream, same root)", async () => {
+    // Conversation anchored at `chan_1`; reply lands in its thread `thr_1`.
+    await existing(makeSource({ id: "conv_a", streamId: "chan_1" }), makeReply("thr_1"))
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_a", "msg_reply", "usr_1")
+  })
+
+  test("rejects a cross-root attach", async () => {
+    // Conversation anchored at `chan_2`; reply lives under `chan_1`'s thread.
+    await expect(existing(makeSource({ id: "conv_a", streamId: "chan_2" }), makeReply("thr_1"))).rejects.toMatchObject({
+      code: "CONVERSATION_NOT_IN_ROOT",
+    })
+    expect(addPrimaryMessage).not.toHaveBeenCalled()
+    expect(emitAssignmentEvents).not.toHaveBeenCalled()
+  })
+
+  test("rejects a missing/foreign conversation id", async () => {
+    findByIdForUpdate.mockResolvedValue(null)
+    await expect(
+      conversationAssigner.assignInTransaction(CLIENT, {
+        workspaceId: WORKSPACE_ID,
+        message: makeReply("chan_1"),
+        directive: { intent: "existing", conversationId: "conv_gone" },
+      })
+    ).rejects.toMatchObject({ code: "CONVERSATION_NOT_FOUND" })
   })
 })

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -55,14 +55,17 @@ export const conversationAssigner: ConversationAssigner = {
     // message's. Same stream (the common case) trivially passes; a cross-stream
     // attach from the root or one of its threads passes; a cross-root attach is
     // rejected (board-view-design.md "Boundary extraction needs no tightening").
-    if (
-      target.streamId !== message.streamId &&
-      (await effectiveRootId(client, target.streamId)) !== (await effectiveRootId(client, message.streamId))
-    ) {
-      throw new HttpError("Conversation is in a different root stream", {
-        status: 400,
-        code: "CONVERSATION_NOT_IN_ROOT",
-      })
+    if (target.streamId !== message.streamId) {
+      const [targetRoot, messageRoot] = await Promise.all([
+        effectiveRootId(client, target.streamId),
+        effectiveRootId(client, message.streamId),
+      ])
+      if (targetRoot !== messageRoot) {
+        throw new HttpError("Conversation is in a different root stream", {
+          status: 400,
+          code: "CONVERSATION_NOT_IN_ROOT",
+        })
+      }
     }
     await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, message.id, message.authorId)
     // Attaching a message to a resolved conversation revives it — it has activity again.

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -1,7 +1,8 @@
+import type { PoolClient } from "pg"
 import { ConversationRepository } from "./repository"
-import type { ConversationAssigner } from "../messaging"
+import type { ConversationAssigner, Message } from "../messaging"
 import { checkStreamAccess, StreamRepository } from "../streams"
-import { emitAssignmentEvents, emitConversationRetired } from "./assignment-events"
+import { emitAssignmentEvents } from "./assignment-events"
 import { conversationId } from "../../lib/id"
 import { ConversationIntents, ConversationStatuses } from "@threa/types"
 import { HttpError } from "../../lib/errors"
@@ -16,77 +17,51 @@ import { HttpError } from "../../lib/errors"
  *  - `new`: mint a fresh conversation in the message's stream, seeded with it.
  *    An authored post is a new topic boundary even inside a scratchpad, so this
  *    always creates rather than joining the stream's existing conversation.
- *  - `existing`: attach the message to the named conversation, which must live in
- *    the same stream + workspace (conversations are per-stream); a stale/foreign
- *    id is rejected (400) rather than silently mis-assigned.
- *  - `threadFromMessage`: mint the thread's conversation seeded with this reply
- *    (the thread's first message), then retire the lone `sourceConversationId`
- *    it threaded off — its only message is now the thread's parent (in the parent
- *    stream, referenced not moved), so emptying it drops the duplicate board
- *    card, leaving just the thread. Retirement is idempotent (a retried send
- *    must not 400) and defensive: a non-lone/foreign source is left intact.
+ *  - `existing`: attach the message to the named conversation. A conversation is
+ *    confined to ONE root stream (board-view-design.md), so the target must share
+ *    the message's effective root — a reply may join it from the root or any of
+ *    its threads, never across roots. A stale/foreign/cross-root id is rejected
+ *    (400) rather than silently mis-assigned.
+ *  - `threadFromMessage`: a board reply to a lone post that just became a thread.
+ *    Keep ONE conversation — attach the reply (now in the thread stream) to the
+ *    SAME source conversation as a cross-stream member (root opener + thread
+ *    reply, one root). Stable conversation id, no card swap. Falls back to a
+ *    fresh mint only when the source can't be verified, so the reply is never
+ *    orphaned.
  */
 export const conversationAssigner: ConversationAssigner = {
   async assignInTransaction(client, { workspaceId, message, directive }) {
-    if (directive.intent === ConversationIntents.NEW || directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
-      const newId = conversationId()
-      await ConversationRepository.insert(client, {
-        id: newId,
-        streamId: message.streamId,
-        workspaceId,
-        confidence: 1,
-        status: ConversationStatuses.ACTIVE,
-      })
-      await ConversationRepository.addPrimaryMessage(client, workspaceId, newId, message.id, message.authorId)
-      await ConversationRepository.bumpActivityForIds(client, workspaceId, [newId])
-      await emitAssignmentEvents(client, {
-        workspaceId,
-        message,
-        conversationId: newId,
-        created: true,
-        reason: "declared",
-      })
-
-      if (directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
-        // Retire the source — but ONLY the lone conversation this thread was
-        // actually created off, never an arbitrary id the client supplied. The
-        // thread (this reply's stream) carries its parent message/stream, so the
-        // source is bound to that identity: it must live in the parent stream and
-        // its single message must BE the thread's parent message. Lock +
-        // workspace-scope (INV-8/20); gate on the actor's access to the source
-        // stream (INV-62). Any mismatch — foreign/non-lone/wrong-parent/no-access —
-        // is a silent no-op, so retirement stays idempotent (never a 400).
-        const thread = await StreamRepository.findById(client, message.streamId)
-        const source = await ConversationRepository.findByIdForUpdate(
-          client,
-          workspaceId,
-          directive.sourceConversationId
-        )
-        if (
-          thread?.parentStreamId &&
-          thread.parentMessageId &&
-          source &&
-          source.streamId === thread.parentStreamId &&
-          source.messageIds.length === 1 &&
-          source.messageIds[0] === thread.parentMessageId &&
-          (await checkStreamAccess(client, source.streamId, workspaceId, message.authorId))
-        ) {
-          await ConversationRepository.removePrimaryMessage(client, workspaceId, source.id, thread.parentMessageId)
-          await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
-          await emitConversationRetired(client, { workspaceId, conversationId: source.id, streamId: source.streamId })
-        }
+    if (directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
+      if (await attachThreadReplyToSource(client, workspaceId, message, directive.sourceConversationId)) {
+        return
       }
+      await mintConversationForMessage(client, workspaceId, message)
       return
     }
 
-    // Workspace-scoped + row-locked (INV-8, INV-20): a stale/foreign id resolves
-    // to null (rejected below) and a concurrent resolve/delete serializes behind
-    // this attach instead of racing it.
+    if (directive.intent === ConversationIntents.NEW) {
+      await mintConversationForMessage(client, workspaceId, message)
+      return
+    }
+
+    // `existing`. Workspace-scoped + row-locked (INV-8, INV-20): a stale/foreign
+    // id resolves to null (rejected below) and a concurrent resolve/delete
+    // serializes behind this attach instead of racing it.
     const target = await ConversationRepository.findByIdForUpdate(client, workspaceId, directive.conversationId)
-    if (!target || target.streamId !== message.streamId) {
-      throw new HttpError("Conversation not found in this stream", {
+    if (!target) {
+      throw new HttpError("Conversation not found", { status: 400, code: "CONVERSATION_NOT_FOUND" })
+    }
+    // One-root invariant: the target conversation's effective root must equal the
+    // message's. Same stream (the common case) trivially passes; a cross-stream
+    // attach from the root or one of its threads passes; a cross-root attach is
+    // rejected (board-view-design.md "Boundary extraction needs no tightening").
+    if (
+      target.streamId !== message.streamId &&
+      (await effectiveRootId(client, target.streamId)) !== (await effectiveRootId(client, message.streamId))
+    ) {
+      throw new HttpError("Conversation is in a different root stream", {
         status: 400,
-        code: "CONVERSATION_NOT_IN_STREAM",
+        code: "CONVERSATION_NOT_IN_ROOT",
       })
     }
     await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, message.id, message.authorId)
@@ -101,4 +76,79 @@ export const conversationAssigner: ConversationAssigner = {
       reason: "declared",
     })
   },
+}
+
+/** Mint a fresh conversation in the message's stream, seeded with the message. */
+async function mintConversationForMessage(client: PoolClient, workspaceId: string, message: Message): Promise<void> {
+  const newId = conversationId()
+  await ConversationRepository.insert(client, {
+    id: newId,
+    streamId: message.streamId,
+    workspaceId,
+    confidence: 1,
+    status: ConversationStatuses.ACTIVE,
+  })
+  await ConversationRepository.addPrimaryMessage(client, workspaceId, newId, message.id, message.authorId)
+  await ConversationRepository.bumpActivityForIds(client, workspaceId, [newId])
+  await emitAssignmentEvents(client, {
+    workspaceId,
+    message,
+    conversationId: newId,
+    created: true,
+    reason: "declared",
+  })
+}
+
+/**
+ * Convert-to-thread, corrected (board-view-design.md): attach the board reply
+ * (now in the thread stream) to its SOURCE conversation as a cross-stream member
+ * rather than minting a new conversation and retiring the source. Keeps one
+ * conversation spanning the root + thread (one root), so the board card renders
+ * in place with no swap.
+ *
+ * The reply's stream must be a thread whose parent message belongs to the source
+ * conversation, the source must be anchored at that parent stream (the root), and
+ * the actor must be able to reach it (INV-62). Any mismatch
+ * (foreign/non-member/no-access/race) returns false so the caller mints a fresh
+ * conversation instead — the reply is never left without a primary.
+ */
+async function attachThreadReplyToSource(
+  client: PoolClient,
+  workspaceId: string,
+  message: Message,
+  sourceConversationId: string
+): Promise<boolean> {
+  const thread = await StreamRepository.findById(client, message.streamId)
+  const source = await ConversationRepository.findByIdForUpdate(client, workspaceId, sourceConversationId)
+  if (
+    !thread?.parentStreamId ||
+    !thread.parentMessageId ||
+    !source ||
+    source.streamId !== thread.parentStreamId ||
+    !source.messageIds.includes(thread.parentMessageId) ||
+    !(await checkStreamAccess(client, source.streamId, workspaceId, message.authorId))
+  ) {
+    return false
+  }
+  await ConversationRepository.addPrimaryMessage(client, workspaceId, source.id, message.id, message.authorId)
+  await ConversationRepository.reactivateIfResolved(client, workspaceId, source.id)
+  await ConversationRepository.bumpActivityForIds(client, workspaceId, [source.id])
+  await emitAssignmentEvents(client, {
+    workspaceId,
+    message,
+    conversationId: source.id,
+    created: false,
+    reason: "declared",
+  })
+  return true
+}
+
+/**
+ * The stream's effective access root: a top-level stream is its own root, a
+ * thread defers to `root_stream_id` (board-view-design.md / INV-62). Falls back
+ * to the stream's own id when the row is missing (FK-less schema, INV-1).
+ */
+async function effectiveRootId(client: PoolClient, streamId: string): Promise<string> {
+  const stream = await StreamRepository.findById(client, streamId)
+  return stream?.rootStreamId ?? streamId
 }

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -124,36 +124,53 @@ export class ConversationService {
       (streamIds.length > 0 ? await StreamRepository.findByIds(this.pool, streamIds) : []).map((s) => [s.id, s])
     )
 
-    // Hydrate each post's origin message plus its last few replies so the board
-    // renders real post content + reactions, not just a topic line. One batch
-    // read over the union of needed ids (INV-56); the access filter already ran
-    // in the conversation query, so these ids are all viewer-readable.
+    // Fetch every member message row (opening + all replies) in one batch
+    // (INV-56) so the recent window is chosen by `createdAt`, not by `message_ids`
+    // insertion order — a cross-stream attach interleaves the array out of time
+    // (board-view-design.md). The access filter already ran in the conversation
+    // query, so these ids are viewer-readable. Rich hydration (attachments / link
+    // previews) below is then limited to the opening + the chosen window.
+    const memberIdsToFetch = new Set<string>()
+    for (const conversation of conversations) {
+      const stream = streamById.get(conversation.streamId)
+      if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) memberIdsToFetch.add(stream.parentMessageId)
+      for (const id of conversation.messageIds) memberIdsToFetch.add(id)
+    }
+    const memberIds = [...memberIdsToFetch]
+    const messageById: Map<string, Message> =
+      memberIds.length > 0 ? await MessageRepository.findByIds(this.pool, memberIds) : new Map()
+
     const planByConversation = new Map<
       string,
       { originId: string | undefined; recentIds: string[]; totalReplies: number }
     >()
-    const idsToFetch = new Set<string>()
+    const hydrateIds = new Set<string>()
     for (const conversation of conversations) {
       const stream = streamById.get(conversation.streamId)
-      const ids = conversation.messageIds
       let originId: string | undefined
       let replyIds: string[]
       if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
         originId = stream.parentMessageId
-        replyIds = ids
+        replyIds = conversation.messageIds
       } else {
-        originId = ids[0]
-        replyIds = ids.slice(1)
+        originId = conversation.messageIds[0]
+        replyIds = conversation.messageIds.slice(1)
       }
-      const recentIds = replyIds.slice(Math.max(0, replyIds.length - 3))
+      // Chronological by `createdAt`; an id with no fetched row (deleted /
+      // unreadable) sinks to the end so it can't claim a recent slot.
+      const orderedReplyIds = [...replyIds].sort(
+        (a, b) =>
+          (messageById.get(a)?.createdAt.getTime() ?? Infinity) - (messageById.get(b)?.createdAt.getTime() ?? Infinity)
+      )
+      const recentIds = orderedReplyIds.slice(Math.max(0, orderedReplyIds.length - 3))
       planByConversation.set(conversation.id, { originId, recentIds, totalReplies: replyIds.length })
-      if (originId) idsToFetch.add(originId)
-      for (const id of recentIds) idsToFetch.add(id)
+      if (originId) hydrateIds.add(originId)
+      for (const id of recentIds) hydrateIds.add(id)
     }
-    const ids = [...idsToFetch]
-    const messageById: Map<string, Message> =
-      ids.length > 0 ? await MessageRepository.findByIds(this.pool, ids) : new Map()
-    const hydratedById = await this.hydrateBoardMessages(workspaceId, [...messageById.values()])
+    const hydratedById = await this.hydrateBoardMessages(
+      workspaceId,
+      [...hydrateIds].map((id) => messageById.get(id)).filter((m): m is Message => Boolean(m))
+    )
 
     const posts: BoardPost[] = conversations.map((conversation) => {
       const plan = planByConversation.get(conversation.id)!

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -32,6 +32,10 @@ export interface ListWorkspaceConversationsOptions extends ListConversationsOpti
  */
 export interface BoardPostMessage {
   id: string
+  /** The stream this message lives in. A conversation can span its root + the
+   * root's threads (one root, board-view-design.md), so each message carries its
+   * own origin — the client merges the rails of the streams its members span. */
+  streamId: string
   authorId: string
   authorType: Message["authorType"]
   contentMarkdown: string
@@ -51,6 +55,10 @@ export interface BoardPost {
   recentMessages: BoardPostMessage[]
   /** Total replies under the origin (excludes the origin). Drives the "N more" gap. */
   totalReplies: number
+  /** Distinct streams this post's rendered messages span (opening + recent) — the
+   * root and any threads the conversation reaches under it. The client subscribes
+   * to each one's rail so a cross-stream member draws live (board-view-design.md). */
+  streamIds: string[]
 }
 
 export interface ReassignMessageParams {
@@ -153,11 +161,23 @@ export class ConversationService {
       const recentMessages = plan.recentIds
         .map((id) => hydratedById.get(id))
         .filter((m): m is BoardPostMessage => Boolean(m))
+      // The streams this card's rendered messages span — the conversation's
+      // anchor plus any thread an opening/recent message lives in. The client
+      // merges these rails so a cross-stream member draws live; new threads added
+      // after this snapshot arrive via `conversation:message_assigned`.
+      const streamIds = [
+        ...new Set([
+          conversation.streamId,
+          ...(opening ? [opening.streamId] : []),
+          ...recentMessages.map((m) => m.streamId),
+        ]),
+      ]
       return {
         conversation,
         openingMessage: opening ?? null,
         recentMessages,
         totalReplies: plan.totalReplies,
+        streamIds,
       }
     })
 
@@ -201,7 +221,11 @@ export class ConversationService {
     const messagesMap = await MessageRepository.findByIds(this.pool, conversation.messageIds)
     const ordered = conversation.messageIds.map((id) => messagesMap.get(id)).filter((m): m is Message => Boolean(m))
     const hydratedById = await this.hydrateBoardMessages(workspaceId, ordered)
-    return conversation.messageIds.map((id) => hydratedById.get(id)).filter((m): m is BoardPostMessage => Boolean(m))
+    // Flattened-chronological across the root + its threads (the conversation can
+    // span streams under one root, board-view-design.md): `message_ids` is
+    // insertion order, which a cross-stream attach interleaves out of time, so
+    // sort by `createdAt` rather than trusting array position.
+    return [...hydratedById.values()].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
   }
 
   async listByMessage(workspaceId: string, messageId: string): Promise<ConversationWithStaleness[]> {
@@ -355,6 +379,7 @@ function toBoardPostMessage(
 ): BoardPostMessage {
   return {
     id: message.id,
+    streamId: message.streamId,
     authorId: message.authorId,
     authorType: message.authorType,
     contentMarkdown: message.contentMarkdown,

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -171,10 +171,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         workspaceId={workspaceId}
         post={post}
         hostStreamType={streamType}
-        // The conversation's most-recently-active stream — the latest reply's own
-        // stream (it can be a thread under the root), so a continuation lands where
-        // the conversation is live instead of re-interleaving the channel.
-        lastActiveStreamId={railReplies.at(-1)?.streamId ?? openingMessage?.streamId ?? streamId}
+        // The conversation's most-recently-active stream — the latest displayed
+        // reply's own stream (a thread under the root), INCLUDING the viewer's own
+        // pending reply, so a continuation follows the conversation into the thread
+        // it just moved to instead of re-interleaving the channel. `displayedReplies`
+        // is chronological; its last entry is the freshest activity.
+        lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? openingMessage?.streamId ?? streamId}
       />
     </div>
   )

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -173,10 +173,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         hostStreamType={streamType}
         // The conversation's most-recently-active stream — the latest displayed
         // reply's own stream (a thread under the root), INCLUDING the viewer's own
-        // pending reply, so a continuation follows the conversation into the thread
-        // it just moved to instead of re-interleaving the channel. `displayedReplies`
-        // is chronological; its last entry is the freshest activity.
-        lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? openingMessage?.streamId ?? streamId}
+        // pending reply and any expand-backfilled rows, so a continuation follows
+        // the conversation into the thread it moved to instead of re-interleaving
+        // the channel. `displayedReplies` is chronological; its last entry is the
+        // freshest activity. Falls back to the conversation's own stream — NOT the
+        // opening message's, which for a thread post is the parent-stream message.
+        lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? streamId}
       />
     </div>
   )

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -48,7 +48,13 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // `pendingReplies` are the viewer's own just-sent replies awaiting their echo:
   // they aren't in the conversation's `messageIds` yet, so the card appends them
   // in place (deduped by id below) until the echo swaps each for the real row.
-  const { openingMessage, replies: railReplies, totalReplies, pendingReplies, source } = useBoardCardMessages(post)
+  const {
+    openingMessage,
+    replies: railReplies,
+    totalReplies,
+    pendingReplies,
+    source,
+  } = useBoardCardMessages(post, streamType)
 
   const streamId = conversation.streamId
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
@@ -98,7 +104,10 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     <MessageItem
       key={message.id}
       workspaceId={workspaceId}
-      streamId={streamId}
+      // A conversation can span its root + threads (one root); render each row
+      // against its own stream so reactions and the permalink target where the
+      // message actually lives, falling back to the card's anchor stream.
+      streamId={message.streamId ?? streamId}
       message={message}
       authorName={getActorName(message.authorId, message.authorType)}
       currentUserId={currentUserId}
@@ -158,7 +167,15 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         )}
       </div>
 
-      <BoardReplyComposer workspaceId={workspaceId} post={post} hostStreamType={streamType} />
+      <BoardReplyComposer
+        workspaceId={workspaceId}
+        post={post}
+        hostStreamType={streamType}
+        // The conversation's most-recently-active stream — the latest reply's own
+        // stream (it can be a thread under the root), so a continuation lands where
+        // the conversation is live instead of re-interleaving the channel.
+        lastActiveStreamId={railReplies.at(-1)?.streamId ?? openingMessage?.streamId ?? streamId}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -20,26 +20,25 @@ import type { BoardPost, JSONContent } from "@threa/types"
 // the Radix poppers and dialog.
 const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
 
-// Resting-affordance state. `draft` signals a persisted-but-collapsed reply (so
-// the user knows reopening restores it); `posted` is a transient confirmation
-// that a convert-to-thread reply went through — it bridges the brief swap where
-// this lone card retires and the thread card takes its place on the server echo,
-// since (unlike a same-conversation reply) the reply isn't shown in place here.
-type RestingState = "idle" | "draft" | "posted"
+// Resting-affordance state. `draft` signals a persisted-but-collapsed reply, so
+// the user knows reopening restores it. Every reply — including a lone post's
+// convert-to-thread — now joins the same conversation and renders in place on the
+// card (board-view-design.md "Convert-to-thread, corrected"), so there is no card
+// swap to bridge: a successful send just returns the affordance to its invitation.
+type RestingState = "idle" | "draft"
 const RESTING_LABEL: Record<RestingState, string> = {
   idle: "Write a reply…",
   draft: "Continue reply…",
-  posted: "Posted to a new thread",
 }
-// How long the transient "posted" confirmation stays before the affordance
-// returns to its normal invitation.
-const POSTED_NOTE_MS = 4000
 
 interface BoardReplyComposerProps {
   workspaceId: string
   post: BoardPost
   /** Host stream type of the post's conversation, selecting the reply routing. */
   hostStreamType: string | undefined
+  /** The conversation's most-recently-active stream, for recency-biased
+   *  continuation (a reply follows the conversation into its thread). */
+  lastActiveStreamId: string | null
 }
 
 /**
@@ -51,13 +50,12 @@ interface BoardReplyComposerProps {
  * and placeholder — and the composer mounts already open (`initialMobileChromeOpen`)
  * so the tap lands straight in the toolbar view instead of stepping through the
  * mobile compacted phase. Routing — a lone channel/DM post converts to a thread,
- * everything else replies flat into the conversation — lives in
- * {@link useReplyToBoardPost}.
+ * everything else replies flat into the conversation (recency-biased — into the
+ * thread the conversation moved to) — lives in {@link useReplyToBoardPost}.
  *
  * The resting affordance carries state (best-effort, in-session): it flags a
- * persisted draft after an Escape ("Continue reply…") and a transient "Posted to
- * a new thread" confirmation after a convert-to-thread send, so a collapse never
- * reads as a no-op or an accidental discard.
+ * persisted draft after an Escape ("Continue reply…") so a collapse never reads
+ * as an accidental discard.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
@@ -75,18 +73,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
     }
   }, [open])
 
-  // Let the transient "posted" confirmation fade back to the normal invitation.
-  useEffect(() => {
-    if (resting !== "posted") return
-    const timer = window.setTimeout(() => setResting("idle"), POSTED_NOTE_MS)
-    return () => window.clearTimeout(timer)
-  }, [resting])
-
-  const close = useCallback((opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => {
+  const close = useCallback((opts?: { refocus?: boolean; hadContent?: boolean }) => {
     refocusOnCollapseRef.current = opts?.refocus ?? false
-    if (opts?.posted) setResting("posted")
-    else if (opts?.hadContent) setResting("draft")
-    else setResting("idle")
+    setResting(opts?.hadContent ? "draft" : "idle")
     setOpen(false)
   }, [])
 
@@ -116,9 +105,10 @@ function BoardReplyComposerForm({
   workspaceId,
   post,
   hostStreamType,
+  lastActiveStreamId,
   onClose,
 }: BoardReplyComposerProps & {
-  onClose: (opts?: { refocus?: boolean; hadContent?: boolean; posted?: boolean }) => void
+  onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
 }) {
   const { preferences } = usePreferences()
   const streams = useWorkspaceStreams(workspaceId)
@@ -198,17 +188,17 @@ function BoardReplyComposerForm({
     composer.setIsSending(true)
     try {
       // Eager + offline-first: the reply is enqueued as an optimistic event and
-      // the send drains in the background, so there's no created message to await
-      // here — only the resolved plan, which selects the resting note. An
-      // `intoConversation` reply rides the card's own rail and shows in place; a
-      // `convertToThread` reply lands in a thread off the opener (and retires this
-      // lone card, which swaps to the thread on echo), so the transient "Posted to
-      // a new thread" note bridges the brief swap.
-      const { plan } = await reply.mutateAsync({
+      // the send drains in the background, so there's no created message to await.
+      // Every reply joins the same conversation and rides the card's own (merged)
+      // rail — an `intoConversation` reply shows in place, and a `convertToThread`
+      // reply shows in place too now that it stays one conversation (no card swap),
+      // so a successful send just collapses the affordance.
+      await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
         hostStreamType,
         messageCount: post.conversation.messageIds.length,
+        lastActiveStreamId,
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
         attachments: attachments.length > 0 ? attachments : undefined,
@@ -216,7 +206,7 @@ function BoardReplyComposerForm({
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
-      onClose({ refocus: true, posted: plan.kind === "convertToThread" })
+      onClose({ refocus: true })
     } catch {
       toast.error("Couldn't post your reply. Please try again.")
     } finally {

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -186,6 +186,11 @@ function BoardReplyComposerForm({
     const attachmentIds = attachments.map((a) => a.id)
 
     composer.setIsSending(true)
+    // Clear the editor up front so it empties in the same frame the optimistic
+    // reply appears on the card — otherwise the just-sent text lingers in the
+    // composer for a frame next to its own posted copy. Restored on failure so
+    // nothing the user typed is lost.
+    composer.setContent(EMPTY_DOC)
     try {
       // Eager + offline-first: the reply is enqueued as an optimistic event and
       // the send drains in the background, so there's no created message to await.
@@ -203,11 +208,11 @@ function BoardReplyComposerForm({
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
         attachments: attachments.length > 0 ? attachments : undefined,
       })
-      composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()
       composer.clearAttachments()
       onClose({ refocus: true })
     } catch {
+      composer.setContent(normalizedContent)
       toast.error("Couldn't post your reply. Please try again.")
     } finally {
       composer.setIsSending(false)

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -90,9 +90,9 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
         }}
         className="mt-3 flex w-full min-w-0 items-center rounded-[16px] border border-input bg-card p-3 text-left text-sm text-muted-foreground transition-colors hover:text-foreground"
       >
-        {/* Label-only confirmation: the text IS the in-place signal. No leading
-            icon — adding one only in the "posted" state would shift the label
-            (INV-21) and misalign the resting text against the open composer's. */}
+        {/* No leading icon: it would misalign the resting text against the open
+            composer's placeholder, and a state-dependent icon would shift the
+            label (INV-21). */}
         <span className="truncate">{RESTING_LABEL[resting]}</span>
       </button>
     )

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -40,6 +40,10 @@ export const GROUP_WINDOW_MS = 5 * 60_000
  */
 export interface RenderableMessage {
   id: string
+  /** The stream this message lives in. A board conversation can span its root +
+   * threads (one root), so a card renders each row against its own stream — the
+   * caller passes `message.streamId ?? <card stream>` to {@link MessageItem}. */
+  streamId?: string
   authorId: string
   authorType: AuthorType
   contentMarkdown: string

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -189,6 +189,47 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
   })
 
+  it("bridges a convert-to-thread reply across the swap (no blink / no '1 more') until the real row renders", async () => {
+    // Lone root post; the opener is synced in the root stream.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM)])
+    const lone = makePost({ messageIds: ["m1"], openingId: "m1", streamIds: [STREAM] })
+    const { result, rerender } = renderHook((p: BoardViewPost) => useBoardCardMessages(p, "channel"), {
+      initialProps: lone,
+    })
+
+    // 1) Optimistic convert reply: tagged with the conversation, written under the
+    //    draft-thread panel (a stream the card watches for a lone threadable post).
+    const PANEL = "draft:" + STREAM + ":m1"
+    await db.events.put({
+      id: "temp_c",
+      workspaceId: WS,
+      streamId: PANEL,
+      sequence: "1700000000001",
+      _sequenceNum: 1700000000001,
+      eventType: "message_created",
+      payload: { messageId: "temp_c", contentMarkdown: "my convert reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+    // The card must subscribe to the draft panel for a lone channel post.
+    rerender({ ...lone } as BoardViewPost)
+    await waitFor(() =>
+      expect([...result.current.replies, ...result.current.pendingReplies].map((m) => m.id)).toContain("temp_c")
+    )
+
+    // 2) The swap deletes the optimistic row (it moved to the real thread stream,
+    //    which the card isn't subscribed to yet) AND messageIds now lists the real
+    //    id — the gap where it belongs to no rail. The reply must NOT blink out and
+    //    must NOT collapse under a "1 more" gap.
+    await db.events.delete("temp_c")
+    rerender(makePost({ messageIds: ["m1", "msg_real_c"], openingId: "m1", streamIds: [STREAM] }))
+    await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["my convert reply"]))
+    expect(result.current.totalReplies).toBe(1)
+  })
+
   it("keeps a reply continuously visible across the optimistic→echo→messageIds hand-off (no blink-out)", async () => {
     await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "first reply", 2)])
     const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1" })

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -90,7 +90,7 @@ describe("useBoardCardMessages", () => {
   })
 
   it("merges a conversation that spans its root + a thread (one root) into one chronological run", async () => {
-    const THREAD = "thr_2"
+    const THREAD = "stream_thread2"
     await db.events.bulkPut([
       msgEvent("m1", "the opening", 1, STREAM),
       // The reply lives in a thread under the same root — a cross-stream member.
@@ -114,7 +114,7 @@ describe("useBoardCardMessages", () => {
   })
 
   it("subscribes to a thread resolved from db.streams even before it lands in the post's streamIds (no convert blink)", async () => {
-    const THREAD = "thr_blink"
+    const THREAD = "stream_threadblink"
     // The thread off the opener exists in db.streams (created at promotion) but the
     // server projection's streamIds hasn't widened yet (message_assigned lags).
     await db.streams.put({
@@ -135,7 +135,7 @@ describe("useBoardCardMessages", () => {
   })
 
   it("keeps rendering live events when a discovered thread is present but unsynced (no projection flip)", async () => {
-    const THREAD = "thr_unsynced"
+    const THREAD = "stream_threadunsynced"
     // A thread off the opener exists in db.streams but has no events synced yet —
     // a discovered (non-gating) rail. The root rail IS synced, so the card must
     // keep its live view instead of flipping back to the projection.

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -7,11 +7,11 @@ import { useBoardCardMessages, __clearBoardRailRegistry } from "./use-board-card
 const WS = "ws_1"
 const STREAM = "stream_1"
 
-function msgEvent(messageId: string, contentMarkdown: string, seq: number): CachedEvent {
+function msgEvent(messageId: string, contentMarkdown: string, seq: number, streamId = STREAM): CachedEvent {
   return {
     id: `evt_${messageId}`,
     workspaceId: WS,
-    streamId: STREAM,
+    streamId,
     sequence: String(seq),
     _sequenceNum: seq,
     eventType: "message_created",
@@ -23,9 +23,10 @@ function msgEvent(messageId: string, contentMarkdown: string, seq: number): Cach
   } as CachedEvent
 }
 
-function projectionMessage(id: string) {
+function projectionMessage(id: string, streamId = STREAM) {
   return {
     id,
+    streamId,
     authorId: "usr_1",
     authorType: "user" as const,
     contentMarkdown: `projection ${id}`,
@@ -40,15 +41,18 @@ function makePost(opts: {
   messageIds: string[]
   openingId: string | null
   recentMessages?: ReturnType<typeof projectionMessage>[]
+  /** Streams the card reads — defaults to the anchor stream only. */
+  streamIds?: string[]
   /** Server-projected reply count; defaults to the flat/thread derivation. */
   totalReplies?: number
 }): BoardViewPost {
-  const { messageIds, openingId, recentMessages = [] } = opts
+  const { messageIds, openingId, recentMessages = [], streamIds = [STREAM] } = opts
   return {
     id: "conv_1",
     workspaceId: WS,
     _lastActivityMs: 0,
     _cachedAt: 0,
+    streamIds,
     conversation: {
       id: "conv_1",
       streamId: STREAM,
@@ -82,6 +86,30 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies.map((m) => m.id)).toEqual(["r1", "r2"])
     expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["first reply", "second reply"])
     expect(result.current.totalReplies).toBe(2)
+  })
+
+  it("merges a conversation that spans its root + a thread (one root) into one chronological run", async () => {
+    const THREAD = "thr_2"
+    await db.events.bulkPut([
+      msgEvent("m1", "the opening", 1, STREAM),
+      // The reply lives in a thread under the same root — a cross-stream member.
+      msgEvent("r1", "thread reply", 2, THREAD),
+    ])
+    const post = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      streamIds: [STREAM, THREAD],
+      recentMessages: [projectionMessage("r1", THREAD)],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect(result.current.openingMessage?.contentMarkdown).toBe("the opening")
+    // The thread member draws live from its own stream's rail, merged in by time.
+    expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
+    expect(result.current.replies[0]?.contentMarkdown).toBe("thread reply")
+    expect(result.current.replies[0]?.streamId).toBe(THREAD)
+    expect(result.current.totalReplies).toBe(1)
   })
 
   it("surfaces a pending optimistic reply tagged with its conversation, before the id lands in messageIds", async () => {

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -134,6 +134,33 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies[0]?.streamId).toBe(THREAD)
   })
 
+  it("keeps rendering live events when a discovered thread is present but unsynced (no projection flip)", async () => {
+    const THREAD = "thr_unsynced"
+    // A thread off the opener exists in db.streams but has no events synced yet —
+    // a discovered (non-gating) rail. The root rail IS synced, so the card must
+    // keep its live view instead of flipping back to the projection.
+    await db.streams.put({
+      id: THREAD,
+      workspaceId: WS,
+      type: "thread",
+      parentMessageId: "m1",
+      rootStreamId: STREAM,
+      parentStreamId: STREAM,
+    } as never)
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "root reply", 2, STREAM)])
+    const post = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      streamIds: [STREAM],
+      recentMessages: [projectionMessage("r1")],
+    })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect(result.current.replies.map((m) => m.id)).toEqual(["r1"])
+    expect(result.current.replies[0]?.contentMarkdown).toBe("root reply")
+  })
+
   it("surfaces a pending optimistic reply tagged with its conversation, before the id lands in messageIds", async () => {
     await db.events.bulkPut([msgEvent("m1", "the opening", 1), msgEvent("r1", "first reply", 2)])
     // The viewer's just-sent reply: an optimistic pending event tagged with the

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -69,6 +69,7 @@ function makePost(opts: {
 beforeEach(async () => {
   __clearBoardRailRegistry()
   await db.events.clear()
+  await db.streams.clear()
 })
 
 describe("useBoardCardMessages", () => {
@@ -110,6 +111,27 @@ describe("useBoardCardMessages", () => {
     expect(result.current.replies[0]?.contentMarkdown).toBe("thread reply")
     expect(result.current.replies[0]?.streamId).toBe(THREAD)
     expect(result.current.totalReplies).toBe(1)
+  })
+
+  it("subscribes to a thread resolved from db.streams even before it lands in the post's streamIds (no convert blink)", async () => {
+    const THREAD = "thr_blink"
+    // The thread off the opener exists in db.streams (created at promotion) but the
+    // server projection's streamIds hasn't widened yet (message_assigned lags).
+    await db.streams.put({
+      id: THREAD,
+      workspaceId: WS,
+      type: "thread",
+      parentMessageId: "m1",
+      rootStreamId: STREAM,
+      parentStreamId: STREAM,
+    } as never)
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "thread reply", 2, THREAD)])
+    const post = makePost({ messageIds: ["m1", "r1"], openingId: "m1", streamIds: [STREAM] })
+    const { result } = renderHook(() => useBoardCardMessages(post))
+
+    // The reply draws live from the discovered thread rail despite streamIds=[STREAM].
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["r1"]))
+    expect(result.current.replies[0]?.streamId).toBe(THREAD)
   })
 
   it("surfaces a pending optimistic reply tagged with its conversation, before the id lands in messageIds", async () => {

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -144,18 +144,22 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
 
 /** Union several stream rails into one. A conversation can span its root + the
  *  root's threads (one root — board-view-design.md), so the card reads every
- *  member's stream and merges them by id. A single rail passes through unchanged
- *  (referentially stable, so a one-stream card never re-merges). */
-function mergeRails(rails: StreamRail[]): StreamRail {
+ *  member's stream and merges them by id. `gatingCount` is how many of the leading
+ *  rails are server-known member streams that gate `resolved`; rails past it are
+ *  opportunistically-discovered threads (and the optimistic draft panel) that
+ *  CONTRIBUTE content but must not drag the card back to its projection while they
+ *  load — otherwise discovering a new thread re-flashes an already-live card. */
+function mergeRails(rails: StreamRail[], gatingCount: number): StreamRail {
   if (rails.length === 1) return rails[0]
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
-  // Resolved only once every constituent rail has read — until then the card
-  // keeps the cached projection rather than treating an unsynced thread as empty.
+  // Resolved once every GATING rail has read — a still-loading discovered thread
+  // doesn't count, so the card keeps its live view instead of dropping to the
+  // projection the instant a thread appears.
   let resolved = true
-  for (const rail of rails) {
-    if (!rail.resolved) resolved = false
+  rails.forEach((rail, i) => {
+    if (i < gatingCount && !rail.resolved) resolved = false
     for (const [id, message] of rail.messages) messages.set(id, message)
     for (const id of rail.seen) seen.add(id)
     for (const [conversationId, list] of rail.taggedByConversation) {
@@ -163,7 +167,7 @@ function mergeRails(rails: StreamRail[]): StreamRail {
       if (existing) existing.push(...list)
       else taggedByConversation.set(conversationId, [...list])
     }
-  }
+  })
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
@@ -172,14 +176,20 @@ function mergeRails(rails: StreamRail[]): StreamRail {
 
 /**
  * Subscribe to the rails of several streams and return their union as one rail.
- * `streamIds` must be a stable, deduped, sorted array (the caller derives it from
- * the post's stream set) so subscribe/getSnapshot identities only change when the
- * set changes. The merged snapshot is cached and recomputed only when one of the
- * underlying rail references changes — `useSyncExternalStore` requires a stable
- * snapshot, so re-merging on every read would loop.
+ * `gatingStreamIds` are the server-known member streams (their loading gates the
+ * card's resolved state); `extraStreamIds` are discovered threads + the optimistic
+ * draft panel (content only). Both must be stable, deduped, sorted arrays so
+ * subscribe/getSnapshot identities only change when the set changes. The merged
+ * snapshot is cached and recomputed only when one of the underlying rail
+ * references changes — `useSyncExternalStore` requires a stable snapshot, so
+ * re-merging on every read would loop.
  */
-function useMergedStreamRail(streamIds: string[]): StreamRail {
-  const key = streamIds.join(",")
+function useMergedStreamRail(gatingStreamIds: string[], extraStreamIds: string[]): StreamRail {
+  const gatingCount = gatingStreamIds.length
+  const gatingKey = gatingStreamIds.join(",")
+  const extraKey = extraStreamIds.join(",")
+  const streamIds = useMemo(() => [...gatingStreamIds, ...extraStreamIds], [gatingKey, extraKey])
+  const key = gatingKey + "|" + extraKey
   const cacheRef = useRef<{ inputs: StreamRail[]; merged: StreamRail } | null>(null)
 
   const subscribe = useCallback(
@@ -199,7 +209,7 @@ function useMergedStreamRail(streamIds: string[]): StreamRail {
     if (cached && cached.inputs.length === inputs.length && cached.inputs.every((rail, i) => rail === inputs[i])) {
       return cached.merged
     }
-    const merged = mergeRails(inputs)
+    const merged = mergeRails(inputs, gatingCount)
     cacheRef.current = { inputs, merged }
     return merged
   }, [key])
@@ -374,19 +384,30 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   const openingStreamId = post.openingMessage?.streamId ?? null
   const recentStreamsKey = post.recentMessages.map((m) => m.streamId ?? "").join(",")
   const threadable = hostStreamType === StreamTypes.CHANNEL || hostStreamType === StreamTypes.DM
-  // Keyed on stable primitives, not the post.* objects (which a parent re-render
-  // would re-create, churning every rail subscription).
-  const streamIds = useMemo(() => {
+  // Server-known member streams gate the card's resolved state; discovered threads
+  // + the optimistic draft panel only contribute content (so finding one mid-render
+  // never flips the card back to its projection). Keyed on stable primitives, not
+  // the post.* objects (which a parent re-render would re-create, churning subs).
+  const gatingStreamIds = useMemo(() => {
     const set = new Set<string>([streamId])
     for (const id of post.streamIds ?? []) set.add(id)
     if (openingStreamId) set.add(openingStreamId)
     for (const message of post.recentMessages) if (message.streamId) set.add(message.streamId)
-    for (const id of childThreadIds) set.add(id)
-    if (threadable && messageIds.length <= 1 && openingId) set.add(createDraftPanelId(streamId, openingId))
     return [...set].sort()
-  }, [streamId, streamIdsKey, openingStreamId, recentStreamsKey, childThreadKey, threadable, messageIdsKey, openingId])
+  }, [streamId, streamIdsKey, openingStreamId, recentStreamsKey])
+  const gatingKey = gatingStreamIds.join(",")
+  const extraStreamIds = useMemo(() => {
+    const gating = new Set(gatingStreamIds)
+    const set = new Set<string>()
+    for (const id of childThreadIds) if (!gating.has(id)) set.add(id)
+    if (threadable && messageIds.length <= 1 && openingId) {
+      const panel = createDraftPanelId(streamId, openingId)
+      if (!gating.has(panel)) set.add(panel)
+    }
+    return [...set].sort()
+  }, [childThreadKey, gatingKey, threadable, messageIdsKey, openingId, streamId])
 
-  const rail = useMergedStreamRail(streamIds)
+  const rail = useMergedStreamRail(gatingStreamIds, extraStreamIds)
   const conversationId = post.conversation.id
 
   return useMemo(() => {

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -409,6 +409,13 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
 
   const rail = useMergedStreamRail(gatingStreamIds, extraStreamIds)
   const conversationId = post.conversation.id
+  // The viewer's just-sent reply, kept alive across the convert-to-thread hand-off.
+  // When a lone post's first reply lands, its optimistic row is swapped onto a
+  // freshly-created thread stream the card is still catching up to, and for a beat
+  // it's also absent from `messageIds` — so it belongs to no subscribed rail and
+  // would blink out / collapse under "1 more". Holding the last-shown copy bridges
+  // that window until the real row renders.
+  const retainedPendingRef = useRef<RenderableMessage[]>(NO_PENDING)
 
   return useMemo(() => {
     // Replies for this conversation the card knows from the rail but the server
@@ -419,6 +426,7 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     const tagged = rail.taggedByConversation.get(conversationId)
     const unconfirmed = tagged ? tagged.filter((m) => !replyIdSet.has(m.id)) : NO_PENDING
     const pendingReplies = unconfirmed.length > 0 ? unconfirmed : NO_PENDING
+    if (pendingReplies !== NO_PENDING) retainedPendingRef.current = pendingReplies
 
     // The server's count excludes `messageIds[0]` for a flat conversation even
     // when that opening was deleted, so trust it when the flat relationship is
@@ -453,13 +461,29 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     }
     liveReplies.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
 
+    // Bridge the convert-to-thread hand-off: when the optimistic reply has left
+    // every subscribed rail (`pendingReplies` empty) but the real row hasn't
+    // rendered yet, keep showing the retained copy in its place. `bridgeCount`
+    // shrinks to zero as the live rows render, so the retained copy never
+    // double-renders alongside its confirmed twin, and is forgotten once covered.
+    const retained = retainedPendingRef.current
+    const bridgeCount = pendingReplies === NO_PENDING ? Math.max(0, retained.length - liveReplies.length) : 0
+    if (bridgeCount === 0 && pendingReplies === NO_PENDING) retainedPendingRef.current = NO_PENDING
+    const replies =
+      bridgeCount > 0
+        ? [...liveReplies, ...retained.slice(retained.length - bridgeCount)].sort(
+            (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+          )
+        : liveReplies
+
     // When the rail holds every one of this conversation's replies, its displayable
     // (non-deleted) count IS the total — a tombstone is "seen" but not shown, so it
-    // must not inflate the "N more" gap. Otherwise older replies aren't local yet,
-    // so trust the server count and let expand backfill the rest.
+    // must not inflate the "N more" gap. Otherwise trust the server count, but never
+    // below what's already on screen (a bridged reply fills its own slot, so it
+    // mustn't also leave a phantom "1 more").
     const fullySynced = replyIds.every((id) => rail.seen.has(id))
-    const totalReplies = fullySynced ? liveReplies.length : serverTotal
+    const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal, replies.length)
 
-    return { openingMessage, replies: liveReplies, totalReplies, pendingReplies, source: "events" }
+    return { openingMessage, replies, totalReplies, pendingReplies, source: "events" }
   }, [rail, replyIds, openingId, messageIds, post, conversationId])
 }

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
 import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedEvent } from "@/db"
+import { createDraftPanelId } from "@/contexts/panel-context"
 import type { RenderableMessage } from "@/components/message/message-item"
-import type { AuthorType } from "@threa/types"
+import { StreamTypes, type AuthorType } from "@threa/types"
 import type { BoardViewPost } from "./use-stable-board-view"
 
 interface MessageCreatedPayloadShape {
@@ -24,6 +25,7 @@ function eventToRenderable(event: CachedEvent): RenderableMessage | null {
   if (!p.messageId || p.deletedAt) return null
   return {
     id: p.messageId,
+    streamId: event.streamId,
     authorId: event.actorId ?? "",
     authorType: (event.actorType ?? "user") as AuthorType,
     contentMarkdown: p.contentMarkdown ?? "",
@@ -140,9 +142,68 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
   }
 }
 
-function useStreamRail(streamId: string): StreamRail {
-  const subscribe = useCallback((onChange: () => void) => subscribeStreamRail(streamId, onChange), [streamId])
-  const getSnapshot = useCallback(() => railRegistry.get(streamId)?.rail ?? LOADING_RAIL, [streamId])
+/** Union several stream rails into one. A conversation can span its root + the
+ *  root's threads (one root — board-view-design.md), so the card reads every
+ *  member's stream and merges them by id. A single rail passes through unchanged
+ *  (referentially stable, so a one-stream card never re-merges). */
+function mergeRails(rails: StreamRail[]): StreamRail {
+  if (rails.length === 1) return rails[0]
+  const messages = new Map<string, RenderableMessage>()
+  const seen = new Set<string>()
+  const taggedByConversation = new Map<string, RenderableMessage[]>()
+  // Resolved only once every constituent rail has read — until then the card
+  // keeps the cached projection rather than treating an unsynced thread as empty.
+  let resolved = true
+  for (const rail of rails) {
+    if (!rail.resolved) resolved = false
+    for (const [id, message] of rail.messages) messages.set(id, message)
+    for (const id of rail.seen) seen.add(id)
+    for (const [conversationId, list] of rail.taggedByConversation) {
+      const existing = taggedByConversation.get(conversationId)
+      if (existing) existing.push(...list)
+      else taggedByConversation.set(conversationId, [...list])
+    }
+  }
+  for (const list of taggedByConversation.values()) {
+    list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+  }
+  return { messages, seen, taggedByConversation, resolved }
+}
+
+/**
+ * Subscribe to the rails of several streams and return their union as one rail.
+ * `streamIds` must be a stable, deduped, sorted array (the caller derives it from
+ * the post's stream set) so subscribe/getSnapshot identities only change when the
+ * set changes. The merged snapshot is cached and recomputed only when one of the
+ * underlying rail references changes — `useSyncExternalStore` requires a stable
+ * snapshot, so re-merging on every read would loop.
+ */
+function useMergedStreamRail(streamIds: string[]): StreamRail {
+  const key = streamIds.join(",")
+  const cacheRef = useRef<{ inputs: StreamRail[]; merged: StreamRail } | null>(null)
+
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubscribes = streamIds.map((id) => subscribeStreamRail(id, onChange))
+      return () => {
+        for (const unsubscribe of unsubscribes) unsubscribe()
+      }
+    },
+    // `key` captures the set; the closure over `streamIds` is consistent with it.
+    [key]
+  )
+
+  const getSnapshot = useCallback(() => {
+    const inputs = streamIds.map((id) => railRegistry.get(id)?.rail ?? LOADING_RAIL)
+    const cached = cacheRef.current
+    if (cached && cached.inputs.length === inputs.length && cached.inputs.every((rail, i) => rail === inputs[i])) {
+      return cached.merged
+    }
+    const merged = mergeRails(inputs)
+    cacheRef.current = { inputs, merged }
+    return merged
+  }, [key])
+
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
@@ -191,7 +252,7 @@ const NO_PENDING: RenderableMessage[] = []
  * which catches them up + joins their rooms, so the fallback resolves to the live
  * rail once that sync lands — the projection just covers the cold-open window.
  */
-export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
+export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: string): BoardCardMessages {
   const streamId = post.conversation.streamId
   const messageIds = post.conversation.messageIds
   const openingId = post.openingMessage?.id ?? null
@@ -204,7 +265,25 @@ export function useBoardCardMessages(post: BoardViewPost): BoardCardMessages {
     [openingId, messageIds]
   )
 
-  const rail = useStreamRail(streamId)
+  // The streams this conversation's members span — its anchor, plus every stream
+  // the server projection's opening/recent messages live in (a conversation spans
+  // its root + the root's threads, one root — board-view-design.md). For a lone
+  // channel/DM post mid-convert-to-thread, also watch the optimistic draft-thread
+  // panel: the reply is written there (tagged with this conversation) before the
+  // thread is promoted, so the card surfaces it in place; once promoted, the real
+  // thread joins `streamIds` via `conversation:message_assigned`.
+  const streamIdsKey = (post.streamIds ?? []).join(",")
+  const threadable = hostStreamType === StreamTypes.CHANNEL || hostStreamType === StreamTypes.DM
+  const streamIds = useMemo(() => {
+    const set = new Set<string>([streamId])
+    for (const id of post.streamIds ?? []) set.add(id)
+    if (post.openingMessage?.streamId) set.add(post.openingMessage.streamId)
+    for (const message of post.recentMessages) if (message.streamId) set.add(message.streamId)
+    if (threadable && messageIds.length <= 1 && openingId) set.add(createDraftPanelId(streamId, openingId))
+    return [...set].sort()
+  }, [streamId, streamIdsKey, post.openingMessage, post.recentMessages, threadable, messageIds.length, openingId])
+
+  const rail = useMergedStreamRail(streamIds)
   const conversationId = post.conversation.id
 
   return useMemo(() => {

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react"
 import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
@@ -417,7 +417,12 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   // that window until the real row renders.
   const retainedPendingRef = useRef<RenderableMessage[]>(NO_PENDING)
 
-  return useMemo(() => {
+  const view = useMemo(() => {
+    // The retained copy is read here but written only after commit (the effect
+    // below) — mutating a ref during render is unsafe under concurrent rendering,
+    // where a discarded render could clear the bridge before it paints.
+    const retained = retainedPendingRef.current
+
     // Replies for this conversation the card knows from the rail but the server
     // `messageIds` doesn't list yet — the optimistic row, and the swapped real
     // row in the window before `conversation:updated` lands. Exclude ids already
@@ -426,7 +431,6 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     const tagged = rail.taggedByConversation.get(conversationId)
     const unconfirmed = tagged ? tagged.filter((m) => !replyIdSet.has(m.id)) : NO_PENDING
     const pendingReplies = unconfirmed.length > 0 ? unconfirmed : NO_PENDING
-    if (pendingReplies !== NO_PENDING) retainedPendingRef.current = pendingReplies
 
     // The server's count excludes `messageIds[0]` for a flat conversation even
     // when that opening was deleted, so trust it when the flat relationship is
@@ -445,12 +449,15 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     if (openingId !== null && rail.seen.has(openingId)) openingMessage = rail.messages.get(openingId) ?? null
 
     if (!conversationSeen) {
+      // Cold/unsynced: capture a fresh pending row but never drop a live bridge.
+      const nextRetained = pendingReplies.length > 0 ? pendingReplies : retained
       return {
         openingMessage,
         replies: post.recentMessages as RenderableMessage[],
         totalReplies: serverTotal,
         pendingReplies,
-        source: "projection",
+        source: "projection" as const,
+        nextRetained,
       }
     }
 
@@ -466,9 +473,7 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     // rendered yet, keep showing the retained copy in its place. `bridgeCount`
     // shrinks to zero as the live rows render, so the retained copy never
     // double-renders alongside its confirmed twin, and is forgotten once covered.
-    const retained = retainedPendingRef.current
     const bridgeCount = pendingReplies === NO_PENDING ? Math.max(0, retained.length - liveReplies.length) : 0
-    if (bridgeCount === 0 && pendingReplies === NO_PENDING) retainedPendingRef.current = NO_PENDING
     const replies =
       bridgeCount > 0
         ? [...liveReplies, ...retained.slice(retained.length - bridgeCount)].sort(
@@ -484,6 +489,20 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     const fullySynced = replyIds.every((id) => rail.seen.has(id))
     const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal, replies.length)
 
-    return { openingMessage, replies, totalReplies, pendingReplies, source: "events" }
+    // Retain a fresh pending row; keep the retained copy while it's still bridging;
+    // forget it once the live rows cover it.
+    let nextRetained: RenderableMessage[]
+    if (pendingReplies.length > 0) nextRetained = pendingReplies
+    else if (bridgeCount > 0) nextRetained = retained
+    else nextRetained = NO_PENDING
+
+    return { openingMessage, replies, totalReplies, pendingReplies, source: "events" as const, nextRetained }
   }, [rail, replyIds, openingId, messageIds, post, conversationId])
+
+  // Commit the bridge bookkeeping after render, never during it.
+  useEffect(() => {
+    retainedPendingRef.current = view.nextRetained
+  }, [view])
+
+  return view
 }

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -207,11 +207,98 @@ function useMergedStreamRail(streamIds: string[]): StreamRail {
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
+interface ThreadIndexEntry {
+  /** parent message id → its thread's stream id, for every thread in the workspace. */
+  byParent: Map<string, string>
+  listeners: Set<() => void>
+  subscription: Subscription
+  refCount: number
+}
+
+// INV-9 exception: one shared `[workspaceId+type]=thread` liveQuery for the whole
+// board, ref-counted across cards. A board card's conversation can move into a
+// thread (convert-to-thread, or a cross-stream continuation); the thread's stream
+// is created at promotion — BEFORE the reply's message echo swaps the optimistic
+// row onto it — so resolving "the thread off message X" from `db.streams` here
+// subscribes the card to that rail ahead of the swap, closing the gap where a
+// just-sent reply would otherwise blink out between the swap and the slower
+// `conversation:message_assigned` widening of the server `streamIds`.
+const threadIndexRegistry = new Map<string, ThreadIndexEntry>()
+const EMPTY_THREAD_IDS: string[] = []
+
+function subscribeChildThreadIndex(workspaceId: string, listener: () => void): () => void {
+  let entry = threadIndexRegistry.get(workspaceId)
+  if (!entry) {
+    const created: ThreadIndexEntry = {
+      byParent: new Map(),
+      listeners: new Set(),
+      refCount: 0,
+      subscription: { unsubscribe() {} } as Subscription,
+    }
+    threadIndexRegistry.set(workspaceId, created)
+    created.subscription = liveQuery(() =>
+      db.streams.where("[workspaceId+type]").equals([workspaceId, StreamTypes.THREAD]).toArray()
+    ).subscribe((threads) => {
+      const live = threadIndexRegistry.get(workspaceId)
+      if (!live) return
+      const byParent = new Map<string, string>()
+      for (const thread of threads) if (thread.parentMessageId) byParent.set(thread.parentMessageId, thread.id)
+      live.byParent = byParent
+      for (const notify of live.listeners) notify()
+    })
+    entry = created
+  }
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  return () => {
+    const current = threadIndexRegistry.get(workspaceId)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) {
+      current.subscription.unsubscribe()
+      threadIndexRegistry.delete(workspaceId)
+    }
+  }
+}
+
+/** The stream ids of the threads hanging off any of `parentMessageIds`, live from
+ *  `db.streams`. Used to fold a conversation's thread streams into the card's rail
+ *  set the moment the thread exists, independent of `conversation:*` event timing. */
+function useChildThreadStreamIds(workspaceId: string, parentMessageIds: string[]): string[] {
+  const parentsKey = parentMessageIds.join(",")
+  const cacheRef = useRef<{ byParent: Map<string, string> | null; parentsKey: string; result: string[] } | null>(null)
+
+  const subscribe = useCallback(
+    (onChange: () => void) => subscribeChildThreadIndex(workspaceId, onChange),
+    [workspaceId]
+  )
+
+  const getSnapshot = useCallback(() => {
+    const byParent = threadIndexRegistry.get(workspaceId)?.byParent ?? null
+    const cached = cacheRef.current
+    if (cached && cached.byParent === byParent && cached.parentsKey === parentsKey) return cached.result
+    const ids: string[] = []
+    if (byParent)
+      for (const parentId of parentMessageIds) {
+        const threadId = byParent.get(parentId)
+        if (threadId) ids.push(threadId)
+      }
+    const result = ids.length > 0 ? ids : EMPTY_THREAD_IDS
+    cacheRef.current = { byParent, parentsKey, result }
+    return result
+  }, [workspaceId, parentsKey])
+
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
 /** Tear down every shared stream subscription — for tests, so a module-level
  *  registry can't leak a liveQuery (or a snapshot) across cases. */
 export function __clearBoardRailRegistry(): void {
   for (const entry of railRegistry.values()) entry.subscription.unsubscribe()
   railRegistry.clear()
+  for (const entry of threadIndexRegistry.values()) entry.subscription.unsubscribe()
+  threadIndexRegistry.clear()
 }
 
 export interface BoardCardMessages {
@@ -265,23 +352,39 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     [openingId, messageIds]
   )
 
-  // The streams this conversation's members span — its anchor, plus every stream
-  // the server projection's opening/recent messages live in (a conversation spans
-  // its root + the root's threads, one root — board-view-design.md). For a lone
-  // channel/DM post mid-convert-to-thread, also watch the optimistic draft-thread
-  // panel: the reply is written there (tagged with this conversation) before the
-  // thread is promoted, so the card surfaces it in place; once promoted, the real
-  // thread joins `streamIds` via `conversation:message_assigned`.
+  // The streams this conversation's members span — its anchor, the streams the
+  // server projection's opening/recent messages live in, and the threads hanging
+  // off its messages resolved live from `db.streams` (a conversation spans its
+  // root + the root's threads, one root — board-view-design.md). The live thread
+  // resolution closes the convert-to-thread gap: the thread stream exists at
+  // promotion, ahead of the reply's message echo, so the card is already
+  // subscribed to it when the optimistic row swaps onto it — no blink. The
+  // optimistic draft-thread panel covers the pre-promotion window (the reply is
+  // tagged with this conversation there, before any real thread exists).
+  // `messageIdsKey` proxies the messageIds content so the memos below key on a
+  // stable string, not the array reference.
+  const messageIdsKey = messageIds.join(",")
+  const parentMessageIds = useMemo(
+    () => [...new Set([...(openingId ? [openingId] : []), ...messageIds])],
+    [openingId, messageIdsKey]
+  )
+  const childThreadIds = useChildThreadStreamIds(post.workspaceId, parentMessageIds)
+  const childThreadKey = childThreadIds.join(",")
   const streamIdsKey = (post.streamIds ?? []).join(",")
+  const openingStreamId = post.openingMessage?.streamId ?? null
+  const recentStreamsKey = post.recentMessages.map((m) => m.streamId ?? "").join(",")
   const threadable = hostStreamType === StreamTypes.CHANNEL || hostStreamType === StreamTypes.DM
+  // Keyed on stable primitives, not the post.* objects (which a parent re-render
+  // would re-create, churning every rail subscription).
   const streamIds = useMemo(() => {
     const set = new Set<string>([streamId])
     for (const id of post.streamIds ?? []) set.add(id)
-    if (post.openingMessage?.streamId) set.add(post.openingMessage.streamId)
+    if (openingStreamId) set.add(openingStreamId)
     for (const message of post.recentMessages) if (message.streamId) set.add(message.streamId)
+    for (const id of childThreadIds) set.add(id)
     if (threadable && messageIds.length <= 1 && openingId) set.add(createDraftPanelId(streamId, openingId))
     return [...set].sort()
-  }, [streamId, streamIdsKey, post.openingMessage, post.recentMessages, threadable, messageIds.length, openingId])
+  }, [streamId, streamIdsKey, openingStreamId, recentStreamsKey, childThreadKey, threadable, messageIdsKey, openingId])
 
   const rail = useMergedStreamRail(streamIds)
   const conversationId = post.conversation.id

--- a/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
+++ b/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
@@ -39,6 +39,9 @@ export function useBoardStreamSubscriptions(posts: BoardViewPost[]): void {
       add(post.conversation.streamId)
       for (const streamId of post.streamIds ?? []) add(streamId)
     }
+    // Sort so the key reflects stream membership, not card order — a reorder of
+    // the same visible streams mustn't re-fire setBoardStreamIds.
+    ids.sort()
     return ids.join(",")
     // Stream ids are prefixed ULIDs (no commas), so join/split round-trips cleanly.
   }, [posts])

--- a/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
+++ b/apps/frontend/src/hooks/use-board-stream-subscriptions.ts
@@ -26,11 +26,18 @@ export function useBoardStreamSubscriptions(posts: BoardViewPost[]): void {
   const streamSetKey = useMemo(() => {
     const seen = new Set<string>()
     const ids: string[] = []
-    for (const post of posts) {
-      const streamId = post.conversation.streamId
-      if (seen.has(streamId)) continue
+    const add = (streamId: string) => {
+      if (seen.has(streamId)) return
       seen.add(streamId)
       ids.push(streamId)
+    }
+    for (const post of posts) {
+      // A conversation spans its root + the root's threads (one root); declare
+      // every stream the card reads so the SyncEngine catches up + joins each
+      // thread's room, not just the anchor — otherwise a cross-stream reply never
+      // syncs into the rail (board-view-design.md).
+      add(post.conversation.streamId)
+      for (const streamId of post.streamIds ?? []) add(streamId)
     }
     return ids.join(",")
     // Stream ids are prefixed ULIDs (no commas), so join/split round-trips cleanly.

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -413,4 +413,31 @@ describe("useReplyToBoardPost", () => {
       })
     )
   })
+
+  it("targets the conversation's most-recently-active stream, not its anchor (recency-biased)", async () => {
+    const { queueDraftMessage } = mockReplyDeps()
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
+
+    // A channel-anchored conversation that has moved into a thread: the
+    // continuation must follow it into the thread, not re-interleave the channel.
+    await act(async () => {
+      await result.current.mutateAsync({
+        conversation: { id: "conv_1", streamId: "chan_1" },
+        openingMessageId: "msg_open",
+        hostStreamType: StreamTypes.CHANNEL,
+        messageCount: 3,
+        lastActiveStreamId: "thread_x",
+        contentJson: DOC,
+      })
+    })
+
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ contentJson: DOC }),
+      expect.objectContaining({
+        streamId: "thread_x",
+        conversation: { intent: "existing", conversationId: "conv_1" },
+      })
+    )
+  })
 })

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -304,7 +304,7 @@ describe("useReplyToBoardPost", () => {
 
   const DOC = { type: "doc", content: [] }
 
-  it("converts a lone channel post into a thread, retiring the source via the threadFromMessage directive", async () => {
+  it("converts a lone channel post into a thread, attaching the reply to the same source via threadFromMessage", async () => {
     const { queueDraftMessage } = mockReplyDeps()
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useReplyToBoardPost(WORKSPACE_ID), { wrapper })
@@ -321,8 +321,8 @@ describe("useReplyToBoardPost", () => {
     })
 
     // The reply rides the durable queue with THREAD stream-creation (keyed on the
-    // draft panel id) AND the threadFromMessage directive, which mints the thread's
-    // conversation and retires the lone source `conv_1`.
+    // draft panel id) AND the threadFromMessage directive, which attaches the reply
+    // to the same source conversation `conv_1` (one conversation, no card swap).
     expect(queueDraftMessage).toHaveBeenCalledWith(
       expect.objectContaining({ contentJson: DOC }),
       expect.objectContaining({

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -196,6 +196,14 @@ export interface ReplyToBoardPostInput {
   hostStreamType: string | undefined
   /** Count of messages in the conversation, deciding the lone-root case. */
   messageCount: number
+  /**
+   * The conversation's most-recently-active stream — its latest message's stream
+   * (a conversation can span its root + threads, one root). A continuation targets
+   * this, not the anchor: once a conversation has moved into a thread, replying in
+   * the root would re-interleave the channel (board-view-design.md "Continuation
+   * is recency-biased"). Omit to fall back to the conversation's anchor stream.
+   */
+  lastActiveStreamId?: string | null
   contentJson: JSONContent
   attachmentIds?: string[]
   /** Full attachment info for the optimistic event so files render in place. */
@@ -254,6 +262,7 @@ export function useReplyToBoardPost(workspaceId: string) {
       openingMessageId,
       hostStreamType,
       messageCount,
+      lastActiveStreamId,
       contentJson,
       attachmentIds,
       attachments,
@@ -289,9 +298,14 @@ export function useReplyToBoardPost(workspaceId: string) {
         return { plan }
       }
 
+      // Recency-biased continuation: target the conversation's most-recently-active
+      // stream (the thread, if it has moved there), not its anchor — posting into
+      // the anchor root would re-interleave the channel a convert avoided
+      // (board-view-design.md). The same-root `existing` guard accepts a reply from
+      // any stream under the conversation's root.
       await queueDraftMessage(input, {
         workspaceId,
-        streamId: conversation.streamId,
+        streamId: lastActiveStreamId ?? conversation.streamId,
         conversation: { intent: "existing", conversationId: conversation.id },
       })
       return { plan }

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -219,12 +219,13 @@ export interface ReplyToBoardPostInput {
  *
  *  - **lone message in a channel or DM** (≤1 message, has an opening id) →
  *    `convertToThread`: thread off the opener (it stays in the parent stream as
- *    the thread's root) and retire the now-empty source conversation, so the
- *    board shows one card — the thread — not the post plus the thread.
- *  - **everything else** → flat into the conversation's own stream via the
- *    `existing` directive: an established channel/DM conversation stays where it
- *    is, a thread card replies into its thread, a scratchpad stays flat. A
- *    deleted opener (no id) can't be threaded, so it stays flat too.
+ *    the thread's root). The reply joins the SAME conversation as a cross-stream
+ *    member (root opener + thread reply, one root — board-view-design.md), so the
+ *    board keeps showing one card and the reply renders in place; no card swap.
+ *  - **everything else** → flat into the conversation's most-recently-active
+ *    stream via the `existing` directive: an established channel/DM conversation
+ *    stays where it is, a thread card replies into its thread, a scratchpad stays
+ *    flat. A deleted opener (no id) can't be threaded, so it stays flat too.
  */
 export type BoardReplyPlan = { kind: "convertToThread"; parentMessageId: string } | { kind: "intoConversation" }
 
@@ -246,11 +247,11 @@ export function planBoardReply(input: {
  * event into the same `db.events` rail the card reads (and a durable pending row
  * the background queue drains), so it shows the instant the user sends — no
  * round-trip — exactly like a stream send. The server echo swaps the optimistic
- * event for the real one. Returns the resolved plan so the composer can confirm
- * a conversion: a `convertToThread` reply lands in a thread off the opener and
- * retires the lone source (the board card becomes the thread); an
- * `intoConversation` reply is tagged with the target conversation so it renders
- * in place under the card that produced it (see `useQueueDraftMessage` /
+ * event for the real one. Returns the resolved plan for the caller. Both kinds
+ * render in place: a `convertToThread` reply lands in a thread off the opener but
+ * joins the SAME conversation (no card swap), and an `intoConversation` reply
+ * attaches to the conversation directly — each is tagged with the conversation so
+ * it shows under the card that produced it (see `useQueueDraftMessage` /
  * `useBoardCardMessages`).
  */
 export function useReplyToBoardPost(workspaceId: string) {
@@ -279,10 +280,10 @@ export function useReplyToBoardPost(workspaceId: string) {
         // Promote a draft thread off the opener, mirroring the timeline's
         // thread-reply path (`stream-panel.tsx`): the queue create-or-finds the
         // thread (idempotent server-side on (parentStreamId, parentMessageId))
-        // then sends into it. The `threadFromMessage` directive mints the thread's
-        // conversation seeded with this reply AND retires the lone source so the
-        // board shows one card (the thread), not the post plus the thread. A lone
-        // channel/DM root is never E2E, so no sealing.
+        // then sends into it. The `threadFromMessage` directive attaches this reply
+        // to the SAME source conversation as a cross-stream member (root opener +
+        // thread reply, one root), so the board keeps one card and the reply renders
+        // in place. A lone channel/DM root is never E2E, so no sealing.
         const panelId = createDraftPanelId(conversation.streamId, plan.parentMessageId)
         await queueDraftMessage(input, {
           workspaceId,

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -92,7 +92,11 @@ export function useQueueDraftMessage(workspaceId: string) {
           // surfaces it under the right card before the server echo (which carries
           // the real id in the conversation aggregate) lands. Read-side only; the
           // timeline ignores it, and the row is swapped for the real event on echo.
-          ...(params.conversation?.intent === "existing" ? { conversationId: params.conversation.conversationId } : {}),
+          // `existing` names the conversation directly; `threadFromMessage` (a
+          // lone post converting to a thread) joins its source conversation, so the
+          // reply renders in place under the same card — no card swap
+          // (board-view-design.md "Convert-to-thread, corrected").
+          ...conversationTag(params.conversation),
           ...(input.attachments && input.attachments.length > 0 ? { attachments: input.attachments } : {}),
         },
         actorId: currentUserId,
@@ -230,4 +234,15 @@ export function useQueueDraftMessage(workspaceId: string) {
   )
 
   return { queueDraftMessage, currentUserId }
+}
+
+/** The conversation a board reply's optimistic event is tagged with, so the card
+ *  surfaces it in place before the server echo. `existing` carries the id; a
+ *  `threadFromMessage` convert joins its source conversation. */
+function conversationTag(
+  directive: ConversationDirective | undefined
+): { conversationId: string } | Record<string, never> {
+  if (directive?.intent === "existing") return { conversationId: directive.conversationId }
+  if (directive?.intent === "threadFromMessage") return { conversationId: directive.sourceConversationId }
+  return {}
 }

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -43,6 +43,7 @@ function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): C
 function makeOpeningMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
   return {
     id: "msg_1",
+    streamId: "stream_1",
     // usr_me isn't in the mocked user cache, so the author renders as a short id
     // — distinct from any DM-peer name asserted on elsewhere.
     authorId: "usr_me",
@@ -63,12 +64,22 @@ function makePost(
   totalReplies?: number
 ): BoardPost {
   const conversation = makeConversation(convOverrides)
+  const openingMessage =
+    msgOverrides === null ? null : makeOpeningMessage({ streamId: conversation.streamId, ...msgOverrides })
   return {
     conversation,
-    openingMessage: msgOverrides === null ? null : makeOpeningMessage(msgOverrides),
+    openingMessage,
     recentMessages,
     // Default mirrors a non-thread post: every message after the origin is a reply.
     totalReplies: totalReplies ?? Math.max(0, conversation.messageIds.length - 1),
+    // The streams the card reads — anchor plus any opening/recent message's stream.
+    streamIds: [
+      ...new Set([
+        conversation.streamId,
+        ...(openingMessage ? [openingMessage.streamId] : []),
+        ...recentMessages.map((m) => m.streamId),
+      ]),
+    ],
   }
 }
 

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -27,9 +27,10 @@ function makeConversation(id: string, lastActivityAt: string): ConversationWithS
   }
 }
 
-function makeMessage(id: string): BoardPostMessage {
+function makeMessage(id: string, streamId = "stream_1"): BoardPostMessage {
   return {
     id,
+    streamId,
     authorId: "usr_1",
     authorType: "user",
     contentMarkdown: id,
@@ -41,11 +42,14 @@ function makeMessage(id: string): BoardPostMessage {
 }
 
 function makePost(id: string, lastActivityAt: string, recentMessages: BoardPostMessage[] = []): BoardPost {
+  const conversation = makeConversation(id, lastActivityAt)
+  const openingMessage = makeMessage("m1")
   return {
-    conversation: makeConversation(id, lastActivityAt),
-    openingMessage: makeMessage("m1"),
+    conversation,
+    openingMessage,
     recentMessages,
     totalReplies: recentMessages.length,
+    streamIds: [...new Set([conversation.streamId, openingMessage.streamId, ...recentMessages.map((m) => m.streamId)])],
   }
 }
 

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -59,6 +59,26 @@ export async function seedBoardPosts(workspaceId: string, posts: BoardPost[]): P
 }
 
 /**
+ * Record a stream a conversation now reaches, from a `conversation:message_assigned`
+ * event, onto its board row's `streamIds`. A conversation can span its root + the
+ * root's threads (one root — board-view-design.md); the card subscribes to each
+ * stream's rail, and a convert-to-thread / cross-stream reply lands in a stream
+ * the snapshot didn't list yet. Adding it here lets the card draw that member live
+ * without a board refetch. No-op when the card isn't cached or already lists the
+ * stream; never creates a row (a card we don't have can't be rendered from this
+ * event alone).
+ */
+export async function addBoardConversationStream(conversationId: string, streamId: string): Promise<void> {
+  await db.transaction("rw", db.conversations, async () => {
+    const existing = await db.conversations.get(conversationId)
+    if (!existing) return
+    const streamIds = existing.streamIds ?? []
+    if (streamIds.includes(streamId)) return
+    await db.conversations.put({ ...existing, streamIds: [...streamIds, streamId] })
+  })
+}
+
+/**
  * Apply a conversation aggregate from a `conversation:*` event onto the board's
  * IDB row: merge the new aggregate (re-sorting on `lastActivityAt`) while
  * keeping the cached preview messages — the event carries the aggregate, not the

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -37,7 +37,7 @@ import type {
 } from "@threa/types"
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
 import { conversationKeys } from "@/hooks/use-conversations"
-import { mergeBoardConversation } from "@/stores/board-store"
+import { mergeBoardConversation, addBoardConversationStream } from "@/stores/board-store"
 import { activityKeys } from "@/hooks/use-activity"
 import { memoKeys } from "@/hooks/use-memos"
 import { invitationKeys } from "@/api/invitations"
@@ -1681,6 +1681,21 @@ export function registerWorkspaceSocketHandlers(
     })
   }
 
+  // A conversation can span its root + the root's threads (one root —
+  // board-view-design.md). When a reply lands in a stream the card's snapshot
+  // didn't list (a convert-to-thread, or a cross-stream continuation), record
+  // that stream on the board row so the card subscribes to its rail and draws the
+  // member live — no board refetch. The aggregate `conversation:updated` re-sorts
+  // the card; this only widens its stream set.
+  const handleConversationMessageAssigned = (payload: {
+    workspaceId: string
+    streamId: string
+    conversationId: string
+  }) => {
+    if (payload.workspaceId !== workspaceId) return
+    void addBoardConversationStream(payload.conversationId, payload.streamId)
+  }
+
   socket.on("stream:created", handleStreamCreated)
   socket.on("stream:updated", handleStreamUpdated)
   socket.on("stream:archived", handleStreamArchived)
@@ -1727,6 +1742,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("draft:deleted", handleDraftDeleted)
   socket.on("conversation:created", handleConversationUpserted)
   socket.on("conversation:updated", handleConversationUpserted)
+  socket.on("conversation:message_assigned", handleConversationMessageAssigned)
 
   return () => {
     abortController.abort()
@@ -1778,6 +1794,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("draft:deleted", handleDraftDeleted)
     socket.off("conversation:created", handleConversationUpserted)
     socket.off("conversation:updated", handleConversationUpserted)
+    socket.off("conversation:message_assigned", handleConversationMessageAssigned)
   }
 }
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -652,6 +652,13 @@ export interface ConversationWithStaleness extends Conversation {
  */
 export interface BoardPostMessage {
   id: string
+  /**
+   * The stream this message lives in. A conversation can span its root and the
+   * root's threads (one root — board-view-design.md), so each rendered message
+   * carries its own origin; the client merges the rails of the streams a post's
+   * members span and opens each message in its own stream.
+   */
+  streamId: string
   authorId: string
   authorType: AuthorType
   contentMarkdown: string
@@ -665,15 +672,11 @@ export interface BoardPostMessage {
 
 /**
  * A message gathered under a label, for the label landing page's Messages
- * section. Same lean rendering projection as {@link BoardPostMessage}, plus the
- * `streamId` it lives in: labeled messages span streams, so each row carries its
- * own origin to render the author/context and to open in its own stream
- * (`/w/:workspaceId/s/:streamId?m=:id`) — the board derives `streamId` from the
- * post instead.
+ * section. Same lean rendering projection as {@link BoardPostMessage} — including
+ * the `streamId` it lives in, so each labeled row (they span streams) renders its
+ * author/context and opens in its own stream (`/w/:workspaceId/s/:streamId?m=:id`).
  */
-export interface LabeledMessage extends BoardPostMessage {
-  streamId: string
-}
+export type LabeledMessage = BoardPostMessage
 
 /**
  * One board post: a conversation (the grouping) surfaced as a feed post (the
@@ -698,6 +701,14 @@ export interface BoardPost {
   recentMessages: BoardPostMessage[]
   /** Total replies under the origin (excludes it). Drives the "N more" gap. */
   totalReplies: number
+  /**
+   * Distinct streams this post's rendered messages span — the conversation's root
+   * and any threads an opening/recent message reaches under it (one root —
+   * board-view-design.md). The client subscribes to each stream's rail so a
+   * cross-stream member draws live; threads added after this snapshot arrive via
+   * `conversation:message_assigned`.
+   */
+  streamIds: string[]
 }
 
 /**


### PR DESCRIPTION
**Design doc:** [`docs/board-view-design.md`](docs/board-view-design.md) § "Conversations span streams within one root — the model, made precise (2026-06-30)"

## Problem

The design has always said a board conversation "spans a root message and its thread replies", but the implementation drifted to one-stream-per-conversation in three places, and dogfooding surfaced the gap: a DM top-level message rendered as *missing* from the board because its conversation also held a thread reply, and the card reads only one stream.

- **Convert-to-thread** (#1113): a board reply to a lone post **retired** the source conversation and **minted a new** thread conversation. #1114 then built optimistic-swap machinery to mask the cross-row card swap that retire+mint creates — and was abandoned (closed) once we recognized the swap itself was the defect.
- **The `existing` assigner** rejected any cross-stream attach (`streamId !== message.streamId` → `CONVERSATION_NOT_IN_STREAM`).
- **The board card** (`useBoardCardMessages` → one rail on `conversation.streamId`) never drew a member that lived in another stream of the same conversation.

## Solution

A conversation is confined to **exactly one root stream**: it may span that root and any of its threads (equal effective root), never two roots. This matches the access model exactly — access is root-stream membership only, threads inherit (INV-62) — so a single access check on the conversation's root gates every member, with no per-message-stream gating.

### How it works

**Backend**

1. **Convert-to-thread keeps one conversation** (`conversation-assigner.ts`, `attachThreadReplyToSource`). The `threadFromMessage` directive now attaches the reply (in the freshly-created thread stream) to the **same** source conversation as a cross-stream member — root opener + thread reply, one root. Stable conversation id, no retire, no mint, no card swap. It verifies the reply's stream is a thread whose `parentMessageId` is a member of the source, the source is anchored at that parent stream, and the actor can reach it (`checkStreamAccess`); any mismatch falls back to `mintConversationForMessage` so the reply is never orphaned.
2. **Same-root guard** (`conversation-assigner.ts`, `existing` path). Relaxed from same-*stream* to same-*root*: `effectiveRootId(target.streamId) === effectiveRootId(message.streamId)` (`COALESCE(root_stream_id, id)` semantics, short-circuited when the streams are identical). Cross-root is rejected with `CONVERSATION_NOT_IN_ROOT`; a missing/foreign id is `CONVERSATION_NOT_FOUND`.
3. **Board projection across streams** (`service.ts`). `BoardPostMessage` carries `streamId`; `BoardPost` carries `streamIds` (the distinct streams its opening + recent messages span). `getBoardMessages` (the "N more" expand) is sorted flattened-chronological by `createdAt`, since a cross-stream attach interleaves `message_ids` out of insertion order. The opening/reply hydration is already by-id, so it was stream-agnostic already.

**Frontend**

4. **Merged rail** (`use-board-card-messages.ts`, `useMergedStreamRail`). The card subscribes to the rails of every stream in its set (anchor + `post.streamIds` + each opening/recent message's stream, plus the optimistic draft-thread panel id for a lone channel/DM post mid-convert) and merges them by id, rendering flattened-chronological and live. A single-stream set passes through unchanged (referentially stable). Each row renders against its own `message.streamId` so reactions and the permalink target where the message actually lives.
5. **Live stream set.** `streamIds` stay current without a refetch via a `conversation:message_assigned` board handler (`board-store.ts` `addBoardConversationStream`, wired in `workspace-sync.ts`), and `useBoardStreamSubscriptions` declares the full per-card set so the SyncEngine catches up + joins each thread's room.
6. **Recency-biased continuation** (`use-conversations.ts`). A reply targets the conversation's most-recently-active stream (`lastActiveStreamId` — the latest reply's own stream, computed in `board-card.tsx`), not the anchor root; posting into the anchor would re-interleave the channel a convert avoided. The lone-post→thread special case stays. The convert optimistic event is tagged with its source conversation id (`use-queue-draft-message.ts`) so it renders in place before the echo.

### Key design decisions

**1. One conversation, no swap (over #1114's optimistic bridge).** Keeping a stable conversation id means the seamless behavior #1114 chased with `usePendingThreadConversions` + a pending-row bridge falls out for free: the reply is an ordinary tagged optimistic message on the card's own (now merged) rail. The composer's transient "Posted to a new thread" note is removed because there is no longer a card swap to bridge.

**2. Access stays a single root check.** Per the doc and the user ruling ("only root stream membership is used for access control, thread membership is for participation"), the board feed keeps its single `streamAccessPredicateSql(conversation.stream_id)` and the assigner does not add per-message-stream gating — redundant under the one-root invariant and only an invitation to drift.

**3. `streamId` on `BoardPostMessage` + live `streamIds` (over a per-event refetch).** The client needs to know which rails to merge. The server snapshot provides the steady-state set; `conversation:message_assigned` widens it live when a reply lands in a new thread (a convert, or a cross-stream continuation), so the card draws the member without a board refetch.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/.../conversation-assigner.ts` | `threadFromMessage` attaches to source (one conversation, mint fallback); `existing` guard relaxed to same-root; `effectiveRootId`/`mintConversationForMessage`/`attachThreadReplyToSource` helpers |
| `apps/backend/.../assignment-events.ts` | removed the now-dead `emitConversationRetired` (INV-38) |
| `apps/backend/.../conversations/service.ts` | `streamId` on internal `BoardPostMessage`; `streamIds` on `BoardPost`; `getBoardMessages` chronological |
| `packages/types/src/domain.ts` | wire `BoardPostMessage.streamId`, `BoardPost.streamIds`; `LabeledMessage` collapsed to a type alias |
| `apps/frontend/.../use-board-card-messages.ts` | `useMergedStreamRail`; card derives its stream set; per-message `streamId` |
| `apps/frontend/.../board-card.tsx` | passes `streamType` + `lastActiveStreamId`; per-message `streamId` to `MessageItem` |
| `apps/frontend/.../board-reply-composer.tsx` | recency `lastActiveStreamId`; dropped the "posted"/swap resting state |
| `apps/frontend/.../use-conversations.ts` | recency-biased `existing` target |
| `apps/frontend/.../use-queue-draft-message.ts` | tag the `threadFromMessage` optimistic event with its source conversation |
| `apps/frontend/.../stores/board-store.ts` | `addBoardConversationStream` |
| `apps/frontend/.../sync/workspace-sync.ts` | `conversation:message_assigned` board handler |
| `apps/frontend/.../use-board-stream-subscriptions.ts` | declare the full per-card stream set |
| `apps/frontend/.../message/message-item.tsx` | optional `RenderableMessage.streamId` |
| tests | assigner (attach/same-root), merged cross-stream rail, recency routing, board/store fixtures carry `streamId`/`streamIds` |

## Out of scope (deliberate)

- **Legacy data — no migration.** Conversations converted under #1113 are thread-anchored with the source retired (empty); they still render via the thread-anchored projection path and stay filtered by `cardinality(message_ids) > 0`. An optional re-anchor backfill isn't required.
- **Move-message — no change needed.** `moveMessagesToThread` moves into a thread that inherits the source's `rootStreamId`, so it is root-preserving by construction, and there is no cross-root move feature. The new model embraces the resulting same-root cross-stream membership.
- **Boundary extraction not tightened.** Same-root thread conversations appearing as assignment candidates is correct under this model; the mis-clustering that surfaced this was a quality (recency/eval) error, not structural.

## Test plan

- [x] Backend `bun test src/features/conversations src/features/messaging` — 148 pass
- [x] Frontend `vitest run` (full) — 3345 pass / 308 files
- [x] `tsc --noEmit` across types / backend / frontend — clean
- [x] `eslint` (frontend) + `prettier --check` — clean
- [x] Pre-commit hook (monorepo typecheck + OpenAPI `--check` + lint) — passed
- [ ] No live-DB / browser harness here, so the cross-stream rendering is covered by the merged-rail unit test (`use-board-card-messages.test.tsx`) and the assigner is covered by stubbed-repo tests like its siblings — not exercised end-to-end against a real board

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0158utcPARKdkAxV1PWEUi4w)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785392897&installation_id=129946197&pr_number=1117&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1117&signature=477585e696b2e1c92ef1438fb75a615230f62418cad861ef8ec63cbf6b6ca124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->