### PR TITLE
feat(board): open a conversation in the side panel (Mechanism B)

### DIFF
--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -36,6 +36,7 @@ describe("Conversation Handlers", () => {
   )
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
+  const mockGetBoardPostById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetFlag = mock(() => Promise.resolve("on" as string))
 
   const handlers = createConversationHandlers({
@@ -44,6 +45,7 @@ describe("Conversation Handlers", () => {
       listByWorkspace: mockListByWorkspace,
       getById: mockGetById,
       getMessages: mockGetMessages,
+      getBoardPostById: mockGetBoardPostById,
     } as never,
     streamService: {
       validateStreamAccess: mockValidateStreamAccess,
@@ -59,6 +61,7 @@ describe("Conversation Handlers", () => {
     mockListByWorkspace.mockReset()
     mockGetById.mockReset()
     mockGetMessages.mockReset()
+    mockGetBoardPostById.mockReset()
     mockGetFlag.mockReset()
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
@@ -71,6 +74,7 @@ describe("Conversation Handlers", () => {
       workspaceId: "ws_1",
     })
     mockGetMessages.mockResolvedValue([])
+    mockGetBoardPostById.mockResolvedValue({ conversation: { id: "conv_1" }, openingMessage: null })
   })
 
   describe("listByStream", () => {
@@ -182,6 +186,52 @@ describe("Conversation Handlers", () => {
       await handlers.getMessages(mockReq({ params: { conversationId: "conv_1" } }), res)
 
       expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+    })
+  })
+
+  describe("getBoardPost", () => {
+    test("404s when the board-view feature flag is not 'on'", async () => {
+      mockGetFlag.mockResolvedValue("off")
+      await expect(
+        handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
+      ).rejects.toMatchObject({ status: 404 })
+      expect(mockGetBoardPostById).not.toHaveBeenCalled()
+    })
+
+    test("gates on the conversation's single root via validateStreamAccess (INV-62)", async () => {
+      await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
+      expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+    })
+
+    test("propagates a stream-access rejection", async () => {
+      mockValidateStreamAccess.mockRejectedValue(new StreamNotFoundError())
+      await expect(handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), mockRes())).rejects.toThrow(
+        "Stream not found"
+      )
+      expect(mockGetBoardPostById).not.toHaveBeenCalled()
+    })
+
+    test("404s when the conversation is in another workspace", async () => {
+      mockGetById.mockResolvedValue({ id: "conv_1", streamId: "stream_1", workspaceId: "ws_other" })
+      const res = mockRes()
+      await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), res)
+      expect((res as unknown as { statusCode: number }).statusCode).toBe(404)
+      expect(mockValidateStreamAccess).not.toHaveBeenCalled()
+    })
+
+    test("404s when the post is empty/gone after the access check", async () => {
+      mockGetBoardPostById.mockResolvedValue(null)
+      const res = mockRes()
+      await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), res)
+      expect((res as unknown as { statusCode: number }).statusCode).toBe(404)
+    })
+
+    test("returns the projected post the service resolves", async () => {
+      const post = { conversation: { id: "conv_1" }, openingMessage: null, recentMessages: [], streamIds: ["stream_1"] }
+      mockGetBoardPostById.mockResolvedValue(post)
+      const res = mockRes()
+      await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), res)
+      expect((res as unknown as { body: unknown }).body).toEqual({ post })
     })
   })
 })

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -145,6 +145,38 @@ export function createConversationHandlers({ conversationService, streamService,
     },
 
     /**
+     * The board post for a single conversation — backs the conversation side
+     * panel (Mechanism B, board-view-design.md), which renders the same projection
+     * a board card does but reachable by id (a board-card expand or an /s/:id
+     * deep-link, where the board feed never seeded the post). Board-gated (404
+     * without the flag), same access as {@link getBoardMessages}.
+     */
+    async getBoardPost(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { conversationId } = req.params
+
+      const boardFlag = await featureFlagService.getFlag(workspaceId, userId, "board-view")
+      if (boardFlag !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const post = await conversationService.getBoardPostById(workspaceId, conversationId)
+      if (!post) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+      res.json({ post })
+    },
+
+    /**
      * User correction from the timeline conversation overlay: make
      * `conversationId` the message's primary conversation. Applies the move
      * and records it as boundary-extraction feedback.

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -115,6 +115,43 @@ export class ConversationService {
     })
     const conversations = rows.map(addStalenessFields)
 
+    const posts = await this.buildBoardPosts(workspaceId, conversations)
+
+    // A full page means there may be more; the last row's (activity, id) is the
+    // next cursor — matching the repo's `(last_activity_at, id) DESC` order.
+    const last = conversations.length === limit ? conversations[conversations.length - 1] : null
+    const nextCursor = last ? `${last.lastActivityAt.toISOString()}|${last.id}` : null
+    return { posts, nextCursor }
+  }
+
+  /**
+   * The board post for a single conversation — the same projection
+   * {@link listByWorkspace} builds per row, for the conversation panel
+   * (Mechanism B, board-view-design.md). Access is the caller's responsibility
+   * (the handler runs the single-root check, INV-62), matching
+   * {@link getBoardMessages}. Returns `null` when the conversation is in another
+   * workspace or has no messages (an emptied conversation is no longer a card,
+   * mirroring the board feed's `cardinality(message_ids) > 0` filter).
+   */
+  async getBoardPostById(workspaceId: string, conversationId: string): Promise<BoardPost | null> {
+    const conversation = await ConversationRepository.findById(this.pool, conversationId)
+    if (!conversation || conversation.workspaceId !== workspaceId || conversation.messageIds.length === 0) return null
+    const [post] = await this.buildBoardPosts(workspaceId, [addStalenessFields(conversation)])
+    return post ?? null
+  }
+
+  /**
+   * Project access-filtered conversations into board posts: resolve each one's
+   * origin (a thread's opener lives in the parent stream, not the thread), pick
+   * the recent reply window by `createdAt` (not `message_ids` insertion order — a
+   * cross-stream attach interleaves the array out of time, board-view-design.md),
+   * and hydrate the opening + window with attachments/link previews. Callers must
+   * have already enforced access (SQL filter for the feed, single-root check for
+   * the single fetch); this does no access work of its own.
+   */
+  private async buildBoardPosts(workspaceId: string, conversations: ConversationWithStaleness[]): Promise<BoardPost[]> {
+    if (conversations.length === 0) return []
+
     // Resolve each conversation's stream so a thread post can show its true
     // origin: a thread is its own stream, so its `messageIds` are the replies and
     // the originating message lives in the parent stream (`parentMessageId`),
@@ -198,11 +235,7 @@ export class ConversationService {
       }
     })
 
-    // A full page means there may be more; the last row's (activity, id) is the
-    // next cursor — matching the repo's `(last_activity_at, id) DESC` order.
-    const last = conversations.length === limit ? conversations[conversations.length - 1] : null
-    const nextCursor = last ? `${last.lastActivityAt.toISOString()}|${last.id}` : null
-    return { posts, nextCursor }
+    return posts
   }
 
   /**

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -494,6 +494,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     conversation.getBoardMessages
   )
+  app.get("/api/workspaces/:workspaceId/conversations/:conversationId/board-post", ...authed, conversation.getBoardPost)
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/reassign",
     ...authed,

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -78,6 +78,20 @@ export const conversationsApi = {
   },
 
   /**
+   * The board post for a single conversation — backs the conversation side panel
+   * (Mechanism B). Used when the panel is opened by id without the board feed
+   * having seeded the post (a /s/:id deep-link, or the in-stream conversation
+   * list). Board-gated server-side (404 without the flag); 404 when the
+   * conversation is gone/empty/cross-workspace.
+   */
+  async getBoardPost(workspaceId: string, conversationId: string): Promise<BoardPost> {
+    const res = await api.get<{ post: BoardPost }>(
+      `/api/workspaces/${workspaceId}/conversations/${conversationId}/board-post`
+    )
+    return res.post
+  },
+
+  /**
    * User correction: make `conversationId` the message's primary conversation.
    * The backend applies the move and records it as boundary-extraction feedback.
    */

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
-import { Hash, FileEdit, User, MessageSquareText, ChevronDown, type LucideIcon } from "lucide-react"
+import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type LucideIcon } from "lucide-react"
 import { RelativeTime } from "@/components/relative-time"
+import { Button } from "@/components/ui/button"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { useActors } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
-import { useConversationService } from "@/contexts"
+import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { RECENT_PREVIEW_CAP } from "@/stores/board-store"
@@ -41,6 +42,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
+  const { openPanel } = usePanel()
   const [expanded, setExpanded] = useState(false)
 
   // Bodies ride the same `db.events` rail the timeline does — live and
@@ -127,6 +129,17 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
           <span className="truncate font-medium">{contextLabel}</span>
         </Link>
         <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
+        {/* Open the whole conversation in the side panel (Mechanism B) — reads it
+            coherently and replies scoped to it, peer to a thread. */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          aria-label="Open conversation"
+          onClick={() => openPanel(createConversationPanelId(conversation.id))}
+        >
+          <PanelRight className="h-3.5 w-3.5" />
+        </Button>
       </div>
 
       <div className="mt-3 [&>*:first-child]:mt-0">

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type LucideIcon } from "lucide-react"
 import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { useActors } from "@/hooks"
@@ -131,15 +132,20 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
         <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
         {/* Open the whole conversation in the side panel (Mechanism B) — reads it
             coherently and replies scoped to it, peer to a thread. */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-          aria-label="Open conversation"
-          onClick={() => openPanel(createConversationPanelId(conversation.id))}
-        >
-          <PanelRight className="h-3.5 w-3.5" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="Open conversation"
+              onClick={() => openPanel(createConversationPanelId(conversation.id))}
+            >
+              <PanelRight className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Open conversation</TooltipContent>
+        </Tooltip>
       </div>
 
       <div className="mt-3 [&>*:first-child]:mt-0">

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
-import { ChevronDown, ChevronRight } from "lucide-react"
+import { ChevronDown, ChevronRight, PanelRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { RelativeTime } from "@/components/relative-time"
-import { useConversationService } from "@/contexts"
+import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { useActors } from "@/hooks"
 import { conversationKeys } from "@/hooks/use-conversations"
 import type { AuthorType, ConversationWithStaleness, Message } from "@threa/types"
@@ -30,38 +31,62 @@ export function ConversationItem({
   className,
 }: ConversationItemProps) {
   const { topicSummary, messageIds, status, lastActivityAt, effectiveCompleteness, temporalStaleness } = conversation
+  const { openPanel } = usePanel()
 
   return (
     <Collapsible open={isExpanded} onOpenChange={onToggle}>
       <div
         className={cn("rounded-lg border bg-card transition-colors", temporalStaleness >= 3 && "opacity-60", className)}
       >
-        <CollapsibleTrigger asChild>
-          <button type="button" className="w-full text-left p-3 hover:bg-accent/50 transition-colors rounded-lg">
-            <div className="flex items-start justify-between gap-2">
-              <div className="flex items-start gap-2 flex-1 min-w-0">
-                {isExpanded ? (
-                  <ChevronDown className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-                ) : (
-                  <ChevronRight className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{topicSummary || "Untitled conversation"}</p>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span className="text-xs text-muted-foreground">
-                      {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
-                    </span>
-                    <StatusBadge status={status} />
+        {/* Header row: the inline-expand trigger fills the row, the panel-open
+            button sits beside it (outside the trigger so it isn't a nested button). */}
+        <div className="flex items-stretch">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="min-w-0 flex-1 rounded-l-lg p-3 text-left transition-colors hover:bg-accent/50"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex items-start gap-2 flex-1 min-w-0">
+                  {isExpanded ? (
+                    <ChevronDown className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{topicSummary || "Untitled conversation"}</p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-xs text-muted-foreground">
+                        {messageIds.length} {messageIds.length === 1 ? "message" : "messages"}
+                      </span>
+                      <StatusBadge status={status} />
+                    </div>
                   </div>
                 </div>
+                <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                  <CompletenessIndicator score={effectiveCompleteness} />
+                  <RelativeTime date={lastActivityAt} className="text-xs text-muted-foreground" />
+                </div>
               </div>
-              <div className="flex flex-col items-end gap-1 flex-shrink-0">
-                <CompletenessIndicator score={effectiveCompleteness} />
-                <RelativeTime date={lastActivityAt} className="text-xs text-muted-foreground" />
-              </div>
-            </div>
-          </button>
-        </CollapsibleTrigger>
+            </button>
+          </CollapsibleTrigger>
+          {/* Open the whole conversation in the side panel (Mechanism B) — peer to
+              the inline expand, but coherent and reply-able. */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="m-1 h-8 w-8 shrink-0 self-center text-muted-foreground hover:text-foreground"
+            aria-label="Open conversation in panel"
+            onClick={() => {
+              openPanel(createConversationPanelId(conversation.id))
+              // Close the conversation-list overlay (when this item is shown in one)
+              // so the panel it just opened isn't hidden behind it.
+              onMessageClick?.()
+            }}
+          >
+            <PanelRight className="h-4 w-4" />
+          </Button>
+        </div>
         <CollapsibleContent>
           <div className="border-t px-3 py-2">
             <ConversationMessages

--- a/apps/frontend/src/components/conversations/conversation-item.tsx
+++ b/apps/frontend/src/components/conversations/conversation-item.tsx
@@ -72,20 +72,25 @@ export function ConversationItem({
           </CollapsibleTrigger>
           {/* Open the whole conversation in the side panel (Mechanism B) — peer to
               the inline expand, but coherent and reply-able. */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="m-1 h-8 w-8 shrink-0 self-center text-muted-foreground hover:text-foreground"
-            aria-label="Open conversation in panel"
-            onClick={() => {
-              openPanel(createConversationPanelId(conversation.id))
-              // Close the conversation-list overlay (when this item is shown in one)
-              // so the panel it just opened isn't hidden behind it.
-              onMessageClick?.()
-            }}
-          >
-            <PanelRight className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="m-1 h-8 w-8 shrink-0 self-center text-muted-foreground hover:text-foreground"
+                aria-label="Open conversation in panel"
+                onClick={() => {
+                  openPanel(createConversationPanelId(conversation.id))
+                  // Close the conversation-list overlay (when this item is shown in
+                  // one) so the panel it just opened isn't hidden behind it.
+                  onMessageClick?.()
+                }}
+              >
+                <PanelRight className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in panel</TooltipContent>
+          </Tooltip>
         </div>
         <CollapsibleContent>
           <div className="border-t px-3 py-2">

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+import { ConversationPanel } from "./conversation-panel"
+import { ServicesProvider, SidebarProvider, PanelProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import * as boardStoreModule from "@/stores/board-store"
+import * as streamStoreModule from "@/stores/stream-store"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as userProfileModule from "@/components/user-profile"
+import * as contextsModule from "@/contexts"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+
+const WORKSPACE_ID = "ws_1"
+const CONVERSATION_ID = "conv_1"
+
+function makeMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
+  return {
+    id: "msg_1",
+    streamId: "stream_1",
+    authorId: "usr_me",
+    authorType: "user",
+    contentMarkdown: "Opening message body.",
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-06-22T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function makeConversation(): ConversationWithStaleness {
+  const now = "2026-06-22T12:00:00.000Z"
+  return {
+    id: CONVERSATION_ID,
+    streamId: "stream_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["msg_1", "msg_2"],
+    participantIds: ["usr_me"],
+    secondaryMessageIds: [],
+    topicSummary: "CC Teams tokens",
+    completenessScore: 4,
+    confidence: 0.8,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+    temporalStaleness: 0,
+    effectiveCompleteness: 4,
+  }
+}
+
+function makePost(): BoardPost {
+  const conversation = makeConversation()
+  return {
+    conversation,
+    openingMessage: makeMessage({ id: "msg_1" }),
+    recentMessages: [makeMessage({ id: "msg_2", contentMarkdown: "Reply two body." })],
+    totalReplies: 1,
+    streamIds: ["stream_1"],
+  }
+}
+
+function asCached(post: BoardPost): BoardViewPost {
+  return { ...post, id: post.conversation.id, workspaceId: WORKSPACE_ID, _lastActivityMs: 0, _cachedAt: 0 }
+}
+
+function mountPanel(opts: {
+  cached?: BoardViewPost | null
+  getBoardPost?: () => Promise<BoardPost>
+  getBoardMessages?: () => Promise<BoardPostMessage[]>
+}) {
+  const getBoardPost = vi.fn(opts.getBoardPost ?? (async () => makePost()))
+  const getBoardMessages = vi.fn(
+    opts.getBoardMessages ?? (async () => [makeMessage({ id: "msg_2", contentMarkdown: "Reply two body." })])
+  )
+  vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(opts.cached as never)
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: { getBoardPost, getBoardMessages } as never }}>
+          <SidebarProvider>
+            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${CONVERSATION_ID}`]}>
+              <PanelProvider>
+                <ConversationPanel workspaceId={WORKSPACE_ID} onClose={vi.fn()} />
+              </PanelProvider>
+            </MemoryRouter>
+          </SidebarProvider>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+  return { getBoardPost, getBoardMessages }
+}
+
+beforeEach(() => {
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  // The panel resolves its host stream type from the synced IDB row.
+  vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue({ id: "stream_1", type: "channel" } as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  // The panel declares its conversation's streams to the SyncEngine (own slot).
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+    setPanelStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("ConversationPanel", () => {
+  it("renders the conversation from the reactive store row without a by-id fetch", async () => {
+    const { getBoardPost } = mountPanel({ cached: asCached(makePost()) })
+    expect(await screen.findByText("Opening message body.")).toBeTruthy()
+    expect(await screen.findByText("Reply two body.")).toBeTruthy()
+    // A card already on the board never round-trips for its projection.
+    expect(getBoardPost).not.toHaveBeenCalled()
+  })
+
+  it("offers a scoped reply affordance", async () => {
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
+  })
+
+  it("fetches the post by id when the store has no row (deep-link / in-stream list)", async () => {
+    const { getBoardPost } = mountPanel({ cached: null })
+    expect(await screen.findByText("Opening message body.")).toBeTruthy()
+    await waitFor(() => expect(getBoardPost).toHaveBeenCalledWith(WORKSPACE_ID, CONVERSATION_ID))
+  })
+
+  it("shows a not-found state when the conversation is gone/unreadable", async () => {
+    mountPanel({
+      cached: null,
+      getBoardPost: async () => {
+        throw new Error("404")
+      },
+    })
+    expect(await screen.findByText("Conversation not found")).toBeTruthy()
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -158,6 +158,6 @@ describe("ConversationPanel", () => {
         throw new Error("404")
       },
     })
-    expect(await screen.findByText("Conversation not found")).toBeTruthy()
+    expect(await screen.findByText("Couldn't open this conversation")).toBeTruthy()
   })
 })

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1,0 +1,234 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, type LucideIcon } from "lucide-react"
+import {
+  SidePanel,
+  SidePanelHeader,
+  SidePanelTitle,
+  SidePanelClose,
+  SidePanelContent,
+} from "@/components/ui/side-panel"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
+import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { RelativeTime } from "@/components/relative-time"
+import { BoardReplyComposer } from "@/components/board/board-reply-composer"
+import { SidebarToggle } from "@/components/layout"
+import { useActors } from "@/hooks"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { useConversationService, usePanel, parseConversationPanel, useSidebar } from "@/contexts"
+import { useStreamFromStore } from "@/stores/stream-store"
+import { conversationKeys, useConversationBoardPost } from "@/hooks/use-conversations"
+import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
+import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+
+const TYPE_GLYPH: Record<string, LucideIcon> = {
+  channel: Hash,
+  scratchpad: FileEdit,
+  dm: User,
+}
+
+interface ConversationPanelProps {
+  workspaceId: string
+  onClose: () => void
+}
+
+/**
+ * A single conversation opened in the side panel (Mechanism B,
+ * board-view-design.md) — a projection peer to a thread, keyed by `?panel=conv:<id>`.
+ * Reads the conversation flattened-chronological across its root + threads (one
+ * root), live off the same `db.events` rail the board card and timeline ride, and
+ * replies scoped to it via the recency-biased board-reply path. No stream is
+ * mutated and access is the conversation's single root check (enforced when the
+ * by-id post is fetched, INV-62) — the panel adds no per-message gating.
+ */
+export function ConversationPanel({ workspaceId, onClose }: ConversationPanelProps) {
+  const { isMobile } = useSidebar()
+  const { panelId } = usePanel()
+  const conversationId = panelId ? parseConversationPanel(panelId) : null
+  const { post, isLoading, notFound, refetch } = useConversationBoardPost(workspaceId, conversationId)
+
+  // Keep the conversation's streams (root + threads) caught up + joined while the
+  // panel is open, so the rail is live and offline-first. Its own SyncEngine slot,
+  // so it composes with the board feed rather than clobbering it.
+  const panelStreamIds = useMemo(
+    () => (post ? [...new Set([post.conversation.streamId, ...(post.streamIds ?? [])])] : []),
+    [post]
+  )
+  usePanelStreamSubscriptions(panelStreamIds)
+
+  const anchorStreamId = post?.conversation.streamId
+  const hostStream = useStreamFromStore(anchorStreamId)
+  const hostStreamType = hostStream?.type
+  const locator = useStreamName(workspaceId, anchorStreamId ?? "", "generic") ?? "Conversation"
+  const ContextGlyph = (hostStreamType && TYPE_GLYPH[hostStreamType]) || MessageSquareText
+
+  let body: React.ReactNode
+  if (post) {
+    body = <ConversationPanelBody workspaceId={workspaceId} post={post} hostStreamType={hostStreamType} />
+  } else if (isLoading) {
+    body = (
+      <div className="flex flex-col gap-3 p-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-2">
+            <Skeleton className="h-8 w-8 shrink-0 rounded-[8px]" />
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-3.5 w-1/4" />
+              <Skeleton className="h-3 w-4/5" />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  } else if (notFound) {
+    body = (
+      <Empty className="min-h-[16rem] border-0">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <MessageSquareText />
+          </EmptyMedia>
+          <EmptyTitle>Conversation not found</EmptyTitle>
+          <EmptyDescription>It may have been moved, merged, or you no longer have access.</EmptyDescription>
+        </EmptyHeader>
+        <Button variant="outline" size="sm" onClick={() => refetch()} className="mt-2">
+          Try again
+        </Button>
+      </Empty>
+    )
+  } else {
+    // Resolved to no post and not an error — transient; show nothing rather than flash.
+    body = null
+  }
+
+  return (
+    <SidePanel data-editor-zone="panel">
+      <SidePanelHeader>
+        {isMobile && <SidebarToggle location="page" />}
+        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={onClose}>
+          <ChevronLeft className="h-4 w-4" />
+          <span className="sr-only">Back</span>
+        </Button>
+        <SidePanelTitle className="flex min-w-0 flex-1 items-center gap-1.5">
+          <ContextGlyph className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate">{locator}</span>
+          {post && (
+            <RelativeTime
+              date={post.conversation.lastActivityAt}
+              terse
+              className="ml-1 shrink-0 text-xs font-normal text-muted-foreground"
+            />
+          )}
+        </SidePanelTitle>
+        {!isMobile && <SidePanelClose onClose={onClose} />}
+      </SidePanelHeader>
+      <SidePanelContent className="flex flex-col">{body}</SidePanelContent>
+    </SidePanel>
+  )
+}
+
+interface ConversationPanelBodyProps {
+  workspaceId: string
+  post: BoardViewPost
+  hostStreamType: string | undefined
+}
+
+/**
+ * The panel's message column + scoped composer. Always renders the FULL
+ * conversation (the panel is permanently "expanded"): the live rail from
+ * {@link useBoardCardMessages} for opening + recent + the viewer's pending
+ * replies, backfilled with the complete ordered list when the local rail is
+ * incomplete — the same merge the board card runs on expand.
+ */
+function ConversationPanelBody({ workspaceId, post, hostStreamType }: ConversationPanelBodyProps) {
+  const { getActorName } = useActors(workspaceId)
+  const currentUserId = useWorkspaceUserId(workspaceId)
+  const conversationService = useConversationService()
+  const { conversation } = post
+
+  const {
+    openingMessage,
+    replies: railReplies,
+    totalReplies,
+    pendingReplies,
+    source,
+  } = useBoardCardMessages(post, hostStreamType)
+
+  // Backfill the full window when the local rail is missing older replies (or the
+  // stream isn't synced yet); the live rail shows immediately, this only fills the
+  // gap when online. Mirrors board-card's expand path.
+  const incompleteLocally = source === "projection" || railReplies.length < totalReplies
+  const {
+    data: allMessages,
+    isError: backfillFailed,
+    refetch: refetchMessages,
+  } = useQuery({
+    queryKey: conversationKeys.boardMessages(conversation.id),
+    queryFn: () => conversationService.getBoardMessages(workspaceId, conversation.id),
+    enabled: incompleteLocally,
+    staleTime: 60_000,
+  })
+
+  // Prefer the server backfill only while the local rail is still incomplete; once
+  // it catches up, fall through to the rail so live edits keep flowing.
+  let replies: RenderableMessage[]
+  if (incompleteLocally && allMessages)
+    replies = (allMessages as RenderableMessage[]).filter((m) => m.id !== openingMessage?.id)
+  else replies = railReplies
+  // Merge the viewer's own just-sent replies (deduped), then sort by time — a
+  // pending reply can be older than a confirmed one.
+  const seenReplyIds = new Set(replies.map((m) => m.id))
+  const displayedReplies = [...replies, ...pendingReplies.filter((m) => !seenReplyIds.has(m.id))].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  )
+  const loadingMore = incompleteLocally && !allMessages && !backfillFailed
+
+  const all = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
+  // The conversation's most-recently-active stream — the latest reply's own stream
+  // (a thread under the root), so a continuation follows the conversation there
+  // instead of re-interleaving the channel (board-view-design.md). Falls back to
+  // the conversation's anchor, NOT the opening message's stream (a thread post's
+  // opener lives in the parent stream).
+  const lastActiveStreamId = displayedReplies.at(-1)?.streamId ?? conversation.streamId
+
+  return (
+    <>
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
+        {all.map((message, i) => (
+          <MessageItem
+            key={message.id}
+            workspaceId={workspaceId}
+            // Each row renders against its own stream so reactions and the
+            // permalink target where the message actually lives (one root, many
+            // streams); fall back to the anchor.
+            streamId={message.streamId ?? conversation.streamId}
+            message={message}
+            authorName={getActorName(message.authorId, message.authorType)}
+            currentUserId={currentUserId}
+            continuation={i > 0 && isContinuation(all[i - 1], message)}
+          />
+        ))}
+        {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
+        {backfillFailed && (
+          <button
+            type="button"
+            onClick={() => void refetchMessages()}
+            className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+          >
+            Couldn't load the full conversation. Retry.
+          </button>
+        )}
+      </div>
+      <div className="border-t px-4 py-3">
+        <BoardReplyComposer
+          workspaceId={workspaceId}
+          post={post}
+          hostStreamType={hostStreamType}
+          lastActiveStreamId={lastActiveStreamId}
+        />
+      </div>
+    </>
+  )
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, type LucideIcon } from "lucide-react"
 import {
@@ -60,6 +60,21 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   )
   usePanelStreamSubscriptions(panelStreamIds)
 
+  // Escape closes the panel, matching StreamPanel — the two are peers in the same
+  // slot, so the keyboard affordance should be consistent. Skip when the event was
+  // already handled (the reply composer's own Escape collapses the editor first) or
+  // when focus is in a text field, so closing the panel never eats a composer Escape.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return
+      const active = document.activeElement as HTMLElement | null
+      if (active?.closest('[contenteditable="true"], input, textarea')) return
+      onClose()
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [onClose])
+
   const anchorStreamId = post?.conversation.streamId
   const hostStream = useStreamFromStore(anchorStreamId)
   const hostStreamType = hostStream?.type
@@ -90,8 +105,13 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
           <EmptyMedia variant="icon">
             <MessageSquareText />
           </EmptyMedia>
-          <EmptyTitle>Conversation not found</EmptyTitle>
-          <EmptyDescription>It may have been moved, merged, or you no longer have access.</EmptyDescription>
+          <EmptyTitle>Couldn't open this conversation</EmptyTitle>
+          {/* The state covers both a transient load failure (retry helps) and a
+              gone/merged/access-lost conversation (retry won't) — so the copy names
+              both rather than asserting one, keeping "Try again" honest. */}
+          <EmptyDescription>
+            It may have moved or been merged, you may have lost access, or there was a problem loading it.
+          </EmptyDescription>
         </EmptyHeader>
         <Button variant="outline" size="sm" onClick={() => refetch()} className="mt-2">
           Try again

--- a/apps/frontend/src/components/layout/panel-host.tsx
+++ b/apps/frontend/src/components/layout/panel-host.tsx
@@ -1,0 +1,23 @@
+import { usePanel, isConversationPanel } from "@/contexts"
+import { StreamPanel } from "@/components/thread"
+import { ConversationPanel } from "@/components/conversations/conversation-panel"
+
+interface PanelHostProps {
+  workspaceId: string
+  onClose: () => void
+}
+
+/**
+ * Picks the side panel's content by panel kind: a `conv:<id>` panel opens a
+ * conversation projection (Mechanism B), every other id is a stream/thread/draft
+ * handled by {@link StreamPanel}. Both stream.tsx and board.tsx host the panel
+ * through this, so either surface can open either kind. Keyed on the panel id so
+ * switching targets remounts cleanly.
+ */
+export function PanelHost({ workspaceId, onClose }: PanelHostProps) {
+  const { panelId } = usePanel()
+  if (panelId && isConversationPanel(panelId)) {
+    return <ConversationPanel key={panelId} workspaceId={workspaceId} onClose={onClose} />
+  }
+  return <StreamPanel key={panelId} workspaceId={workspaceId} onClose={onClose} />
+}

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -32,7 +32,16 @@ export {
   type SocketStatus,
 } from "./socket-context"
 export { PendingMessagesProvider, usePendingMessages } from "./pending-messages-context"
-export { PanelProvider, usePanel, isDraftPanel, parseDraftPanel, createDraftPanelId } from "./panel-context"
+export {
+  PanelProvider,
+  usePanel,
+  isDraftPanel,
+  parseDraftPanel,
+  createDraftPanelId,
+  isConversationPanel,
+  parseConversationPanel,
+  createConversationPanelId,
+} from "./panel-context"
 export { QuickSwitcherProvider, useQuickSwitcher } from "./quick-switcher-context"
 export { PreferencesProvider, usePreferences, usePreferencesOptional, useResolvedTheme } from "./preferences-context"
 export { SettingsProvider, useSettings } from "./settings-context"

--- a/apps/frontend/src/contexts/panel-context.tsx
+++ b/apps/frontend/src/contexts/panel-context.tsx
@@ -31,6 +31,25 @@ export function createDraftPanelId(parentStreamId: string, parentMessageId: stri
   return `draft:${parentStreamId}:${parentMessageId}`
 }
 
+/** A conversation panel (Mechanism B) opens a single conversation as a projection
+ *  peer to a thread, keyed by its conversation id rather than a stream id. */
+const CONVERSATION_PANEL_PREFIX = "conv:"
+
+export function isConversationPanel(panelId: string): boolean {
+  return panelId.startsWith(CONVERSATION_PANEL_PREFIX)
+}
+
+/** The conversation id behind a `conv:<id>` panel, or null when it isn't one. */
+export function parseConversationPanel(panelId: string): string | null {
+  if (!isConversationPanel(panelId)) return null
+  const conversationId = panelId.slice(CONVERSATION_PANEL_PREFIX.length)
+  return conversationId || null
+}
+
+export function createConversationPanelId(conversationId: string): string {
+  return `${CONVERSATION_PANEL_PREFIX}${conversationId}`
+}
+
 interface PanelContextValue {
   /** ID of the currently open panel (stream ID or draft panel ID) */
   panelId: string | null

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -68,6 +68,7 @@ export interface ConversationService {
   getById: typeof conversationsApi.getById
   getMessages: typeof conversationsApi.getMessages
   getBoardMessages: typeof conversationsApi.getBoardMessages
+  getBoardPost: typeof conversationsApi.getBoardPost
   reassignMessage: typeof conversationsApi.reassignMessage
 }
 

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -8,13 +8,14 @@ import {
   createDraftPanelId,
 } from "@/contexts"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import { seedBoardPosts } from "@/stores/board-store"
+import { seedBoardPosts, useBoardPost } from "@/stores/board-store"
+import type { BoardViewPost } from "./use-stable-board-view"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import { StreamTypes } from "@threa/types"
-import type { CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent } from "@threa/types"
+import type { BoardPost, CompanionMode, ConversationWithStaleness, ConversationStatus, JSONContent } from "@threa/types"
 
 /**
  * Where a board post lands: an existing channel/DM the user picked, or a
@@ -41,6 +42,7 @@ export const conversationKeys = {
     [...conversationKeys.all, "detail", workspaceId, conversationId] as const,
   messages: (conversationId: string) => ["conversations", conversationId, "messages"] as const,
   boardMessages: (conversationId: string) => ["conversations", conversationId, "board-messages"] as const,
+  boardPost: (conversationId: string) => ["conversations", conversationId, "board-post"] as const,
 }
 
 interface ConversationCreatedPayload {
@@ -312,6 +314,71 @@ export function useReplyToBoardPost(workspaceId: string) {
       return { plan }
     },
   })
+}
+
+function toBoardViewPost(workspaceId: string, post: BoardPost): BoardViewPost {
+  const ms = Date.parse(post.conversation.lastActivityAt)
+  return {
+    ...post,
+    id: post.conversation.id,
+    workspaceId,
+    _lastActivityMs: Number.isNaN(ms) ? 0 : ms,
+    _cachedAt: Date.now(),
+  }
+}
+
+export interface ConversationBoardPost {
+  /** The post projection for the conversation panel, or null until it resolves. */
+  post: BoardViewPost | null
+  /** True only before any source (the reactive store or the by-id fetch) resolves. */
+  isLoading: boolean
+  /** The conversation couldn't be found — gone, emptied, or not readable. */
+  notFound: boolean
+  refetch: () => void
+}
+
+/**
+ * The board post backing the conversation side panel (Mechanism B), reachable by
+ * id from any surface. Prefers the reactive board-store row — already live and
+ * already feeding the board — and falls back to a by-id fetch when the panel is
+ * opened without the board feed having seeded it (a `/s/:id` deep-link or the
+ * in-stream conversation list). The fetched projection is held in query cache,
+ * NOT seeded into the board store, so opening a conversation panel never surfaces
+ * a spurious card / "N new" bump on the board. Either way the panel body reads
+ * live message rows off the `db.events` rail (use-board-card-messages), so a
+ * synthesized projection still fills in and patches in place.
+ */
+export function useConversationBoardPost(workspaceId: string, conversationId: string | null): ConversationBoardPost {
+  const conversationService = useConversationService()
+  const cached = useBoardPost(conversationId)
+  // Fetch only once the store has resolved to genuinely no row (`null`, not the
+  // still-loading `undefined`) — a card already on the board never round-trips.
+  const shouldFetch = !!conversationId && cached === null
+
+  const {
+    data: fetched,
+    isLoading: fetchLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: conversationId ? conversationKeys.boardPost(conversationId) : conversationKeys.boardPost("none"),
+    queryFn: () => conversationService.getBoardPost(workspaceId, conversationId!),
+    enabled: shouldFetch,
+    staleTime: 60_000,
+  })
+
+  if (cached) return { post: cached, isLoading: false, notFound: false, refetch: () => void refetch() }
+  if (fetched)
+    return {
+      post: toBoardViewPost(workspaceId, fetched),
+      isLoading: false,
+      notFound: false,
+      refetch: () => void refetch(),
+    }
+  // A 404 (gone/empty/cross-workspace) resolves the load as not-found, not a spinner.
+  const notFound = shouldFetch && isError
+  const isLoading = cached === undefined || (shouldFetch && fetchLoading)
+  return { post: null, isLoading, notFound, refetch: () => void refetch() }
 }
 
 export function useConversations(workspaceId: string, streamId: string, options?: UseConversationsOptions) {

--- a/apps/frontend/src/hooks/use-panel-stream-subscriptions.ts
+++ b/apps/frontend/src/hooks/use-panel-stream-subscriptions.ts
@@ -1,0 +1,32 @@
+import { useEffect, useMemo } from "react"
+import { useSyncEngine } from "@/sync/sync-engine"
+
+/**
+ * Keep an open conversation panel's streams live + offline-first. The panel body
+ * reads message rows off the `db.events` rail (use-board-card-messages), so a
+ * conversation is only fully reactive once each of its streams — its root and any
+ * threads it spans (one root, board-view-design.md) — is caught up and its room
+ * joined. Declaring them drives the SyncEngine to do that for the ones not already
+ * subscribed (a thread the viewer never opened), via its own panel slot so it
+ * composes with the board feed's declaration rather than clobbering it.
+ *
+ * Cleared on unmount so a closed panel doesn't widen the reconnect catch-up set;
+ * the engine never tears the subscriptions down (a card click may navigate into
+ * one), exactly as the board declaration behaves.
+ */
+export function usePanelStreamSubscriptions(streamIds: string[]): void {
+  const syncEngine = useSyncEngine()
+
+  // Stable, sorted, deduped key so the declaration effect only re-fires when the
+  // set of streams changes — not when a parent hands back a fresh array identity.
+  const key = useMemo(() => [...new Set(streamIds)].sort().join(","), [streamIds])
+  const ids = useMemo(() => (key ? key.split(",") : []), [key])
+
+  useEffect(() => {
+    syncEngine.setPanelStreamIds(ids)
+  }, [syncEngine, ids])
+
+  useEffect(() => {
+    return () => syncEngine.setPanelStreamIds([])
+  }, [syncEngine])
+}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import * as boardStoreModule from "@/stores/board-store"
-import { ServicesProvider, SidebarProvider } from "@/contexts"
+import { ServicesProvider, SidebarProvider, PanelProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
@@ -110,9 +110,11 @@ function mountBoard(
         <ServicesProvider services={{ conversations: { listByWorkspace, getBoardMessages } as never }}>
           <SidebarProvider>
             <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
-              <Routes>
-                <Route path="/w/:workspaceId/board" element={<BoardPage />} />
-              </Routes>
+              <PanelProvider>
+                <Routes>
+                  <Route path="/w/:workspaceId/board" element={<BoardPage />} />
+                </Routes>
+              </PanelProvider>
             </MemoryRouter>
           </SidebarProvider>
         </ServicesProvider>

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -4,7 +4,10 @@ import { Navigate, useParams } from "react-router-dom"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import { PageHeaderTabs } from "@/components/layout"
+import { PageHeaderTabs, ThreadPanelSlot } from "@/components/layout"
+import { PanelHost } from "@/components/layout/panel-host"
+import { usePanel, useSidebar } from "@/contexts"
+import { usePanelLayout } from "@/hooks"
 import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
 import { localStartOfDayMs } from "@/lib/dates"
@@ -85,6 +88,22 @@ function BoardPageGate({ workspaceId }: { workspaceId: string }) {
 }
 
 function BoardPageInner({ workspaceId }: { workspaceId: string }) {
+  const { isMobile } = useSidebar()
+  const { isPanelOpen, closePanel } = usePanel()
+  const {
+    containerRef,
+    panelWidth,
+    maxWidth,
+    minWidth,
+    displayWidth,
+    shouldAnimate,
+    isResizing,
+    showContent,
+    handleResizeStart,
+    handleResizeKeyDown,
+    handleTransitionEnd,
+  } = usePanelLayout(isPanelOpen)
+
   // The query is the fetch/seed engine; the board reads reactively from IDB. The
   // stable-view projection holds the order the viewer is looking at frozen and
   // accumulates live changes behind the "N new" pill (INV-61, extended from the
@@ -225,7 +244,7 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
     )
   }
 
-  return (
+  const boardColumn = (
     <div className="flex h-full flex-col">
       <PageHeaderTabs
         backTo={`/w/${workspaceId}`}
@@ -263,6 +282,36 @@ function BoardPageInner({ workspaceId }: { workspaceId: string }) {
           </main>
         </ScrollArea>
       </div>
+    </div>
+  )
+
+  // Mobile: an open conversation panel takes over the full screen (mirrors the
+  // stream page), so the narrow board feed isn't crushed beside it.
+  if (isMobile && isPanelOpen) {
+    return (
+      <div className="flex h-full flex-col">
+        <PanelHost workspaceId={workspaceId} onClose={closePanel} />
+      </div>
+    )
+  }
+
+  return (
+    <div ref={containerRef} className="flex h-full">
+      <div className="min-w-0 flex-1 overflow-hidden">{boardColumn}</div>
+      <ThreadPanelSlot
+        displayWidth={displayWidth}
+        panelWidth={panelWidth}
+        shouldAnimate={shouldAnimate}
+        showContent={showContent}
+        isResizing={isResizing}
+        maxWidth={maxWidth}
+        minWidth={minWidth}
+        onTransitionEnd={handleTransitionEnd}
+        onResizeStart={handleResizeStart}
+        onResizeKeyDown={handleResizeKeyDown}
+      >
+        <PanelHost workspaceId={workspaceId} onClose={closePanel} />
+      </ThreadPanelSlot>
     </div>
   )
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -55,8 +55,9 @@ import { useDecryptedStreamName, useStreamNameDecrypting } from "@/hooks/use-dec
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useE2eSession } from "@/stores/e2e-session-store"
-import { StreamPanel, ThreadHeader } from "@/components/thread"
+import { ThreadHeader } from "@/components/thread"
 import { ThreadPanelSlot, SidebarToggle, StreamTitlePreview } from "@/components/layout"
+import { PanelHost } from "@/components/layout/panel-host"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
@@ -822,7 +823,7 @@ export function StreamPage() {
     return (
       <>
         <div className="flex h-full flex-col">
-          <StreamPanel key={panelId} workspaceId={workspaceId} onClose={closePanel} />
+          <PanelHost key={panelId} workspaceId={workspaceId} onClose={closePanel} />
         </div>
         {conversationPanel}
       </>
@@ -852,7 +853,7 @@ export function StreamPage() {
           onResizeStart={handleResizeStart}
           onResizeKeyDown={handleResizeKeyDown}
         >
-          <StreamPanel key={panelId} workspaceId={workspaceId} onClose={closePanel} />
+          <PanelHost key={panelId} workspaceId={workspaceId} onClose={closePanel} />
         </ThreadPanelSlot>
       </div>
       {conversationPanel}

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -47,6 +47,19 @@ export function useBoardPosts(workspaceId: string): CachedBoardPost[] | undefine
 }
 
 /**
+ * One board post from the reactive store, by conversation id — the conversation
+ * panel's static projection (opening/recent/streamIds), live-merged in place as
+ * the feed reconciles. `undefined` until the first IDB read resolves (loading),
+ * `null` once it resolves to no such row (the panel then fetches it by id).
+ */
+export function useBoardPost(conversationId: string | null): CachedBoardPost | null | undefined {
+  return useLiveQuery(async () => {
+    if (!conversationId) return null
+    return (await db.conversations.get(conversationId)) ?? null
+  }, [conversationId])
+}
+
+/**
  * Seed the board store from a bootstrap/page fetch (subscribe-then-fetch,
  * INV-53). `bulkPut` upserts the fetched cards without touching rows the page
  * didn't return, so optimistic-pending rows not yet visible to the server

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -184,6 +184,13 @@ export class SyncEngine {
    *  bodies ride `db.events`, so the board joins + catches them up like any opened
    *  stream and re-asserts them across reconnects (see setBoardStreamIds). */
   private boardStreamIds = new Set<string>()
+  /** Streams an open conversation panel (Mechanism B) reads — its conversation's
+   *  root + threads. Kept in its own slot, NOT folded into boardStreamIds, so the
+   *  panel and the board feed each own their declaration: a panel open over the
+   *  board page mustn't clobber the feed's larger set (both would otherwise race
+   *  the single board slot). Same lifecycle as board streams — caught up + joined
+   *  here, re-asserted across reconnects, never torn down per-card. */
+  private panelStreamIds = new Set<string>()
   private currentUser: { id: string } | null = null
   /** Last workspace bootstrap error, if any. Consumers can check this for 404/403 handling. */
   lastWorkspaceError: unknown = null
@@ -244,6 +251,26 @@ export class SyncEngine {
       toSync.push(streamId)
     }
     this.boardStreamIds = next
+    if (toSync.length > 0) void this.syncBoardStreams(toSync)
+  }
+
+  /**
+   * Declare the streams an open conversation panel reads (its conversation's root
+   * + threads). Same mechanics as {@link setBoardStreamIds} but on its own slot,
+   * so it composes with the board feed instead of clobbering it. Newly-declared
+   * unsubscribed streams are caught up + joined; the set is re-asserted across
+   * reconnects via getVisibleServerStreamIds.
+   */
+  setPanelStreamIds(ids: string[]): void {
+    const next = new Set(ids)
+    const toSync: string[] = []
+    for (const streamId of next) {
+      if (this.panelStreamIds.has(streamId)) continue
+      if (streamId.startsWith("draft_") || streamId.startsWith("draft:")) continue
+      if (this.subscribedStreams.has(streamId)) continue
+      toSync.push(streamId)
+    }
+    this.panelStreamIds = next
     if (toSync.length > 0) void this.syncBoardStreams(toSync)
   }
 
@@ -309,11 +336,11 @@ export class SyncEngine {
     // open that just came online), so sync any declared board streams whose rooms
     // the fresh bootstrap didn't join — otherwise their cards wouldn't go live
     // until the next reconnect.
-    if (!isReconnect && this.boardStreamIds.size > 0) {
-      const pending = [...this.boardStreamIds].filter(
+    if (!isReconnect && (this.boardStreamIds.size > 0 || this.panelStreamIds.size > 0)) {
+      const pending = [...this.boardStreamIds, ...this.panelStreamIds].filter(
         (id) => !this.subscribedStreams.has(id) && !id.startsWith("draft_") && !id.startsWith("draft:")
       )
-      if (pending.length > 0) void this.syncBoardStreams(pending)
+      if (pending.length > 0) void this.syncBoardStreams([...new Set(pending)])
     }
 
     // Process pending offline operations (edits, deletes, reactions, drafts)
@@ -878,6 +905,7 @@ export class SyncEngine {
       ...(this.currentStreamId ? [this.currentStreamId] : []),
       ...this.visibleStreamIds,
       ...this.boardStreamIds,
+      ...this.panelStreamIds,
     ]
     return Array.from(
       new Set(streamIds.filter((streamId) => !streamId.startsWith("draft_") && !streamId.startsWith("draft:")))


### PR DESCRIPTION
## Problem

The board shipped (flag-gated `board-view`) and a conversation can now span its
root + threads under one root (#1117). But a conversation could only be read as a
**board card** — a windowed preview (opening + 3 recent + "N more"). There was no
way to open one conversation on its own, read it in full, and reply scoped to it.
`docs/board-view-design.md` §"Conversations as soft threads" calls this **Mechanism
B**: a conversation as a first-class side panel, peer to a thread.

The side-panel infra is already generic (`panel-context.tsx` routes `?panel=`,
`ThreadPanelSlot` + `usePanelLayout` host arbitrary content), but every panel id
was a stream id or a `draft:` id, and only `stream.tsx` mounted the panel.

## Solution

A `conv:<id>` panel kind that renders a conversation as a projection — read
flattened-chronological across its root + threads off the same `db.events` rail the
board card and timeline ride, replied to through the recency-biased board-reply
path. No stream is mutated; access stays the conversation's **single root check**
(INV-62) — the panel adds no per-message-stream gating, which the one-root invariant
makes redundant.

### How it works

1. **Panel kind + dispatcher.** `panel-context.tsx` gains `conv:<id>` helpers
   (`isConversationPanel` / `parseConversationPanel` / `createConversationPanelId`,
   mirroring the existing `draft:` helpers). A new `PanelHost`
   (`components/layout/panel-host.tsx`) picks `ConversationPanel` vs `StreamPanel`
   by panel kind; both `stream.tsx` and `board.tsx` host the panel through it, so
   either surface opens either kind. `board.tsx` grows the two-column layout
   (`usePanelLayout` + `ThreadPanelSlot`) it didn't have, with the mobile
   full-screen takeover `stream.tsx` already uses.

2. **The panel body reuses the card's projection.** `ConversationPanel` calls
   `useBoardCardMessages` (the #1117 cross-stream rail + the convert-to-thread
   pending-reply bridge) for the live opening + replies, and backfills the full
   ordered list via `getBoardMessages` — the panel is permanently "expanded", so it
   runs the same merge the board card runs on expand. The scoped reply reuses
   `BoardReplyComposer` (directive `existing`, or `threadFromMessage` for a lone
   post), targeting the conversation's most-recently-active stream
   (`displayedReplies.at(-1)?.streamId ?? conversation.streamId`).

3. **Sourcing the post by id.** `useConversationBoardPost` prefers the reactive
   board-store row (`useBoardPost` → live `db.conversations.get`, already feeding the
   board) and falls back to a by-id fetch when the panel is opened without the board
   feed having seeded it — a `/s/:id` deep-link or the in-stream conversation list.
   The fetch hits a new endpoint and is held in **query cache, never seeded into the
   board store**, so opening a conversation panel can't surface a spurious board card
   or "N new" bump.

4. **Backend single fetch.** `GET /conversations/:id/board-post` returns one
   `BoardPost`. The per-row projection in `listByWorkspace` is extracted to a shared
   `buildBoardPosts(workspaceId, conversations)`, so the single fetch and the feed
   produce byte-identical projections. The handler is board-gated (404 without the
   flag) and runs `validateStreamAccess` on the conversation's stream — the same
   single-root check as `getBoardMessages` (INV-62).

5. **Liveness without clobbering the feed.** The SyncEngine declares board-card
   streams through one `boardStreamIds` slot owned by the board page. The panel needs
   its own conversation's streams caught up + joined, but a panel open *over* the
   board page must not overwrite the feed's larger set. So the engine gains a
   separate additive `panelStreamIds` slot (`setPanelStreamIds`), unioned into the
   reconnect catch-up set, declared by `usePanelStreamSubscriptions`.

### Key design decisions

**1. `?panel=conv:<id>` as a peer panel kind.** Open-decision #4 in the design doc
(_lean: yes_). URL-driven so a refresh / shared link lands on the same view (INV-59),
and reuses the generic slot rather than a bespoke drawer.

**2. Fetch fallback held in query cache, not seeded into the board store.** Seeding
would give live reactivity for free but would make a conversation opened from a
stream surface appear as a board card and tick the "N new" pill. The panel body's
liveness comes from the `db.events` rail regardless of the store row, so the
projection only needs to exist in memory — query cache is the right home.

**3. A dedicated `panelStreamIds` slot, not a shared one.** `boardStreamIds` is
replace-on-write and single-owner. Folding the panel's streams in would race the
board feed (last writer wins) whenever both mount on the board page. A second
additive slot composes cleanly; both are unioned in `getVisibleServerStreamIds`.

**4. Access stays one root check.** Per the one-root invariant (#1117,
board-view-design.md §"Conversations span streams within one root"), a conversation
is confined to one root, so a single `validateStreamAccess` on `conversation.streamId`
gates every member. The panel deliberately adds no per-message gating — "redundant
under the invariant and only invites drift."

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | The panel: header locator, full-conversation body (reuses `useBoardCardMessages` + `getBoardMessages` backfill), scoped `BoardReplyComposer` |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | Mounts the real panel: store-row path (no fetch), scoped reply affordance, by-id fetch fallback, not-found state |
| `apps/frontend/src/components/layout/panel-host.tsx` | Dispatches `ConversationPanel` vs `StreamPanel` by panel kind |
| `apps/frontend/src/hooks/use-panel-stream-subscriptions.ts` | Declares an open conversation panel's streams to the SyncEngine's panel slot |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/service.ts` | Extract `buildBoardPosts` from `listByWorkspace`; add `getBoardPostById` |
| `apps/backend/src/features/conversations/handlers.ts` | `getBoardPost` handler (board-gated, single-root access) |
| `apps/backend/src/features/conversations/handlers.test.ts` | 6 cases for `getBoardPost` (flag, access, cross-workspace, empty→404, projection) |
| `apps/backend/src/routes.ts` | Register `GET …/conversations/:id/board-post` |
| `apps/frontend/src/api/conversations.ts`, `contexts/services-context.tsx` | `getBoardPost` client method + service type |
| `apps/frontend/src/contexts/panel-context.tsx`, `contexts/index.ts` | `conv:<id>` panel-kind helpers + exports |
| `apps/frontend/src/hooks/use-conversations.ts` | `useConversationBoardPost` (store-or-fetch) + `conversationKeys.boardPost` |
| `apps/frontend/src/stores/board-store.ts` | `useBoardPost(conversationId)` single-row reactive read |
| `apps/frontend/src/sync/sync-engine.ts` | Additive `panelStreamIds` slot + `setPanelStreamIds` |
| `apps/frontend/src/pages/board.tsx` | Two-column layout + `PanelHost` + mobile takeover |
| `apps/frontend/src/pages/stream.tsx` | `StreamPanel` → `PanelHost` at the three panel mounts |
| `apps/frontend/src/components/board/board-card.tsx` | Panel-open affordance in the card header |
| `apps/frontend/src/components/conversations/conversation-item.tsx` | Panel-open affordance beside the inline-expand trigger |
| `apps/frontend/src/pages/board.test.tsx` | Wrap in `PanelProvider` (board now hosts the panel) |

## Out of scope (deliberate)

- **Mechanism A — on-message provenance chip** (`↪ Pizza · 3h ago`). Depends on this
  panel as its tap target; next PR.
- **Mechanism C — `conversationReference` attached-context node.** Author-side
  declaration; separate workstream.
- **Demoting the `convOverlay` tint** (design follow-up #4) — the in-stream
  conversation list keeps its inline expand; this only *adds* the panel affordance.
- **E2E (sealed) conversations** — `BoardReplyComposer` already blocks board replies
  into an encrypted host; the panel inherits that guard, unchanged.

## Test plan

- [x] Backend `bun test src/features/conversations` — 53 pass (handlers incl. 6 new `getBoardPost` cases)
- [x] Backend `tsc --noEmit` (+ tests project) clean
- [x] Frontend `vitest` — `conversation-panel` (4), `board` (14), `use-conversations`, `use-board-card-messages`, `sync-engine` + `use-board-stream-subscriptions` (63), INV-63 guard — all pass
- [x] Frontend `tsc --noEmit` clean; eslint clean on every touched file
- [x] Pre-commit hook (full-monorepo typecheck + eslint + astro check + OpenAPI `--check` + prettier) passed; "OpenAPI spec is up to date"
- [x] Self-review caught one real layout bug pre-commit: the conversation-list container was `flex items-stretch`, which laid the expanded `CollapsibleContent` in the row instead of below — fixed by splitting the header row from the content
- [ ] No live-DB harness: `getBoardPostById`'s projection is exercised through `buildBoardPosts` (shared with the DB-backed `listByWorkspace`) and the handler is unit-tested with a stubbed service — not integration-tested against Postgres

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5in3QwwZgtddeBpgSfGsM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785410038&installation_id=129946197&pr_number=1119&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1119&signature=d15409e2f6ff25993f8315fc7c7726bcb5c34764a40ab082f8a1aaeac6babee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->