### PR TITLE
feat(conversations): bidirectional message↔conversation navigation

### DIFF
--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -25,8 +25,21 @@ import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { useLongPress } from "@/hooks/use-long-press"
+import { useStreamFromStore } from "@/stores/stream-store"
 import { STREAM_ICONS } from "@/lib/streams"
 import { cn } from "@/lib/utils"
+
+/** Stream-type noun for the "View in …" jump action. Defaults to "channel"
+ * (the common case) when the row's stream isn't cached to read its type. */
+const STREAM_NOUN: Record<string, string> = {
+  channel: "channel",
+  thread: "thread",
+  dm: "DM",
+  scratchpad: "scratchpad",
+}
+function viewInStreamLabel(type: string | undefined): string {
+  return `View in ${(type && STREAM_NOUN[type]) || "channel"}`
+}
 
 /** Same-author messages within this window collapse into a continuation (no
  * repeated header) — matches the timeline's grouping. */
@@ -111,12 +124,14 @@ export function MessageItem({
   const interactiveName = message.authorType === "user" && Boolean(message.authorId)
   const attachments = message.attachments ?? []
   const linkPreviews = message.linkPreviews ?? []
+  // The row's own stream — only to pick the "View in channel/thread/…" noun.
+  const rowStream = useStreamFromStore(streamId)
 
-  // A deliberately small action set for surfaces with no thread context: file
-  // under a label, copy the content, copy a link. `isThreadParent: true`
-  // suppresses "Reply in thread" (its only gate) rather than point it at a
-  // thread we don't have here; the timestamp is the way back into the stream.
-  // No `currentUserId`, so the owner-only edit/delete actions stay hidden.
+  // A deliberately small action set for surfaces with no thread context: jump
+  // to where the message lives, file under a label, copy the content, copy a
+  // link. `isThreadParent: true` suppresses "Reply in thread" (its only gate)
+  // rather than point it at a thread we don't have here. No `currentUserId`,
+  // so the owner-only edit/delete actions stay hidden.
   const menuContext: MessageActionContext = {
     contentMarkdown: message.contentMarkdown,
     actorType: message.authorType,
@@ -126,6 +141,10 @@ export function MessageItem({
     messageId: message.id,
     workspaceId,
     streamId,
+    viewInStream: {
+      href: `/w/${workspaceId}/s/${streamId}?m=${message.id}`,
+      label: viewInStreamLabel(rowStream?.type),
+    },
     onLabelMessage: () => setLabelPickerOpen(true),
   }
 

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -26,19 +26,15 @@ import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { useTouchCapable } from "@/hooks/use-touch-capable"
 import { useLongPress } from "@/hooks/use-long-press"
 import { useStreamFromStore } from "@/stores/stream-store"
-import { STREAM_ICONS } from "@/lib/streams"
+import { STREAM_ICONS, streamFallbackLabel } from "@/lib/streams"
 import { cn } from "@/lib/utils"
 
-/** Stream-type noun for the "View in …" jump action. Defaults to "channel"
- * (the common case) when the row's stream isn't cached to read its type. */
-const STREAM_NOUN: Record<string, string> = {
-  channel: "channel",
-  thread: "thread",
-  dm: "DM",
-  scratchpad: "scratchpad",
-}
-function viewInStreamLabel(type: string | undefined): string {
-  return `View in ${(type && STREAM_NOUN[type]) || "channel"}`
+/** Label for the "View in …" jump action. Uses the shared stream-type noun
+ * ("channel"/"thread"/"DM"/"scratchpad") when the row's stream is cached; a
+ * type-neutral phrase otherwise, so an uncached thread row never mislabels as
+ * "channel". */
+function viewInStreamLabel(type: StreamType | undefined): string {
+  return type ? `View in ${streamFallbackLabel(type, "noun")}` : "Go to message"
 }
 
 /** Same-author messages within this window collapse into a continuation (no

--- a/apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.test.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { MessageConversationProvider, useMessageConversationId } from "./message-conversation-context"
+
+function wrapperFor(map: ReadonlyMap<string, string>) {
+  return ({ children }: { children: ReactNode }) => (
+    <MessageConversationProvider conversationIdByMessageId={map}>{children}</MessageConversationProvider>
+  )
+}
+
+describe("useMessageConversationId", () => {
+  it("returns the primary conversation id for a known message", () => {
+    const map = new Map([["msg_1", "conv_a"]])
+    const { result } = renderHook(() => useMessageConversationId("msg_1"), { wrapper: wrapperFor(map) })
+    expect(result.current).toBe("conv_a")
+  })
+
+  it("returns null for a message with no known conversation", () => {
+    const map = new Map([["msg_1", "conv_a"]])
+    const { result } = renderHook(() => useMessageConversationId("msg_other"), { wrapper: wrapperFor(map) })
+    expect(result.current).toBeNull()
+  })
+
+  it("returns null with no provider (in-stream surfaces without the map)", () => {
+    const { result } = renderHook(() => useMessageConversationId("msg_1"))
+    expect(result.current).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, type ReactNode } from "react"
+
+/**
+ * Primary message→conversation membership for the current stream, provided
+ * regardless of whether the conversation overlay is painting. Powers the
+ * per-message "Show in conversation" action (open the conversation in the side
+ * panel) without requiring the user to first turn the overlay on. Built from
+ * the same `buildConversationOverlayModel` membership the overlay uses, so the
+ * two never disagree about which conversation owns a message.
+ */
+const MessageConversationContext = createContext<ReadonlyMap<string, string> | null>(null)
+
+export function MessageConversationProvider({
+  conversationIdByMessageId,
+  children,
+}: {
+  conversationIdByMessageId: ReadonlyMap<string, string>
+  children: ReactNode
+}) {
+  return (
+    <MessageConversationContext.Provider value={conversationIdByMessageId}>
+      {children}
+    </MessageConversationContext.Provider>
+  )
+}
+
+/**
+ * The primary conversation id for a message in the current stream, or null when
+ * none is known — the message belongs to no conversation, or the stream's
+ * conversation list hasn't loaded (e.g. a thread, where membership resolves
+ * through the root and isn't surfaced here).
+ */
+export function useMessageConversationId(messageId: string): string | null {
+  const map = useContext(MessageConversationContext)
+  return map?.get(messageId) ?? null
+}

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest"
 import type { ConversationWithStaleness, StreamEvent } from "@threa/types"
 import { annotateConversationRows, type TimelineItem } from "../event-list"
-import { buildConversationOverlayModel, CONVERSATION_COLOR_COUNT, conversationColor } from "./model"
+import {
+  buildConversationOverlayModel,
+  buildMessageConversationMap,
+  CONVERSATION_COLOR_COUNT,
+  conversationColor,
+} from "./model"
 
 function makeConversation(overrides: Partial<ConversationWithStaleness>): ConversationWithStaleness {
   return {
@@ -75,6 +80,43 @@ describe("buildConversationOverlayModel", () => {
 
     expect(model.conversations.map((c) => c.id)).toEqual(["conv_here"])
     expect(model.conversationIdByMessageId.has("msg_t1")).toBe(false)
+  })
+})
+
+describe("buildMessageConversationMap", () => {
+  it("maps both primary and secondary members, with primary winning a conflict", () => {
+    const conversations = [
+      makeConversation({ id: "conv_a", messageIds: ["msg_1", "msg_2"], secondaryMessageIds: ["msg_3"] }),
+      // msg_3 is conv_b's primary (its canonical home) and conv_a's secondary.
+      makeConversation({ id: "conv_b", messageIds: ["msg_3"] }),
+    ]
+
+    const map = buildMessageConversationMap(conversations)
+
+    expect(map.get("msg_1")).toBe("conv_a")
+    // Secondary membership is still resolvable — unlike the overlay model.
+    expect(map.get("msg_2")).toBe("conv_a")
+    // Primary wins: msg_3 resolves to its home conv_b, not the secondary conv_a.
+    expect(map.get("msg_3")).toBe("conv_b")
+  })
+
+  it("resolves a cross-stream (thread) member of a root conversation", () => {
+    // A conversation can span the root + its threads (one root): the opener is
+    // a primary member in the root, the thread reply a secondary member living
+    // in the thread stream. Both must resolve to the same conversation.
+    const conversations = [
+      makeConversation({
+        id: "conv_root",
+        streamId: "stream_123",
+        messageIds: ["msg_root"],
+        secondaryMessageIds: ["msg_thread_reply"],
+      }),
+    ]
+
+    const map = buildMessageConversationMap(conversations)
+
+    expect(map.get("msg_root")).toBe("conv_root")
+    expect(map.get("msg_thread_reply")).toBe("conv_root")
   })
 
   it("wraps palette slots beyond the palette size", () => {

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -55,6 +55,32 @@ export function buildConversationOverlayModel(
 }
 
 /**
+ * Map every message id in `conversations` to the conversation it belongs to,
+ * for the "Show in conversation" action. Unlike {@link buildConversationOverlayModel}
+ * (which colors one stream's own conversations by PRIMARY membership), this:
+ *
+ * - includes `secondaryMessageIds` — a reply that joined a conversation as a
+ *   cross-stream member (e.g. a thread reply off a root opener) is mapped too;
+ * - does NOT filter by `streamId` — a conversation spans its root and the root's
+ *   threads (one root), and message ids are globally unique, so any message
+ *   rendered in the current stream resolves regardless of the conversation's
+ *   anchor.
+ *
+ * Primary membership wins when an id appears in both lists (it's the message's
+ * canonical home), so secondaries are written first and overwritten by primaries.
+ */
+export function buildMessageConversationMap(conversations: ConversationWithStaleness[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const conversation of conversations) {
+    for (const messageId of conversation.secondaryMessageIds) map.set(messageId, conversation.id)
+  }
+  for (const conversation of conversations) {
+    for (const messageId of conversation.messageIds) map.set(messageId, conversation.id)
+  }
+  return map
+}
+
+/**
  * Per-row annotation stamped onto message timeline items while the overlay
  * is active (see `annotateConversationRows` in event-list.tsx).
  */

--- a/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-membership-heal.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-membership-heal.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { useConversationMembershipHeal } from "./use-conversation-membership-heal"
+
+describe("useConversationMembershipHeal", () => {
+  it("refetches once when the newest own message is unmapped, then not again after it maps", () => {
+    const refetch = vi.fn()
+    const props = {
+      enabled: true,
+      latestOwnMessageId: "msg_1",
+      conversationIdByMessageId: new Map<string, string>(),
+      refetch,
+    }
+    const { rerender } = renderHook((p) => useConversationMembershipHeal(p), { initialProps: props })
+
+    // Unmapped → one heal refetch.
+    expect(refetch).toHaveBeenCalledTimes(1)
+
+    // Still unmapped, same message id, re-render → ref guard prevents a second.
+    rerender({ ...props, conversationIdByMessageId: new Map<string, string>() })
+    expect(refetch).toHaveBeenCalledTimes(1)
+
+    // Message becomes mapped → no further refetch.
+    rerender({ ...props, conversationIdByMessageId: new Map([["msg_1", "conv_a"]]) })
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-arms for a newer own message", () => {
+    const refetch = vi.fn()
+    const { rerender } = renderHook((p) => useConversationMembershipHeal(p), {
+      initialProps: {
+        enabled: true,
+        latestOwnMessageId: "msg_1" as string | null,
+        conversationIdByMessageId: new Map([["msg_1", "conv_a"]]) as ReadonlyMap<string, string>,
+        refetch,
+      },
+    })
+    // msg_1 already mapped → no refetch.
+    expect(refetch).toHaveBeenCalledTimes(0)
+
+    // A newer own message arrives unmapped → one refetch for it.
+    rerender({
+      enabled: true,
+      latestOwnMessageId: "msg_2",
+      conversationIdByMessageId: new Map([["msg_1", "conv_a"]]),
+      refetch,
+    })
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("does nothing when disabled or there is no own message", () => {
+    const refetch = vi.fn()
+    const { rerender } = renderHook((p) => useConversationMembershipHeal(p), {
+      initialProps: {
+        enabled: false,
+        latestOwnMessageId: "msg_1" as string | null,
+        conversationIdByMessageId: new Map<string, string>() as ReadonlyMap<string, string>,
+        refetch,
+      },
+    })
+    expect(refetch).toHaveBeenCalledTimes(0)
+
+    rerender({
+      enabled: true,
+      latestOwnMessageId: null,
+      conversationIdByMessageId: new Map<string, string>(),
+      refetch,
+    })
+    expect(refetch).toHaveBeenCalledTimes(0)
+  })
+})

--- a/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-membership-heal.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-membership-heal.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Heal a missed/raced conversation assignment so "Show in conversation" resolves
+ * without a manual reload. The per-stream conversation list is a one-time fetch
+ * plus live `conversation:*` events; a message sent from another surface (e.g. a
+ * board reply, then opening the DM) can land before the list's fetch sees it and
+ * after the live event was delivered to a room the sender wasn't yet in. When the
+ * viewer's own newest message (`latestOwnMessageId`) isn't mapped yet, refetch
+ * the list once for it.
+ *
+ * Scoped to the viewer's own send (the case users notice) so an ambient
+ * unassigned message from others doesn't trigger refetches, and ref-guarded so a
+ * genuinely unassigned message refetches at most once — the guard re-arms for a
+ * newer message id.
+ */
+export function useConversationMembershipHeal({
+  enabled,
+  latestOwnMessageId,
+  conversationIdByMessageId,
+  refetch,
+}: {
+  enabled: boolean
+  latestOwnMessageId: string | null
+  conversationIdByMessageId: ReadonlyMap<string, string>
+  refetch: () => void
+}): void {
+  const healedForRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!enabled || !latestOwnMessageId) return
+    if (conversationIdByMessageId.has(latestOwnMessageId)) {
+      healedForRef.current = latestOwnMessageId
+      return
+    }
+    if (healedForRef.current === latestOwnMessageId) return
+    healedForRef.current = latestOwnMessageId
+    refetch()
+  }, [enabled, latestOwnMessageId, conversationIdByMessageId, refetch])
+}

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -445,6 +445,52 @@ describe("mark-unread action", () => {
   })
 })
 
+describe("view-in-stream action (conversation/board → stream)", () => {
+  it("is hidden when viewInStream is not supplied (in-stream timeline)", () => {
+    const actions = getVisibleActions(createContext())
+    expect(actions.find((a) => a.id === "view-in-stream")).toBeUndefined()
+  })
+
+  it("is visible when viewInStream is supplied", () => {
+    const actions = getVisibleActions(
+      createContext({ viewInStream: { href: "/w/ws_1/s/stream_1?m=msg_1", label: "View in channel" } })
+    )
+    expect(actions.find((a) => a.id === "view-in-stream")).toBeDefined()
+  })
+
+  it("navigates to the message permalink via getHref", () => {
+    const ctx = createContext({ viewInStream: { href: "/w/ws_1/s/stream_1?m=msg_1", label: "View in thread" } })
+    const action = getVisibleActions(ctx).find((a) => a.id === "view-in-stream")!
+    expect(action.getHref!(ctx)).toBe("/w/ws_1/s/stream_1?m=msg_1")
+  })
+
+  it("uses the stream-type-aware label", () => {
+    const ctx = createContext({ viewInStream: { href: "/x", label: "View in thread" } })
+    const action = getVisibleActions(ctx).find((a) => a.id === "view-in-stream")!
+    expect(resolveActionLabel(action, ctx)).toBe("View in thread")
+  })
+})
+
+describe("show-in-conversation action (stream → conversation panel)", () => {
+  it("is hidden when onShowInConversation is not supplied", () => {
+    const actions = getVisibleActions(createContext())
+    expect(actions.find((a) => a.id === "show-in-conversation")).toBeUndefined()
+  })
+
+  it("is visible when onShowInConversation is supplied", () => {
+    const actions = getVisibleActions(createContext({ onShowInConversation: () => {} }))
+    expect(actions.find((a) => a.id === "show-in-conversation")).toBeDefined()
+  })
+
+  it("invokes the onShowInConversation callback when run", () => {
+    const onShowInConversation = vi.fn()
+    const ctx = createContext({ onShowInConversation })
+    const action = getVisibleActions(ctx).find((a) => a.id === "show-in-conversation")!
+    action.action!(ctx)
+    expect(onShowInConversation).toHaveBeenCalledOnce()
+  })
+})
+
 describe("groupVisibleActions", () => {
   it("returns single items for ungrouped actions and groups same-id ones", () => {
     const ctx = createContext()

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -18,6 +18,8 @@ import {
   CheckCheck,
   CircleDot,
   Tag,
+  ArrowUpRight,
+  PanelRight,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -132,6 +134,21 @@ export interface MessageActionContext {
    */
   onReassignConversation?: () => void
   /**
+   * Jump to where this message actually lives — its own stream timeline,
+   * `?m=` highlighted. Set only on surfaces that render a message OUTSIDE its
+   * home stream (the board card, the conversation panel, the label page), so
+   * it never appears on the in-stream timeline (you're already there). The
+   * label is stream-type aware ("View in channel" / "View in thread" / …).
+   */
+  viewInStream?: { href: string; label: string }
+  /**
+   * Open this message's conversation in the side panel (Mechanism B). Set on
+   * in-stream message rows whose primary conversation is locally known, so the
+   * action mirrors "View in channel" from the other direction. Absent for
+   * messages with no known conversation.
+   */
+  onShowInConversation?: () => void
+  /**
    * Advance the stream's read pointer to this message. Lets the user mark
    * read up to a chosen row where scroll-driven marking is fiddly (notably
    * mobile). The row only signals intent; the stream decides partial-vs-full.
@@ -241,6 +258,16 @@ async function copyToClipboard(text: string): Promise<void> {
 
 export const messageActions: MessageAction[] = [
   {
+    // Board card / conversation panel / label page → the message's home
+    // stream. Gated on `viewInStream`, which only those out-of-stream surfaces
+    // set, so the in-stream timeline never shows it.
+    id: "view-in-stream",
+    label: (ctx) => ctx.viewInStream?.label ?? "View in channel",
+    icon: ArrowUpRight,
+    when: (ctx) => !!ctx.viewInStream,
+    getHref: (ctx) => ctx.viewInStream?.href,
+  },
+  {
     id: "show-trace",
     label: "Show trace and sources",
     icon: Sparkles,
@@ -277,6 +304,15 @@ export const messageActions: MessageAction[] = [
     groupId: "reply",
     when: (ctx) => !!ctx.onQuoteReply,
     action: (ctx) => ctx.onQuoteReply?.(),
+  },
+  {
+    // In-stream → conversation panel (the mirror of "View in channel"). Only
+    // present when the message's conversation is locally known.
+    id: "show-in-conversation",
+    label: "Show in conversation",
+    icon: PanelRight,
+    when: (ctx) => !!ctx.onShowInConversation,
+    action: (ctx) => ctx.onShowInConversation?.(),
   },
   {
     // Default share entry — opens the cross-stream picker modal. Listed

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -17,7 +17,14 @@ import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-co
 import { MessageContextBadge } from "@/components/composer"
 import { RelativeTime } from "@/components/relative-time"
 import { ActorAvatar } from "@/components/actor-avatar"
-import { usePendingMessages, usePanel, createDraftPanelId, useTrace, useMessageService } from "@/contexts"
+import {
+  usePendingMessages,
+  usePanel,
+  createDraftPanelId,
+  createConversationPanelId,
+  useTrace,
+  useMessageService,
+} from "@/contexts"
 import { useUserProfile } from "@/components/user-profile"
 import { useFormattedDate } from "@/hooks/use-formatted-date"
 import { formatStatusClearLabel } from "@/lib/status"
@@ -83,6 +90,7 @@ import { dispatchMarkReadUpToHere, dispatchMarkUnread } from "@/lib/mark-read-ev
 import { useReadFrontier, rowReadState } from "./read-frontier-context"
 import { ConversationPickerDrawer } from "./conversation-overlay/conversation-overlay"
 import { useConversationOverlayRow } from "./conversation-overlay/row-context"
+import { useMessageConversationId } from "./conversation-overlay/message-conversation-context"
 
 const SLOW_SEND_THRESHOLD_MS = 5000
 
@@ -845,7 +853,7 @@ function SentMessageEvent({
   e2eDecryptedMarkdown,
   batch,
 }: MessageEventInnerProps) {
-  const { panelId, getPanelUrl } = usePanel()
+  const { panelId, getPanelUrl, openPanel } = usePanel()
   const messageService = useMessageService()
   const currentUserId = useWorkspaceUserId(workspaceId)
   const { getTraceUrl } = useTrace()
@@ -1053,6 +1061,15 @@ function SentMessageEvent({
   const [conversationPickerOpen, setConversationPickerOpen] = useState(false)
   const handleRequestConversationPicker = useCallback(() => setConversationPickerOpen(true), [])
 
+  // The message's primary conversation, when the stream's membership is loaded
+  // (channels/DMs). Drives the "Show in conversation" action — the mirror of
+  // the board/panel's "View in channel". Null when no conversation is known.
+  const messageConversationId = useMessageConversationId(payload.messageId)
+  const handleShowInConversation = useCallback(
+    () => messageConversationId && openPanel(createConversationPanelId(messageConversationId)),
+    [messageConversationId, openPanel]
+  )
+
   const startDiscussWithAriadne = useDiscussWithAriadne(workspaceId)
   const handleDiscussWithAriadne = useCallback(
     // `useDiscussWithAriadne` rethrows after toasting so the surrounding
@@ -1172,6 +1189,7 @@ function SentMessageEvent({
       // flight.
       onShowMoveDetails: movedTombstoneEvent ? () => setTimeout(() => setMoveDetailsOpen(true), 0) : undefined,
       onReassignConversation: conversationOverlayRow && !batch?.enabled ? handleRequestConversationPicker : undefined,
+      onShowInConversation: messageConversationId ? handleShowInConversation : undefined,
       onMarkReadUpToHere: rowRead !== "read" ? () => dispatchMarkReadUpToHere(streamId, event.id) : undefined,
       onMarkUnread: rowRead !== "unread" ? () => dispatchMarkUnread(streamId, payload.messageId) : undefined,
     }),
@@ -1215,6 +1233,8 @@ function SentMessageEvent({
       movedTombstoneEvent,
       conversationOverlayRow,
       handleRequestConversationPicker,
+      messageConversationId,
+      handleShowInConversation,
     ]
   )
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -78,6 +78,7 @@ import { useConversationOverlay } from "./conversation-overlay/use-conversation-
 import { buildMessageConversationMap } from "./conversation-overlay/model"
 import type { ConversationOverlayContext } from "./conversation-overlay/model"
 import { MessageConversationProvider } from "./conversation-overlay/message-conversation-context"
+import { useConversationMembershipHeal } from "./conversation-overlay/use-conversation-membership-heal"
 import { useConversations } from "@/hooks/use-conversations"
 import { MessageInput } from "./message-input"
 import { StreamDateHeader } from "./stream-date-header"
@@ -521,16 +522,8 @@ export function StreamContent({
     isJumpMode,
   } = useEvents(workspaceId, streamId, { enabled: !isDraft, loadAll: isThread })
 
-  // Heal a missed/raced conversation assignment so "Show in conversation"
-  // resolves without a manual reload. The per-stream conversation list is a
-  // one-time fetch + live `conversation:*` events; sending from another surface
-  // (e.g. a board reply, then opening the DM) can land the message before the
-  // list's fetch sees it and after the live event was delivered to a room the
-  // sender wasn't yet in. When the viewer's OWN newest message isn't mapped
-  // yet, refetch the list once for it — scoped to own sends (the case users
-  // notice) so an ambient unassigned message from others doesn't trigger
-  // refetches, and ref-guarded so a genuinely unassigned message refetches at
-  // most once.
+  // The viewer's newest message in this stream — drives the "Show in
+  // conversation" membership heal below.
   const ownLatestMessageId = useMemo(() => {
     for (let i = events.length - 1; i >= 0; i--) {
       const event = events[i]
@@ -539,17 +532,12 @@ export function StreamContent({
     }
     return null
   }, [events, currentWorkspaceUserId])
-  const conversationHealedForRef = useRef<string | null>(null)
-  useEffect(() => {
-    if (!supportsConversationOverlay || !ownLatestMessageId) return
-    if (conversationIdByMessageId.has(ownLatestMessageId)) {
-      conversationHealedForRef.current = ownLatestMessageId
-      return
-    }
-    if (conversationHealedForRef.current === ownLatestMessageId) return
-    conversationHealedForRef.current = ownLatestMessageId
-    void refetchStreamConversations()
-  }, [supportsConversationOverlay, ownLatestMessageId, conversationIdByMessageId, refetchStreamConversations])
+  useConversationMembershipHeal({
+    enabled: supportsConversationOverlay,
+    latestOwnMessageId: ownLatestMessageId,
+    conversationIdByMessageId,
+    refetch: refetchStreamConversations,
+  })
 
   // Merge bootstrap + paginated `sharedMessages` so pointers in pages older
   // than the bootstrap window (or in jump-mode windows) hydrate without

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -75,7 +75,7 @@ import {
 } from "./event-list"
 import { ConversationOverlayPanel } from "./conversation-overlay/conversation-overlay"
 import { useConversationOverlay } from "./conversation-overlay/use-conversation-overlay"
-import { buildConversationOverlayModel } from "./conversation-overlay/model"
+import { buildMessageConversationMap } from "./conversation-overlay/model"
 import type { ConversationOverlayContext } from "./conversation-overlay/model"
 import { MessageConversationProvider } from "./conversation-overlay/message-conversation-context"
 import { useConversations } from "@/hooks/use-conversations"
@@ -445,15 +445,16 @@ export function StreamContent({
   // Always-on membership for the per-message "Show in conversation" action —
   // it should open the conversation panel without the user first painting the
   // overlay. Same per-stream conversation query (deduped with the overlay's
-  // when both are live) and the same membership model, so the two never
-  // disagree. Channels/DMs only: a thread's messages resolve through their
-  // root, which this stream's list doesn't carry.
-  const { conversations: streamConversations } = useConversations(workspaceId, streamId, {
-    enabled: supportsConversationOverlay,
-  })
+  // when both are live). Channels/DMs only: a thread's messages resolve through
+  // their root, which this stream's list doesn't carry.
+  const { conversations: streamConversations, refetch: refetchStreamConversations } = useConversations(
+    workspaceId,
+    streamId,
+    { enabled: supportsConversationOverlay }
+  )
   const conversationIdByMessageId = useMemo(
-    () => buildConversationOverlayModel(streamConversations, streamId).conversationIdByMessageId,
-    [streamConversations, streamId]
+    () => buildMessageConversationMap(streamConversations),
+    [streamConversations]
   )
   const closeConversationOverlay = useCallback(() => {
     setSearchParams(
@@ -519,6 +520,36 @@ export function StreamContent({
     exitJumpMode,
     isJumpMode,
   } = useEvents(workspaceId, streamId, { enabled: !isDraft, loadAll: isThread })
+
+  // Heal a missed/raced conversation assignment so "Show in conversation"
+  // resolves without a manual reload. The per-stream conversation list is a
+  // one-time fetch + live `conversation:*` events; sending from another surface
+  // (e.g. a board reply, then opening the DM) can land the message before the
+  // list's fetch sees it and after the live event was delivered to a room the
+  // sender wasn't yet in. When the viewer's OWN newest message isn't mapped
+  // yet, refetch the list once for it — scoped to own sends (the case users
+  // notice) so an ambient unassigned message from others doesn't trigger
+  // refetches, and ref-guarded so a genuinely unassigned message refetches at
+  // most once.
+  const ownLatestMessageId = useMemo(() => {
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i]
+      if (event.eventType !== "message_created" || event.actorId !== currentWorkspaceUserId) continue
+      return (event.payload as { messageId?: string })?.messageId ?? null
+    }
+    return null
+  }, [events, currentWorkspaceUserId])
+  const conversationHealedForRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!supportsConversationOverlay || !ownLatestMessageId) return
+    if (conversationIdByMessageId.has(ownLatestMessageId)) {
+      conversationHealedForRef.current = ownLatestMessageId
+      return
+    }
+    if (conversationHealedForRef.current === ownLatestMessageId) return
+    conversationHealedForRef.current = ownLatestMessageId
+    void refetchStreamConversations()
+  }, [supportsConversationOverlay, ownLatestMessageId, conversationIdByMessageId, refetchStreamConversations])
 
   // Merge bootstrap + paginated `sharedMessages` so pointers in pages older
   // than the bootstrap window (or in jump-mode windows) hydrate without

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -75,7 +75,10 @@ import {
 } from "./event-list"
 import { ConversationOverlayPanel } from "./conversation-overlay/conversation-overlay"
 import { useConversationOverlay } from "./conversation-overlay/use-conversation-overlay"
+import { buildConversationOverlayModel } from "./conversation-overlay/model"
 import type { ConversationOverlayContext } from "./conversation-overlay/model"
+import { MessageConversationProvider } from "./conversation-overlay/message-conversation-context"
+import { useConversations } from "@/hooks/use-conversations"
 import { MessageInput } from "./message-input"
 import { StreamDateHeader } from "./stream-date-header"
 import { JoinChannelBar } from "./join-channel-bar"
@@ -439,6 +442,19 @@ export function StreamContent({
     streamId,
     enabled: conversationOverlayActive,
   })
+  // Always-on membership for the per-message "Show in conversation" action —
+  // it should open the conversation panel without the user first painting the
+  // overlay. Same per-stream conversation query (deduped with the overlay's
+  // when both are live) and the same membership model, so the two never
+  // disagree. Channels/DMs only: a thread's messages resolve through their
+  // root, which this stream's list doesn't carry.
+  const { conversations: streamConversations } = useConversations(workspaceId, streamId, {
+    enabled: supportsConversationOverlay,
+  })
+  const conversationIdByMessageId = useMemo(
+    () => buildConversationOverlayModel(streamConversations, streamId).conversationIdByMessageId,
+    [streamConversations, streamId]
+  )
   const closeConversationOverlay = useCallback(() => {
     setSearchParams(
       (prev) => {
@@ -1849,148 +1865,75 @@ export function StreamContent({
       <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
         <QuoteReplyProvider>
           <SharedMessagesProvider map={mergedSharedMessages}>
-            <TextSelectionQuote streamId={streamId} />
-            <div className="relative h-full">
-              <div className="absolute inset-0 overflow-hidden">
-                {isSearchOpen && (
-                  <StreamSearchBar
-                    search={streamSearch}
-                    onClose={handleSearchClose}
-                    onNavigate={handleSearchNavigate}
-                  />
-                )}
-                {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
-                {activeConversationOverlay && (
-                  <ConversationOverlayPanel
-                    overlay={activeConversationOverlay}
-                    inViewConversations={inViewConversations}
-                    onClose={closeConversationOverlay}
-                    searchBarOpen={isSearchOpen}
-                  />
-                )}
-                {isDraft && (
-                  <div
-                    ref={draftScrollRef}
-                    className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
-                    style={{ paddingBottom: "var(--composer-height, 0px)" }}
-                  >
-                    {hasDraftPendingEvents ? (
-                      <EventList
-                        timelineItems={draftTimelineItems}
-                        isLoading={false}
-                        workspaceId={workspaceId}
-                        streamId={streamId}
-                        batch={batchState}
-                      />
-                    ) : (
-                      <Empty className="h-full border-0">
-                        <EmptyHeader>
-                          <EmptyMedia variant="icon">
-                            <MessageSquare />
-                          </EmptyMedia>
-                          <EmptyTitle>Start a conversation</EmptyTitle>
-                          <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
-                        </EmptyHeader>
-                      </Empty>
-                    )}
-                  </div>
-                )}
-                {!isDraft && useVirtualized && (
-                  <>
-                    <TimelineMessageList
-                      visibleItems={visibleItems}
-                      isLoading={isLoading}
-                      holdForDeepLink={holdForDeepLink}
-                      isConfirmedEmpty={isConfirmedEmpty}
-                      listRef={listRef}
-                      scrollerRef={virtualScrollerRef}
-                      registerScroller={registerVirtualScroller}
-                      contentRef={virtualContentRef}
-                      scrollAbortRef={scrollAbortRef}
-                      shift={shift}
-                      isInitialSettling={virtualIsInitialSettling}
-                      onTimelineScroll={handleVirtualScroll}
-                      isFollowingTailRef={isFollowingTailRef}
-                      hasOlderEvents={hasOlderEvents}
-                      hasNewerEvents={hasNewerEvents}
-                      fetchOlderEvents={fetchOlderEvents}
-                      fetchNewerEvents={fetchNewerEvents}
-                      isFetchingOlder={isFetchingOlder}
-                      isFetchingNewer={isFetchingNewer}
-                      workspaceId={workspaceId}
-                      streamId={streamId}
-                      highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
-                      firstUnreadEventId={dividerEventId}
-                      isDividerDimmed={isDividerDimmed}
-                      agentActivity={agentActivity}
-                      hideSessionCards={isChannel}
-                      newMessageIds={newMessageIds}
-                      isSearchOpen={isSearchOpen}
-                      batch={batchState}
-                      batchPointerHandlers={batchPointerHandlers}
-                      conversationOverlay={activeConversationOverlay}
-                      onJumpToDate={handleJumpToDate}
+            <MessageConversationProvider conversationIdByMessageId={conversationIdByMessageId}>
+              <TextSelectionQuote streamId={streamId} />
+              <div className="relative h-full">
+                <div className="absolute inset-0 overflow-hidden">
+                  {isSearchOpen && (
+                    <StreamSearchBar
+                      search={streamSearch}
+                      onClose={handleSearchClose}
+                      onNavigate={handleSearchNavigate}
                     />
-                    {/* Overlay loading indicators — absolutely positioned so they
-                    don't cause layout shift when prepending older messages. */}
+                  )}
+                  {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
+                  {activeConversationOverlay && (
+                    <ConversationOverlayPanel
+                      overlay={activeConversationOverlay}
+                      inViewConversations={inViewConversations}
+                      onClose={closeConversationOverlay}
+                      searchBarOpen={isSearchOpen}
+                    />
+                  )}
+                  {isDraft && (
                     <div
-                      aria-hidden={!isFetchingOlder}
-                      className={cn(
-                        "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                        isSearchOpen ? "top-14" : "top-2",
-                        isFetchingOlder ? "opacity-100" : "opacity-0"
-                      )}
+                      ref={draftScrollRef}
+                      className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
+                      style={{ paddingBottom: "var(--composer-height, 0px)" }}
                     >
-                      Loading older messages...
-                    </div>
-                    <div
-                      aria-hidden={!isFetchingNewer}
-                      className={cn(
-                        "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                        isFetchingNewer ? "opacity-100" : "opacity-0"
-                      )}
-                      style={{
-                        // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
-                        bottom:
-                          isJumpMode || isScrolledFarFromBottom
-                            ? "calc(var(--composer-height, 0px) + 3.5rem)"
-                            : "calc(var(--composer-height, 0px) + 0.5rem)",
-                      }}
-                    >
-                      Loading newer messages...
-                    </div>
-                  </>
-                )}
-                {!isDraft && !useVirtualized && (
-                  <div
-                    ref={plainScrollRef}
-                    className={cn(
-                      "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
-                      (isSearchOpen || batchMode) && "pt-11",
-                      batchMode && "select-none"
-                    )}
-                    style={{ paddingBottom: "var(--composer-height, 0px)" }}
-                    data-suppress-pull-refresh="true"
-                    onScroll={plainHandleScroll}
-                    {...batchPointerHandlers}
-                  >
-                    <div ref={plainContentRef}>
-                      {isThread && parentMessage && parentStreamId && (
-                        <ThreadParentMessage
-                          event={parentMessage}
+                      {hasDraftPendingEvents ? (
+                        <EventList
+                          timelineItems={draftTimelineItems}
+                          isLoading={false}
                           workspaceId={workspaceId}
-                          streamId={parentStreamId}
-                          replyCount={displayEvents.length}
+                          streamId={streamId}
+                          batch={batchState}
                         />
+                      ) : (
+                        <Empty className="h-full border-0">
+                          <EmptyHeader>
+                            <EmptyMedia variant="icon">
+                              <MessageSquare />
+                            </EmptyMedia>
+                            <EmptyTitle>Start a conversation</EmptyTitle>
+                            <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
+                          </EmptyHeader>
+                        </Empty>
                       )}
-                      {isFetchingOlder && (
-                        <div className="flex justify-center py-2">
-                          <p className="text-sm text-muted-foreground">Loading older messages...</p>
-                        </div>
-                      )}
-                      <EventList
-                        timelineItems={timelineItems}
+                    </div>
+                  )}
+                  {!isDraft && useVirtualized && (
+                    <>
+                      <TimelineMessageList
+                        visibleItems={visibleItems}
                         isLoading={isLoading}
+                        holdForDeepLink={holdForDeepLink}
+                        isConfirmedEmpty={isConfirmedEmpty}
+                        listRef={listRef}
+                        scrollerRef={virtualScrollerRef}
+                        registerScroller={registerVirtualScroller}
+                        contentRef={virtualContentRef}
+                        scrollAbortRef={scrollAbortRef}
+                        shift={shift}
+                        isInitialSettling={virtualIsInitialSettling}
+                        onTimelineScroll={handleVirtualScroll}
+                        isFollowingTailRef={isFollowingTailRef}
+                        hasOlderEvents={hasOlderEvents}
+                        hasNewerEvents={hasNewerEvents}
+                        fetchOlderEvents={fetchOlderEvents}
+                        fetchNewerEvents={fetchNewerEvents}
+                        isFetchingOlder={isFetchingOlder}
+                        isFetchingNewer={isFetchingNewer}
                         workspaceId={workspaceId}
                         streamId={streamId}
                         highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
@@ -1999,153 +1942,228 @@ export function StreamContent({
                         agentActivity={agentActivity}
                         hideSessionCards={isChannel}
                         newMessageIds={newMessageIds}
+                        isSearchOpen={isSearchOpen}
                         batch={batchState}
+                        batchPointerHandlers={batchPointerHandlers}
                         conversationOverlay={activeConversationOverlay}
+                        onJumpToDate={handleJumpToDate}
                       />
-                      {isFetchingNewer && (
-                        <div className="flex justify-center py-2">
-                          <p className="text-sm text-muted-foreground">Loading newer messages...</p>
-                        </div>
+                      {/* Overlay loading indicators — absolutely positioned so they
+                    don't cause layout shift when prepending older messages. */}
+                      <div
+                        aria-hidden={!isFetchingOlder}
+                        className={cn(
+                          "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                          isSearchOpen ? "top-14" : "top-2",
+                          isFetchingOlder ? "opacity-100" : "opacity-0"
+                        )}
+                      >
+                        Loading older messages...
+                      </div>
+                      <div
+                        aria-hidden={!isFetchingNewer}
+                        className={cn(
+                          "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                          isFetchingNewer ? "opacity-100" : "opacity-0"
+                        )}
+                        style={{
+                          // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
+                          bottom:
+                            isJumpMode || isScrolledFarFromBottom
+                              ? "calc(var(--composer-height, 0px) + 3.5rem)"
+                              : "calc(var(--composer-height, 0px) + 0.5rem)",
+                        }}
+                      >
+                        Loading newer messages...
+                      </div>
+                    </>
+                  )}
+                  {!isDraft && !useVirtualized && (
+                    <div
+                      ref={plainScrollRef}
+                      className={cn(
+                        "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
+                        (isSearchOpen || batchMode) && "pt-11",
+                        batchMode && "select-none"
                       )}
+                      style={{ paddingBottom: "var(--composer-height, 0px)" }}
+                      data-suppress-pull-refresh="true"
+                      onScroll={plainHandleScroll}
+                      {...batchPointerHandlers}
+                    >
+                      <div ref={plainContentRef}>
+                        {isThread && parentMessage && parentStreamId && (
+                          <ThreadParentMessage
+                            event={parentMessage}
+                            workspaceId={workspaceId}
+                            streamId={parentStreamId}
+                            replyCount={displayEvents.length}
+                          />
+                        )}
+                        {isFetchingOlder && (
+                          <div className="flex justify-center py-2">
+                            <p className="text-sm text-muted-foreground">Loading older messages...</p>
+                          </div>
+                        )}
+                        <EventList
+                          timelineItems={timelineItems}
+                          isLoading={isLoading}
+                          workspaceId={workspaceId}
+                          streamId={streamId}
+                          highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
+                          firstUnreadEventId={dividerEventId}
+                          isDividerDimmed={isDividerDimmed}
+                          agentActivity={agentActivity}
+                          hideSessionCards={isChannel}
+                          newMessageIds={newMessageIds}
+                          batch={batchState}
+                          conversationOverlay={activeConversationOverlay}
+                        />
+                        {isFetchingNewer && (
+                          <div className="flex justify-center py-2">
+                            <p className="text-sm text-muted-foreground">Loading newer messages...</p>
+                          </div>
+                        )}
+                      </div>
                     </div>
+                  )}
+                </div>
+                {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
+              Positioned above the floating composer pill. */}
+                {(isJumpMode || isScrolledFarFromBottom) && (
+                  <div
+                    className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
+                    style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
+                  >
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className="pointer-events-auto shadow-lg gap-1.5"
+                      onClick={handleJumpToLatest}
+                    >
+                      <ArrowDown className="h-3.5 w-3.5" />
+                      Jump to latest
+                    </Button>
                   </div>
                 )}
-              </div>
-              {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
-              Positioned above the floating composer pill. */}
-              {(isJumpMode || isScrolledFarFromBottom) && (
-                <div
-                  className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
-                  style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
-                >
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="pointer-events-auto shadow-lg gap-1.5"
-                    onClick={handleJumpToLatest}
-                  >
-                    <ArrowDown className="h-3.5 w-3.5" />
-                    Jump to latest
-                  </Button>
-                </div>
-              )}
-              {/* "N new messages" jump — shown when unread sits above the viewport.
+                {/* "N new messages" jump — shown when unread sits above the viewport.
               Jumps up to the "New" divider so the viewer can read from there.
               Hidden while search is open: jumping the timeline would yank it out
               from under the active search-result navigation, and the Escape
               mark-read shortcut is gated on `!isSearchOpen` too. */}
-              {unreadAboveViewport && unreadCount > 0 && !batchMode && !isSearchOpen && (
-                <div
-                  // Sits clearly below the floating date pill (top-2, ~30px tall)
-                  // so the top-center affordances never overlap.
-                  className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5"
-                  style={{ top: "3.5rem" }}
-                >
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="pointer-events-auto shadow-lg gap-1.5"
-                    onClick={scrollToFirstUnread}
+                {unreadAboveViewport && unreadCount > 0 && !batchMode && !isSearchOpen && (
+                  <div
+                    // Sits clearly below the floating date pill (top-2, ~30px tall)
+                    // so the top-center affordances never overlap.
+                    className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5"
+                    style={{ top: "3.5rem" }}
                   >
-                    <ArrowUp className="h-3.5 w-3.5" />
-                    {unreadCount} new message{unreadCount === 1 ? "" : "s"}
-                  </Button>
-                  {/* Dismiss without scrolling up: mark all loaded read and tail
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      className="pointer-events-auto shadow-lg gap-1.5"
+                      onClick={scrollToFirstUnread}
+                    >
+                      <ArrowUp className="h-3.5 w-3.5" />
+                      {unreadCount} new message{unreadCount === 1 ? "" : "s"}
+                    </Button>
+                    {/* Dismiss without scrolling up: mark all loaded read and tail
                   the live bottom — the touchable equivalent of Escape. */}
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    className="pointer-events-auto h-9 w-9 shadow-lg"
-                    onClick={escapeUnread}
-                    aria-label="Mark all read"
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-              {dragGhost && (
-                <div
-                  className="pointer-events-none fixed z-50 max-w-[280px] rounded-md border bg-popover/95 px-3 py-2 text-sm shadow-lg"
-                  style={{ left: dragGhost.x + 12, top: dragGhost.y + 12 }}
-                >
-                  <div className="font-medium">{selectedMessageIds.size} selected</div>
-                  <div className="line-clamp-1 text-xs text-muted-foreground">
-                    {Array.from(selectedMessageIds)
-                      .map((messageId) => {
-                        const content = messageEventMeta.get(messageId)?.content
-                        return content ? stripMarkdownToInline(content) : null
-                      })
-                      .filter(Boolean)
-                      .slice(0, 1)
-                      .join("")}
+                    <Button
+                      variant="secondary"
+                      size="icon"
+                      className="pointer-events-auto h-9 w-9 shadow-lg"
+                      onClick={escapeUnread}
+                      aria-label="Mark all read"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
                   </div>
-                </div>
-              )}
-              <AlertDialog
-                open={moveDialogOpen}
-                onOpenChange={(open) => {
-                  if (open) return
-                  // Cancel + Esc are allowed during validating (we just bump the
-                  // cancellation token and the in-flight request becomes a no-op
-                  // on resolve). Only the irreversible commit phase blocks
-                  // dismiss — there is no rollback once moveToThread succeeds.
-                  if (isMoveConfirming) return
-                  closePendingMove()
-                }}
-              >
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Move messages?</AlertDialogTitle>
-                    <AlertDialogDescription>{`Move ${moveMessageCountLabel} into this thread?`}</AlertDialogDescription>
-                  </AlertDialogHeader>
-                  {/* Custom footer: status row (left) + actions (right). Replaces
+                )}
+                {dragGhost && (
+                  <div
+                    className="pointer-events-none fixed z-50 max-w-[280px] rounded-md border bg-popover/95 px-3 py-2 text-sm shadow-lg"
+                    style={{ left: dragGhost.x + 12, top: dragGhost.y + 12 }}
+                  >
+                    <div className="font-medium">{selectedMessageIds.size} selected</div>
+                    <div className="line-clamp-1 text-xs text-muted-foreground">
+                      {Array.from(selectedMessageIds)
+                        .map((messageId) => {
+                          const content = messageEventMeta.get(messageId)?.content
+                          return content ? stripMarkdownToInline(content) : null
+                        })
+                        .filter(Boolean)
+                        .slice(0, 1)
+                        .join("")}
+                    </div>
+                  </div>
+                )}
+                <AlertDialog
+                  open={moveDialogOpen}
+                  onOpenChange={(open) => {
+                    if (open) return
+                    // Cancel + Esc are allowed during validating (we just bump the
+                    // cancellation token and the in-flight request becomes a no-op
+                    // on resolve). Only the irreversible commit phase blocks
+                    // dismiss — there is no rollback once moveToThread succeeds.
+                    if (isMoveConfirming) return
+                    closePendingMove()
+                  }}
+                >
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Move messages?</AlertDialogTitle>
+                      <AlertDialogDescription>{`Move ${moveMessageCountLabel} into this thread?`}</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    {/* Custom footer: status row (left) + actions (right). Replaces
                   shadcn's AlertDialogFooter, which forces flex-col-reverse on
                   mobile and would invert our vertical stacking. */}
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-                    <MoveStatusRow phase={movePhase} />
-                    <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
-                      <AlertDialogCancel disabled={movePhase === "moving"}>Cancel</AlertDialogCancel>
-                      {/* `preventDefault` keeps the dialog open through the
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                      <MoveStatusRow phase={movePhase} />
+                      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
+                        <AlertDialogCancel disabled={movePhase === "moving"}>Cancel</AlertDialogCancel>
+                        {/* `preventDefault` keeps the dialog open through the
                       moving phase so the inline status row can transition
                       to "Moving…" — Radix's default Action behavior would
                       auto-close on click. confirmPendingMove closes the
                       dialog itself on success via cancelBatchMode. */}
-                      <AlertDialogAction
-                        onClick={(event) => {
-                          event.preventDefault()
-                          void confirmPendingMove()
-                        }}
-                        disabled={movePhase !== "validated"}
-                        aria-busy={movePhase === "moving"}
-                      >
-                        Move
-                      </AlertDialogAction>
+                        <AlertDialogAction
+                          onClick={(event) => {
+                            event.preventDefault()
+                            void confirmPendingMove()
+                          }}
+                          disabled={movePhase !== "validated"}
+                          aria-busy={movePhase === "moving"}
+                        >
+                          Move
+                        </AlertDialogAction>
+                      </div>
                     </div>
+                  </AlertDialogContent>
+                </AlertDialog>
+                {membershipResolved && !isMember && isPublicChannel && (
+                  <div className="absolute inset-x-0 bottom-0 z-10">
+                    <JoinChannelBar
+                      workspaceId={workspaceId}
+                      streamId={streamId}
+                      channelName={stream?.slug ?? stream?.displayName ?? ""}
+                      onJoined={handleJoined}
+                      onHeightChange={handleComposerHeightChange}
+                    />
                   </div>
-                </AlertDialogContent>
-              </AlertDialog>
-              {membershipResolved && !isMember && isPublicChannel && (
-                <div className="absolute inset-x-0 bottom-0 z-10">
-                  <JoinChannelBar
+                )}
+                {(isMember || !isPublicChannel || !membershipResolved) && (
+                  <MessageInput
                     workspaceId={workspaceId}
                     streamId={streamId}
-                    channelName={stream?.slug ?? stream?.displayName ?? ""}
-                    onJoined={handleJoined}
-                    onHeightChange={handleComposerHeightChange}
+                    disabled={isArchived || isSystem}
+                    disabledReason={disabledReason}
+                    autoFocus={autoFocus}
+                    onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
                   />
-                </div>
-              )}
-              {(isMember || !isPublicChannel || !membershipResolved) && (
-                <MessageInput
-                  workspaceId={workspaceId}
-                  streamId={streamId}
-                  disabled={isArchived || isSystem}
-                  disabledReason={disabledReason}
-                  autoFocus={autoFocus}
-                  onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
-                />
-              )}
-            </div>
+                )}
+              </div>
+            </MessageConversationProvider>
           </SharedMessagesProvider>
         </QuoteReplyProvider>
       </EditLastMessageContext.Provider>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -443,15 +443,20 @@ export function StreamContent({
     streamId,
     enabled: conversationOverlayActive,
   })
-  // Always-on membership for the per-message "Show in conversation" action —
-  // it should open the conversation panel without the user first painting the
-  // overlay. Same per-stream conversation query (deduped with the overlay's
-  // when both are live). Channels/DMs only: a thread's messages resolve through
-  // their root, which this stream's list doesn't carry.
+  // Always-on membership for the per-message "Show in conversation" action — it
+  // should open the conversation panel without the user first painting the
+  // overlay. A conversation spans its root + the root's threads (one root), so a
+  // THREAD view resolves membership from the ROOT's conversation list (where the
+  // thread's replies live as secondary members and the opener as primary), not
+  // the thread's own list (which has none). A channel/DM uses its own list. The
+  // query key matches the overlay's when both are live, so they dedupe.
+  const conversationMembershipStreamId = isThread ? rootStreamId : streamId
+  const conversationMembershipEnabled =
+    !isDraft && !!conversationMembershipStreamId && (isThread || supportsConversationOverlay)
   const { conversations: streamConversations, refetch: refetchStreamConversations } = useConversations(
     workspaceId,
-    streamId,
-    { enabled: supportsConversationOverlay }
+    conversationMembershipStreamId ?? "",
+    { enabled: conversationMembershipEnabled }
   )
   const conversationIdByMessageId = useMemo(
     () => buildMessageConversationMap(streamConversations),
@@ -533,7 +538,7 @@ export function StreamContent({
     return null
   }, [events, currentWorkspaceUserId])
   useConversationMembershipHeal({
-    enabled: supportsConversationOverlay,
+    enabled: conversationMembershipEnabled,
     latestOwnMessageId: ownLatestMessageId,
     conversationIdByMessageId,
     refetch: refetchStreamConversations,

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -164,6 +164,93 @@ describe("useConversations event registration", () => {
 
     gate.dispose()
   })
+
+  it("patches list-cache membership from conversation:message_assigned (primary → messageIds, idempotent)", async () => {
+    const { socket, emit } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(null)
+
+    const { queryClient, wrapper } = createWrapper()
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await waitFor(() => expect(queryClient.getQueryData(listKey())).toEqual([]))
+
+    const conv = {
+      id: "conv_1",
+      messageIds: ["msg_1"],
+      secondaryMessageIds: [],
+    } as unknown as ConversationWithStaleness
+    const other = {
+      id: "conv_2",
+      messageIds: ["msg_x"],
+      secondaryMessageIds: [],
+    } as unknown as ConversationWithStaleness
+    queryClient.setQueryData(listKey(), [conv, other])
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+
+    act(() => {
+      emit("conversation:message_assigned", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        messageId: "msg_2",
+        conversationId: "conv_1",
+        isPrimary: true,
+        reason: "declared",
+      })
+    })
+
+    const afterAssign = queryClient.getQueryData<ConversationWithStaleness[]>(listKey())!
+    // Appends to the matching conversation's primary membership; others untouched.
+    expect(afterAssign.find((c) => c.id === "conv_1")!.messageIds).toEqual(["msg_1", "msg_2"])
+    expect(afterAssign.find((c) => c.id === "conv_2")!.messageIds).toEqual(["msg_x"])
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: conversationKeys.messages("conv_1") })
+
+    // Idempotent: re-emitting the same assignment adds no duplicate.
+    act(() => {
+      emit("conversation:message_assigned", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        messageId: "msg_2",
+        conversationId: "conv_1",
+        isPrimary: true,
+        reason: "declared",
+      })
+    })
+    expect(
+      queryClient.getQueryData<ConversationWithStaleness[]>(listKey())!.find((c) => c.id === "conv_1")!.messageIds
+    ).toEqual(["msg_1", "msg_2"])
+  })
+
+  it("routes a non-primary assignment to secondaryMessageIds", async () => {
+    const { socket, emit } = createTestSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    vi.spyOn(syncEngineModule, "useOptionalSyncEngine").mockReturnValue(null)
+
+    const { queryClient, wrapper } = createWrapper()
+    renderHook(() => useConversations(WORKSPACE_ID, STREAM_ID), { wrapper })
+    await waitFor(() => expect(queryClient.getQueryData(listKey())).toEqual([]))
+
+    const conv = {
+      id: "conv_1",
+      messageIds: ["msg_1"],
+      secondaryMessageIds: [],
+    } as unknown as ConversationWithStaleness
+    queryClient.setQueryData(listKey(), [conv])
+
+    act(() => {
+      emit("conversation:message_assigned", {
+        workspaceId: WORKSPACE_ID,
+        streamId: STREAM_ID,
+        messageId: "msg_thread",
+        conversationId: "conv_1",
+        isPrimary: false,
+        reason: "thread-reply",
+      })
+    })
+
+    const updated = queryClient.getQueryData<ConversationWithStaleness[]>(listKey())![0]
+    expect(updated.secondaryMessageIds).toEqual(["msg_thread"])
+    expect(updated.messageIds).toEqual(["msg_1"])
+  })
 })
 
 describe("useCreateBoardPost", () => {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -471,6 +471,21 @@ export function useConversations(workspaceId: string, streamId: string, options?
     // reflects the new membership.
     const handleMessageAssigned = (payload: ConversationMessageAssignedPayload) => {
       if (payload.streamId !== streamId && payload.parentStreamId !== streamId) return
+      // Reflect the new membership in the list aggregate immediately so the
+      // message→conversation map (and "Show in conversation") updates from this
+      // per-message event, not only when the heavier `conversation:updated`
+      // aggregate replace lands. Idempotent: skip when the id is already
+      // present, append to the field its primacy selects.
+      queryClient.setQueryData(
+        conversationKeys.list(workspaceId, streamId, { status, limit }),
+        (old: ConversationWithStaleness[] | undefined) =>
+          old?.map((c) => {
+            if (c.id !== payload.conversationId) return c
+            const field = payload.isPrimary ? "messageIds" : "secondaryMessageIds"
+            if (c[field].includes(payload.messageId)) return c
+            return { ...c, [field]: [...c[field], payload.messageId] }
+          })
+      )
       queryClient.invalidateQueries({ queryKey: conversationKeys.messages(payload.conversationId) })
     }
 

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -32,6 +32,9 @@ export interface CreateBoardPostInput {
   attachmentIds?: string[]
 }
 
+/** Shared stable empty list so a disabled/loading query returns one identity. */
+const EMPTY_CONVERSATIONS: ConversationWithStaleness[] = []
+
 export const conversationKeys = {
   all: ["conversations"] as const,
   list: (workspaceId: string, streamId: string, options?: { status?: string; limit?: number }) =>
@@ -391,7 +394,11 @@ export function useConversations(workspaceId: string, streamId: string, options?
   const syncEngine = useOptionalSyncEngine()
 
   const {
-    data: conversations = [],
+    // Stable empty fallback: a fresh `[]` here would change identity every
+    // render while the query is disabled/loading, defeating downstream
+    // `useMemo`s keyed on the list (e.g. the overlay model rebuild) and
+    // re-rendering every consumer of the derived map.
+    data: conversations = EMPTY_CONVERSATIONS,
     isLoading,
     error,
     refetch,


### PR DESCRIPTION
**Design:** `docs/board-view-design.md` §"Conversations as soft threads — panel + provenance + attached context" (Mechanisms A/B). Follows PR #1119 (conversation side panel, Mechanism B).

## Problem

After #1119 a conversation opens in the side panel (`?panel=conv:<id>`), but the two surfaces — the stream timeline and the conversation surfaces (board card, conversation panel) — were one-way streets. From a conversation row you could only reach the message's home stream via the timestamp permalink (easy to miss); from a stream message there was no way at all to jump to the conversation it belongs to. The data to link them already exists client-side (each out-of-stream row carries its own origin `streamId`; the per-stream conversation list carries `messageId → conversationId`), it just wasn't surfaced as an action.

## Solution

Two per-message context-menu actions, one in each direction, both routed through the shared `messageActions` registry so the desktop dropdown (`MessageContextMenu`) and the mobile drawer (`MessageActionDrawer`) pick them up with no per-surface wiring.

### How it works

**Direction A — conversation/board → stream ("View in channel/thread/DM/scratchpad").** A new `viewInStream: { href; label }` field on `MessageActionContext`, set only by `MessageItem` (the component that renders a message *outside* its home stream — board card, conversation panel, label page). The `view-in-stream` action is gated on it (`when: (ctx) => !!ctx.viewInStream`) and navigates via `getHref` to the existing message permalink `/w/:wid/s/:streamId?m=:messageId` — the same URL the row's timestamp already used, so no new routing. Because the in-stream timeline never sets `viewInStream`, the action never appears there (you're already in the stream). The label noun is stream-type aware (`viewInStreamLabel`), read from `useStreamFromStore(streamId)`, defaulting to "channel" when the row's stream isn't cached.

**Direction B — stream → conversation ("Show in conversation").** A new `onShowInConversation` callback on `MessageActionContext`, wired in `SentMessageEvent` to `openPanel(createConversationPanelId(conversationId))`. The message's primary conversation is resolved through a new `MessageConversationProvider` / `useMessageConversationId(messageId)` context, built from the same `buildConversationOverlayModel(...).conversationIdByMessageId` membership the overlay uses — so the two never disagree about which conversation owns a message. The action is gated on a known conversation, so it's absent for messages with none.

To make Direction B work *without* the user first toggling the overlay on (`?convOverlay=on`), `stream-content` now fetches the per-stream conversation list always for channels/DMs (`useConversations(..., { enabled: supportsConversationOverlay })`) and builds the map once. This call shares the query key with the overlay's own `useConversations`, so the two dedupe to one request when both are live, and reuses that hook's socket subscription + reconnect invalidation (INV-53).

### Key design decisions

**1. Gate by context field, not by surface flag.** Each action keys off a context field that exactly one side sets (`viewInStream` ← `MessageItem`; `onShowInConversation` ← `SentMessageEvent`). Both directions live in the one `messageActions` array shared by the stream timeline and the board/conversation surfaces, yet each appears only where it makes sense — no `if (surface === ...)` branching, and the mobile drawer inherits both for free.

**2. Always-fetch the conversation list for channels/DMs.** Reading cache-only (no new fetch) would mean the action only appears after the user opened the overlay — almost never — making it dead weight. Resolving lazily on click risks a menu item that no-ops. Always-fetching the small per-stream list on open is the only option that makes the action reliably present; it's deduped with the overlay's fetch and reuses its INV-53 wiring, so the cost is one small request per channel/DM open and no new sync path.

**3. Reuse the overlay membership model, don't re-derive.** `useMessageConversationId` is backed by `buildConversationOverlayModel`, the same builder the overlay uses, so "Show in conversation" and the overlay's per-row coloring/reassignment can never point at different conversations for the same message.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.tsx` | `MessageConversationProvider` + `useMessageConversationId` — per-stream primary `messageId → conversationId` membership, available regardless of overlay state. |
| `apps/frontend/src/components/timeline/conversation-overlay/message-conversation-context.test.tsx` | Hook coverage: known message → id, unknown message → null, no provider → null. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-actions.ts` | Add `viewInStream` + `onShowInConversation` to `MessageActionContext`; add `view-in-stream` (getHref nav) and `show-in-conversation` (callback) actions. |
| `apps/frontend/src/components/message/message-item.tsx` | Set `viewInStream` on the menu context (stream-type-aware label via `useStreamFromStore`). |
| `apps/frontend/src/components/timeline/message-event.tsx` | `SentMessageEvent`: resolve the message's conversation via `useMessageConversationId`, wire `onShowInConversation` → `openPanel(createConversationPanelId(...))`. |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Always-on per-stream conversation fetch for channels/DMs; build the membership map; wrap the timeline in `MessageConversationProvider`. (Large diff is mechanical re-indentation from the one added wrapper level — `git diff -w` shows 18 real lines.) |
| `apps/frontend/src/components/timeline/message-actions.test.ts` | Coverage for both new actions (visibility gating, href, callback). |

## Out of scope (deliberate)

- **Direction B is channel/DM-only.** A thread's messages resolve membership through their root, which isn't in the thread's own `listByStream` result, so "Show in conversation" doesn't appear on thread rows — matching where the conversation overlay itself applies. Thread support needs a root-scoped lookup; left for a follow-up.
- **FU2** (full message actions on board/conversation rows + surface-aware copy-link that yields a `?panel=conv:` URL + conversation-level copy-link / mod+Shift+L) is the next build, not this PR.

## Test plan

- [x] `apps/frontend` `vitest run` over `message-actions.test.ts` + `message-conversation-context.test.tsx` + `message-context-menu.test.tsx` — 77 pass
- [x] `apps/frontend` `vitest run` over `timeline/`, `message/`, `board/` + the `no-happy-path-success-toast` guard — 353 pass
- [x] `tsc --noEmit` (frontend) clean; eslint clean on all changed files; prettier formatted
- [x] Self-review (claim-verification pass): every named symbol/file/URL confirmed against the diff; permalink URL matches the existing timestamp link; `createConversationPanelId` confirmed exported from the `@/contexts` barrel
- [ ] No manual browser pass this session — behavior verified via unit/integration tests and the shared-registry wiring (both actions render through the same `MessageContextMenu` / `MessageActionDrawer` paths already exercised by existing tests)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013F3MgsttAHoufXppr2Lmb7)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785430416&installation_id=129946197&pr_number=1121&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1121&signature=06510fdeb3133e802bc7b85b0dd54faa8c0c5a535a904a481430d351dc24c601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->