### PR TITLE
fix: re-resolve read frontier after optimistic message id swap

### DIFF
--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -502,6 +502,59 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.lastSeenEventId).toBeUndefined()
   })
 
+  it("re-resolves lastSeenEventId when the trailing row's id is swapped in place (optimistic send reconciled)", () => {
+    // The viewer sends their own message: it renders immediately as an
+    // optimistic `temp_` row at the bottom, and the frontier advances to it
+    // (no gap, viewport covers it). When the server echo lands, the optimistic
+    // row is reconciled to its real id in the SAME array slot — same length, no
+    // scroll, no resize — so neither the scroll listener nor the ResizeObserver
+    // fires. Without depending on `events` itself (not just `.length`), the
+    // frontier's index stays correct but `lastSeenEventId` stays pinned to the
+    // now-dead `temp_` id forever, and auto-mark-as-read refuses to ever persist
+    // a `temp_`-prefixed id — so the viewer's own send never gets marked read.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      e0: { top: 5, bottom: 50 },
+      temp_abc: { top: 50, bottom: 95 },
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const optimisticEvents = [
+      { id: "e0", sequence: "0" },
+      { id: "temp_abc", sequence: "1" },
+    ] as unknown as StreamEvent[]
+    const scrollContainerRef = { current: container }
+
+    const { result, rerender } = renderHook(
+      ({ events }) =>
+        useLastSeenEvent({ scrollContainerRef, events, streamId: "stream_1", lastReadEventId: "e0", enabled: true }),
+      { initialProps: { events: optimisticEvents } }
+    )
+
+    // Frontier advances straight through to the optimistic row.
+    expect(result.current.lastSeenEventId).toBe("temp_abc")
+
+    // Server echo reconciles the optimistic row to its real id, same slot, same
+    // array length — no scroll or resize accompanies this.
+    container.querySelector('[data-event-id="temp_abc"]')!.setAttribute("data-event-id", "evt_real")
+    const reconciledEvents = [
+      { id: "e0", sequence: "0" },
+      { id: "evt_real", sequence: "1" },
+    ] as unknown as StreamEvent[]
+    act(() => rerender({ events: reconciledEvents }))
+
+    // Must re-resolve to the real id — staying on "temp_abc" would permanently
+    // block auto-mark-as-read for this stream.
+    expect(result.current.lastSeenEventId).toBe("evt_real")
+  })
+
   it("does not emit a mark target while the read pointer sits outside the loaded window", () => {
     // Mark-as-unread on the oldest loaded row moves the pointer to a message below
     // the loaded window, so it is unresolvable in `events`. Emitting the stale

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -281,8 +281,16 @@ export function useLastSeenEvent({
     }
   }, [enabled, streamId, recompute, scrollContainerRef, scrollContainerEl, contentRef])
 
-  // Re-scan when the window grows (live append) or the read pointer moves under
-  // us (external read), so the frontier and the affordance stay current.
+  // Re-scan when the window grows (live append), an event at the same index is
+  // replaced (the optimistic temp_ row for the viewer's own send is swapped for
+  // its server-confirmed id in place — same length, new reference), or the read
+  // pointer moves under us (external read) — so the frontier and the affordance
+  // stay current. Depending on `events` itself (not just `.length`) matters: a
+  // same-length swap leaves the frontier's index unchanged but its `.id` stale,
+  // and `lastSeenEventId` is read off that id — without this, a viewer whose own
+  // message is the last thing they did stays pinned to the dead temp_ id, and
+  // auto-mark-as-read silently never advances past it (it refuses to persist a
+  // temp_ id as the read pointer) until some other event nudges a re-scan.
   useEffect(() => {
     if (!enabled) return
     // Detect a genuine pointer move (the id changed), not a windowing artifact
@@ -306,7 +314,7 @@ export function useLastSeenEvent({
     prevLastReadIdRef.current = lastReadEventId
     const raf = requestAnimationFrame(recompute)
     return () => cancelAnimationFrame(raf)
-  }, [enabled, events.length, streamId, lastReadEventId, readIndex, recompute])
+  }, [enabled, events, streamId, lastReadEventId, readIndex, recompute])
 
   return { lastSeenEventId, atLastRow, unreadAboveViewport }
 }


### PR DESCRIPTION
## Problem

Auto-read was reported as inconsistent: a user's own message could stay "unread" until they manually triggered mark-as-read, even though the backend already advances the author's `last_read_event_id` transactionally on send (`apps/backend/src/features/messaging/event-service.ts:591-596`). The repro stream had a `memos:captured` broadcast event land just before the user's own reply, but that turned out to be a coincidence of timing, not the cause.

The actual bug is client-side, in the read-frontier tracker. A sent message renders immediately as an optimistic row with a `temp_...` id. `useAutoMarkAsRead` debounces and calls `markAsRead(streamId, lastSeenEventId)`, but `use-unread-counts.ts:211-218` deliberately refuses to persist a `temp_`-prefixed id as the read pointer (it has no server `stream_events` row, so persisting it would pin the watermark to sequence 0). The comment there says "the auto-read effect re-fires with the real id once the server echo swaps it in" — but that re-fire never happened.

`apps/frontend/src/sync/stream-sync.ts:707-725` reconciles the server echo by `put`-ing the real event and then `delete`-ing the optimistic row in the same IDB transaction, deliberately ordered so live-query observers never see a frame with neither event. Net effect: the events array stays the **same length**, only one row's `id` changes underneath it. `use-last-seen-event.ts`'s re-scan effect was keyed on `events.length`, so this same-length swap never triggered a re-scan. The hook's `lastSeenEventId` state stayed permanently pinned to the now-dead `temp_...` id, `markAsRead` kept no-oping against it, and the stream's read pointer never silently advanced past the user's own message — until a scroll, a resize, or some *later* event changed the array length and forced a fresh scan, or the user manually marked it read.

This explains the "inconsistent" part of the report: it only manifests when the user's own message is the last thing that happens in a stream while they're caught up — any later event nudges a re-scan and self-heals it for whatever came before.

## Solution

Make the re-scan effect in `use-last-seen-event.ts` depend on `events` itself, not `events.length`, so any in-place id swap (not just an append) triggers a fresh scan.

### How it works

- `recompute()` already reads the *current* `events` via a ref (`eventsRef.current`, updated every render) and resolves `lastSeenEventId` as `eventsRef.current[frontier]?.id` — so once `recompute()` runs again after the swap, it picks up the real id at the unchanged frontier index for free.
- The only thing missing was a trigger to call `recompute()` again when the array reference changes but its length doesn't. Swapping the effect's dependency from `events.length` to `events` (`apps/frontend/src/hooks/use-last-seen-event.ts:317`) covers that, in addition to the append case it already handled.
- `events` (from `useEvents()` in `use-events.ts`) gets a new reference on every actual IDB write that affects this stream's query (Dexie live-query semantics), and is referentially stable otherwise — so this doesn't introduce spurious re-scans on unrelated re-renders.

### Key design decisions

**1. Widen the effect dependency instead of special-casing the temp_→real swap.** An alternative would have been to detect "the row at the frontier index had its id replaced" specifically. Depending on `events` directly is simpler, strictly a superset of the existing append-triggered re-scans, and covers any other same-length in-place mutation (not just this one), at the cost of a few more cheap DOM-read recomputes per write.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | Re-scan effect now depends on `events` (the array reference) instead of `events.length`, so a same-length optimistic-id reconciliation re-resolves the frontier instead of leaving `lastSeenEventId` pinned to a dead `temp_` id. |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | New regression test: sends an optimistic `temp_` row, advances the frontier to it, swaps it for a real id in the same array slot with no scroll/resize, and asserts `lastSeenEventId` re-resolves to the real id. |

## Out of scope (deliberate)

- The in-thread "New" unread divider's session-long latch (it deliberately does not move forward once the viewer's read pointer advances past it, including via their own sends) is unrelated and working as designed — confirmed with the reporting user before starting this fix.
- No backend changes: the server-side read-cursor advance on self-send (`event-service.ts:591-596`) was already correct.

## Test plan

- [x] `bun run test use-last-seen-event` (apps/frontend) — 22 pass, including the new regression test
- [x] `bun run test stream-content use-auto-mark-as-read use-unread` (apps/frontend) — 61 pass
- [x] Full monorepo `bun run typecheck` — clean
- [x] Pre-commit hooks (eslint, dockerfile/migration checks, OpenAPI check) — clean
- [x] Full frontend `bun run test` (apps/frontend) — 3358 pass

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01UgCiqHyhBXfZYHxxJfDPJv)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785450846&installation_id=129946197&pr_number=1123&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1123&signature=898f49bf2c8dc2fc43ef6c19d05b99032651a35c6c25794261aeddf63539503c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->