### PR TITLE
feat(conversations): context-aware copy-link + react on board/conversation rows (FU2)

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -115,6 +115,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
       authorName={getActorName(message.authorId, message.authorType)}
       currentUserId={currentUserId}
       continuation={continuation}
+      conversationId={conversation.id}
     />
   )
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -75,6 +75,8 @@ function mountPanel(opts: {
   cached?: BoardViewPost | null
   getBoardPost?: () => Promise<BoardPost>
   getBoardMessages?: () => Promise<BoardPostMessage[]>
+  /** `?m=` deep-link target appended to the panel URL. */
+  highlightMessageId?: string
 }) {
   const getBoardPost = vi.fn(opts.getBoardPost ?? (async () => makePost()))
   const getBoardMessages = vi.fn(
@@ -82,13 +84,14 @@ function mountPanel(opts: {
   )
   vi.spyOn(boardStoreModule, "useBoardPost").mockReturnValue(opts.cached as never)
 
+  const mParam = opts.highlightMessageId ? `&m=${opts.highlightMessageId}` : ""
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <ServicesProvider services={{ conversations: { getBoardPost, getBoardMessages } as never }}>
           <SidebarProvider>
-            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${CONVERSATION_ID}`]}>
+            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board?panel=conv:${CONVERSATION_ID}${mParam}`]}>
               <PanelProvider>
                 <ConversationPanel workspaceId={WORKSPACE_ID} onClose={vi.fn()} />
               </PanelProvider>
@@ -149,6 +152,21 @@ describe("ConversationPanel", () => {
     const { getBoardPost } = mountPanel({ cached: null })
     expect(await screen.findByText("Opening message body.")).toBeTruthy()
     await waitFor(() => expect(getBoardPost).toHaveBeenCalledWith(WORKSPACE_ID, CONVERSATION_ID))
+  })
+
+  it("flashes the ?m= deep-link target row and leaves the others unhighlighted", async () => {
+    mountPanel({ cached: asCached(makePost()), highlightMessageId: "msg_2" })
+    const replyBody = await screen.findByText("Reply two body.")
+    expect(replyBody.closest(".animate-highlight-flash")).toBeTruthy()
+
+    const openingBody = screen.getByText("Opening message body.")
+    expect(openingBody.closest(".animate-highlight-flash")).toBeNull()
+  })
+
+  it("offers a conversation-level copy-link affordance in the header", async () => {
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    expect(screen.getByRole("button", { name: "Copy link to conversation" })).toBeTruthy()
   })
 
   it("shows a not-found state when the conversation is gone/unreadable", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
-import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, type LucideIcon } from "lucide-react"
+import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, Link2, type LucideIcon } from "lucide-react"
 import {
   SidePanel,
   SidePanelHeader,
@@ -9,6 +10,7 @@ import {
   SidePanelContent,
 } from "@/components/ui/side-panel"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
@@ -23,6 +25,7 @@ import { useStreamFromStore } from "@/stores/stream-store"
 import { conversationKeys, useConversationBoardPost } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
+import { copyConversationLink } from "@/lib/stream-links"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 const TYPE_GLYPH: Record<string, LucideIcon> = {
@@ -142,6 +145,22 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
             />
           )}
         </SidePanelTitle>
+        {conversationId && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label="Copy link to conversation"
+                onClick={() => void copyConversationLink(workspaceId, conversationId)}
+              >
+                <Link2 className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Copy link</TooltipContent>
+          </Tooltip>
+        )}
         {!isMobile && <SidePanelClose onClose={onClose} />}
       </SidePanelHeader>
       <SidePanelContent className="flex flex-col">{body}</SidePanelContent>
@@ -167,6 +186,13 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType }: Conversati
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const { conversation } = post
+  // Deep-link target from `?m=` — the row to scroll to + flash. Shared with the
+  // host page's `m` param, but only the conversation panel reads it here (the
+  // board page, the panel's host for a conversation link, ignores it), so a
+  // shared conversation link lands on the right message without a competing
+  // main-view highlight.
+  const [searchParams] = useSearchParams()
+  const highlightMessageId = searchParams.get("m")
 
   const {
     openingMessage,
@@ -228,6 +254,8 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType }: Conversati
             authorName={getActorName(message.authorId, message.authorType)}
             currentUserId={currentUserId}
             continuation={i > 0 && isContinuation(all[i - 1], message)}
+            conversationId={conversation.id}
+            isHighlighted={message.id === highlightMessageId}
           />
         ))}
         {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
-import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, Link2, type LucideIcon } from "lucide-react"
+import { toast } from "sonner"
+import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, Link2, Check, type LucideIcon } from "lucide-react"
 import {
   SidePanel,
   SidePanelHeader,
@@ -25,7 +26,7 @@ import { useStreamFromStore } from "@/stores/stream-store"
 import { conversationKeys, useConversationBoardPost } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
-import { copyConversationLink } from "@/lib/stream-links"
+import { buildConversationLink } from "@/lib/stream-links"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 const TYPE_GLYPH: Record<string, LucideIcon> = {
@@ -77,6 +78,31 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [onClose])
+
+  // Header "Copy link" confirms in place — the icon swaps to a checkmark for a
+  // beat (same footprint, no shift per INV-21) rather than a toast, because a
+  // persistent header button is an on-screen anchor (INV-63; mirrors the
+  // image-gallery toolbar). Only the anchorless callers (the mod+Shift+L
+  // shortcut, the message-menu item) keep `copyConversationLink`'s toast.
+  const [copyDone, setCopyDone] = useState(false)
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+    },
+    []
+  )
+  const handleCopyLink = useCallback(async () => {
+    if (!conversationId) return
+    try {
+      await navigator.clipboard.writeText(buildConversationLink(workspaceId, conversationId))
+      setCopyDone(true)
+      if (copyResetRef.current) clearTimeout(copyResetRef.current)
+      copyResetRef.current = setTimeout(() => setCopyDone(false), 1200)
+    } catch {
+      toast.error("Failed to copy link")
+    }
+  }, [conversationId, workspaceId])
 
   const anchorStreamId = post?.conversation.streamId
   const hostStream = useStreamFromStore(anchorStreamId)
@@ -152,13 +178,13 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
                 variant="ghost"
                 size="icon"
                 className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Copy link to conversation"
-                onClick={() => void copyConversationLink(workspaceId, conversationId)}
+                aria-label={copyDone ? "Link copied" : "Copy link to conversation"}
+                onClick={() => void handleCopyLink()}
               >
-                <Link2 className="h-4 w-4" />
+                {copyDone ? <Check className="h-4 w-4" /> : <Link2 className="h-4 w-4" />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">Copy link</TooltipContent>
+            <TooltipContent side="bottom">{copyDone ? "Copied" : "Copy link"}</TooltipContent>
           </Tooltip>
         )}
         {!isMobile && <SidePanelClose onClose={onClose} />}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import {
   LabelableResourceTypes,
@@ -18,7 +18,9 @@ import { GiphyPreviewList } from "@/components/timeline/giphy-preview-list"
 import { MessageReactions } from "@/components/timeline/message-reactions"
 import { MessageContextMenu } from "@/components/timeline/message-context-menu"
 import { MessageActionDrawer } from "@/components/timeline/message-action-drawer"
+import { ReactionEmojiPicker } from "@/components/timeline/reaction-emoji-picker"
 import type { MessageActionContext } from "@/components/timeline/message-actions"
+import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { LabelStack } from "@/components/labels/label-stack"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { useUserProfile } from "@/components/user-profile"
@@ -83,6 +85,13 @@ interface MessageItemProps {
    * label page (messages span streams, so each row names its origin); the board
    * leaves it off because it shows the stream at the card level. */
   streamLabel?: { name: string; type: StreamType }
+  /** The conversation this row belongs to, set by the conversation surfaces
+   * (board card, conversation panel). Makes "Copy link" emit a conversation-panel
+   * link instead of the stream permalink; the label page leaves it unset. */
+  conversationId?: string
+  /** Scroll this row into view and flash it — the conversation panel sets it for
+   * the `?m=` deep-link target so a shared message link lands on the right row. */
+  isHighlighted?: boolean
 }
 
 /**
@@ -103,11 +112,14 @@ export function MessageItem({
   currentUserId,
   continuation,
   streamLabel,
+  conversationId,
+  isHighlighted,
 }: MessageItemProps) {
   const { formatTime, formatFull } = useFormattedDate()
   const { openUserProfile } = useUserProfile()
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [mobilePickerOpen, setMobilePickerOpen] = useState(false)
   // Touch reaches the actions via long-press → the same `MessageActionDrawer`
   // the timeline uses; the hover overflow button is desktop/keyboard only. This
   // mirrors `SentMessageEvent` rather than exposing a tap-sized dropdown.
@@ -123,20 +135,52 @@ export function MessageItem({
   // The row's own stream — only to pick the "View in channel/thread/…" noun.
   const rowStream = useStreamFromStore(streamId)
 
-  // A deliberately small action set for surfaces with no thread context: jump
-  // to where the message lives, file under a label, copy the content, copy a
-  // link. `isThreadParent: true` suppresses "Reply in thread" (its only gate)
-  // rather than point it at a thread we don't have here. No `currentUserId`,
-  // so the owner-only edit/delete actions stay hidden.
+  // Reactions are self-contained on any surface (no thread/composer context),
+  // so the out-of-stream row gets the same add/toggle path the timeline uses.
+  const { toggleByEmoji } = useMessageReactions(workspaceId, message.id)
+  const handleAddReaction = useCallback(
+    (emoji: string) => toggleByEmoji(emoji, message.reactions, currentUserId),
+    [toggleByEmoji, message.reactions, currentUserId]
+  )
+  const activeReactionShortcodes = useMemo(() => {
+    if (!currentUserId) return new Set<string>()
+    const active = new Set<string>()
+    for (const [shortcode, userIds] of Object.entries(message.reactions)) {
+      if (userIds.includes(currentUserId)) active.add(stripColons(shortcode))
+    }
+    return active
+  }, [currentUserId, message.reactions])
+  const allReactionShortcodes = useMemo(() => reactionShortcodes(message.reactions), [message.reactions])
+
+  // Scroll + flash the `?m=` deep-link target (conversation panel sets
+  // `isHighlighted`). Mirrors the timeline's highlight effect.
+  const containerRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (isHighlighted && containerRef.current) {
+      containerRef.current.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }, [isHighlighted])
+
+  // Reactions/copy/label plus copy-link (surface-specific via `conversationId`)
+  // and "View in channel/thread/…". `isThreadParent: true` suppresses "Reply in
+  // thread" (no thread context here); `currentUserId` powers react toggling —
+  // edit/delete stay hidden because this surface supplies no edit/delete handler
+  // (their `when` gates require one). Quote/reply are deferred (no composer
+  // context on board/conversation surfaces yet).
   const menuContext: MessageActionContext = {
     contentMarkdown: message.contentMarkdown,
     actorType: message.authorType,
     authorId: message.authorId,
+    currentUserId: currentUserId ?? undefined,
     isThreadParent: true,
     replyUrl: "",
     messageId: message.id,
     workspaceId,
     streamId,
+    conversationId,
+    reactions: message.reactions,
+    onReact: handleAddReaction,
+    onOpenFullPicker: () => setMobilePickerOpen(true),
     viewInStream: {
       href: `/w/${workspaceId}/s/${streamId}?m=${message.id}`,
       label: viewInStreamLabel(rowStream?.type),
@@ -149,10 +193,16 @@ export function MessageItem({
   // opacity-0 + pointer-events-none for touch (so a tap can't trigger the
   // invisible button — it passes through), revealing it on mouse hover / focus.
   // Touch reaches the same actions through the long-press drawer below. The body
-  // columns carry `pr-7` so this absolute button never overlays the row's
-  // top-right content (INV-21).
+  // columns carry `pr-14` so this absolute react+overflow cluster never overlays
+  // the row's top-right content (INV-21).
   const overflowMenu = (
-    <div className="reveal-actions-hover-only absolute right-0 top-0">
+    <div className="reveal-actions-hover-only absolute right-0 top-0 flex items-center gap-0.5">
+      <ReactionEmojiPicker
+        workspaceId={workspaceId}
+        onSelect={handleAddReaction}
+        activeShortcodes={activeReactionShortcodes}
+        allReactionShortcodes={allReactionShortcodes}
+      />
       <MessageContextMenu context={menuContext} />
     </div>
   )
@@ -174,6 +224,16 @@ export function MessageItem({
           onOpenChange={setDrawerOpen}
           context={menuContext}
           authorName={authorName}
+        />
+      )}
+      {mobilePickerOpen && (
+        <ReactionEmojiPicker
+          workspaceId={workspaceId}
+          onSelect={handleAddReaction}
+          activeShortcodes={activeReactionShortcodes}
+          allReactionShortcodes={allReactionShortcodes}
+          open={mobilePickerOpen}
+          onOpenChange={setMobilePickerOpen}
         />
       )}
     </>
@@ -235,9 +295,11 @@ export function MessageItem({
     const sentAt = new Date(message.createdAt)
     return (
       <div
+        ref={containerRef}
         className={cn(
-          "group reveal-host relative mt-0.5 flex gap-3",
-          longPress.isPressed && "opacity-70 transition-opacity"
+          "group reveal-host relative mt-0.5 flex scroll-mt-12 gap-3",
+          longPress.isPressed && "opacity-70 transition-opacity",
+          isHighlighted && "animate-highlight-flash"
         )}
         {...touchHandlers}
       >
@@ -249,7 +311,7 @@ export function MessageItem({
         >
           {formatTime(sentAt)}
         </div>
-        <div className="min-w-0 flex-1 pr-7">
+        <div className="min-w-0 flex-1 pr-14">
           {body}
           {labelStack}
         </div>
@@ -261,9 +323,11 @@ export function MessageItem({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
-        "group reveal-host relative mt-3 flex items-start gap-3",
-        longPress.isPressed && "opacity-70 transition-opacity"
+        "group reveal-host relative mt-3 flex scroll-mt-12 items-start gap-3",
+        longPress.isPressed && "opacity-70 transition-opacity",
+        isHighlighted && "animate-highlight-flash"
       )}
       {...touchHandlers}
     >
@@ -275,7 +339,7 @@ export function MessageItem({
         alt={authorName}
         showStatus={false}
       />
-      <div className="min-w-0 flex-1 pr-7">
+      <div className="min-w-0 flex-1 pr-14">
         <div className="mb-0.5 flex items-baseline gap-2">
           {interactiveName ? (
             <button

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -73,9 +73,17 @@ describe("getVisibleActions", () => {
 
   describe("edit action visibility", () => {
     it("should show edit action when author matches current user", () => {
-      const actions = getVisibleActions(createContext({ authorId: "member_1", currentUserId: "member_1" }))
+      const actions = getVisibleActions(
+        createContext({ authorId: "member_1", currentUserId: "member_1", onEdit: () => {} })
+      )
 
       expect(actions.find((a) => a.id === "edit-message")).toBeDefined()
+    })
+
+    it("should not show edit action when the surface supplies no onEdit handler (react-only row)", () => {
+      const actions = getVisibleActions(createContext({ authorId: "member_1", currentUserId: "member_1" }))
+
+      expect(actions.find((a) => a.id === "edit-message")).toBeUndefined()
     })
 
     it("should not show edit action when author differs from current user", () => {
@@ -100,7 +108,7 @@ describe("getVisibleActions", () => {
 
     it("should not show edit action for own messages in an E2E stream (E2EE-1)", () => {
       const actions = getVisibleActions(
-        createContext({ authorId: "member_1", currentUserId: "member_1", e2eEnabled: true })
+        createContext({ authorId: "member_1", currentUserId: "member_1", e2eEnabled: true, onEdit: () => {} })
       )
 
       expect(actions.find((a) => a.id === "edit-message")).toBeUndefined()
@@ -123,11 +131,19 @@ describe("getVisibleActions", () => {
 
   describe("delete action visibility", () => {
     it("should show delete action when author matches current user", () => {
-      const actions = getVisibleActions(createContext({ authorId: "member_1", currentUserId: "member_1" }))
+      const actions = getVisibleActions(
+        createContext({ authorId: "member_1", currentUserId: "member_1", onDelete: () => {} })
+      )
 
       const deleteAction = actions.find((a) => a.id === "delete-message")
       expect(deleteAction).toBeDefined()
       expect(deleteAction!.variant).toBe("destructive")
+    })
+
+    it("should not show delete action when the surface supplies no onDelete handler (react-only row)", () => {
+      const actions = getVisibleActions(createContext({ authorId: "member_1", currentUserId: "member_1" }))
+
+      expect(actions.find((a) => a.id === "delete-message")).toBeUndefined()
     })
 
     it("should not show delete action when author differs from current user", () => {
@@ -147,7 +163,9 @@ describe("getVisibleActions", () => {
 
   describe("action ordering for own messages", () => {
     it("should place edit before copy and delete after copy", () => {
-      const actions = getVisibleActions(createContext({ authorId: "member_1", currentUserId: "member_1" }))
+      const actions = getVisibleActions(
+        createContext({ authorId: "member_1", currentUserId: "member_1", onEdit: () => {}, onDelete: () => {} })
+      )
 
       const ids = actions.map((a) => a.id)
       const editIdx = ids.indexOf("edit-message")
@@ -160,7 +178,12 @@ describe("getVisibleActions", () => {
 
     it("should place see-revisions between edit and copy for edited messages", () => {
       const actions = getVisibleActions(
-        createContext({ authorId: "member_1", currentUserId: "member_1", editedAt: "2026-02-17T12:00:00Z" })
+        createContext({
+          authorId: "member_1",
+          currentUserId: "member_1",
+          editedAt: "2026-02-17T12:00:00Z",
+          onEdit: () => {},
+        })
       )
 
       const ids = actions.map((a) => a.id)
@@ -442,6 +465,37 @@ describe("mark-unread action", () => {
     const ctx = createContext({ onMarkReadUpToHere: () => {}, onMarkUnread: () => {} })
     const ids = getVisibleActions(ctx).map((a) => a.id)
     expect(ids.indexOf("mark-unread")).toBe(ids.indexOf("mark-read-up-to-here") + 1)
+  })
+})
+
+describe("copy-link action (surface-specific)", () => {
+  it("writes the stream permalink when no conversationId is set", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const action = messageActions.find((a) => a.id === "copy-link")!
+    await action.action!(createContext({ messageId: "msg_1", workspaceId: "ws_1", streamId: "stream_1" }))
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/ws_1/s/stream_1?m=msg_1`)
+  })
+
+  it("writes a conversation-panel link when conversationId is set (board/conversation surface)", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const action = messageActions.find((a) => a.id === "copy-link")!
+    await action.action!(
+      createContext({ messageId: "msg_1", workspaceId: "ws_1", streamId: "stream_1", conversationId: "conv_1" })
+    )
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/ws_1/board?panel=conv%3Aconv_1&m=msg_1`)
+  })
+
+  it("is visible when only conversationId (no streamId) is present", () => {
+    const actions = getVisibleActions(
+      createContext({ messageId: "msg_1", workspaceId: "ws_1", conversationId: "conv_1" })
+    )
+    expect(actions.find((a) => a.id === "copy-link")).toBeDefined()
   })
 })
 

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -23,7 +23,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
-import { buildStreamLink } from "@/lib/stream-links"
+import { buildStreamLink, buildConversationLink } from "@/lib/stream-links"
 
 /**
  * Context available to message actions.
@@ -45,6 +45,15 @@ export interface MessageActionContext {
   workspaceId?: string
   /** Stream ID for constructing permalink URLs */
   streamId?: string
+  /**
+   * Conversation ID — set ONLY by the conversation surfaces (board card,
+   * conversation panel) so "Copy link" emits a conversation-panel link
+   * (`?panel=conv:<id>&m=<msgId>`) that reopens the message in the panel rather
+   * than its home stream. A stream or label surface leaves this unset and the
+   * link stays the stream permalink, so copy-link is surface-specific (the same
+   * gate-by-a-field-exactly-one-side-sets pattern as `viewInStream`).
+   */
+  conversationId?: string
   /** Author's user ID */
   authorId?: string
   /** Current user's user ID */
@@ -278,8 +287,16 @@ export const messageActions: MessageAction[] = [
     id: "edit-message",
     label: "Edit message",
     icon: Pencil,
+    // Requires `onEdit` so the entry never shows on a surface that supplies
+    // identity (for reactions) but no edit handler — e.g. the board/conversation
+    // row, which carries `currentUserId` for react toggling but can't host the
+    // inline edit form.
     when: (ctx) =>
-      ctx.actorType === "user" && !!ctx.authorId && ctx.authorId === ctx.currentUserId && ctx.e2eEnabled !== true,
+      ctx.actorType === "user" &&
+      !!ctx.authorId &&
+      ctx.authorId === ctx.currentUserId &&
+      ctx.e2eEnabled !== true &&
+      !!ctx.onEdit,
     action: (ctx) => ctx.onEdit?.(),
   },
   {
@@ -471,12 +488,16 @@ export const messageActions: MessageAction[] = [
     id: "copy-link",
     label: "Copy link to message",
     icon: Link2,
-    when: (ctx) => !!ctx.messageId && !!ctx.workspaceId && !!ctx.streamId,
+    when: (ctx) => !!ctx.messageId && !!ctx.workspaceId && (!!ctx.streamId || !!ctx.conversationId),
     action: async (ctx) => {
       try {
-        // `when` above guarantees these are present; compose on the shared
-        // builder so the route shape lives in one place (stream-links.ts).
-        const url = `${buildStreamLink(ctx.workspaceId!, ctx.streamId!)}?m=${ctx.messageId}`
+        // Surface-specific: a conversation surface (board/panel) sets
+        // `conversationId`, so the link reopens the message in the conversation
+        // panel; otherwise it's the stream permalink. Both compose on the shared
+        // builders so each route shape lives in one place (stream-links.ts).
+        const url = ctx.conversationId
+          ? buildConversationLink(ctx.workspaceId!, ctx.conversationId, ctx.messageId)
+          : `${buildStreamLink(ctx.workspaceId!, ctx.streamId!)}?m=${ctx.messageId}`
         await copyToClipboard(url)
         toast.success("Link copied") // INV-63-allow: clipboard copy from a closing menu has no inline anchor
       } catch {
@@ -490,7 +511,9 @@ export const messageActions: MessageAction[] = [
     icon: Trash2,
     separatorBefore: true,
     variant: "destructive",
-    when: (ctx) => ctx.actorType === "user" && !!ctx.authorId && ctx.authorId === ctx.currentUserId,
+    // See edit-message: gate on the handler so a react-only surface that
+    // supplies `currentUserId` doesn't surface a no-op Delete.
+    when: (ctx) => ctx.actorType === "user" && !!ctx.authorId && ctx.authorId === ctx.currentUserId && !!ctx.onDelete,
     action: (ctx) => ctx.onDelete?.(),
   },
 ]

--- a/apps/frontend/src/components/timeline/message-context-menu.test.tsx
+++ b/apps/frontend/src/components/timeline/message-context-menu.test.tsx
@@ -79,6 +79,8 @@ describe("MessageContextMenu", () => {
         context={createContext({
           authorId: "member_1",
           currentUserId: "member_1",
+          onEdit: () => {},
+          onDelete: () => {},
         })}
       />
     )

--- a/apps/frontend/src/lib/stream-links.test.ts
+++ b/apps/frontend/src/lib/stream-links.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { toast } from "sonner"
-import { buildStreamLink, copyStreamLink } from "./stream-links"
+import { buildStreamLink, copyStreamLink, buildConversationLink, copyConversationLink } from "./stream-links"
 
 describe("buildStreamLink", () => {
   it("builds an absolute main-view URL from workspace and stream ids", () => {
     expect(buildStreamLink("ws_1", "stream_abc")).toBe(`${window.location.origin}/w/ws_1/s/stream_abc`)
+  })
+})
+
+describe("buildConversationLink", () => {
+  it("builds a board-hosted conversation panel URL", () => {
+    expect(buildConversationLink("ws_1", "conv_1")).toBe(`${window.location.origin}/w/ws_1/board?panel=conv%3Aconv_1`)
+  })
+
+  it("deep-links to a single message via ?m= when a messageId is given", () => {
+    expect(buildConversationLink("ws_1", "conv_1", "msg_9")).toBe(
+      `${window.location.origin}/w/ws_1/board?panel=conv%3Aconv_1&m=msg_9`
+    )
   })
 })
 
@@ -30,6 +42,33 @@ describe("copyStreamLink", () => {
     const error = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
 
     await copyStreamLink("ws_1", "stream_abc")
+
+    expect(error).toHaveBeenCalledWith("Failed to copy link")
+  })
+})
+
+describe("copyConversationLink", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("writes the conversation link to the clipboard and reports success", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    const success = vi.spyOn(toast, "success").mockReturnValue("" as ReturnType<typeof toast.success>)
+
+    await copyConversationLink("ws_1", "conv_1", "msg_9")
+
+    expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/w/ws_1/board?panel=conv%3Aconv_1&m=msg_9`)
+    expect(success).toHaveBeenCalledWith("Link copied")
+  })
+
+  it("reports an error toast when the clipboard write fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"))
+    Object.assign(navigator, { clipboard: { writeText } })
+    const error = vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
+
+    await copyConversationLink("ws_1", "conv_1")
 
     expect(error).toHaveBeenCalledWith("Failed to copy link")
   })

--- a/apps/frontend/src/lib/stream-links.ts
+++ b/apps/frontend/src/lib/stream-links.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner"
+import { createConversationPanelId } from "@/contexts/panel-context"
 
 /**
  * Absolute, shareable URL for a stream's main view. The "copy link" affordances
@@ -11,6 +12,22 @@ export function buildStreamLink(workspaceId: string, streamId: string): string {
 }
 
 /**
+ * Absolute, shareable URL that reopens a conversation in the side panel
+ * (Mechanism B). A conversation is not a stream — it spans its root + threads —
+ * so its link can't be a stream permalink: it opens the board (the panel host
+ * that doesn't itself consume `?m=`) with the `conv:<id>` panel, optionally
+ * deep-linked to a single message via `?m=`. The conversation panel honors that
+ * `m` (scroll + flash); the board page ignores it, so there's no competing
+ * main-view highlight. Pairs with {@link buildStreamLink} as the conversation-
+ * surface counterpart to a stream permalink.
+ */
+export function buildConversationLink(workspaceId: string, conversationId: string, messageId?: string): string {
+  const params = new URLSearchParams({ panel: createConversationPanelId(conversationId) })
+  if (messageId) params.set("m", messageId)
+  return `${window.location.origin}/w/${workspaceId}/board?${params.toString()}`
+}
+
+/**
  * Copy a stream link to the clipboard with user feedback. Centralized so every
  * copy-link surface reports success/failure the same way (mirrors the message
  * permalink action in message-actions.ts).
@@ -18,6 +35,21 @@ export function buildStreamLink(workspaceId: string, streamId: string): string {
 export async function copyStreamLink(workspaceId: string, streamId: string): Promise<void> {
   try {
     await navigator.clipboard.writeText(buildStreamLink(workspaceId, streamId))
+    toast.success("Link copied") // INV-63-allow: clipboard copy from a menu/shortcut has no inline anchor
+  } catch {
+    toast.error("Failed to copy link")
+  }
+}
+
+/** Copy a conversation panel link (optionally message-deep-linked) with the
+ *  same success/failure feedback as {@link copyStreamLink}. */
+export async function copyConversationLink(
+  workspaceId: string,
+  conversationId: string,
+  messageId?: string
+): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(buildConversationLink(workspaceId, conversationId, messageId))
     toast.success("Link copied") // INV-63-allow: clipboard copy from a menu/shortcut has no inline anchor
   } catch {
     toast.error("Failed to copy link")

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -146,10 +146,12 @@ function StreamLinkKeyboardHandler({
       if (getFocusedPane() === "panel" && panelId) {
         if (isConversationPanel(panelId)) {
           const conversationId = parseConversationPanel(panelId)
-          if (conversationId) void copyConversationLink(workspaceId, conversationId)
-          return
-        }
-        if (!isDraftPanel(panelId)) {
+          if (conversationId) {
+            void copyConversationLink(workspaceId, conversationId)
+            return
+          }
+          // Malformed `conv:` id (hand-edited/stale URL) — fall through to the main link.
+        } else if (!isDraftPanel(panelId)) {
           void copyStreamLink(workspaceId, panelId)
           return
         }

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -42,6 +42,8 @@ import {
   MediaGalleryProvider,
   usePanel,
   isDraftPanel,
+  isConversationPanel,
+  parseConversationPanel,
 } from "@/contexts"
 import {
   useKeyboardShortcuts,
@@ -72,7 +74,7 @@ import { EnclaveRewrapNudgeListener } from "@/components/encryption/enclave-rewr
 import { TraceDialog } from "@/components/trace"
 import { useQueryClient } from "@tanstack/react-query"
 import { SyncStatusStore, SyncStatusContext } from "@/sync/sync-status"
-import { copyStreamLink } from "@/lib/stream-links"
+import { copyStreamLink, copyConversationLink } from "@/lib/stream-links"
 import { useResolveOrBounce } from "./use-resolve-or-bounce"
 import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 
@@ -126,8 +128,9 @@ function useOnlineStatus(): boolean {
 /**
  * Registers the "copy link" shortcut. Must be rendered inside PanelProvider so
  * it can read which pane (main view vs thread panel) the user last interacted
- * with. Copies the thread link when the panel is focused and shows a real
- * (non-draft) thread; otherwise copies the main stream link.
+ * with. When the panel is focused: a conversation panel copies the conversation
+ * link, a real (non-draft) thread copies the thread link; otherwise it falls
+ * through to the main stream link.
  */
 function StreamLinkKeyboardHandler({
   workspaceId,
@@ -140,9 +143,18 @@ function StreamLinkKeyboardHandler({
 
   useKeyboardShortcuts({
     copyStreamLink: () => {
-      const targetStreamId = getFocusedPane() === "panel" && panelId && !isDraftPanel(panelId) ? panelId : mainStreamId
-      if (!targetStreamId) return
-      void copyStreamLink(workspaceId, targetStreamId)
+      if (getFocusedPane() === "panel" && panelId) {
+        if (isConversationPanel(panelId)) {
+          const conversationId = parseConversationPanel(panelId)
+          if (conversationId) void copyConversationLink(workspaceId, conversationId)
+          return
+        }
+        if (!isDraftPanel(panelId)) {
+          void copyStreamLink(workspaceId, panelId)
+          return
+        }
+      }
+      if (mainStreamId) void copyStreamLink(workspaceId, mainStreamId)
     },
   })
 


### PR DESCRIPTION
## Problem

Out-of-stream message rows — the board card and the conversation panel (Mechanism B) — render through the shared `MessageItem`, which shipped with "a deliberately small action set": jump-to-stream, label, copy text, copy link. Two gaps followed from that:

1. **No reactions and no surface-aware link.** A board/conversation row couldn't react, and its "Copy link" always emitted the message's *stream* permalink (`buildStreamLink(...)?m=`) — so copying a link from a conversation dropped you into the raw channel/thread, not the conversation you were reading.
2. **No conversation deep-link at all.** There was no URL that reopens a conversation in the panel, let alone one scrolled to a specific message. `ConversationPanel` didn't read `?m=`.

This is the FU2 follow-up to the bidirectional message↔conversation navigation shipped in #1121.

## Solution

Extend the shared `MessageItem` toward parity with a stream message — react, copy text, copy link — and make the link **surface-specific**: a conversation surface emits a conversation-panel link, everything else keeps the stream permalink. A conversation is not a stream (it spans its root + threads), so its link can't be a stream permalink — it opens the board with the `conv:` panel.

### How it works

1. **Conversation links** (`lib/stream-links.ts`). `buildConversationLink(workspaceId, conversationId, messageId?)` → `${origin}/w/<wid>/board?panel=conv:<id>[&m=<msgId>]` (composed via `URLSearchParams`, so the `conv:` colon serializes as `%3A` — the same round-trip `PanelProvider` already uses). `copyConversationLink(...)` mirrors `copyStreamLink`'s success/failure toast.

2. **Surface-specific copy-link** (`message-actions.ts`). `MessageActionContext` gains `conversationId`, set **only** by the conversation surfaces. The `copy-link` action branches: `conversationId` present → `buildConversationLink`, else the stream permalink. Same "gate by a field exactly one side sets" pattern as `viewInStream` — no `if (surface === …)`.

3. **`ConversationPanel` honors `?m=`.** `ConversationPanelBody` reads `searchParams.get("m")` and passes `isHighlighted` to the matching row; `MessageItem` scrolls it into view + flashes (`animate-highlight-flash`, `scroll-mt-12`) via a `containerRef` effect — the same shape `SentMessageEvent` uses. The board page (the link's host) doesn't consume `m`, so there's no competing main-view highlight.

4. **Conversation-level "Copy link"** in the panel header (a `Link2` ghost button, gated on the parsed `conversationId`), plus **mod+Shift+L**: `StreamLinkKeyboardHandler` now routes a focused `conv:` panel to `copyConversationLink`, a real (non-draft) thread to `copyStreamLink`, else the main stream.

5. **React on the row.** `MessageItem` wires the self-contained `useMessageReactions` path: a desktop hover `ReactionEmojiPicker` beside the overflow menu, and `onReact` / `onOpenFullPicker` / `reactions` / `currentUserId` in the action context so the touch drawer's quick-bar + full picker work. The reserved top-right gutter widens `pr-7` → `pr-14` for the two-button cluster (INV-21: no overlay/shift).

### Key design decisions

**1. Board is the conversation-link base, not a stream route.** `?panel=conv:` is a query param on top of *some* page. Hanging it off `/s/:streamId` would make the stream page highlight `?m=` in its main timeline while the panel also tried to — two highlights, one param. `/board` hosts the panel (`PanelHost`) and ignores `m`, so the panel is the sole reader. The panel fetches the conversation by id independently, so an empty board is irrelevant.

**2. Surface-specificity via a context field, not a surface flag.** `conversationId` is set by board card + conversation panel and left unset by the label page and the in-stream timeline, so one shared `copy-link` action does the right thing on each surface without branching on identity. Mirrors the FU1 decision for `viewInStream` / `onShowInConversation`.

**3. Hardened the `edit`/`delete` `when` gates to require their handlers.** React needs `currentUserId` in the action context (both `toggleByEmoji` and the drawer's toggle early-return on a null user). But `currentUserId === authorId` is exactly the `edit`/`delete` visibility gate — and `MessageItem` can't host the inline edit form, so those would have rendered as no-op rows. Adding `&& !!ctx.onEdit` / `&& !!ctx.onDelete` makes the registry robust: an action doesn't show without its handler. `SentMessageEvent` sets both unconditionally, so the timeline is unaffected.

**4. Quote-reply deferred.** "Reply/quote" on these surfaces would target the `BoardReplyComposer`, which consumes no `QuoteReplyProvider` — none exists outside the stream timeline. Wiring that provider + registering a board-composer handler is a standalone change that overlaps the separately-flagged composer follow-up, so it's not in this PR.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/stream-links.ts` | Add `buildConversationLink` / `copyConversationLink` |
| `apps/frontend/src/components/timeline/message-actions.ts` | `conversationId` in context; `copy-link` branches on it; `edit`/`delete` `when` require their handlers |
| `apps/frontend/src/components/message/message-item.tsx` | `conversationId` + `isHighlighted` props; self-contained react (hover + touch pickers); `currentUserId` into context; scroll/flash on highlight; `pr-7`→`pr-14` |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Read `?m=` → highlight row; pass `conversationId`; header "Copy link" button |
| `apps/frontend/src/components/board/board-card.tsx` | Pass `conversationId` to `MessageItem` |
| `apps/frontend/src/pages/workspace-layout.tsx` | mod+Shift+L copies the conversation link for a focused `conv:` panel |
| `apps/frontend/src/lib/stream-links.test.ts` | Cover `buildConversationLink` / `copyConversationLink` |
| `apps/frontend/src/components/timeline/message-actions.test.ts` | copy-link surface branches; edit/delete hidden without handler |
| `apps/frontend/src/components/timeline/message-context-menu.test.tsx` | Pass `onEdit`/`onDelete` for the own-message visibility case |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | `?m=` highlight; header copy-link affordance |

## Out of scope (deliberate)

- **Quote-reply on board/conversation rows** — needs a `QuoteReplyProvider` + `BoardReplyComposer` wiring; overlaps the composer follow-up. Deferred (see decision 4).
- **Nested-thread membership** — the FU1 immediate-root resolution is unchanged; the handover flags this for a discussion-first follow-up.
- **The label page** keeps the stream permalink (it sets no `conversationId`) — correct, since a labeled message isn't scoped to one conversation. It does inherit the react affordance (it already passes `currentUserId`), which is harmless parity.

## Test plan

- [x] `bun run --cwd apps/frontend typecheck` (`tsc --noEmit`) — clean
- [x] `vitest run` `stream-links` + `message-actions` + `conversation-panel` — 85 pass (incl. new conversation-link, `?m=` highlight, header copy-link, hardened edit/delete tests)
- [x] `vitest run` `message-context-menu` + `message-action-drawer` — 7 pass
- [x] `vitest run` `no-happy-path-success-toast` guard (INV-63) — pass (new `toast.success` carry `INV-63-allow`)
- [x] Broader sweep: `vitest run src/components/{timeline,board,message}` + `pages/board.test.tsx` — 376 pass after fixing the one menu-visibility test that needed `onEdit`/`onDelete`
- [x] prettier + eslint clean on all touched files
- [ ] Not manually exercised in a running app — behavior is covered by the unit/integration suites above; staging deploy via the `staging` label for a live check

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdhYtZ8orhsLetbLcq4iU5)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785473123&installation_id=129946197&pr_number=1124&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1124&signature=89552558823916ae86b2d5f4a5bc3d9283b870c1073a034e95758874056ed911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->