### PR TITLE
feat(timeline): uplift link-preview cards to the Linear visual bar

### DIFF
--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -8,6 +8,7 @@ import { ActorAvatar } from "@/components/actor-avatar"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
 import { useStreamName } from "@/hooks/use-stream-name"
+import { AccentGlow } from "./link-preview-primitives"
 import { linkPreviewsApi } from "@/api"
 import type {
   InAppLinkPreviewData,
@@ -385,16 +386,6 @@ function MemoLinkCard({
   )
 }
 
-/** Soft golden corner glow — the "golden thread" depth cue shared by every in-app card body. */
-function CardGlow() {
-  return (
-    <div
-      aria-hidden="true"
-      className="pointer-events-none absolute -right-12 -top-12 h-28 w-28 rounded-full bg-primary/10 blur-2xl"
-    />
-  )
-}
-
 /** Rounded primary-tinted tile that anchors a stream/memo card the way an avatar anchors a message. */
 function IconTile({ children }: { children: ReactNode }) {
   return (
@@ -434,7 +425,7 @@ function CardHeader({ label, onDismiss }: { label: string; onDismiss?: () => voi
 function CardBody({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <div className={cn("relative overflow-hidden px-3.5 py-3", className)}>
-      <CardGlow />
+      <AccentGlow />
       <div className="relative">{children}</div>
     </div>
   )

--- a/apps/frontend/src/components/timeline/link-preview-body.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-body.tsx
@@ -8,8 +8,8 @@ import { useLinkPreviewCollapse } from "@/hooks/use-link-preview-collapse"
  * overflow detection compares `scrollHeight` against this value. Keep in sync
  * with `BODY_HEIGHT_CLASS`.
  */
-export const LINK_PREVIEW_BODY_HEIGHT_PX = 128
-const BODY_HEIGHT_CLASS = "max-h-32"
+export const LINK_PREVIEW_BODY_HEIGHT_PX = 200
+const BODY_HEIGHT_CLASS = "max-h-[200px]"
 
 interface LinkPreviewBodyProps {
   children: ReactNode

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -21,6 +21,7 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { cn } from "@/lib/utils"
 import { LinkPreviewBody } from "./link-preview-body"
+import { AccentGlow, colorWithAlpha, Field, FieldGrid, LabelChip, MonoTag, StatePill } from "./link-preview-primitives"
 import type {
   GitHubFilePreviewData,
   GitHubPrPreviewData,
@@ -330,31 +331,40 @@ function GenericPreviewContent({
 }) {
   const fallbackLabel = getGenericFallbackLabel(preview.url)
   const hasPrimaryMetadata = Boolean(preview.title || preview.description || preview.imageUrl)
+  const showImage = Boolean(preview.imageUrl) && !imageError
 
   // Text intentionally flows at natural height — `LinkPreviewBody` clips the
   // whole card to a shared ceiling and reveals a "Show more" toggle when
   // overflow occurs. Pre-truncating with `line-clamp-*` hid overflow from
   // `scrollHeight`, which suppressed the toggle and left blank space below.
   return (
-    <div className="flex gap-4 p-3">
-      <div className="flex-1 min-w-0">
-        {preview.title && <h4 className="text-sm font-medium text-foreground mb-0.5">{preview.title}</h4>}
-        {preview.description && <p className="text-xs text-muted-foreground">{preview.description}</p>}
-        {!hasPrimaryMetadata && (
-          <p className="text-xs text-muted-foreground">
-            Open link: <span className="font-medium text-foreground">{fallbackLabel}</span>
-          </p>
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow />
+      <div className="relative flex gap-3.5">
+        <div className="min-w-0 flex-1">
+          {preview.title && <h4 className="text-sm font-semibold leading-snug text-foreground">{preview.title}</h4>}
+          {preview.description && (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{preview.description}</p>
+          )}
+          {!hasPrimaryMetadata && (
+            <p className="text-xs text-muted-foreground">
+              Open link: <span className="font-medium text-foreground">{fallbackLabel}</span>
+            </p>
+          )}
+        </div>
+        {showImage && (
+          // Fixed footprint so the lazy image swapping in doesn't reflow the card (INV-21).
+          <div className="h-[4.5rem] w-28 shrink-0 overflow-hidden rounded-md border bg-muted/40 shadow-sm">
+            <img
+              src={preview.imageUrl!}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+              onError={onImageError}
+            />
+          </div>
         )}
       </div>
-      {preview.imageUrl && !imageError && (
-        <img
-          src={preview.imageUrl}
-          alt=""
-          className="h-16 w-24 rounded object-cover shrink-0"
-          loading="lazy"
-          onError={onImageError}
-        />
-      )}
     </div>
   )
 }
@@ -368,47 +378,53 @@ function getGenericFallbackLabel(url: string): string {
   }
 }
 
+// GitHub state hues mirror github.com: green (open), purple (merged / done), red
+// (closed). One source drives both the state pill and the card's accent glow.
+const GITHUB_OPEN_COLOR = "#22c55e"
+const GITHUB_DONE_COLOR = "#a855f7"
+const GITHUB_CLOSED_COLOR = "#ef4444"
+
+const PR_STATE_LABELS = { merged: "Merged", closed: "Closed", open: "Open" } as const
+
+function prStateColor(state: GitHubPrPreviewData["state"]): string {
+  if (state === "merged") return GITHUB_DONE_COLOR
+  if (state === "closed") return GITHUB_CLOSED_COLOR
+  return GITHUB_OPEN_COLOR
+}
+
 function GitHubPrContent({ data }: { data: GitHubPrPreviewData }) {
-  const stateLabels = { merged: "Merged", closed: "Closed", open: "Open" } as const
-  const stateLabel = stateLabels[data.state]
+  const stateColor = prStateColor(data.state)
 
   return (
-    <div className="p-3">
-      <div className="flex items-start gap-2">
-        <ActorAvatar actor={data.author} className="mt-0.5" />
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow color={stateColor} />
+      <div className="relative flex items-start gap-2.5">
+        <ActorAvatar actor={data.author} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground">
-            {data.title}
-            <span className="ml-1.5 font-normal text-muted-foreground">#{data.number}</span>
-          </h4>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-            <PrStateBadge state={data.state} label={stateLabel} />
-            <span className="truncate max-w-[10rem]" title={`${data.headBranch} → ${data.baseBranch}`}>
-              {data.headBranch}
-              <span className="mx-0.5">{"\u2192"}</span>
-              {data.baseBranch}
-            </span>
-            <DiffStats additions={data.additions} deletions={data.deletions} />
+          <div className="flex flex-wrap items-center gap-1.5">
+            <StatePill color={stateColor} dot>
+              {PR_STATE_LABELS[data.state]}
+            </StatePill>
+            <MonoTag>#{data.number}</MonoTag>
           </div>
+          <h4 className="mt-1.5 text-sm font-semibold leading-snug text-foreground line-clamp-2">{data.title}</h4>
+          <FieldGrid className="mt-3">
+            <Field label="Branch">
+              <span title={`${data.headBranch} → ${data.baseBranch}`}>
+                {data.headBranch}
+                <span className="mx-0.5 text-muted-foreground">{"→"}</span>
+                {data.baseBranch}
+              </span>
+            </Field>
+            <Field label="Changes">
+              <DiffStats additions={data.additions} deletions={data.deletions} />
+            </Field>
+            {data.author && <Field label="Author">@{data.author.login}</Field>}
+          </FieldGrid>
           <ReviewSummary summary={data.reviewStatusSummary} />
         </div>
       </div>
     </div>
-  )
-}
-
-function PrStateBadge({ state, label }: { state: "open" | "closed" | "merged"; label: string }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center rounded-full px-1.5 py-px text-[11px] font-medium leading-tight",
-        state === "open" && "bg-green-500/15 text-green-600 dark:text-green-400",
-        state === "merged" && "bg-purple-500/15 text-purple-600 dark:text-purple-400",
-        state === "closed" && "bg-red-500/15 text-red-600 dark:text-red-400"
-      )}
-    >
-      {label}
-    </span>
   )
 }
 
@@ -419,44 +435,40 @@ function ReviewSummary({ summary }: { summary: GitHubPrPreviewData["reviewStatus
   if (summary.pendingReviewers > 0) parts.push(`${summary.pendingReviewers} pending`)
   if (parts.length === 0) return null
 
-  return <p className="mt-1 text-[11px] text-muted-foreground">{parts.join(" \u00b7 ")}</p>
+  return <p className="mt-2.5 text-[11px] text-muted-foreground">{parts.join(" · ")}</p>
 }
 
 function GitHubIssueContent({ data }: { data: GitHubIssuePreviewData }) {
+  const stateColor = data.state === "open" ? GITHUB_OPEN_COLOR : GITHUB_DONE_COLOR
+
   return (
-    <div className="p-3">
-      <div className="flex items-start gap-2">
-        <ActorAvatar actor={data.author} className="mt-0.5" />
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow color={stateColor} />
+      <div className="relative flex items-start gap-2.5">
+        <ActorAvatar actor={data.author} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground">
-            {data.title}
-            <span className="ml-1.5 font-normal text-muted-foreground">#{data.number}</span>
-          </h4>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-            <span
-              className={cn(
-                "inline-flex items-center rounded-full px-1.5 py-px text-[11px] font-medium leading-tight",
-                data.state === "open"
-                  ? "bg-green-500/15 text-green-600 dark:text-green-400"
-                  : "bg-purple-500/15 text-purple-600 dark:text-purple-400"
-              )}
-            >
+          <div className="flex flex-wrap items-center gap-1.5">
+            <StatePill color={stateColor} dot>
               {data.state === "open" ? "Open" : "Closed"}
-            </span>
+            </StatePill>
+            <MonoTag>#{data.number}</MonoTag>
             {data.commentCount > 0 && (
-              <span className="inline-flex items-center gap-0.5">
+              <span className="inline-flex items-center gap-0.5 text-xs text-muted-foreground">
                 <MessageSquare className="h-3 w-3" />
                 {data.commentCount}
               </span>
             )}
           </div>
+          <h4 className="mt-1.5 text-sm font-semibold leading-snug text-foreground line-clamp-2">{data.title}</h4>
           {data.labels.length > 0 && (
-            <div className="mt-1.5 flex flex-wrap gap-1">
-              {data.labels.slice(0, 4).map((label) => (
-                <IssueLabel key={label.name} name={label.name} color={label.color} />
+            <div className="mt-2.5 flex flex-wrap gap-1">
+              {data.labels.slice(0, 5).map((label) => (
+                <LabelChip key={label.name} color={label.color}>
+                  {label.name}
+                </LabelChip>
               ))}
-              {data.labels.length > 4 && (
-                <span className="text-[11px] text-muted-foreground">+{data.labels.length - 4}</span>
+              {data.labels.length > 5 && (
+                <span className="self-center text-[11px] text-muted-foreground">+{data.labels.length - 5}</span>
               )}
             </div>
           )}
@@ -466,33 +478,21 @@ function GitHubIssueContent({ data }: { data: GitHubIssuePreviewData }) {
   )
 }
 
-function IssueLabel({ name, color }: { name: string; color: string }) {
-  const hex = color.startsWith("#") ? color : `#${color}`
-  return (
-    <span
-      className="inline-flex items-center rounded-full px-1.5 py-px text-[11px] font-medium leading-tight border"
-      style={{
-        backgroundColor: `${hex}20`,
-        borderColor: `${hex}40`,
-        color: hex,
-      }}
-    >
-      {name}
-    </span>
-  )
-}
-
 function GitHubCommitContent({ data }: { data: GitHubCommitPreviewData }) {
   const firstLine = data.message.split("\n")[0]
 
   return (
-    <div className="p-3">
-      <div className="flex items-start gap-2">
-        <ActorAvatar actor={data.author} className="mt-0.5" />
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow />
+      <div className="relative flex items-start gap-2.5">
+        <ActorAvatar actor={data.author} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground">{firstLine}</h4>
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-            <code className="rounded bg-muted px-1 py-px font-mono text-[11px]">{data.shortSha}</code>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <MonoTag>{data.shortSha}</MonoTag>
+            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/80">Commit</span>
+          </div>
+          <h4 className="mt-1.5 text-sm font-semibold leading-snug text-foreground line-clamp-2">{firstLine}</h4>
+          <div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
             <span>
               {data.filesChanged} file{data.filesChanged !== 1 ? "s" : ""}
             </span>
@@ -525,36 +525,42 @@ function GitHubFileContent({ preview, data }: { preview: LinkPreviewSummary; dat
   }
 
   return (
-    <div className="p-3">
-      <div className="min-w-0">
-        {preview.title && <h4 className="text-sm font-medium text-foreground line-clamp-1">{preview.title}</h4>}
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow />
+      <div className="relative min-w-0">
+        {preview.title && (
+          <h4 className="text-sm font-semibold leading-snug text-foreground line-clamp-1">{preview.title}</h4>
+        )}
         <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">
           {preview.previewData && "repository" in preview.previewData && preview.previewData.repository.fullName}
-          {" \u00b7 "}
+          {" · "}
           {data.ref}
-          {data.language ? ` \u00b7 ${data.language}` : ""}
-          {data.renderMode !== "markdown" ? ` \u00b7 ${formatLineRange(data)}` : ""}
+          {data.language ? ` · ${data.language}` : ""}
+          {data.renderMode !== "markdown" ? ` · ${formatLineRange(data)}` : ""}
         </p>
+
+        {content}
+
+        {data.truncated && (
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {data.renderMode === "markdown"
+              ? "Showing the beginning of the file only."
+              : "Showing the first snippet lines only."}
+          </p>
+        )}
       </div>
-
-      {content}
-
-      {data.truncated && (
-        <p className="mt-2 text-[11px] text-muted-foreground">
-          {data.renderMode === "markdown"
-            ? "Showing the beginning of the file only."
-            : "Showing the first snippet lines only."}
-        </p>
-      )}
     </div>
   )
 }
 
 function GitHubDiffContent({ data }: { data: GitHubDiffPreviewData }) {
+  const stateColor = prStateColor(data.pullRequest.state)
+
   return (
-    <div className="p-3">
-      <div className="min-w-0">
-        <h4 className="text-sm font-medium text-foreground line-clamp-1">{data.path}</h4>
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow color={stateColor} />
+      <div className="relative min-w-0">
+        <h4 className="text-sm font-semibold leading-snug text-foreground line-clamp-1">{data.path}</h4>
         <p className="mt-0.5 text-xs text-muted-foreground">
           PR #{data.pullRequest.number} · {data.pullRequest.title} · {capitalizeChangeType(data.changeType)}
           {data.language ? ` · ${data.language}` : ""}
@@ -563,47 +569,47 @@ function GitHubDiffContent({ data }: { data: GitHubDiffPreviewData }) {
         {data.previousPath && data.previousPath !== data.path && (
           <p className="mt-1 text-[11px] text-muted-foreground">Renamed from {data.previousPath}</p>
         )}
-      </div>
 
-      <div className="mt-2 overflow-hidden rounded-md border bg-muted/20">
-        <div className="overflow-x-auto font-mono text-xs leading-snug text-foreground">
-          {data.lines.map((line, index) => (
-            <div
-              key={`${line.oldNumber ?? "x"}-${line.newNumber ?? "x"}-${index}`}
-              className={cn(
-                "grid grid-cols-[2.75rem_2.75rem_1fr] items-start",
-                line.type === "add" && "bg-green-500/10",
-                line.type === "delete" && "bg-red-500/10",
-                line.selected && "bg-primary/10 ring-1 ring-inset ring-primary/20"
-              )}
-            >
-              <span className="px-2 py-1 text-right text-muted-foreground">{line.oldNumber ?? ""}</span>
-              <span className="px-2 py-1 text-right text-muted-foreground">{line.newNumber ?? ""}</span>
-              <span className="px-2 py-1 whitespace-pre">
-                <span
-                  className={cn(
-                    "mr-2 inline-block w-3 text-center",
-                    line.type === "add" && "text-green-700 dark:text-green-300",
-                    line.type === "delete" && "text-red-700 dark:text-red-300",
-                    line.type === "context" && "text-muted-foreground"
-                  )}
-                >
-                  {getDiffLinePrefix(line.type)}
+        <div className="mt-2 overflow-hidden rounded-md border bg-muted/20">
+          <div className="overflow-x-auto font-mono text-xs leading-snug text-foreground">
+            {data.lines.map((line, index) => (
+              <div
+                key={`${line.oldNumber ?? "x"}-${line.newNumber ?? "x"}-${index}`}
+                className={cn(
+                  "grid grid-cols-[2.75rem_2.75rem_1fr] items-start",
+                  line.type === "add" && "bg-green-500/10",
+                  line.type === "delete" && "bg-red-500/10",
+                  line.selected && "bg-primary/10 ring-1 ring-inset ring-primary/20"
+                )}
+              >
+                <span className="px-2 py-1 text-right text-muted-foreground">{line.oldNumber ?? ""}</span>
+                <span className="px-2 py-1 text-right text-muted-foreground">{line.newNumber ?? ""}</span>
+                <span className="px-2 py-1 whitespace-pre">
+                  <span
+                    className={cn(
+                      "mr-2 inline-block w-3 text-center",
+                      line.type === "add" && "text-green-700 dark:text-green-300",
+                      line.type === "delete" && "text-red-700 dark:text-red-300",
+                      line.type === "context" && "text-muted-foreground"
+                    )}
+                  >
+                    {getDiffLinePrefix(line.type)}
+                  </span>
+                  {line.text}
                 </span>
-                {line.text}
-              </span>
-            </div>
-          ))}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
 
-      <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
-        <DiffStats additions={data.additions} deletions={data.deletions} />
-        {data.truncated && (
-          <span>
-            {data.anchorStartLine ? "Showing the linked diff hunk only." : "Showing the beginning of the diff only."}
-          </span>
-        )}
+        <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
+          <DiffStats additions={data.additions} deletions={data.deletions} />
+          {data.truncated && (
+            <span>
+              {data.anchorStartLine ? "Showing the linked diff hunk only." : "Showing the beginning of the diff only."}
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )
@@ -613,24 +619,28 @@ function GitHubCommentContent({ data }: { data: GitHubCommentPreviewData }) {
   const parentLabel = data.parent.kind === "pull_request" ? "PR" : "Issue"
 
   return (
-    <div className="p-3">
-      <div className="flex items-start gap-2">
-        <ActorAvatar actor={data.author} className="mt-0.5" />
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow />
+      <div className="relative flex items-start gap-2.5">
+        <ActorAvatar actor={data.author} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
           <p className="text-xs text-muted-foreground line-clamp-1">
-            <span className="font-medium text-foreground">{data.author?.login ?? "Unknown"}</span>
+            <span className="font-semibold text-foreground">{data.author?.login ?? "Unknown"}</span>
             {" commented on "}
             {parentLabel} #{data.parent.number}
           </p>
           {data.body && (
-            <div className="mt-1.5 overflow-hidden rounded-md border bg-muted/20 px-2.5 py-1.5">
-              <MarkdownContent
-                content={data.body}
-                className="text-xs leading-relaxed text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-              />
+            <div className="mt-2 flex gap-2">
+              <div className="w-0.5 shrink-0 rounded-full bg-primary/40" />
+              <div className="min-w-0 flex-1 rounded-r-lg bg-muted/25 py-1 pr-2">
+                <MarkdownContent
+                  content={data.body}
+                  className="text-xs leading-relaxed text-foreground/90 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                />
+              </div>
             </div>
           )}
-          {data.truncated && <p className="mt-1 text-[11px] text-muted-foreground">Comment truncated</p>}
+          {data.truncated && <p className="mt-1.5 text-[11px] text-muted-foreground">Comment truncated</p>}
         </div>
       </div>
     </div>
@@ -712,15 +722,13 @@ function LinearContent({ preview }: { preview: LinearPreview }) {
 function LinearIssueContent({ data }: { data: LinearIssuePreviewData }) {
   return (
     <div className="relative overflow-hidden p-3">
-      <LinearGlow color={data.state.color} />
+      <AccentGlow color={data.state.color} />
       <div className="relative flex items-start gap-2.5">
         <LinearActorAvatar actor={data.assignee} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <LinearStateBadge state={data.state} />
-            <span className="rounded-full bg-muted/70 px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground">
-              {data.identifier}
-            </span>
+            <StatePill color={data.state.color}>{data.state.name}</StatePill>
+            <MonoTag>{data.identifier}</MonoTag>
           </div>
           <h4 className="mt-1.5 text-sm font-semibold leading-snug text-foreground line-clamp-2">{data.title}</h4>
           {data.summary && (
@@ -734,25 +742,18 @@ function LinearIssueContent({ data }: { data: LinearIssuePreviewData }) {
               </div>
             </div>
           )}
-          <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-            <LinearField label="Status">{data.state.name}</LinearField>
-            {data.assignee && <LinearField label="Assignee">@{data.assignee.displayName}</LinearField>}
-            {data.projectName && <LinearField label="Project">{data.projectName}</LinearField>}
-            {data.priority && <LinearField label="Priority">{data.priority.label}</LinearField>}
-          </div>
+          <FieldGrid className="mt-3">
+            <Field label="Status">{data.state.name}</Field>
+            {data.assignee && <Field label="Assignee">@{data.assignee.displayName}</Field>}
+            {data.projectName && <Field label="Project">{data.projectName}</Field>}
+            {data.priority && <Field label="Priority">{data.priority.label}</Field>}
+          </FieldGrid>
           {data.labels.length > 0 && (
             <div className="mt-2.5 flex flex-wrap gap-1">
               {data.labels.slice(0, 5).map((label) => (
-                <span
-                  key={label.name}
-                  className="inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium text-foreground/80 shadow-sm"
-                  style={{
-                    backgroundColor: colorWithAlpha(label.color, 0.12),
-                    borderColor: colorWithAlpha(label.color, 0.28),
-                  }}
-                >
+                <LabelChip key={label.name} color={label.color}>
                   {label.name}
-                </span>
+                </LabelChip>
               ))}
               {data.labels.length > 5 && (
                 <span className="self-center text-[11px] text-muted-foreground">+{data.labels.length - 5}</span>
@@ -768,16 +769,14 @@ function LinearIssueContent({ data }: { data: LinearIssuePreviewData }) {
 function LinearCommentContent({ data }: { data: LinearCommentPreviewData }) {
   return (
     <div className="relative overflow-hidden p-3">
-      <LinearGlow color={data.parent.state.color} />
+      <AccentGlow color={data.parent.state.color} />
       <div className="relative flex items-start gap-2.5">
         <LinearActorAvatar actor={data.author} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs">
             <span className="font-semibold text-foreground">{data.author?.displayName ?? "Unknown"}</span>
             <span className="text-muted-foreground">commented on</span>
-            <span className="rounded-full bg-muted/70 px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground">
-              {data.parent.identifier}
-            </span>
+            <MonoTag>{data.parent.identifier}</MonoTag>
           </div>
           <p className="mt-1 text-xs font-medium leading-snug text-foreground line-clamp-2">{data.parent.title}</p>
           {data.body && (
@@ -805,7 +804,7 @@ function LinearProjectContent({ data }: { data: LinearProjectPreviewData }) {
   const progressPct = Math.max(0, Math.min(100, Math.round(data.progress * 100)))
   return (
     <div className="relative overflow-hidden p-3">
-      <LinearGlow color="#5E6AD2" />
+      <AccentGlow color="#5E6AD2" />
       <div className="relative flex items-start gap-2.5">
         <LinearActorAvatar actor={data.lead} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
@@ -824,12 +823,12 @@ function LinearProjectContent({ data }: { data: LinearProjectPreviewData }) {
           <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
             <div className="h-full rounded-full bg-indigo-500" style={{ width: `${progressPct}%` }} />
           </div>
-          <div className="mt-2.5 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-            <LinearField label="Progress">{progressPct}%</LinearField>
-            {data.lead && <LinearField label="Lead">@{data.lead.displayName}</LinearField>}
-            {data.initiativeName && <LinearField label="Initiative">{data.initiativeName}</LinearField>}
-            {data.targetDate && <LinearField label="Target">{data.targetDate}</LinearField>}
-          </div>
+          <FieldGrid className="mt-2.5">
+            <Field label="Progress">{progressPct}%</Field>
+            {data.lead && <Field label="Lead">@{data.lead.displayName}</Field>}
+            {data.initiativeName && <Field label="Initiative">{data.initiativeName}</Field>}
+            {data.targetDate && <Field label="Target">{data.targetDate}</Field>}
+          </FieldGrid>
         </div>
       </div>
     </div>
@@ -838,46 +837,17 @@ function LinearProjectContent({ data }: { data: LinearProjectPreviewData }) {
 
 function LinearDocumentContent({ data }: { data: LinearDocumentPreviewData }) {
   return (
-    <div className="p-3">
-      <div className="flex items-start gap-2">
-        <LinearActorAvatar actor={data.updatedBy} className="mt-0.5" />
+    <div className="relative overflow-hidden p-3">
+      <AccentGlow color="#5E6AD2" />
+      <div className="relative flex items-start gap-2.5">
+        <LinearActorAvatar actor={data.updatedBy} className="mt-0.5 ring-2 ring-background" />
         <div className="min-w-0 flex-1">
-          <h4 className="text-sm font-medium text-foreground">{data.title}</h4>
+          <h4 className="text-sm font-semibold leading-snug text-foreground line-clamp-2">{data.title}</h4>
           {data.parentProject && <p className="mt-0.5 text-xs text-muted-foreground">in {data.parentProject.name}</p>}
           {data.summary && <p className="mt-1.5 text-xs text-muted-foreground line-clamp-3">{data.summary}</p>}
         </div>
       </div>
     </div>
-  )
-}
-
-function LinearField({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <div className="min-w-0">
-      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/80">{label}</p>
-      <div className="mt-0.5 truncate font-medium text-foreground/90">{children}</div>
-    </div>
-  )
-}
-
-function LinearGlow({ color }: { color: string }) {
-  return (
-    <div
-      aria-hidden="true"
-      className="pointer-events-none absolute -right-10 -top-10 h-24 w-24 rounded-full blur-2xl"
-      style={{ backgroundColor: colorWithAlpha(color, 0.13) }}
-    />
-  )
-}
-
-function LinearStateBadge({ state }: { state: LinearIssuePreviewData["state"] }) {
-  return (
-    <span
-      className="inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-foreground shadow-sm"
-      style={{ backgroundColor: colorWithAlpha(state.color, 0.14), borderColor: colorWithAlpha(state.color, 0.32) }}
-    >
-      {state.name}
-    </span>
   )
 }
 
@@ -897,13 +867,4 @@ function formatLinearStatus(status: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ")
-}
-
-function colorWithAlpha(hex: string, alpha: number): string {
-  const clean = hex.replace(/^#/, "")
-  if (!/^[0-9a-fA-F]{6}$/.test(clean)) return `rgba(149, 162, 179, ${alpha})`
-  const r = parseInt(clean.slice(0, 2), 16)
-  const g = parseInt(clean.slice(2, 4), 16)
-  const b = parseInt(clean.slice(4, 6), 16)
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }

--- a/apps/frontend/src/components/timeline/link-preview-primitives.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-primitives.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+/**
+ * Shared visual chrome for every rich link-preview card (GitHub, Linear, generic
+ * web). The Linear cards set the bar — soft corner glow keyed to a semantic
+ * color, colored state pills, mono identifier tags, an uppercase-label field
+ * grid — and these primitives carry that one vocabulary across the other
+ * providers so no card type invents a parallel look (INV-35, INV-37).
+ */
+
+/** Converts a `#rrggbb` (or bare `rrggbb`) hex to `rgba(...)`, falling back to a neutral slate. */
+export function colorWithAlpha(hex: string, alpha: number): string {
+  const clean = hex.replace(/^#/, "")
+  if (!/^[0-9a-fA-F]{6}$/.test(clean)) return `rgba(149, 162, 179, ${alpha})`
+  const r = parseInt(clean.slice(0, 2), 16)
+  const g = parseInt(clean.slice(2, 4), 16)
+  const b = parseInt(clean.slice(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+/**
+ * Soft corner glow that gives a card depth and a color identity. Pass a hex
+ * `color` for a semantic tint (issue/PR state, brand color); omit it for the
+ * golden-thread primary tint shared by stateless cards (commits, generic web).
+ * Absolutely positioned, so it never affects layout height (INV-21).
+ */
+export function AccentGlow({ color }: { color?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute -right-10 -top-10 h-24 w-24 rounded-full blur-2xl",
+        !color && "bg-primary/10"
+      )}
+      style={color ? { backgroundColor: colorWithAlpha(color, 0.13) } : undefined}
+    />
+  )
+}
+
+/**
+ * Pill that names a status with a color-tinted background and border. Text stays
+ * `foreground` (legible across every workspace-defined hue); the optional `dot`
+ * carries the raw color for an at-a-glance state signal on providers whose state
+ * is semantically load-bearing (GitHub open/merged/closed).
+ */
+export function StatePill({ color, dot, children }: { color: string; dot?: boolean; children: ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold leading-tight text-foreground shadow-sm"
+      style={{ backgroundColor: colorWithAlpha(color, 0.14), borderColor: colorWithAlpha(color, 0.32) }}
+    >
+      {dot && <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />}
+      {children}
+    </span>
+  )
+}
+
+/** Monospace identifier chip — issue keys (`THR-12`), PR numbers (`#42`), commit SHAs. */
+export function MonoTag({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-muted/70 px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground">
+      {children}
+    </span>
+  )
+}
+
+/** Colored label chip (issue/Linear labels). Tints background + border from the label's own hex. */
+export function LabelChip({ color, children }: { color: string; children: ReactNode }) {
+  return (
+    <span
+      className="inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium text-foreground/80 shadow-sm"
+      style={{ backgroundColor: colorWithAlpha(color, 0.12), borderColor: colorWithAlpha(color, 0.28) }}
+    >
+      {children}
+    </span>
+  )
+}
+
+/** Two-column metadata grid for `Field` cells. */
+export function FieldGrid({ children, className }: { children: ReactNode; className?: string }) {
+  return <div className={cn("grid grid-cols-2 gap-x-4 gap-y-2 text-xs", className)}>{children}</div>
+}
+
+/** Uppercase-label / value pair used inside `FieldGrid`. */
+export function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/80">{label}</p>
+      <div className="mt-0.5 truncate font-medium text-foreground/90">{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

The timeline's link-preview cards had three different levels of polish. The **Linear** renderers in `link-preview-card.tsx` (`LinearIssueContent`, `LinearCommentContent`, `LinearProjectContent`) carried a distinct visual treatment — a soft corner glow keyed to the issue/project state color, colored state pills, a mono identifier tag, and an uppercase-label field grid. The **GitHub** cards had colored state icons but no glow or structured layout, the **generic web** card was the plainest (favicon + title + description + a small side thumbnail), and the **in-app** cards sat in the middle with their own bespoke `CardGlow`. Same surface, three visual languages.

The ask (Kris): bring every preview family up to the Linear cards' bar, treating Linear as the reference for "flashiness" rather than inventing a third look per provider.

## Solution

Extract the Linear cards' recipe into a shared `link-preview-primitives.tsx` module, then apply that one vocabulary across GitHub, generic-web, and in-app cards. No provider renders a parallel treatment (INV-35 / INV-37 — reuse shared helpers instead of parallel implementations).

### How it works

The new primitives (all top-level components, INV-18):

- **`AccentGlow({ color? })`** — the corner glow, generalized from the old `LinearGlow`. A hex `color` gives a semantic tint via `colorWithAlpha(color, 0.13)`; omitting it falls back to the golden-thread `bg-primary/10` for stateless cards. Absolutely positioned (`-right-10 -top-10 h-24 w-24 blur-2xl`), so it never contributes layout height.
- **`StatePill({ color, dot?, children })`** — generalized `LinearStateBadge`. Text stays `foreground` (legible across any workspace-defined hue); the optional `dot` renders the raw color as a status dot, used by GitHub where open/merged/closed is semantically load-bearing.
- **`MonoTag`** — the mono identifier chip (`#42`, `abc1234`, `THR-128`).
- **`LabelChip({ color })`** — colored label pill, shared by GitHub issue labels and Linear labels.
- **`FieldGrid` / `Field`** — the two-column uppercase-label metadata grid (generalized `LinearField`).
- **`colorWithAlpha`** — moved verbatim from `link-preview-card.tsx`; the hex→rgba helper the glows/pills/borders share.

Applied per family:

1. **GitHub PR / issue** — state-colored `AccentGlow` + `StatePill` with a status dot, `#number` `MonoTag`, and a `FieldGrid` (PR: Branch / Changes / Author; issue keeps its `LabelChip` row). PR state hues are `#22c55e` open / `#a855f7` merged / `#ef4444` closed via `prStateColor`; the issue maps open→green, closed→purple. Avatars gain `ring-2 ring-background`.
2. **GitHub commit / comment / file / diff** — golden-thread `AccentGlow`, semibold titles. The comment body moves into a left-border blockquote (`bg-primary/40` bar). The diff borrows its PR's state color for the glow via `prStateColor(data.pullRequest.state)`; the code/diff blocks themselves are unchanged.
3. **Generic web** — glow, bolder title hierarchy (`font-semibold`), and the side thumbnail moves into a fixed `h-[4.5rem] w-28` box so a lazy `og:image` swapping in doesn't reflow the card.
4. **Linear** — repointed onto the shared primitives; visuals are unchanged except the previously-plain `LinearDocumentContent`, which now gets the `#5E6AD2` glow and ringed avatar for consistency.
5. **In-app** — the bespoke `CardGlow` is deleted in favor of the shared `AccentGlow`.

Second commit: the **body clamp** in `link-preview-body.tsx` goes from 128px to 200px (`LINK_PREVIEW_BODY_HEIGHT_PX` + `BODY_HEIGHT_CLASS` kept in sync, now `max-h-[200px]`). The richer PR/issue/Linear cards run taller than the old ceiling, so 128px clipped them into a "Show more" fade by default; 200px lets the common rich card show in full while still bounding a runaway preview.

### Key design decisions

**1. One vocabulary, not three (INV-35 / INV-37).** The alternative — copy the Linear glow/badge/field markup inline into each GitHub renderer — would have been a parallel implementation of the same look. Extracting the primitives means a future tweak to the glow or pill lands everywhere at once, and there's a single "preview card language" to reason about.

**2. INV-21 height safety preserved.** The timeline scroll anchor no-ops content resizes while reading history, so a card that grows after first paint makes the list jump. Every visual addition here is height-neutral: glows are absolutely positioned, and the generic-web thumbnail reserves a fixed box so the async image load can't reflow. The in-app async reserve system (`CARD_BODY_MESSAGE` / `CARD_BODY_MEMO`, skeleton↔resolved equal heights) is **left untouched** — that's the genuinely hard dynamic-height case, and changing it risks the known regression.

**3. Raising the clamp is safe for these cards specifically.** The GitHub/Linear/web cards render synchronously from data present in the message payload at first paint — there is no skeleton→resolved height change on their path, so a taller ceiling carries no INV-21 risk. It only affects timeline density and the multi-preview alignment rationale (a message with a PR + a diff still lines up because both share the ceiling). Kris signed off on the raise.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/timeline/link-preview-primitives.tsx` | Shared preview-card chrome — `AccentGlow`, `StatePill`, `MonoTag`, `LabelChip`, `FieldGrid`/`Field`, `colorWithAlpha`. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/link-preview-card.tsx` | GitHub + generic-web renderers uplifted to the shared primitives; Linear renderers repointed onto them (`LinearGlow`/`LinearStateBadge`/`LinearField`/`colorWithAlpha` removed, now imported); `PrStateBadge`/`IssueLabel` deleted (INV-38, superseded by `StatePill`/`LabelChip`). |
| `apps/frontend/src/components/timeline/in-app-link-preview-card.tsx` | Bespoke `CardGlow` deleted; `CardBody` uses the shared `AccentGlow`. |
| `apps/frontend/src/components/timeline/link-preview-body.tsx` | Body clamp 128 → 200px (`LINK_PREVIEW_BODY_HEIGHT_PX` + `max-h-[200px]`). |

## Out of scope (deliberate)

- **Image / embedded-media previews** (the top `contentType === "image"` branch) — Kris flagged richer image/embed previews as a separate follow-up; untouched here.
- **In-app async height reserve** — kept as-is on purpose (see decision 2). Dynamic heights on that path remain a locked, known-hard problem.
- **No backend / type changes** — this is purely a render-layer restyle; `LinkPreviewSummary` and the provider preview shapes are unchanged.

## Test plan

- [x] `apps/frontend` — `link-preview-card` / `link-preview-list` / `in-app-link-preview-card` / `link-preview-body` suites: 23 pass. Tests assert text presence, not structure, so the restyle preserves them; `link-preview-body` uses the exported `LINK_PREVIEW_BODY_HEIGHT_PX` constant, so the clamp bump needed no test edit.
- [x] `tsc --noEmit` across the frontend — clean.
- [x] `eslint` on the three changed component files — clean.
- [x] Visual check — rendered the uplifted cards against the project's real golden-thread Tailwind tokens (dark) and eyeballed all families; screenshot shared with Kris.
- [ ] `/code-review` to 7/7 — running next per Kris's request; findings will be addressed on this branch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AoeX6qA6R9YthS2WadwZ9k)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785473138&installation_id=129946197&pr_number=1125&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1125&signature=2c5cf3e0bfc713336245fd49976e0a91122d2fe076e5fa9f0057060913dfd5fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->