### PR TITLE
feat(timeline): uplift image link previews with shared chrome + gallery

### DIFF
--- a/apps/frontend/src/components/gallery/link-preview-gallery-id.ts
+++ b/apps/frontend/src/components/gallery/link-preview-gallery-id.ts
@@ -1,0 +1,14 @@
+// A link-preview image is an external URL, not an uploaded attachment — it has
+// no attachment id, just the source url. The gallery keys item identity on
+// `attachmentId`, so a preview image carries this sentinel id instead (mirrors
+// the Giphy sentinel). Attachment-only actions (download and cross-origin copy)
+// branch on it and are suppressed; render works straight from the url.
+const LINK_PREVIEW_GALLERY_PREFIX = "link-preview:"
+
+export function linkPreviewGalleryId(url: string): string {
+  return `${LINK_PREVIEW_GALLERY_PREFIX}${url}`
+}
+
+export function isLinkPreviewGalleryId(id: string): boolean {
+  return id.startsWith(LINK_PREVIEW_GALLERY_PREFIX)
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -30,6 +30,7 @@ import { attachmentsApi } from "@/api"
 import { triggerDownload } from "@/lib/image-utils"
 import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
 import { isGiphyGalleryId } from "@/components/gallery/giphy-gallery-id"
+import { isLinkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
 import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
 import { HtmlViewer } from "@/components/gallery/html-viewer"
@@ -589,8 +590,14 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // Giphy items are cross-origin CDN urls, not attachments — the attachment
   // download API can't serve them, so the download affordance is hidden.
   const isGiphy = current ? isGiphyGalleryId(current.attachmentId) : false
+  // Link-preview images are arbitrary external urls: the download API can't
+  // serve them, and copy fetches the bytes so a site without CORS would only
+  // toast an error — hide both, leaving view/zoom (which need no fetch).
+  const isLinkPreviewImage = current ? isLinkPreviewGalleryId(current.attachmentId) : false
+  const canDownload = !isGiphy && !isLinkPreviewImage
   const canCopy =
-    current?.type === "image" || current?.type === "markdown" || current?.type === "html" || current?.type === "text"
+    !isLinkPreviewImage &&
+    (current?.type === "image" || current?.type === "markdown" || current?.type === "html" || current?.type === "text")
   const copyLabel = copyLabelForType(current?.type)
   const canToggleRaw = current?.type === "markdown" || current?.type === "html"
 
@@ -832,7 +839,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
               <span className="sr-only">{rawMode ? "Show rendered preview" : "Show raw source"}</span>
             </Button>
           )}
-          {!isGiphy && (
+          {canDownload && (
             <Button
               variant="ghost"
               size="icon"

--- a/apps/frontend/src/components/timeline/link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent, within } from "@testing-library/react"
 import { LinkPreviewCard } from "./link-preview-card"
 import type { LinkPreviewSummary } from "@threa/types"
 
@@ -281,5 +281,43 @@ describe("LinkPreviewCard", () => {
     expect(screen.getByText(/commented on/)).toBeInTheDocument()
     expect(screen.getByText(/Issue #7/)).toBeInTheDocument()
     expect(screen.getByText("Looks good to me!")).toBeInTheDocument()
+  })
+
+  it("renders an image preview inside the shared card chrome", () => {
+    const preview = makeGitHubPreview({
+      url: "https://example.com/photo.png",
+      contentType: "image",
+      title: "A nice photo",
+      siteName: "Example",
+      imageUrl: null,
+      previewType: null,
+      previewData: null,
+    })
+
+    render(<LinkPreviewCard preview={preview} onToggleCollapse={() => {}} />)
+
+    expect(screen.getByText("Example")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Collapse preview/i })).toBeInTheDocument()
+    const img = screen.getByAltText("A nice photo") as HTMLImageElement
+    expect(img.src).toContain("https://example.com/photo.png")
+  })
+
+  it("opens the media gallery when an image preview is clicked", () => {
+    const preview = makeGitHubPreview({
+      url: "https://example.com/photo.png",
+      contentType: "image",
+      title: "A nice photo",
+      siteName: "Example",
+      imageUrl: null,
+      previewType: null,
+      previewData: null,
+    })
+
+    render(<LinkPreviewCard preview={preview} workspaceId="ws_1" onToggleCollapse={() => {}} />)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Open image preview/i }))
+    const dialog = screen.getByRole("dialog")
+    expect(within(dialog).getAllByText("A nice photo").length).toBeGreaterThan(0)
   })
 })

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, type ReactNode } from "react"
+import { useState, useCallback, useEffect, useMemo, type ReactNode } from "react"
 import {
   ExternalLink,
   X,
@@ -138,8 +138,13 @@ export function LinkPreviewCard({
   )
 
   if (preview.contentType === "image") {
+    // data-native-context makes the row long-press hook defer to the browser's
+    // native menu (via `deferToNativeLinks`), so long-pressing the image still
+    // gets "save/copy image" on touch instead of the app drawer — the tap opens
+    // the gallery, and the gallery gates download/copy off for external images.
     return (
       <div
+        data-native-context="true"
         className={cn(
           "group/preview reveal-host relative overflow-hidden rounded-lg border bg-card transition-all max-w-md",
           "hover:border-primary/50 hover:shadow-sm",
@@ -276,6 +281,15 @@ function ImagePreviewContent({ preview, workspaceId }: { preview: LinkPreviewSum
 
   const src = preview.imageUrl ?? preview.url
   const filename = preview.title ?? getDomain(preview.url)
+
+  // A link preview is PATCHed in place as its metadata resolves (a real
+  // `imageUrl` can replace the raw url on the same mounted card), so a stale
+  // error or a `contain` fit measured off the previous image must not carry
+  // over to the new one.
+  useEffect(() => {
+    setImageError(false)
+    setFit("cover")
+  }, [src])
 
   const galleryItems = useMemo<GalleryItem[]>(
     () => [{ type: "image", url: src, thumbnailUrl: src, filename, attachmentId: linkPreviewGalleryId(src) }],

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useMemo, type ReactNode } from "react"
 import {
   ExternalLink,
   X,
@@ -20,6 +20,8 @@ import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { cn } from "@/lib/utils"
+import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
+import { linkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
 import { LinkPreviewBody } from "./link-preview-body"
 import { AccentGlow, colorWithAlpha, Field, FieldGrid, LabelChip, MonoTag, StatePill } from "./link-preview-primitives"
 import type {
@@ -51,6 +53,11 @@ interface LinkPreviewCardProps {
    * transient previews without a host message still render.
    */
   messageId?: string
+  /**
+   * Workspace scope for the image gallery. Unused for external link-preview
+   * images (their download/copy are gated off), so optional for tests.
+   */
+  workspaceId?: string
   isHighlighted?: boolean
   isCollapsed?: boolean
   onDismiss?: (previewId: string) => void
@@ -100,6 +107,7 @@ function resolveHeaderLabel(
 export function LinkPreviewCard({
   preview,
   messageId,
+  workspaceId,
   isHighlighted,
   isCollapsed: isCollapsedProp,
   onDismiss,
@@ -131,47 +139,23 @@ export function LinkPreviewCard({
 
   if (preview.contentType === "image") {
     return (
-      <a
-        href={preview.url}
-        target="_blank"
-        rel="noopener noreferrer"
+      <div
         className={cn(
-          "group/preview reveal-host relative block overflow-hidden rounded-lg border bg-muted/30 transition-all max-w-xs",
-          "hover:border-primary hover:shadow-sm",
+          "group/preview reveal-host relative overflow-hidden rounded-lg border bg-card transition-all max-w-md",
+          "hover:border-primary/50 hover:shadow-sm",
           isHighlighted && "ring-2 ring-primary border-primary shadow-sm"
         )}
       >
-        <div className="reveal-actions absolute top-1.5 right-1.5 z-10 flex gap-1">
-          {onDismiss && (
-            <Button
-              variant="secondary"
-              size="icon"
-              className="h-6 w-6 shadow-sm"
-              onClick={handleDismiss}
-              aria-label="Dismiss preview"
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          )}
-        </div>
-        {!imageError ? (
-          <img
-            src={preview.url}
-            alt={preview.title ?? "Image preview"}
-            className="h-32 w-auto max-w-xs object-cover"
-            loading="lazy"
-            onError={() => setImageError(true)}
-          />
-        ) : (
-          <div className="flex h-32 w-40 items-center justify-center text-muted-foreground">
-            <ImageIcon className="h-8 w-8" />
-          </div>
-        )}
-        <div className="flex items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground">
-          <ExternalLink className="h-3 w-3 shrink-0" />
-          <span className="truncate">{domain}</span>
-        </div>
-      </a>
+        <PreviewCardHeader
+          icon={<ContentTypeIcon contentType="image" />}
+          label={preview.siteName ?? domain}
+          faviconUrl={preview.faviconUrl}
+          isCollapsed={isCollapsedProp}
+          onToggleCollapse={handleToggleCollapse}
+          onDismiss={onDismiss ? handleDismiss : undefined}
+        />
+        {!isCollapsedProp && <ImagePreviewContent preview={preview} workspaceId={workspaceId} />}
+      </div>
     )
   }
 
@@ -190,43 +174,14 @@ export function LinkPreviewCard({
         isHighlighted && "ring-2 ring-primary border-primary shadow-sm"
       )}
     >
-      <div className="flex items-center gap-1.5 px-3 py-1.5 border-b bg-muted/30">
-        <button
-          type="button"
-          onClick={handleToggleCollapse}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-          aria-label={isCollapsedProp ? "Expand preview" : "Collapse preview"}
-        >
-          {isCollapsedProp ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-        </button>
-        {headerIcon}
-        {!githubPreview && !linearPreview && preview.faviconUrl && (
-          <img
-            src={preview.faviconUrl}
-            alt=""
-            className="h-3.5 w-3.5 rounded-sm"
-            loading="lazy"
-            onError={(e) => {
-              ;(e.target as HTMLImageElement).style.display = "none"
-            }}
-          />
-        )}
-        <span className="text-xs text-muted-foreground truncate">{headerLabel}</span>
-        <ExternalLink className="h-3 w-3 text-muted-foreground/50 shrink-0 ml-auto" />
-        <div className="reveal-actions flex gap-1">
-          {onDismiss && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-5 w-5"
-              onClick={handleDismiss}
-              aria-label="Dismiss preview"
-            >
-              <X className="h-3 w-3" />
-            </Button>
-          )}
-        </div>
-      </div>
+      <PreviewCardHeader
+        icon={headerIcon}
+        label={headerLabel}
+        faviconUrl={!githubPreview && !linearPreview ? preview.faviconUrl : null}
+        isCollapsed={isCollapsedProp}
+        onToggleCollapse={handleToggleCollapse}
+        onDismiss={onDismiss ? handleDismiss : undefined}
+      />
 
       {/* Clamped to a shared body height so a message with mixed preview types
           (e.g. a PR + a diff) lines up. */}
@@ -243,6 +198,132 @@ export function LinkPreviewCard({
         </LinkPreviewBody>
       )}
     </div>
+  )
+}
+
+/**
+ * Card chrome header shared by every preview family: collapse toggle, provider
+ * icon, optional favicon, source label, and dismiss. `faviconUrl` is null when
+ * the provider already carries its own icon (GitHub/Linear).
+ */
+function PreviewCardHeader({
+  icon,
+  label,
+  faviconUrl,
+  isCollapsed,
+  onToggleCollapse,
+  onDismiss,
+}: {
+  icon: ReactNode
+  label: string
+  faviconUrl: string | null
+  isCollapsed?: boolean
+  onToggleCollapse: (e: React.MouseEvent) => void
+  onDismiss?: (e: React.MouseEvent) => void
+}) {
+  return (
+    <div className="flex items-center gap-1.5 px-3 py-1.5 border-b bg-muted/30">
+      <button
+        type="button"
+        onClick={onToggleCollapse}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        aria-label={isCollapsed ? "Expand preview" : "Collapse preview"}
+      >
+        {isCollapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+      </button>
+      {icon}
+      {faviconUrl && (
+        <img
+          src={faviconUrl}
+          alt=""
+          className="h-3.5 w-3.5 rounded-sm"
+          loading="lazy"
+          onError={(e) => {
+            ;(e.target as HTMLImageElement).style.display = "none"
+          }}
+        />
+      )}
+      <span className="text-xs text-muted-foreground truncate">{label}</span>
+      <ExternalLink className="h-3 w-3 text-muted-foreground/50 shrink-0 ml-auto" />
+      <div className="reveal-actions flex gap-1">
+        {onDismiss && (
+          <Button variant="ghost" size="icon" className="h-5 w-5" onClick={onDismiss} aria-label="Dismiss preview">
+            <X className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Below this width/height (px) an og:image is a logo/icon rather than a hero
+// shot: filling the box would upscale and crop it, so switch to a contained,
+// centered fit. The box height is fixed either way, so this never reflows the
+// timeline (INV-21) — only object-fit changes.
+const HERO_MIN_WIDTH = 400
+const HERO_MIN_HEIGHT = 200
+
+/**
+ * Image link preview: fixed-height hero inside the shared card chrome. Clicking
+ * opens the full media gallery (zoom/pan) rather than leaving the app — the
+ * image rides the gallery via a `link-preview:` sentinel id, so its bytes never
+ * touch the attachment API (download/copy are gated off there).
+ */
+function ImagePreviewContent({ preview, workspaceId }: { preview: LinkPreviewSummary; workspaceId?: string }) {
+  const [imageError, setImageError] = useState(false)
+  const [galleryOpen, setGalleryOpen] = useState(false)
+  const [fit, setFit] = useState<"cover" | "contain">("cover")
+
+  const src = preview.imageUrl ?? preview.url
+  const filename = preview.title ?? getDomain(preview.url)
+
+  const galleryItems = useMemo<GalleryItem[]>(
+    () => [{ type: "image", url: src, thumbnailUrl: src, filename, attachmentId: linkPreviewGalleryId(src) }],
+    [src, filename]
+  )
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setGalleryOpen(true)}
+        className="relative block w-full cursor-zoom-in overflow-hidden"
+        aria-label={`Open image preview${preview.title ? `: ${preview.title}` : ""}`}
+      >
+        <AccentGlow />
+        {!imageError ? (
+          <div className="relative flex h-48 w-full items-center justify-center overflow-hidden bg-muted/30">
+            <img
+              src={src}
+              alt={preview.title ?? "Image preview"}
+              loading="lazy"
+              onLoad={(e) => {
+                const img = e.currentTarget
+                if (img.naturalWidth < HERO_MIN_WIDTH || img.naturalHeight < HERO_MIN_HEIGHT) setFit("contain")
+              }}
+              onError={() => setImageError(true)}
+              className={cn(
+                "transition-transform duration-200 group-hover/preview:scale-[1.02]",
+                fit === "cover" ? "h-full w-full object-cover" : "max-h-full max-w-full object-contain"
+              )}
+            />
+          </div>
+        ) : (
+          <div className="flex h-48 w-full items-center justify-center bg-muted/30 text-muted-foreground">
+            <ImageIcon className="h-8 w-8" />
+          </div>
+        )}
+      </button>
+      {galleryOpen && (
+        <MediaGallery
+          isOpen={galleryOpen}
+          onClose={() => setGalleryOpen(false)}
+          items={galleryItems}
+          initialIndex={0}
+          workspaceId={workspaceId ?? ""}
+        />
+      )}
+    </>
   )
 }
 

--- a/apps/frontend/src/components/timeline/link-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.tsx
@@ -129,6 +129,7 @@ export function LinkPreviewList({
             <LinkPreviewCard
               preview={preview}
               messageId={messageId}
+              workspaceId={workspaceId}
               isHighlighted={isHighlighted}
               isCollapsed={isCollapsed}
               onDismiss={handleDismiss}


### PR DESCRIPTION
## Problem

Image link previews were the one card family PR #1125 deliberately left untouched. While GitHub, Linear, and generic-web cards all speak the shared visual vocabulary (`link-preview-primitives.tsx` — collapse/icon/domain header, `AccentGlow`, state pills), the `contentType === "image"` branch in `link-preview-card.tsx` was still the original bespoke card: a bare `h-32 w-auto max-w-xs` `<img>` with a plain domain footer, no shared chrome, and a click that just left the app for the raw image URL.

## Solution

Fold image previews into the same chrome as every other card, and make the image itself the interaction: clicking opens the in-app media gallery (zoom/pan) instead of a new tab.

### How it works

1. **Shared chrome.** Extracted `PreviewCardHeader` (collapse toggle, provider icon, optional favicon, source label, dismiss) as a top-level component (INV-18) used by both the image and non-image return paths, so the image card gains the identical header + `AccentGlow` treatment and no path invents a parallel look (INV-35/37).

2. **Responsive fit without reflow.** The image sits in a fixed-height (`h-48`, 192px) box and swaps `object-fit` on load — `cover` for hero-sized og:images, `contain` (centered on the muted panel) for logos/icons, decided by `naturalWidth < HERO_MIN_WIDTH (400) || naturalHeight < HERO_MIN_HEIGHT (200)`. Only `object-fit` changes; the box height is fixed either way, so the timeline never reflows (INV-21). Default is `cover` so the common case (large og:image) never flashes a swap.

3. **Opens in the gallery.** The image is a `<button>` (INV-40: gallery-open is an action, not navigation) that mounts a single-item `MediaGallery`. The external URL rides the gallery via a `link-preview:` sentinel id (`linkPreviewGalleryId`), mirroring the existing Giphy `giphy:` pattern for non-attachment CDN images — its bytes never touch the attachment API.

4. **Gated actions in the gallery.** For a `link-preview:` item, `image-gallery.tsx` hides both download (the attachment download API can't serve an external URL) and copy (`copyImage` fetches the bytes, so a site without CORS would only `toast.error`). View and zoom need no fetch, so they stay.

### Key design decisions

**1. Fixed-height box over dynamic per-image height** — a variable height means a post-load vertical resize, which pops the timeline while the reader is scrolled up (the locked hard problem from PR #1125, decision #4). The accepted cost is horizontal empty space around a small logo centered in the full-width box; that reads as a deliberate "logo card" and keeps INV-21 intact. `object-fit` adaptation is the responsiveness that fits within that constraint.

**2. Ride the gallery via a sentinel id, not a new gallery host** — the Giphy path already established that non-attachment URL images can be gallery items keyed by a synthetic `attachmentId`. Reusing that (rather than threading external URLs through the `?media=` attachment-host routing) keeps the change to one new 14-line helper plus a two-line guard in the gallery.

**3. Gallery uses local state, not the `?media=` URL param** — a single preview image doesn't warrant deep-link/back-button integration, and local state keeps the card renderable outside `MediaGalleryProvider` (the existing card tests mount it standalone).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/gallery/link-preview-gallery-id.ts` | `linkPreviewGalleryId(url)` / `isLinkPreviewGalleryId(id)` — the `link-preview:` sentinel so external preview images ride the gallery without an attachment id (mirrors `giphy-gallery-id.ts`). |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/link-preview-card.tsx` | Extracted shared `PreviewCardHeader`; replaced the bespoke image branch with shared chrome + a new `ImagePreviewContent` (fixed-height responsive image opening a single-item `MediaGallery`); added optional `workspaceId` prop. |
| `apps/frontend/src/components/image-gallery.tsx` | Hide download and copy for `link-preview:` items (`canDownload`/`canCopy`), same rationale as the existing Giphy download-hide. |
| `apps/frontend/src/components/timeline/link-preview-list.tsx` | Thread `workspaceId` into `LinkPreviewCard`. |
| `apps/frontend/src/components/timeline/link-preview-card.test.tsx` | Added two image-card tests (chrome renders; click opens the gallery dialog). |

## Out of scope (deliberate)

- **Video / non-image embeds** — there is no `embed`/`video` link-preview `contentType` today (only `image` in `LINK_PREVIEW_CONTENT_TYPES`), so there was nothing to uplift there.
- **Generic-web og:image handling** — unchanged; PR #1125 already gave it a fixed-box thumbnail (`h-[4.5rem] w-28`).
- **Deep-link / back-button gallery integration for preview images** — intentionally local state (decision #3).

## Test plan

- [x] `bunx vitest run` on `link-preview-card` / `-list` / `-body` / `in-app-link-preview-card` / `giphy-gallery-id` — 27 pass (incl. 2 new image-card tests)
- [x] `bunx vitest run image-gallery.reopen.test.tsx` — 2 pass (gallery action-gating change is safe)
- [x] `tsc --noEmit -p apps/frontend/tsconfig.json` — clean
- [x] Visual verification via offline-compiled-Tailwind static harness + Playwright screenshot — hero-cover and logo-contain both render in the shared chrome at a matching 192px body height

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01NbV4wDRg8rwTKBGymgixdx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785502469&installation_id=129946197&pr_number=1127&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1127&signature=beba70c83b90b10898a1b6a028079753a69576b2b9d36b6bc4fc39058d40d85b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->