### PR TITLE
fix(e2e): suppress app-update toast in the Playwright build to fix flaky clicks

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   currentAppVersion,
+  isE2eBuild,
   reconcilePostReload,
   reloadForUpdate,
   shouldAnnounceWaiting,
@@ -9,6 +10,28 @@ import {
 } from "./use-app-update"
 import * as swRecovery from "@/lib/sw-recovery"
 import { SW_MSG_SKIP_WAITING } from "@/lib/sw-messages"
+
+describe("isE2eBuild", () => {
+  // The vite `define` isn't applied under vitest, so the bare `__E2E_BUILD__`
+  // resolves to the global — stub it to stand in for the E2E vs. prod build.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("is false when the define wasn't applied (prod/unit build): the toast still fires", () => {
+    expect(isE2eBuild()).toBe(false)
+  })
+
+  it("is true only in the E2E build, so announceIfWaiting suppresses the click-blocking toast", () => {
+    vi.stubGlobal("__E2E_BUILD__", true)
+    expect(isE2eBuild()).toBe(true)
+  })
+
+  it("is false when the flag is explicitly false", () => {
+    vi.stubGlobal("__E2E_BUILD__", false)
+    expect(isE2eBuild()).toBe(false)
+  })
+})
 
 describe("shouldAnnounceWaiting", () => {
   // Distinct objects stand in for distinct parked workers — the gate keys on

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -17,6 +17,20 @@ export const RELOAD_FALLBACK_TIMEOUT_MS = 3000
 // reload actually swapped in new code — see reconcilePostReload.
 declare const __APP_VERSION__: string
 
+// True only in the Playwright E2E build (vite `define`, gated on VITE_BACKEND_PORT).
+// The update toast uses `duration: Infinity` and renders in the aria-live
+// Notifications region, so under Playwright it parks over the composer and
+// intercepts pointer events for the rest of the test — every spec that clicks a
+// button underneath it flakes. Suppress only the toast in that build; the SW and
+// its update pipeline still run (push tests need the registration). typeof-guarded
+// because the `define` isn't applied under vitest (see currentAppVersion). Never
+// gated in production — the toast is the only signal a new build is parked.
+declare const __E2E_BUILD__: boolean
+
+function isE2eBuild(): boolean {
+  return typeof __E2E_BUILD__ === "boolean" && __E2E_BUILD__
+}
+
 // Marks that the user clicked Reload, so the first check after the page comes
 // back can verify the swap actually happened (running build == server's latest)
 // rather than silently re-announcing the same build forever. The window bounds a
@@ -194,6 +208,7 @@ function announceIfWaiting(registration: ServiceWorkerRegistration): void {
   const waiting = registration.waiting
   if (!shouldAnnounceWaiting(waiting, announcedWaiting)) return
   announcedWaiting = waiting
+  if (isE2eBuild()) return
   toast("A new version of Threa is available", {
     id: TOAST_ID,
     duration: Infinity,

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -27,7 +27,7 @@ declare const __APP_VERSION__: string
 // gated in production — the toast is the only signal a new build is parked.
 declare const __E2E_BUILD__: boolean
 
-function isE2eBuild(): boolean {
+export function isE2eBuild(): boolean {
   return typeof __E2E_BUILD__ === "boolean" && __E2E_BUILD__
 }
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -125,6 +125,12 @@ export default defineConfig({
   // Same value as the emitted version.json, so a post-reload mismatch is decisive.
   define: {
     __APP_VERSION__: JSON.stringify(buildVersion),
+    // True only in the Playwright E2E build (VITE_BACKEND_PORT is set). Lets the
+    // app suppress the persistent "new version available" update toast, which
+    // otherwise parks over the composer in the aria-live region and intercepts
+    // pointer events for the rest of a test (see use-app-update). The SW itself
+    // still registers — only the click-blocking toast is gated.
+    __E2E_BUILD__: JSON.stringify(isE2ETest),
   },
   resolve: {
     dedupe: ["react", "react-dom"],


### PR DESCRIPTION
## Problem

A pre-existing, main-wide E2E flake: specs that click a button (`getByRole("button", { name: "Send" }).click()` and friends) intermittently retry until timeout because the app's persistent update toast intercepts the click.

`announceIfWaiting` in `apps/frontend/src/hooks/use-app-update.ts` fires `toast("A new version of Threa is available", { duration: Infinity, ... })` whenever a service-worker build parks in `registration.waiting`. The E2E frontend runs a real production build behind `vite preview` (see `playwright.config.ts`), so this pipeline is live — unlike the dev server, where every update effect is gated behind `IS_DEV`. `duration: Infinity` means once it appears it never dismisses, and it renders inside `<section aria-label="Notifications">`, whose subtree intercepts pointer events. Playwright's actionability check then never resolves for any button underneath it.

The failing signature (from CI logs of `tests/browser/sidebar-updates.spec.ts:68`):

> `<div>A new version of Threa is available</div>` from `<section aria-label="Notifications alt+T">…</section>` subtree intercepts pointer events

This is a **class** of flake, not one spec — `inline-file-upload`, `new-channel-socket-subscription`, `emoji-shortcuts`, `reconnect-rehydrate`, `user-journey`, `dm-lazy-creation`, `conversation-overlay`, `edit-last-message`, `sidebar-updates`, `invite-command`, … all click Send. It surfaced on `main` on unrelated commits (Browser E2E runs #4748, #4747, #4720), so a per-spec dismiss would be whack-a-mole.

## Solution

Suppress only the toast in the E2E build via a compile-time flag, so no spec has to dodge it and the fix can't race the toast in at runtime.

### How it works

- `vite.config.ts` already derives `isE2ETest = !!process.env.VITE_BACKEND_PORT`, which the Playwright frontend `webServer` sets. Bake it into the bundle as a new `define`: `__E2E_BUILD__: JSON.stringify(isE2ETest)`, alongside the existing `__APP_VERSION__`.
- `use-app-update.ts` reads it through `isE2eBuild()` (`typeof __E2E_BUILD__ === "boolean" && __E2E_BUILD__`) and returns early in `announceIfWaiting` before the `toast(...)` call.
- Because `__E2E_BUILD__` folds to the literal `true` in the E2E build, esbuild dead-code-eliminates the toast call entirely — verified: the string `"A new version of Threa is available"` is absent from the E2E bundle (`VITE_BACKEND_PORT=… vite build`) and present in a normal build.

### Key design decisions

**1. Suppress the toast, not the service worker.** The SW still registers (push-notification E2E tests need `navigator.serviceWorker.ready`); only the click-blocking toast is gated. The rest of the update pipeline — background fetch, `registration.update()`, reconcile — is untouched.

**2. A dedicated compile flag, not `IS_DEV`.** Reusing `IS_DEV` would be wrong: the E2E build is a production build (`IS_DEV` is `false` there) and overloading it risks disabling real dev-vs-prod behavior. `isE2ETest` is the precise, already-existing signal for "this is the Playwright build".

**3. Never gated in production** (INV-11, no silent fallback). The flag is `false` in every non-E2E build, so the toast — the only signal to a real user that a new build is parked and Reload is available — is unchanged in prod. `typeof`-guarded because the `define` isn't applied under vitest (same reason `currentAppVersion()` guards `__APP_VERSION__`).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/vite.config.ts` | Add `__E2E_BUILD__: JSON.stringify(isE2ETest)` to the `define` block. |
| `apps/frontend/src/hooks/use-app-update.ts` | Add `isE2eBuild()` + `declare const __E2E_BUILD__`; early-return in `announceIfWaiting` before the toast. |

## Out of scope (deliberate)

- Not making the aria-live toast container `pointer-events: none` — that's a real UX change to the Reload affordance and every toast, higher-risk, and a separate concern from the flake.
- Not touching the toast's `duration: Infinity` — persist-until-Reload is correct product behavior; the fix is to keep it out of tests, not weaken it in prod.
- Not adding a runtime Playwright dismiss fixture — a build-time DCE is deterministic where a fixture still races the toast in.

## Test plan

- [x] `bunx tsc --noEmit -p apps/frontend/tsconfig.json` — clean
- [x] `bunx vitest run src/hooks/use-app-update.test.ts` — 17 pass (existing coverage of the update/reload/reconcile logic, unaffected)
- [x] E2E build DCE verified: `VITE_BACKEND_PORT=9999 vite build` → toast string absent; plain `vite build` → toast string present
- [ ] Did not run the full Browser E2E suite locally — no browser-test infra (postgres/minio) in this session. The real proof for a flake is CI going green across the affected specs; a single green run isn't conclusive on its own.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012GaCSFFehL65LbHJ4FgDms)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785508679&installation_id=129946197&pr_number=1128&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1128&signature=ed0b9ad79492a1e6ca89d79af89297c03c03a64f0823a1c094cc112049f9683b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->