### PR TITLE
feat(timeline): video-embed link previews (YouTube/Vimeo/Loom/Twitch)

### DIFF
--- a/apps/backend/src/features/link-previews/config.ts
+++ b/apps/backend/src/features/link-previews/config.ts
@@ -28,6 +28,7 @@ export const OEMBED_PROVIDERS: ReadonlyArray<{ pattern: RegExp; endpoint: string
   { pattern: /^https?:\/\/(?:www\.)?youtube\.com\/watch/, endpoint: "https://www.youtube.com/oembed" },
   { pattern: /^https?:\/\/youtu\.be\//, endpoint: "https://www.youtube.com/oembed" },
   { pattern: /^https?:\/\/(?:www\.)?vimeo\.com\/\d+/, endpoint: "https://vimeo.com/api/oembed.json" },
+  { pattern: /^https?:\/\/(?:www\.)?loom\.com\/share\//, endpoint: "https://www.loom.com/v1/oembed" },
   {
     pattern: /^https?:\/\/(?:www\.)?(?:x|twitter)\.com\/[^/]+\/status\/\d+/,
     endpoint: "https://publish.twitter.com/oembed",

--- a/apps/backend/src/features/link-previews/linear-preview.test.ts
+++ b/apps/backend/src/features/link-previews/linear-preview.test.ts
@@ -189,7 +189,7 @@ describe("fetchLinearPreview", () => {
       })
     )
 
-    const data = preview?.previewData?.data as { body: string; truncated: boolean } | undefined
+    const data = (preview?.previewData as { data?: { body: string; truncated: boolean } } | null | undefined)?.data
     expect(data?.truncated).toBe(true)
     expect(data?.body.length).toBeLessThanOrEqual(321) // 320 chars + trailing ellipsis
     expect(data?.body.endsWith("…")).toBe(true)

--- a/apps/backend/src/features/link-previews/repository.ts
+++ b/apps/backend/src/features/link-previews/repository.ts
@@ -4,15 +4,17 @@ import {
   type GitHubPreviewType,
   type LinearPreview,
   type LinearPreviewType,
+  type VideoPreview,
+  type VideoPreviewType,
   type LinkPreviewContentType,
   type LinkPreviewStatus,
   isInAppLinkContentType,
 } from "@threa/types"
 
 /** Union of all rich provider preview types persisted in `link_previews.preview_type`. */
-export type RichPreviewType = GitHubPreviewType | LinearPreviewType
+export type RichPreviewType = GitHubPreviewType | LinearPreviewType | VideoPreviewType
 /** Union of all rich provider preview payloads stored in `link_previews.preview_data`. */
-export type RichPreview = GitHubPreview | LinearPreview
+export type RichPreview = GitHubPreview | LinearPreview | VideoPreview
 
 export interface LinkPreview {
   id: string

--- a/apps/backend/src/features/link-previews/video-preview.test.ts
+++ b/apps/backend/src/features/link-previews/video-preview.test.ts
@@ -55,6 +55,8 @@ describe("detectVideoProvider", () => {
     ["https://www.youtube.com/watch?v=short"], // id too short
     ["https://www.youtube.com/watch?list=PLxyz"], // no v param
     ["https://vimeo.com/about"], // no numeric id
+    ["https://vimeo.com/blog/12345"], // non-video page with an incidental numeric segment
+    ["https://vimeo.com/settings/67890"], // settings page, not a video
     ["https://www.loom.com/share/tiny"], // id too short
     ["https://www.twitch.tv/somestreamer"], // bare channel, not a VOD/clip
     ["https://www.twitch.tv/clip/videos/12345"], // channel named "clip" browsing VODs — not a clip

--- a/apps/backend/src/features/link-previews/video-preview.test.ts
+++ b/apps/backend/src/features/link-previews/video-preview.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test"
+import type { VideoPreviewProvider } from "@threa/types"
+import { buildVideoPreviewParams, detectVideoProvider } from "./video-preview"
+
+describe("detectVideoProvider", () => {
+  const cases: Array<[string, VideoPreviewProvider, string, string]> = [
+    [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "youtube",
+      "dQw4w9WgXcQ",
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+    ],
+    ["https://youtu.be/dQw4w9WgXcQ", "youtube", "dQw4w9WgXcQ", "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"],
+    [
+      "https://www.youtube.com/shorts/dQw4w9WgXcQ",
+      "youtube",
+      "dQw4w9WgXcQ",
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+    ],
+    [
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "youtube",
+      "dQw4w9WgXcQ",
+      "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+    ],
+    ["https://vimeo.com/76979871", "vimeo", "76979871", "https://player.vimeo.com/video/76979871"],
+    ["https://player.vimeo.com/video/76979871", "vimeo", "76979871", "https://player.vimeo.com/video/76979871"],
+    ["https://vimeo.com/channels/staffpicks/76979871", "vimeo", "76979871", "https://player.vimeo.com/video/76979871"],
+    [
+      "https://www.loom.com/share/0123456789abcdef0123456789abcdef",
+      "loom",
+      "0123456789abcdef0123456789abcdef",
+      "https://www.loom.com/embed/0123456789abcdef0123456789abcdef",
+    ],
+    ["https://www.twitch.tv/videos/123456789", "twitch", "123456789", "https://player.twitch.tv/?video=123456789"],
+    [
+      "https://www.twitch.tv/somestreamer/clip/HappyClipSlug-abc123",
+      "twitch",
+      "HappyClipSlug-abc123",
+      "https://clips.twitch.tv/embed?clip=HappyClipSlug-abc123",
+    ],
+    [
+      "https://clips.twitch.tv/HappyClipSlug-abc123",
+      "twitch",
+      "HappyClipSlug-abc123",
+      "https://clips.twitch.tv/embed?clip=HappyClipSlug-abc123",
+    ],
+  ]
+  test.each(cases)("classifies %s", (url, provider, videoId, embedUrl) => {
+    expect(detectVideoProvider(url)).toEqual({ provider, videoId, embedUrl })
+  })
+
+  test.each([
+    ["https://example.com/watch?v=dQw4w9WgXcQ"],
+    ["https://www.youtube.com/watch?v=short"], // id too short
+    ["https://www.youtube.com/watch?list=PLxyz"], // no v param
+    ["https://vimeo.com/about"], // no numeric id
+    ["https://www.loom.com/share/tiny"], // id too short
+    ["https://www.twitch.tv/somestreamer"], // bare channel, not a VOD/clip
+    ["javascript:alert(1)//youtube.com/watch?v=dQw4w9WgXcQ"],
+    ["not a url"],
+  ])("returns null for %s", (url) => {
+    expect(detectVideoProvider(url)).toBeNull()
+  })
+
+  test("embed URL is always reconstructed from the parsed id, never from surrounding junk", () => {
+    // Even with an attacker-controlled query/fragment, the embed origin is fixed.
+    const match = detectVideoProvider("https://www.youtube.com/watch?v=dQw4w9WgXcQ&evil=<script>")
+    expect(match?.embedUrl).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ")
+  })
+})
+
+describe("buildVideoPreviewParams", () => {
+  const match = detectVideoProvider("https://www.youtube.com/watch?v=dQw4w9WgXcQ")!
+  const fetchedAt = "2026-07-01T00:00:00.000Z"
+
+  test("produces a completed video preview whose embed URL comes from the match, not oEmbed html", () => {
+    const params = buildVideoPreviewParams(
+      match,
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      {
+        title: "Never Gonna Give You Up",
+        posterUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        authorName: "Rick Astley",
+        width: 480,
+        height: 270,
+        siteName: "YouTube",
+        faviconUrl: "https://www.youtube.com/favicon.ico",
+      },
+      fetchedAt
+    )
+
+    expect(params).toEqual({
+      title: "Never Gonna Give You Up",
+      description: null,
+      imageUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+      faviconUrl: "https://www.youtube.com/favicon.ico",
+      siteName: "YouTube",
+      contentType: "video",
+      previewType: "video",
+      previewData: {
+        type: "video",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+        embedUrl: "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+        posterUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        aspectRatio: 480 / 270,
+        title: "Never Gonna Give You Up",
+        authorName: "Rick Astley",
+        fetchedAt,
+      },
+      status: "completed",
+      expiresAt: expect.any(Date),
+    })
+  })
+
+  test("falls back to 16:9 when the provider gives no usable dimensions", () => {
+    const params = buildVideoPreviewParams(
+      match,
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      { title: null, posterUrl: null, authorName: null, width: null, height: 0, siteName: null, faviconUrl: null },
+      fetchedAt
+    )
+    expect((params.previewData as { aspectRatio: number }).aspectRatio).toBe(16 / 9)
+  })
+})

--- a/apps/backend/src/features/link-previews/video-preview.test.ts
+++ b/apps/backend/src/features/link-previews/video-preview.test.ts
@@ -57,6 +57,7 @@ describe("detectVideoProvider", () => {
     ["https://vimeo.com/about"], // no numeric id
     ["https://www.loom.com/share/tiny"], // id too short
     ["https://www.twitch.tv/somestreamer"], // bare channel, not a VOD/clip
+    ["https://www.twitch.tv/clip/videos/12345"], // channel named "clip" browsing VODs — not a clip
     ["javascript:alert(1)//youtube.com/watch?v=dQw4w9WgXcQ"],
     ["not a url"],
   ])("returns null for %s", (url) => {

--- a/apps/backend/src/features/link-previews/video-preview.ts
+++ b/apps/backend/src/features/link-previews/video-preview.ts
@@ -1,0 +1,176 @@
+import type { VideoPreview, VideoPreviewProvider } from "@threa/types"
+import { VideoPreviewProviders, VideoPreviewTypes } from "@threa/types"
+import { MAX_TITLE_LENGTH } from "./config"
+import type { UpdateLinkPreviewParams } from "./repository"
+
+/** Landscape 16:9, the default when a provider gives no dimensions. */
+const DEFAULT_VIDEO_ASPECT_RATIO = 16 / 9
+
+/** How long a completed video preview stays fresh before the worker refetches. */
+const VIDEO_PREVIEW_TTL_MS = 24 * 60 * 60 * 1000
+
+export interface VideoProviderMatch {
+  provider: VideoPreviewProvider
+  videoId: string
+  /**
+   * Player URL on a trusted per-provider origin, built purely from `videoId`.
+   * Twitch players additionally require a `parent` query param matching the
+   * host — the frontend appends that at play time (it can't be known here).
+   */
+  embedUrl: string
+}
+
+/** Metadata harvested from oEmbed or HTML, folded into the stored VideoPreview. */
+export interface VideoMetaSource {
+  title: string | null
+  posterUrl: string | null
+  authorName: string | null
+  width: number | null
+  height: number | null
+  siteName: string | null
+  faviconUrl: string | null
+}
+
+// YouTube ids are exactly 11 url-safe base64 chars; the tight shape stops a junk
+// path segment from being templated into an embed src.
+const YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/
+const VIMEO_ID = /^\d+$/
+const LOOM_ID = /^[A-Za-z0-9]{16,64}$/
+const TWITCH_VOD_ID = /^\d+$/
+const TWITCH_CLIP_SLUG = /^[A-Za-z0-9_-]+$/
+
+function stripWww(hostname: string): string {
+  return hostname.replace(/^www\./, "").replace(/^m\./, "")
+}
+
+function detectYouTube(url: URL, host: string): VideoProviderMatch | null {
+  let id: string | undefined
+  if (host === "youtu.be") {
+    id = url.pathname.split("/").filter(Boolean)[0]
+  } else if (host === "youtube.com" || host === "music.youtube.com") {
+    if (url.pathname === "/watch") {
+      id = url.searchParams.get("v") ?? undefined
+    } else {
+      const match = url.pathname.match(/^\/(?:shorts|embed|live|v)\/([^/]+)/)
+      id = match?.[1]
+    }
+  }
+  if (!id || !YOUTUBE_ID.test(id)) return null
+  return {
+    provider: VideoPreviewProviders.YOUTUBE,
+    videoId: id,
+    embedUrl: `https://www.youtube-nocookie.com/embed/${id}`,
+  }
+}
+
+function detectVimeo(url: URL, host: string): VideoProviderMatch | null {
+  if (host !== "vimeo.com" && host !== "player.vimeo.com") return null
+  const segments = url.pathname.split("/").filter(Boolean)
+  // Vimeo nests the numeric id at the tail of several shapes: /<id>,
+  // /video/<id>, /channels/<name>/<id>, /groups/<name>/videos/<id>.
+  const id = [...segments].reverse().find((s) => VIMEO_ID.test(s))
+  if (!id) return null
+  return { provider: VideoPreviewProviders.VIMEO, videoId: id, embedUrl: `https://player.vimeo.com/video/${id}` }
+}
+
+function detectLoom(url: URL, host: string): VideoProviderMatch | null {
+  if (host !== "loom.com") return null
+  const match = url.pathname.match(/^\/(?:share|embed)\/([^/]+)/)
+  const id = match?.[1]
+  if (!id || !LOOM_ID.test(id)) return null
+  return { provider: VideoPreviewProviders.LOOM, videoId: id, embedUrl: `https://www.loom.com/embed/${id}` }
+}
+
+function detectTwitch(url: URL, host: string): VideoProviderMatch | null {
+  if (host === "clips.twitch.tv") {
+    // /embed?clip=<slug> or /<slug>
+    const slug = url.searchParams.get("clip") ?? url.pathname.split("/").filter(Boolean).pop()
+    if (!slug || slug === "embed" || !TWITCH_CLIP_SLUG.test(slug)) return null
+    return {
+      provider: VideoPreviewProviders.TWITCH,
+      videoId: slug,
+      embedUrl: `https://clips.twitch.tv/embed?clip=${slug}`,
+    }
+  }
+  if (host !== "twitch.tv") return null
+  const segments = url.pathname.split("/").filter(Boolean)
+  if (segments[0] === "videos" && segments[1] && TWITCH_VOD_ID.test(segments[1])) {
+    return {
+      provider: VideoPreviewProviders.TWITCH,
+      videoId: segments[1],
+      embedUrl: `https://player.twitch.tv/?video=${segments[1]}`,
+    }
+  }
+  // /<channel>/clip/<slug>
+  const clipIndex = segments.indexOf("clip")
+  if (clipIndex >= 0 && segments[clipIndex + 1] && TWITCH_CLIP_SLUG.test(segments[clipIndex + 1])) {
+    const slug = segments[clipIndex + 1]
+    return {
+      provider: VideoPreviewProviders.TWITCH,
+      videoId: slug,
+      embedUrl: `https://clips.twitch.tv/embed?clip=${slug}`,
+    }
+  }
+  return null
+}
+
+/**
+ * Classify a URL as an embeddable video and return the trusted embed URL built
+ * from the parsed id. Returns null for anything that isn't a supported video
+ * link. The returned `embedUrl` never derives from provider-supplied markup.
+ */
+export function detectVideoProvider(rawUrl: string): VideoProviderMatch | null {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null
+  const host = stripWww(url.hostname.toLowerCase())
+
+  return detectYouTube(url, host) ?? detectVimeo(url, host) ?? detectLoom(url, host) ?? detectTwitch(url, host) ?? null
+}
+
+/**
+ * Build the `UpdateLinkPreviewParams` for a matched video link. `imageUrl`
+ * mirrors the poster so non-video surfaces (that only read `imageUrl`) still
+ * show a thumbnail. Aspect ratio comes from provider dimensions when present,
+ * else falls back to 16:9 so the card can reserve a fixed box (INV-21).
+ */
+export function buildVideoPreviewParams(
+  match: VideoProviderMatch,
+  url: string,
+  meta: VideoMetaSource,
+  fetchedAt: string
+): UpdateLinkPreviewParams {
+  const aspectRatio =
+    meta.width && meta.height && meta.height > 0 ? meta.width / meta.height : DEFAULT_VIDEO_ASPECT_RATIO
+  const title = meta.title?.slice(0, MAX_TITLE_LENGTH) ?? null
+
+  const preview: VideoPreview = {
+    type: VideoPreviewTypes.VIDEO,
+    url,
+    provider: match.provider,
+    videoId: match.videoId,
+    embedUrl: match.embedUrl,
+    posterUrl: meta.posterUrl,
+    aspectRatio,
+    title,
+    authorName: meta.authorName,
+    fetchedAt,
+  }
+
+  return {
+    title,
+    description: null,
+    imageUrl: meta.posterUrl,
+    faviconUrl: meta.faviconUrl,
+    siteName: meta.siteName,
+    contentType: "video",
+    previewType: VideoPreviewTypes.VIDEO,
+    previewData: preview,
+    status: "completed",
+    expiresAt: new Date(Date.now() + VIDEO_PREVIEW_TTL_MS),
+  }
+}

--- a/apps/backend/src/features/link-previews/video-preview.ts
+++ b/apps/backend/src/features/link-previews/video-preview.ts
@@ -66,10 +66,15 @@ function detectYouTube(url: URL, host: string): VideoProviderMatch | null {
 function detectVimeo(url: URL, host: string): VideoProviderMatch | null {
   if (host !== "vimeo.com" && host !== "player.vimeo.com") return null
   const segments = url.pathname.split("/").filter(Boolean)
-  // Vimeo nests the numeric id at the tail of several shapes: /<id>,
-  // /video/<id>, /channels/<name>/<id>, /groups/<name>/videos/<id>.
-  const id = [...segments].reverse().find((s) => VIMEO_ID.test(s))
-  if (!id) return null
+  // Anchor to Vimeo's known video shapes so an unrelated numeric segment (a blog
+  // post id, a settings page) isn't misread as a video: /<id>, /video/<id>,
+  // /channels/<name>/<id>, /groups/<name>/videos/<id>.
+  let id: string | undefined
+  if (segments.length === 1) id = segments[0]
+  else if (segments[0] === "video" && segments.length === 2) id = segments[1]
+  else if (segments[0] === "channels" && segments.length === 3) id = segments[2]
+  else if (segments[0] === "groups" && segments[2] === "videos" && segments.length === 4) id = segments[3]
+  if (!id || !VIMEO_ID.test(id)) return null
   return { provider: VideoPreviewProviders.VIMEO, videoId: id, embedUrl: `https://player.vimeo.com/video/${id}` }
 }
 

--- a/apps/backend/src/features/link-previews/video-preview.ts
+++ b/apps/backend/src/features/link-previews/video-preview.ts
@@ -101,10 +101,10 @@ function detectTwitch(url: URL, host: string): VideoProviderMatch | null {
       embedUrl: `https://player.twitch.tv/?video=${segments[1]}`,
     }
   }
-  // /<channel>/clip/<slug>
-  const clipIndex = segments.indexOf("clip")
-  if (clipIndex >= 0 && segments[clipIndex + 1] && TWITCH_CLIP_SLUG.test(segments[clipIndex + 1])) {
-    const slug = segments[clipIndex + 1]
+  // /<channel>/clip/<slug> — anchored at position 1 so a channel named "clip"
+  // browsing its own VODs (/clip/videos/123) can't be misread as a clip.
+  if (segments[1] === "clip" && segments[2] && TWITCH_CLIP_SLUG.test(segments[2])) {
+    const slug = segments[2]
     return {
       provider: VideoPreviewProviders.TWITCH,
       videoId: slug,

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -1276,6 +1276,64 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  test("does not retry a video URL whose recent fetch failed while its backoff is still fresh", async () => {
+    // A failed row keeps the default "website" contentType; the reclassify path must
+    // not bypass the 1-minute retry backoff, or a burst of messages referencing the
+    // same failing link would hammer the provider.
+    const fetchMock = mock(async () => {
+      throw new Error("fetch should not run while the failure backoff is fresh")
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_fail", url }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_fail",
+          workspaceId: "ws_123",
+          url,
+          normalizedUrl: url,
+          title: null,
+          description: null,
+          imageUrl: null,
+          faviconUrl: null,
+          siteName: null,
+          contentType: "website",
+          status: "failed",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: new Date("2026-06-30T10:00:00.000Z"),
+          expiresAt: new Date(Date.now() + 60 * 1000), // backoff still active
+          createdAt: new Date("2026-06-30T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: { getGithubClient: mock(async () => null) } as any,
+    })
+
+    await worker({
+      id: "job_fail",
+      name: "link_preview.extract",
+      data: { workspaceId: "ws_123", streamId: "stream_123", messageId: "msg_fail", contentMarkdown: url },
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_fail",
+      [{ id: "lp_fail", skipped: true }],
+      { forcePublish: undefined }
+    )
+  })
+
   /** Build the link-preview service mock for a single pending preview of `url`. */
   function redditServiceMock(url: string, completePreviewsAndPublish: ReturnType<typeof mock>) {
     return {

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -978,6 +978,150 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  /** Build a link-preview service mock for a single pending preview of `url`. */
+  function pendingServiceMock(id: string, url: string, completePreviewsAndPublish: ReturnType<typeof mock>) {
+    return {
+      extractAndCreatePending: mock(async () => [{ id, url }]),
+      getPreviewById: mock(async () => ({
+        id,
+        workspaceId: "ws_123",
+        url,
+        normalizedUrl: url,
+        title: null,
+        description: null,
+        imageUrl: null,
+        faviconUrl: null,
+        siteName: null,
+        contentType: "website",
+        status: "pending",
+        previewType: null,
+        previewData: null,
+        targetWorkspaceId: null,
+        targetStreamId: null,
+        targetMessageId: null,
+        fetchedAt: null,
+        expiresAt: null,
+        createdAt: new Date("2026-07-01T10:00:00.000Z"),
+      })),
+      completePreviewsAndPublish,
+      replacePreviewsForMessage: mock(async () => []),
+      publishEmptyPreviews: mock(async () => {}),
+    } as any
+  }
+
+  test("classifies a YouTube link as a video preview with an embed URL built from the parsed id", async () => {
+    // The oEmbed `html` deliberately points its iframe at an attacker origin; the stored embedUrl
+    // must be reconstructed from the video id against youtube-nocookie.com, never lifted from html.
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.startsWith("https://www.youtube.com/oembed")) {
+        return new Response(
+          JSON.stringify({
+            title: "Never Gonna Give You Up",
+            author_name: "Rick Astley",
+            provider_name: "YouTube",
+            thumbnail_url: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            width: 480,
+            height: 270,
+            html: '<iframe src="https://evil.example.com/steal"></iframe>',
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: pendingServiceMock("lp_yt", url, completePreviewsAndPublish),
+      workspaceIntegrationService: { getGithubClient: mock(async () => null) } as any,
+    })
+
+    await worker({
+      id: "job_yt",
+      name: "link_preview.extract",
+      data: { workspaceId: "ws_123", streamId: "stream_123", messageId: "msg_yt", contentMarkdown: url },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_yt",
+      [
+        expect.objectContaining({
+          id: "lp_yt",
+          skipped: false,
+          metadata: expect.objectContaining({
+            contentType: "video",
+            previewType: "video",
+            imageUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            previewData: expect.objectContaining({
+              provider: "youtube",
+              videoId: "dQw4w9WgXcQ",
+              embedUrl: "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+              authorName: "Rick Astley",
+            }),
+          }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
+  })
+
+  test("classifies a Twitch VOD as a video preview via the HTML fallback (no oEmbed)", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          `<html><head>` +
+            `<meta property="og:title" content="Epic Play">` +
+            `<meta property="og:image" content="https://static-cdn.jtvnw.net/cf_vods/thumb.jpg">` +
+            `<meta property="og:site_name" content="Twitch">` +
+            `</head></html>`,
+          { status: 200, headers: { "content-type": "text/html; charset=utf-8" } }
+        )
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const url = "https://www.twitch.tv/videos/123456789"
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: pendingServiceMock("lp_tw", url, completePreviewsAndPublish),
+      workspaceIntegrationService: { getGithubClient: mock(async () => null) } as any,
+    })
+
+    await worker({
+      id: "job_tw",
+      name: "link_preview.extract",
+      data: { workspaceId: "ws_123", streamId: "stream_123", messageId: "msg_tw", contentMarkdown: url },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_tw",
+      [
+        expect.objectContaining({
+          id: "lp_tw",
+          skipped: false,
+          metadata: expect.objectContaining({
+            contentType: "video",
+            previewType: "video",
+            imageUrl: "https://static-cdn.jtvnw.net/cf_vods/thumb.jpg",
+            previewData: expect.objectContaining({
+              provider: "twitch",
+              videoId: "123456789",
+              embedUrl: "https://player.twitch.tv/?video=123456789",
+              title: "Epic Play",
+            }),
+          }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
+  })
+
   /** Build the link-preview service mock for a single pending preview of `url`. */
   function redditServiceMock(url: string, completePreviewsAndPublish: ReturnType<typeof mock>) {
     return {

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -1122,6 +1122,89 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  test("refetches an expired video preview instead of freezing it past its TTL", async () => {
+    // A completed video row whose 24h TTL has lapsed must re-run classification.
+    // Regression guard: the GitHub/Linear-scoped "keep existing rich preview when
+    // provider fetch is empty" skip must not apply to video (which never populates
+    // providerMetadata), or every video preview freezes at first classification.
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.startsWith("https://www.youtube.com/oembed")) {
+        return new Response(
+          JSON.stringify({
+            title: "Refreshed Title",
+            provider_name: "YouTube",
+            thumbnail_url: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            width: 480,
+            height: 270,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_ttl", url }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_ttl",
+          workspaceId: "ws_123",
+          url,
+          normalizedUrl: url,
+          title: "Stale Title",
+          description: null,
+          imageUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/old.jpg",
+          faviconUrl: null,
+          siteName: "YouTube",
+          contentType: "video",
+          status: "completed",
+          previewType: "video",
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: new Date("2026-06-01T10:00:00.000Z"),
+          expiresAt: new Date("2026-06-02T10:00:00.000Z"), // long past — expired
+          createdAt: new Date("2026-06-01T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: { getGithubClient: mock(async () => null) } as any,
+    })
+
+    await worker({
+      id: "job_ttl",
+      name: "link_preview.extract",
+      data: { workspaceId: "ws_123", streamId: "stream_123", messageId: "msg_ttl", contentMarkdown: url },
+    })
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_ttl",
+      [
+        expect.objectContaining({
+          id: "lp_ttl",
+          skipped: false,
+          overwrite: true,
+          metadata: expect.objectContaining({
+            contentType: "video",
+            title: "Refreshed Title",
+            previewData: expect.objectContaining({ embedUrl: "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ" }),
+          }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
+  })
+
   /** Build the link-preview service mock for a single pending preview of `url`. */
   function redditServiceMock(url: string, completePreviewsAndPublish: ReturnType<typeof mock>) {
     return {

--- a/apps/backend/src/features/link-previews/worker.test.ts
+++ b/apps/backend/src/features/link-previews/worker.test.ts
@@ -1205,6 +1205,77 @@ describe("createLinkPreviewWorker", () => {
     )
   })
 
+  test("upgrades a still-fresh website-cached video URL to a video preview", async () => {
+    // A YouTube link cached as a plain website before this feature shipped must
+    // reclassify to a video card even while the website TTL is still fresh —
+    // detectContentType() is extension-based and never yields "video" at insert.
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.startsWith("https://www.youtube.com/oembed")) {
+        return new Response(
+          JSON.stringify({ title: "A Video", provider_name: "YouTube", thumbnail_url: "https://i.ytimg.com/x.jpg" }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`)
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const completePreviewsAndPublish = mock(async () => {})
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    const worker = createLinkPreviewWorker({
+      linkPreviewService: {
+        extractAndCreatePending: mock(async () => [{ id: "lp_up", url }]),
+        getPreviewById: mock(async () => ({
+          id: "lp_up",
+          workspaceId: "ws_123",
+          url,
+          normalizedUrl: url,
+          title: "Generic OG Title",
+          description: "og desc",
+          imageUrl: "https://og.example/img.jpg",
+          faviconUrl: null,
+          siteName: "YouTube",
+          contentType: "website",
+          status: "completed",
+          previewType: null,
+          previewData: null,
+          targetWorkspaceId: null,
+          targetStreamId: null,
+          targetMessageId: null,
+          fetchedAt: new Date("2026-06-30T10:00:00.000Z"),
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000), // still fresh
+          createdAt: new Date("2026-06-30T10:00:00.000Z"),
+        })),
+        completePreviewsAndPublish,
+        replacePreviewsForMessage: mock(async () => []),
+        publishEmptyPreviews: mock(async () => {}),
+      } as any,
+      workspaceIntegrationService: { getGithubClient: mock(async () => null) } as any,
+    })
+
+    await worker({
+      id: "job_up",
+      name: "link_preview.extract",
+      data: { workspaceId: "ws_123", streamId: "stream_123", messageId: "msg_up", contentMarkdown: url },
+    })
+
+    expect(completePreviewsAndPublish).toHaveBeenCalledWith(
+      "ws_123",
+      "stream_123",
+      "msg_up",
+      [
+        expect.objectContaining({
+          id: "lp_up",
+          skipped: false,
+          overwrite: true,
+          metadata: expect.objectContaining({ contentType: "video", previewType: "video" }),
+        }),
+      ],
+      { forcePublish: undefined }
+    )
+  })
+
   /** Build the link-preview service mock for a single pending preview of `url`. */
   function redditServiceMock(url: string, completePreviewsAndPublish: ReturnType<typeof mock>) {
     return {

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -585,8 +585,13 @@ export function createLinkPreviewWorker(deps: WorkerDeps): JobHandler<LinkPrevie
         const isLinearUrl = !isGitHubUrl && parseLinearUrl(p.url) !== null
         const isProviderUrl = isGitHubUrl || isLinearUrl
         const shouldAttemptProviderUpgrade = isProviderUrl && existing.previewType === null
+        // A video URL cached as a plain website (e.g. before this feature shipped)
+        // must re-run classification even while fresh; video classification happens
+        // inside fetchGenericMetadata, not the provider-fetch branch below.
+        const shouldReclassifyVideo =
+          !isProviderUrl && existing.contentType !== "video" && detectVideoProvider(p.url) !== null
 
-        if (isPreviewCacheFresh(existing) && !shouldAttemptProviderUpgrade) {
+        if (isPreviewCacheFresh(existing) && !shouldAttemptProviderUpgrade && !shouldReclassifyVideo) {
           return { id: p.id, skipped: true }
         }
 
@@ -597,7 +602,10 @@ export function createLinkPreviewWorker(deps: WorkerDeps): JobHandler<LinkPrevie
           providerMetadata = await fetchLinearPreview(workspaceId, p.url, deps.workspaceIntegrationService)
         }
 
-        if (existing.previewType && providerMetadata === null) {
+        // Guard against downgrading a rich provider (GitHub/Linear) preview when its
+        // fetch comes back empty. Scoped to provider URLs: video never populates
+        // providerMetadata, so an unscoped check froze video rows past their TTL.
+        if (isProviderUrl && existing.previewType && providerMetadata === null) {
           return { id: p.id, skipped: true }
         }
         if (shouldAttemptProviderUpgrade && providerMetadata === null && isPreviewCacheFresh(existing)) {

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -587,9 +587,14 @@ export function createLinkPreviewWorker(deps: WorkerDeps): JobHandler<LinkPrevie
         const shouldAttemptProviderUpgrade = isProviderUrl && existing.previewType === null
         // A video URL cached as a plain website (e.g. before this feature shipped)
         // must re-run classification even while fresh; video classification happens
-        // inside fetchGenericMetadata, not the provider-fetch branch below.
+        // inside fetchGenericMetadata, not the provider-fetch branch below. Gated to
+        // `completed` rows so a recently-failed fetch still honors its retry backoff
+        // (a failed row also carries the default `website` contentType).
         const shouldReclassifyVideo =
-          !isProviderUrl && existing.contentType !== "video" && detectVideoProvider(p.url) !== null
+          !isProviderUrl &&
+          existing.status === "completed" &&
+          existing.contentType !== "video" &&
+          detectVideoProvider(p.url) !== null
 
         if (isPreviewCacheFresh(existing) && !shouldAttemptProviderUpgrade && !shouldReclassifyVideo) {
           return { id: p.id, skipped: true }

--- a/apps/backend/src/features/link-previews/worker.ts
+++ b/apps/backend/src/features/link-previews/worker.ts
@@ -6,6 +6,7 @@ import type { LinkPreview, UpdateLinkPreviewParams } from "./repository"
 import { detectContentType, isBlockedUrl, parseGitHubUrl, parseLinearUrl } from "./url-utils"
 import { fetchGitHubPreview } from "./github-preview"
 import { fetchLinearPreview } from "./linear-preview"
+import { buildVideoPreviewParams, detectVideoProvider } from "./video-preview"
 import {
   FETCH_TIMEOUT_MS,
   FETCH_USER_AGENT,
@@ -31,6 +32,8 @@ interface OEmbedResponse {
   provider_name?: string
   thumbnail_url?: string
   html?: string
+  width?: number
+  height?: number
 }
 
 /**
@@ -70,6 +73,27 @@ async function tryOEmbed(url: string): Promise<UpdateLinkPreviewParams | null> {
       faviconUrl = `${new URL(url).origin}/favicon.ico`
     } catch {
       /* ignore */
+    }
+
+    // A video provider that also serves oEmbed (YouTube/Vimeo/Loom): fold the
+    // oEmbed title/thumbnail/dimensions into a video preview whose embed URL is
+    // reconstructed from the parsed id — never from `data.html`.
+    const videoMatch = detectVideoProvider(url)
+    if (videoMatch) {
+      return buildVideoPreviewParams(
+        videoMatch,
+        url,
+        {
+          title: data.title ?? null,
+          posterUrl: data.thumbnail_url ?? null,
+          authorName: data.author_name ?? null,
+          width: data.width ?? null,
+          height: data.height ?? null,
+          siteName: data.provider_name ?? null,
+          faviconUrl,
+        },
+        new Date().toISOString()
+      )
     }
 
     return {
@@ -316,6 +340,26 @@ async function fetchGenericMetadata(url: string): Promise<UpdateLinkPreviewParam
     if (isRedditUrl(url) && !metadata.imageUrl && !metadata.description) {
       log.warn({ url }, "Reddit served anti-bot interstitial; marking preview failed for retry")
       return { status: "failed", expiresAt: minutesFromNow(30) }
+    }
+
+    // Video providers without oEmbed (Twitch), or one whose oEmbed failed above:
+    // classify from the URL pattern and use the scraped og:image/title as poster.
+    const videoMatch = detectVideoProvider(url)
+    if (videoMatch && metadata.status === "completed") {
+      return buildVideoPreviewParams(
+        videoMatch,
+        url,
+        {
+          title: metadata.title ?? null,
+          posterUrl: metadata.imageUrl ?? null,
+          authorName: null,
+          width: null,
+          height: null,
+          siteName: metadata.siteName ?? null,
+          faviconUrl: metadata.faviconUrl ?? null,
+        },
+        new Date().toISOString()
+      )
     }
 
     return metadata

--- a/apps/frontend/src/components/gallery/video-embed.ts
+++ b/apps/frontend/src/components/gallery/video-embed.ts
@@ -1,0 +1,37 @@
+import type { GitHubPreview, LinearPreview, VideoPreview, VideoPreviewProvider } from "@threa/types"
+
+/**
+ * Narrow a link preview's `previewData` union to the video-embed variant.
+ * Video previews carry `type === "video"`; GitHub/Linear use prefixed types.
+ */
+export function isVideoPreview(
+  preview: GitHubPreview | LinearPreview | VideoPreview | null | undefined
+): preview is VideoPreview {
+  return !!preview && preview.type === "video"
+}
+
+/**
+ * Build the iframe `src` for click-to-play. Appends the provider's autoplay
+ * param (playback is only ever started after an explicit user gesture) and,
+ * for Twitch, the required `parent` matching the current host. `embedUrl` is a
+ * trusted per-provider origin baked server-side from the parsed video id, so
+ * appending query params here is safe.
+ */
+export function buildEmbedPlaybackSrc(embedUrl: string, provider: VideoPreviewProvider): string {
+  try {
+    const url = new URL(embedUrl)
+    if (provider === "twitch") {
+      url.searchParams.set("autoplay", "true")
+      url.searchParams.set("parent", window.location.hostname)
+    } else {
+      url.searchParams.set("autoplay", "1")
+    }
+    return url.toString()
+  } catch {
+    return embedUrl
+  }
+}
+
+export function videoPlaybackSrc(preview: VideoPreview): string {
+  return buildEmbedPlaybackSrc(preview.embedUrl, preview.provider)
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -31,6 +31,8 @@ import { triggerDownload } from "@/lib/image-utils"
 import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
 import { isGiphyGalleryId } from "@/components/gallery/giphy-gallery-id"
 import { isLinkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
+import { buildEmbedPlaybackSrc } from "@/components/gallery/video-embed"
+import type { VideoPreviewProvider } from "@threa/types"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
 import { MarkdownViewer } from "@/components/gallery/markdown-viewer"
 import { HtmlViewer } from "@/components/gallery/html-viewer"
@@ -41,6 +43,18 @@ import { fetchTextContent } from "@/components/gallery/use-text-content"
 export type GalleryItem =
   | { type: "image"; url: string; thumbnailUrl: string; filename: string; attachmentId: string }
   | { type: "video"; url: string; thumbnailUrl: string; filename: string; attachmentId: string }
+  // Third-party video embed (link preview). No attachment bytes — plays via an
+  // iframe against a trusted provider origin; download/copy are gated off.
+  | {
+      type: "video-embed"
+      url: string
+      embedUrl: string
+      provider: VideoPreviewProvider
+      posterUrl: string | null
+      aspectRatio: number
+      filename: string
+      attachmentId: string
+    }
   | { type: "markdown"; url: string; filename: string; attachmentId: string }
   | { type: "html"; url: string; filename: string; attachmentId: string }
   | { type: "pdf"; url: string; filename: string; attachmentId: string }
@@ -49,6 +63,7 @@ export type GalleryItem =
 const GALLERY_TYPE_LABELS: Record<GalleryItem["type"], string> = {
   image: "Image",
   video: "Video",
+  "video-embed": "Video",
   markdown: "Markdown document",
   html: "HTML document",
   pdf: "PDF document",
@@ -206,6 +221,48 @@ function GalleryMediaContent({
       </div>
     )
   }
+  if (current.type === "video-embed") {
+    // Inactive slides never mount the iframe — poster only, so no third-party
+    // player loads for a video the user isn't looking at.
+    if (!isActive) {
+      return (
+        <div className="absolute inset-0 flex items-center justify-center">
+          {current.posterUrl ? (
+            <img
+              src={current.posterUrl}
+              alt={current.filename}
+              className="max-w-full max-h-full object-contain select-none"
+              draggable={false}
+            />
+          ) : (
+            <div className="h-16 w-16 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center">
+              <Play className="h-7 w-7 text-white/60 ml-0.5" fill="currentColor" />
+            </div>
+          )}
+        </div>
+      )
+    }
+    return (
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div
+          className="relative max-w-full max-h-full overflow-hidden rounded-lg bg-black shadow-2xl"
+          style={{
+            aspectRatio: current.aspectRatio,
+            width: `min(100%, calc(85vh * ${current.aspectRatio}))`,
+          }}
+        >
+          <iframe
+            src={buildEmbedPlaybackSrc(current.embedUrl, current.provider)}
+            title={current.filename}
+            className="absolute inset-0 h-full w-full"
+            allow="autoplay; fullscreen; picture-in-picture; encrypted-media"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+          />
+        </div>
+      </div>
+    )
+  }
   // While the full-resolution URL hasn't arrived yet, show the already-loaded
   // thumbnail as a poster instead of a blank loader — matches the video path
   // (poster while bytes stream in) and makes large-image opens feel instant.
@@ -271,8 +328,9 @@ function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
       </div>
     )
   }
-  if (item.type === "video") {
-    if (!item.thumbnailUrl) {
+  if (item.type === "video" || item.type === "video-embed") {
+    const poster = item.type === "video" ? item.thumbnailUrl : item.posterUrl
+    if (!poster) {
       return (
         <div className="w-full h-20 flex items-center justify-center bg-gradient-to-br from-white/10 to-white/5">
           <div className="h-7 w-7 rounded-full bg-white/10 backdrop-blur-sm flex items-center justify-center">
@@ -284,7 +342,7 @@ function GalleryThumbnailContent({ item }: { item: GalleryItem }) {
     return (
       <div className="relative w-full h-20 bg-black/40">
         <img
-          src={item.thumbnailUrl}
+          src={poster}
           alt={item.filename}
           className="absolute inset-0 w-full h-full object-contain"
           loading="lazy"

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -129,6 +129,10 @@ function GalleryVideo({ current }: { current: Extract<GalleryItem, { type: "vide
 interface GalleryMediaContentProps {
   current: GalleryItem
   isActive?: boolean
+  /** True only for the exact viewed slide (not the ±1 preload window `isActive`
+   *  covers). Gates third-party embed playback so a swipe-adjacent video-embed
+   *  never autoplays off-screen. Defaults to `isActive` for single-slide callers. */
+  isCurrent?: boolean
   /** Non-null only for the currently-displayed slide. When present with an image,
    *  the image is rendered via ZoomableImage so it can be zoomed/panned. */
   zoomableRef?: React.Ref<ZoomableImageHandle>
@@ -141,6 +145,7 @@ interface GalleryMediaContentProps {
 function GalleryMediaContent({
   current,
   isActive = true,
+  isCurrent = isActive,
   zoomableRef,
   onZoomChange,
   onScaleChange,
@@ -222,9 +227,9 @@ function GalleryMediaContent({
     )
   }
   if (current.type === "video-embed") {
-    // Inactive slides never mount the iframe — poster only, so no third-party
-    // player loads for a video the user isn't looking at.
-    if (!isActive) {
+    // Only the exact current slide mounts the (autoplaying) iframe — a ±1 preload
+    // neighbor shows the poster, so no third-party player loads or plays off-screen.
+    if (!isCurrent) {
       return (
         <div className="absolute inset-0 flex items-center justify-center">
           {current.posterUrl ? (
@@ -989,6 +994,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
                         <GalleryMediaContent
                           current={item}
                           isActive={Math.abs(i - currentIndex) <= 1}
+                          isCurrent={i === currentIndex}
                           zoomableRef={i === currentIndex && item.type === "image" ? zoomableRef : undefined}
                           onZoomChange={i === currentIndex && item.type === "image" ? setIsZoomed : undefined}
                           onScaleChange={i === currentIndex && item.type === "image" ? publishScale : undefined}

--- a/apps/frontend/src/components/timeline/link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.test.tsx
@@ -353,14 +353,17 @@ describe("LinkPreviewCard", () => {
     expect(within(dialog).getByTitle("Never Gonna Give You Up")).toBeInTheDocument()
   })
 
-  it("keeps the expand-to-gallery control available after playback starts", () => {
+  it("keeps expand reachable during playback and hands off to a single gallery embed", () => {
     render(<LinkPreviewCard preview={makeVideoPreview()} workspaceId="ws_1" onToggleCollapse={() => {}} />)
 
     fireEvent.click(screen.getByRole("button", { name: /Play video/i }))
     // Iframe is now mounted, and the expand control must still be reachable.
-    expect(screen.getByTitle("Never Gonna Give You Up")).toBeInTheDocument()
+    expect(screen.getAllByTitle("Never Gonna Give You Up")).toHaveLength(1)
     fireEvent.click(screen.getByRole("button", { name: /Open video in fullscreen gallery/i }))
     expect(screen.getByRole("dialog")).toBeInTheDocument()
+    // The facade's iframe must stop when the gallery takes over — exactly one
+    // embed plays, never two overlapping audio streams.
+    expect(screen.getAllByTitle("Never Gonna Give You Up")).toHaveLength(1)
   })
 
   it("opens the media gallery when an image preview is clicked", () => {

--- a/apps/frontend/src/components/timeline/link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.test.tsx
@@ -302,6 +302,57 @@ describe("LinkPreviewCard", () => {
     expect(img.src).toContain("https://example.com/photo.png")
   })
 
+  function makeVideoPreview(overrides: Partial<LinkPreviewSummary> = {}): LinkPreviewSummary {
+    return makeGitHubPreview({
+      url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      contentType: "video",
+      title: "Never Gonna Give You Up",
+      siteName: "YouTube",
+      imageUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+      previewType: "video",
+      previewData: {
+        type: "video",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ",
+        embedUrl: "https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ",
+        posterUrl: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        aspectRatio: 16 / 9,
+        title: "Never Gonna Give You Up",
+        authorName: "Rick Astley",
+        fetchedAt: "2026-07-01T00:00:00.000Z",
+      },
+      ...overrides,
+    })
+  }
+
+  it("renders a video preview as a click-to-play facade with no iframe mounted", () => {
+    render(<LinkPreviewCard preview={makeVideoPreview()} onToggleCollapse={() => {}} />)
+
+    expect(screen.getByText("YouTube")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Play video: Never Gonna Give You Up/i })).toBeInTheDocument()
+    // The third-party iframe must not load until the user clicks play.
+    expect(screen.queryByTitle("Never Gonna Give You Up")).not.toBeInTheDocument()
+  })
+
+  it("mounts the embed iframe with the trusted playback src after clicking play", () => {
+    render(<LinkPreviewCard preview={makeVideoPreview()} onToggleCollapse={() => {}} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Play video/i }))
+
+    const iframe = screen.getByTitle("Never Gonna Give You Up") as HTMLIFrameElement
+    expect(iframe.src).toBe("https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?autoplay=1")
+  })
+
+  it("opens the media gallery with the embed when the expand control is clicked", () => {
+    render(<LinkPreviewCard preview={makeVideoPreview()} workspaceId="ws_1" onToggleCollapse={() => {}} />)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Open video fullscreen/i }))
+    const dialog = screen.getByRole("dialog")
+    expect(within(dialog).getByTitle("Never Gonna Give You Up")).toBeInTheDocument()
+  })
+
   it("opens the media gallery when an image preview is clicked", () => {
     const preview = makeGitHubPreview({
       url: "https://example.com/photo.png",

--- a/apps/frontend/src/components/timeline/link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.test.tsx
@@ -348,9 +348,19 @@ describe("LinkPreviewCard", () => {
     render(<LinkPreviewCard preview={makeVideoPreview()} workspaceId="ws_1" onToggleCollapse={() => {}} />)
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: /Open video fullscreen/i }))
+    fireEvent.click(screen.getByRole("button", { name: /Open video in fullscreen gallery/i }))
     const dialog = screen.getByRole("dialog")
     expect(within(dialog).getByTitle("Never Gonna Give You Up")).toBeInTheDocument()
+  })
+
+  it("keeps the expand-to-gallery control available after playback starts", () => {
+    render(<LinkPreviewCard preview={makeVideoPreview()} workspaceId="ws_1" onToggleCollapse={() => {}} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Play video/i }))
+    // Iframe is now mounted, and the expand control must still be reachable.
+    expect(screen.getByTitle("Never Gonna Give You Up")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /Open video in fullscreen gallery/i }))
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
   })
 
   it("opens the media gallery when an image preview is clicked", () => {

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -15,6 +15,9 @@ import {
   FileCode,
   Folder,
   File,
+  Play,
+  Video as VideoIcon,
+  Maximize2,
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar"
@@ -22,6 +25,7 @@ import { MarkdownContent } from "@/components/ui/markdown-content"
 import { cn } from "@/lib/utils"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { linkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
+import { isVideoPreview, videoPlaybackSrc } from "@/components/gallery/video-embed"
 import { LinkPreviewBody } from "./link-preview-body"
 import { AccentGlow, colorWithAlpha, Field, FieldGrid, LabelChip, MonoTag, StatePill } from "./link-preview-primitives"
 import type {
@@ -40,9 +44,12 @@ import type {
   LinearPreview,
   LinearProjectPreviewData,
   LinkPreviewSummary,
+  VideoPreview,
 } from "@threa/types"
 
-function isLinearPreview(preview: GitHubPreview | LinearPreview | null | undefined): preview is LinearPreview {
+function isLinearPreview(
+  preview: GitHubPreview | LinearPreview | VideoPreview | null | undefined
+): preview is LinearPreview {
   return !!preview && typeof preview.type === "string" && preview.type.startsWith("linear_")
 }
 
@@ -70,6 +77,8 @@ function ContentTypeIcon({ contentType }: { contentType: string }) {
       return <FileText className="h-4 w-4 text-red-500 shrink-0" />
     case "image":
       return <ImageIcon className="h-4 w-4 text-blue-500 shrink-0" />
+    case "video":
+      return <VideoIcon className="h-4 w-4 text-rose-500 shrink-0" />
     default:
       return <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
   }
@@ -116,7 +125,9 @@ export function LinkPreviewCard({
   const [imageError, setImageError] = useState(false)
   const domain = getDomain(preview.url)
   const providerPreview = preview.previewData
-  const githubPreview = providerPreview && !isLinearPreview(providerPreview) ? providerPreview : null
+  const videoPreview = isVideoPreview(providerPreview) ? providerPreview : null
+  const githubPreview =
+    providerPreview && !isLinearPreview(providerPreview) && !isVideoPreview(providerPreview) ? providerPreview : null
   const linearPreview = isLinearPreview(providerPreview) ? providerPreview : null
 
   const handleDismiss = useCallback(
@@ -160,6 +171,29 @@ export function LinkPreviewCard({
           onDismiss={onDismiss ? handleDismiss : undefined}
         />
         {!isCollapsedProp && <ImagePreviewContent preview={preview} workspaceId={workspaceId} />}
+      </div>
+    )
+  }
+
+  if (preview.contentType === "video" && videoPreview) {
+    return (
+      <div
+        data-native-context="true"
+        className={cn(
+          "group/preview reveal-host relative overflow-hidden rounded-lg border bg-card transition-all max-w-md",
+          "hover:border-primary/50 hover:shadow-sm",
+          isHighlighted && "ring-2 ring-primary border-primary shadow-sm"
+        )}
+      >
+        <PreviewCardHeader
+          icon={<ContentTypeIcon contentType="video" />}
+          label={preview.siteName ?? domain}
+          faviconUrl={preview.faviconUrl}
+          isCollapsed={isCollapsedProp}
+          onToggleCollapse={handleToggleCollapse}
+          onDismiss={onDismiss ? handleDismiss : undefined}
+        />
+        {!isCollapsedProp && <VideoPreviewContent video={videoPreview} workspaceId={workspaceId} />}
       </div>
     )
   }
@@ -328,6 +362,109 @@ function ImagePreviewContent({ preview, workspaceId }: { preview: LinkPreviewSum
           </div>
         )}
       </button>
+      {galleryOpen && (
+        <MediaGallery
+          isOpen={galleryOpen}
+          onClose={() => setGalleryOpen(false)}
+          items={galleryItems}
+          initialIndex={0}
+          workspaceId={workspaceId ?? ""}
+        />
+      )}
+    </>
+  )
+}
+
+/**
+ * Video link preview: a click-to-play facade. The poster + play button occupy a
+ * fixed-aspect box (reserved up front so neither the poster nor the iframe swap
+ * reflows the timeline — INV-21). The third-party iframe only mounts after an
+ * explicit click, so no external JS/cookies load until the user opts in. A
+ * separate expand control opens the same embed fullscreen in the media gallery.
+ */
+function VideoPreviewContent({ video, workspaceId }: { video: VideoPreview; workspaceId?: string }) {
+  const [playing, setPlaying] = useState(false)
+  const [posterError, setPosterError] = useState(false)
+  const [galleryOpen, setGalleryOpen] = useState(false)
+
+  // Previews are PATCHed in place as metadata resolves; if the embed target
+  // changes on the same mounted card, drop any in-progress playback/error state.
+  useEffect(() => {
+    setPlaying(false)
+    setPosterError(false)
+  }, [video.embedUrl])
+
+  const title = video.title ?? getDomain(video.url)
+  const aspectRatio = video.aspectRatio > 0 ? video.aspectRatio : 16 / 9
+
+  const galleryItems = useMemo<GalleryItem[]>(
+    () => [
+      {
+        type: "video-embed",
+        url: video.url,
+        embedUrl: video.embedUrl,
+        provider: video.provider,
+        posterUrl: video.posterUrl,
+        aspectRatio,
+        filename: title,
+        attachmentId: linkPreviewGalleryId(video.embedUrl),
+      },
+    ],
+    [video.url, video.embedUrl, video.provider, video.posterUrl, aspectRatio, title]
+  )
+
+  return (
+    <>
+      <div className="relative w-full overflow-hidden bg-black" style={{ aspectRatio }}>
+        <AccentGlow />
+        {playing ? (
+          <iframe
+            src={videoPlaybackSrc(video)}
+            title={title}
+            className="absolute inset-0 h-full w-full"
+            allow="autoplay; fullscreen; picture-in-picture; encrypted-media"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+          />
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => setPlaying(true)}
+              className="group/play absolute inset-0 flex cursor-pointer items-center justify-center"
+              aria-label={`Play video: ${title}`}
+            >
+              {video.posterUrl && !posterError ? (
+                <img
+                  src={video.posterUrl}
+                  alt=""
+                  loading="lazy"
+                  onError={() => setPosterError(true)}
+                  className="absolute inset-0 h-full w-full object-cover"
+                />
+              ) : (
+                <div className="absolute inset-0 bg-gradient-to-br from-muted to-muted/40" />
+              )}
+              <span className="relative flex h-14 w-14 items-center justify-center rounded-full bg-black/60 text-white shadow-lg backdrop-blur-sm transition-transform group-hover/play:scale-110">
+                <Play className="h-7 w-7 translate-x-0.5" fill="currentColor" />
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setGalleryOpen(true)}
+              className="absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
+              aria-label="Open video fullscreen"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </button>
+            {video.title && (
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2.5">
+                <span className="line-clamp-1 text-xs font-medium text-white">{video.title}</span>
+              </div>
+            )}
+          </>
+        )}
+      </div>
       {galleryOpen && (
         <MediaGallery
           isOpen={galleryOpen}

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -463,7 +463,12 @@ function VideoPreviewContent({ video, workspaceId }: { video: VideoPreview; work
             left corner avoids colliding with the player's own controls. */}
         <button
           type="button"
-          onClick={() => setGalleryOpen(true)}
+          onClick={() => {
+            // The gallery mounts its own playing embed; stop the facade's iframe
+            // so the same video doesn't autoplay twice behind the overlay.
+            setPlaying(false)
+            setGalleryOpen(true)
+          }}
           title="Open in gallery"
           className="absolute left-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
           aria-label="Open video in fullscreen gallery"

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -449,14 +449,6 @@ function VideoPreviewContent({ video, workspaceId }: { video: VideoPreview; work
                 <Play className="h-7 w-7 translate-x-0.5" fill="currentColor" />
               </span>
             </button>
-            <button
-              type="button"
-              onClick={() => setGalleryOpen(true)}
-              className="absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
-              aria-label="Open video fullscreen"
-            >
-              <Maximize2 className="h-4 w-4" />
-            </button>
             {video.title && (
               <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-2.5">
                 <span className="line-clamp-1 text-xs font-medium text-white">{video.title}</span>
@@ -464,6 +456,18 @@ function VideoPreviewContent({ video, workspaceId }: { video: VideoPreview; work
             )}
           </>
         )}
+        {/* Expand-to-gallery stays mounted in both the facade and playing states
+            (z-10 above the iframe) so fullscreen is reachable after playback
+            starts — the moment a user is most likely to want it. */}
+        <button
+          type="button"
+          onClick={() => setGalleryOpen(true)}
+          title="Open in gallery"
+          className="absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
+          aria-label="Open video in fullscreen gallery"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </button>
       </div>
       {galleryOpen && (
         <MediaGallery

--- a/apps/frontend/src/components/timeline/link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-card.tsx
@@ -458,12 +458,14 @@ function VideoPreviewContent({ video, workspaceId }: { video: VideoPreview; work
         )}
         {/* Expand-to-gallery stays mounted in both the facade and playing states
             (z-10 above the iframe) so fullscreen is reachable after playback
-            starts — the moment a user is most likely to want it. */}
+            starts. Anchored top-LEFT: every provider's interactive chrome
+            (share/logo/fullscreen) lives top-right or along the bottom, so the
+            left corner avoids colliding with the player's own controls. */}
         <button
           type="button"
           onClick={() => setGalleryOpen(true)}
           title="Open in gallery"
-          className="absolute right-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
+          className="absolute left-2 top-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black/55 text-white shadow-md backdrop-blur-sm transition-colors hover:bg-black/75"
           aria-label="Open video in fullscreen gallery"
         >
           <Maximize2 className="h-4 w-4" />

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -623,6 +623,7 @@ export const LINK_PREVIEW_CONTENT_TYPES = [
   "website",
   "pdf",
   "image",
+  "video",
   "message_link",
   "stream_link",
   "memo_link",
@@ -633,6 +634,7 @@ export const LinkPreviewContentTypes = {
   WEBSITE: "website",
   PDF: "pdf",
   IMAGE: "image",
+  VIDEO: "video",
   MESSAGE_LINK: "message_link",
   STREAM_LINK: "stream_link",
   MEMO_LINK: "memo_link",
@@ -705,6 +707,29 @@ export const LinearPreviewTypes = {
   PROJECT: "linear_project",
   DOCUMENT: "linear_document",
 } as const satisfies Record<string, LinearPreviewType>
+
+// Video-embed providers whose links unfurl into a click-to-play facade card.
+// The embed URL is always reconstructed from the parsed video id against a
+// trusted per-provider origin — never from oEmbed HTML (iframe-injection guard).
+export const VIDEO_PREVIEW_PROVIDERS = ["youtube", "vimeo", "loom", "twitch"] as const
+export type VideoPreviewProvider = (typeof VIDEO_PREVIEW_PROVIDERS)[number]
+
+export const VideoPreviewProviders = {
+  YOUTUBE: "youtube",
+  VIMEO: "vimeo",
+  LOOM: "loom",
+  TWITCH: "twitch",
+} as const satisfies Record<string, VideoPreviewProvider>
+
+// Video is a single rich preview variant (unlike GitHub/Linear which fan out
+// into many). Kept as a one-member list for parity with the other unions so
+// `preview_type` stays a closed set derived from a source-of-truth constant.
+export const VIDEO_PREVIEW_TYPES = ["video"] as const
+export type VideoPreviewType = (typeof VIDEO_PREVIEW_TYPES)[number]
+
+export const VideoPreviewTypes = {
+  VIDEO: "video",
+} as const satisfies Record<string, VideoPreviewType>
 
 export const SHARE_FLAVORS = ["pointer", "quote"] as const
 export type ShareFlavor = (typeof SHARE_FLAVORS)[number]

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -46,6 +46,8 @@ import type {
   WorkspaceIntegrationStatus,
   GitHubPreviewType,
   LinearPreviewType,
+  VideoPreviewType,
+  VideoPreviewProvider,
   BotRuntimeKind,
   BotRuntimeSessionLinkStatus,
   BotRuntimeStatus,
@@ -1009,8 +1011,8 @@ export interface LinkPreview {
   siteName: string | null
   contentType: LinkPreviewContentType
   status: LinkPreviewStatus
-  previewType?: GitHubPreviewType | LinearPreviewType | null
-  previewData?: GitHubPreview | LinearPreview | null
+  previewType?: GitHubPreviewType | LinearPreviewType | VideoPreviewType | null
+  previewData?: GitHubPreview | LinearPreview | VideoPreview | null
   fetchedAt: string | null
   expiresAt?: string | null
   createdAt: string
@@ -1029,8 +1031,8 @@ export interface LinkPreviewSummary {
   faviconUrl: string | null
   siteName: string | null
   contentType: LinkPreviewContentType
-  previewType?: GitHubPreviewType | LinearPreviewType | null
-  previewData?: GitHubPreview | LinearPreview | null
+  previewType?: GitHubPreviewType | LinearPreviewType | VideoPreviewType | null
+  previewData?: GitHubPreview | LinearPreview | VideoPreview | null
   position: number
   /**
    * Resolved, access-tiered in-app link data (message/stream/memo), populated
@@ -1227,6 +1229,28 @@ export interface GitHubPreview {
     | GitHubFilePreviewData
     | GitHubDiffPreviewData
     | GitHubCommentPreviewData
+  fetchedAt: string
+}
+
+/**
+ * Rich preview for an embeddable video link (YouTube/Vimeo/Loom/Twitch).
+ * `embedUrl` is reconstructed server-side from the parsed `videoId` against a
+ * trusted per-provider origin, so it is safe to hand to an `<iframe src>` — it
+ * is never taken from the provider's oEmbed HTML. `aspectRatio` is width/height
+ * (defaults to 16/9 when the provider gives no dimensions) and lets the card
+ * reserve a fixed box up front (INV-21). Twitch embeds still need a `parent`
+ * query param matching the host, which the frontend appends at play time.
+ */
+export interface VideoPreview {
+  type: VideoPreviewType
+  url: string
+  provider: VideoPreviewProvider
+  videoId: string
+  embedUrl: string
+  posterUrl: string | null
+  aspectRatio: number
+  title: string | null
+  authorName: string | null
   fetchedAt: string
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -182,6 +182,12 @@ export {
   LINEAR_PREVIEW_TYPES,
   type LinearPreviewType,
   LinearPreviewTypes,
+  VIDEO_PREVIEW_PROVIDERS,
+  type VideoPreviewProvider,
+  VideoPreviewProviders,
+  VIDEO_PREVIEW_TYPES,
+  type VideoPreviewType,
+  VideoPreviewTypes,
   // Share flavors
   SHARE_FLAVORS,
   type ShareFlavor,
@@ -333,6 +339,8 @@ export type {
   GitHubCommentParent,
   GitHubCommentPreviewData,
   GitHubPreview,
+  // Video-embed previews
+  VideoPreview,
   // Linear integration + previews
   LinearWorkspaceIntegration,
   LinearAuthorizedUser,


### PR DESCRIPTION
## Problem

Video links (YouTube, Vimeo, …) unfurled as plain website cards. The link-preview worker already pattern-matched YouTube and Vimeo in `OEMBED_PROVIDERS` and fetched their oEmbed title + thumbnail, but `tryOEmbed` collapsed everything to `contentType: "website"` and discarded the embed data — so a video URL rendered as a generic OG card with no way to play it inline. There was no `video` content type and no player surface.

## Solution

Introduce a `video` link-preview type that unfurls embeddable video links into a **click-to-play facade card** and lets that same embed **expand fullscreen in the media gallery**. Providers for v1: YouTube, Vimeo, Loom, Twitch.

The load-bearing decision is a security one: the embed URL is **reconstructed from the parsed video id against a trusted per-provider origin — never lifted from the provider's oEmbed `html`** (which is attacker-influenceable markup). Playback is a facade: the third-party iframe mounts only after an explicit click, so no third-party JS/cookies load until the user opts in, and a fixed-aspect box is reserved up front so nothing reflows (INV-21).

### How it works

1. **Classification (`video-preview.ts`, new).** `detectVideoProvider(url)` matches each provider's URL shapes, validates the id against a tight per-provider charset (`^[A-Za-z0-9_-]{11}$` for YouTube, `^\d+$` for Vimeo/Twitch VODs, etc.), and returns `{ provider, videoId, embedUrl }` where `embedUrl` is templated onto the trusted origin (`youtube-nocookie.com/embed/<id>`, `player.vimeo.com/video/<id>`, `loom.com/embed/<id>`, `player.twitch.tv/?video=<id>` / `clips.twitch.tv/embed?clip=<slug>`). `buildVideoPreviewParams(...)` folds harvested metadata (title, poster, dimensions) into the stored `VideoPreview` and sets `contentType: "video"`.

2. **Worker wiring (`worker.ts`).** Two paths both classify to `video`:
   - **oEmbed path** — YouTube/Vimeo/Loom serve oEmbed; `tryOEmbed` now reads `width`/`height` and, when `detectVideoProvider` matches, returns a video preview built from the oEmbed title/thumbnail/dimensions. The `html` field is never read for the embed URL.
   - **HTML fallback** — Twitch has no public oEmbed, so it falls through to the HTML scrape; the same `detectVideoProvider` check there produces a video preview using the scraped `og:image` (poster) and `og:title`, defaulting to 16:9.
   - Loom added to `OEMBED_PROVIDERS` (`https://www.loom.com/v1/oembed`).

3. **Aspect ratio.** From oEmbed `width`/`height` when present (Vimeo verticals, non-16:9), else 16:9. Stored as a number so the card and gallery reserve a fixed box before the poster or iframe loads.

4. **Facade card (`link-preview-card.tsx`).** A `video` branch renders `PreviewCardHeader` + a fixed-aspect poster with a centered play button (`<button aria-label="Play video: …">`, INV-40). Clicking swaps the poster for `<iframe src={videoPlaybackSrc(video)}>` — autoplay appended only at that point, on user intent. A separate expand control opens the embed in `MediaGallery`.

5. **Gallery integration (`image-gallery.tsx`).** A new `video-embed` `GalleryItem` variant renders the iframe fullscreen for the active slide (poster only for inactive slides, so no off-screen player loads). Download/copy are gated off (the embed rides a `link-preview:` sentinel id, same as external preview images). `videoPlaybackSrc`/`buildEmbedPlaybackSrc` (`gallery/video-embed.ts`) build the iframe `src`, appending the per-provider autoplay param and, for Twitch, the required `parent=<host>` at play time.

### Key design decisions

**1. Embed URL from the parsed id, never from oEmbed `html`.** oEmbed `html` is provider-supplied markup an attacker can influence; injecting its iframe `src` is an iframe-injection vector. Instead the id is extracted, validated against a per-provider charset (INV-55), and templated onto a trusted embed origin. A worker test feeds a malicious oEmbed `html` (`<iframe src="https://evil.example.com/steal">`) and asserts the stored `embedUrl` is still `youtube-nocookie.com`.

**2. Facade, not auto-iframe.** Click-to-play only — no iframe on first render. Protects INV-21 (fixed aspect, no third-party layout shift), perf (no third-party JS until intent), and privacy (no third-party cookies until opt-in). Chosen over an explicit "load external content?" gate — the facade already conveys intent with one fewer click. `youtube-nocookie.com` over `youtube.com` for the same privacy reason.

**3. Also expandable in `MediaGallery`.** The gallery is otherwise for images and uploaded-video attachments; here it gains a `video-embed` variant that renders the embed iframe so a preview can go fullscreen, matching how image previews open there. (This overrides an earlier scoping note that kept embeds out of the gallery — done at the reviewer's request.)

**4. Twitch via HTML, not oEmbed.** Twitch removed its public oEmbed endpoint, so it's classified purely from the URL pattern in the HTML-scrape path and its `parent` query param (required by Twitch, host-dependent) is appended client-side at play time rather than baked server-side.

**5. Structured `VideoPreview` on the `previewData` union.** Mirrors the existing GitHub/Linear provider-preview pattern (`previewType` + `previewData`) rather than adding loose top-level fields, so `toLinkPreviewSummary` already carries it to the wire with no serializer change (INV-31, types derived from the `VIDEO_PREVIEW_*` constants).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/link-previews/video-preview.ts` | `detectVideoProvider` (URL → provider/id/trusted embed URL) + `buildVideoPreviewParams` |
| `apps/backend/src/features/link-previews/video-preview.test.ts` | Per-provider id extraction, junk-URL rejection, embed-from-id security property |
| `apps/frontend/src/components/gallery/video-embed.ts` | `isVideoPreview` guard + `videoPlaybackSrc`/`buildEmbedPlaybackSrc` (autoplay + Twitch `parent`) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | Add `"video"` to `LINK_PREVIEW_CONTENT_TYPES`; add `VIDEO_PREVIEW_PROVIDERS` + `VIDEO_PREVIEW_TYPES` |
| `packages/types/src/domain.ts` | `VideoPreview` interface; widen `LinkPreviewSummary`/`LinkPreview` `previewType`/`previewData` unions |
| `packages/types/src/index.ts` | Barrel exports for the new constants and `VideoPreview` |
| `apps/backend/src/features/link-previews/repository.ts` | Widen `RichPreviewType`/`RichPreview` to include video |
| `apps/backend/src/features/link-previews/worker.ts` | `OEmbedResponse` `width`/`height`; video branch in `tryOEmbed` and the HTML fallback |
| `apps/backend/src/features/link-previews/config.ts` | Loom oEmbed provider |
| `apps/backend/src/features/link-previews/worker.test.ts` | YouTube-oEmbed-→-video (with malicious-html guard) and Twitch-via-HTML cases |
| `apps/backend/src/features/link-previews/linear-preview.test.ts` | Cast `previewData.data` access for the widened union (no behavior change) |
| `apps/frontend/src/components/timeline/link-preview-card.tsx` | Video facade branch + `VideoPreviewContent`; exclude video from the GitHub-preview narrowing |
| `apps/frontend/src/components/image-gallery.tsx` | `video-embed` `GalleryItem` variant: fullscreen iframe + poster thumbnail |
| `apps/frontend/src/components/timeline/link-preview-card.test.tsx` | Facade renders poster, click mounts trusted iframe src, expand opens gallery |

## Out of scope (deliberate)

- **No CSP change needed.** No document-level `frame-src` CSP restricts third-party iframes — the backend helmet CSP governs only the API origin, and `frameguard` only controls whether *our* pages can be framed. Verified `index.html` and `workspace-router` carry no meta/edge CSP.
- **Twitch live channels** — only stable, previewable content (VODs and clips) is classified; a bare `twitch.tv/<channel>` live URL is not embedded.
- **No migration.** `preview_type`/`preview_data` are existing `TEXT`/`jsonb` columns (INV-3, no enum); `"video"` is a new value, not a schema change.

## Test plan

- [x] Backend `bun test src/features/link-previews/` — 182 pass (incl. new `video-preview.test.ts` + worker video cases)
- [x] Frontend `bunx vitest run link-preview-card.test.tsx` — 13 pass (3 new: facade / click-to-play / expand-to-gallery); gallery reopen + media-gallery-context regression suites pass
- [x] `bunx tsc --noEmit` clean across `packages/types`, `apps/backend`, `apps/frontend`
- [ ] No live-browser check of real provider embeds in this session — playback verified via jsdom (poster→iframe swap, trusted `src`), not against live YouTube/Vimeo/Loom/Twitch players

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXaAXyxETGPsbsuJa7QQtM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785525527&installation_id=129946197&pr_number=1129&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1129&signature=a8990511390e585d605cba5cef0c549d7d5807ae4f2808d806a445ffee6d883f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->