### PR TITLE
fix(pwa): announce updates to controller-swapped pages; bound the Reload click path

### DIFF
--- a/apps/frontend/src/hooks/use-app-update.test.ts
+++ b/apps/frontend/src/hooks/use-app-update.test.ts
@@ -4,8 +4,11 @@ import {
   isE2eBuild,
   reconcilePostReload,
   reloadForUpdate,
+  shouldAnnounceControllerSwap,
+  shouldAnnounceStalePage,
   shouldAnnounceWaiting,
   shouldRecoverForVersion,
+  CLICK_UPDATE_TIMEOUT_MS,
   RELOAD_FALLBACK_TIMEOUT_MS,
 } from "./use-app-update"
 import * as swRecovery from "@/lib/sw-recovery"
@@ -54,6 +57,46 @@ describe("shouldAnnounceWaiting", () => {
 
   it("announces again only for a genuinely newer build (a new waiting worker)", () => {
     expect(shouldAnnounceWaiting(workerB, workerA)).toBe(true)
+  })
+})
+
+describe("shouldAnnounceControllerSwap", () => {
+  it("announces when another client swapped the controller under this page", () => {
+    expect(shouldAnnounceControllerSwap({ hadController: true, hasController: true, reloadPending: false })).toBe(true)
+  })
+
+  it("stays silent on the first-ever install claiming the page", () => {
+    expect(shouldAnnounceControllerSwap({ hadController: false, hasController: true, reloadPending: false })).toBe(
+      false
+    )
+  })
+
+  it("stays silent when the SW was unregistered (recovery) — a reload follows", () => {
+    expect(shouldAnnounceControllerSwap({ hadController: true, hasController: false, reloadPending: false })).toBe(
+      false
+    )
+  })
+
+  it("stays silent for this tab's own Reload click — reloadForUpdate reloads already", () => {
+    expect(shouldAnnounceControllerSwap({ hadController: true, hasController: true, reloadPending: true })).toBe(false)
+  })
+})
+
+describe("shouldAnnounceStalePage", () => {
+  it("announces only on two known, differing versions not yet announced", () => {
+    expect(shouldAnnounceStalePage("a", "b", null)).toBe(true)
+    expect(shouldAnnounceStalePage("a", "a", null)).toBe(false)
+    expect(shouldAnnounceStalePage("a", null, null)).toBe(false)
+    expect(shouldAnnounceStalePage(null, "b", null)).toBe(false)
+    expect(shouldAnnounceStalePage(null, null, null)).toBe(false)
+  })
+
+  it("stays silent for a target version already announced this session", () => {
+    expect(shouldAnnounceStalePage("a", "b", "b")).toBe(false)
+  })
+
+  it("re-announces when an even newer version supersedes the announced one", () => {
+    expect(shouldAnnounceStalePage("a", "c", "b")).toBe(true)
   })
 })
 
@@ -230,6 +273,23 @@ describe("reloadForUpdate", () => {
     expect(recoverySpy).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(RELOAD_FALLBACK_TIMEOUT_MS)
+    expect(reloadSpy).toHaveBeenCalledOnce()
+    expect(recoverySpy).not.toHaveBeenCalled()
+  })
+
+  it("plain-reloads when the click-path update check hangs (stalled mobile network)", async () => {
+    // registration.update() has no timeout of its own — unbounded, a stalled
+    // network would leave the click looking dead. The bounded race must fall
+    // through to the offline-safe plain reload.
+    vi.useFakeTimers()
+    const registration = makeRegistration()
+    registration.update = vi.fn(() => new Promise(() => {})) as FakeRegistration["update"]
+    setServiceWorker(registration, { controller: {} })
+
+    const promise = reloadForUpdate()
+    await vi.advanceTimersByTimeAsync(CLICK_UPDATE_TIMEOUT_MS)
+    await promise
+
     expect(reloadSpy).toHaveBeenCalledOnce()
     expect(recoverySpy).not.toHaveBeenCalled()
   })

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -11,6 +11,7 @@ const IS_DEV = import.meta.env.DEV
 
 export const WAITING_WORKER_TIMEOUT_MS = 1500
 export const RELOAD_FALLBACK_TIMEOUT_MS = 3000
+export const CLICK_UPDATE_TIMEOUT_MS = 5000
 
 // The build version baked into this bundle at build time (vite `define`). The
 // running app otherwise has no idea which build it is, so it can't tell whether a
@@ -109,7 +110,11 @@ async function findWaitingWorker(registration: ServiceWorkerRegistration): Promi
   if (registration.waiting || alreadyInstalling) return registration.waiting ?? alreadyInstalling
 
   try {
-    await registration.update()
+    // update() has no timeout of its own; on a stalled mobile network the
+    // awaited click would look dead for as long as the browser waits. Bound it
+    // and fall through — a plain reload is offline-safe, and reconcilePostReload
+    // catches a reload that landed stale.
+    await Promise.race([registration.update(), new Promise((resolve) => setTimeout(resolve, CLICK_UPDATE_TIMEOUT_MS))])
   } catch {
     return null
   }
@@ -199,15 +204,7 @@ export function shouldAnnounceWaiting(
   return Boolean(waiting) && waiting !== announced
 }
 
-/**
- * Surface the update toast for a build that has finished downloading and is
- * parked in `registration.waiting`. Gated by `shouldAnnounceWaiting`, so Reload
- * is always a one-click, already-local activation.
- */
-function announceIfWaiting(registration: ServiceWorkerRegistration): void {
-  const waiting = registration.waiting
-  if (!shouldAnnounceWaiting(waiting, announcedWaiting)) return
-  announcedWaiting = waiting
+function showUpdateToast(): void {
   if (isE2eBuild()) return
   toast("A new version of Threa is available", {
     id: TOAST_ID,
@@ -217,6 +214,79 @@ function announceIfWaiting(registration: ServiceWorkerRegistration): void {
       onClick: () => void reloadForUpdate(),
     },
   })
+}
+
+/**
+ * Surface the update toast for a build that has finished downloading and is
+ * parked in `registration.waiting`. Gated by `shouldAnnounceWaiting`, so Reload
+ * is always a one-click, already-local activation.
+ */
+function announceIfWaiting(registration: ServiceWorkerRegistration): void {
+  const waiting = registration.waiting
+  if (!shouldAnnounceWaiting(waiting, announcedWaiting)) return
+  announcedWaiting = waiting
+  showUpdateToast()
+}
+
+/**
+ * Whether a controllerchange event means another client activated a new build
+ * under this page, which should be announced. Not announced:
+ * - `hadController` false: the first-ever install claiming the page — the page
+ *   already runs the build that worker serves.
+ * - `hasController` false: the SW was unregistered (recovery) — a reload follows.
+ * - `reloadPending`: this tab's own Reload click; reloadForUpdate is about to
+ *   reload onto the new build already.
+ */
+export function shouldAnnounceControllerSwap(opts: {
+  hadController: boolean
+  hasController: boolean
+  reloadPending: boolean
+}): boolean {
+  return opts.hadController && opts.hasController && !opts.reloadPending
+}
+
+// The server build version we've already shown the stale-page toast for, so a
+// persistent skew doesn't re-toast a dismissed announce on every poll. Module
+// state for the same lifetime reasons as announcedWaiting.
+let announcedStaleVersion: string | null = null
+
+/**
+ * Whether to announce that this page itself is the stale artifact: both
+ * versions known and different, and not already announced for this target.
+ */
+export function shouldAnnounceStalePage(
+  current: string | null,
+  latest: string | null,
+  announced: string | null
+): boolean {
+  return Boolean(current && latest && current !== latest && latest !== announced)
+}
+
+/**
+ * Announce when the running page is the stale artifact — the complement of the
+ * parked-worker announce. After another client activates a new build (its
+ * Reload ran skipWaiting), clients.claim() re-points this page at the new
+ * worker but the JS heap keeps running the old build, and no worker will ever
+ * park in `waiting` again — update() finds the server's sw.js already active.
+ * Without this, such a page stays silently stale until a lazy chunk 404s into
+ * the cache-wipe recovery. The controllerchange listener announces this
+ * instantly when the event is delivered; this check is the safety net for the
+ * platforms that drop it (iOS standalone) and for pages frozen through the swap.
+ *
+ * Only runs when nothing is installing or waiting: a genuinely newer server
+ * build announces through the parked-worker path once downloaded. That gate is
+ * what separates this from the premature version.json-delta toast this codebase
+ * removed — here the new build's precache is already the active one, so Reload
+ * is still an instant local activation (plain reload, nothing parked).
+ */
+async function announceIfPageStale(registration: ServiceWorkerRegistration): Promise<void> {
+  if (registration.waiting || registration.installing) return
+  const latest = await fetchLatestVersion()
+  if (!shouldAnnounceStalePage(currentAppVersion(), latest, announcedStaleVersion)) return
+  // A worker that started installing during the fetch owns the announce.
+  if (registration.waiting || registration.installing) return
+  announcedStaleVersion = latest
+  showUpdateToast()
 }
 
 /** This bundle's build version, or null if the `define` wasn't applied (e.g. some test envs). */
@@ -321,6 +391,7 @@ export function useAppUpdate(): void {
     // escalates to recovery instead of re-announcing the same build.
     if (await reconcileOnce()) return
     announceIfWaiting(registration)
+    await announceIfPageStale(registration)
   }, [reconcileOnce])
 
   // Announce a build that finishes installing between checks: the browser may
@@ -328,9 +399,29 @@ export function useAppUpdate(): void {
   // completing), so listen for the install rather than only polling.
   useEffect(() => {
     if (IS_DEV) return
+    const sw = navigator.serviceWorker
+    if (!sw) return
     let disposed = false
     let cleanup: (() => void) | null = null
-    void navigator.serviceWorker?.getRegistration().then(async (registration) => {
+    // A controller swap this tab didn't request means another client (a second
+    // tab, or the installed PWA next to a browser tab) activated a new build
+    // under us. This page keeps running its old JS, and since the new build is
+    // already active no worker will ever park in `waiting` for it again — so
+    // announce here, the only signal this page gets. Reload then takes the
+    // plain-reload path (controller exists, nothing parked) and lands the
+    // already-active build, offline included.
+    let hadController = Boolean(sw.controller)
+    const onControllerChange = () => {
+      const announce = shouldAnnounceControllerSwap({
+        hadController,
+        hasController: Boolean(sw.controller),
+        reloadPending: reloadRecentlyAttempted(),
+      })
+      hadController = Boolean(sw.controller)
+      if (announce) showUpdateToast()
+    }
+    sw.addEventListener("controllerchange", onControllerChange)
+    void sw.getRegistration().then(async (registration) => {
       if (!registration || disposed) return
       // A prior Reload click that didn't swap in new code escalates to recovery
       // here; a reload follows, so don't announce on top of it.
@@ -367,6 +458,7 @@ export function useAppUpdate(): void {
     })
     return () => {
       disposed = true
+      sw.removeEventListener("controllerchange", onControllerChange)
       cleanup?.()
     }
   }, [reconcileOnce])

--- a/apps/frontend/src/hooks/use-app-update.ts
+++ b/apps/frontend/src/hooks/use-app-update.ts
@@ -281,6 +281,13 @@ export function shouldAnnounceStalePage(
  */
 async function announceIfPageStale(registration: ServiceWorkerRegistration): Promise<void> {
   if (registration.waiting || registration.installing) return
+  // Only while a controller is serving this page: the announce's premise is
+  // that Reload is an instant local activation onto the already-active
+  // precache. An uncontrolled page has no precache to land on — its version
+  // mismatch is a stale server response, not an SW update, and a toast here
+  // would route a later (possibly offline) click into reloadOrRecover's
+  // no-controller branch: a cache wipe not proven online at wipe time.
+  if (!navigator.serviceWorker?.controller) return
   const latest = await fetchLatestVersion()
   if (!shouldAnnounceStalePage(currentAppVersion(), latest, announcedStaleVersion)) return
   // A worker that started installing during the fetch owns the announce.

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -80,10 +80,10 @@ import { useNotificationAccountSwitch } from "./use-notification-account-switch"
 
 /**
  * How long the tab must be backgrounded before a resume triggers the engine's
- * socket probe + catch-up. Tighter than `useAppUpdate`'s 10s version-check
- * window: a few seconds away is enough for socket events to be missed (a
- * notification-shade peek that delivered a push, a quick app switch), and the
- * resume path is cheap in active mode (cursor catch-up + per-stream deltas).
+ * socket probe + catch-up. A few seconds away is enough for socket events to
+ * be missed (a notification-shade peek that delivered a push, a quick app
+ * switch), and the resume path is cheap in active mode (cursor catch-up +
+ * per-stream deltas).
  */
 const PAGE_RESUME_THRESHOLD_MS = 5_000
 


### PR DESCRIPTION
## Problem

The update toast (`useAppUpdate` in `apps/frontend/src/hooks/use-app-update.ts`) announces a new build only when a new service worker is parked in `registration.waiting`. That gate is what made Reload trustworthy as a one-click local activation (#1081, #1095) — but it leaves a whole class of clients with no announcement at all: pages whose **controller was swapped under them**.

Concretely: with two clients open (a second browser tab, or — the mobile case — the installed PWA alongside a browser tab, since links open in the browser), one client clicks Reload. `skipWaiting` + `clients.claim()` re-point *every* open page at the new worker, but the other pages keep running their old JS. From then on no worker will ever park in `waiting` for them again — `registration.update()` finds the server's sw.js already active — so `checkForUpdate` stays silent forever. The page runs stale code until a lazy route chunk 404s (its hashed filename is gone from the new precache) and falls into the cache-wipe recovery. That is the "Reload button isn't trustworthy anymore" symptom: updates land cleanly in one client and silently strand the others.

Two smaller gaps in the same path:

- On the Reload-click path, `findWaitingWorker` awaits `registration.update()` with no bound. On a stalled mobile network the click dismisses the toast and then visibly does nothing for as long as the browser waits.
- A comment in `workspace-layout.tsx` referenced `useAppUpdate`'s "10s version-check window", which no longer exists.

## Solution

Give a controller-swapped page its own announcement, on two complementary signals, and keep every Reload outcome inside the existing offline-safe reload/reconcile machinery.

### How it works

1. **`controllerchange` announce (instant, works offline).** The mount effect in `useAppUpdate` now listens for `controllerchange`. `shouldAnnounceControllerSwap` gates it: announce only when the page *had* a controller (not the first-ever install claiming the page), *still has* one (not the recovery unregister), and this tab didn't itself just click Reload (`reloadRecentlyAttempted()` — `reloadForUpdate` is about to reload it anyway). The toast's Reload then takes the existing plain-reload path — controller exists, nothing parked — and lands the already-active build, offline included.
2. **Stale-page version check (safety net).** `announceIfPageStale`, called from `checkForUpdate` after the parked-worker announce: when nothing is `installing` or `waiting` after `registration.update()` **and a controller is serving the page**, fetch `/version.json` and toast if it differs from the baked `__APP_VERSION__`. This covers the platforms that drop `controllerchange` (iOS standalone — already documented in this file for the Reload path) and pages frozen through the swap. Deduped per announced server version via module state (`announcedStaleVersion`), so a dismissed toast doesn't re-toast on every 5-minute poll.
3. **Bounded click-path update check.** `findWaitingWorker` races `registration.update()` against `CLICK_UPDATE_TIMEOUT_MS` (5s). On timeout it falls through to the plain reload; if that lands stale, the existing `reconcilePostReload` catches it on the next boot.

Both new announce paths reuse the one toast (`showUpdateToast`, extracted from `announceIfWaiting`) — same `TOAST_ID`, same Reload action, same E2E-build suppression.

### Key design decisions

**1. This is not the premature version.json-delta toast that #1081 removed.** That toast fired on a server-ahead version before the new build was downloaded, making Reload a race against an in-flight precache. `announceIfPageStale` only runs when nothing is installing or waiting *after* `update()` ran — a genuinely newer server build starts installing and announces through the parked-worker path instead. In the stale-page case the new build's precache is already the *active* one, so Reload stays an instant local activation. The gate is re-checked after the version fetch so a worker that started installing mid-fetch keeps ownership of the announce.

**2. Toast, never auto-reload, for swapped-under pages.** vite-plugin-pwa's `autoUpdate` convention reloads all clients on `controllerchange`. Rejected: an unrequested reload of a visible page can eat in-progress user state, and the whole point of this design (per #1081/#1095) is user-consented reloads. A parked toast (duration `Infinity`) is there when a backgrounded PWA client is resumed.

**3. Accepted residual: a silently failed `update()` plus a successful version fetch can toast a page whose SW never downloaded the new build.** Reload then plain-reloads onto the old shell, and `reconcilePostReload` escalates to the forced recovery — which is online by proof (the version fetch succeeded) and lands the new build. Converges in one extra hop; guarding against it would mean threading `update()` success state through for a case where recovery is the right tool anyway.

**4. Design evolution (self-review): the stale-page announce requires a controller.** The initial version could toast on an *uncontrolled* page whose version mismatched — the one spot where a later (possibly offline) Reload click could route into `reloadOrRecover`'s no-controller branch and wipe caches without an online proof at wipe time. The announce's premise is "Reload is an instant local activation onto the already-active precache", which only holds under a controller; `announceIfPageStale` now returns early without one (commit 2). An uncontrolled page's mismatch is a stale server response, not an SW update.

**5. Cost: one extra `/version.json` GET per update check** (5-minute poll / tab-visible / socket reconnect) for up-to-date clients. Same order as the sw.js byte-check `registration.update()` already performs on each of those triggers; the response is ~30 bytes, `cache: "no-store"`.

## Audit notes (what was checked and found sound)

This PR came out of a full audit of the update path, prompted by post-#1095 trust concerns. Verified sound, no changes needed: the parked-worker announce lifecycle (identity-keyed dedup across `AppUpdateChecker` remounts), `reloadForUpdate`'s skipWaiting → `controllerchange` → reload with the 3s iOS fallback, `reconcilePostReload`'s single-shot sessionStorage flag with the shared in-flight promise, the offline-first recovery gating (`shouldRecoverForVersion` requires two known differing versions), the build-atomic precached shell navigation in `sw.ts`, `updateViaCache: "none"` + the `/*` no-cache / `/assets/*` immutable header split, and `/version.json` / `/sw.js` / `/recover` staying outside every SW route.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-app-update.ts` | `controllerchange` announce (`shouldAnnounceControllerSwap`), stale-page announce (`announceIfPageStale`, `shouldAnnounceStalePage`, `announcedStaleVersion`), 5s bound on the click-path `registration.update()`, `showUpdateToast` extraction |
| `apps/frontend/src/hooks/use-app-update.test.ts` | Tests for both new gates and the bounded click-path update (hung-network → plain reload, never recovery) |
| `apps/frontend/src/pages/workspace-layout.tsx` | Drop stale comment reference to a removed "10s version-check window" |

## Out of scope (deliberate)

- **Auto-reloading hidden/backgrounded clients** on controller swap — would remove even the one tap, but risks losing unpersisted state; revisit if the toast-on-resume proves annoying in practice.
- **Re-announcing a swipe-dismissed toast within the same page lifetime** — existing once-per-session-per-build behavior kept (it re-surfaces on the next real launch).
- **E2E coverage of the SW update lifecycle** — the Playwright build deliberately precaches nothing and suppresses the toast (#1128), so this stays unit-tested.

## Test plan

- [x] `bun run test src/hooks/use-app-update.test.ts` — 28 pass (10 new)
- [x] Full frontend unit suite `bun run test` — 3404 pass
- [x] `tsc --noEmit` frontend clean; pre-commit ran monorepo-wide lint + typecheck, all green
- [x] Pre-PR review (1 reviewer agent over the full final file + SW/recovery interactions): no real bugs; 1 edge hardened (uncontrolled-page stale announce → controller guard, commit 2), 2 edges accepted and documented here (dismissed swap-toast re-raised once by the safety net; a swap during another tab's 60s reload window defers to the next check), 3 nits accepted (stray race timer, private-mode toast flash, added version.json chatter)
- [ ] Manual two-client swap on a deployed preview (browser tab + installed PWA) — no deployed environment in this session; the swap mechanics are exercised by the unit gates and the unchanged reload/reconcile paths

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ9bA7h2pr3etpkLyUQXrr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785536223&installation_id=129946197&pr_number=1132&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1132&signature=6367c953bbb98fac85e802e422a361599c6ed305bcc6a4ab6f3364e382d6fab8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->