### PR TITLE
fix(sync): account-correct SW push prefetch, HTTP-first resume delta, bounded deep-link skeleton

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react"
 import type { QueryClient } from "@tanstack/react-query"
 import { API_BASE } from "@/api/client"
-import { ThreaDatabase } from "@/db"
+import { ThreaDatabase, accountDbName } from "@/db"
 // Imported from the module directly, not the @/db barrel: AccountScope is the
 // sole writer of the active-db pointer, so the mutator is intentionally kept
 // off the shared barrel (INV-9 — single-owner scope bridge).
@@ -110,7 +110,7 @@ export function AccountScopeProvider({ children }: AccountScopeProviderProps) {
   const resolveDb = useCallback((id: string): ThreaDatabase => {
     let inst = dbRegistry.current.get(id)
     if (!inst) {
-      inst = new ThreaDatabase(`threa_${id}`)
+      inst = new ThreaDatabase(accountDbName(id))
       dbRegistry.current.set(id, inst)
     }
     return inst

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   classifyDeepLinkScrollTick,
   shouldStartHighlightClear,
+  shouldHoldForDeepLink,
   canActOnDeepLinkNavigation,
   computeScrollEdges,
   shouldPrefetchOlderHistory,
@@ -157,6 +158,48 @@ describe("shouldStartHighlightClear", () => {
         deepLinkGaveUp: true,
       })
     ).toBe(true)
+  })
+})
+
+describe("shouldHoldForDeepLink", () => {
+  const base = {
+    highlightMessageId: "msg_1" as string | null,
+    deepLinkTargetLoaded: false,
+    deepLinkGaveUp: false,
+    holdExpired: false,
+    isLoading: false,
+    isConfirmedEmpty: false,
+    hasEvents: true,
+  }
+
+  it("holds while the target is being fetched into the window", () => {
+    expect(shouldHoldForDeepLink(base)).toBe(true)
+  })
+
+  it("releases when the hold expires so a slow jump shows the cached window instead of a skeleton", () => {
+    // The regression guard for the bound: a cold push-open whose events-around
+    // fetch is slow must not sit on a skeleton indefinitely — past
+    // DEEP_LINK_HOLD_MAX_MS the cached timeline paints and the jump snaps to
+    // the target when it lands.
+    expect(shouldHoldForDeepLink({ ...base, holdExpired: true })).toBe(false)
+  })
+
+  it("releases when the target lands in the loaded window", () => {
+    expect(shouldHoldForDeepLink({ ...base, deepLinkTargetLoaded: true })).toBe(false)
+  })
+
+  it("releases when the jump conclusively fails", () => {
+    expect(shouldHoldForDeepLink({ ...base, deepLinkGaveUp: true })).toBe(false)
+  })
+
+  it("never holds without a highlight target", () => {
+    expect(shouldHoldForDeepLink({ ...base, highlightMessageId: null })).toBe(false)
+  })
+
+  it("defers to the loading skeleton and empty states while the window itself is unresolved", () => {
+    expect(shouldHoldForDeepLink({ ...base, isLoading: true })).toBe(false)
+    expect(shouldHoldForDeepLink({ ...base, isConfirmedEmpty: true })).toBe(false)
+    expect(shouldHoldForDeepLink({ ...base, hasEvents: false })).toBe(false)
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1869,11 +1869,14 @@ export function StreamContent({
     hasEvents: events.length > 0,
   })
 
+  // Keyed on the target too: a second ?m= navigation arriving while the first
+  // hold is still up must get its own full window, not the remainder of the
+  // previous target's.
   useEffect(() => {
-    if (!holdForDeepLink) return
+    if (!holdForDeepLink || !highlightMessageId) return
     const timer = setTimeout(() => setDeepLinkHoldExpired(true), DEEP_LINK_HOLD_MAX_MS)
     return () => clearTimeout(timer)
-  }, [holdForDeepLink])
+  }, [holdForDeepLink, highlightMessageId])
 
   const prevHoldForDeepLinkRef = useRef(holdForDeepLink)
   if (prevHoldForDeepLinkRef.current !== holdForDeepLink) {

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -178,6 +178,39 @@ export function shouldStartHighlightClear(args: {
 }
 
 /**
+ * Max time the deep-link (?m=) mount hold may keep the skeleton up while the
+ * jump window is fetched. The hold exists so a fast fetch mounts the list
+ * already anchored on the target (no tail-paint-then-yank), and the push
+ * prefetch usually has the target in IDB already — so within this bound the
+ * hold is invisible. Past it, a skeleton is strictly worse than showing the
+ * cached timeline: release, paint the window we have, and let the jump swap
+ * anchor/highlight the target when it lands.
+ */
+export const DEEP_LINK_HOLD_MAX_MS = 600
+
+/**
+ * Whether the timeline should keep showing the skeleton while a deep-link
+ * (?m=) target is fetched into the window. Holds only while there is real
+ * cached content that would otherwise paint at the wrong anchor, and never
+ * past `DEEP_LINK_HOLD_MAX_MS` (`holdExpired`), never after the target loaded,
+ * and never after the jump conclusively failed.
+ */
+export function shouldHoldForDeepLink(args: {
+  highlightMessageId: string | null | undefined
+  deepLinkTargetLoaded: boolean
+  deepLinkGaveUp: boolean
+  holdExpired: boolean
+  isLoading: boolean
+  isConfirmedEmpty: boolean
+  hasEvents: boolean
+}): boolean {
+  if (!args.highlightMessageId || args.deepLinkTargetLoaded || args.deepLinkGaveUp || args.holdExpired) {
+    return false
+  }
+  return !args.isLoading && !args.isConfirmedEmpty && args.hasEvents
+}
+
+/**
  * Whether the deep-link / search highlight effect may claim a navigation and
  * act on it this render. The event window must have hydrated first: on a cold
  * open `isLoading` can read false while `events` is still empty (the IDB
@@ -347,6 +380,10 @@ export function StreamContent({
   // access / fetch failed). Releases the deep-link mount hold so the timeline
   // falls back to the loaded window instead of holding the skeleton forever.
   const [deepLinkGaveUp, setDeepLinkGaveUp] = useState(false)
+  // Set when the deep-link mount hold has been up for DEEP_LINK_HOLD_MAX_MS
+  // without the target landing — releases the skeleton in favor of the cached
+  // window while the jump keeps working. Re-armed with deepLinkGaveUp.
+  const [deepLinkHoldExpired, setDeepLinkHoldExpired] = useState(false)
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [batchMode, setBatchMode] = useState(false)
@@ -1512,6 +1549,7 @@ export function StreamContent({
     // Fresh navigation: re-arm the mount hold for this target and clear any
     // prior manual-control stamp so the refine loop is allowed to run.
     setDeepLinkGaveUp(false)
+    setDeepLinkHoldExpired(false)
     userInteractedAtRef.current = 0
 
     // Disable auto-scroll so highlight scroll-into-view isn't overridden
@@ -1565,6 +1603,7 @@ export function StreamContent({
     }
     pendingScrollTarget.current = null
     setDeepLinkGaveUp(false)
+    setDeepLinkHoldExpired(false)
     userInteractedAtRef.current = 0
     exitJumpMode()
     setIsSearchOpen(false)
@@ -1809,21 +1848,32 @@ export function StreamContent({
   // makes the single keyed mount land already-anchored on it (the pre-paint
   // centering jump needs the target row to exist at mount). Uses the
   // raw ?m= id (not the search-active id) so in-stream search is unaffected,
-  // and releases when the target loads (deepLinkTargetLoaded) or the jump
-  // conclusively fails (deepLinkGaveUp) so it never hangs.
+  // and releases when the target loads (deepLinkTargetLoaded), the jump
+  // conclusively fails (deepLinkGaveUp), or the hold has been up for
+  // DEEP_LINK_HOLD_MAX_MS (deepLinkHoldExpired) — past that bound a skeleton
+  // reads worse than painting the cached window and snapping to the target
+  // when the jump lands.
   const deepLinkTargetLoaded = useMemo(
     () =>
       !highlightMessageId ||
       events.some((e) => (e.payload as { messageId?: string })?.messageId === highlightMessageId),
     [events, highlightMessageId]
   )
-  const holdForDeepLink =
-    !!highlightMessageId &&
-    !deepLinkTargetLoaded &&
-    !deepLinkGaveUp &&
-    !isLoading &&
-    !isConfirmedEmpty &&
-    events.length > 0
+  const holdForDeepLink = shouldHoldForDeepLink({
+    highlightMessageId,
+    deepLinkTargetLoaded,
+    deepLinkGaveUp,
+    holdExpired: deepLinkHoldExpired,
+    isLoading,
+    isConfirmedEmpty,
+    hasEvents: events.length > 0,
+  })
+
+  useEffect(() => {
+    if (!holdForDeepLink) return
+    const timer = setTimeout(() => setDeepLinkHoldExpired(true), DEEP_LINK_HOLD_MAX_MS)
+    return () => clearTimeout(timer)
+  }, [holdForDeepLink])
 
   const prevHoldForDeepLinkRef = useRef(holdForDeepLink)
   if (prevHoldForDeepLinkRef.current !== holdForDeepLink) {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -1238,6 +1238,15 @@ export class ThreaDatabase extends Dexie {
 // which have no account yet) keep working unchanged.
 let activeDb: ThreaDatabase = new ThreaDatabase("threa")
 
+// Single source of truth for the per-account database name (INV-33). The main
+// thread (AccountScope) and the service worker's push prefetch open the same
+// IndexedDB independently — they only meet if they derive the name from the
+// same place. The argument is the WorkOS user id (the auth identity), which is
+// also what push payloads carry as `workosUserId`.
+export function accountDbName(workosUserId: string): string {
+  return `threa_${workosUserId}`
+}
+
 /** AccountScope-only: point the shared `db` proxy at an account's instance. */
 export function setActiveDb(instance: ThreaDatabase): void {
   activeDb = instance

--- a/apps/frontend/src/db/index.ts
+++ b/apps/frontend/src/db/index.ts
@@ -1,6 +1,7 @@
 export {
   db,
   ThreaDatabase,
+  accountDbName,
   clearAllCachedData,
   clearPendingMessages,
   sequenceToNum,

--- a/apps/frontend/src/hooks/use-background-bootstrap-sync.test.tsx
+++ b/apps/frontend/src/hooks/use-background-bootstrap-sync.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from "@testing-library/react"
 import { createElement, type ReactNode } from "react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { useBackgroundBootstrapSync } from "./use-background-bootstrap-sync"
+import * as accountScope from "@/auth/account-scope"
 import { SW_MSG_QUEUE_BOOTSTRAP_SYNC } from "@/lib/sw-messages"
 
 let visibilityState: DocumentVisibilityState = "visible"
@@ -48,6 +49,7 @@ describe("useBackgroundBootstrapSync", () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     if (originalVisibilityState) {
       Object.defineProperty(document, "visibilityState", originalVisibilityState)
     } else {
@@ -71,6 +73,26 @@ describe("useBackgroundBootstrapSync", () => {
       type: SW_MSG_QUEUE_BOOTSTRAP_SYNC,
       workspaceId: "ws_1",
       streamId: "stream_1",
+      workosUserId: null,
+    })
+  })
+
+  it("carries the active account id so the SW can open the per-account database", () => {
+    vi.spyOn(accountScope, "useAccountScopeOptional").mockReturnValue({
+      activeWorkosUserId: "user_workos_1",
+    } as ReturnType<typeof accountScope.useAccountScopeOptional>)
+
+    renderHook(() => useBackgroundBootstrapSync(), {
+      wrapper: makeWrapper("/w/ws_1/s/stream_1"),
+    })
+
+    act(() => setVisibility("hidden"))
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: SW_MSG_QUEUE_BOOTSTRAP_SYNC,
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      workosUserId: "user_workos_1",
     })
   })
 
@@ -85,6 +107,7 @@ describe("useBackgroundBootstrapSync", () => {
       type: SW_MSG_QUEUE_BOOTSTRAP_SYNC,
       workspaceId: "ws_1",
       streamId: null,
+      workosUserId: null,
     })
   })
 

--- a/apps/frontend/src/hooks/use-background-bootstrap-sync.ts
+++ b/apps/frontend/src/hooks/use-background-bootstrap-sync.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { useParams } from "react-router-dom"
+import { useAccountScopeOptional } from "@/auth/account-scope"
 import { SW_MSG_QUEUE_BOOTSTRAP_SYNC } from "@/lib/sw-messages"
 
 /**
@@ -7,6 +8,11 @@ import { SW_MSG_QUEUE_BOOTSTRAP_SYNC } from "@/lib/sw-messages"
  * focus, so the SW can prefetch the workspace + active stream bootstrap while
  * the tab is closed. The `sync` event in the SW retries on network failure,
  * which the inline fetch path can't do.
+ *
+ * The message carries the active account's WorkOS user id because the SW has
+ * no AccountScope: it needs the id to open the per-account IndexedDB
+ * (accountDbName) that the app actually reads. Without it the SW skips the
+ * IDB half of the prefetch.
  *
  * Browsers without a controller (first ever load before activation) or without
  * Background Sync support no-op; the resume hook still catches up on next
@@ -16,6 +22,7 @@ import { SW_MSG_QUEUE_BOOTSTRAP_SYNC } from "@/lib/sw-messages"
  */
 export function useBackgroundBootstrapSync(): void {
   const { workspaceId, streamId } = useParams<{ workspaceId: string; streamId?: string }>()
+  const workosUserId = useAccountScopeOptional()?.activeWorkosUserId ?? null
 
   useEffect(() => {
     if (!workspaceId) return
@@ -28,10 +35,11 @@ export function useBackgroundBootstrapSync(): void {
         type: SW_MSG_QUEUE_BOOTSTRAP_SYNC,
         workspaceId,
         streamId: streamId ?? null,
+        workosUserId,
       })
     }
 
     document.addEventListener("visibilitychange", onVisibilityChange)
     return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [workspaceId, streamId])
+  }, [workspaceId, streamId, workosUserId])
 }

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
@@ -157,4 +157,10 @@ describe("parsePersistedSyncTarget", () => {
     expect(parsePersistedSyncTarget(null)).toBeNull()
     expect(parsePersistedSyncTarget("junk")).toBeNull()
   })
+
+  it("rejects entries whose optional fields are not strings", () => {
+    expect(parsePersistedSyncTarget({ workspaceId: "ws_1", streamId: 42 })).toBeNull()
+    expect(parsePersistedSyncTarget({ workspaceId: "ws_1", messageId: {} })).toBeNull()
+    expect(parsePersistedSyncTarget({ workspaceId: "ws_1", workosUserId: ["user_1"] })).toBeNull()
+  })
 })

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { StreamEvent } from "@threa/types"
+import { ThreaDatabase, accountDbName, db } from "@/db"
+import { parsePersistedSyncTarget, runBootstrapSync } from "./sw-bootstrap-prefetch"
+
+// The SW has no AccountScope, so the prefetch must open the per-account
+// database (accountDbName) explicitly — writing through the default `db` proxy
+// lands in the pre-auth "threa" database the signed-in app never reads. These
+// tests are the regression guard for that account routing.
+
+function makeEvent(overrides: Partial<StreamEvent> & { id: string; streamId: string; sequence: string }): StreamEvent {
+  return {
+    eventType: "message_created",
+    payload: { messageId: overrides.id, contentMarkdown: "hello" },
+    actorId: "user_1",
+    actorType: "user",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  } as StreamEvent
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+/**
+ * Mock fetch per-path. The workspace bootstrap URL answers 404 so
+ * prefetchWorkspaceBootstrap returns before touching the Cache API (jsdom has
+ * no CacheStorage); its cache-write path is unchanged by this refactor.
+ */
+function mockFetch(routes: Record<string, unknown>): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    for (const [fragment, data] of Object.entries(routes)) {
+      if (url.includes(fragment)) return jsonResponse(data)
+    }
+    return new Response(null, { status: 404 })
+  })
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("runBootstrapSync account routing", () => {
+  it("writes stream bootstrap events into the account's database, not the default one", async () => {
+    const workosUserId = "user_acct_route"
+    const streamId = "stream_route1"
+    mockFetch({
+      [`/streams/${streamId}/bootstrap`]: {
+        stream: { id: streamId, workspaceId: "ws_1", type: "channel", slug: "general" },
+        events: [
+          makeEvent({ id: "evt_1", streamId, sequence: "1" }),
+          makeEvent({ id: "evt_2", streamId, sequence: "2" }),
+        ],
+      },
+    })
+
+    await runBootstrapSync({ workspaceId: "ws_1", streamId, messageId: null, workosUserId })
+
+    const accountDb = new ThreaDatabase(accountDbName(workosUserId))
+    const accountEvents = await accountDb.events.where("streamId").equals(streamId).toArray()
+    expect(accountEvents.map((e) => e.id).sort()).toEqual(["evt_1", "evt_2"])
+    expect(accountEvents[0].workspaceId).toBe("ws_1")
+    expect(accountEvents[0]._sequenceNum).toBe(1)
+
+    // The default (pre-auth) database the signed-in app never reads must stay
+    // untouched — writing there is exactly the bug this guards against.
+    const defaultEvents = await db.events.where("streamId").equals(streamId).toArray()
+    expect(defaultEvents).toEqual([])
+  })
+
+  it("writes events-around results for the pushed message into the account's database", async () => {
+    const workosUserId = "user_acct_around"
+    const streamId = "stream_around1"
+    mockFetch({
+      [`/streams/${streamId}/bootstrap`]: {
+        stream: { id: streamId, workspaceId: "ws_1", type: "channel", slug: "general" },
+        events: [makeEvent({ id: "evt_old", streamId, sequence: "1" })],
+      },
+      "/events/around": {
+        events: [makeEvent({ id: "evt_pushed", streamId, sequence: "9" })],
+      },
+    })
+
+    await runBootstrapSync({ workspaceId: "ws_1", streamId, messageId: "evt_pushed", workosUserId })
+
+    const accountDb = new ThreaDatabase(accountDbName(workosUserId))
+    const events = await accountDb.events.where("streamId").equals(streamId).toArray()
+    expect(events.map((e) => e.id).sort()).toEqual(["evt_old", "evt_pushed"])
+  })
+
+  it("merges onto an existing stream row instead of clobbering it", async () => {
+    const workosUserId = "user_acct_merge"
+    const streamId = "stream_merge1"
+    const accountDb = new ThreaDatabase(accountDbName(workosUserId))
+    await accountDb.streams.put({
+      id: streamId,
+      workspaceId: "ws_1",
+      type: "channel",
+      slug: "general",
+      notificationLevel: "mentions",
+      _cachedAt: 1,
+    } as never)
+
+    mockFetch({
+      [`/streams/${streamId}/bootstrap`]: {
+        stream: { id: streamId, workspaceId: "ws_1", type: "channel", slug: "general" },
+        events: [makeEvent({ id: "evt_m1", streamId, sequence: "3" })],
+      },
+    })
+
+    await runBootstrapSync({ workspaceId: "ws_1", streamId, messageId: null, workosUserId })
+
+    const row = (await accountDb.streams.get(streamId)) as { notificationLevel?: string; lastMessagePreview?: unknown }
+    expect(row.notificationLevel).toBe("mentions")
+    expect(row.lastMessagePreview).toMatchObject({ authorId: "user_1" })
+  })
+
+  it("skips all IndexedDB writes when the target carries no account id", async () => {
+    const streamId = "stream_noacct1"
+    const fetchMock = mockFetch({
+      [`/streams/${streamId}/bootstrap`]: {
+        stream: { id: streamId, workspaceId: "ws_1", type: "channel", slug: "general" },
+        events: [makeEvent({ id: "evt_n1", streamId, sequence: "1" })],
+      },
+    })
+
+    await runBootstrapSync({ workspaceId: "ws_1", streamId, messageId: "evt_n1", workosUserId: null })
+
+    const defaultEvents = await db.events.where("streamId").equals(streamId).toArray()
+    expect(defaultEvents).toEqual([])
+    // The stream endpoints are never even fetched; only the (account-agnostic)
+    // workspace bootstrap warm-up runs.
+    const fetchedUrls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(fetchedUrls).toEqual(["/api/workspaces/ws_1/bootstrap"])
+  })
+})
+
+describe("parsePersistedSyncTarget", () => {
+  it("normalizes a legacy target persisted without workosUserId", () => {
+    expect(parsePersistedSyncTarget({ workspaceId: "ws_1", streamId: "stream_1", messageId: null })).toEqual({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      messageId: null,
+      workosUserId: null,
+    })
+  })
+
+  it("rejects entries with no workspace id", () => {
+    expect(parsePersistedSyncTarget({ streamId: "stream_1" })).toBeNull()
+    expect(parsePersistedSyncTarget(null)).toBeNull()
+    expect(parsePersistedSyncTarget("junk")).toBeNull()
+  })
+})

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -1,0 +1,262 @@
+import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
+import type { ThreaDatabase } from "../db/database"
+
+// Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
+// (stream: IndexedDB; workspace: the Cache API entry served by the SW fetch
+// interceptor). Lives outside sw.ts so unit tests can drive it without a
+// ServiceWorkerGlobalScope; sw.ts wires it to the push/message/sync events.
+
+/** Cache name for pre-fetched workspace bootstrap responses triggered by push or background sync. */
+export const PUSH_BOOTSTRAP_CACHE = "push-bootstrap"
+
+/** Cache name used to persist pending Background Sync targets across SW restarts. */
+export const PENDING_SYNC_CACHE = "pending-sync"
+
+/** Single sync tag for bootstrap refresh — browsers coalesce repeat registrations under the same tag. */
+export const BOOTSTRAP_SYNC_TAG = "threa-bootstrap-refresh"
+
+/** Cache key for the persisted sync target. Last write wins; only the most recent target is replayed. */
+export const PENDING_SYNC_KEY = `/_sync/${BOOTSTRAP_SYNC_TAG}`
+
+/** Regex matching workspace bootstrap API paths. */
+export const WORKSPACE_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/bootstrap$/
+
+export interface BootstrapSyncTarget {
+  workspaceId: string
+  streamId: string | null
+  messageId: string | null
+  /**
+   * Recipient account's WorkOS user id — selects the per-account IndexedDB
+   * (`accountDbName`). The worker has no AccountScope, so without it there is
+   * no way to know which account's database to warm: the IDB half of the
+   * prefetch is skipped (writing to the pre-auth default DB would warm a
+   * database the app never reads once signed in). Null on targets persisted by
+   * older SW versions.
+   */
+  workosUserId: string | null
+}
+
+// Account databases opened by this worker, keyed by database name. The worker
+// never calls setActiveDb (that pointer belongs to the main thread's
+// AccountScope), so it must open the account's database explicitly.
+const accountDbs = new Map<string, ThreaDatabase>()
+
+async function openAccountDb(workosUserId: string): Promise<ThreaDatabase> {
+  // Dynamic import keeps Dexie off the SW critical path (push display must not
+  // wait on it). The SW shares the origin — and therefore the databases — with
+  // the main thread.
+  const { ThreaDatabase: Database, accountDbName } = await import("../db/database")
+  const name = accountDbName(workosUserId)
+  let inst = accountDbs.get(name)
+  if (!inst) {
+    inst = new Database(name)
+    accountDbs.set(name, inst)
+  }
+  return inst
+}
+
+/** Find the most recent message_created event. Bootstrap events are ordered oldest → newest. */
+function findLatestMessageEvent(events: StreamEvent[]): StreamEvent | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].eventType === "message_created") return events[i]
+  }
+  return null
+}
+
+function buildPreviewFromEvent(event: StreamEvent): LastMessagePreview {
+  const payload = (event.payload ?? {}) as { contentJson?: unknown; contentMarkdown?: string }
+  return {
+    authorId: event.actorId ?? "",
+    authorType: event.actorType ?? AuthorTypes.USER,
+    // Sidebar's truncateContent accepts either JSONContent or a markdown string.
+    content: (payload.contentJson ?? payload.contentMarkdown ?? "") as string,
+    createdAt: event.createdAt,
+  }
+}
+
+/**
+ * Pre-fetch events around a specific message so it's available in IDB
+ * when the user taps the push notification. Best-effort.
+ */
+async function prefetchEventsAround(
+  workosUserId: string,
+  workspaceId: string,
+  streamId: string,
+  messageId: string
+): Promise<void> {
+  try {
+    const url = `/api/workspaces/${workspaceId}/streams/${streamId}/events/around?messageId=${messageId}&limit=30`
+    const response = await fetch(url, { credentials: "include" })
+    if (!response.ok) return
+
+    const body = await response.json()
+    const data = body.data ?? body
+    if (data?.events?.length > 0) {
+      const now = Date.now()
+      const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
+      await db.events.bulkPut(
+        data.events.map((e: Record<string, unknown>) => ({
+          ...e,
+          workspaceId,
+          _sequenceNum: sequenceToNum(e.sequence as string),
+          _cachedAt: now,
+        }))
+      )
+    }
+  } catch {
+    // Best-effort
+  }
+}
+
+async function prefetchStreamBootstrap(workosUserId: string, workspaceId: string, streamId: string): Promise<void> {
+  const url = `/api/workspaces/${workspaceId}/streams/${streamId}/bootstrap`
+  const response = await fetch(url, { credentials: "include" })
+  if (!response.ok) return
+
+  // Warm IndexedDB so useLiveQuery renders the stream instantly when the user
+  // taps the notification. We deliberately do NOT cache the response for the
+  // fetch interceptor to replay: the page's own bootstrap GET passes through to
+  // the network and applies the fresh result on top of this warm paint
+  // (stale-while-revalidate), so replaying a snapshot captured before later
+  // activity would only reintroduce staleness. Best-effort: errors are swallowed.
+  try {
+    const body = await response.json()
+    const bootstrap = body.data ?? body
+    if (!bootstrap?.events?.length) return
+
+    const now = Date.now()
+    const [db, { sequenceToNum }] = await Promise.all([openAccountDb(workosUserId), import("../db/database")])
+
+    const events: StreamEvent[] = bootstrap.events
+    const latestMessageEvent = findLatestMessageEvent(events)
+    const derivedPreview = latestMessageEvent ? buildPreviewFromEvent(latestMessageEvent) : null
+
+    // The stream bootstrap endpoint returns a plain Stream without
+    // lastMessagePreview — a blind put would wipe the sidebar preview and
+    // sink the stream into "Other". Merge via update() so lastMessagePreview
+    // and membership-derived fields (notificationLevel, lastReadEventId)
+    // from applyWorkspaceBootstrap survive.
+    await db.transaction("rw", [db.events, db.streams], async () => {
+      await db.events.bulkPut(
+        events.map((e) => ({
+          ...e,
+          workspaceId,
+          _sequenceNum: sequenceToNum(e.sequence),
+          _cachedAt: now,
+        }))
+      )
+
+      if (!bootstrap.stream) return
+
+      const patch: { _cachedAt: number; lastMessagePreview?: LastMessagePreview } = { _cachedAt: now }
+      if (derivedPreview) patch.lastMessagePreview = derivedPreview
+
+      const updated = await db.streams.update(bootstrap.stream.id, patch)
+      if (updated === 0) {
+        await db.streams.put({ ...bootstrap.stream, ...patch })
+      }
+    })
+  } catch {
+    // Best-effort — normal fetch path takes over if this fails
+  }
+}
+
+/**
+ * Pre-fetch the workspace bootstrap so the next workspace bootstrap fetch in the
+ * page is served from the warm push cache by the SW's fetch interceptor.
+ *
+ * Errors propagate so the `sync` event handler sees the rejection and the
+ * browser retries Background Sync. Inline callers (push handler, no-sync
+ * fallback) catch separately and treat failures as best-effort.
+ *
+ * Unlike stream bootstrap, we don't seed IDB here — the workspace bootstrap
+ * apply pipeline is large and lives in workspace-sync; running it from the SW
+ * would duplicate that surface. Cache-API hydration alone is enough because
+ * TanStack always issues a fresh GET on app load and that GET hits the cache.
+ */
+async function prefetchWorkspaceBootstrap(workspaceId: string): Promise<void> {
+  const url = `/api/workspaces/${workspaceId}/bootstrap`
+  const response = await fetch(url, { credentials: "include" })
+  if (!response.ok) return
+  const cache = await caches.open(PUSH_BOOTSTRAP_CACHE)
+  await cache.put(url, response)
+}
+
+/**
+ * Run a bootstrap prefetch for the given target. Pure-ish: does network + cache
+ * + IDB writes but no event-listener wiring, so unit tests can drive it directly.
+ *
+ * Stream prefetch runs first because that's the user's perceived loading path
+ * after tapping a notification; workspace prefetch is the ambient sidebar
+ * freshness pass that can land slightly later without affecting the open-stream
+ * experience.
+ *
+ * The IDB half requires `workosUserId` (see BootstrapSyncTarget); without it
+ * only the workspace Cache API warm-up runs — that entry is keyed by URL and
+ * fetched with the session cookie, so it needs no account routing.
+ */
+export async function runBootstrapSync(target: BootstrapSyncTarget): Promise<void> {
+  if (target.streamId && target.workosUserId) {
+    await prefetchStreamBootstrap(target.workosUserId, target.workspaceId, target.streamId)
+    if (target.messageId) {
+      await prefetchEventsAround(target.workosUserId, target.workspaceId, target.streamId, target.messageId)
+    }
+  }
+  await prefetchWorkspaceBootstrap(target.workspaceId)
+}
+
+/**
+ * Persist the sync target and register a Background Sync. The browser fires the
+ * `sync` event once connectivity is available and retries on failure, so the
+ * prefetch survives flaky networks and SW termination.
+ *
+ * Browsers without Background Sync (Safari, Firefox) throw on register — we
+ * fall through to running the prefetch immediately. Inline runs delete the
+ * persisted target after the run so a sync-capable browser that gains support
+ * later (or a leftover entry from a previous SW version) doesn't replay stale.
+ */
+export async function queueBootstrapSync(
+  target: BootstrapSyncTarget,
+  registration: ServiceWorkerRegistration
+): Promise<void> {
+  const cache = await caches.open(PENDING_SYNC_CACHE)
+  await cache.put(
+    PENDING_SYNC_KEY,
+    new Response(JSON.stringify(target), { headers: { "Content-Type": "application/json" } })
+  )
+
+  const reg = registration as ServiceWorkerRegistration & {
+    sync?: { register: (tag: string) => Promise<void> }
+  }
+  if (reg.sync) {
+    try {
+      await reg.sync.register(BOOTSTRAP_SYNC_TAG)
+      return
+    } catch {
+      // Fall through to immediate prefetch below
+    }
+  }
+
+  try {
+    await runBootstrapSync(target)
+  } finally {
+    void caches.open(PENDING_SYNC_CACHE).then((c) => c.delete(PENDING_SYNC_KEY))
+  }
+}
+
+/**
+ * Read back a target persisted by queueBootstrapSync. Targets written by older
+ * SW versions predate `workosUserId`; normalize the missing field to null so
+ * replay skips their IDB half instead of guessing a database.
+ */
+export function parsePersistedSyncTarget(raw: unknown): BootstrapSyncTarget | null {
+  if (typeof raw !== "object" || raw === null) return null
+  const t = raw as Partial<BootstrapSyncTarget>
+  if (typeof t.workspaceId !== "string") return null
+  return {
+    workspaceId: t.workspaceId,
+    streamId: t.streamId ?? null,
+    messageId: t.messageId ?? null,
+    workosUserId: t.workosUserId ?? null,
+  }
+}

--- a/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
+++ b/apps/frontend/src/lib/sw-bootstrap-prefetch.ts
@@ -253,6 +253,9 @@ export function parsePersistedSyncTarget(raw: unknown): BootstrapSyncTarget | nu
   if (typeof raw !== "object" || raw === null) return null
   const t = raw as Partial<BootstrapSyncTarget>
   if (typeof t.workspaceId !== "string") return null
+  if (t.streamId != null && typeof t.streamId !== "string") return null
+  if (t.messageId != null && typeof t.messageId !== "string") return null
+  if (t.workosUserId != null && typeof t.workosUserId !== "string") return null
   return {
     workspaceId: t.workspaceId,
     streamId: t.streamId ?? null,

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -1,8 +1,17 @@
 /// <reference lib="webworker" />
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
-import { AuthorTypes, type LastMessagePreview, type StreamEvent } from "@threa/types"
 import { resolveTag } from "./lib/sw-notification-format"
 import { isDevicePresent, PRESENCE_CACHE } from "./lib/sw-presence"
+import {
+  BOOTSTRAP_SYNC_TAG,
+  PENDING_SYNC_CACHE,
+  PENDING_SYNC_KEY,
+  PUSH_BOOTSTRAP_CACHE,
+  WORKSPACE_BOOTSTRAP_PATH_RE,
+  parsePersistedSyncTarget,
+  queueBootstrapSync,
+  runBootstrapSync,
+} from "./lib/sw-bootstrap-prefetch"
 import {
   SW_MSG_NOTIFICATION_CLICK,
   SW_MSG_SUBSCRIPTION_CHANGED,
@@ -163,202 +172,28 @@ self.addEventListener("fetch", (event) => {
 
 // Push bootstrap pre-fetch — warm stream data so it's instant on notification tap
 // (stream: IndexedDB; workspace: the Cache API entry served by the interceptor).
-
-/** Cache name for pre-fetched workspace bootstrap responses triggered by push or background sync. */
-const PUSH_BOOTSTRAP_CACHE = "push-bootstrap"
-
-/** Cache name used to persist pending Background Sync targets across SW restarts. */
-const PENDING_SYNC_CACHE = "pending-sync"
-
-/** Single sync tag for bootstrap refresh — browsers coalesce repeat registrations under the same tag. */
-const BOOTSTRAP_SYNC_TAG = "threa-bootstrap-refresh"
-
-/** Cache key for the persisted sync target. Last write wins; only the most recent target is replayed. */
-const PENDING_SYNC_KEY = `/_sync/${BOOTSTRAP_SYNC_TAG}`
-
-/** Regex matching workspace bootstrap API paths. */
-const WORKSPACE_BOOTSTRAP_PATH_RE = /^\/api\/workspaces\/[^/]+\/bootstrap$/
-
-interface BootstrapSyncTarget {
-  workspaceId: string
-  streamId: string | null
-  messageId: string | null
-}
-
-/**
- * Pre-fetch events around a specific message so it's available in IDB
- * when the user taps the push notification. Best-effort.
- */
-async function prefetchEventsAround(workspaceId: string, streamId: string, messageId: string): Promise<void> {
-  try {
-    const url = `/api/workspaces/${workspaceId}/streams/${streamId}/events/around?messageId=${messageId}&limit=30`
-    const response = await fetch(url, { credentials: "include" })
-    if (!response.ok) return
-
-    const body = await response.json()
-    const data = body.data ?? body
-    if (data?.events?.length > 0) {
-      const now = Date.now()
-      const { db, sequenceToNum } = await import("./db/database")
-      await db.events.bulkPut(
-        data.events.map((e: Record<string, unknown>) => ({
-          ...e,
-          workspaceId,
-          _sequenceNum: sequenceToNum(e.sequence as string),
-          _cachedAt: now,
-        }))
-      )
-    }
-  } catch {
-    // Best-effort
-  }
-}
-
-async function prefetchStreamBootstrap(workspaceId: string, streamId: string): Promise<void> {
-  const url = `/api/workspaces/${workspaceId}/streams/${streamId}/bootstrap`
-  const response = await fetch(url, { credentials: "include" })
-  if (!response.ok) return
-
-  // Warm IndexedDB so useLiveQuery renders the stream instantly when the user
-  // taps the notification. We deliberately do NOT cache the response for the
-  // fetch interceptor to replay: the page's own bootstrap GET passes through to
-  // the network and applies the fresh result on top of this warm paint
-  // (stale-while-revalidate), so replaying a snapshot captured before later
-  // activity would only reintroduce staleness. Best-effort: errors are swallowed.
-  try {
-    const body = await response.json()
-    const bootstrap = body.data ?? body
-    if (!bootstrap?.events?.length) return
-
-    const now = Date.now()
-    // Dynamic import to avoid bundling Dexie into the SW critical path.
-    // The SW shares the same origin and IndexedDB database as the main thread.
-    const { db, sequenceToNum } = await import("./db/database")
-
-    const events: StreamEvent[] = bootstrap.events
-    const latestMessageEvent = findLatestMessageEvent(events)
-    const derivedPreview = latestMessageEvent ? buildPreviewFromEvent(latestMessageEvent) : null
-
-    // The stream bootstrap endpoint returns a plain Stream without
-    // lastMessagePreview — a blind put would wipe the sidebar preview and
-    // sink the stream into "Other". Merge via update() so lastMessagePreview
-    // and membership-derived fields (notificationLevel, lastReadEventId)
-    // from applyWorkspaceBootstrap survive.
-    await db.transaction("rw", [db.events, db.streams], async () => {
-      await db.events.bulkPut(
-        events.map((e) => ({
-          ...e,
-          workspaceId,
-          _sequenceNum: sequenceToNum(e.sequence),
-          _cachedAt: now,
-        }))
-      )
-
-      if (!bootstrap.stream) return
-
-      const patch: { _cachedAt: number; lastMessagePreview?: LastMessagePreview } = { _cachedAt: now }
-      if (derivedPreview) patch.lastMessagePreview = derivedPreview
-
-      const updated = await db.streams.update(bootstrap.stream.id, patch)
-      if (updated === 0) {
-        await db.streams.put({ ...bootstrap.stream, ...patch })
-      }
-    })
-  } catch {
-    // Best-effort — normal fetch path takes over if this fails
-  }
-}
-
-/**
- * Pre-fetch the workspace bootstrap so the next workspace bootstrap fetch in the
- * page is served from the warm push cache by the interceptor above.
- *
- * Errors propagate so the `sync` event handler sees the rejection and the
- * browser retries Background Sync. Inline callers (push handler, no-sync
- * fallback) catch separately and treat failures as best-effort.
- *
- * Unlike stream bootstrap, we don't seed IDB here — the workspace bootstrap
- * apply pipeline is large and lives in workspace-sync; running it from the SW
- * would duplicate that surface. Cache-API hydration alone is enough because
- * TanStack always issues a fresh GET on app load and that GET hits the cache.
- */
-async function prefetchWorkspaceBootstrap(workspaceId: string): Promise<void> {
-  const url = `/api/workspaces/${workspaceId}/bootstrap`
-  const response = await fetch(url, { credentials: "include" })
-  if (!response.ok) return
-  const cache = await caches.open(PUSH_BOOTSTRAP_CACHE)
-  await cache.put(url, response)
-}
-
-/**
- * Run a bootstrap prefetch for the given target. Pure-ish: does network + cache
- * + IDB writes but no event-listener wiring, so unit tests can drive it directly.
- *
- * Stream prefetch runs first because that's the user's perceived loading path
- * after tapping a notification; workspace prefetch is the ambient sidebar
- * freshness pass that can land slightly later without affecting the open-stream
- * experience.
- */
-export async function runBootstrapSync(target: BootstrapSyncTarget): Promise<void> {
-  if (target.streamId) {
-    await prefetchStreamBootstrap(target.workspaceId, target.streamId)
-    if (target.messageId) {
-      await prefetchEventsAround(target.workspaceId, target.streamId, target.messageId)
-    }
-  }
-  await prefetchWorkspaceBootstrap(target.workspaceId)
-}
-
-/**
- * Persist the sync target and register a Background Sync. The browser fires the
- * `sync` event once connectivity is available and retries on failure, so the
- * prefetch survives flaky networks and SW termination.
- *
- * Browsers without Background Sync (Safari, Firefox) throw on register — we
- * fall through to running the prefetch immediately. Inline runs delete the
- * persisted target after the run so a sync-capable browser that gains support
- * later (or a leftover entry from a previous SW version) doesn't replay stale.
- */
-async function queueBootstrapSync(target: BootstrapSyncTarget): Promise<void> {
-  const cache = await caches.open(PENDING_SYNC_CACHE)
-  await cache.put(
-    PENDING_SYNC_KEY,
-    new Response(JSON.stringify(target), { headers: { "Content-Type": "application/json" } })
-  )
-
-  const reg = self.registration as ServiceWorkerRegistration & {
-    sync?: { register: (tag: string) => Promise<void> }
-  }
-  if (reg.sync) {
-    try {
-      await reg.sync.register(BOOTSTRAP_SYNC_TAG)
-      return
-    } catch {
-      // Fall through to immediate prefetch below
-    }
-  }
-
-  try {
-    await runBootstrapSync(target)
-  } finally {
-    void caches.open(PENDING_SYNC_CACHE).then((c) => c.delete(PENDING_SYNC_KEY))
-  }
-}
+// The prefetch logic lives in lib/sw-bootstrap-prefetch (testable without a
+// ServiceWorkerGlobalScope); this file wires it to the SW events.
 
 self.addEventListener("message", (event) => {
   if (event.data?.type !== SW_MSG_QUEUE_BOOTSTRAP_SYNC) return
-  const { workspaceId, streamId, messageId } = event.data as {
+  const { workspaceId, streamId, messageId, workosUserId } = event.data as {
     workspaceId?: string
     streamId?: string | null
     messageId?: string | null
+    workosUserId?: string | null
   }
   if (!workspaceId) return
   event.waitUntil(
-    queueBootstrapSync({
-      workspaceId,
-      streamId: streamId ?? null,
-      messageId: messageId ?? null,
-    })
+    queueBootstrapSync(
+      {
+        workspaceId,
+        streamId: streamId ?? null,
+        messageId: messageId ?? null,
+        workosUserId: workosUserId ?? null,
+      },
+      self.registration
+    )
   )
 })
 
@@ -375,7 +210,11 @@ self.addEventListener("sync", ((event: SyncEvent) => {
       const cached = await cache.match(PENDING_SYNC_KEY)
       if (!cached) return
 
-      const target = (await cached.json()) as BootstrapSyncTarget
+      const target = parsePersistedSyncTarget(await cached.json())
+      if (!target) {
+        await cache.delete(PENDING_SYNC_KEY)
+        return
+      }
       // Run before delete: if the run throws, the entry stays so the browser's
       // `sync` retry has a target to replay. A new `queueBootstrapSync` call
       // (e.g. another tab hide) overwrites the entry with a fresher target,
@@ -385,25 +224,6 @@ self.addEventListener("sync", ((event: SyncEvent) => {
     })()
   )
 }) as EventListener)
-
-/** Find the most recent message_created event. Bootstrap events are ordered oldest → newest. */
-function findLatestMessageEvent(events: StreamEvent[]): StreamEvent | null {
-  for (let i = events.length - 1; i >= 0; i--) {
-    if (events[i].eventType === "message_created") return events[i]
-  }
-  return null
-}
-
-function buildPreviewFromEvent(event: StreamEvent): LastMessagePreview {
-  const payload = (event.payload ?? {}) as { contentJson?: unknown; contentMarkdown?: string }
-  return {
-    authorId: event.actorId ?? "",
-    authorType: event.actorType ?? AuthorTypes.USER,
-    // Sidebar's truncateContent accepts either JSONContent or a markdown string.
-    content: (payload.contentJson ?? payload.contentMarkdown ?? "") as string,
-    createdAt: event.createdAt,
-  }
-}
 
 /**
  * When the OS shares content to Threa (Web Share Target API), the browser sends
@@ -685,11 +505,15 @@ self.addEventListener("push", (event) => {
         // browser retries `sync` until it succeeds. Best-effort: errors here
         // never block notification display.
         if (data.workspaceId) {
-          await queueBootstrapSync({
-            workspaceId: data.workspaceId,
-            streamId: data.streamId ?? null,
-            messageId: data.messageId ?? null,
-          }).catch(() => {})
+          await queueBootstrapSync(
+            {
+              workspaceId: data.workspaceId,
+              streamId: data.streamId ?? null,
+              messageId: data.messageId ?? null,
+              workosUserId: data.workosUserId ?? null,
+            },
+            self.registration
+          ).catch(() => {})
         }
       }
     )

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -398,7 +398,7 @@ describe("SyncEngine.handlePageResume", () => {
     expect(deps.workspaceService.bootstrap.mock.calls.length).toBeLessThanOrEqual(2)
   })
 
-  it("does not refresh a route stream while the socket transport is disconnected", async () => {
+  it("leaves a fresh open (no persisted window) to the query layer while the socket is disconnected", async () => {
     const deps = makeDeps()
     const engine = new SyncEngine(deps)
     const socket = new MockSocket()
@@ -409,7 +409,9 @@ describe("SyncEngine.handlePageResume", () => {
     engine.onDisconnect()
 
     engine.setCurrentStreamId("stream_1")
-    await Promise.resolve()
+    // The warm-fetch decision reads IDB asynchronously; give it a macrotask to
+    // settle before asserting it declined to fetch.
+    await new Promise((resolve) => setTimeout(resolve, 25))
 
     expect(deps.streamService.bootstrap).not.toHaveBeenCalled()
     expect(socket.emittedEvents.filter((event) => event.event === "join")).toHaveLength(1)
@@ -758,6 +760,131 @@ describe("SyncEngine reconnect catch-up cursor (INV-53 gap safety)", () => {
     await vi.waitFor(() => {
       expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
     })
+  })
+})
+
+describe("SyncEngine HTTP-first warm fetch", () => {
+  beforeEach(async () => {
+    resetRevealGate()
+    await Promise.all([db.workspaces.clear(), db.events.clear(), db.streams.clear(), db.streamMemberships.clear()])
+  })
+
+  async function seedEvent(streamId: string, sequence: number): Promise<void> {
+    await db.events.put({
+      id: `evt_${sequence}`,
+      workspaceId: "ws_1",
+      streamId,
+      sequence: String(sequence),
+      eventType: "message_created",
+      payload: {
+        messageId: `msg_${sequence}`,
+        contentMarkdown: "old",
+        contentJson: { type: "doc", content: [{ type: "paragraph" }] },
+      },
+      actorId: "user_1",
+      actorType: "user",
+      createdAt: new Date().toISOString(),
+      _sequenceNum: sequence,
+      _cachedAt: Date.now(),
+    })
+  }
+
+  it("warms a persisted route stream over HTTP while the socket transport is disconnected", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    deps.streamService.bootstrap.mockClear()
+    const joinsBefore = socket.emittedEvents.filter((event) => event.event === "join").length
+    socket.connected = false
+    engine.onDisconnect()
+
+    engine.setCurrentStreamId("stream_1")
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "1" })
+    })
+    // The delta is applied to IDB so the open timeline fills in immediately…
+    await vi.waitFor(async () => {
+      expect(await db.events.get("evt_2")).toBeTruthy()
+    })
+    // …but no room join happened: the warm fetch is display-only, and the
+    // reconnect path still owns subscription + cursor discipline.
+    expect(socket.emittedEvents.filter((event) => event.event === "join").length).toBe(joinsBefore)
+  })
+
+  it("fires the warm delta for the current stream on page resume before the ping settles", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalled()
+    })
+    await vi.waitFor(async () => {
+      expect(await db.events.get("evt_2")).toBeTruthy()
+    })
+    deps.streamService.bootstrap.mockClear()
+
+    // Zombie transport: the ping never acks. The warm fetch must not wait for it.
+    socket.ackBehavior = "never"
+    const resumePromise = engine.handlePageResume()
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledWith("ws_1", "stream_1", { after: "2" })
+    })
+
+    // Settle the hung ping so the resume promise resolves.
+    socket.trigger("disconnect", "transport close")
+    await resumePromise
+  })
+
+  it("single-flights concurrent warm fetches for the same stream", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    deps.streamService.bootstrap.mockClear()
+    socket.connected = false
+    engine.onDisconnect()
+
+    // Navigation and a page resume land together (notification tap): one fetch.
+    engine.setCurrentStreamId("stream_1")
+    const resumePromise = engine.handlePageResume()
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(1)
+    })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(1)
+    await resumePromise
+  })
+
+  it("swallows warm fetch failures and leaves retries to the socket-gated refresh", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    deps.streamService.bootstrap.mockClear()
+    deps.streamService.bootstrap.mockRejectedValueOnce(new Error("offline"))
+    socket.connected = false
+    engine.onDisconnect()
+
+    engine.setCurrentStreamId("stream_1")
+
+    await vi.waitFor(() => {
+      expect(deps.streamService.bootstrap).toHaveBeenCalledTimes(1)
+    })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    // No error status: the warm fetch is speculative and must not flash chrome.
+    expect(deps.syncStatus.get("stream:stream_1")).not.toBe("error")
   })
 })
 

--- a/apps/frontend/src/sync/sync-engine.test.ts
+++ b/apps/frontend/src/sync/sync-engine.test.ts
@@ -865,6 +865,50 @@ describe("SyncEngine HTTP-first warm fetch", () => {
     await resumePromise
   })
 
+  it("never seeds the bootstrap query cache — an append delta must not become the stream's window", async () => {
+    // Regression guard (caught in pre-PR review): with staleTime Infinity and
+    // all refetch triggers off, a seeded entry permanently suppresses the
+    // query layer's full-window fetch — and an append-mode delta as the entry
+    // truncates the display floor to the delta. Warm fetches merge into an
+    // existing entry only, mirroring backfillStreamGap.
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    deps.streamService.bootstrap.mockClear()
+    socket.connected = false
+    engine.onDisconnect()
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(async () => {
+      expect(await db.events.get("evt_2")).toBeTruthy()
+    })
+
+    expect(deps.queryClient.getQueryData(["streams", "bootstrap", "ws_1", "stream_1"])).toBeUndefined()
+  })
+
+  it("merges the warm delta into an existing bootstrap cache entry", async () => {
+    const deps = makeDeps()
+    const engine = new SyncEngine(deps)
+    const socket = new MockSocket()
+    await primeConnectedEngine(engine, socket)
+
+    await seedEvent("stream_1", 1)
+    deps.queryClient.setQueryData(["streams", "bootstrap", "ws_1", "stream_1"], makeStreamBootstrap("stream_1", "1"))
+    deps.streamService.bootstrap.mockClear()
+    socket.connected = false
+    engine.onDisconnect()
+
+    engine.setCurrentStreamId("stream_1")
+    await vi.waitFor(() => {
+      expect(deps.queryClient.getQueryData(["streams", "bootstrap", "ws_1", "stream_1"])).toMatchObject({
+        latestSequence: "2",
+      })
+    })
+  })
+
   it("swallows warm fetch failures and leaves retries to the socket-gated refresh", async () => {
     const deps = makeDeps()
     const engine = new SyncEngine(deps)

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -945,7 +945,9 @@ export class SyncEngine {
    * board open across dozens of unsynced streams doesn't saturate the network on
    * a spotty connection. Reuses refreshStreamAfterNavigation — the same
    * cursor-before-join → bootstrap → applyStreamBootstrap path opening a stream
-   * runs — which dedupes in-flight refreshes and no-ops while offline.
+   * runs — which dedupes in-flight refreshes and, while the socket is down,
+   * degrades to the display-only HTTP warm fetch (delta-only, so cards with no
+   * persisted window skip instead of fetching).
    */
   private async syncBoardStreams(streamIds: string[]): Promise<void> {
     let cursor = 0

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -138,6 +138,10 @@ export class SyncEngine {
    *  queued upgrades the queued run rather than being collapsed away. */
   private queuedReconnectForceFull = false
   private activeStreamRefreshes = new Map<string, Promise<void>>()
+  /** Single-flighted display-only HTTP warm fetches (see warmStreamOverHttp).
+   *  Kept separate from activeStreamRefreshes: a warm fetch performs no room
+   *  join, so it must never satisfy a reconnect-path refresh that needs one. */
+  private activeWarmFetches = new Map<string, Promise<void>>()
   private activeGapBackfills = new Map<string, { cursor: string; promise: Promise<void> }>()
   /** Lowest gap cursor reported per stream while a backfill was in flight —
    *  drained into one follow-up backfill when the active one settles. */
@@ -387,6 +391,13 @@ export class SyncEngine {
    */
   async handlePageResume(): Promise<void> {
     if (this.isDestroyed || !this.socket || !this.hasEverConnected) return
+    // Warm the open stream over plain HTTP before anything socket-shaped runs.
+    // The socket is the slowest thing on a phone resume — a zombie transport
+    // takes a ping timeout to detect and seconds more to reconnect and rejoin
+    // rooms — while an HTTP delta needs one round trip. This is what puts the
+    // message the user is coming back for on screen; the socket paths below
+    // remain the correctness authority and re-refresh behind it.
+    if (this.currentStreamId) void this.warmStreamOverHttp(this.currentStreamId)
     // If the transport is already down, socket.io is handling the reconnect;
     // don't layer another probe on top of it.
     if (!this.socket.connected) return
@@ -1003,14 +1014,16 @@ export class SyncEngine {
   }
 
   private refreshStreamAfterNavigation(streamId: string): Promise<void> {
-    if (
-      this.isDestroyed ||
-      !this.socket ||
-      !this.socket.connected ||
-      streamId.startsWith("draft_") ||
-      streamId.startsWith("draft:")
-    ) {
+    if (this.isDestroyed || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
       return Promise.resolve()
+    }
+
+    // Socket down (backgrounded transport, reconnect in flight): don't skip
+    // freshness entirely — HTTP can succeed while the socket can't. Warm the
+    // window now; the reconnect's slim bootstrap re-runs the cursor-owned
+    // refresh (with the room join) once the socket is back.
+    if (!this.socket || !this.socket.connected) {
+      return this.warmStreamOverHttp(streamId)
     }
 
     const existing = this.activeStreamRefreshes.get(streamId)
@@ -1053,6 +1066,64 @@ export class SyncEngine {
     } catch (error) {
       this.applyReconnectStreamError(streamId, error)
       syncStatus.set(key, syncStatus.getError(key) ? "error" : "stale")
+    }
+  }
+
+  /**
+   * Display-only warm fetch: pull the stream's bootstrap delta (`after` = the
+   * latest persisted sequence) over plain HTTP and merge it into IDB, without
+   * waiting for the socket. No-op for streams with no persisted window.
+   *
+   * This deliberately performs NO room join and therefore sits outside the
+   * cursor-before-join discipline of joinStreamForCatchUp: nothing here
+   * advances a catch-up cursor or opens a live subscription, so a gap between
+   * this fetch and the eventual join is impossible — the socket-gated refresh
+   * that follows re-derives its own cursor and covers everything after this
+   * fetch's window. Overlap is safe (applyStreamBootstrap merges and dedupes
+   * by event id). It also stays out of SyncStatusStore: it is a speculative
+   * warm-up, not the sync authority, and must not flash loading chrome.
+   */
+  private warmStreamOverHttp(streamId: string): Promise<void> {
+    if (this.isDestroyed || streamId.startsWith("draft_") || streamId.startsWith("draft:")) {
+      return Promise.resolve()
+    }
+
+    const existing = this.activeWarmFetches.get(streamId)
+    if (existing) return existing
+
+    const warm = this.performHttpWarmFetch(streamId).finally(() => {
+      if (this.activeWarmFetches.get(streamId) === warm) {
+        this.activeWarmFetches.delete(streamId)
+      }
+    })
+    this.activeWarmFetches.set(streamId, warm)
+    return warm
+  }
+
+  private async performHttpWarmFetch(streamId: string): Promise<void> {
+    const { workspaceId, streamService, queryClient } = this.deps
+
+    try {
+      // Delta-only: no persisted window means a fresh open, and fresh opens
+      // belong to the bootstrap query layer (useStreamBootstrap / the
+      // coordinated stream queries) — warming here too would double-fetch the
+      // full window on every cold open.
+      const after = await getLatestPersistedSequence(streamId)
+      if (after === null || this.isDestroyed) return
+
+      const bootstrap = await streamService.bootstrap(workspaceId, streamId, { after })
+      if (this.isDestroyed) return
+      await applyStreamBootstrap(workspaceId, streamId, bootstrap)
+
+      const queryKey = streamKeys.bootstrap(workspaceId, streamId)
+      queryClient.setQueryData<CachedStreamBootstrap>(queryKey, (currentBootstrap) =>
+        toCachedStreamBootstrap(bootstrap, currentBootstrap, {
+          incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
+        })
+      )
+    } catch {
+      // Speculative warm-up only — the socket-gated refresh path owns errors,
+      // retries, and terminal 403/404 handling.
     }
   }
 

--- a/apps/frontend/src/sync/sync-engine.ts
+++ b/apps/frontend/src/sync/sync-engine.ts
@@ -978,9 +978,11 @@ export class SyncEngine {
    * by event id); gaps are not.
    *
    * Callers must never read `getLatestPersistedSequence` and order it
-   * against a room join themselves. The one other cursor source is
+   * against a room join themselves. The two other sanctioned readers are
    * `backfillStreamGap`, which intentionally uses an explicit PRE-GAP cursor
-   * (the current latest would skip the very hole it fills).
+   * (the current latest would skip the very hole it fills), and
+   * `performHttpWarmFetch`, which pairs the read with NO join at all — a
+   * display-only fetch outside the subscribe→fetch window this rule guards.
    */
   private async joinStreamForCatchUp(streamId: string): Promise<string | null> {
     const after = await getLatestPersistedSequence(streamId)
@@ -1117,11 +1119,18 @@ export class SyncEngine {
       if (this.isDestroyed) return
       await applyStreamBootstrap(workspaceId, streamId, bootstrap)
 
+      // Merge into the query-cache bridge ONLY when an entry already exists —
+      // same guard as backfillStreamGap. Seeding an append-mode delta as the
+      // entry would freeze it as the stream's bootstrap (staleTime: Infinity,
+      // no refetch triggers), truncating the display floor to the delta and
+      // suppressing the query layer's full-window fetch for the session.
       const queryKey = streamKeys.bootstrap(workspaceId, streamId)
       queryClient.setQueryData<CachedStreamBootstrap>(queryKey, (currentBootstrap) =>
-        toCachedStreamBootstrap(bootstrap, currentBootstrap, {
-          incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
-        })
+        currentBootstrap
+          ? toCachedStreamBootstrap(bootstrap, currentBootstrap, {
+              incrementWindowVersionOnReplace: bootstrap.syncMode === "replace",
+            })
+          : currentBootstrap
       )
     } catch {
       // Speculative warm-up only — the socket-gated refresh path owns errors,

--- a/docs/features/architecture/sync-engine.md
+++ b/docs/features/architecture/sync-engine.md
@@ -88,9 +88,12 @@ cursor read would advance the cursor past the disconnect gap — the `after` fet
 permanently skips everything missed while offline ("an older message never appears while
 newer ones do"). Overlap is safe (writes dedupe by event id); gaps are not. Both the
 reconnect path and the navigation refresh go through it; call sites never read
-`getLatestPersistedSequence` and order it against a join themselves. The one intentional
-exception is `backfillStreamGap`, which takes an explicit **pre-gap** cursor — the current
-latest would skip the very hole it exists to fill.
+`getLatestPersistedSequence` and order it against a join themselves. Two intentional
+exceptions: `backfillStreamGap` takes an explicit **pre-gap** cursor (the current latest
+would skip the very hole it exists to fill), and `performHttpWarmFetch` — the display-only
+HTTP delta fired on page resume and socket-down navigation — reads the latest persisted
+sequence with **no join paired at all**, so it sits outside the subscribe→fetch window
+this rule guards; the socket-gated refresh that follows re-derives its own cursor.
 
 ### Timeline contiguity is verified, not assumed (INV-61)
 


### PR DESCRIPTION
## Problem

Opening the app on a phone — especially from a push notification — shows a stale timeline, a skeleton flash, or both, even though the architecture was built to prevent exactly this. Three distinct defects:

**1. The push prefetch has been writing to a database the app never reads.** The service worker's push/tab-hide prefetch (`prefetchStreamBootstrap`, `prefetchEventsAround` in `sw.ts`) wrote stream events through the `db` proxy from `db/database.ts`. That proxy's module instance inside the worker context always points at the pre-auth default `new ThreaDatabase("threa")` — `setActiveDb` is only ever called by `AccountScopeProvider` on the main thread, and a service worker is a separate JS realm. A signed-in app reads `threa_<workosUserId>` (`account-scope.tsx`), so every prefetch since per-account databases landed has been a silent no-op: the fetch succeeded, the `bulkPut` succeeded, the errors-swallowed `catch {}` hid nothing, and the data landed in a database nothing reads. This is the direct cause of "the push told me the message exists, I open the stream, it isn't there."

**2. Freshness for the open stream is gated entirely on the socket.** `refreshStreamAfterNavigation` bailed outright when `!socket.connected`, and `handlePageResume` runs a ping (3s timeout, `DEFAULT_PING_TIMEOUT_MS` in `lib/socket-health.ts`) before doing anything. So the resume path on a phone was: radio wake → ping hangs 3s on the zombie transport → forced reconnect → workspace room join ack → per-stream `bootstrap?after=` — several round trips before the message the user came back for appears, while a one-round-trip HTTP delta was available the whole time.

**3. The deep-link (`?m=`) mount hold is unbounded.** `holdForDeepLink` keeps the timeline on a skeleton until the target message is in the loaded window. With (1) broken, the target was never local, so every cold push-tap sat on a skeleton for the full `events/around` round trip — seconds on a slow network — while a perfectly good cached timeline was already in IndexedDB.

## Solution

Make the existing warm-path design actually work end to end: route the service worker's IndexedDB writes to the account's database, add a socket-independent HTTP delta for the open stream on resume, and bound the deep-link skeleton.

### How it works

**Account-correct SW writes** (`30af6ea`)

1. `accountDbName(workosUserId)` in `db/database.ts` is the single source of the per-account database name (INV-33). `AccountScopeProvider.resolveDb` and the worker both derive from it — the two contexts can no longer drift.
2. The prefetch logic moved from `sw.ts` to `lib/sw-bootstrap-prefetch.ts`, which has no `ServiceWorkerGlobalScope` dependency (registration is a parameter), so vitest drives `runBootstrapSync` directly against fake-indexeddb. `sw.ts` keeps only the event wiring.
3. `openAccountDb` opens `new ThreaDatabase(accountDbName(id))` explicitly (cached per name, Dexie dynamic-imported off the push critical path). The `db` proxy is no longer touched from the worker.
4. `workosUserId` rides everywhere a prefetch target does: the push payload already carried it (`push/service.ts` stamps it per recipient); the tab-hide message now includes it (`useBackgroundBootstrapSync` reads `useAccountScopeOptional().activeWorkosUserId`); persisted Background Sync targets store it, and `parsePersistedSyncTarget` normalizes entries written by older SW versions to `workosUserId: null`.
5. A target without an account id skips the IndexedDB half entirely rather than guessing a database — the workspace-bootstrap half (Cache API, keyed by URL, cookie-authenticated) still runs since it needs no account routing. That Cache-interceptor path is behaviorally unchanged.

**HTTP-first stream delta** (`2c0a85f`, guard in `bf906f0`)

1. `SyncEngine.warmStreamOverHttp` → `performHttpWarmFetch`: read `getLatestPersistedSequence`, fetch `bootstrap?after=`, merge via `applyStreamBootstrap`, merge into the TanStack bridge entry **only if one exists**. Single-flighted per stream in its own map (`activeWarmFetches`), deliberately **not** shared with `activeStreamRefreshes` — a warm fetch performs no room join, so it must never satisfy a reconnect-path refresh that needs one.
2. `handlePageResume` fires it for the current stream before the ping, so the delta races the zombie-detection instead of waiting behind it.
3. `refreshStreamAfterNavigation` falls back to it when the socket is absent or disconnected (navigation from a notification tap while the transport is asleep). `syncBoardStreams` inherits the same degradation for board cards.
4. It is delta-only: a stream with no persisted window skips, because fresh opens are owned by the bootstrap query layer (`useStreamBootstrap` / the coordinated stream queries) and warming there too would double-fetch the full window on every cold open.
5. Cursor discipline (INV-53/INV-61) is preserved by construction, not by ordering: the warm fetch joins no room and advances no cursor, so there is no subscribe→fetch window to lose events in. Overlap with the socket-gated refresh is dedup-safe (`applyStreamBootstrap` merges by event id, `_patchedAt` freshness skip). It also stays out of `SyncStatusStore`, so it never lights the top-bar indicator. The cursor-ownership rule in `docs/features/architecture/sync-engine.md` now names `performHttpWarmFetch` as a sanctioned `getLatestPersistedSequence` reader (no join paired), alongside `backfillStreamGap`.

**Bounded deep-link hold** (`81af75a`)

1. The hold condition moved into the exported pure `shouldHoldForDeepLink`; a `deepLinkHoldExpired` state flips after `DEEP_LINK_HOLD_MAX_MS` (600ms) of active hold and releases the skeleton in favor of the cached window. The jump swap + post-jump scroll driver still anchor and highlight the target when the `events/around` fetch lands.
2. Expiry re-arms exactly where `setDeepLinkGaveUp(false)` re-arms: on a fresh navigation claim and on stream switch, so each `?m=` navigation gets its own 600ms budget.
3. The fast path is intact: a target already in IndexedDB (which fix 1 makes the common case for push opens) or a sub-600ms fetch still mounts the list pre-anchored with no tail flash.

### Key design decisions

**1. The SW opens the account DB by name instead of replicating AccountScope.** The alternative — messaging the active account id into the worker and mimicking `setActiveDb` — reintroduces the exact drift this fixes: worker-held state dies on every SW termination (mobile browsers kill the worker between push receipt and tap), while the push payload and the persisted sync target survive it. Deriving the name per target from durable data is the shape that matches the SW lifecycle.

**2. Warm fetch is a separate, join-less path rather than a relaxation of `performStreamRefresh`.** Relaxing the socket guard inside the existing refresh would have made the room join conditional, and `slimReconnectBootstrap` relies on that join to re-subscribe visible streams after reconnect — a deduped join-less refresh could leave a stream silently unsubscribed. Keeping two maps means the canonical path is untouched and the warm path is provably side-effect-free (no join, no cursor, no status).

**3. Delta-only warm, full windows stay with the query layer.** The first draft mirrored `performStreamRefresh`'s "no cached bootstrap → fetch full window" rule; self-review caught that this double-fetches every cold open (the coordinated queries fetch the same full window as the render-blocking path). Delta-only removes the overlap and keeps the warm fetch strictly additive.

**4. 600ms for the hold bound.** Long enough that a same-region `events/around` round trip usually beats it (no behavior change in the common case), short enough that the skeleton can't be the dominant experience on a slow network. Matches the coordinated-loading `SKELETON_DELAY_MS` (600ms) so loading chrome timings stay in one register.

### Design evolution (pre-PR review)

The initial warm fetch did an **unconditional** `setQueryData`. Review traced the failure: with `STREAM_BOOTSTRAP_QUERY_OPTIONS` at `staleTime: Infinity` and all refetch triggers off, an entry seeded from an append-mode delta becomes the stream's bootstrap window for the whole session — `useEvents` derives its display floor from `getMinimumSequence(bootstrap.events)`, so the visible history truncates to the delta, `hasOlderEvents: false` kills back-pagination, and the seeded `success` state suppresses the query layer's full-window fetch (it even resurrects a previously errored query). Reachable via board cards synced while the socket is down, and via streams opened offline. Fixed in `bf906f0` by guarding the merge on an existing entry — the exact guard `backfillStreamGap` already carried — with regression tests for both the never-seeds and merges-into-existing cases.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/sw-bootstrap-prefetch.ts` | SW bootstrap prefetch: account-DB routing (`openAccountDb`), stream/events-around/workspace prefetch, `queueBootstrapSync`, `parsePersistedSyncTarget`. Testable without a worker scope. |
| `apps/frontend/src/lib/sw-bootstrap-prefetch.test.ts` | Regression guard: writes land in `threa_<id>`, never the default DB; legacy persisted targets normalize; no-account targets skip IDB and only warm the workspace cache. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sw.ts` | Prefetch logic removed (imported from the lib module); `workosUserId` threaded through the push handler, the tab-hide message handler, and the `sync` replay (via `parsePersistedSyncTarget`). |
| `apps/frontend/src/db/database.ts` | `accountDbName()` — single source of the per-account DB name. |
| `apps/frontend/src/db/index.ts` | Export `accountDbName`. |
| `apps/frontend/src/auth/account-scope.tsx` | `resolveDb` derives from `accountDbName` instead of an inline template. |
| `apps/frontend/src/hooks/use-background-bootstrap-sync.ts` | Tab-hide message carries `workosUserId` from `useAccountScopeOptional`. |
| `apps/frontend/src/hooks/use-background-bootstrap-sync.test.tsx` | Message-shape assertions updated; new test for the account id pass-through. |
| `apps/frontend/src/sync/sync-engine.ts` | `warmStreamOverHttp` / `performHttpWarmFetch` + `activeWarmFetches`; fired from `handlePageResume` (pre-ping) and the socket-down branch of `refreshStreamAfterNavigation`; merge-not-seed guard on the query cache. |
| `apps/frontend/src/sync/sync-engine.test.ts` | 6 new warm-fetch tests (offline navigation, pre-ping resume, single-flight, swallowed failure, never-seeds, merges-into-existing); the old "does not refresh while disconnected" test rewritten to the new policy (fresh opens still skip). |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `shouldHoldForDeepLink` + `DEEP_LINK_HOLD_MAX_MS` + `deepLinkHoldExpired`, re-armed alongside `deepLinkGaveUp`. |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | 6 tests for the hold decision, including the expiry release. |
| `docs/features/architecture/sync-engine.md` | Cursor-ownership rule names `performHttpWarmFetch` as the second sanctioned `getLatestPersistedSequence` reader. |

## Out of scope (deliberate)

Named in the sync-reliability review that produced this PR, left for follow-ups:

- The pending-sync store is still a single last-write-wins slot (`PENDING_SYNC_KEY`) — two pushes for different streams while away warm only the newer one.
- No Periodic Background Sync registration (Chromium ambient refresh) and no payload-carried event write (zero-network push apply).
- No prefetch observability — the `catch {}` blocks are still silent, which is how defect 1 went unnoticed; a diag trail is a follow-up.
- **Dexie cross-context upgrade race (review finding 2, tracked follow-up):** the SW now opens the same per-account DB live tabs hold. On a deploy that bumps the schema version, a new-schema SW woken by a push can upgrade the DB under an old-JS tab, whose Dexie connection then dies with `VersionError` until reload — `ThreaDatabase` installs no `versionchange` handler. The same race already exists tab-to-tab after an update (one reloaded tab upgrades under the others); this PR widens the trigger window rather than creating the class. Proper fix is a main-thread `versionchange` handler routed into the existing update-toast/reload flow.
- **Deep-link hold timer is per-hold, not per-target (review finding 3, cosmetic):** back-to-back `?m=` navigations share one 600ms budget (early release only — the safe direction), and re-navigating after an expiry can flash one released frame before the re-arm. Mirrors the pre-existing `deepLinkGaveUp` re-arm shape; left symmetric.

## Test plan

- [x] `bun run test` (frontend suite) — 3415 pass, 0 fail
- [x] New coverage: `sw-bootstrap-prefetch.test.ts` (6), sync-engine warm-fetch describe (6), `shouldHoldForDeepLink` (6), `use-background-bootstrap-sync` (6, 1 new)
- [x] `bun run typecheck` — all workspaces clean
- [x] `vite build` — SW bundle (`dist/sw.js`) compiles with the extracted module
- [x] Pre-PR review (adversarial reviewer agent over the full diff): 1 HIGH finding fixed (`bf906f0`, query-cache seeding, see Design evolution), 1 stale comment fixed (`dddb237`), cursor-discipline doc nit addressed; 1 MEDIUM (pre-existing-class Dexie upgrade race) and 1 LOW (hold-timer granularity) recorded above as tracked follow-ups
- [ ] Not verified on a physical device — the account-DB fix is asserted via fake-indexeddb, not a real push on iOS/Android

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiuP3KSxYMBKn6HhXfXepq)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785560010&installation_id=129946197&pr_number=1133&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1133&signature=ea113682e09acfa3081486ec5c8008088663df0a7fa95fe311cdb97941edbb78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->