### PR TITLE
feat(conversations): standalone Delete message on board/conversation rows

### DIFF
--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -254,6 +254,26 @@ describe("ConversationPanel", () => {
 
     await screen.findByRole("menu")
     expect(screen.queryByText("Edit message")).toBeNull()
+    expect(screen.queryByText("Delete message")).toBeNull()
+  })
+
+  it("offers a standalone Delete message action that confirms then deletes the row", async () => {
+    const deleteMessage = vi.fn().mockResolvedValue({})
+    vi.spyOn(contextsModule, "useMessageService").mockReturnValue({
+      delete: deleteMessage,
+    } as unknown as ReturnType<typeof contextsModule.useMessageService>)
+
+    const user = userEvent.setup()
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    const [firstRowMenu] = screen.getAllByRole("button", { name: "Message actions" })
+    await user.click(firstRowMenu)
+    await user.click(await screen.findByText("Delete message"))
+
+    // The owner-only action opens the same confirm dialog as clear-to-empty.
+    await user.click(await screen.findByRole("button", { name: "Delete" }))
+    await waitFor(() => expect(deleteMessage).toHaveBeenCalledWith(WORKSPACE_ID, "msg_1"))
   })
 
   it("clearing an edit to empty confirms then deletes the message", async () => {

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -288,6 +288,11 @@ export function MessageItem({
     onReact: handleAddReaction,
     onOpenFullPicker: () => setMobilePickerOpen(true),
     onEdit: startEditing,
+    // Standalone Delete (the registry's owner-only `delete-message`) opens the
+    // same confirm dialog as the edit form's clear-to-empty path — both land on
+    // `handleDelete` → `useDeleteMessage`. The action's own gate keeps it to the
+    // author's rows, mirroring the timeline row (`MessageEvent`).
+    onDelete: () => setDeleteDialogOpen(true),
     onQuoteReply: quoteReplyCtx ? triggerQuote : undefined,
     viewInStream: {
       href: `/w/${workspaceId}/s/${streamId}?m=${message.id}`,


### PR DESCRIPTION
## Problem

The shared out-of-stream message row (`MessageItem` — board card, conversation panel, label page) surfaced **Edit** for your own messages (shipped in #1134) but not a standalone **Delete**. Deletion was reachable only indirectly, by opening the edit form and clearing the body to empty. The in-stream timeline row (`MessageEvent`) has offered a first-class "Delete message" menu action all along, so the two surfaces were out of parity.

## Solution

Wire the one missing callback. The registry's owner-gated `delete-message` action already exists in `message-actions.ts` (used by `MessageEvent` since #1085) and gates on `actorType === "user" && authorId === currentUserId && !!onDelete`. `MessageItem` already had every other piece — `deleteDialogOpen` state, `DeleteMessageDialog` in its `overlays`, and `handleDelete` routing through the shared `useDeleteMessage` hook — but its `menuContext` never set `onDelete`, so the action stayed hidden.

Adding `onDelete: () => setDeleteDialogOpen(true)` to `menuContext` surfaces the action on board/conversation/label rows. It opens the **same** confirm dialog as the edit form's clear-to-empty path — both land on `handleDelete` → `useDeleteMessage` — so there is one delete mechanism across surfaces (INV-35), matching the wiring `MessageEvent` uses at `message-event.tsx:1091`.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/message/message-item.tsx` | Add `onDelete: () => setDeleteDialogOpen(true)` to `menuContext` (1 line + explanatory comment) |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | New test: standalone Delete confirms → `messageService.delete(ws, msg_1)`; extend the "hides Edit for others" test to also assert Delete is hidden |

## Out of scope (deliberate)

Remaining action-parity follow-ups are untouched: Discuss-with-Ariadne conversation context, Save + Set-reminder deep-link origin, Share back-link. Reply-in-thread and Move/Mark-read stay suppressed on this surface by design.

## Test plan

- [x] `conversation-panel.test.tsx` — 13 pass (2 new: standalone-delete flow, Delete-hidden-for-others)
- [x] `tsc --noEmit` (frontend) clean; ESLint clean; Prettier clean
- [x] Pre-PR review (1 combined Sonnet reviewer — spec+design, correctness+data-flow, UX, mobile): no issues (7/7); confirmed parity with `MessageEvent`, owner gate, and no edit-form collision (the menu is gated behind `!inlineEditing`)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkZAg6kcfCxAp91JkcGd3M)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785585858&installation_id=129946197&pr_number=1136&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1136&signature=addb3ae5b8af1d15e8357943d62c0ffe600d5f35f2ef47fd1b481e5230934efc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->