### PR TITLE
fix(commands): parse resolved mention pointers (INV-64) in /invite args

### DIFF
--- a/apps/backend/src/features/commands/invite-command.test.ts
+++ b/apps/backend/src/features/commands/invite-command.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { InviteCommand } from "./invite-command"
+import { StreamRepository } from "../streams"
+import { UserRepository } from "../workspaces"
+import { BotRepository } from "../public-api"
+import type { CommandContext } from "./registry"
+
+const WORKSPACE_ID = "ws_1"
+const STREAM_ID = "stream_1"
+const ACTOR_ID = "usr_actor"
+
+const channel = { id: STREAM_ID, workspaceId: WORKSPACE_ID, type: "channel" } as any
+const admin = { id: ACTOR_ID, role: "admin" } as any
+const alice = { id: "usr_alice", slug: "alice", name: "Alice" } as any
+const testBot = { id: "bot_test", slug: "test-bot", name: "TestBot", archivedAt: null } as any
+
+function makeCommand(streamService: { addMember?: any; addBotToStream?: any } = {}) {
+  return new InviteCommand({
+    pool: {} as any,
+    streamService: {
+      addMember: streamService.addMember ?? mock(async () => {}),
+      addBotToStream: streamService.addBotToStream ?? mock(async () => {}),
+    } as any,
+  })
+}
+
+function ctx(args: string): CommandContext {
+  return { workspaceId: WORKSPACE_ID, streamId: STREAM_ID, userId: ACTOR_ID, args } as CommandContext
+}
+
+function setupRepos({ usersById = [], botsById = [], usersBySlug = [], botsBySlug = [] }: any) {
+  spyOn(StreamRepository, "findById").mockResolvedValue(channel)
+  spyOn(UserRepository, "findById").mockResolvedValue(admin)
+  spyOn(UserRepository, "findByIds").mockResolvedValue(usersById)
+  spyOn(BotRepository, "findByIds").mockResolvedValue(botsById)
+  spyOn(UserRepository, "findBySlugs").mockResolvedValue(usersBySlug)
+  spyOn(BotRepository, "findBySlugs").mockResolvedValue(botsBySlug)
+}
+
+describe("InviteCommand mention parsing (INV-64)", () => {
+  afterEach(() => mock.restore())
+
+  it("invites a bot from the resolved pointer form the composer sends", async () => {
+    setupRepos({ botsById: [testBot] })
+    const addBotToStream = mock(async () => {})
+    const command = makeCommand({ addBotToStream })
+
+    const result = await command.execute(ctx("[@test-bot](bot:bot_test)"))
+
+    expect(result).toEqual({
+      success: true,
+      result: { invited: [{ name: "TestBot", slug: "test-bot", type: "bot" }] },
+    })
+    expect(addBotToStream).toHaveBeenCalledWith(STREAM_ID, "bot_test", WORKSPACE_ID, ACTOR_ID)
+  })
+
+  it("invites a user from the resolved pointer form by id, not slug", async () => {
+    setupRepos({ usersById: [alice] })
+    const addMember = mock(async () => {})
+    const command = makeCommand({ addMember })
+
+    const result = await command.execute(ctx("[@alice](user:usr_alice)"))
+
+    expect(result).toEqual({
+      success: true,
+      result: { invited: [{ name: "Alice", slug: "alice", type: "user" }] },
+    })
+    expect(addMember).toHaveBeenCalledWith(STREAM_ID, "usr_alice", WORKSPACE_ID, ACTOR_ID)
+    expect(UserRepository.findBySlugs).not.toHaveBeenCalled()
+  })
+
+  it("still accepts bare @slug as lenient input", async () => {
+    setupRepos({ usersBySlug: [alice] })
+    const command = makeCommand()
+
+    const result = await command.execute(ctx("@alice"))
+
+    expect(result).toEqual({
+      success: true,
+      result: { invited: [{ name: "Alice", slug: "alice", type: "user" }] },
+    })
+  })
+
+  it("handles a mix of pointer and bare mentions, deduping the same actor", async () => {
+    setupRepos({ usersById: [alice], usersBySlug: [alice], botsById: [testBot] })
+    const addMember = mock(async () => {})
+    const command = makeCommand({ addMember })
+
+    const result = await command.execute(ctx("[@alice](user:usr_alice) @alice [@test-bot](bot:bot_test)"))
+
+    expect(result.success).toBe(true)
+    expect(addMember).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports non-invitable pointer kinds (persona, broadcast) as unknown", async () => {
+    setupRepos({ usersById: [alice] })
+    const command = makeCommand()
+
+    const result = await command.execute(ctx("[@alice](user:usr_alice) [@ariadne](persona:persona_x) [@here](broadcast:here)"))
+
+    expect(result).toEqual({
+      success: true,
+      result: {
+        invited: [{ name: "Alice", slug: "alice", type: "user" }],
+        unknown: ["@ariadne", "@here"],
+      },
+    })
+  })
+
+  it("fails with usage when no mentions are present", async () => {
+    const command = makeCommand()
+    const result = await command.execute(ctx("nobody here"))
+    expect(result.success).toBe(false)
+  })
+
+  it("treats a pointer to an archived bot as unknown", async () => {
+    setupRepos({ usersById: [alice], botsById: [{ ...testBot, archivedAt: new Date() }] })
+    const command = makeCommand()
+
+    const result = await command.execute(ctx("[@alice](user:usr_alice) [@test-bot](bot:bot_test)"))
+
+    expect(result).toEqual({
+      success: true,
+      result: {
+        invited: [{ name: "Alice", slug: "alice", type: "user" }],
+        unknown: ["@test-bot"],
+      },
+    })
+  })
+
+  it("requires bots:manage for pointer-form bot invites", async () => {
+    setupRepos({ botsById: [testBot] })
+    spyOn(UserRepository, "findById").mockResolvedValue({ id: ACTOR_ID, role: "member" } as any)
+    const command = makeCommand()
+
+    const result = await command.execute(ctx("[@test-bot](bot:bot_test)"))
+
+    expect(result).toEqual({ success: false, error: "Insufficient permissions to invite bots" })
+  })
+})

--- a/apps/backend/src/features/commands/invite-command.ts
+++ b/apps/backend/src/features/commands/invite-command.ts
@@ -3,7 +3,14 @@ import type { Command, CommandContext, CommandResult } from "./registry"
 import { StreamRepository, type Stream, type StreamService } from "../streams"
 import { UserRepository } from "../workspaces"
 import { BotRepository } from "../public-api"
-import { permissionsForRole, StreamTypes, WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
+import { parseMarkdown } from "@threa/prosemirror"
+import {
+  actorTypeFromMentionId,
+  permissionsForRole,
+  StreamTypes,
+  WORKSPACE_PERMISSION_SCOPES,
+  type JSONContent,
+} from "@threa/types"
 
 interface InviteCommandDeps {
   pool: Pool
@@ -37,8 +44,8 @@ export class InviteCommand implements Command {
   constructor(private readonly deps: InviteCommandDeps) {}
 
   async execute(ctx: CommandContext): Promise<CommandResult> {
-    const slugs = parseSlugs(ctx.args)
-    if (slugs.length === 0) {
+    const mentions = parseMentionArgs(ctx.args)
+    if (mentions.length === 0) {
       return { success: false, error: "Usage: /invite @user1 @user2 ..." }
     }
 
@@ -50,29 +57,58 @@ export class InviteCommand implements Command {
       return { success: false, error: "/invite is only available in channels and threads whose root is a channel" }
     }
 
-    const [users, bots, actor] = await Promise.all([
-      UserRepository.findBySlugs(this.deps.pool, ctx.workspaceId, slugs),
-      BotRepository.findBySlugs(this.deps.pool, ctx.workspaceId, slugs),
+    const userIds: string[] = []
+    const botIds: string[] = []
+    const slugs: string[] = []
+    for (const mention of mentions) {
+      const kind = actorTypeFromMentionId(mention.id)
+      if (kind === "user") userIds.push(mention.id)
+      else if (kind === "bot") botIds.push(mention.id)
+      else if (kind === null) slugs.push(mention.slug)
+      // persona/broadcast pointers are not invitable; they surface as unknown below
+    }
+
+    const [usersById, botsByIdRaw, usersBySlug, botsBySlug, actor] = await Promise.all([
+      userIds.length > 0 ? UserRepository.findByIds(this.deps.pool, ctx.workspaceId, userIds) : [],
+      botIds.length > 0 ? BotRepository.findByIds(this.deps.pool, ctx.workspaceId, botIds) : [],
+      slugs.length > 0 ? UserRepository.findBySlugs(this.deps.pool, ctx.workspaceId, slugs) : [],
+      slugs.length > 0 ? BotRepository.findBySlugs(this.deps.pool, ctx.workspaceId, slugs) : [],
       UserRepository.findById(this.deps.pool, ctx.workspaceId, ctx.userId),
     ])
+    // findBySlugs excludes archived bots in SQL; findByIds doesn't — filter so a
+    // stale pointer to an archived bot lands in `unknown` like an unknown slug.
+    const botsById = botsByIdRaw.filter((b) => b.archivedAt === null)
 
     const canInviteBots =
       actor != null && permissionsForRole(actor.role).includes(WORKSPACE_PERMISSION_SCOPES.BOTS_MANAGE)
-    if (bots.length > 0 && !canInviteBots) {
+    if (botsById.length + botsBySlug.length > 0 && !canInviteBots) {
       return { success: false, error: "Insufficient permissions to invite bots" }
     }
 
-    const entities: Entity[] = [
-      ...users.map<Entity>((u) => ({ type: "user", id: u.id, slug: u.slug, name: u.name })),
-      // findBySlugs matches on slug = ANY(...), so b.slug is guaranteed non-null here.
-      ...bots.map<Entity>((b) => ({ type: "bot", id: b.id, slug: b.slug!, name: b.name })),
-    ]
-    if (entities.length === 0) {
-      return { success: false, error: `Unknown users or bots: ${slugs.map((s) => `@${s}`).join(" ")}` }
+    const entityById = new Map<string, Entity>()
+    for (const u of [...usersById, ...usersBySlug]) {
+      entityById.set(u.id, { type: "user", id: u.id, slug: u.slug, name: u.name })
     }
+    for (const b of [...botsById, ...botsBySlug]) {
+      entityById.set(b.id, { type: "bot", id: b.id, slug: b.slug ?? b.name, name: b.name })
+    }
+    const entities = [...entityById.values()]
 
-    const found = new Set(entities.map((e) => e.slug))
-    const unknown = slugs.filter((s) => !found.has(s))
+    // A mention is unknown when neither its id nor its slug matched an
+    // invitable entity — covers stale pointer ids, unknown bare slugs, and
+    // non-invitable pointer kinds (persona, broadcast) alike.
+    const foundSlugs = new Set(entities.map((e) => e.slug.toLowerCase()))
+    const unknown = [
+      ...new Set(
+        mentions
+          .filter((m) => !entityById.has(m.id) && !foundSlugs.has(m.slug.toLowerCase()))
+          .map((m) => m.slug)
+      ),
+    ]
+
+    if (entities.length === 0) {
+      return { success: false, error: `Unknown users or bots: ${unknown.map((s) => `@${s}`).join(" ")}` }
+    }
 
     const invited: InvitedWire[] = []
     const errors: string[] = []
@@ -108,11 +144,25 @@ export class InviteCommand implements Command {
   }
 }
 
-function parseSlugs(args: string): string[] {
-  return args
-    .trim()
-    .split(/\s+/)
-    .filter((t) => t.startsWith("@"))
-    .map((t) => t.slice(1))
-    .filter(Boolean)
+/**
+ * Extract mention targets from the raw command args. The composer dispatches
+ * commands as markdown, so a picked mention arrives as a resolved pointer link
+ * (`[@test-bot](bot:bot_x)`, INV-64) while a hand-typed one is a bare `@slug`.
+ * `parseMarkdown` yields a mention node for both; the id prefix tells them
+ * apart (a bare slug's id has no prefix).
+ */
+function parseMentionArgs(args: string): Array<{ id: string; slug: string }> {
+  const mentions: Array<{ id: string; slug: string }> = []
+  const walk = (node: JSONContent): void => {
+    if (node.type === "mention") {
+      const id = node.attrs?.id
+      const slug = node.attrs?.slug
+      if (typeof id === "string" && typeof slug === "string" && slug) {
+        mentions.push({ id, slug })
+      }
+    }
+    for (const child of node.content ?? []) walk(child)
+  }
+  walk(parseMarkdown(args))
+  return mentions
 }

--- a/apps/frontend/src/components/timeline/command-event.tsx
+++ b/apps/frontend/src/components/timeline/command-event.tsx
@@ -3,6 +3,7 @@ import type { StreamEvent, CommandDispatchedPayload, CommandCompletedPayload, Co
 import { Loader2, CheckCircle, XCircle, ChevronRight } from "lucide-react"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { useFormattedDate } from "@/hooks"
+import { stripMarkdownToInline } from "@/lib/markdown"
 
 interface CommandEventProps {
   /** All events for this command, grouped by commandId */
@@ -97,7 +98,7 @@ function TimelineEntry({ event, formatTime }: { event: StreamEvent; formatTime: 
           <span>
             Command dispatched:{" "}
             <code className="font-mono bg-muted text-primary font-bold px-1 rounded">/{p.name}</code>
-            {p.args && <span className="text-muted-foreground/70"> {p.args}</span>}
+            {p.args && <span className="text-muted-foreground/70"> {stripMarkdownToInline(p.args)}</span>}
           </span>
         </div>
       )
@@ -129,9 +130,12 @@ function TimelineEntry({ event, formatTime }: { event: StreamEvent; formatTime: 
   }
 }
 
+// Args are command markdown — a picked mention arrives as a pointer link
+// (`[@bot](bot:bot_x)`, INV-64) that must strip to `@bot` for display (INV-60).
 function truncateArgs(args: string, maxLength = 50): string {
-  if (args.length <= maxLength) return args
-  return args.slice(0, maxLength) + "..."
+  const inline = stripMarkdownToInline(args)
+  if (inline.length <= maxLength) return inline
+  return inline.slice(0, maxLength) + "..."
 }
 
 function formatResult(result: unknown): string {


### PR DESCRIPTION
## Problem

INV-64 (#1043) made the composer serialize a picked mention to a pointer link, so a dispatched slash command's markdown args now carry `[@test-bot](bot:bot_test)` where they used to carry `@test-bot`. `/invite`'s `parseSlugs` (`apps/backend/src/features/commands/invite-command.ts`) was a private whitespace-token scan for `@`-prefixed words — the pointer form starts with `[@`, so it matched nothing, the command returned its usage error, and nobody was invited. The two `invite-command.spec.ts` browser tests caught this: **main's Browser E2E workflow is red on the #1043 squash commit (`661a5aea`)**. Second, smaller casualty of the same change: the timeline's command row (`command-event.tsx`) renders `args` raw, so users now see literal `[@test-bot](bot:bot_test)` link syntax (INV-60).

## Solution

Make `/invite` consume mentions the INV-64 way — parse the args with the shared markdown parser and invite resolved pointers **by id**, keeping bare `@slug` as the lenient fallback — and strip the command row's args markdown at render.

### How it works

1. **`parseMentionArgs`** replaces `parseSlugs`: it runs `parseMarkdown` (from `@threa/prosemirror`, the same parser the message write path uses) over `ctx.args` and walks the doc for `mention` nodes, yielding `{ id, slug }` per mention. A picker-inserted mention arrives resolved (`bot:bot_x` → id `bot_x`); a hand-typed `@slug` parses as an unresolved node whose id has no prefix.
2. **Partition by `actorTypeFromMentionId`**: `usr_` ids → `UserRepository.findByIds`, `bot_` ids → `BotRepository.findByIds`, prefixless (bare slugs) → the existing `findBySlugs` pair. Persona and broadcast pointers are not invitable and fall through to `unknown`.
3. **Dedupe by id** (`entityById` map) so the same actor mentioned in both forms is invited once.
4. **Archived-bot parity**: `findBySlugs` excludes archived bots in SQL but `findByIds` doesn't, so the id path filters `archivedAt === null` — a stale pointer to an archived bot reports as unknown instead of inviting it (caught in self-review).
5. **`unknown`** is now computed per mention — an entry is unknown when neither its id nor its slug matched an invitable entity, which covers stale pointer ids, unknown bare slugs, and persona/broadcast pointers with one rule.
6. **Timeline row (INV-60)**: `command-event.tsx` routes `args` through `stripMarkdownToInline()` in both the collapsed header and the expanded lifecycle entry, so the pointer form displays as `@test-bot`.

### Key design decisions

**Fix the parser, not the serialization.** The alternative — having the composer dispatch commands with bare-slug markdown — would strip the resolved id from the command payload and re-introduce the slug-re-resolution INV-64 exists to remove. Commands are exactly the consumer that benefits from the id riding along: `/invite [@alice](user:usr_x)` invites `usr_x` even if the slug was renamed between pick and dispatch.

**Reuse `parseMarkdown` instead of extending the token scan.** A regex for the pointer form would be a second, drifting implementation of the wire format (INV-35/37). The shared parser already understands both forms and every future one.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/commands/invite-command.ts` | `parseSlugs` → `parseMentionArgs` (shared parser); id-first lookup with slug fallback; dedupe; archived-bot filter; per-mention `unknown` |
| `apps/frontend/src/components/timeline/command-event.tsx` | Strip args markdown to inline text in both render spots (INV-60) |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/commands/invite-command.test.ts` | Pointer-form user/bot invite, bare-slug fallback, mixed-form dedupe, persona/broadcast → unknown, archived-bot pointer → unknown, bots:manage gate |

## Out of scope (deliberate)

- Other slash commands: `/invite` is the only command that consumed mention args (verified by sweep; `dm-search.ts`'s `@` parsing is a typed search-box query, not message markdown).
- `PointerMentionChip` rendering of command args — command rows are plain-text summaries; chip rendering there is #1044's concern for message bodies only.

## Test plan

- [x] `bun test src/features/commands` — 11 pass (8 new; the pointer cases fail without the fix, verified test-first)
- [x] Frontend `src/components/timeline` via vitest — 374 pass
- [x] `bun run typecheck` — clean across all packages/apps
- [x] Self-review pass: `findByIds` archived-bot gap found and fixed (item 4); other `BotRepository.findByIds` caller (public-api display-name resolution) deliberately untouched — archived names should still resolve for historical mentions
- [ ] The failing browser tests (`invite-command.spec.ts`) are not runnable locally (no browser-test DB harness in this session) — this PR's CI run is the verification

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0198JfHFK2rs9epDxcpae3Xs)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785597492&installation_id=129946197&pr_number=1139&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1139&signature=23b10f8aa450fc6fee69c45dac18035e7079bab88fb7e089e800709812b1f290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->