### PR TITLE
feat: in-stream conversation provenance chip for topic revivals

### DIFF
--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -260,6 +260,19 @@ describe("annotateConversationRevivals", () => {
     expect(revivals(items, membership)).toEqual([null, null, null])
   })
 
+  it("does not manufacture a revival when only an unassigned aside separates two members", () => {
+    // a1 → x1(unassigned) → a2, all with no *other* conversation between. A lone
+    // unclustered message is not a topic switch, so a2 must not get a chip.
+    const items = [
+      msg("a1", "2026-06-01T00:00:00.000Z"),
+      msg("x1", "2026-06-01T00:01:00.000Z"),
+      msg("a2", "2026-06-01T00:02:00.000Z"),
+    ]
+    const membership = { a1: "conv_a", a2: "conv_a" }
+
+    expect(revivals(items, membership)).toEqual([null, null, null])
+  })
+
   it("ignores unassigned rows and does not break the run across non-message items", () => {
     const gap: TimelineItem = { type: "gap", afterEventId: "evt_a1", missingCount: 1 }
     const items = [

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import type { ConversationWithStaleness, StreamEvent } from "@threa/types"
-import { annotateConversationRows, type TimelineItem } from "../event-list"
+import { annotateConversationRows, annotateConversationRevivals, type TimelineItem } from "../event-list"
 import {
   buildConversationOverlayModel,
   buildMessageConversationMap,
@@ -203,5 +203,82 @@ describe("annotateConversationRows", () => {
 
     const result = annotateConversationRows([deleted, membership], model)
     expect(result.every((item) => item.type === "event" && item.conversationRow === undefined)).toBe(true)
+  })
+})
+
+describe("annotateConversationRevivals", () => {
+  function msg(messageId: string, createdAt: string): TimelineItem {
+    return {
+      type: "event",
+      event: {
+        id: `evt_${messageId}`,
+        streamId: "stream_123",
+        sequence: "1",
+        eventType: "message_created",
+        payload: { messageId, contentMarkdown: "hi" },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt,
+      },
+    }
+  }
+
+  const conversationsById = new Map<string, ConversationWithStaleness>([
+    ["conv_a", makeConversation({ id: "conv_a", topicSummary: "Pizza" })],
+    ["conv_b", makeConversation({ id: "conv_b", topicSummary: "Bug" })],
+  ])
+
+  function revivals(items: TimelineItem[], membership: Record<string, string>) {
+    return annotateConversationRevivals(items, new Map(Object.entries(membership)), conversationsById).map((item) =>
+      item.type === "event" ? (item.revival ?? null) : null
+    )
+  }
+
+  it("marks a reopened conversation as a revival, anchored to its prior member time", () => {
+    const items = [
+      msg("a1", "2026-06-01T00:00:00.000Z"),
+      msg("b1", "2026-06-01T00:01:00.000Z"),
+      msg("a2", "2026-06-01T03:00:00.000Z"),
+    ]
+    const membership = { a1: "conv_a", b1: "conv_b", a2: "conv_a" }
+
+    expect(revivals(items, membership)).toEqual([
+      null,
+      null,
+      { conversationId: "conv_a", topicSummary: "Pizza", previousActivityAt: "2026-06-01T00:00:00.000Z" },
+    ])
+  })
+
+  it("does not mark a contiguous run or a conversation's first appearance", () => {
+    const items = [
+      msg("a1", "2026-06-01T00:00:00.000Z"),
+      msg("a2", "2026-06-01T00:01:00.000Z"),
+      msg("b1", "2026-06-01T00:02:00.000Z"),
+    ]
+    const membership = { a1: "conv_a", a2: "conv_a", b1: "conv_b" }
+
+    expect(revivals(items, membership)).toEqual([null, null, null])
+  })
+
+  it("ignores unassigned rows and does not break the run across non-message items", () => {
+    const gap: TimelineItem = { type: "gap", afterEventId: "evt_a1", missingCount: 1 }
+    const items = [
+      msg("a1", "2026-06-01T00:00:00.000Z"),
+      msg("x1", "2026-06-01T00:01:00.000Z"),
+      msg("b1", "2026-06-01T00:02:00.000Z"),
+      gap,
+      msg("a2", "2026-06-01T00:03:00.000Z"),
+    ]
+    // x1 is unassigned (no membership entry); the gap sits between b1 and a2.
+    const membership = { a1: "conv_a", b1: "conv_b", a2: "conv_a" }
+
+    const result = revivals(items, membership)
+    expect(result[1]).toBeNull()
+    expect(result[3]).toBeNull()
+    expect(result[4]).toEqual({
+      conversationId: "conv_a",
+      topicSummary: "Pizza",
+      previousActivityAt: "2026-06-01T00:00:00.000Z",
+    })
   })
 })

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -81,6 +81,26 @@ export function buildMessageConversationMap(conversations: ConversationWithStale
 }
 
 /**
+ * A topic revival: a message that reopens a conversation whose previous member
+ * message is not the immediately-preceding timeline row (scattered / old), so
+ * in the flat timeline it reads as a non-sequitur. Drives the on-message
+ * provenance chip ("↪ continues Pizza · 3h ago") that links to the
+ * conversation panel. Computed always-on for channels/DMs (independent of the
+ * overlay) by `annotateConversationRevivals` in event-list.tsx.
+ */
+export interface ConversationRevival {
+  /** Conversation to open when the chip is tapped (`conv:<id>` panel). */
+  conversationId: string
+  /** Topic label for the chip; null falls back to a generic label. */
+  topicSummary: string | null
+  /**
+   * `createdAt` of the conversation's previous member row — the "· 3h ago"
+   * anchor. The prior activity of this topic, not this reviving message.
+   */
+  previousActivityAt: string
+}
+
+/**
  * Per-row annotation stamped onto message timeline items while the overlay
  * is active (see `annotateConversationRows` in event-list.tsx).
  */

--- a/apps/frontend/src/components/timeline/event-item.tsx
+++ b/apps/frontend/src/components/timeline/event-item.tsx
@@ -1,6 +1,7 @@
 import type { StreamEvent } from "@threa/types"
 import type { MessageAgentActivity } from "@/hooks"
 import type { BatchTimelineState } from "./event-list"
+import type { ConversationRevival } from "./conversation-overlay/model"
 import { MessageEvent } from "./message-event"
 import { MembershipEvent } from "./membership-event"
 import { MessagesMovedEvent } from "./messages-moved-event"
@@ -35,6 +36,11 @@ interface EventItemProps {
    * — only the opening message gets the breadcrumb.
    */
   isFirstMessage?: boolean
+  /**
+   * Topic-revival annotation for the on-message provenance chip, when this
+   * message reopens a scattered conversation (channel/DM timelines only).
+   */
+  revival?: ConversationRevival
   batch?: BatchTimelineState
 }
 
@@ -49,6 +55,7 @@ export function EventItem({
   deferSecondaryHydration = false,
   groupContinuation = false,
   isFirstMessage = false,
+  revival,
   batch,
 }: EventItemProps) {
   const messageId = (event.payload as { messageId?: string })?.messageId
@@ -78,6 +85,7 @@ export function EventItem({
             deferSecondaryHydration={deferSecondaryHydration}
             groupContinuation={groupContinuation}
             isFirstMessage={isFirstMessage}
+            revival={revival}
             batch={batch}
           />
         </div>

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -245,9 +245,12 @@ export function annotateConversationRows(items: TimelineItem[], model: Conversat
  *
  * `membership` is the always-on `messageId → conversationId` map
  * (`buildMessageConversationMap`), including cross-stream secondary members.
- * Non-message items (session/command cards) don't break a run, and unrevived
- * rows pass through untouched, both mirroring `annotateConversationRows`. Pure
- * and export-only for isolated coverage.
+ * Non-message items (session/command cards) and unassigned message rows don't
+ * break a run — only a different real conversation does. This diverges from
+ * `annotateConversationRows` (which resets its run on an unassigned row for
+ * coloring): a lone unclustered aside between two members of the same topic is
+ * not a topic switch, so it must not manufacture a revival. Pure and
+ * export-only for isolated coverage.
  */
 export function annotateConversationRevivals(
   items: TimelineItem[],
@@ -275,8 +278,14 @@ export function annotateConversationRevivals(
       }
       seen.add(conversationId)
       lastActivityByConversation.set(conversationId, item.event.createdAt)
+      // Only a real conversation breaks the run. An unassigned message
+      // (extraction pending, or a genuinely unclustered aside) must NOT reset
+      // this — otherwise the next same-conversation message reads as a block
+      // start and gets a false revival chip even though no *other* topic
+      // intervened, just one stray message. A revival requires a different
+      // conversation between the prior member and now, not merely a gap.
+      previousConversationId = conversationId
     }
-    previousConversationId = conversationId
     return revival ? { ...item, revival } : item
   })
 }
@@ -645,10 +654,13 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
         isNew={ctx.newMessageIds?.has(item.event.id)}
         deferSecondaryHydration={deferSecondaryHydration}
         batch={ctx.batch}
-        // Continuations directly under an UnreadDivider promote back to head so
-        // the first unread message in a run still reads as a fresh turn for the
-        // viewer (fixes the "continuation starting an unread block" edge case).
-        groupContinuation={item.groupContinuation && !showUnreadDivider}
+        // Continuations directly under an UnreadDivider — or that revive a
+        // scattered topic — promote back to head so the row reads as a fresh
+        // turn. A revival is a topic switch, so it should never render as a
+        // silent same-author continuation; the head also restores the message's
+        // own send-time in the header, keeping it distinct from the provenance
+        // chip's topic-activity time above it.
+        groupContinuation={item.groupContinuation && !showUnreadDivider && !item.revival}
         isFirstMessage={
           ctx.firstMessageId != null && (item.event.payload as { messageId?: string })?.messageId === ctx.firstMessageId
         }

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -654,13 +654,10 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
         isNew={ctx.newMessageIds?.has(item.event.id)}
         deferSecondaryHydration={deferSecondaryHydration}
         batch={ctx.batch}
-        // Continuations directly under an UnreadDivider — or that revive a
-        // scattered topic — promote back to head so the row reads as a fresh
-        // turn. A revival is a topic switch, so it should never render as a
-        // silent same-author continuation; the head also restores the message's
-        // own send-time in the header, keeping it distinct from the provenance
-        // chip's topic-activity time above it.
-        groupContinuation={item.groupContinuation && !showUnreadDivider && !item.revival}
+        // Continuations directly under an UnreadDivider promote back to head so
+        // the first unread message in a run still reads as a fresh turn for the
+        // viewer (fixes the "continuation starting an unread block" edge case).
+        groupContinuation={item.groupContinuation && !showUnreadDivider}
         isFirstMessage={
           ctx.firstMessageId != null && (item.event.payload as { messageId?: string })?.messageId === ctx.firstMessageId
         }

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -26,8 +26,10 @@ import { ConversationOverlayRow } from "./conversation-overlay/conversation-over
 import type {
   ConversationOverlayContext,
   ConversationOverlayModel,
+  ConversationRevival,
   ConversationRowAnnotation,
 } from "./conversation-overlay/model"
+import type { ConversationWithStaleness } from "@threa/types"
 
 interface EventListProps {
   timelineItems: TimelineItem[]
@@ -121,6 +123,13 @@ export type TimelineItem =
        * active. Absent on non-message events and when the overlay is off.
        */
       conversationRow?: ConversationRowAnnotation
+      /**
+       * Topic-revival annotation, stamped always-on by
+       * `annotateConversationRevivals` on channel/DM timelines. Present only on
+       * a message that reopens a scattered conversation; drives the on-message
+       * provenance chip. Absent on non-message events and non-revival rows.
+       */
+      revival?: ConversationRevival
     }
   | { type: "command_group"; commandId: string; events: StreamEvent[] }
   | { type: "session_group"; sessionId: string; sessionVersion: number; events: StreamEvent[] }
@@ -218,6 +227,57 @@ export function annotateConversationRows(items: TimelineItem[], model: Conversat
     const blockStart = conversationId != null && conversationId !== previousConversationId
     previousConversationId = conversationId
     return { ...item, conversationRow: { conversationId, blockStart } }
+  })
+}
+
+/**
+ * Stamp message rows that revive a scattered conversation with a
+ * {@link ConversationRevival} for the always-on provenance chip (board-view-
+ * design.md §"Conversations as soft threads", mechanism A) — no dependence on
+ * the conversation overlay being painted.
+ *
+ * A revival is a *block start* (the conversation differs from the previous
+ * message row) whose conversation has already appeared earlier in the timeline.
+ * Because a block start means the previous row is a different conversation, an
+ * earlier member is necessarily separated from this one — that separation is
+ * exactly the non-sequitur the chip explains. A conversation's first appearance
+ * is a fresh topic, not a revival, so it carries no chip.
+ *
+ * `membership` is the always-on `messageId → conversationId` map
+ * (`buildMessageConversationMap`), including cross-stream secondary members.
+ * Non-message items (session/command cards) don't break a run, and unrevived
+ * rows pass through untouched, both mirroring `annotateConversationRows`. Pure
+ * and export-only for isolated coverage.
+ */
+export function annotateConversationRevivals(
+  items: TimelineItem[],
+  membership: ReadonlyMap<string, string>,
+  conversationsById: ReadonlyMap<string, ConversationWithStaleness>
+): TimelineItem[] {
+  const seen = new Set<string>()
+  const lastActivityByConversation = new Map<string, string>()
+  let previousConversationId: string | null = null
+  return items.map((item) => {
+    if (item.type !== "event" || !isGroupableMessage(item.event)) return item
+    const messageId = (item.event.payload as { messageId?: string })?.messageId
+    if (!messageId) return item
+    const conversationId = membership.get(messageId) ?? null
+    let revival: ConversationRevival | undefined
+    if (conversationId != null) {
+      const blockStart = conversationId !== previousConversationId
+      const previousActivityAt = lastActivityByConversation.get(conversationId)
+      if (blockStart && seen.has(conversationId) && previousActivityAt) {
+        revival = {
+          conversationId,
+          topicSummary: conversationsById.get(conversationId)?.topicSummary ?? null,
+          previousActivityAt,
+        }
+      }
+      seen.add(conversationId)
+      lastActivityByConversation.set(conversationId, item.event.createdAt)
+    }
+    previousConversationId = conversationId
+    return revival ? { ...item, revival } : item
   })
 }
 
@@ -592,6 +652,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
         isFirstMessage={
           ctx.firstMessageId != null && (item.event.payload as { messageId?: string })?.messageId === ctx.firstMessageId
         }
+        revival={item.revival}
       />
     )
     const overlayMessageId = (item.event.payload as { messageId?: string })?.messageId
@@ -699,11 +760,15 @@ export function timelineItemEqual(a: TimelineItem, b: TimelineItem): boolean {
       if (a.event !== other.event || (a.groupContinuation ?? false) !== (other.groupContinuation ?? false)) {
         return false
       }
-      // Overlay annotation objects are rebuilt by every annotation pass, so
-      // compare by value — identity would defeat the memo on each data tick.
+      // Overlay + revival annotation objects are rebuilt by every annotation
+      // pass, so compare by value — identity would defeat the memo on each
+      // data tick.
       return (
         (a.conversationRow?.conversationId ?? null) === (other.conversationRow?.conversationId ?? null) &&
-        (a.conversationRow?.blockStart ?? false) === (other.conversationRow?.blockStart ?? false)
+        (a.conversationRow?.blockStart ?? false) === (other.conversationRow?.blockStart ?? false) &&
+        (a.revival?.conversationId ?? null) === (other.revival?.conversationId ?? null) &&
+        (a.revival?.topicSummary ?? null) === (other.revival?.topicSummary ?? null) &&
+        (a.revival?.previousActivityAt ?? null) === (other.revival?.previousActivityAt ?? null)
       )
     }
     case "command_group": {

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -171,6 +171,37 @@ describe("MessageEvent", () => {
     })
   })
 
+  describe("provenance chip", () => {
+    it("renders a revival chip linking to the conversation panel", () => {
+      const event = createMessageEvent("msg_123", "Pizza")
+
+      render(
+        <MessageEvent
+          event={event}
+          workspaceId={workspaceId}
+          streamId={streamId}
+          revival={{
+            conversationId: "conv_a",
+            topicSummary: "Pizza",
+            previousActivityAt: "2026-06-01T00:00:00.000Z",
+          }}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      const chip = screen.getByRole("link", { name: /continues pizza/i })
+      expect(chip).toHaveAttribute("href", "/panel/conv:conv_a")
+    })
+
+    it("renders no chip when the message is not a revival", () => {
+      const event = createMessageEvent("msg_123", "Pizza")
+
+      render(<MessageEvent event={event} workspaceId={workspaceId} streamId={streamId} />, { wrapper: Wrapper })
+
+      expect(screen.queryByRole("link", { name: /continues/i })).not.toBeInTheDocument()
+    })
+  })
+
   describe("content rendering", () => {
     it("should render message content", () => {
       const event = createMessageEvent("msg_123", "Hello, world!")

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -200,6 +200,27 @@ describe("MessageEvent", () => {
 
       expect(screen.queryByRole("link", { name: /continues/i })).not.toBeInTheDocument()
     })
+
+    it("omits the chip on a grouped continuation (no header to anchor it)", () => {
+      const event = createMessageEvent("msg_123", "Pizza")
+
+      render(
+        <MessageEvent
+          event={event}
+          workspaceId={workspaceId}
+          streamId={streamId}
+          groupContinuation
+          revival={{
+            conversationId: "conv_a",
+            topicSummary: "Pizza",
+            previousActivityAt: "2026-06-01T00:00:00.000Z",
+          }}
+        />,
+        { wrapper: Wrapper }
+      )
+
+      expect(screen.queryByRole("link", { name: /continues/i })).not.toBeInTheDocument()
+    })
   })
 
   describe("content rendering", () => {

--- a/apps/frontend/src/components/timeline/message-event.test.tsx
+++ b/apps/frontend/src/components/timeline/message-event.test.tsx
@@ -201,7 +201,7 @@ describe("MessageEvent", () => {
       expect(screen.queryByRole("link", { name: /continues/i })).not.toBeInTheDocument()
     })
 
-    it("omits the chip on a grouped continuation (no header to anchor it)", () => {
+    it("still renders the chip on a grouped continuation (footer, both row types)", () => {
       const event = createMessageEvent("msg_123", "Pizza")
 
       render(
@@ -219,7 +219,7 @@ describe("MessageEvent", () => {
         { wrapper: Wrapper }
       )
 
-      expect(screen.queryByRole("link", { name: /continues/i })).not.toBeInTheDocument()
+      expect(screen.getByRole("link", { name: /continues pizza/i })).toHaveAttribute("href", "/panel/conv:conv_a")
     })
   })
 

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -174,13 +174,6 @@ interface MessageLayoutProps {
    */
   hoverActions?: ReactNode
   footer?: ReactNode
-  /**
-   * Slot rendered above the header row inside the content column — the topic
-   * provenance chip on a revived-conversation message ("↪ continues X · 3h
-   * ago"). Renders on continuations too (which have no header row), so it
-   * always prefaces the body.
-   */
-  preface?: ReactNode
   children?: ReactNode
   /**
    * Decrypted E2E attachment refs (key/iv/filename/mime), surfaced from the
@@ -267,17 +260,28 @@ function MessageLinkPreviews({
 
 /**
  * On-message topic-provenance chip (board-view-design.md mechanism A). Rendered
- * above a message that revives a scattered conversation — its previous member
- * row is not the one directly above — so a late "Pizza" reads as
- * "continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens the
- * conversation's side panel (`conv:<id>`); a `<Link>` keeps it URL-driven
- * (INV-40, INV-59). Static footprint — no hover-driven resize (INV-21).
+ * in the header meta row of a message that revives a scattered conversation —
+ * its previous member row is not the one directly above — so a late "Pizza"
+ * reads as "continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens
+ * the conversation's side panel (`conv:<id>`); a `<Link>` keeps it URL-driven
+ * (INV-40, INV-59).
+ *
+ * It sits in the header beside `MovedFromIndicator`/labels — the app's existing
+ * home for per-message provenance — precisely so its late appearance shifts
+ * nothing: conversation membership resolves from a query that lands after the
+ * timeline has painted (the coordinated-loading reveal gates on bootstrap/
+ * events, not conversations), and the header is a fixed-height, non-wrapping
+ * baseline row, so the chip fills horizontal space without growing the row or
+ * pushing the body down (INV-21). Because the header renders only on head rows,
+ * the chip is naturally absent on grouped continuations — which have no visible
+ * send-time of their own, so the chip's topic time can't be misread as one.
  *
  * Uses the `Layers` glyph (the conversation identity across the overlay) rather
  * than the move indicator's `CornerDownRight`, and stays neutral/muted rather
  * than the thread affordance's gold — a conversation is a quiet "soft thread",
  * not Ariadne's structural gold line. The topic label mirrors the overlay's
- * `topicSummary || fallback` rendering and separator (`·` + terse time).
+ * `topicSummary || fallback` rendering and separator (`·` + terse time), capped
+ * so a long topic truncates instead of crowding the header.
  */
 function ConversationProvenanceChip({ revival }: { revival: ConversationRevival }) {
   const { getPanelUrl } = usePanel()
@@ -288,7 +292,7 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
       to={href}
       aria-label={`Continues ${topic} — open conversation`}
       className={cn(
-        "group/prov mb-1 inline-flex max-w-full items-center gap-1.5 text-xs",
+        "group/prov inline-flex min-w-0 max-w-[200px] items-center gap-1 text-xs",
         "text-muted-foreground transition-colors hover:text-foreground"
       )}
     >
@@ -301,29 +305,6 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
       </span>
       <RelativeTime date={revival.previousActivityAt} terse className="shrink-0 text-muted-foreground/70" />
     </Link>
-  )
-}
-
-/**
- * Always-mounted wrapper for the provenance chip. Conversation membership
- * resolves from a separate query that lands after the timeline has already
- * painted (the coordinated-loading reveal gates on bootstrap/events, not
- * conversations), so a revival is stamped onto a row that is already on screen.
- * Rendering the chip directly would grow the row and shove the body down
- * mid-read (INV-21). Keeping this grid mounted at `0fr` and easing to `1fr`
- * when `revival` arrives slides the chip in instead of snapping — the same
- * `grid-template-rows` transition `ThreadSlot` uses for its late-hydrating card.
- * A row scrolled in after membership loaded mounts already at `1fr`, so the
- * transition plays only on the real appearance, never on virtua remount.
- */
-function MessagePreface({ revival }: { revival?: ConversationRevival }) {
-  return (
-    <div
-      className="grid transition-[grid-template-rows] duration-300 ease-out"
-      style={{ gridTemplateRows: revival ? "1fr" : "0fr" }}
-    >
-      <div className="overflow-hidden">{revival && <ConversationProvenanceChip revival={revival} />}</div>
-    </div>
   )
 }
 
@@ -556,7 +537,6 @@ function MessageLayout({
   actions,
   hoverActions,
   footer,
-  preface,
   children,
   attachmentRefs,
   sources,
@@ -811,7 +791,6 @@ function MessageLayout({
           inert={batchEnabled || undefined}
           className={cn("message-content flex-1 min-w-0", batchEnabled && "pointer-events-none")}
         >
-          {preface}
           {headerRow}
           {messageBody}
           {footer}
@@ -1344,7 +1323,6 @@ function SentMessageEvent({
         isFirstMessage={isFirstMessage}
         attachmentRefs={attachmentRefs}
         sources={sources}
-        preface={<MessagePreface revival={revival} />}
         statusIndicator={
           <>
             <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
@@ -1358,6 +1336,7 @@ function SentMessageEvent({
                 onClick={movedTombstoneEvent ? () => setMoveDetailsOpen(true) : undefined}
               />
             )}
+            {revival && <ConversationProvenanceChip revival={revival} />}
             <SavedIndicator saved={savedForMessage ?? null} />
             {/* Labels beside the time — standalone rows only; this header isn't
                 rendered for continuations, which keep them in the footer. */}

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -305,6 +305,29 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
 }
 
 /**
+ * Always-mounted wrapper for the provenance chip. Conversation membership
+ * resolves from a separate query that lands after the timeline has already
+ * painted (the coordinated-loading reveal gates on bootstrap/events, not
+ * conversations), so a revival is stamped onto a row that is already on screen.
+ * Rendering the chip directly would grow the row and shove the body down
+ * mid-read (INV-21). Keeping this grid mounted at `0fr` and easing to `1fr`
+ * when `revival` arrives slides the chip in instead of snapping — the same
+ * `grid-template-rows` transition `ThreadSlot` uses for its late-hydrating card.
+ * A row scrolled in after membership loaded mounts already at `1fr`, so the
+ * transition plays only on the real appearance, never on virtua remount.
+ */
+function MessagePreface({ revival }: { revival?: ConversationRevival }) {
+  return (
+    <div
+      className="grid transition-[grid-template-rows] duration-300 ease-out"
+      style={{ gridTemplateRows: revival ? "1fr" : "0fr" }}
+    >
+      <div className="overflow-hidden">{revival && <ConversationProvenanceChip revival={revival} />}</div>
+    </div>
+  )
+}
+
+/**
  * Per-actor-type row styling. Each entry is the single source of truth for
  * how a message from that actor type looks: the row accent gradient + inset
  * stripe, the author-name color, and an optional inline header badge.
@@ -1321,7 +1344,7 @@ function SentMessageEvent({
         isFirstMessage={isFirstMessage}
         attachmentRefs={attachmentRefs}
         sources={sources}
-        preface={revival ? <ConversationProvenanceChip revival={revival} /> : undefined}
+        preface={<MessagePreface revival={revival} />}
         statusIndicator={
           <>
             <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -34,7 +34,7 @@ import {
   focusAtEnd,
   type MessageAgentActivity,
 } from "@/hooks"
-import { Quote, MessageSquareReply, Check } from "lucide-react"
+import { Quote, MessageSquareReply, Check, CornerDownRight } from "lucide-react"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -84,6 +84,7 @@ import { useReadFrontier, rowReadState } from "./read-frontier-context"
 import { ConversationPickerDrawer } from "./conversation-overlay/conversation-overlay"
 import { useConversationOverlayRow } from "./conversation-overlay/row-context"
 import { useMessageConversationId } from "./conversation-overlay/message-conversation-context"
+import type { ConversationRevival } from "./conversation-overlay/model"
 
 const SLOW_SEND_THRESHOLD_MS = 5000
 
@@ -141,6 +142,11 @@ interface MessageEventProps {
    * lives on the message that "carried" it.
    */
   isFirstMessage?: boolean
+  /**
+   * Topic-revival annotation for the on-message provenance chip, when this
+   * message reopens a scattered conversation (channel/DM timelines only).
+   */
+  revival?: ConversationRevival
   batch?: BatchTimelineState
 }
 
@@ -168,6 +174,13 @@ interface MessageLayoutProps {
    */
   hoverActions?: ReactNode
   footer?: ReactNode
+  /**
+   * Slot rendered above the header row inside the content column — the topic
+   * provenance chip on a revived-conversation message ("↪ continues X · 3h
+   * ago"). Renders on continuations too (which have no header row), so it
+   * always prefaces the body.
+   */
+  preface?: ReactNode
   children?: ReactNode
   /**
    * Decrypted E2E attachment refs (key/iv/filename/mime), surfaced from the
@@ -249,6 +262,40 @@ function MessageLinkPreviews({
       hoveredUrl={linkPreviewContext?.hoveredLinkUrl}
       hydrateFromApi={hydrateFromApi}
     />
+  )
+}
+
+/**
+ * On-message topic-provenance chip (board-view-design.md mechanism A). Rendered
+ * above a message that revives a scattered conversation — its previous member
+ * row is not the one directly above — so a late "Pizza" reads as
+ * "↪ continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens the
+ * conversation's side panel (`conv:<id>`); a `<Link>` keeps it URL-driven
+ * (INV-40, INV-59). Static footprint — no hover-driven resize (INV-21). The
+ * topic label mirrors the overlay's `topicSummary || fallback` rendering.
+ */
+function ConversationProvenanceChip({ revival }: { revival: ConversationRevival }) {
+  const { getPanelUrl } = usePanel()
+  const href = getPanelUrl(createConversationPanelId(revival.conversationId))
+  const topic = revival.topicSummary || "an earlier conversation"
+  return (
+    <Link
+      to={href}
+      aria-label={`Continues ${topic} — open conversation`}
+      className={cn(
+        "group/prov mb-1 inline-flex max-w-full items-center gap-1 text-xs",
+        "text-muted-foreground/80 transition-colors hover:text-foreground"
+      )}
+    >
+      <CornerDownRight className="h-3 w-3 shrink-0 text-muted-foreground/50 transition-colors group-hover/prov:text-foreground/70" />
+      <span className="min-w-0 truncate">
+        continues <span className="font-medium text-foreground/75 group-hover/prov:underline">{topic}</span>
+      </span>
+      <span aria-hidden className="text-muted-foreground/40">
+        ·
+      </span>
+      <RelativeTime date={revival.previousActivityAt} terse className="shrink-0 text-muted-foreground/70" />
+    </Link>
   )
 }
 
@@ -481,6 +528,7 @@ function MessageLayout({
   actions,
   hoverActions,
   footer,
+  preface,
   children,
   attachmentRefs,
   sources,
@@ -735,6 +783,7 @@ function MessageLayout({
           inert={batchEnabled || undefined}
           className={cn("message-content flex-1 min-w-0", batchEnabled && "pointer-events-none")}
         >
+          {preface}
           {headerRow}
           {messageBody}
           {footer}
@@ -788,6 +837,8 @@ interface MessageEventInnerProps {
   groupContinuation?: boolean
   /** True when this is the first message in the stream — drives the context-bag attachment badge. */
   isFirstMessage?: boolean
+  /** Topic-revival annotation for the on-message provenance chip (channel/DM only). */
+  revival?: ConversationRevival
   /** Decrypted E2E attachment refs, threaded to the body's `<E2eAttachmentList>`. */
   attachmentRefs?: AttachmentRef[]
   /** Decrypted E2E citation sources, threaded to the body's `<MessageSourceList>` (E2EE-9). */
@@ -840,6 +891,7 @@ function SentMessageEvent({
   deferSecondaryHydration,
   groupContinuation,
   isFirstMessage,
+  revival,
   attachmentRefs,
   sources,
   e2eEnabled,
@@ -1264,6 +1316,7 @@ function SentMessageEvent({
         isFirstMessage={isFirstMessage}
         attachmentRefs={attachmentRefs}
         sources={sources}
+        preface={revival ? <ConversationProvenanceChip revival={revival} /> : undefined}
         statusIndicator={
           <>
             <RelativeTime date={event.createdAt} className="text-xs text-muted-foreground" />
@@ -1782,6 +1835,7 @@ export function MessageEvent({
   deferSecondaryHydration = false,
   groupContinuation = false,
   isFirstMessage = false,
+  revival,
   batch,
 }: MessageEventProps) {
   const rawPayload = event.payload as MessagePayload
@@ -1863,6 +1917,7 @@ export function MessageEvent({
           deferSecondaryHydration={deferSecondaryHydration}
           groupContinuation={groupContinuation}
           isFirstMessage={isFirstMessage}
+          revival={revival}
           attachmentRefs={decrypted.status === "decrypted" ? decrypted.attachmentRefs : undefined}
           sources={decrypted.status === "decrypted" ? decrypted.sources : undefined}
           e2eEnabled={decrypted.status !== "plaintext"}

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -34,7 +34,7 @@ import {
   focusAtEnd,
   type MessageAgentActivity,
 } from "@/hooks"
-import { Quote, MessageSquareReply, Check, CornerDownRight } from "lucide-react"
+import { Quote, MessageSquareReply, Check, Layers } from "lucide-react"
 import { Link, useLocation, useNavigate } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -269,10 +269,15 @@ function MessageLinkPreviews({
  * On-message topic-provenance chip (board-view-design.md mechanism A). Rendered
  * above a message that revives a scattered conversation — its previous member
  * row is not the one directly above — so a late "Pizza" reads as
- * "↪ continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens the
+ * "continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens the
  * conversation's side panel (`conv:<id>`); a `<Link>` keeps it URL-driven
- * (INV-40, INV-59). Static footprint — no hover-driven resize (INV-21). The
- * topic label mirrors the overlay's `topicSummary || fallback` rendering.
+ * (INV-40, INV-59). Static footprint — no hover-driven resize (INV-21).
+ *
+ * Uses the `Layers` glyph (the conversation identity across the overlay) rather
+ * than the move indicator's `CornerDownRight`, and stays neutral/muted rather
+ * than the thread affordance's gold — a conversation is a quiet "soft thread",
+ * not Ariadne's structural gold line. The topic label mirrors the overlay's
+ * `topicSummary || fallback` rendering and separator (`·` + terse time).
  */
 function ConversationProvenanceChip({ revival }: { revival: ConversationRevival }) {
   const { getPanelUrl } = usePanel()
@@ -283,13 +288,13 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
       to={href}
       aria-label={`Continues ${topic} — open conversation`}
       className={cn(
-        "group/prov mb-1 inline-flex max-w-full items-center gap-1 text-xs",
-        "text-muted-foreground/80 transition-colors hover:text-foreground"
+        "group/prov mb-1 inline-flex max-w-full items-center gap-1.5 text-xs",
+        "text-muted-foreground transition-colors hover:text-foreground"
       )}
     >
-      <CornerDownRight className="h-3 w-3 shrink-0 text-muted-foreground/50 transition-colors group-hover/prov:text-foreground/70" />
+      <Layers className="h-3 w-3 shrink-0 text-muted-foreground/60 transition-colors group-hover/prov:text-foreground/70" />
       <span className="min-w-0 truncate">
-        continues <span className="font-medium text-foreground/75 group-hover/prov:underline">{topic}</span>
+        continues <span className="font-medium text-foreground/80 group-hover/prov:underline">{topic}</span>
       </span>
       <span aria-hidden className="text-muted-foreground/40">
         ·

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -260,28 +260,32 @@ function MessageLinkPreviews({
 
 /**
  * On-message topic-provenance chip (board-view-design.md mechanism A). Rendered
- * in the header meta row of a message that revives a scattered conversation —
- * its previous member row is not the one directly above — so a late "Pizza"
- * reads as "continues Pizza · 3h ago" instead of a non-sequitur. Tapping opens
- * the conversation's side panel (`conv:<id>`); a `<Link>` keeps it URL-driven
- * (INV-40, INV-59).
+ * in the message footer — under the body, mirroring `ThreadSlot`, which the
+ * design doc names as the affordance to mirror — on a message that revives a
+ * scattered conversation (its previous member row is not the one directly
+ * above), so a late "Pizza" reads as "continues Pizza · 3h ago" instead of a
+ * non-sequitur. Tapping opens the conversation's side panel (`conv:<id>`); a
+ * `<Link>` keeps it URL-driven (INV-40, INV-59).
  *
- * It sits in the header beside `MovedFromIndicator`/labels — the app's existing
- * home for per-message provenance — precisely so its late appearance shifts
- * nothing: conversation membership resolves from a query that lands after the
- * timeline has painted (the coordinated-loading reveal gates on bootstrap/
- * events, not conversations), and the header is a fixed-height, non-wrapping
- * baseline row, so the chip fills horizontal space without growing the row or
- * pushing the body down (INV-21). Because the header renders only on head rows,
- * the chip is naturally absent on grouped continuations — which have no visible
- * send-time of their own, so the chip's topic time can't be misread as one.
+ * On its own full-width line (not squeezed into the header meta row), so a long
+ * topic truncates cleanly instead of overflowing a phone's non-wrapping header.
+ * Its late appearance — conversation membership resolves from a query that
+ * lands after the timeline paints — occupies space the way `ThreadSlot`'s card,
+ * `LabelStack`, and link previews already do on this row: it just appears, with
+ * no grow-in animation. Animating the height (an earlier attempt) reads as
+ * "messages loading in late" and jitters virtua's scroll on mobile — the exact
+ * antipattern `ThreadSlot`'s settle-guard exists to avoid — so it is omitted
+ * deliberately, not forgotten.
+ *
+ * The "· <terse time>" is the topic's last activity, the same shape as
+ * `ThreadSlot`'s "<n> replies · <last reply>" — a footer affordance's own time,
+ * read as such, not the message's send time.
  *
  * Uses the `Layers` glyph (the conversation identity across the overlay) rather
  * than the move indicator's `CornerDownRight`, and stays neutral/muted rather
  * than the thread affordance's gold — a conversation is a quiet "soft thread",
  * not Ariadne's structural gold line. The topic label mirrors the overlay's
- * `topicSummary || fallback` rendering and separator (`·` + terse time), capped
- * so a long topic truncates instead of crowding the header.
+ * `topicSummary || fallback` rendering.
  */
 function ConversationProvenanceChip({ revival }: { revival: ConversationRevival }) {
   const { getPanelUrl } = usePanel()
@@ -292,7 +296,7 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
       to={href}
       aria-label={`Continues ${topic} — open conversation`}
       className={cn(
-        "group/prov inline-flex min-w-0 max-w-[200px] items-center gap-1 text-xs",
+        "group/prov mt-1 flex min-w-0 items-center gap-1.5 text-xs",
         "text-muted-foreground transition-colors hover:text-foreground"
       )}
     >
@@ -1289,6 +1293,7 @@ function SentMessageEvent({
   } else {
     footerContent = (
       <>
+        {revival && <ConversationProvenanceChip revival={revival} />}
         {payload.reactions && Object.keys(payload.reactions).length > 0 && (
           <MessageReactions
             reactions={payload.reactions}
@@ -1336,7 +1341,6 @@ function SentMessageEvent({
                 onClick={movedTombstoneEvent ? () => setMoveDetailsOpen(true) : undefined}
               />
             )}
-            {revival && <ConversationProvenanceChip revival={revival} />}
             <SavedIndicator saved={savedForMessage ?? null} />
             {/* Labels beside the time — standalone rows only; this header isn't
                 rendered for continuations, which keep them in the footer. */}

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -269,15 +269,15 @@ function MessageLinkPreviews({
  *
  * On its own full-width line (not squeezed into the header meta row), so a long
  * topic truncates cleanly instead of overflowing a phone's non-wrapping header.
- * Its late appearance — conversation membership resolves from a query that
- * lands after the timeline paints — occupies space the way `ThreadSlot`'s card,
- * `LabelStack`, and link previews already do on this row: it just appears, with
- * no grow-in animation. Animating the height (an earlier attempt) reads as
- * "messages loading in late" and jitters virtua's scroll on mobile — the exact
- * antipattern `ThreadSlot`'s settle-guard exists to avoid — so it is omitted
- * deliberately, not forgotten.
+ * Conversation membership resolves from a query that lands after the timeline
+ * paints, so the chip mounts at its final size like `ThreadSlot`'s card,
+ * `LabelStack`, and link previews already do on this row — no grow-in height
+ * animation, which on a late-hydrating row jitters virtua's scroll compensation
+ * on mobile.
  *
- * The "· <terse time>" is the topic's last activity, the same shape as
+ * `min-h` matches the footer's tap-target floor (`MessageReactions` pills are
+ * `min-h-[26px]`) so this navigation target isn't smaller than its neighbors on
+ * touch. The "· <terse time>" is the topic's last activity, the same shape as
  * `ThreadSlot`'s "<n> replies · <last reply>" — a footer affordance's own time,
  * read as such, not the message's send time.
  *
@@ -296,7 +296,7 @@ function ConversationProvenanceChip({ revival }: { revival: ConversationRevival 
       to={href}
       aria-label={`Continues ${topic} — open conversation`}
       className={cn(
-        "group/prov mt-1 flex min-w-0 items-center gap-1.5 text-xs",
+        "group/prov mt-0.5 flex min-h-[26px] min-w-0 items-center gap-1.5 text-xs",
         "text-muted-foreground transition-colors hover:text-foreground"
       )}
     >

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -52,6 +52,7 @@ import {
   type StreamMember,
   type WorkspaceBootstrap,
   type StreamBootstrap,
+  type ConversationWithStaleness,
 } from "@threa/types"
 import { isAbortableStepType } from "@/lib/step-config"
 import {
@@ -60,6 +61,7 @@ import {
   groupTimelineItems,
   annotateAuthorGroups,
   annotateConversationRows,
+  annotateConversationRevivals,
   injectGapItems,
   injectDayDividers,
   itemDayStartMs,
@@ -687,6 +689,12 @@ export function StreamContent({
       })
   }, [events, isThread])
 
+  // Conversation lookup for the always-on provenance chips (mechanism A below).
+  const conversationsById = useMemo(() => {
+    const map = new Map<string, ConversationWithStaleness>()
+    for (const conversation of streamConversations) map.set(conversation.id, conversation)
+    return map
+  }, [streamConversations])
   // Gap placeholders are injected AFTER grouping/annotation so a hole in the
   // broadcast chain (INV-61) renders as its own in-place loading row — see
   // useEvents' contiguity gate for how holes are detected and backfilled.
@@ -696,8 +704,24 @@ export function StreamContent({
     if (conversationOverlayModel && conversationOverlayModel.conversations.length > 0) {
       items = annotateConversationRows(items, conversationOverlayModel)
     }
+    // On-message provenance chips (board-view-design.md mechanism A): a late
+    // reply that revives a scattered topic gets a "↪ continues X · 3h ago" chip
+    // linking to the conversation panel. Always-on for the flat channel/DM
+    // timeline (never threads — thread replies are contiguous by construction,
+    // so nothing reads as a revival there).
+    if (supportsConversationOverlay) {
+      items = annotateConversationRevivals(items, conversationIdByMessageId, conversationsById)
+    }
     return injectGapItems(items, holes)
-  }, [displayEvents, currentWorkspaceUserId, holes, conversationOverlayModel])
+  }, [
+    displayEvents,
+    currentWorkspaceUserId,
+    holes,
+    conversationOverlayModel,
+    supportsConversationOverlay,
+    conversationIdByMessageId,
+    conversationsById,
+  ])
 
   // `order` is the position in the rendered timeline. Non-thread streams
   // happen to sort by sequence already, but threads re-sort by


### PR DESCRIPTION
**Design of record:** `docs/board-view-design.md` §"Conversations as soft threads", bullet **A. On-message provenance indicator (read)**, and Open-decision #1 (indicator trigger).

## Problem

A conversation is a *projected* grouping — a filter over a stream's flat messages — so a topic's messages are scattered through the timeline rather than contiguous like a thread. When someone replies to an old topic after unrelated chatter ("we talked lunch, then a bug, the demo, and now someone out of a meeting replies *Pizza*"), the reply lands at the tail (sequence-appended, INV-61) detached from the lunch exchange three hours up. In the flat timeline that reads as a non-sequitur. The board and the conversation panel are already coherent by construction; the flat timeline is the one broken read, and the fix is to make it self-explaining at that one spot — not to move anything (Kris's standing rule: never mutate/reorder a stream to fix alignment).

## Solution

A quiet on-message provenance chip. When a message *revives* a scattered conversation, it renders `⧉ continues <topic> · 3h ago` above the message body, linking to that conversation's side panel (`?panel=conv:<id>`, Mechanism B, already shipped). The reply stays exactly where it is — this is a pure read annotation.

### How it works

1. **Revival detection** — `annotateConversationRevivals` (`event-list.tsx`) walks the timeline and stamps a `revival` annotation on any message that *block-starts* a conversation (its conversation differs from the previous message row) whose conversation has already appeared earlier in the timeline. Because a block start means the previous row is a different conversation, an earlier member is necessarily separated from this one — that separation is the non-sequitur the chip explains. A conversation's first appearance is a fresh topic, not a revival, so it carries no chip; a contiguous run carries no chip. `previousActivityAt` anchors the "· 3h ago" to the prior member row's time (the topic's last activity), not the reviving message.

2. **Always-on membership** — detection reads `conversationIdByMessageId` (`buildMessageConversationMap`), the always-on `messageId → conversationId` map that already backs the per-message "Show in conversation" action. No dependence on the conversation overlay being painted (`convOverlay=on`) — the handover's stated obstacle ("membership annotated only when the overlay is on") was already solved by that provider, so the chip rides it.

3. **Flat-timeline only** — `annotateConversationRevivals` runs in the `timelineItems` memo (`stream-content.tsx`) gated on `supportsConversationOverlay` (`!isDraft && (channel || dm)`), so it never runs for threads or drafts. Thread replies are contiguous by construction; nothing reads as a revival there.

4. **Render** — `revival` threads through the existing `TimelineItem → EventItem → MessageEvent → SentMessageEvent` path as a `preface` slot rendered above the header row, and is compared in `timelineItemEqual` so only the reviving row re-renders on a new message. The chip is a `<Link to={getPanelUrl(createConversationPanelId(id))}>` (URL-driven, INV-40/INV-59).

### Key design decisions

**1. Trigger only on revivals (Open-decision #1, on the recorded lean).** A loud "continues X" fires only when the prior member is old/non-adjacent; an ordinary sequential topic switch or a fresh conversation gets nothing. In-window detection is conservative by construction — a block start with an earlier member can never be a false positive, and the worst case is a missing chip when the prior member is scrolled out of the loaded window (a false negative, not a wrong one).

**2. Annotation on `TimelineItem`, not a React context.** The always-on membership for "Show in conversation" uses a context (`MessageConversationProvider`), but that map is conversation-event-driven (rarely changes). Revival status is order-driven — it changes on every new message. A revival *context* would change identity every message and re-render **every** message row (context consumers bypass the row memo), regressing this heavily-memoized timeline. Stamping `revival` onto the item and folding it into `timelineItemEqual` keeps the per-row memo intact: appending a message doesn't change the revival status of rows above it, so only the new row re-renders.

**3. `Layers` glyph, neutral/muted, not gold (frontend-design pass).** The chip uses `Layers` — the conversation identity across the overlay (`conversation-overlay.tsx`) — rather than `CornerDownRight`, which `moved-from-indicator.tsx` already reserves as the "moved here" identity; reusing it would blur two meanings. It stays neutral/muted rather than the thread affordance's `primary` gold: a conversation is a quiet "soft thread", not Ariadne's structural gold line. Topic label + `·` + terse `RelativeTime` mirror the overlay's `topicSummary || fallback` rendering. Static footprint (INV-21) — hover only shifts color/underline.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/event-list.tsx` | Add `annotateConversationRevivals` (pure, exported); add `revival?` to the `event` `TimelineItem`, its `timelineItemEqual` comparison, and pass-through to `EventItem` |
| `apps/frontend/src/components/timeline/conversation-overlay/model.ts` | Add the `ConversationRevival` type (conversationId, topicSummary, previousActivityAt) |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Build `conversationsById`; run `annotateConversationRevivals` in the `timelineItems` memo, gated on `supportsConversationOverlay` |
| `apps/frontend/src/components/timeline/event-item.tsx` | Accept + forward `revival` to `MessageEvent` |
| `apps/frontend/src/components/timeline/message-event.tsx` | `ConversationProvenanceChip` component + `preface` slot on `MessageLayout`, above the header row; thread `revival` through `MessageEvent` → `SentMessageEvent` |
| `apps/frontend/src/components/timeline/conversation-overlay/model.test.ts` | 3 unit tests for `annotateConversationRevivals` (revival anchored to prior time; no chip on contiguous run / first appearance; unassigned + non-message items don't break the run) |
| `apps/frontend/src/components/timeline/message-event.test.tsx` | 2 render tests (chip links to `conv:<id>`; absent on non-revivals) |

## Out of scope (deliberate)

- **The "subtle tick" on ordinary sequential switches** (doc: "at most a subtle tick") — the doc frames it as optional/minimal, so v1 ships only the revival chip (INV-36).
- **Mechanism C** (`conversationReference` PM node — author-side "attach context") and the overlay demotion / lenses+scope tracks — separate follow-ups per the design doc.
- **Cross-window revival** — when the prior member of a revived topic is not in the loaded page, no chip renders (see decision #1). Detecting it from the conversation's own `messageIds` rather than in-window order is a deliberate non-goal here.

## Test plan

- [x] `apps/frontend` `vitest run` on the touched suites — `model.test.ts`, `event-list.test.ts`, `message-event.test.tsx`, `event-item.test.tsx`: **98 pass**
- [x] `tsc --noEmit -p apps/frontend/tsconfig.json` clean
- [x] Full-monorepo `tsc` via the pre-commit hook on both commits — clean
- [ ] Not driven in a live browser — the render path is covered by the two component tests (real `MessageEvent` mount asserting the chip's `href`), not a full-app screenshot

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tNf68pV5HB8B4UVNyEZaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014tNf68pV5HB8B4UVNyEZaQ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785602566&installation_id=129946197&pr_number=1140&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1140&signature=6b4ec19024c352c03a0dea36a14bfc2a964398a5725e438bd0c0110e37fcccf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->