### PR TITLE
feat(agents): follow-up turn invocation (roadmap 1.2)

### DIFF
--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -46,6 +46,13 @@ export interface ContextParams {
   policy: ContextWindowPolicy
   /** Invocation time override for deterministic evals/tests. Production uses Date.now(). */
   currentTime?: Date
+  /**
+   * Present when this turn is a fired follow-up (roadmap 1.2): the note the
+   * follow-up carried and when it was scheduled. Drives the "Scheduled follow-up
+   * firing now" prompt section so the turn knows it IS the check-in, not a fresh
+   * request to schedule one.
+   */
+  followUp?: { note: string; scheduledFor: Date }
 }
 
 export interface AgentContext {
@@ -102,7 +109,7 @@ async function resolveScratchpadCustomPrompt(
  */
 export async function buildAgentContext(deps: ContextDeps, params: ContextParams): Promise<AgentContext> {
   const { db, userPreferencesService, conversationSummaryService } = deps
-  const { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime } = params
+  const { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime, followUp } = params
 
   const triggerMessage = await MessageRepository.findById(db, messageId)
   const invokingUserId = triggerMessage?.authorType === AuthorTypes.USER ? triggerMessage.authorId : undefined
@@ -374,7 +381,8 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
       rollingConversationSummary,
       tools,
       conversationTopic,
-      spawnedFromContext
+      spawnedFromContext,
+      followUp
     )
     if (turnDigestBlock) {
       systemPrompt += `\n\n${turnDigestBlock}`

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -145,6 +145,58 @@ describe("buildSystemPrompt", () => {
     expect(blank).not.toContain("## Discussion This Thread Was Spawned From")
   })
 
+  test("injects the scheduled-follow-up section when the turn is a fired follow-up", () => {
+    const prompt = buildSystemPrompt(
+      persona,
+      {
+        ...scratchpadContext,
+        temporal: {
+          currentTime: "2026-07-03T09:00:00.000Z",
+          timezone: "UTC",
+          utcOffset: "UTC+0",
+          dateFormat: "YYYY-MM-DD",
+          timeFormat: "24h",
+        },
+      },
+      null,
+      undefined,
+      undefined,
+      null,
+      [],
+      null,
+      null,
+      { note: "check whether the deploy went out", scheduledFor: new Date("2026-07-03T09:00:00.000Z") }
+    )
+
+    expect(prompt).toContain("## Scheduled follow-up firing now")
+    // Carries the note and the scheduled time rendered in the user's timezone.
+    expect(prompt).toContain("check whether the deploy went out")
+    expect(prompt).toContain("2026-07-03 09:00")
+    // The two staging-bug guards: act now (don't decline) and don't re-schedule.
+    expect(prompt).toContain("This IS that reminder firing")
+    expect(prompt).toContain("Do NOT schedule another follow-up")
+    expect(prompt).toContain("keep_response")
+  })
+
+  test("omits the scheduled-follow-up section for a normal turn", () => {
+    const provided = buildSystemPrompt(persona, scratchpadContext, null, undefined, undefined, null, [], null, null)
+    const explicitNull = buildSystemPrompt(
+      persona,
+      scratchpadContext,
+      null,
+      undefined,
+      undefined,
+      null,
+      [],
+      null,
+      null,
+      null
+    )
+
+    expect(provided).not.toContain("## Scheduled follow-up firing now")
+    expect(explicitNull).not.toContain("## Scheduled follow-up firing now")
+  })
+
   test("web search recency guidance references Current Time when the tool is temporally grounded", () => {
     const prompt = buildSystemPrompt(
       persona,

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -1,6 +1,6 @@
 import { AgentTriggers, StreamTypes } from "@threa/types"
 import { buildToolPromptSections, formatConversationMemoryForPrompt, type AgentTool } from "@threa/agent-runtime"
-import { buildTemporalPromptSection } from "../../../../lib/temporal"
+import { buildTemporalPromptSection, formatCurrentTime } from "../../../../lib/temporal"
 import type { Persona } from "../../persona-repository"
 import type { StreamContext } from "../../context-builder"
 import { WORKSPACE_RESEARCH_TOOL_NAME } from "../../tools"
@@ -25,7 +25,8 @@ export function buildSystemPrompt(
   rollingConversationSummary?: string | null,
   tools: AgentTool[] = [],
   conversationTopic?: string | null,
-  spawnedFromContext?: string | null
+  spawnedFromContext?: string | null,
+  followUp?: { note: string; scheduledFor: Date } | null
 ): string {
   if (!persona.systemPrompt) {
     throw new Error(`Persona "${persona.name}" (${persona.id}) has no system prompt configured`)
@@ -57,6 +58,28 @@ You were explicitly @mentioned by ${mentionerDesc} who wants your assistance.`
     if (context.streamType === StreamTypes.CHANNEL) {
       prompt += ` This conversation is happening in a thread created specifically for your response.`
     }
+  }
+
+  if (followUp) {
+    const scheduledForDisplay = context.temporal
+      ? formatCurrentTime(
+          followUp.scheduledFor,
+          context.temporal.timezone,
+          context.temporal.dateFormat,
+          context.temporal.timeFormat
+        )
+      : followUp.scheduledFor.toISOString()
+
+    prompt += `
+
+## Scheduled follow-up firing now
+
+This turn is a follow-up you scheduled for yourself — not a new message from anyone. You are waking up on your own timer to revisit this stream.
+
+- You set this reminder (at ${scheduledForDisplay}) to: "${followUp.note.trim()}"
+- This IS that reminder firing. Act on it now — look at what has happened in the stream since you scheduled it and, if there's something worth saying, post your check-in with \`send_message\`. Do not decline or promise to check back later; later is now.
+- Do NOT schedule another follow-up for the same thing. The note above is what this turn is already handling — re-reading it as a fresh instruction and scheduling again just loops forever. Only schedule a new follow-up if genuinely new future work has surfaced.
+- If nothing needs saying (the matter resolved itself, nothing changed, or you're still waiting on someone), call \`keep_response\` with a brief reason and stay silent. Do not post filler.`
   }
 
   prompt += buildPromptSectionForStreamType(context, workspaceResearchEnabled)

--- a/apps/backend/src/features/agents/follow-up-repository.test.ts
+++ b/apps/backend/src/features/agents/follow-up-repository.test.ts
@@ -146,6 +146,31 @@ describe("AgentFollowUpRepository.acquireStreamCapLock", () => {
   })
 })
 
+describe("AgentFollowUpRepository.findById", () => {
+  afterEach(() => mock.restore())
+
+  it("selects the row scoped to workspace + id and maps it (INV-8)", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [ROW])
+
+    const result = await AgentFollowUpRepository.findById(db, "ws_1", "agfu_01")
+
+    expect(captured.text).toContain("SELECT")
+    expect(captured.text).toContain("FROM agent_follow_ups")
+    expect(captured.values).toEqual(["agfu_01", "ws_1"])
+    expect(result).toMatchObject({ id: "agfu_01", note: "check back on the deploy", scheduledFor: SCHEDULED_FOR })
+  })
+
+  it("returns null when no row matches", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    const result = await AgentFollowUpRepository.findById(db, "ws_1", "agfu_missing")
+
+    expect(result).toBeNull()
+  })
+})
+
 describe("AgentFollowUpRepository.countPending", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/agents/follow-up-repository.ts
+++ b/apps/backend/src/features/agents/follow-up-repository.ts
@@ -118,6 +118,15 @@ export const AgentFollowUpRepository = {
     return result.rows[0] ? mapRow(result.rows[0]) : null
   },
 
+  /** Read a single follow-up by id, workspace-scoped (INV-8). */
+  async findById(db: Querier, workspaceId: string, id: string): Promise<AgentFollowUp | null> {
+    const result = await db.query<AgentFollowUpRow>(sql`
+      SELECT ${sql.raw(COLUMNS)} FROM agent_follow_ups
+      WHERE id = ${id} AND workspace_id = ${workspaceId}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
   /** Count pending follow-ups for a stream (INV-8 workspace-scoped). */
   async countPending(db: Querier, workspaceId: string, streamId: string): Promise<number> {
     const result = await db.query<{ count: string }>(sql`

--- a/apps/backend/src/features/agents/follow-up-service.test.ts
+++ b/apps/backend/src/features/agents/follow-up-service.test.ts
@@ -145,3 +145,25 @@ describe("AgentFollowUpService.fire", () => {
     expect(queueInsert).not.toHaveBeenCalled()
   })
 })
+
+describe("AgentFollowUpService.getById", () => {
+  afterEach(() => mock.restore())
+
+  it("reads the row workspace-scoped via the pool (roadmap 1.2 context load)", async () => {
+    const row = fakeFollowUp()
+    const findById = spyOn(AgentFollowUpRepository, "findById").mockResolvedValue(row)
+
+    const result = await makeService().getById({ workspaceId: "ws_1", followUpId: "agfu_01" })
+
+    expect(result).toEqual(row)
+    expect(findById.mock.calls[0]?.slice(1)).toEqual(["ws_1", "agfu_01"])
+  })
+
+  it("returns null when the row is gone", async () => {
+    spyOn(AgentFollowUpRepository, "findById").mockResolvedValue(null)
+
+    const result = await makeService().getById({ workspaceId: "ws_1", followUpId: "agfu_missing" })
+
+    expect(result).toBeNull()
+  })
+})

--- a/apps/backend/src/features/agents/follow-up-service.ts
+++ b/apps/backend/src/features/agents/follow-up-service.ts
@@ -105,6 +105,15 @@ export class AgentFollowUpService {
   }
 
   /**
+   * Load a follow-up's context so the fired turn can be told why it woke up
+   * (roadmap 1.2). Read-only single-query path, so pass the pool directly
+   * (INV-30). Returns `null` when the row is gone (e.g. hard-deleted).
+   */
+  async getById(params: { workspaceId: string; followUpId: string }): Promise<AgentFollowUp | null> {
+    return AgentFollowUpRepository.findById(this.pool, params.workspaceId, params.followUpId)
+  }
+
+  /**
    * Cancel a pending follow-up (CAS `pending → cancelled`) and tombstone its
    * fire queue row in the same tx. Returns the cancelled row, or `null` when the
    * cancel lost the race to the fire worker (already fired/cancelled).

--- a/apps/backend/src/features/agents/persona-agent-worker.test.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test"
+import type { Pool } from "pg"
+import type { QueueManager, PersonaAgentJobData } from "../../lib/queue"
+import { createPersonaAgentWorker, type PersonaAgentLike } from "./persona-agent-worker"
+import type { PersonaAgentInput, PersonaAgentResult } from "./persona-agent"
+
+function makeAgent(capture: (input: PersonaAgentInput) => void): PersonaAgentLike {
+  return {
+    run: async (input) => {
+      capture(input)
+      // Skipped avoids the post-completion checkForUnseenMessages path (which
+      // would need a real pool); this test only cares that run() gets the input.
+      return { sessionId: null, messagesSent: 0, sentMessageIds: [], status: "skipped" } satisfies PersonaAgentResult
+    },
+  }
+}
+
+describe("createPersonaAgentWorker", () => {
+  it("forwards followUpId from the fired-follow-up job to agent.run", async () => {
+    let captured: PersonaAgentInput | undefined
+    const worker = createPersonaAgentWorker({
+      agent: makeAgent((input) => (captured = input)),
+      serverId: "srv_1",
+      pool: {} as Pool,
+      jobQueue: {} as QueueManager,
+    })
+
+    const data: PersonaAgentJobData = {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      messageId: "followup_agfu_01",
+      personaId: "persona_ariadne",
+      triggeredBy: "system",
+      followUpId: "agfu_01",
+    }
+    await worker({ id: "job_1", name: "persona.agent", data })
+
+    expect(captured?.followUpId).toBe("agfu_01")
+    expect(captured?.messageId).toBe("followup_agfu_01")
+  })
+
+  it("leaves followUpId undefined for a normal companion job", async () => {
+    let captured: PersonaAgentInput | undefined
+    const worker = createPersonaAgentWorker({
+      agent: makeAgent((input) => (captured = input)),
+      serverId: "srv_1",
+      pool: {} as Pool,
+      jobQueue: {} as QueueManager,
+    })
+
+    const data: PersonaAgentJobData = {
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      messageId: "msg_1",
+      personaId: "persona_ariadne",
+      triggeredBy: "user",
+    }
+    await worker({ id: "job_2", name: "persona.agent", data })
+
+    expect(captured?.followUpId).toBeUndefined()
+  })
+})

--- a/apps/backend/src/features/agents/persona-agent-worker.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.ts
@@ -35,9 +35,10 @@ export function createPersonaAgentWorker(deps: PersonaAgentWorkerDeps): JobHandl
   const { agent, serverId, pool, jobQueue } = deps
 
   return async (job) => {
-    const { workspaceId, streamId, messageId, personaId, trigger, supersedesSessionId, rerunContext } = job.data
+    const { workspaceId, streamId, messageId, personaId, trigger, supersedesSessionId, rerunContext, followUpId } =
+      job.data
 
-    logger.info({ jobId: job.id, streamId, messageId, personaId, trigger }, "Processing persona agent job")
+    logger.info({ jobId: job.id, streamId, messageId, personaId, trigger, followUpId }, "Processing persona agent job")
 
     const result = await agent.run({
       workspaceId,
@@ -48,6 +49,7 @@ export function createPersonaAgentWorker(deps: PersonaAgentWorkerDeps): JobHandl
       trigger,
       supersedesSessionId,
       rerunContext,
+      followUpId,
     })
 
     if (result.status === "failed") {

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -149,6 +149,17 @@ export interface PersonaAgentDeps {
     note: string
     scheduledFor: Date
   }) => Promise<import("./tools/tool-deps").ScheduleFollowUpToolResult>
+  /**
+   * Load a fired follow-up's context (the note it carries + when it was
+   * scheduled) so the turn it wakes can be told why. Bound to
+   * `AgentFollowUpService.getById` in server.ts; consulted only when a job
+   * carries `followUpId`. Absent in harnesses that don't wire follow-ups, in
+   * which case the turn degrades to a plain catch-up.
+   */
+  loadFollowUp?: (params: {
+    workspaceId: string
+    followUpId: string
+  }) => Promise<{ note: string; scheduledFor: Date } | null>
 }
 
 export interface PersonaAgentInput {
@@ -160,6 +171,12 @@ export interface PersonaAgentInput {
   trigger?: typeof AgentTriggers.MENTION
   supersedesSessionId?: string
   rerunContext?: AgentSessionRerunContext
+  /**
+   * Set when this run was enqueued by a fired follow-up. `messageId` is then
+   * synthetic (no real trigger message); the agent loads the follow-up's context
+   * and injects the "why you woke up" prompt section (roadmap 1.2).
+   */
+  followUpId?: string
   /** Invocation time override for deterministic evals/tests. Production leaves this unset. */
   currentTime?: Date
 }
@@ -217,6 +234,7 @@ export class PersonaAgent {
       removeReaction,
       createThread,
       scheduleFollowUp,
+      loadFollowUp,
     } = this.deps
     const {
       workspaceId,
@@ -227,6 +245,7 @@ export class PersonaAgent {
       trigger,
       supersedesSessionId,
       rerunContext,
+      followUpId,
       currentTime,
     } = input
 
@@ -272,6 +291,25 @@ export class PersonaAgent {
     }
 
     const { persona, stream, initialSequence, triggerMessageRevision, streamToolPolicy } = precheck
+
+    // A fired follow-up has no trigger message (synthetic `messageId`); load its
+    // row so the turn can be told it IS the scheduled check-in firing (roadmap
+    // 1.2). If the row is gone or no loader is wired the turn degrades to a plain
+    // catch-up — the two live staging bugs (declining the check-in, re-scheduling
+    // in a loop) stem from exactly that context-less path, so this is the fix.
+    let followUpContext: { note: string; scheduledFor: Date } | undefined
+    if (followUpId) {
+      const followUp = loadFollowUp ? await loadFollowUp({ workspaceId, followUpId }) : null
+      if (followUp) {
+        followUpContext = { note: followUp.note, scheduledFor: followUp.scheduledFor }
+      } else {
+        logger.warn(
+          { workspaceId, followUpId, streamId },
+          "Fired follow-up row not found or loader unbound; running as a plain catch-up turn"
+        )
+      }
+    }
+    const isFollowUp = followUpContext !== undefined
 
     // Create the thread eagerly so session events go there for channel mentions.
     const isChannelMention = trigger === AgentTriggers.MENTION && stream.type === StreamTypes.CHANNEL
@@ -326,7 +364,7 @@ export class PersonaAgent {
 
         const agentContext = await buildAgentContext(
           { db: pool, userPreferencesService, conversationSummaryService },
-          { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime }
+          { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime, followUp: followUpContext }
         )
 
         // Resolve an attached ContextBag (if any) so `stable + delta` flow into
@@ -694,7 +732,10 @@ export class PersonaAgent {
           tools,
           maxTokens: persona.maxTokens,
           temperature: persona.temperature,
-          allowNoMessageOutput: isSupersedeRerun,
+          // Follow-up turns may legitimately conclude "nothing to add" — enabling
+          // this exposes `keep_response` so they can end silently instead of the
+          // runtime auto-committing filler or throwing (roadmap 1.2).
+          allowNoMessageOutput: isSupersedeRerun || isFollowUp,
           validateFinalResponse: isSupersedeRerun
             ? buildSupersedeResponseValidator({
                 ai,

--- a/apps/backend/src/lib/queue/job-queue.ts
+++ b/apps/backend/src/lib/queue/job-queue.ts
@@ -48,11 +48,10 @@ export interface PersonaAgentJobData {
   supersedesSessionId?: string
   rerunContext?: AgentSessionRerunContext
   /**
-   * Set when this job was enqueued by a fired follow-up. The turn handling that
-   * reads it (context assembly + "why you woke up" prompt) lands in roadmap 1.2;
-   * 1.1 only emits it so the fire path is identifiable. When present, `messageId`
-   * is synthetic (no real trigger message) and the job runs as a companion-mode
-   * catch-up turn until 1.2 wires the dedicated context.
+   * Set when this job was enqueued by a fired follow-up. `messageId` is synthetic
+   * (no real trigger message); the persona agent loads this follow-up's row and
+   * injects a "why you woke up" prompt section so the turn knows it IS the
+   * scheduled check-in firing (roadmap 1.2).
    */
   followUpId?: string
 }

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -791,6 +791,7 @@ export async function startServer(): Promise<ServerInstance> {
           }
         : { ok: false, reason: "cap_reached", pendingCount: result.pendingCount, limit: result.limit }
     },
+    loadFollowUp: ({ workspaceId, followUpId }) => agentFollowUpService.getById({ workspaceId, followUpId }),
   })
   // Tier assignments (see QueueManager `tiers` config above):
   //  - INTERACTIVE: user-facing work that must drain quickly (agent responses,

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -35,7 +35,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | Step | Deliverable                                          | Status | PR    |
 | ---- | ---------------------------------------------------- | ------ | ----- |
 | 1.1  | `schedule_follow_up` tool + follow-up infra          | ☑      | #1138 |
-| 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #TBD  |
+| 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #1142 |
 | 1.3  | Follow-up visibility: timeline card + cancel         | ☐      |       |
 | 1.4  | Configurable follow-up limits (workspace setting)    | ☐      |       |
 | 2.1  | Generalized session abort                            | ☐      |       |

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -35,7 +35,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | Step | Deliverable                                          | Status | PR    |
 | ---- | ---------------------------------------------------- | ------ | ----- |
 | 1.1  | `schedule_follow_up` tool + follow-up infra          | ☑      | #1138 |
-| 1.2  | Follow-up turn invocation (context + prompt)         | ☐      |       |
+| 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #TBD  |
 | 1.3  | Follow-up visibility: timeline card + cancel         | ☐      |       |
 | 1.4  | Configurable follow-up limits (workspace setting)    | ☐      |       |
 | 2.1  | Generalized session abort                            | ☐      |       |
@@ -103,7 +103,14 @@ The cheapest team-member behavior ("I'll check back tomorrow") and the pathfinde
 
 **Files:** `persona-agent.ts`, `companion/context.ts`, `companion/prompt/system-prompt.ts`, `companion/session.ts`, possibly a migration for nullable trigger.
 
-**Tests:** integration-style test of the fired job → session created with follow-up context; silent-completion path (model stub returns keep-quiet) produces no message.
+**Deviations (shipped):**
+
+- No `follow_up` trigger enum. The variant is signalled by the additive `followUpId` on the job/`PersonaAgentInput` (same decision as 1.1 — a `trigger` union would touch every `trigger === MENTION` reader). The agent loads the row through a `loadFollowUp` seam (`AgentFollowUpService.getById` → `AgentFollowUpRepository.findById`), bound in `server.ts` like `scheduleFollowUp`.
+- No migration. The synthetic `followup_<id>` `messageId` already serves as `trigger_message_id` (a non-null synthetic string), so `withCompanionSession`'s `findByTriggerMessage` dedup is keyed on it unchanged — nullable trigger wasn't needed.
+- Silent completion reuses the supersede machinery: the follow-up turn sets `allowNoMessageOutput` so `keep_response` is exposed and a "nothing to add" turn returns gracefully instead of the runtime auto-committing filler. The prompt section instructs `send_message` for the check-in or `keep_response` to stay silent.
+- The prompt section ("## Scheduled follow-up firing now") is the fix for the two live staging bugs: it states the turn IS the reminder firing (kills the "I'll ping you then" decline) and forbids re-scheduling the same note (kills the every-cycle re-schedule loop), while still allowing a follow-up for genuinely new future work.
+
+**Tests:** `buildSystemPrompt` follow-up section (present with note + local time + both bug guards; absent otherwise); `AgentFollowUpService.getById` / `AgentFollowUpRepository.findById`; worker threads `followUpId` into `agent.run`. (Full fired-job → live turn is exercised on staging — the DB+queue+AI stack the two bugs were observed in.)
 
 **Done when:** a fired follow-up posts a contextual message referencing the original conversation — or completes silently — with a normal trace.
 


### PR DESCRIPTION
Roadmap: [`docs/plans/ariadne-collaborator-roadmap.md`](docs/plans/ariadne-collaborator-roadmap.md) step **1.2** (follows #1138 which shipped step 1.1).

## Problem

Step 1.1 shipped the `schedule_follow_up` tool and its firing substrate: a fired follow-up CASes `pending → fired` and enqueues a `PERSONA_AGENT` job carrying an additive `followUpId` (`follow-up-service.ts` `enqueuePersonaTurn`). But nothing **read** `followUpId`. The job ran as a plain companion-mode catch-up turn on a synthetic `messageId` (`followup_<id>`) with no idea *why* it woke up. Two bugs followed, both observed live on staging:

1. **The fired turn declines the check-in.** With no context that it *is* the reminder, Ariadne reads the stream, sees she has a pending follow-up, and says "I already have a follow-up scheduled… I'll ping you then" — not knowing this turn is that ping.
2. **Infinite re-scheduling.** Given "check in in two minutes", the fired turn re-reads the note as a fresh instruction and calls `schedule_follow_up` again — every cycle, forever, until the user says stop. The tool is bound on the fired turn (the `followUpDeps` closure only needs the `scheduleFollowUp` dep, which is present), so nothing stopped it.

Both stem from the same root: the synthetic-messageId catch-up turn has no follow-up context.

## Solution

Read `followUpId` on the turn, load the follow-up row, and inject a system-prompt section that tells the persona the turn **is** the scheduled check-in firing now — act on it, don't re-schedule the same note, and stay silent if there's nothing to add.

### How it works

1. **Threading** — `followUpId` flows job → `createPersonaAgentWorker` (`persona-agent-worker.ts`) → `PersonaAgentInput` → `PersonaAgent.run`. Additive field, no `trigger` enum (see decisions).
2. **Row load** — `run()` loads the follow-up through a new `loadFollowUp` dep seam (`AgentFollowUpService.getById` → `AgentFollowUpRepository.findById`, a workspace-scoped single-query read, INV-30), bound in `server.ts` next to `scheduleFollowUp`. If the row is gone or the seam is unbound (test harnesses), it logs and degrades to the old plain catch-up rather than failing.
3. **Prompt section** — the loaded `{ note, scheduledFor }` threads through `buildAgentContext` (`ContextParams.followUp`) into `buildSystemPrompt`, which emits `## Scheduled follow-up firing now`: it quotes the note and the scheduled time rendered in the user's timezone (reusing `formatCurrentTime` from `lib/temporal`, INV-42), states "This IS that reminder firing" (kills bug 1), forbids re-scheduling the same note while allowing a follow-up for genuinely new future work (kills bug 2), and points at `keep_response` for silent completion.
4. **Silent completion** — follow-up turns set `allowNoMessageOutput` on the `TurnRequest` (previously supersede-only). That exposes the runtime's `keep_response` tool and makes a no-message turn return gracefully with `noMessageReason` instead of the runtime auto-committing the model's last plain-text draft as filler or throwing "completed without sending a message".

### Key design decisions

**1. `followUpId` presence, not a `follow_up` trigger enum** — the roadmap's original Shape called for a `follow_up` trigger variant. Shipped instead as the additive `followUpId`, consistent with 1.1's own recorded deviation: a `trigger` union would touch every `trigger === MENTION` reader across the agent. Presence of `followUpId` (and a successfully loaded row) is the variant signal.

**2. No migration** — the Shape flagged a possible nullable `trigger_message_id` migration. Not needed: the synthetic `followup_<id>` is a non-null string that already serves as `trigger_message_id`, so `withCompanionSession`'s `findByTriggerMessage` dedup (idempotency keyed on the synthetic id) works unchanged.

**3. Silent completion reuses the supersede machinery** — rather than a new "keep quiet" path, follow-up turns flip the same `allowNoMessageOutput` flag the supersede rerun uses, so `keep_response` and the graceful no-message return are the exact same runtime code path (`agent-runtime.ts`). The prompt does the steering; no runtime change.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/persona-agent.ts` | Load the follow-up row via `loadFollowUp` when `followUpId` is set; thread `followUp` into `buildAgentContext`; set `allowNoMessageOutput` for follow-up turns; add `followUpId` to `PersonaAgentInput` and `loadFollowUp` to `PersonaAgentDeps`. |
| `apps/backend/src/features/agents/persona-agent-worker.ts` | Extract `followUpId` from job data and pass to `agent.run`. |
| `apps/backend/src/features/agents/companion/context.ts` | Add `ContextParams.followUp`; pass it through `composeSystemPrompt` → `buildSystemPrompt`. |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` | New `## Scheduled follow-up firing now` section; import `formatCurrentTime` for user-tz rendering. |
| `apps/backend/src/features/agents/follow-up-service.ts` | `getById` read seam. |
| `apps/backend/src/features/agents/follow-up-repository.ts` | `findById` (workspace-scoped SELECT). |
| `apps/backend/src/server.ts` | Bind `loadFollowUp: agentFollowUpService.getById`. |
| `apps/backend/src/lib/queue/job-queue.ts` | Update the `followUpId` doc comment (now read, not just emitted). |
| `docs/plans/ariadne-collaborator-roadmap.md` | Check 1.2; record the three shipped deviations. |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/persona-agent-worker.test.ts` | Worker threads `followUpId` into `agent.run`; leaves it undefined for a normal companion job. |

## Out of scope (deliberate)

- **Follow-up visibility (timeline card + cancel affordance)** is roadmap **1.3** — this PR is the invocation/context turn only.
- **Enclave/E2E parity** — the fired turn runs the plaintext companion path; the enclave still omits the tool (backlogged in the roadmap; needs a sealed note + enclave fire dispatch).
- The `## Scheduled follow-up firing now` continuation prompt in the runtime (`prepareConversationForModel`) still uses supersede-flavored wording when `allowNoMessageOutput` is set; it's only reached when the last history message is assistant/system and is harmless here — left untouched rather than branching the runtime for a prompt nicety.

## Test plan

- [x] `bun test apps/backend/src/features/agents/` — 338 pass (includes the new/updated cases below)
- [x] `buildSystemPrompt` follow-up section — present with note + user-tz time + both bug-guards (`This IS that reminder firing`, `Do NOT schedule another follow-up`) + `keep_response`; absent for a normal turn
- [x] `AgentFollowUpService.getById` — reads workspace-scoped via `findById`; null when gone
- [x] `AgentFollowUpRepository.findById` — SELECT scoped to `(id, workspace_id)`, maps the row; null on no match
- [x] `createPersonaAgentWorker` — forwards `followUpId`; undefined for a normal job
- [x] `bun run --cwd apps/backend typecheck` — clean (app + tests tsconfig)
- [x] Pre-commit hook (full monorepo lint + typecheck + prettier + OpenAPI check) — green
- [ ] Live fired-job → turn is exercised on staging, not in an automated integration test — the two bugs live in the DB+queue+AI stack this repo has no live-DB harness for; the seams (prompt content, flag, worker threading) are unit-tested individually instead.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2SHDkYnQWRXFb45PCNur8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785620860&installation_id=129946197&pr_number=1142&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1142&signature=30b7ed28dcb55fa673d823b6a35a97e06fe58d55936e77217820750514f268d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->