### PR TITLE
feat(sharing): conversation-aware back-link for shared messages

### DIFF
--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -21,6 +21,7 @@ import * as userProfileModule from "@/components/user-profile"
 import * as contextsModule from "@/contexts"
 import * as touchCapableModule from "@/hooks/use-touch-capable"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
+import * as shareHandoffModule from "@/stores/share-handoff-store"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 const WORKSPACE_ID = "ws_1"
@@ -180,6 +181,30 @@ describe("ConversationPanel", () => {
     await user.click(firstRowMenu)
 
     expect(await screen.findByText("Quote reply")).toBeTruthy()
+  })
+
+  it("shares a conversation row with a conversation-aware pointer (conversationId in the handoff)", async () => {
+    const user = userEvent.setup()
+    // Give the share picker one selectable target channel.
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      { id: "stream_target", type: "channel", slug: "general", displayName: null, visibility: "public" },
+    ] as never)
+    const queueSpy = vi.spyOn(shareHandoffModule, "queueShareHandoff").mockImplementation(() => {})
+
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+
+    const [firstRowMenu] = screen.getAllByRole("button", { name: "Message actions" })
+    await user.click(firstRowMenu)
+    await user.click(await screen.findByText("Share message"))
+
+    // The cross-stream picker opens; selecting a target queues the share.
+    await user.click(await screen.findByText("#general"))
+
+    expect(queueSpy).toHaveBeenCalledWith(
+      "stream_target",
+      expect.objectContaining({ messageId: "msg_1", conversationId: CONVERSATION_ID })
+    )
   })
 
   it("reveals the quote affordance when a row is swiped left on touch", async () => {

--- a/apps/frontend/src/components/editor/shared-message-extension.ts
+++ b/apps/frontend/src/components/editor/shared-message-extension.ts
@@ -13,6 +13,14 @@ export interface SharedMessageAttrs {
   authorId: string
   /** The actor type of the source author, cached for the same reason */
   actorType: string
+  /**
+   * The conversation this message was shared from, set only when the share
+   * originated on a conversation surface (board card / conversation panel). When
+   * present the rendered pointer card's back-link reopens the source in that
+   * conversation's side panel instead of its home-stream permalink; in-stream
+   * shares leave it undefined and the card links to the stream permalink.
+   */
+  conversationId?: string
 }
 
 /**
@@ -55,6 +63,13 @@ export const SharedMessageExtension = Node.create({
         default: "user",
         parseHTML: (element) => element.getAttribute("data-actor-type"),
         renderHTML: (attrs) => ({ "data-actor-type": attrs.actorType }),
+      },
+      conversationId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-conversation-id"),
+        // Omit the attribute entirely when there's no conversation origin so an
+        // in-stream share's HTML/markdown stays the legacy two-segment shape.
+        renderHTML: (attrs) => (attrs.conversationId ? { "data-conversation-id": attrs.conversationId } : {}),
       },
     }
   },

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -26,6 +26,7 @@ import { DeleteMessageDialog } from "@/components/timeline/delete-message-dialog
 import { EditedIndicator } from "@/components/timeline/edited-indicator"
 import { MessageHistoryDialog } from "@/components/timeline/message-history-dialog"
 import { ReminderPickerSheet } from "@/components/timeline/reminder-picker-sheet"
+import { ShareMessageModal } from "@/components/share/share-message-modal"
 import type { MessageActionContext } from "@/components/timeline/message-actions"
 import { useQuoteReply } from "@/components/timeline/quote-reply-context"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
@@ -155,6 +156,7 @@ export function MessageItem({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
   const [reminderSheetOpen, setReminderSheetOpen] = useState(false)
+  const [shareModalOpen, setShareModalOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   // Touch reaches the actions via long-press → the same `MessageActionDrawer`
   // the timeline uses; the hover overflow button is desktop/keyboard only. This
@@ -358,6 +360,13 @@ export function MessageItem({
     // author's rows, mirroring the timeline row (`MessageEvent`).
     onDelete: () => setDeleteDialogOpen(true),
     onQuoteReply: quoteReplyCtx ? triggerQuote : undefined,
+    // Cross-stream Share picker — parity with the in-stream row (`MessageEvent`).
+    // A share from a conversation surface stamps `conversationId` on the pointer
+    // (see the modal render below) so the shared card deep-links back into the
+    // conversation panel. Hidden on E2E rows: there's no plaintext-decrypt path
+    // here (that lives on the in-stream row), and a ciphertext pointer share is
+    // rejected server-side — so route E2E sharing through the timeline instead.
+    onShare: rowStream?.e2eEnabled === true ? undefined : () => setShareModalOpen(true),
     isSaved,
     onToggleSave: handleToggleSave,
     onRequestReminder: handleRequestReminder,
@@ -449,6 +458,24 @@ export function MessageItem({
           messageId={message.id}
           conversationId={conversationId}
           saved={savedForMessage ?? null}
+        />
+      )}
+      {shareModalOpen && (
+        <ShareMessageModal
+          open={shareModalOpen}
+          onOpenChange={setShareModalOpen}
+          workspaceId={workspaceId}
+          attrs={{
+            messageId: message.id,
+            streamId,
+            authorName,
+            authorId: message.authorId,
+            actorType: message.authorType,
+            // Set only on conversation surfaces (undefined on the label page),
+            // so the resulting pointer's back-link is conversation-aware exactly
+            // where the message was shared from a conversation.
+            conversationId,
+          }}
         />
       )}
     </>

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -61,10 +61,15 @@ function matchAnchorParagraph<T>(
  */
 function findSharedMessageInChildren(
   children: ReactNode
-): { streamId: string; messageId: string; authorName: string } | null {
+): { streamId: string; messageId: string; authorName: string; conversationId?: string } | null {
   const match = matchAnchorParagraph(children, SHARED_MESSAGE_PREFIX, parseSharedMessageHref)
   if (!match) return null
-  return { streamId: match.streamId, messageId: match.messageId, authorName: match.linkText }
+  return {
+    streamId: match.streamId,
+    messageId: match.messageId,
+    authorName: match.linkText,
+    conversationId: match.conversationId,
+  }
 }
 
 /**
@@ -307,6 +312,7 @@ export const markdownComponents: Components = {
           streamId={share.streamId}
           messageId={share.messageId}
           authorName={share.authorName}
+          conversationId={share.conversationId}
         />
       )
     }

--- a/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/shared-message-block.test.tsx
@@ -99,6 +99,24 @@ describe("MarkdownContent — sharedMessage paragraph swap", () => {
     })
   })
 
+  it("links a two-segment (in-stream) pointer back to the source stream permalink", () => {
+    renderMarkdown("Shared a message from [Ariadne](shared-message:stream_src/msg_abc)")
+    const anchor = document.querySelector('[data-type="shared-message"]')?.closest("a")
+    expect(anchor?.getAttribute("href")).toBe("/w/ws_1/s/stream_src?m=msg_abc")
+  })
+
+  it("links a conversation-origin pointer back to the conversation panel (deep-linked to the message)", () => {
+    renderMarkdown("Shared a message from [Ariadne](shared-message:stream_src/msg_abc/conv_xyz)")
+    const anchor = document.querySelector('[data-type="shared-message"]')?.closest("a")
+    const href = anchor?.getAttribute("href") ?? ""
+    // Opens the board's conversation panel for conv_xyz rather than the stream
+    // permalink, still deep-linked to the shared message via `?m=`.
+    expect(href).toContain("/w/ws_1/board?")
+    expect(href).toContain("conv_xyz")
+    expect(href).toContain("m=msg_abc")
+    expect(href).not.toContain("/s/stream_src")
+  })
+
   it("leaves plain paragraphs without shared-message anchors untouched", () => {
     renderMarkdown("Just a regular paragraph")
     expect(screen.getByText("Just a regular paragraph").tagName).toBe("P")

--- a/apps/frontend/src/lib/markdown/shared-message-block.tsx
+++ b/apps/frontend/src/lib/markdown/shared-message-block.tsx
@@ -3,12 +3,20 @@ import { Link, useParams } from "react-router-dom"
 import { cn } from "@/lib/utils"
 import { useSharedMessageSource } from "@/hooks/use-shared-message-source"
 import { SharedMessageCardBody } from "@/components/shared-messages/card-body"
+import { buildConversationPanelPath } from "@/lib/stream-links"
 
 interface SharedMessagePointerBlockProps {
   streamId: string
   messageId: string
   /** Author name parsed from the markdown link text; used as a pre-hydration fallback. */
   authorName: string
+  /**
+   * The conversation the message was shared from, when the pointer carries one
+   * (share originated on a board card / conversation panel). Reopens the source
+   * in that conversation's side panel; absent pointers link to the home-stream
+   * permalink as before.
+   */
+  conversationId?: string
 }
 
 /**
@@ -18,7 +26,12 @@ interface SharedMessagePointerBlockProps {
  * in `SharedMessageView` (a TipTap NodeView); both route through the shared
  * resolver hook + `SharedMessageCardBody` so cache + render behavior matches.
  */
-export function SharedMessagePointerBlock({ streamId, messageId, authorName }: SharedMessagePointerBlockProps) {
+export function SharedMessagePointerBlock({
+  streamId,
+  messageId,
+  authorName,
+  conversationId,
+}: SharedMessagePointerBlockProps) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const source = useSharedMessageSource(messageId, streamId)
 
@@ -39,8 +52,15 @@ export function SharedMessagePointerBlock({ streamId, messageId, authorName }: S
 
   if (!workspaceId) return card
 
+  // A conversation-origin pointer reopens the source in its conversation panel
+  // (resolved under the clicking viewer's own access — the panel self-guards);
+  // otherwise the card links to the message's home-stream permalink as before.
+  const target = conversationId
+    ? buildConversationPanelPath(workspaceId, conversationId, messageId)
+    : `/w/${workspaceId}/s/${streamId}?m=${messageId}`
+
   return (
-    <Link to={`/w/${workspaceId}/s/${streamId}?m=${messageId}`} className="block no-underline">
+    <Link to={target} className="block no-underline">
       {card}
     </Link>
   )

--- a/packages/prosemirror/src/markdown.test.ts
+++ b/packages/prosemirror/src/markdown.test.ts
@@ -353,6 +353,41 @@ describe("@threa/prosemirror quote reply round-trip", () => {
     expect(parsed.content?.[1]?.type).toBe("paragraph")
   })
 
+  it("round-trips a conversation-origin sharedMessage node with the third segment", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "sharedMessage",
+          attrs: {
+            messageId: "msg_01ABC",
+            streamId: "stream_01XYZ",
+            authorName: "Ariadne",
+            conversationId: "conv_01DEF",
+            authorId: "",
+            actorType: "user",
+          },
+        },
+      ],
+    }
+
+    const markdown = serializeToMarkdown(doc)
+    expect(markdown).toBe("Shared a message from [Ariadne](shared-message:stream_01XYZ/msg_01ABC/conv_01DEF)")
+
+    const parsed = parseMarkdown(markdown)
+    expect(parsed.content?.[0]).toEqual({
+      type: "sharedMessage",
+      attrs: {
+        messageId: "msg_01ABC",
+        streamId: "stream_01XYZ",
+        authorName: "Ariadne",
+        conversationId: "conv_01DEF",
+        authorId: "",
+        actorType: "user",
+      },
+    })
+  })
+
   it("does not match shared-message line when prefix or trailing text differs", () => {
     const onlyParagraph = parseMarkdown("Hi! [Ariadne](shared-message:stream_01XYZ/msg_01ABC)")
     expect(onlyParagraph.content?.[0]?.type).toBe("paragraph")

--- a/packages/prosemirror/src/markdown.ts
+++ b/packages/prosemirror/src/markdown.ts
@@ -126,10 +126,11 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
     }
 
     case "sharedMessage": {
-      const { messageId, streamId, authorName } = node.attrs as {
+      const { messageId, streamId, authorName, conversationId } = node.attrs as {
         messageId: string
         streamId: string
         authorName?: string
+        conversationId?: string
       }
       // Wire-format serialization only — the frontend hydrates live content
       // on render, so this fallback is what external API consumers see and
@@ -138,7 +139,7 @@ function serializeNode(node: JSONContent, listDepth = 0, listIndex?: number): st
       // the line to a clean sentence: "Shared a message from Alice".
       const rawName = authorName && authorName.length > 0 ? authorName : "another stream"
       const escapedName = rawName.replace(/\\/g, "\\\\").replace(/\]/g, "\\]")
-      return `Shared a message from [${escapedName}](${buildSharedMessageHref({ streamId, messageId })})`
+      return `Shared a message from [${escapedName}](${buildSharedMessageHref({ streamId, messageId, conversationId })})`
     }
 
     case "bulletList":
@@ -680,6 +681,7 @@ export function parseMarkdown(
           messageId: sharedMessageMatch.messageId,
           streamId: sharedMessageMatch.streamId,
           authorName: sharedMessageMatch.authorName,
+          ...(sharedMessageMatch.conversationId && { conversationId: sharedMessageMatch.conversationId }),
           authorId: "",
           actorType: "user",
         },
@@ -701,16 +703,22 @@ export function parseMarkdown(
 
 /**
  * Match the canonical shared-message pointer line:
- *   `Shared a message from [Author](shared-message:streamId/messageId)`
+ *   `Shared a message from [Author](shared-message:streamId/messageId[/conversationId])`
  *
- * Returns the parsed metadata or `null` when the line is anything else.
+ * Returns the parsed metadata or `null` when the line is anything else. The
+ * optional trailing `/conversationId` segment round-trips a conversation-origin
+ * pointer; a two-segment (legacy / in-stream) link parses with it undefined.
  * Author names containing `]` are escaped as `\]` per the serializer.
  */
-function parseSharedMessageLine(line: string): { authorName: string; streamId: string; messageId: string } | null {
-  const match = line.match(/^Shared a message from \[((?:\\.|[^\]])+)\]\(shared-message:([\w-]+)\/([\w-]+)\)\s*$/)
+function parseSharedMessageLine(
+  line: string
+): { authorName: string; streamId: string; messageId: string; conversationId?: string } | null {
+  const match = line.match(
+    /^Shared a message from \[((?:\\.|[^\]])+)\]\(shared-message:([\w-]+)\/([\w-]+)(?:\/([\w-]+))?\)\s*$/
+  )
   if (!match) return null
   const authorName = match[1].replace(/\\([\]\\])/g, "$1")
-  return { authorName, streamId: match[2], messageId: match[3] }
+  return { authorName, streamId: match[2], messageId: match[3], conversationId: match[4] || undefined }
 }
 
 /**

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -85,9 +85,12 @@ describe("shared-message href", () => {
     })
   })
 
-  it("returns null for a non-shared-message href or a single segment", () => {
+  it("returns null for a non-shared-message href, a single segment, or too many segments", () => {
     expect(parseSharedMessageHref("memo:memo_1")).toBeNull()
     expect(parseSharedMessageHref("shared-message:stream_1")).toBeNull()
+    // A malformed 4-segment href is rejected outright rather than silently
+    // dropping the trailing data (parser-strictness parity with markdown.ts).
+    expect(parseSharedMessageHref("shared-message:stream_1/msg_1/conv_1/extra")).toBeNull()
   })
 })
 

--- a/packages/prosemirror/src/pointer-urls.test.ts
+++ b/packages/prosemirror/src/pointer-urls.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test"
-import { buildMemoHref, parseMemoHref, parseMentionPointerHref } from "./pointer-urls"
+import {
+  buildMemoHref,
+  buildSharedMessageHref,
+  parseMemoHref,
+  parseMentionPointerHref,
+  parseSharedMessageHref,
+} from "./pointer-urls"
 
 describe("parseMentionPointerHref", () => {
   it("decodes user/persona/bot mention schemes to kind + id + type", () => {
@@ -43,6 +49,45 @@ describe("parseMentionPointerHref", () => {
     expect(parseMentionPointerHref("persona:usr_1")).toBeNull()
     expect(parseMentionPointerHref("bot:usr_1")).toBeNull()
     expect(parseMentionPointerHref("channel:usr_1")).toBeNull()
+  })
+})
+
+describe("shared-message href", () => {
+  it("round-trips a two-segment (in-stream) pointer with no conversation origin", () => {
+    const href = buildSharedMessageHref({ streamId: "stream_01ABC", messageId: "msg_01XYZ" })
+    expect(href).toBe("shared-message:stream_01ABC/msg_01XYZ")
+    expect(parseSharedMessageHref(href)).toEqual({
+      streamId: "stream_01ABC",
+      messageId: "msg_01XYZ",
+      conversationId: undefined,
+    })
+  })
+
+  it("round-trips a conversation-origin pointer with the third segment", () => {
+    const href = buildSharedMessageHref({
+      streamId: "stream_01ABC",
+      messageId: "msg_01XYZ",
+      conversationId: "conv_01DEF",
+    })
+    expect(href).toBe("shared-message:stream_01ABC/msg_01XYZ/conv_01DEF")
+    expect(parseSharedMessageHref(href)).toEqual({
+      streamId: "stream_01ABC",
+      messageId: "msg_01XYZ",
+      conversationId: "conv_01DEF",
+    })
+  })
+
+  it("parses a legacy two-segment link with conversationId undefined (backward compat)", () => {
+    expect(parseSharedMessageHref("shared-message:stream_1/msg_1")).toEqual({
+      streamId: "stream_1",
+      messageId: "msg_1",
+      conversationId: undefined,
+    })
+  })
+
+  it("returns null for a non-shared-message href or a single segment", () => {
+    expect(parseSharedMessageHref("memo:memo_1")).toBeNull()
+    expect(parseSharedMessageHref("shared-message:stream_1")).toBeNull()
   })
 })
 

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -89,7 +89,11 @@ export function buildSharedMessageHref(params: SharedMessageHref): string {
 export function parseSharedMessageHref(href: string): SharedMessageHref | null {
   if (!href.startsWith("shared-message:")) return null
   const parts = href.slice("shared-message:".length).split("/")
-  if (parts.length < 2) return null
+  // Exactly the 2-segment (legacy / in-stream) or 3-segment (conversation
+  // origin) shapes `buildSharedMessageHref` emits — reject anything longer so a
+  // malformed href can't silently drop trailing data, matching the strictness
+  // of the regex-anchored `parseSharedMessageLine` in markdown.ts.
+  if (parts.length < 2 || parts.length > 3) return null
   return { streamId: parts[0], messageId: parts[1], conversationId: parts[2] || undefined }
 }
 

--- a/packages/prosemirror/src/pointer-urls.ts
+++ b/packages/prosemirror/src/pointer-urls.ts
@@ -7,8 +7,13 @@
  *     link inside a `quoteReply` block. `authorId`/`actorType` are
  *     optional for backward compat with messages serialized before
  *     denormalised author metadata was added.
- *   - `shared-message:streamId/messageId` — the inline pointer link a
- *     `sharedMessage` block serialises to. Two segments only.
+ *   - `shared-message:streamId/messageId[/conversationId]` — the inline
+ *     pointer link a `sharedMessage` block serialises to. The optional third
+ *     segment is the conversation the message was shared from; when present the
+ *     card's back-link reopens the source in that conversation's side panel
+ *     instead of its home-stream permalink. Omitted for in-stream shares (and
+ *     for pointers serialized before conversation-awareness landed), so a
+ *     two-segment link stays valid.
  *   - `attachment:attachmentId` — the inline reference an
  *     `attachmentReference` node serialises to (metadata rides on the
  *     link title; see `attachment-markdown.ts`).
@@ -62,17 +67,30 @@ export function parseQuoteHref(href: string): QuoteHref | null {
 export interface SharedMessageHref {
   streamId: string
   messageId: string
+  /**
+   * The conversation the message was shared from, when the share originated on
+   * a conversation surface (board card / conversation panel). Drives the card's
+   * conversation-panel back-link; absent for in-stream shares and legacy
+   * two-segment pointers.
+   */
+  conversationId?: string
 }
 
 export function buildSharedMessageHref(params: SharedMessageHref): string {
-  return `shared-message:${params.streamId}/${params.messageId}`
+  // Emit the legacy two-segment form when there's no conversation origin so
+  // older readers keep parsing it and the wire form stays stable for the common
+  // in-stream case; append the third segment only when it carries information.
+  if (!params.conversationId) {
+    return `shared-message:${params.streamId}/${params.messageId}`
+  }
+  return `shared-message:${params.streamId}/${params.messageId}/${params.conversationId}`
 }
 
 export function parseSharedMessageHref(href: string): SharedMessageHref | null {
   if (!href.startsWith("shared-message:")) return null
   const parts = href.slice("shared-message:".length).split("/")
   if (parts.length < 2) return null
-  return { streamId: parts[0], messageId: parts[1] }
+  return { streamId: parts[0], messageId: parts[1], conversationId: parts[2] || undefined }
 }
 
 export interface MemoHref {


### PR DESCRIPTION
Continues the board/conversation action-parity line (#1124 copy-link+react → #1126/#1130 quote → #1134 edit → #1136 delete → #1137 discuss → #1141 save/reminder deep-linking) with **#4 Share**. Design basis: `docs/board-view-design.md` §"Conversations span streams within one root"; access model INV-62; deep-link precedent `buildConversationPanelPath` (`apps/frontend/src/lib/stream-links.ts`, added in #1141).

## Problem

Two gaps on the conversation surfaces (board card / conversation panel / label page), all rendered through `MessageItem`:

1. **No Share action.** The in-stream row (`MessageEvent`) has offered the cross-stream Share picker for a while, but `MessageItem` never wired `onShare`, so a message viewed on a board card or in the conversation panel had no way to be shared into another stream.

2. **The shared pointer's back-link is always the stream permalink.** When message M is shared into stream T, the resulting card in T links back to M via `/w/:ws/s/:streamId?m=:messageId` (`shared-message-block.tsx`). A conversation spans its root + threads, so a message shared *from* a conversation loses that context on the round-trip back — the reader lands in the raw home stream rather than the conversation they were looking at.

## Solution

Wire the cross-stream Share picker onto `MessageItem` (parity with `MessageEvent`), and carry the source conversation on the pointer so its back-link reopens the message in that conversation's side panel instead of the stream permalink. The conversation origin rides as an **optional third segment** on the pointer wire format, mirroring the `quote:` optional-segment pattern, so every existing two-segment pointer round-trips unchanged.

### How it works

1. **Wire format (`packages/prosemirror/src/pointer-urls.ts`, `markdown.ts`).** `SharedMessageHref` gains optional `conversationId`. `buildSharedMessageHref` emits the legacy two-segment `shared-message:streamId/messageId` when there's no origin and appends `/conversationId` only when present; `parseSharedMessageHref` reads `parts[2] || undefined`. The markdown line serializer/`parseSharedMessageLine` regex gain an optional `(?:\/([\w-]+))?` segment. A two-segment (legacy / in-stream) link parses with `conversationId` undefined.

2. **Node attr (`shared-message-extension.ts`).** `SharedMessageAttrs` + the TipTap node gain `conversationId` (`data-conversation-id`, `default: null`). `renderHTML` omits the attribute entirely when absent, so an in-stream share's HTML/markdown stays the legacy shape. The attr round-trips through copy/paste (composer insertion in `message-input.tsx` already spreads the whole attrs object).

3. **Back-link (`lib/markdown/components.tsx`, `shared-message-block.tsx`).** `findSharedMessageInChildren` threads `conversationId` from the parsed href to `SharedMessagePointerBlock`, which links to `buildConversationPanelPath(workspaceId, conversationId, messageId)` when present, else the stream permalink as before.

4. **Share surface (`components/message/message-item.tsx`).** `onShare` opens `ShareMessageModal` with `attrs` that include the row's `conversationId` prop (set by the board card / conversation panel; undefined on the label page → plain stream pointer). `MessageEvent`'s share attrs are unchanged — in-stream shares stay two-segment.

### Key design decisions

**1. Conversation-aware pointer, not just the Share affordance.** The user chose the fuller scope ("do it in full, with backwards compatibility") over shipping only the picker with a stream-permalink back-link. So the pointer itself carries the origin.

**2. `conversationId` is a display/nav hint, not an access vector — so no backend change.** The back-link is built client-side from the node attr / parsed markdown and is resolved under the *clicking viewer's own* access when followed: the conversation panel fetches the conversation workspace-scoped and self-guards, so a stale or tampered id at worst opens an empty/denied panel for the tamperer. Content hydration stays `messageId`-keyed with the existing `shared_messages` grant checks (`hydrateSharedMessageIds`, `ShareService.validateAndRecordShares` — both untouched). This is the same treatment the pointer's cached `authorName` already gets (trusted display data), distinct from `streamId`, which *is* validated server-side because it gates access. Given that, a backend body-rewrite/validation pass (as #1141 did for the persisted `saved_messages.conversation_id`, which is the *saver's own* return path) would add a conversation lookup to the hot render/ingest path purely for a cosmetic back-link — disproportionate (INV-36).

**3. E2E rows on `MessageItem` don't offer Share.** There's no plaintext-decrypt path on this surface (that lives on the in-stream row, which passes `sourcePlaintext`), and a ciphertext pointer share is rejected server-side (`E2E_SHARING_NOT_ALLOWED`). Gated on `rowStream?.e2eEnabled === true` → route E2E sharing through the timeline instead. Board/conversation surfaces are non-E2E anyway (GAM can't run over ciphertext); the only E2E-capable `MessageItem` surface is the label page.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/pointer-urls.ts` | `SharedMessageHref.conversationId?`; build appends optional 3rd segment; parse reads it |
| `packages/prosemirror/src/markdown.ts` | `sharedMessage` serializer passes `conversationId`; `parseSharedMessageLine` regex + return gain the optional segment |
| `apps/frontend/src/components/editor/shared-message-extension.ts` | `SharedMessageAttrs.conversationId?` + node attr (`data-conversation-id`, omitted when null) |
| `apps/frontend/src/lib/markdown/components.tsx` | `findSharedMessageInChildren` threads `conversationId` to the pointer block |
| `apps/frontend/src/lib/markdown/shared-message-block.tsx` | conversation-aware back-link via `buildConversationPanelPath`, else stream permalink |
| `apps/frontend/src/components/message/message-item.tsx` | wire `onShare` → `ShareMessageModal` with `conversationId` in attrs; gated off E2E rows |

## Test files

| File | Change |
| ---- | ------ |
| `packages/prosemirror/src/pointer-urls.test.ts` | round-trip: two-segment, three-segment, legacy-parse, reject bad href |
| `packages/prosemirror/src/markdown.test.ts` | round-trip a conversation-origin `sharedMessage` node losslessly |
| `apps/frontend/src/lib/markdown/shared-message-block.test.tsx` | two-segment → stream permalink; three-segment → conversation panel back-link |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | end-to-end: share a panel row → handoff carries `conversationId` |

## Out of scope (deliberate)

- **The `truncated` deep-chain placeholder** (`shared-messages/card-body.tsx`) still links to the stream permalink. The hydration payload (`HydratedSharedMessage`) doesn't carry `conversationId`, and `truncated` is a pathological-depth guard (`MAX_HYDRATION_DEPTH`), so threading the field through the recursive hydrator isn't worth it.
- **Public developer markdown reference** (`apps/public-site/.../markdown.astro`) keeps documenting the two-segment form. The third segment is an internal frontend origin hint that external API authors have no conversation context to set; two-segment stays canonical for external authoring.
- **No backend change** — see design decision #2.

## Test plan

- [x] `bun test` in `packages/prosemirror` — 135 pass (incl. new pointer-urls + markdown cases)
- [x] Frontend `vitest run` over `lib/markdown`, `components/editor`, `components/share`, `components/shared-messages`, `stores/share-handoff-store`, `components/conversations/conversation-panel` — all green (conversation-panel 15 pass incl. new share test; shared-message-block 8 pass)
- [x] `apps/backend` `bun test src/features/messaging/sharing` — 52 pass (grant-recording path unaffected by the wire-format change)
- [x] `tsc --noEmit` clean in `apps/frontend` and `packages/prosemirror`; full-monorepo pre-commit tsc (app + test), astro check, and OpenAPI `--check` all passed on commit
- [x] eslint + prettier clean on all changed files
- [x] Self-review (claim-verification pass): every named symbol/path/behavioral claim above checked against the diff; no findings

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJugH9pBZBv9y8Dh5dNQMg)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785651355&installation_id=129946197&pr_number=1143&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1143&signature=f83f1561acd2e89e99bf66d7d21b2b53bb7be3d3a56f42cb801c4c34087ab186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->