### PR TITLE
feat(conversations): file a message into a conversation via a hidden field + "Reply in conversation"

### DIFF
--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test"
-import { AttachmentSafetyStatuses, E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
+import { AttachmentSafetyStatuses, ConversationIntents, E2E_PLACEHOLDER_CONTENT_MARKDOWN } from "@threa/types"
 import { EventService } from "./event-service"
 import { MessageRepository } from "./repository"
 import { SharedMessageRepository } from "./sharing/repository"
@@ -760,6 +760,106 @@ describe("EventService.createMessage metadata propagation", () => {
 
     const insertParams = (MessageRepository.insert as any).mock.calls[0][1]
     expect(insertParams.metadata).toBeUndefined()
+  })
+})
+
+describe("EventService.createMessage conversation declaration (Mechanism C)", () => {
+  const baseParams = {
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    authorId: "usr_1",
+    authorType: "user" as const,
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "hello",
+  }
+
+  const assignInTransaction = mock(async () => {})
+  const conversationAssigner = { assignInTransaction }
+
+  beforeEach(() => {
+    assignInTransaction.mockClear()
+    spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
+      callback({})) as any)
+    spyOn(StreamRepository, "findById").mockResolvedValue({ id: "stream_1", type: "scratchpad" } as any)
+    spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
+    spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
+    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
+    spyOn(StreamMemberRepository, "update").mockResolvedValue(undefined as any)
+    spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: "evt_1",
+      streamId: params.streamId,
+      sequence: 1n,
+      eventType: params.eventType,
+      payload: params.payload,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: params.id,
+      streamId: params.streamId,
+      sequence: params.sequence,
+      authorId: params.authorId,
+      authorType: params.authorType,
+      contentJson: params.contentJson,
+      contentMarkdown: params.contentMarkdown,
+      replyCount: 0,
+      clientMessageId: params.clientMessageId ?? null,
+      sentVia: params.sentVia ?? null,
+      reactions: {},
+      metadata: params.metadata ?? {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "findById").mockResolvedValue(null)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+    spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
+    spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
+    spyOn(SharedMessageRepository, "insert").mockResolvedValue({} as any)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("stamps declaredConversationId on the payload for an existing-conversation directive and runs the assigner", async () => {
+    const service = new EventService({} as any, conversationAssigner)
+
+    await service.createMessage({
+      ...baseParams,
+      conversation: { intent: ConversationIntents.EXISTING, conversationId: "conv_abc" },
+    })
+
+    expect(StreamEventRepository.insert).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: "message_created",
+        payload: expect.objectContaining({ declaredConversationId: "conv_abc" }),
+      })
+    )
+    expect(assignInTransaction).toHaveBeenCalled()
+  })
+
+  it("omits declaredConversationId for a new-conversation directive — a fresh topic is a chip-less opener", async () => {
+    const service = new EventService({} as any, conversationAssigner)
+
+    await service.createMessage({ ...baseParams, conversation: { intent: ConversationIntents.NEW } })
+
+    const eventPayload = (StreamEventRepository.insert as any).mock.calls[0][1].payload
+    expect(eventPayload).not.toHaveProperty("declaredConversationId")
+    expect(assignInTransaction).toHaveBeenCalled()
+  })
+
+  it("omits declaredConversationId and skips the assigner when the send declares no conversation", async () => {
+    const service = new EventService({} as any, conversationAssigner)
+
+    await service.createMessage({ ...baseParams })
+
+    const eventPayload = (StreamEventRepository.insert as any).mock.calls[0][1].payload
+    expect(eventPayload).not.toHaveProperty("declaredConversationId")
+    expect(assignInTransaction).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -28,6 +28,7 @@ import { deriveContentMarkdown } from "./content"
 import {
   AuthorTypes,
   CompanionModes,
+  ConversationIntents,
   StreamTypes,
   Visibilities,
   draftStreamScope,
@@ -75,6 +76,19 @@ export interface MessageCreatedPayload {
   sentVia?: string
   /** External references attached by the sender (string->string). Omitted when empty. */
   metadata?: Record<string, string>
+  /**
+   * The conversation this message declared at send time via an `existing`
+   * directive (a board/panel reply, or a future "reply in conversation" action)
+   * — board-view-design.md §"Conversations as soft threads", Mechanism C. Lets
+   * the flat-timeline provenance chip render membership the instant the message
+   * arrives, without waiting for the async conversation list to load. Only the
+   * id is carried (messaging stays decoupled from conversation internals — no
+   * topic read here); the frontend resolves the topic label from the same-root
+   * conversation list the timeline already loads. Absent for `new`/thread-from-
+   * message declarations (a fresh topic is chip-less) and for messages the async
+   * extractor classifies later (Mechanism A's membership map still covers those).
+   */
+  declaredConversationId?: string
   /**
    * Populated at bootstrap enrichment time when this message has at least one
    * non-deleted reply. Not present on initial `message_created` emission (the
@@ -546,6 +560,16 @@ export class EventService {
     // Non-empty metadata only — keep payloads and projections clean of `{}`.
     const metadata = params.metadata && Object.keys(params.metadata).length > 0 ? params.metadata : undefined
 
+    // A message that declares an EXISTING conversation carries that id on its
+    // event payload so the flat-timeline provenance chip renders membership the
+    // instant the message lands (board-view-design.md Mechanism C), instead of
+    // waiting for the async conversation list. The id is known here without any
+    // conversation read; the assigner below still row-locks + validates it (a
+    // cross-root/stale id rolls back the whole send). `new`/thread-from-message
+    // declarations are chip-less openers, so only `existing` is stamped.
+    const declaredConversationId =
+      params.conversation?.intent === ConversationIntents.EXISTING ? params.conversation.conversationId : undefined
+
     const event = await StreamEventRepository.insert(client, {
       id: evtId,
       streamId: params.streamId,
@@ -559,6 +583,7 @@ export class EventService {
         ...(params.sessionId && { sessionId: params.sessionId }),
         ...(params.clientMessageId && { clientMessageId: params.clientMessageId }),
         ...(params.sentVia && { sentVia: params.sentVia }),
+        ...(declaredConversationId && { declaredConversationId }),
         ...(metadata && { metadata }),
         ...(params.ciphertext && { ciphertext: params.ciphertext.toString("base64") }),
         ...(params.envelope !== undefined && { envelope: params.envelope }),

--- a/apps/frontend/src/components/timeline/conversation-reply-context.tsx
+++ b/apps/frontend/src/components/timeline/conversation-reply-context.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useCallback, useMemo, useRef } from "react"
+import type { ReactNode } from "react"
+
+export interface ConversationReplyData {
+  conversationId: string
+}
+
+interface ConversationReplyContextValue {
+  /** Arm the composer with a conversation to file the next send into — called by message actions */
+  triggerReplyInConversation: (data: ConversationReplyData) => void
+  /** Register the composer's handler */
+  registerHandler: (handler: (data: ConversationReplyData) => void) => () => void
+}
+
+const ConversationReplyCtx = createContext<ConversationReplyContextValue | null>(null)
+
+/**
+ * Relays "Reply in conversation" from a message row to the stream composer
+ * (mirrors QuoteReplyProvider). Unlike quote reply, nothing is inserted into
+ * the body: the composer holds the conversation as a pending send directive
+ * (`{ intent: "existing" }`) and shows a dismissible strip, so the next send
+ * files into the conversation and its provenance chip renders instantly.
+ */
+export function ConversationReplyProvider({ children }: { children: ReactNode }) {
+  const handlerRef = useRef<((data: ConversationReplyData) => void) | null>(null)
+
+  const registerHandler = useCallback((handler: (data: ConversationReplyData) => void) => {
+    handlerRef.current = handler
+    return () => {
+      handlerRef.current = null
+    }
+  }, [])
+
+  const triggerReplyInConversation = useCallback((data: ConversationReplyData) => {
+    handlerRef.current?.(data)
+  }, [])
+
+  const value = useMemo(
+    () => ({ triggerReplyInConversation, registerHandler }),
+    [triggerReplyInConversation, registerHandler]
+  )
+
+  return <ConversationReplyCtx.Provider value={value}>{children}</ConversationReplyCtx.Provider>
+}
+
+export function useConversationReply(): ConversationReplyContextValue | null {
+  return useContext(ConversationReplyCtx)
+}

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest"
-import type { StreamEvent } from "@threa/types"
+import type { ConversationWithStaleness, StreamEvent } from "@threa/types"
 import {
   annotateAuthorGroups,
+  annotateConversationRevivals,
   filterVisibleItems,
   findFirstMessageId,
   findMessageItemIndex,
@@ -350,6 +351,85 @@ describe("findFirstMessageId", () => {
 
   it("returns undefined for an empty timeline so the badge stays in the composer strip", () => {
     expect(findFirstMessageId([])).toBeUndefined()
+  })
+})
+
+describe("annotateConversationRevivals", () => {
+  function messageItem(
+    id: string,
+    messageId: string,
+    createdAt: string,
+    declaredConversationId?: string
+  ): TimelineItem {
+    return {
+      type: "event",
+      event: {
+        ...createEvent({
+          id,
+          sequence: id,
+          eventType: "message_created",
+          payload: { messageId, ...(declaredConversationId ? { declaredConversationId } : {}) },
+        }),
+        createdAt,
+      },
+    }
+  }
+
+  const topics = (entries: Record<string, string>): ReadonlyMap<string, ConversationWithStaleness> =>
+    new Map(Object.entries(entries).map(([id, topicSummary]) => [id, { topicSummary } as ConversationWithStaleness]))
+
+  const revivalOf = (item: TimelineItem) => (item.type === "event" ? item.revival : undefined)
+
+  // A → conv_x, B → conv_y, C → conv_x: the intervening conv_y makes C revive a
+  // scattered conv_x, so C carries the chip anchored on A's activity.
+  const scattered = (declared: boolean): TimelineItem[] => [
+    messageItem("evt_a", "msg_a", "2026-02-19T00:00:00.000Z", declared ? "conv_x" : undefined),
+    messageItem("evt_b", "msg_b", "2026-02-19T01:00:00.000Z", declared ? "conv_y" : undefined),
+    messageItem("evt_c", "msg_c", "2026-02-19T02:00:00.000Z", declared ? "conv_x" : undefined),
+  ]
+
+  it("derives the revival from declared conversation ids with no async membership map (flicker-free)", () => {
+    const items = annotateConversationRevivals(scattered(true), new Map(), new Map())
+
+    expect(revivalOf(items[2])).toEqual({
+      conversationId: "conv_x",
+      topicSummary: null,
+      previousActivityAt: "2026-02-19T00:00:00.000Z",
+    })
+    expect(revivalOf(items[0])).toBeUndefined()
+    expect(revivalOf(items[1])).toBeUndefined()
+  })
+
+  it("resolves the topic label from the conversation list when it has loaded", () => {
+    const items = annotateConversationRevivals(scattered(true), new Map(), topics({ conv_x: "Pizza" }))
+
+    expect(revivalOf(items[2])?.topicSummary).toBe("Pizza")
+  })
+
+  it("prefers a declared id over a stale async membership entry", () => {
+    const membership = new Map([
+      ["msg_a", "conv_stale"],
+      ["msg_b", "conv_y"],
+      ["msg_c", "conv_stale"],
+    ])
+    const items = annotateConversationRevivals(scattered(true), membership, new Map())
+
+    expect(revivalOf(items[2])?.conversationId).toBe("conv_x")
+  })
+
+  it("still derives the revival from the async membership map for classifier-assigned messages", () => {
+    const membership = new Map([
+      ["msg_a", "conv_x"],
+      ["msg_b", "conv_y"],
+      ["msg_c", "conv_x"],
+    ])
+    const items = annotateConversationRevivals(scattered(false), membership, topics({ conv_x: "Pizza" }))
+
+    expect(revivalOf(items[2])).toEqual({
+      conversationId: "conv_x",
+      topicSummary: "Pizza",
+      previousActivityAt: "2026-02-19T00:00:00.000Z",
+    })
   })
 })
 

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -244,7 +244,9 @@ export function annotateConversationRows(items: TimelineItem[], model: Conversat
  * is a fresh topic, not a revival, so it carries no chip.
  *
  * `membership` is the always-on `messageId → conversationId` map
- * (`buildMessageConversationMap`), including cross-stream secondary members.
+ * (`buildMessageConversationMap`), including cross-stream secondary members. A
+ * message that declared its conversation at send time overrides it from its own
+ * payload (`declaredConversationId`) so its membership needs no list round-trip.
  * Non-message items (session/command cards) and unassigned message rows don't
  * break a run — only a different real conversation does. This diverges from
  * `annotateConversationRows` (which resets its run on an unassigned row for
@@ -262,9 +264,17 @@ export function annotateConversationRevivals(
   let previousConversationId: string | null = null
   return items.map((item) => {
     if (item.type !== "event" || !isGroupableMessage(item.event)) return item
-    const messageId = (item.event.payload as { messageId?: string })?.messageId
+    const payload = item.event.payload as { messageId?: string; declaredConversationId?: string }
+    const messageId = payload?.messageId
     if (!messageId) return item
-    const conversationId = membership.get(messageId) ?? null
+    // A message that DECLARED its conversation at send time carries the id on its
+    // payload (board-view-design.md Mechanism C) — prefer it so the chip renders
+    // the instant the message lands, without waiting for the async membership
+    // list. Falls back to the async `membership` map for classifier-assigned
+    // messages (Mechanism A). The topic label still resolves from
+    // `conversationsById` (loaded per-stream); a declared-but-not-yet-listed
+    // conversation shows the generic label until the list catches up.
+    const conversationId = payload.declaredConversationId ?? membership.get(messageId) ?? null
     let revival: ConversationRevival | undefined
     if (conversationId != null) {
       const blockStart = conversationId !== previousConversationId

--- a/apps/frontend/src/components/timeline/message-actions.test.ts
+++ b/apps/frontend/src/components/timeline/message-actions.test.ts
@@ -66,6 +66,14 @@ describe("getVisibleActions", () => {
     expect(ids).toEqual(["copy-as-markdown", "copy-as-plain-text"])
   })
 
+  it("should include reply-in-conversation only when the surface supplies its handler", () => {
+    const without = getVisibleActions(createContext()).map((a) => a.id)
+    expect(without).not.toContain("reply-in-conversation")
+
+    const withHandler = getVisibleActions(createContext({ onReplyInConversation: vi.fn() })).map((a) => a.id)
+    expect(withHandler).toContain("reply-in-conversation")
+  })
+
   it("should include copy-link when permalink fields are present", () => {
     const actions = getVisibleActions(createContext({ messageId: "msg_1", workspaceId: "ws_1", streamId: "stream_1" }))
     expect(actions.map((a) => a.id)).toContain("copy-link")

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -83,6 +83,13 @@ export interface MessageActionContext {
   /** Callback to insert a partial quote reply with a user-selected snippet */
   onQuoteReplyWithSnippet?: (snippet: string) => void
   /**
+   * Arm the stream composer to file its next send into this message's
+   * conversation (an `existing` directive — Mechanism C). Set on in-stream
+   * message rows whose primary conversation is locally known; the reply lands
+   * in the flat timeline with an instant provenance chip.
+   */
+  onReplyInConversation?: () => void
+  /**
    * Share-to-root fast path: queue a pointer share into the top-level non-thread
    * ancestor (channel/dm/scratchpad) and navigate there. Always preferred over
    * share-to-parent for nested-thread cases — the root is by far the more
@@ -321,6 +328,17 @@ export const messageActions: MessageAction[] = [
     groupId: "reply",
     when: (ctx) => !!ctx.onQuoteReply,
     action: (ctx) => ctx.onQuoteReply?.(),
+  },
+  {
+    // Files the next composer send into this message's conversation (the soft-
+    // thread analog of quote reply). Only present when the conversation is
+    // locally known.
+    id: "reply-in-conversation",
+    label: "Reply in conversation",
+    icon: Layers,
+    groupId: "reply",
+    when: (ctx) => !!ctx.onReplyInConversation,
+    action: (ctx) => ctx.onReplyInConversation?.(),
   },
   {
     // In-stream → conversation panel (the mirror of "View in channel"). Only

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -71,6 +71,7 @@ import { MessageHistoryDialog } from "./message-history-dialog"
 import { MessageReactions } from "./message-reactions"
 import { ReactionEmojiPicker } from "./reaction-emoji-picker"
 import { useQuoteReply } from "./quote-reply-context"
+import { useConversationReply } from "./conversation-reply-context"
 import { useSwipeAction } from "@/hooks/use-swipe-action"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { queueShareHandoff } from "@/stores/share-handoff-store"
@@ -1116,6 +1117,16 @@ function SentMessageEvent({
     [messageConversationId, openPanel]
   )
 
+  // "Reply in conversation" — arm the stream composer to file its next send
+  // into this message's conversation (Mechanism C). Same membership gate as
+  // "Show in conversation"; also needs a composer registered via the context.
+  const conversationReplyCtx = useConversationReply()
+  const handleReplyInConversation = useCallback(() => {
+    if (messageConversationId) {
+      conversationReplyCtx?.triggerReplyInConversation({ conversationId: messageConversationId })
+    }
+  }, [messageConversationId, conversationReplyCtx])
+
   const startDiscussWithAriadne = useDiscussWithAriadne(workspaceId)
   const handleDiscussWithAriadne = useCallback(
     // `useDiscussWithAriadne` rethrows after toasting so the surrounding
@@ -1240,6 +1251,10 @@ function SentMessageEvent({
       onShowMoveDetails: movedTombstoneEvent ? () => setTimeout(() => setMoveDetailsOpen(true), 0) : undefined,
       onReassignConversation: conversationOverlayRow && !batch?.enabled ? handleRequestConversationPicker : undefined,
       onShowInConversation: messageConversationId ? handleShowInConversation : undefined,
+      // Gated off E2E streams like Edit: the E2E create wire format carries no
+      // conversation directive, so the send would silently drop the filing.
+      onReplyInConversation:
+        messageConversationId && conversationReplyCtx && !e2eEnabled ? handleReplyInConversation : undefined,
       onMarkReadUpToHere: rowRead !== "read" ? () => dispatchMarkReadUpToHere(streamId, event.id) : undefined,
       onMarkUnread: rowRead !== "unread" ? () => dispatchMarkUnread(streamId, payload.messageId) : undefined,
     }),
@@ -1285,6 +1300,8 @@ function SentMessageEvent({
       handleRequestConversationPicker,
       messageConversationId,
       handleShowInConversation,
+      conversationReplyCtx,
+      handleReplyInConversation,
     ]
   )
 

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import type { ReactNode } from "react"
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { Router } from "react-router-dom"
 import { useState } from "react"
@@ -9,6 +9,8 @@ import * as hooksModule from "@/hooks"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as authModule from "@/auth"
 import * as quoteReplyModule from "./quote-reply-context"
+import * as conversationReplyModule from "./conversation-reply-context"
+import * as useConversationsModule from "@/hooks/use-conversations"
 import * as composerModule from "@/components/composer"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
@@ -75,6 +77,7 @@ let registeredQuoteReplyHandler:
       snippet: string
     }) => void)
   | null = null
+let registeredConversationReplyHandler: ((data: { conversationId: string }) => void) | null = null
 
 // Composer state that tests can modify
 let mockComposerState = {
@@ -114,6 +117,7 @@ beforeEach(() => {
   }
   mockSubmitContentOverride = undefined
   registeredQuoteReplyHandler = null
+  registeredConversationReplyHandler = null
   mockComposerFocus.mockReset()
   mockComposerFocusAfterQuoteReply.mockReset()
 
@@ -162,6 +166,29 @@ beforeEach(() => {
       }
     },
   } as unknown as ReturnType<typeof quoteReplyModule.useQuoteReply>)
+
+  vi.spyOn(conversationReplyModule, "useConversationReply").mockReturnValue({
+    triggerReplyInConversation: vi.fn(),
+    registerHandler: (handler: (data: { conversationId: string }) => void) => {
+      registeredConversationReplyHandler = handler
+      return () => {
+        if (registeredConversationReplyHandler === handler) {
+          registeredConversationReplyHandler = null
+        }
+      }
+    },
+  } as unknown as ReturnType<typeof conversationReplyModule.useConversationReply>)
+  // The armed-reply strip resolves its topic label via the board-post hook,
+  // which needs the services context + query client; stub it with a fixed topic.
+  vi.spyOn(useConversationsModule, "useConversationBoardPost").mockImplementation(
+    (_workspaceId: string, conversationId: string | null) =>
+      ({
+        post: conversationId ? { conversation: { id: conversationId, topicSummary: "Pizza plans" } } : null,
+        isLoading: false,
+        notFound: false,
+        refetch: vi.fn(),
+      }) as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>
+  )
 
   vi.spyOn(hooksModule, "useStreamOrDraft").mockReturnValue({
     sendMessage: mockSendMessage,
@@ -516,6 +543,66 @@ describe("MessageInput", () => {
       })
       expect(mockComposerFocusAfterQuoteReply).toHaveBeenCalledTimes(1)
       expect(mockComposerFocus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("reply in conversation", () => {
+    it("arms the composer with a dismissible strip showing the conversation topic and focuses the editor", () => {
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+
+      expect(registeredConversationReplyHandler).not.toBeNull()
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      const strip = screen.getByTestId("conversation-reply-strip")
+      expect(strip).toHaveTextContent("Replying in Pizza plans")
+      expect(mockComposerFocus).toHaveBeenCalledTimes(1)
+    })
+
+    it("files the send into the armed conversation and clears the strip on success", async () => {
+      const helloContent = makeDoc("late pizza take")
+      mockComposerState.canSend = true
+      mockComposerState.content = helloContent
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        contentJson: helloContent,
+        attachmentIds: undefined,
+        attachments: undefined,
+        conversation: { intent: "existing", conversationId: "conv_1" },
+      })
+      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    })
+
+    it("keeps the filing armed when the send fails, so a retry still files", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("doomed")
+      mockSendMessage.mockRejectedValue(new Error("stream creation failed"))
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument()
+    })
+
+    it("dismissing the strip disarms the filing — the next send carries no directive", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("just a normal message")
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await userEvent.click(screen.getByRole("button", { name: /cancel reply in conversation/i }))
+      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ conversation: undefined }))
     })
   })
 

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -27,6 +27,9 @@ import { extractCommandNode, extractCommandFromRawText } from "@/lib/commands"
 import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quote-reply-context"
+import { useConversationReply, type ConversationReplyData } from "./conversation-reply-context"
+import { useConversationBoardPost } from "@/hooks/use-conversations"
+import { Layers, X } from "lucide-react"
 import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { consumeSnippetRequest, subscribeSnippetRequest } from "@/stores/snippet-request-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
@@ -287,6 +290,30 @@ function MessageInputComponent({
       composerFocusRef.current?.focusAfterQuoteReply()
     })
   }, [quoteReplyCtx])
+
+  // "Reply in conversation" (Mechanism C): the armed conversation rides the send
+  // as an `existing` directive — nothing is inserted into the body. Held as
+  // in-memory state (not part of the durable draft): a stale filing surviving a
+  // reload would silently misfile whatever is typed next, so it resets with the
+  // session and with the stream.
+  const conversationReplyCtx = useConversationReply()
+  const [conversationReply, setConversationReply] = useState<ConversationReplyData | null>(null)
+  useEffect(() => {
+    if (!conversationReplyCtx) return
+    return conversationReplyCtx.registerHandler((data: ConversationReplyData) => {
+      setConversationReply(data)
+      composerFocusRef.current?.focus()
+    })
+  }, [conversationReplyCtx])
+  useEffect(() => {
+    setConversationReply(null)
+  }, [streamId])
+  // Topic label for the strip — cached board card or a one-shot by-id fetch.
+  const { post: conversationReplyPost } = useConversationBoardPost(
+    workspaceId,
+    conversationReply?.conversationId ?? null
+  )
+  const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
 
   // Consume any pending share handoff for this stream, pre-inserting the
   // shared-message pointer into the composer and leaving the cursor after it.
@@ -554,8 +581,15 @@ function MessageInputComponent({
           contentJson: normalizedContent,
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
           attachments: attachments.length > 0 ? attachments : undefined,
+          // Armed by "Reply in conversation": file this send into the
+          // conversation synchronously (Mechanism C). Cleared only on success —
+          // a failed send keeps the filing armed alongside the restored content.
+          conversation: conversationReply
+            ? { intent: "existing", conversationId: conversationReply.conversationId }
+            : undefined,
         })
 
+        setConversationReply(null)
         composer.setContent(EMPTY_DOC)
         composer.resolveDraft()
         composer.clearAttachments()
@@ -580,6 +614,7 @@ function MessageInputComponent({
       startDiscussWithAriadne,
       queueCommand,
       availableCommandByName,
+      conversationReply,
     ]
   )
 
@@ -739,14 +774,40 @@ function MessageInputComponent({
     ),
   } as const
 
+  // Armed "Reply in conversation" strip — the send's only signal that it will
+  // file into a conversation, so it renders wherever the composer does (inline
+  // and expanded). Dismissible: X disarms without touching the typed content.
+  const conversationReplyStrip = conversationReply ? (
+    <div
+      data-testid="conversation-reply-strip"
+      className="mb-1.5 flex items-center gap-1.5 rounded-md border border-border/60 bg-muted/50 px-2 py-1 text-xs text-muted-foreground"
+    >
+      <Layers className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">
+        Replying in <span className="font-medium">{conversationReplyTopic ?? "conversation"}</span>
+      </span>
+      <button
+        type="button"
+        aria-label="Cancel reply in conversation"
+        onClick={() => setConversationReply(null)}
+        className="ml-auto shrink-0 rounded p-0.5 hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  ) : null
+
   return (
     <>
       {/* Expanded overlay — portaled into the stream view area */}
       {expanded &&
         portalTargetRef.current &&
         createPortal(
-          <div ref={expandedRef} className="absolute inset-0 z-30 bg-background">
-            <MessageComposer {...composerProps} expanded onCollapse={handleCollapse} autoFocus />
+          <div ref={expandedRef} className="absolute inset-0 z-30 flex flex-col bg-background">
+            {conversationReplyStrip}
+            <div className="min-h-0 flex-1">
+              <MessageComposer {...composerProps} expanded onCollapse={handleCollapse} autoFocus />
+            </div>
           </div>,
           portalTargetRef.current
         )}
@@ -755,6 +816,7 @@ function MessageInputComponent({
           composer via the body-level inline-edit presence attribute. */}
       <FloatingComposerShell ref={selfRef} hidden={expanded} data-message-composer-root>
         <ComposerEncryptionNotice workspaceId={workspaceId} encrypted={e2eEnabled} streamId={e2eRootStreamId} />
+        {!expanded && conversationReplyStrip}
         {!expanded && <MessageComposer {...composerProps} autoFocus={autoFocus} onExpandClick={handleExpandClick} />}
         {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       </FloatingComposerShell>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -88,6 +88,7 @@ import { JoinChannelBar } from "./join-channel-bar"
 import { ThreadParentMessage } from "../thread/thread-parent-message"
 import { EditLastMessageContext } from "./edit-last-message-context"
 import { QuoteReplyProvider } from "./quote-reply-context"
+import { ConversationReplyProvider } from "./conversation-reply-context"
 import { SharedMessagesProvider } from "@/components/shared-messages/context"
 import { TextSelectionQuote } from "./text-selection-quote"
 import { StreamSearchBar } from "./stream-search-bar"
@@ -1971,150 +1972,77 @@ export function StreamContent({
     <ReadFrontierContext.Provider value={readFrontierSequence}>
       <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
         <QuoteReplyProvider>
-          <SharedMessagesProvider map={mergedSharedMessages}>
-            <MessageConversationProvider conversationIdByMessageId={conversationIdByMessageId}>
-              <TextSelectionQuote streamId={streamId} containerRef={quoteScopeRef} />
-              <div ref={quoteScopeRef} className="relative h-full">
-                <div className="absolute inset-0 overflow-hidden">
-                  {isSearchOpen && (
-                    <StreamSearchBar
-                      search={streamSearch}
-                      onClose={handleSearchClose}
-                      onNavigate={handleSearchNavigate}
-                    />
-                  )}
-                  {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
-                  {activeConversationOverlay && (
-                    <ConversationOverlayPanel
-                      overlay={activeConversationOverlay}
-                      inViewConversations={inViewConversations}
-                      onClose={closeConversationOverlay}
-                      searchBarOpen={isSearchOpen}
-                    />
-                  )}
-                  {isDraft && (
-                    <div
-                      ref={draftScrollRef}
-                      className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
-                      style={{ paddingBottom: "var(--composer-height, 0px)" }}
-                    >
-                      {hasDraftPendingEvents ? (
-                        <EventList
-                          timelineItems={draftTimelineItems}
-                          isLoading={false}
-                          workspaceId={workspaceId}
-                          streamId={streamId}
-                          batch={batchState}
-                        />
-                      ) : (
-                        <Empty className="h-full border-0">
-                          <EmptyHeader>
-                            <EmptyMedia variant="icon">
-                              <MessageSquare />
-                            </EmptyMedia>
-                            <EmptyTitle>Start a conversation</EmptyTitle>
-                            <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
-                          </EmptyHeader>
-                        </Empty>
-                      )}
-                    </div>
-                  )}
-                  {!isDraft && useVirtualized && (
-                    <>
-                      <TimelineMessageList
-                        visibleItems={visibleItems}
-                        isLoading={isLoading}
-                        holdForDeepLink={holdForDeepLink}
-                        isConfirmedEmpty={isConfirmedEmpty}
-                        listRef={listRef}
-                        scrollerRef={virtualScrollerRef}
-                        registerScroller={registerVirtualScroller}
-                        contentRef={virtualContentRef}
-                        scrollAbortRef={scrollAbortRef}
-                        shift={shift}
-                        isInitialSettling={virtualIsInitialSettling}
-                        onTimelineScroll={handleVirtualScroll}
-                        isFollowingTailRef={isFollowingTailRef}
-                        hasOlderEvents={hasOlderEvents}
-                        hasNewerEvents={hasNewerEvents}
-                        fetchOlderEvents={fetchOlderEvents}
-                        fetchNewerEvents={fetchNewerEvents}
-                        isFetchingOlder={isFetchingOlder}
-                        isFetchingNewer={isFetchingNewer}
-                        workspaceId={workspaceId}
-                        streamId={streamId}
-                        highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
-                        firstUnreadEventId={dividerEventId}
-                        isDividerDimmed={isDividerDimmed}
-                        agentActivity={agentActivity}
-                        hideSessionCards={isChannel}
-                        newMessageIds={newMessageIds}
-                        isSearchOpen={isSearchOpen}
-                        batch={batchState}
-                        batchPointerHandlers={batchPointerHandlers}
-                        conversationOverlay={activeConversationOverlay}
-                        onJumpToDate={handleJumpToDate}
+          <ConversationReplyProvider>
+            <SharedMessagesProvider map={mergedSharedMessages}>
+              <MessageConversationProvider conversationIdByMessageId={conversationIdByMessageId}>
+                <TextSelectionQuote streamId={streamId} containerRef={quoteScopeRef} />
+                <div ref={quoteScopeRef} className="relative h-full">
+                  <div className="absolute inset-0 overflow-hidden">
+                    {isSearchOpen && (
+                      <StreamSearchBar
+                        search={streamSearch}
+                        onClose={handleSearchClose}
+                        onNavigate={handleSearchNavigate}
                       />
-                      {/* Overlay loading indicators — absolutely positioned so they
-                    don't cause layout shift when prepending older messages. */}
+                    )}
+                    {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
+                    {activeConversationOverlay && (
+                      <ConversationOverlayPanel
+                        overlay={activeConversationOverlay}
+                        inViewConversations={inViewConversations}
+                        onClose={closeConversationOverlay}
+                        searchBarOpen={isSearchOpen}
+                      />
+                    )}
+                    {isDraft && (
                       <div
-                        aria-hidden={!isFetchingOlder}
-                        className={cn(
-                          "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                          isSearchOpen ? "top-14" : "top-2",
-                          isFetchingOlder ? "opacity-100" : "opacity-0"
-                        )}
+                        ref={draftScrollRef}
+                        className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
+                        style={{ paddingBottom: "var(--composer-height, 0px)" }}
                       >
-                        Loading older messages...
-                      </div>
-                      <div
-                        aria-hidden={!isFetchingNewer}
-                        className={cn(
-                          "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
-                          isFetchingNewer ? "opacity-100" : "opacity-0"
-                        )}
-                        style={{
-                          // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
-                          bottom:
-                            isJumpMode || isScrolledFarFromBottom
-                              ? "calc(var(--composer-height, 0px) + 3.5rem)"
-                              : "calc(var(--composer-height, 0px) + 0.5rem)",
-                        }}
-                      >
-                        Loading newer messages...
-                      </div>
-                    </>
-                  )}
-                  {!isDraft && !useVirtualized && (
-                    <div
-                      ref={plainScrollRef}
-                      className={cn(
-                        "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
-                        (isSearchOpen || batchMode) && "pt-11",
-                        batchMode && "select-none"
-                      )}
-                      style={{ paddingBottom: "var(--composer-height, 0px)" }}
-                      data-suppress-pull-refresh="true"
-                      onScroll={plainHandleScroll}
-                      {...batchPointerHandlers}
-                    >
-                      <div ref={plainContentRef}>
-                        {isThread && parentMessage && parentStreamId && (
-                          <ThreadParentMessage
-                            event={parentMessage}
+                        {hasDraftPendingEvents ? (
+                          <EventList
+                            timelineItems={draftTimelineItems}
+                            isLoading={false}
                             workspaceId={workspaceId}
-                            streamId={parentStreamId}
-                            replyCount={displayEvents.length}
+                            streamId={streamId}
+                            batch={batchState}
                           />
+                        ) : (
+                          <Empty className="h-full border-0">
+                            <EmptyHeader>
+                              <EmptyMedia variant="icon">
+                                <MessageSquare />
+                              </EmptyMedia>
+                              <EmptyTitle>Start a conversation</EmptyTitle>
+                              <EmptyDescription>Type a message below to begin this scratchpad.</EmptyDescription>
+                            </EmptyHeader>
+                          </Empty>
                         )}
-                        {isFetchingOlder && (
-                          <div className="flex justify-center py-2">
-                            <p className="text-sm text-muted-foreground">Loading older messages...</p>
-                          </div>
-                        )}
-                        <EventList
-                          timelineItems={timelineItems}
+                      </div>
+                    )}
+                    {!isDraft && useVirtualized && (
+                      <>
+                        <TimelineMessageList
+                          visibleItems={visibleItems}
                           isLoading={isLoading}
+                          holdForDeepLink={holdForDeepLink}
+                          isConfirmedEmpty={isConfirmedEmpty}
+                          listRef={listRef}
+                          scrollerRef={virtualScrollerRef}
+                          registerScroller={registerVirtualScroller}
+                          contentRef={virtualContentRef}
+                          scrollAbortRef={scrollAbortRef}
+                          shift={shift}
+                          isInitialSettling={virtualIsInitialSettling}
+                          onTimelineScroll={handleVirtualScroll}
+                          isFollowingTailRef={isFollowingTailRef}
+                          hasOlderEvents={hasOlderEvents}
+                          hasNewerEvents={hasNewerEvents}
+                          fetchOlderEvents={fetchOlderEvents}
+                          fetchNewerEvents={fetchNewerEvents}
+                          isFetchingOlder={isFetchingOlder}
+                          isFetchingNewer={isFetchingNewer}
                           workspaceId={workspaceId}
                           streamId={streamId}
                           highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
@@ -2123,155 +2051,230 @@ export function StreamContent({
                           agentActivity={agentActivity}
                           hideSessionCards={isChannel}
                           newMessageIds={newMessageIds}
+                          isSearchOpen={isSearchOpen}
                           batch={batchState}
+                          batchPointerHandlers={batchPointerHandlers}
                           conversationOverlay={activeConversationOverlay}
+                          onJumpToDate={handleJumpToDate}
                         />
-                        {isFetchingNewer && (
-                          <div className="flex justify-center py-2">
-                            <p className="text-sm text-muted-foreground">Loading newer messages...</p>
-                          </div>
+                        {/* Overlay loading indicators — absolutely positioned so they
+                    don't cause layout shift when prepending older messages. */}
+                        <div
+                          aria-hidden={!isFetchingOlder}
+                          className={cn(
+                            "pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                            isSearchOpen ? "top-14" : "top-2",
+                            isFetchingOlder ? "opacity-100" : "opacity-0"
+                          )}
+                        >
+                          Loading older messages...
+                        </div>
+                        <div
+                          aria-hidden={!isFetchingNewer}
+                          className={cn(
+                            "pointer-events-none absolute left-1/2 -translate-x-1/2 z-20 rounded-full bg-background/90 px-3 py-1 shadow-sm border text-xs text-muted-foreground transition-opacity",
+                            isFetchingNewer ? "opacity-100" : "opacity-0"
+                          )}
+                          style={{
+                            // Sit above the Jump to latest button (when visible) which itself sits above the floating composer.
+                            bottom:
+                              isJumpMode || isScrolledFarFromBottom
+                                ? "calc(var(--composer-height, 0px) + 3.5rem)"
+                                : "calc(var(--composer-height, 0px) + 0.5rem)",
+                          }}
+                        >
+                          Loading newer messages...
+                        </div>
+                      </>
+                    )}
+                    {!isDraft && !useVirtualized && (
+                      <div
+                        ref={plainScrollRef}
+                        className={cn(
+                          "h-full overflow-y-auto overflow-x-hidden overscroll-y-contain",
+                          (isSearchOpen || batchMode) && "pt-11",
+                          batchMode && "select-none"
                         )}
+                        style={{ paddingBottom: "var(--composer-height, 0px)" }}
+                        data-suppress-pull-refresh="true"
+                        onScroll={plainHandleScroll}
+                        {...batchPointerHandlers}
+                      >
+                        <div ref={plainContentRef}>
+                          {isThread && parentMessage && parentStreamId && (
+                            <ThreadParentMessage
+                              event={parentMessage}
+                              workspaceId={workspaceId}
+                              streamId={parentStreamId}
+                              replyCount={displayEvents.length}
+                            />
+                          )}
+                          {isFetchingOlder && (
+                            <div className="flex justify-center py-2">
+                              <p className="text-sm text-muted-foreground">Loading older messages...</p>
+                            </div>
+                          )}
+                          <EventList
+                            timelineItems={timelineItems}
+                            isLoading={isLoading}
+                            workspaceId={workspaceId}
+                            streamId={streamId}
+                            highlightMessageId={streamSearch.activeMessageId ?? highlightMessageId}
+                            firstUnreadEventId={dividerEventId}
+                            isDividerDimmed={isDividerDimmed}
+                            agentActivity={agentActivity}
+                            hideSessionCards={isChannel}
+                            newMessageIds={newMessageIds}
+                            batch={batchState}
+                            conversationOverlay={activeConversationOverlay}
+                          />
+                          {isFetchingNewer && (
+                            <div className="flex justify-center py-2">
+                              <p className="text-sm text-muted-foreground">Loading newer messages...</p>
+                            </div>
+                          )}
+                        </div>
                       </div>
+                    )}
+                  </div>
+                  {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
+              Positioned above the floating composer pill. */}
+                  {(isJumpMode || isScrolledFarFromBottom) && (
+                    <div
+                      className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
+                      style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
+                    >
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className="pointer-events-auto shadow-lg gap-1.5"
+                        onClick={handleJumpToLatest}
+                      >
+                        <ArrowDown className="h-3.5 w-3.5" />
+                        Jump to latest
+                      </Button>
                     </div>
                   )}
-                </div>
-                {/* Jump to latest button — shown when scrolled far from bottom or in jump mode.
-              Positioned above the floating composer pill. */}
-                {(isJumpMode || isScrolledFarFromBottom) && (
-                  <div
-                    className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10"
-                    style={{ bottom: "calc(var(--composer-height, 0px) + 0.5rem)" }}
-                  >
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      className="pointer-events-auto shadow-lg gap-1.5"
-                      onClick={handleJumpToLatest}
-                    >
-                      <ArrowDown className="h-3.5 w-3.5" />
-                      Jump to latest
-                    </Button>
-                  </div>
-                )}
-                {/* "N new messages" jump — shown when unread sits above the viewport.
+                  {/* "N new messages" jump — shown when unread sits above the viewport.
               Jumps up to the "New" divider so the viewer can read from there.
               Hidden while search is open: jumping the timeline would yank it out
               from under the active search-result navigation, and the Escape
               mark-read shortcut is gated on `!isSearchOpen` too. */}
-                {unreadAboveViewport && unreadCount > 0 && !batchMode && !isSearchOpen && (
-                  <div
-                    // Sits clearly below the floating date pill (top-2, ~30px tall)
-                    // so the top-center affordances never overlap.
-                    className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5"
-                    style={{ top: "3.5rem" }}
-                  >
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      className="pointer-events-auto shadow-lg gap-1.5"
-                      onClick={scrollToFirstUnread}
+                  {unreadAboveViewport && unreadCount > 0 && !batchMode && !isSearchOpen && (
+                    <div
+                      // Sits clearly below the floating date pill (top-2, ~30px tall)
+                      // so the top-center affordances never overlap.
+                      className="pointer-events-none absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5"
+                      style={{ top: "3.5rem" }}
                     >
-                      <ArrowUp className="h-3.5 w-3.5" />
-                      {unreadCount} new message{unreadCount === 1 ? "" : "s"}
-                    </Button>
-                    {/* Dismiss without scrolling up: mark all loaded read and tail
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className="pointer-events-auto shadow-lg gap-1.5"
+                        onClick={scrollToFirstUnread}
+                      >
+                        <ArrowUp className="h-3.5 w-3.5" />
+                        {unreadCount} new message{unreadCount === 1 ? "" : "s"}
+                      </Button>
+                      {/* Dismiss without scrolling up: mark all loaded read and tail
                   the live bottom — the touchable equivalent of Escape. */}
-                    <Button
-                      variant="secondary"
-                      size="icon"
-                      className="pointer-events-auto h-9 w-9 shadow-lg"
-                      onClick={escapeUnread}
-                      aria-label="Mark all read"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                )}
-                {dragGhost && (
-                  <div
-                    className="pointer-events-none fixed z-50 max-w-[280px] rounded-md border bg-popover/95 px-3 py-2 text-sm shadow-lg"
-                    style={{ left: dragGhost.x + 12, top: dragGhost.y + 12 }}
-                  >
-                    <div className="font-medium">{selectedMessageIds.size} selected</div>
-                    <div className="line-clamp-1 text-xs text-muted-foreground">
-                      {Array.from(selectedMessageIds)
-                        .map((messageId) => {
-                          const content = messageEventMeta.get(messageId)?.content
-                          return content ? stripMarkdownToInline(content) : null
-                        })
-                        .filter(Boolean)
-                        .slice(0, 1)
-                        .join("")}
+                      <Button
+                        variant="secondary"
+                        size="icon"
+                        className="pointer-events-auto h-9 w-9 shadow-lg"
+                        onClick={escapeUnread}
+                        aria-label="Mark all read"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
                     </div>
-                  </div>
-                )}
-                <AlertDialog
-                  open={moveDialogOpen}
-                  onOpenChange={(open) => {
-                    if (open) return
-                    // Cancel + Esc are allowed during validating (we just bump the
-                    // cancellation token and the in-flight request becomes a no-op
-                    // on resolve). Only the irreversible commit phase blocks
-                    // dismiss — there is no rollback once moveToThread succeeds.
-                    if (isMoveConfirming) return
-                    closePendingMove()
-                  }}
-                >
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Move messages?</AlertDialogTitle>
-                      <AlertDialogDescription>{`Move ${moveMessageCountLabel} into this thread?`}</AlertDialogDescription>
-                    </AlertDialogHeader>
-                    {/* Custom footer: status row (left) + actions (right). Replaces
+                  )}
+                  {dragGhost && (
+                    <div
+                      className="pointer-events-none fixed z-50 max-w-[280px] rounded-md border bg-popover/95 px-3 py-2 text-sm shadow-lg"
+                      style={{ left: dragGhost.x + 12, top: dragGhost.y + 12 }}
+                    >
+                      <div className="font-medium">{selectedMessageIds.size} selected</div>
+                      <div className="line-clamp-1 text-xs text-muted-foreground">
+                        {Array.from(selectedMessageIds)
+                          .map((messageId) => {
+                            const content = messageEventMeta.get(messageId)?.content
+                            return content ? stripMarkdownToInline(content) : null
+                          })
+                          .filter(Boolean)
+                          .slice(0, 1)
+                          .join("")}
+                      </div>
+                    </div>
+                  )}
+                  <AlertDialog
+                    open={moveDialogOpen}
+                    onOpenChange={(open) => {
+                      if (open) return
+                      // Cancel + Esc are allowed during validating (we just bump the
+                      // cancellation token and the in-flight request becomes a no-op
+                      // on resolve). Only the irreversible commit phase blocks
+                      // dismiss — there is no rollback once moveToThread succeeds.
+                      if (isMoveConfirming) return
+                      closePendingMove()
+                    }}
+                  >
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Move messages?</AlertDialogTitle>
+                        <AlertDialogDescription>{`Move ${moveMessageCountLabel} into this thread?`}</AlertDialogDescription>
+                      </AlertDialogHeader>
+                      {/* Custom footer: status row (left) + actions (right). Replaces
                   shadcn's AlertDialogFooter, which forces flex-col-reverse on
                   mobile and would invert our vertical stacking. */}
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-                      <MoveStatusRow phase={movePhase} />
-                      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
-                        <AlertDialogCancel disabled={movePhase === "moving"}>Cancel</AlertDialogCancel>
-                        {/* `preventDefault` keeps the dialog open through the
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                        <MoveStatusRow phase={movePhase} />
+                        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:gap-2">
+                          <AlertDialogCancel disabled={movePhase === "moving"}>Cancel</AlertDialogCancel>
+                          {/* `preventDefault` keeps the dialog open through the
                       moving phase so the inline status row can transition
                       to "Moving…" — Radix's default Action behavior would
                       auto-close on click. confirmPendingMove closes the
                       dialog itself on success via cancelBatchMode. */}
-                        <AlertDialogAction
-                          onClick={(event) => {
-                            event.preventDefault()
-                            void confirmPendingMove()
-                          }}
-                          disabled={movePhase !== "validated"}
-                          aria-busy={movePhase === "moving"}
-                        >
-                          Move
-                        </AlertDialogAction>
+                          <AlertDialogAction
+                            onClick={(event) => {
+                              event.preventDefault()
+                              void confirmPendingMove()
+                            }}
+                            disabled={movePhase !== "validated"}
+                            aria-busy={movePhase === "moving"}
+                          >
+                            Move
+                          </AlertDialogAction>
+                        </div>
                       </div>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                  {membershipResolved && !isMember && isPublicChannel && (
+                    <div className="absolute inset-x-0 bottom-0 z-10">
+                      <JoinChannelBar
+                        workspaceId={workspaceId}
+                        streamId={streamId}
+                        channelName={stream?.slug ?? stream?.displayName ?? ""}
+                        onJoined={handleJoined}
+                        onHeightChange={handleComposerHeightChange}
+                      />
                     </div>
-                  </AlertDialogContent>
-                </AlertDialog>
-                {membershipResolved && !isMember && isPublicChannel && (
-                  <div className="absolute inset-x-0 bottom-0 z-10">
-                    <JoinChannelBar
+                  )}
+                  {(isMember || !isPublicChannel || !membershipResolved) && (
+                    <MessageInput
                       workspaceId={workspaceId}
                       streamId={streamId}
-                      channelName={stream?.slug ?? stream?.displayName ?? ""}
-                      onJoined={handleJoined}
-                      onHeightChange={handleComposerHeightChange}
+                      disabled={isArchived || isSystem}
+                      disabledReason={disabledReason}
+                      autoFocus={autoFocus}
+                      onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
                     />
-                  </div>
-                )}
-                {(isMember || !isPublicChannel || !membershipResolved) && (
-                  <MessageInput
-                    workspaceId={workspaceId}
-                    streamId={streamId}
-                    disabled={isArchived || isSystem}
-                    disabledReason={disabledReason}
-                    autoFocus={autoFocus}
-                    onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
-                  />
-                )}
-              </div>
-            </MessageConversationProvider>
-          </SharedMessagesProvider>
+                  )}
+                </div>
+              </MessageConversationProvider>
+            </SharedMessagesProvider>
+          </ConversationReplyProvider>
         </QuoteReplyProvider>
       </EditLastMessageContext.Provider>
     </ReadFrontierContext.Provider>

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -89,12 +89,13 @@ export function useQueueDraftMessage(workspaceId: string) {
           // would flash the opaque placeholder for its own author.
           contentJson: input.contentJson,
           // Tag the optimistic reply with its target conversation so a board card
-          // surfaces it under the right card before the server echo (which carries
-          // the real id in the conversation aggregate) lands. Read-side only; the
-          // timeline ignores it, and the row is swapped for the real event on echo.
-          // `existing` names the conversation directly; `threadFromMessage` (a
-          // lone post converting to a thread) joins its source conversation, so the
-          // reply renders in place under the same card — no card swap
+          // surfaces it under the right card before the server echo lands, and so
+          // the sender's own flat-timeline provenance chip is stable across the
+          // swap (see conversationTag — `existing` also carries the chip key the
+          // server puts on the real payload). The row is swapped for the real event
+          // on echo. `existing` names the conversation directly; `threadFromMessage`
+          // (a lone post converting to a thread) joins its source conversation, so
+          // the reply renders in place under the same card — no card swap
           // (board-view-design.md "Convert-to-thread, corrected").
           ...conversationTag(params.conversation),
           ...(input.attachments && input.attachments.length > 0 ? { attachments: input.attachments } : {}),
@@ -238,11 +239,19 @@ export function useQueueDraftMessage(workspaceId: string) {
 
 /** The conversation a board reply's optimistic event is tagged with, so the card
  *  surfaces it in place before the server echo. `existing` carries the id; a
- *  `threadFromMessage` convert joins its source conversation. */
-function conversationTag(
-  directive: ConversationDirective | undefined
-): { conversationId: string } | Record<string, never> {
-  if (directive?.intent === "existing") return { conversationId: directive.conversationId }
+ *  `threadFromMessage` convert joins its source conversation.
+ *
+ *  `existing` also stamps `declaredConversationId` — the same key the server puts
+ *  on the real `message_created` payload — so the sender's own flat-timeline
+ *  provenance chip (Mechanism C) renders on the optimistic row and stays put when
+ *  the echo swaps in. A `threadFromMessage` reply is an opener the timeline chip
+ *  ignores, so it tags the board card (`conversationId`) only. */
+function conversationTag(directive: ConversationDirective | undefined): {
+  conversationId?: string
+  declaredConversationId?: string
+} {
+  if (directive?.intent === "existing")
+    return { conversationId: directive.conversationId, declaredConversationId: directive.conversationId }
   if (directive?.intent === "threadFromMessage") return { conversationId: directive.sourceConversationId }
   return {}
 }

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -246,7 +246,7 @@ export function useQueueDraftMessage(workspaceId: string) {
  *  provenance chip (Mechanism C) renders on the optimistic row and stays put when
  *  the echo swaps in. A `threadFromMessage` reply is an opener the timeline chip
  *  ignores, so it tags the board card (`conversationId`) only. */
-function conversationTag(directive: ConversationDirective | undefined): {
+export function conversationTag(directive: ConversationDirective | undefined): {
   conversationId?: string
   declaredConversationId?: string
 } {

--- a/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
+++ b/apps/frontend/src/hooks/use-stream-or-draft.test.tsx
@@ -70,7 +70,8 @@ describe("useStreamOrDraft real stream send", () => {
     await clearAllCachedData()
   })
 
-  it("queues the optimistic event in IndexedDB without mutating an empty bootstrap window", async () => {
+  /** Seed the workspace cache + bootstrap for a plain channel and mount the hook on it. */
+  async function mountRealStreamSend() {
     const createdAt = "2026-03-31T10:00:00Z"
     const stream = {
       id: "stream_socket_seen",
@@ -192,6 +193,12 @@ describe("useStreamOrDraft real stream send", () => {
       expect(result.current.stream?.id).toBe("stream_socket_seen")
     })
 
+    return { result, queryClient }
+  }
+
+  it("queues the optimistic event in IndexedDB without mutating an empty bootstrap window", async () => {
+    const { result, queryClient } = await mountRealStreamSend()
+
     await act(async () => {
       await result.current.sendMessage({
         contentJson: {
@@ -221,6 +228,34 @@ describe("useStreamOrDraft real stream send", () => {
       actorId: "member_1",
       eventType: "message_created",
       _status: "pending",
+    })
+  })
+
+  it("forwards a conversation directive to the pending row and tags the optimistic payload (reply in conversation)", async () => {
+    const { result } = await mountRealStreamSend()
+
+    await act(async () => {
+      await result.current.sendMessage({
+        contentJson: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text: "late pizza take" }] }],
+        },
+        conversation: { intent: "existing", conversationId: "conv_1" },
+      })
+    })
+
+    // The queue drain forwards `conversation` from the pending row to the API,
+    // and the optimistic payload carries the same keys the server stamps on the
+    // real event, so the sender's provenance chip survives the echo swap.
+    // `pendingMessages` is the durable send outbox (not cached data), so rows
+    // from earlier tests survive clearAllCachedData — assert on this send's row.
+    const pendingMessage = (await db.pendingMessages.toArray()).find((m) => m.content === "late pizza take")
+    expect(pendingMessage?.conversation).toEqual({ intent: "existing", conversationId: "conv_1" })
+
+    const queuedEvent = (await db.events.toArray()).find((e) => e._clientId === pendingMessage?.clientId)
+    expect(queuedEvent?.payload).toMatchObject({
+      conversationId: "conv_1",
+      declaredConversationId: "conv_1",
     })
   })
 })

--- a/apps/frontend/src/hooks/use-stream-or-draft.ts
+++ b/apps/frontend/src/hooks/use-stream-or-draft.ts
@@ -11,7 +11,7 @@ import { sealStreamRename } from "@/lib/crypto/stream-rename"
 import { useStreamBootstrap, streamKeys } from "./use-streams"
 import { workspaceKeys } from "./use-workspaces"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
-import { useQueueDraftMessage } from "./use-queue-draft-message"
+import { useQueueDraftMessage, conversationTag } from "./use-queue-draft-message"
 import { useWorkspaceUsers, useWorkspaceStreams, useWorkspaceDmPeers } from "@/stores/workspace-store"
 import { useSyncEngine } from "@/sync/sync-engine"
 import { hasSeededDraftCache } from "@/stores/draft-store"
@@ -25,6 +25,7 @@ import type {
   StreamMember,
   StreamType,
   CompanionMode,
+  ConversationDirective,
   StreamEvent,
   JSONContent,
   WorkspaceBootstrap,
@@ -138,6 +139,12 @@ export interface SendMessageInput {
   attachmentIds?: string[]
   /** Full attachment info for optimistic UI - required when attachmentIds is provided */
   attachments?: AttachmentSummary[]
+  /**
+   * Files the send into a conversation synchronously ("Reply in conversation",
+   * Mechanism C). Only meaningful on real streams — draft paths ignore it, since
+   * a stream that doesn't exist yet has no conversations to reply into.
+   */
+  conversation?: ConversationDirective
 }
 
 export interface UseStreamOrDraftReturn {
@@ -589,6 +596,10 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
           messageId: clientId,
           contentMarkdown,
           contentJson: input.contentJson,
+          // Same conversation keys the server stamps on the real payload, so the
+          // sender's provenance chip renders on the optimistic row and survives
+          // the echo swap (see conversationTag).
+          ...conversationTag(input.conversation),
           ...(input.attachments && input.attachments.length > 0 ? { attachments: input.attachments } : {}),
         },
         actorId: currentUserId,
@@ -656,6 +667,7 @@ function useRealStream(workspaceId: string, streamId: string, enabled: boolean):
         contentFormat: "markdown",
         contentJson: input.contentJson,
         attachmentIds: input.attachmentIds,
+        conversation: input.conversation,
         createdAt: Date.now(),
         retryCount: 0,
         ...(e2eFields ?? {}),


### PR DESCRIPTION
## What this does

Lets a message declare the conversation it belongs to so the flat-timeline
provenance chip ("↪ continues Pizza · 3h ago") renders the instant the message
arrives, instead of waiting for the async conversation-membership list — and
adds the **"Reply in conversation"** context-menu action that makes the filing
reachable from any channel/DM timeline.

This is Mechanism C from `docs/board-view-design.md` §"Conversations as soft
threads". Mechanism A (#1140) already shows the chip, but it derives membership
from the async classifier, so the chip flickers in once the list loads and can't
exist for a topic the classifier hasn't clustered. A declared message doesn't
depend on any of that.

## How

The declaration is a **hidden message property**, not body content. A board or
panel reply already sends an `existing` conversation directive on the send. The
send now stamps that conversation id onto the `message_created` event payload as
`declaredConversationId`, and `annotateConversationRevivals` prefers it over the
async membership map — so a declared message's chip needs no list round-trip.

- **Backend** (`event-service.ts`): for an `existing` directive, copy
  `conversation.conversationId` onto the payload before the event insert. The id
  is already in the directive, so there's no conversation read in the send path —
  messaging stays decoupled from conversation internals (the assigner is still
  the only thing that touches conversation rows). `new` / thread-from-message
  declarations are chip-less openers and carry no id.
- **Frontend** (`event-list.tsx`): `annotateConversationRevivals` reads
  `payload.declaredConversationId` as a higher-priority membership source than
  the async map. Everything else (block-start / seen / previous-activity gating)
  is unchanged, so a contiguous run of the same conversation still shows no chip.
- **Optimistic** (`use-queue-draft-message.ts`): the sender's optimistic board
  reply carries the same key, so their own chip is stable across the server echo.

The topic **label** still resolves from the same-root conversation list the
timeline already loads; a declared-but-not-yet-listed conversation shows the
generic label until the list catches up. Only the id rides on the wire.

## Why a field, not a content node

The first cut of this PR filed the message by embedding a `conversationReference`
ProseMirror node in the body (a `[topic](conversation:conv_x)` markdown pointer,
an in-body chip, an editor pill). That had two problems:

1. **Duplication.** The in-body chip and the footer provenance chip render the
   same fact in two places on the same message. The node version suppressed the
   footer chip to compensate; the field version just feeds the one footer chip.
2. **Filing is message metadata, not content.** Baking a routing pointer into
   user-authored body content (with a markdown round-trip to keep it lossless)
   is machinery in service of the content embedding itself. The only thing it
   bought was passing the reference around losslessly, which the existing send
   directive already does for the authoring paths that matter (board/panel
   replies, and the "reply in conversation" action below).

So filing is now a property the send declares, and nothing renders in the body.

## "Reply in conversation" — the authoring path

The second commit makes the field reachable from the UI (before it, only
board/panel replies populated it). A **"Reply in conversation"** entry joins the
message context menu's reply group (next to "Quote reply"), on any in-stream
message whose conversation is locally known — the same membership gate as "Show
in conversation".

Picking it arms the stream composer with a dismissible **"Replying in
\<topic\>"** strip (topic resolves from the cached board card or a one-shot
by-id fetch) and focuses the editor. The next send carries
`conversation: { intent: "existing", conversationId }` — the same directive
rail board replies use — so the message files synchronously and its provenance
chip renders instantly. The X disarms without touching typed content; a failed
send keeps the filing armed for retry; the armed state resets on stream switch
and is deliberately not part of the durable draft (a stale filing surviving a
reload would silently misfile whatever is typed next).

Plumbing: `ConversationReplyProvider` mirrors the quote-reply relay
(trigger from the row → registered composer handler). `SendMessageInput` gains
`conversation`; the real-stream send writes it to the pending row (the queue
drain already forwards it to the API) and tags the optimistic payload via the
shared `conversationTag`, so the sender's own chip is stable across the echo
swap.

Two deliberate gates:

- **Hidden on E2E streams** (like Edit): the E2E create wire format carries no
  conversation directive, so offering the action there would silently drop the
  filing (INV-11 — no silent fallback).
- **No special-casing the immediate reply**: a reply landing right after the
  conversation's previous member isn't a block start, so the revival annotator
  already shows no chip; a scattered continuation gets one. Exactly the
  intended "chip only when it reads as a non-sequitur" behavior, for free.

## Files

**Commit 1 — the hidden field:**

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/messaging/event-service.ts` | Stamp `declaredConversationId` on the `message_created` payload for an `existing` directive; field added to `MessageCreatedPayload` |
| `apps/frontend/src/components/timeline/event-list.tsx` | `annotateConversationRevivals` prefers the payload's declared id over the async membership map |
| `apps/frontend/src/hooks/use-queue-draft-message.ts` | Optimistic board reply carries `declaredConversationId` (alongside the existing board-card `conversationId` tag); `conversationTag` exported for reuse |

**Commit 2 — the "Reply in conversation" action:**

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/conversation-reply-context.tsx` | New — trigger/handler relay from message rows to the stream composer (mirrors quote-reply) |
| `apps/frontend/src/components/timeline/message-actions.ts` | "Reply in conversation" entry in the reply group, gated on the handler |
| `apps/frontend/src/components/timeline/message-event.tsx` | Wires the action: membership known + composer registered + not E2E |
| `apps/frontend/src/components/timeline/message-input.tsx` | Armed-reply state, "Replying in \<topic\>" strip (inline + expanded), directive on submit, clear-on-success/stream-switch |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Mounts `ConversationReplyProvider` beside `QuoteReplyProvider` |
| `apps/frontend/src/hooks/use-stream-or-draft.ts` | `SendMessageInput.conversation`; real-stream send forwards it to the pending row + tags the optimistic payload |
| `*.test.ts(x)` | Backend stamp/omit; revival-from-declared; strip arm/send/fail/dismiss; pending-row + optimistic-tag forwarding; action visibility |

## Test plan

- [x] `bun test apps/backend/.../event-service.test.ts` — 25 pass (incl. 3 new: stamps for `existing`, omits for `new`, omits + skips the assigner when undeclared)
- [x] `vitest run apps/frontend/.../event-list.test.ts` — 53 pass (incl. 4 new `annotateConversationRevivals` cases)
- [x] `vitest run` message-input — 23 pass (incl. 4 new: strip arms + focuses, send carries directive + clears, failed send keeps it armed, dismiss disarms)
- [x] `vitest run` use-stream-or-draft — pending row carries the directive; optimistic payload tagged with `declaredConversationId`
- [x] `vitest run` message-actions / message-event / stream-content / queue hooks / text-selection-quote — 251 tests green across the 10 touched suites
- [x] `tsc --noEmit` across `packages/types`, `apps/backend`, `apps/frontend` — clean (full-monorepo pre-commit hook green on both commits)

## Out of scope (deliberate)

- **Thread-follow routing.** When a conversation has moved into a thread, the
  recency-biased continuation would open the thread and file there instead of
  replying in the flat timeline. The signal (`lastActiveStreamId`) currently
  exists only in the board projection, not in the stream timeline's data — the
  follow-up wires it through. Today the reply lands where you are, which the
  same-root guard accepts and which revives the conversation in the channel.
- **E2E directive support.** The E2E create wire format doesn't carry
  `conversation`; rather than extend that contract here, the action is hidden on
  E2E streams (same gating pattern as Edit).
- **Scheduled sends.** The schedule path doesn't carry the directive; an armed
  filing applies only to a live send.
- **Backend topic on the wire.** Kept the send path decoupled from conversation
  internals — only the id is stamped, and the frontend resolves the label from
  the conversation list it already loads. Denormalising the topic onto the
  payload would need the assigner to return it (a signature + ordering change),
  not worth it while the label is reliably available client-side.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)