### PR TITLE
feat(public-site): login button in marketing nav

### DIFF
--- a/apps/public-site/src/lib/config.ts
+++ b/apps/public-site/src/lib/config.ts
@@ -1,0 +1,7 @@
+// The app origin: app.threa.io serves the app UI, and the workspace-router
+// proxies /api/* on the same host, so this doubles as the API base for the
+// waitlist POST. Overridable at build via PUBLIC_API_BASE so staging/preview
+// builds of the marketing site don't point users at production.
+export const apiBase = import.meta.env.PUBLIC_API_BASE ?? "https://app.threa.io"
+
+export const loginUrl = `${apiBase}/login`

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -42,6 +42,7 @@ const schema = [
             <a href="/developers">Developer</a>
             <a href="/about" aria-current="page">About</a>
           </nav>
+          <a class="nav-login" href="https://app.threa.io/login">Log in</a>
           <ThemeToggle />
         </div>
 

--- a/apps/public-site/src/pages/about.astro
+++ b/apps/public-site/src/pages/about.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro"
 import SvgDefs from "../components/SvgDefs.astro"
 import ThemeToggle from "../components/ThemeToggle.astro"
+import { loginUrl } from "../lib/config"
 
 const schema = [
   {
@@ -42,7 +43,7 @@ const schema = [
             <a href="/developers">Developer</a>
             <a href="/about" aria-current="page">About</a>
           </nav>
-          <a class="nav-login" href="https://app.threa.io/login">Log in</a>
+          <a class="nav-login" href={loginUrl}>Log in</a>
           <ThemeToggle />
         </div>
 

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -2,11 +2,7 @@
 import Layout from "../layouts/Layout.astro"
 import SvgDefs from "../components/SvgDefs.astro"
 import ThemeToggle from "../components/ThemeToggle.astro"
-
-// Where the waitlist form POSTs. The marketing site is a separate origin from
-// the API, so this is a cross-origin call to the workspace-router, which proxies
-// /api/waitlist to the control-plane. Overridable at build via PUBLIC_API_BASE.
-const apiBase = import.meta.env.PUBLIC_API_BASE ?? "https://app.threa.io"
+import { apiBase, loginUrl } from "../lib/config"
 
 // URLs derive from astro.config.mjs's site so the @id cross-reference always
 // matches the Organization entity BaseHead emits.
@@ -41,7 +37,7 @@ const schema = [
         <nav class="nav-links">
           <a href="/" aria-current="page">Product</a><a href="/developers">Developer</a><a href="/about">About</a>
         </nav>
-        <a class="nav-login" href="https://app.threa.io/login">Log in</a>
+        <a class="nav-login" href={loginUrl}>Log in</a>
         <ThemeToggle />
       </div>
       <div class="hero-stage">

--- a/apps/public-site/src/pages/index.astro
+++ b/apps/public-site/src/pages/index.astro
@@ -41,6 +41,7 @@ const schema = [
         <nav class="nav-links">
           <a href="/" aria-current="page">Product</a><a href="/developers">Developer</a><a href="/about">About</a>
         </nav>
+        <a class="nav-login" href="https://app.threa.io/login">Log in</a>
         <ThemeToggle />
       </div>
       <div class="hero-stage">

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -292,47 +292,39 @@ body::after {
   color: hsl(var(--muted));
 }
 
-/* Login — the outlined-secondary counterpart to the filled .cta: the door into
-   the app that sits in the marketing nav. Mono-caps to read as a nav element
-   beside the links, gold-outlined, and it borrows the primary CTA's hover
-   arrow-nudge so the two share a motion language. Tokens carry it into dark. */
+/* Login — the app's own primary button, dropped into the marketing nav so the
+   door into the app looks like the app. Mirrors the Shadcn `Button` default
+   variant in apps/frontend/src/components/ui/button.tsx: solid --primary fill
+   with --primary-foreground text, Space Grotesk medium at text-sm, and the
+   app's 10px button radius. --gold === app --primary and --paper ===
+   --primary-foreground, so it tracks light/dark exactly. Hover shifts instantly
+   (no transition): a var-based color transition freezes on this static site's
+   theme toggle, and the app's real buttons transition-colors only because React
+   re-renders force the restyle a static page never gets. */
 .nav-login {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 15px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: hsl(var(--ink));
+  justify-content: center;
+  padding: 9px 18px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  color: hsl(var(--paper));
+  background: hsl(var(--gold));
+  border: none;
+  border-radius: 10px;
   text-decoration: none;
   white-space: nowrap;
-  border: 1px solid hsl(var(--gold) / 0.55);
-  border-radius: 2px;
-  background: hsl(var(--gold) / 0.06);
-  transition:
-    color 0.2s ease,
-    border-color 0.2s ease,
-    background 0.2s ease;
-}
-.nav-login::after {
-  content: "→";
-  font-family: var(--font-display);
-  font-size: 12px;
-  transition: transform 0.2s ease-out;
 }
 .nav-login:hover {
-  color: hsl(var(--gold));
-  border-color: hsl(var(--gold));
-  background: hsl(var(--gold) / 0.13);
-}
-.nav-login:hover::after {
-  transform: translateX(3px);
+  background: hsl(var(--gold-soft));
 }
 .nav-login:focus-visible {
-  outline: 2px solid hsl(var(--gold));
-  outline-offset: 2px;
+  outline: none;
+  box-shadow:
+    0 0 0 2px hsl(var(--paper)),
+    0 0 0 4px hsl(var(--gold) / 0.6);
 }
 
 /* ---------- OPEN TIMELINE ----------
@@ -2310,9 +2302,8 @@ body::after {
     letter-spacing: 0.1em;
   }
   .nav-row .nav-login {
-    padding: 7px 11px;
-    font-size: 10px;
-    letter-spacing: 0.1em;
+    padding: 8px 15px;
+    font-size: 13px;
   }
 
   /* The chat demo's composer mirrors the real one with a full action row. At

--- a/apps/public-site/src/styles/global.css
+++ b/apps/public-site/src/styles/global.css
@@ -292,6 +292,49 @@ body::after {
   color: hsl(var(--muted));
 }
 
+/* Login — the outlined-secondary counterpart to the filled .cta: the door into
+   the app that sits in the marketing nav. Mono-caps to read as a nav element
+   beside the links, gold-outlined, and it borrows the primary CTA's hover
+   arrow-nudge so the two share a motion language. Tokens carry it into dark. */
+.nav-login {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 15px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--ink));
+  text-decoration: none;
+  white-space: nowrap;
+  border: 1px solid hsl(var(--gold) / 0.55);
+  border-radius: 2px;
+  background: hsl(var(--gold) / 0.06);
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+.nav-login::after {
+  content: "→";
+  font-family: var(--font-display);
+  font-size: 12px;
+  transition: transform 0.2s ease-out;
+}
+.nav-login:hover {
+  color: hsl(var(--gold));
+  border-color: hsl(var(--gold));
+  background: hsl(var(--gold) / 0.13);
+}
+.nav-login:hover::after {
+  transform: translateX(3px);
+}
+.nav-login:focus-visible {
+  outline: 2px solid hsl(var(--gold));
+  outline-offset: 2px;
+}
+
 /* ---------- OPEN TIMELINE ----------
      Anchored to the real chat view in apps/frontend/src/components/timeline:
      - Rows render at full opacity from frame 1; "new" is signalled by
@@ -2266,6 +2309,11 @@ body::after {
     font-size: 10px;
     letter-spacing: 0.1em;
   }
+  .nav-row .nav-login {
+    padding: 7px 11px;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+  }
 
   /* The chat demo's composer mirrors the real one with a full action row. At
      phone width nine icons plus send overflow the card, so we keep the
@@ -2321,13 +2369,35 @@ body::after {
 [data-theme="dark"] .theme-toggle .tt-moon {
   display: none;
 }
-/* Marketing nav-row gains a third child; keep the links hugging the toggle
-   on the right instead of letting space-between spread all three apart. */
+/* Marketing nav-row gains extra children; keep the links, the login button,
+   and the toggle hugging together on the right instead of letting
+   space-between spread them apart. */
 .nav-row .nav-links {
   margin-left: auto;
 }
+.nav-row .nav-login {
+  margin-left: 22px;
+}
 .nav-row .theme-toggle {
   margin-left: 20px;
+}
+/* Phone width can't fit brand + links + login + toggle on one line. Wrap the
+   nav: brand keeps the left, login + toggle hug the right, and the links drop
+   to their own full-width second line. (Placed after the margin rules above so
+   the cascade resolves in its favor at equal specificity.) */
+@media (max-width: 560px) {
+  .nav-row {
+    flex-wrap: wrap;
+  }
+  .nav-row .nav-links {
+    order: 1;
+    flex-basis: 100%;
+    margin-left: 0;
+    margin-top: 18px;
+  }
+  .nav-row .nav-login {
+    margin-left: auto;
+  }
 }
 
 /* ---------- DARK MODE OVERRIDES ----------


### PR DESCRIPTION
## Problem

The marketing site has no way into the app. The nav on home + about has Product / Developer / About links and a theme toggle, but a visitor who already has an account has nowhere to click to log in — the only CTA is "Join the waitlist".

## Solution

A **Log in** button in the marketing nav (home + about), linking to `https://app.threa.io/login` (the app's real login route).

The button is the **app's own primary button**, not a marketing invention. It mirrors the Shadcn `Button` default variant in `apps/frontend/src/components/ui/button.tsx`: solid `--primary` fill, `--primary-foreground` text, Space Grotesk medium at `text-sm`, and the app's 10px button radius. On the public site `--gold === --primary` and `--paper === --primary-foreground`, so the same button tracks light/dark exactly (near-white text on gold in light, dark-ink text on lifted gold in dark). Hover shifts to `--gold-soft` instantly — no color transition, because a `var()`-based transition freezes on this static site's theme toggle (the app's real buttons `transition-colors` only get away with it because React re-renders force the restyle a static page never gets). `:focus-visible` gets a ring.

At phone width (≤560px) the single-line nav can't fit brand + links + button + toggle, so the nav wraps: brand left, Log in + theme toggle right, section links on their own full-width second line.

Scope: home + about only. The `/developers` section uses its own docs header (`DocsLayout.astro`) — a different surface, deliberately left as is.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/public-site/src/pages/index.astro` | `.nav-login` link in the hero nav-row |
| `apps/public-site/src/pages/about.astro` | Same link in the about nav-row |
| `apps/public-site/src/styles/global.css` | `.nav-login` styles matching the app `Button`, phone-width sizing, and the ≤560px nav wrap |

## Test plan

- [x] `astro check` — 0 errors / 0 warnings (pre-commit hook also ran repo-wide lint + typecheck, clean)
- [x] Visually verified via Playwright screenshots at 1440px and 390px, light and dark: solid gold button renders, theme tokens flip correctly (dark-ink text on gold in dark, no freeze), mobile nav wraps without overflow
- [x] Computed-style check confirms the button matches the app spec exactly: Space Grotesk / 14px / 500 / `text-transform: none` / 10px radius / `--primary` fill / `--primary-foreground` text
- [ ] No automated test — the public site is static Astro markup/CSS with no test suite

### Revision note

First cut styled the button as an outlined, mono-caps, uppercase pill with a hover arrow-nudge — a marketing aesthetic that didn't match how buttons look in the actual app. Reworked to the real app `Button` (solid gold, rounded, sentence-case sans) per review feedback.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
