### PR TITLE
fix(drafts): write-lineage versioning — stop same-device splits, sent-draft zombies, and lost-ack content loss

### DIFF
--- a/apps/backend/src/db/migrations/20260703082208_drafts_superseded_write_ids.sql
+++ b/apps/backend/src/db/migrations/20260703082208_drafts_superseded_write_ids.sql
@@ -1,0 +1,12 @@
+-- Persist superseded write ids on draft tombstones.
+--
+-- Resolve-on-send (and explicit discard) can race the author's own in-flight
+-- upsert: a push that left the device before the send but reaches the server
+-- after the tombstone. Until now the superseded write ids were only checked at
+-- resolve time, so that late write hit "tombstoned + version drift" and SPLIT
+-- into a live duplicate of already-sent content — a zombie draft on every
+-- device. Storing the ids on the tombstone lets the upsert path recognize the
+-- late write as superseded and drop it instead.
+
+ALTER TABLE drafts
+ADD COLUMN IF NOT EXISTS superseded_write_ids JSONB;

--- a/apps/backend/src/features/drafts/handlers.ts
+++ b/apps/backend/src/features/drafts/handlers.ts
@@ -24,6 +24,9 @@ const upsertSchema = z
     rootStreamId: z.string().min(1).nullable().optional(),
     expectedVersion: z.number().int().min(0),
     writeId: z.string().min(1),
+    // The device's superseded write lineage (bounded — the client caps the
+    // chain; the schema bound is a defensive backstop, not a protocol limit).
+    priorWriteIds: z.array(z.string().min(1)).max(64).optional(),
     clientUpdatedAt: z.string().datetime(),
     contentJson: contentJsonSchema.nullable().optional(),
     attachmentIds: z.array(z.string()).optional(),
@@ -39,7 +42,13 @@ const upsertSchema = z
 
 const resolveSchema = z.object({
   expectedVersion: z.number().int().min(1),
-  supersededWriteIds: z.array(z.string().min(1)).optional(),
+  supersededWriteIds: z.array(z.string().min(1)).max(64).optional(),
+})
+
+// DELETE body is optional (legacy clients send none); when present it carries
+// the discarding device's in-flight write ids for the tombstone.
+const deleteSchema = z.object({
+  supersededWriteIds: z.array(z.string().min(1)).max(64).optional(),
 })
 
 interface Dependencies {
@@ -78,6 +87,7 @@ export function createDraftsHandlers({ draftsService }: Dependencies) {
         rootStreamId: data.rootStreamId ?? null,
         expectedVersion: data.expectedVersion,
         writeId: data.writeId,
+        priorWriteIds: data.priorWriteIds ?? [],
         clientUpdatedAt: new Date(data.clientUpdatedAt),
         contentJson,
         contentMarkdown: contentJson ? deriveContentMarkdown(contentJson) : null,
@@ -117,7 +127,17 @@ export function createDraftsHandlers({ draftsService }: Dependencies) {
       const workspaceId = req.workspaceId!
       const id = req.params.id!
 
-      await draftsService.delete({ workspaceId, userId, id })
+      const parsed = deleteSchema.safeParse(req.body ?? {})
+      if (!parsed.success) {
+        throw new HttpError("Invalid draft delete request", { status: 400, code: "VALIDATION_ERROR" })
+      }
+
+      await draftsService.delete({
+        workspaceId,
+        userId,
+        id,
+        supersededWriteIds: parsed.data.supersededWriteIds ?? [],
+      })
       res.json({ ok: true })
     },
   }

--- a/apps/backend/src/features/drafts/handlers.ts
+++ b/apps/backend/src/features/drafts/handlers.ts
@@ -18,15 +18,19 @@ const commandSchema = z.object({
 // client has never seen a server confirmation). `writeId` is the per-push
 // idempotency key. Exactly one content shape: plaintext (`contentJson`) or the
 // E2E `ciphertext` triple — never both, which would be ambiguous.
+// Write ids are client-minted (`write_{ts}_{rand}`, ~30 chars); the length cap
+// keeps arbitrary payloads out of the tombstone's persisted JSONB.
+const writeIdSchema = z.string().min(1).max(128)
+
 const upsertSchema = z
   .object({
     scope: z.string().min(1),
     rootStreamId: z.string().min(1).nullable().optional(),
     expectedVersion: z.number().int().min(0),
-    writeId: z.string().min(1),
+    writeId: writeIdSchema,
     // The device's superseded write lineage (bounded — the client caps the
     // chain; the schema bound is a defensive backstop, not a protocol limit).
-    priorWriteIds: z.array(z.string().min(1)).max(64).optional(),
+    priorWriteIds: z.array(writeIdSchema).max(64).optional(),
     clientUpdatedAt: z.string().datetime(),
     contentJson: contentJsonSchema.nullable().optional(),
     attachmentIds: z.array(z.string()).optional(),
@@ -42,13 +46,13 @@ const upsertSchema = z
 
 const resolveSchema = z.object({
   expectedVersion: z.number().int().min(1),
-  supersededWriteIds: z.array(z.string().min(1)).max(64).optional(),
+  supersededWriteIds: z.array(writeIdSchema).max(64).optional(),
 })
 
 // DELETE body is optional (legacy clients send none); when present it carries
 // the discarding device's in-flight write ids for the tombstone.
 const deleteSchema = z.object({
-  supersededWriteIds: z.array(z.string().min(1)).max(64).optional(),
+  supersededWriteIds: z.array(writeIdSchema).max(64).optional(),
 })
 
 interface Dependencies {

--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -229,6 +229,60 @@ describe("DraftsRepository.softDelete", () => {
   })
 })
 
+describe("DraftsRepository.mergeTombstoneSupersededWriteIds", () => {
+  afterEach(() => mock.restore())
+
+  it("locks the tombstone, merges + dedupes the lineage, and writes the union", async () => {
+    const queries: Captured[] = []
+    const db: Querier = {
+      query: mock(async (q) => {
+        const config = q as QueryConfig
+        queries.push({ text: config.text ?? null, values: config.values ?? [] })
+        // First query is the FOR UPDATE read; second is the UPDATE.
+        if (queries.length === 1) {
+          return { rows: [{ superseded_write_ids: ["write_a"] }], rowCount: 1 } as QueryResult
+        }
+        return { rows: [], rowCount: 1 } as unknown as QueryResult
+      }),
+    }
+
+    await DraftsRepository.mergeTombstoneSupersededWriteIds(db, {
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      id: "draft_01",
+      supersededWriteIds: ["write_b", "write_a"],
+    })
+
+    expect(queries[0]?.text).toContain("FOR UPDATE")
+    expect(queries[0]?.text).toContain("deleted_at IS NOT NULL")
+    expect(queries[1]?.text).toContain("UPDATE drafts SET superseded_write_ids")
+    expect(queries[1]?.values).toContain(JSON.stringify(["write_a", "write_b"]))
+  })
+
+  it("no-ops on a live or absent row, and when there is nothing to merge", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [])
+
+    await DraftsRepository.mergeTombstoneSupersededWriteIds(db, {
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      id: "draft_01",
+      supersededWriteIds: [],
+    })
+    // Empty input never touches the database.
+    expect(captured.text).toBeNull()
+
+    await DraftsRepository.mergeTombstoneSupersededWriteIds(db, {
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      id: "draft_01",
+      supersededWriteIds: ["write_x"],
+    })
+    // Live/absent row: the FOR UPDATE read finds nothing and no UPDATE runs.
+    expect(captured.text).toContain("FOR UPDATE")
+  })
+})
+
 describe("DraftsRepository.rescopeByScope", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/drafts/repository.test.ts
+++ b/apps/backend/src/features/drafts/repository.test.ts
@@ -21,6 +21,7 @@ const DRAFT_ROW = {
   e2e_version: null,
   version: 1,
   last_client_write_id: "write_1",
+  superseded_write_ids: null,
   client_updated_at: NOW,
   created_at: NOW,
   updated_at: NOW,
@@ -108,7 +109,7 @@ describe("DraftsRepository.findByIdForUpdate", () => {
 describe("DraftsRepository.casUpdate", () => {
   afterEach(() => mock.restore())
 
-  it("gates the update on version and liveness, and bumps the version (INV-20)", async () => {
+  it("gates the update on version-or-own-lineage and liveness, and bumps the version (INV-20)", async () => {
     const captured: Captured = { text: null, values: null }
     const db = createQuerier(captured)
 
@@ -117,6 +118,7 @@ describe("DraftsRepository.casUpdate", () => {
       userId: "usr_1",
       id: "draft_01",
       expectedVersion: 3,
+      ownWriteIds: ["write_2", "write_prior"],
       rootStreamId: "stream_1",
       contentJson: { type: "doc", content: [] },
       contentMarkdown: "edited",
@@ -134,11 +136,15 @@ describe("DraftsRepository.casUpdate", () => {
     expect(captured.text).toContain("version = version + 1")
     expect(captured.text).toContain("deleted_at IS NULL")
     expect(captured.text).toContain("version =")
+    // Lost-ack escape hatch: a row last written by this device's own lineage
+    // updates in place even when expectedVersion trails.
+    expect(captured.text).toContain("last_client_write_id = ANY")
     expect(captured.values).toContain(3)
     expect(captured.values).toContain("write_2")
+    expect(captured.values).toContainEqual(["write_2", "write_prior"])
   })
 
-  it("returns null when the version no longer matches (drift)", async () => {
+  it("returns null when the version no longer matches and the lineage is foreign (drift)", async () => {
     const captured: Captured = { text: null, values: null }
     const db = createQuerier(captured, [])
 
@@ -147,6 +153,7 @@ describe("DraftsRepository.casUpdate", () => {
       userId: "usr_1",
       id: "draft_01",
       expectedVersion: 99,
+      ownWriteIds: ["write_3"],
       rootStreamId: null,
       contentJson: { type: "doc", content: [] },
       contentMarkdown: "x",
@@ -183,8 +190,12 @@ describe("DraftsRepository.softDeleteCas", () => {
     expect(captured.text).toContain("deleted_at IS NULL")
     expect(captured.text).toContain("version =")
     expect(captured.text).toContain("last_client_write_id = ANY")
+    // The superseded ids are persisted on the tombstone so a write from that
+    // lineage landing AFTER the resolve is dropped instead of zombie-split.
+    expect(captured.text).toContain("superseded_write_ids =")
     expect(captured.values).toContain(2)
     expect(captured.values).toContainEqual(["write_sent"])
+    expect(captured.values).toContain(JSON.stringify(["write_sent"]))
   })
 })
 
@@ -205,6 +216,16 @@ describe("DraftsRepository.softDelete", () => {
     expect(captured.values).toContain("draft_01")
     expect(captured.values).toContain("ws_1")
     expect(captured.values).toContain("usr_1")
+  })
+
+  it("persists the discarding device's superseded write ids on the tombstone", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured)
+
+    await DraftsRepository.softDelete(db, "ws_1", "usr_1", "draft_01", ["write_inflight"])
+
+    expect(captured.text).toContain("superseded_write_ids")
+    expect(captured.values).toContain(JSON.stringify(["write_inflight"]))
   })
 })
 

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -276,6 +276,43 @@ export const DraftsRepository = {
   },
 
   /**
+   * Merge write ids into an EXISTING tombstone's `superseded_write_ids`. Covers
+   * the second-tombstoner: when a resolve/discard loses the race (the row is
+   * already tombstoned, so `softDelete` / `softDeleteCas` no-op), its superseded
+   * lineage must still land on the tombstone — otherwise that device's own
+   * late-landing push has a lineage the tombstone doesn't know and splits into
+   * a zombie. Locks the row, merges + dedupes in code (INV-20: read is under
+   * FOR UPDATE), caps the stored set. No-op on live/absent rows.
+   */
+  async mergeTombstoneSupersededWriteIds(
+    db: Querier,
+    params: { workspaceId: string; userId: string; id: string; supersededWriteIds: string[] }
+  ): Promise<void> {
+    if (params.supersededWriteIds.length === 0) return
+    const result = await db.query<{ superseded_write_ids: string[] | null }>(sql`
+      SELECT superseded_write_ids
+      FROM drafts
+      WHERE id = ${params.id}
+        AND workspace_id = ${params.workspaceId}
+        AND user_id = ${params.userId}
+        AND deleted_at IS NOT NULL
+      FOR UPDATE
+    `)
+    const row = result.rows[0]
+    if (!row) return
+    const existing = Array.isArray(row.superseded_write_ids) ? row.superseded_write_ids : []
+    const merged = [...new Set([...existing, ...params.supersededWriteIds])].slice(0, 128)
+    if (merged.length === existing.length) return
+    await db.query(sql`
+      UPDATE drafts SET superseded_write_ids = ${JSON.stringify(merged)}::jsonb
+      WHERE id = ${params.id}
+        AND workspace_id = ${params.workspaceId}
+        AND user_id = ${params.userId}
+        AND deleted_at IS NOT NULL
+    `)
+  },
+
+  /**
    * Re-scope every live draft from `fromScope` to `toScope` (thread re-pointing).
    * When a not-yet-threaded message is converted to a thread, its reply drafts
    * must follow the message into the new thread stream so they keep roaming.

--- a/apps/backend/src/features/drafts/repository.ts
+++ b/apps/backend/src/features/drafts/repository.ts
@@ -1,6 +1,6 @@
 import type { Querier } from "../../db"
 import { sql } from "../../db"
-import type { DraftCommand, JSONContent } from "@threa/types"
+import { MAX_DRAFTS_PER_USER, type DraftCommand, type JSONContent } from "@threa/types"
 
 interface DraftRow {
   id: string
@@ -18,6 +18,7 @@ interface DraftRow {
   e2e_version: number | null
   version: number
   last_client_write_id: string | null
+  superseded_write_ids: string[] | null
   client_updated_at: Date
   created_at: Date
   updated_at: Date
@@ -51,6 +52,13 @@ export interface Draft {
    * so the retry doesn't read as drift and spuriously split.
    */
   lastClientWriteId: string | null
+  /**
+   * Set on tombstones only: the authoring device's write ids that the resolve
+   * or discard superseded. A late upsert whose write lineage matches is a push
+   * of already-sent/discarded content and is dropped instead of split into a
+   * live zombie.
+   */
+  supersededWriteIds: string[] | null
   clientUpdatedAt: Date
   createdAt: Date
   updatedAt: Date
@@ -82,6 +90,13 @@ export interface CasUpdateDraftParams {
   userId: string
   id: string
   expectedVersion: number
+  /**
+   * The incoming write id plus this device's superseded prior write ids. A row
+   * whose `last_client_write_id` is any of them was last written by THIS device
+   * with no other writer since, so updating in place is safe even when
+   * `expectedVersion` trails (the ack of the prior write was lost).
+   */
+  ownWriteIds: string[]
   rootStreamId: string | null
   contentJson: JSONContent | null
   contentMarkdown: string | null
@@ -96,14 +111,7 @@ export interface CasUpdateDraftParams {
 }
 
 const COLUMNS =
-  "id, workspace_id, user_id, scope, root_stream_id, content_json, content_markdown, attachment_ids, command, context_refs, ciphertext, envelope, e2e_version, version, last_client_write_id, client_updated_at, created_at, updated_at, deleted_at"
-
-/**
- * Defensive cap on the per-user bootstrap read. Real stashes are far smaller;
- * this only bounds a pathological account so the list query can never scan an
- * unbounded set.
- */
-const MAX_DRAFTS_PER_USER = 500
+  "id, workspace_id, user_id, scope, root_stream_id, content_json, content_markdown, attachment_ids, command, context_refs, ciphertext, envelope, e2e_version, version, last_client_write_id, superseded_write_ids, client_updated_at, created_at, updated_at, deleted_at"
 
 function mapRow(row: DraftRow): Draft {
   return {
@@ -122,6 +130,7 @@ function mapRow(row: DraftRow): Draft {
     e2eVersion: row.e2e_version,
     version: row.version,
     lastClientWriteId: row.last_client_write_id,
+    supersededWriteIds: Array.isArray(row.superseded_write_ids) ? row.superseded_write_ids : null,
     clientUpdatedAt: row.client_updated_at,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -192,11 +201,16 @@ export const DraftsRepository = {
    * Optimistic-concurrency update (INV-20). Replaces the whole composer payload
    * — a draft is full state, so a cleared field (removed attachment, emptied
    * command) is honored rather than COALESCE-preserved. The CAS in the WHERE
-   * rejects when `version` has moved on; the service splits on a null return.
-   * The `deleted_at IS NULL` guard keeps a resolved tombstone from being
-   * revived through this path.
+   * accepts either a `version` match or a row whose last accepted write is one
+   * of the caller's own (`ownWriteIds`): a lost ack leaves `expectedVersion`
+   * trailing, but if no other device wrote since, updating in place is exactly
+   * "update the one that is live" — splitting there would mint a same-device
+   * duplicate. Rejects otherwise (genuine drift); the service splits on a null
+   * return. The `deleted_at IS NULL` guard keeps a resolved tombstone from
+   * being revived through this path.
    */
   async casUpdate(db: Querier, params: CasUpdateDraftParams): Promise<Draft | null> {
+    const ownWriteIds = params.ownWriteIds
     const result = await db.query<DraftRow>(sql`
       UPDATE drafts SET
         root_stream_id = ${params.rootStreamId},
@@ -216,7 +230,8 @@ export const DraftsRepository = {
         AND workspace_id = ${params.workspaceId}
         AND user_id = ${params.userId}
         AND deleted_at IS NULL
-        AND version = ${params.expectedVersion}
+        AND (version = ${params.expectedVersion}
+          OR (${ownWriteIds.length > 0} AND last_client_write_id = ANY(${ownWriteIds})))
       RETURNING ${sql.raw(COLUMNS)}
     `)
     return result.rows[0] ? mapRow(result.rows[0]) : null
@@ -226,8 +241,11 @@ export const DraftsRepository = {
    * CAS soft-delete for resolve-on-send. Tombstones the row when `version` still
    * matches, or when its last write id is one this device already superseded by
    * sending the message. Unrelated drift survives as a stash entry instead of
-   * being collaterally destroyed. Returns the tombstoned row on success, `null`
-   * on version drift.
+   * being collaterally destroyed. The superseded write ids are PERSISTED on the
+   * tombstone so a write from that lineage landing after this resolve (an
+   * in-flight push the client had already given up on) is dropped by the upsert
+   * path instead of split into a live zombie of sent content. Returns the
+   * tombstoned row on success, `null` on version drift.
    */
   async softDeleteCas(
     db: Querier,
@@ -244,6 +262,7 @@ export const DraftsRepository = {
       UPDATE drafts SET
         deleted_at = NOW(),
         updated_at = NOW(),
+        superseded_write_ids = ${JSON.stringify(supersededWriteIds)}::jsonb,
         version = version + 1
       WHERE id = ${params.id}
         AND workspace_id = ${params.workspaceId}
@@ -295,18 +314,27 @@ export const DraftsRepository = {
    * Unconditional soft-delete for explicit discard and resolve-on-send of a
    * never-confirmed draft (no CAS). Plants a negative tombstone when the id has
    * not been seen yet, so a delete that reaches the server before the draft's
-   * first insert still wins the race. Returns the row when this call tombstoned
-   * it (live row transitioned, or negative marker inserted) and `null` when the
-   * row was already tombstoned.
+   * first insert still wins the race. Like `softDeleteCas`, the discarding
+   * device's superseded write ids are persisted on the tombstone so its own
+   * late-landing push is dropped rather than split into a zombie. Returns the
+   * row when this call tombstoned it (live row transitioned, or negative marker
+   * inserted) and `null` when the row was already tombstoned.
    */
-  async softDelete(db: Querier, workspaceId: string, userId: string, id: string): Promise<Draft | null> {
+  async softDelete(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    id: string,
+    supersededWriteIds: string[] = []
+  ): Promise<Draft | null> {
     const result = await db.query<DraftRow>(sql`
-      INSERT INTO drafts (id, workspace_id, user_id, scope, client_updated_at, deleted_at)
+      INSERT INTO drafts (id, workspace_id, user_id, scope, client_updated_at, deleted_at, superseded_write_ids)
       -- Empty scope is a tombstone-only sentinel; real draft scopes are never blank.
-      VALUES (${id}, ${workspaceId}, ${userId}, '', NOW(), NOW())
+      VALUES (${id}, ${workspaceId}, ${userId}, '', NOW(), NOW(), ${JSON.stringify(supersededWriteIds)}::jsonb)
       ON CONFLICT (id) DO UPDATE SET
         deleted_at = NOW(),
         updated_at = NOW(),
+        superseded_write_ids = ${JSON.stringify(supersededWriteIds)}::jsonb,
         version = drafts.version + 1
       WHERE drafts.workspace_id = ${workspaceId}
         AND drafts.user_id = ${userId}

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -27,6 +27,7 @@ function fakeDraft(overrides: Partial<Draft> = {}): Draft {
     e2eVersion: null,
     version: 1,
     lastClientWriteId: "write_1",
+    supersededWriteIds: null,
     clientUpdatedAt: NOW,
     createdAt: NOW,
     updatedAt: NOW,
@@ -44,6 +45,7 @@ function baseUpsertParams() {
     rootStreamId: "stream_1" as string | null,
     expectedVersion: 0,
     writeId: "write_1",
+    priorWriteIds: [] as string[],
     clientUpdatedAt: NOW,
     contentJson: { type: "doc" as const, content: [] },
     contentMarkdown: "hello",
@@ -81,21 +83,56 @@ describe("DraftsService.upsert", () => {
     )
   })
 
-  it("returns the existing row unchanged on a lost-ack retry (matching writeId), no split, no CAS", async () => {
+  it("applies a lost-ack retry in place through the write-lineage CAS (no split, content not discarded)", async () => {
+    // The row's last accepted write is the incoming writeId (our own push whose
+    // ack was lost). The retry may carry NEWER content (the queue re-reads at
+    // drain), so it must flow through the CAS update — keyed on the lineage,
+    // not the stale expectedVersion — rather than being acked-and-discarded.
     const service = setupService()
     spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
     spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
       fakeDraft({ version: 4, lastClientWriteId: "write_retry" })
     )
-    const casUpdate = spyOn(DraftsRepository, "casUpdate")
+    const casUpdate = spyOn(DraftsRepository, "casUpdate").mockResolvedValue(
+      fakeDraft({ version: 5, lastClientWriteId: "write_retry" })
+    )
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_retry", expectedVersion: 3 })
 
     expect(result.split).toBe(false)
-    expect(result.draft.version).toBe(4)
-    expect(casUpdate).not.toHaveBeenCalled()
-    expect(outbox).not.toHaveBeenCalled()
+    expect(result.draft.version).toBe(5)
+    expect(casUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ expectedVersion: 3, ownWriteIds: ["write_retry"] })
+    )
+    expect(outbox).toHaveBeenCalledWith(expect.anything(), "draft:upserted", expect.objectContaining({}))
+  })
+
+  it("passes the full write lineage (writeId + priorWriteIds) into the CAS", async () => {
+    // A coalesced save replaced an attempted push: the successor carries the
+    // superseded writeId so a lost ack of the predecessor still updates in
+    // place instead of splitting into a same-device duplicate.
+    const service = setupService()
+    spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 4, lastClientWriteId: "write_prior" })
+    )
+    const casUpdate = spyOn(DraftsRepository, "casUpdate").mockResolvedValue(fakeDraft({ version: 5 }))
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({
+      ...baseUpsertParams(),
+      writeId: "write_next",
+      priorWriteIds: ["write_prior"],
+      expectedVersion: 3,
+    })
+
+    expect(result.split).toBe(false)
+    expect(casUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ownWriteIds: ["write_next", "write_prior"] })
+    )
   })
 
   it("CAS-updates on a version match (happy path) without splitting", async () => {
@@ -112,13 +149,15 @@ describe("DraftsService.upsert", () => {
     expect(outbox).toHaveBeenCalledWith(expect.anything(), "draft:upserted", expect.objectContaining({}))
   })
 
-  it("SPLITS on version drift: keeps the original id, mints a fresh draft, returns originalId", async () => {
+  it("SPLITS on genuine drift: keeps the original id, mints a fresh draft, returns originalId + keptDraft", async () => {
     const service = setupService()
     const splitRow = fakeDraft({ id: "draft_split", version: 1 })
     // First call (original id) collides → null; second call (fresh split id) lands.
     spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValueOnce(null).mockResolvedValueOnce(splitRow)
-    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(fakeDraft({ version: 5 }))
-    spyOn(DraftsRepository, "casUpdate").mockResolvedValue(null) // version drift
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 5, lastClientWriteId: "write_other_device" })
+    )
+    spyOn(DraftsRepository, "casUpdate").mockResolvedValue(null) // version drift, foreign lineage
     spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_drift", expectedVersion: 2 })
@@ -126,6 +165,10 @@ describe("DraftsService.upsert", () => {
     expect(result.split).toBe(true)
     expect(result.originalId).toBe(DRAFT_ID)
     expect(result.draft.id).toBe("draft_split")
+    // The untouched live row rides back so the pushing device (which ignored
+    // its echo while dirty) can seed the other copy without waiting for a
+    // bootstrap.
+    expect(result.keptDraft).toMatchObject({ id: DRAFT_ID, version: 5 })
   })
 
   it("drops a fresh insert landing on a tombstone without splitting", async () => {
@@ -147,26 +190,73 @@ describe("DraftsService.upsert", () => {
     expect(outbox).not.toHaveBeenCalled()
   })
 
-  it("does NOT return a tombstoned row as live on a writeId match — splits instead", async () => {
-    // A resolve raced in after the original write landed: the writeId still
-    // matches, but the row is soft-deleted. Branch (b) must not hand it back as
-    // live (that would contradict the draft:deleted already on the wire); it
-    // falls through to the split.
+  it("drops a lost-ack retry landing on its own tombstone (resolve raced the write) — no zombie split", async () => {
+    // The write landed, then resolve-on-send tombstoned the row. The retry of
+    // that same write is content the user already SENT: it must be dropped, not
+    // split into a live duplicate of the sent message.
+    const service = setupService()
+    const insertIfAbsent = spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 3, lastClientWriteId: "write_dup", deletedAt: NOW })
+    )
+    const casUpdate = spyOn(DraftsRepository, "casUpdate")
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_dup", expectedVersion: 2 })
+
+    expect(result.split).toBe(false)
+    expect(result.originalId).toBeUndefined()
+    expect(insertIfAbsent).toHaveBeenCalledTimes(1)
+    expect(casUpdate).not.toHaveBeenCalled()
+    expect(outbox).not.toHaveBeenCalled()
+  })
+
+  it("drops a late write whose lineage the tombstone superseded (persisted at resolve/discard time)", async () => {
+    // The push left the device, the client gave up on it, resolve tombstoned
+    // the row recording the in-flight writeId — then the push finally lands.
+    const service = setupService()
+    spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({
+        version: 3,
+        lastClientWriteId: "write_old",
+        supersededWriteIds: ["write_inflight"],
+        deletedAt: NOW,
+      })
+    )
+    const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_inflight", expectedVersion: 2 })
+
+    expect(result.split).toBe(false)
+    expect(outbox).not.toHaveBeenCalled()
+  })
+
+  it("still SPLITS on a tombstone for a foreign write lineage (no-loss for another device's edits)", async () => {
+    // The draft was resolved/discarded elsewhere while THIS push carries edits
+    // the tombstone knows nothing about — they must survive as a fresh draft.
     const service = setupService()
     const splitRow = fakeDraft({ id: "draft_split", version: 1 })
     spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValueOnce(null).mockResolvedValueOnce(splitRow)
     spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
-      fakeDraft({ version: 2, lastClientWriteId: "write_dup", deletedAt: NOW })
+      fakeDraft({
+        version: 3,
+        lastClientWriteId: "write_other",
+        supersededWriteIds: ["write_other_inflight"],
+        deletedAt: NOW,
+      })
     )
     const casUpdate = spyOn(DraftsRepository, "casUpdate")
     spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
-    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_dup", expectedVersion: 2 })
+    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_mine", expectedVersion: 2 })
 
     expect(result.split).toBe(true)
     expect(result.originalId).toBe(DRAFT_ID)
     expect(result.draft.id).toBe("draft_split")
-    // A tombstoned row skips the CAS update entirely (branch (c) is live-gated).
+    // A tombstoned original is not returned as keptDraft (it is not live).
+    expect(result.keptDraft).toBeUndefined()
+    // A tombstoned row skips the CAS update entirely (the CAS is live-gated).
     expect(casUpdate).not.toHaveBeenCalled()
   })
 })
@@ -221,11 +311,19 @@ describe("DraftsService.delete", () => {
 
   it("publishes draft:deleted when softDelete tombstones or plants a negative marker", async () => {
     const service = setupService()
-    spyOn(DraftsRepository, "softDelete").mockResolvedValue(fakeDraft({ deletedAt: NOW }))
+    const softDelete = spyOn(DraftsRepository, "softDelete").mockResolvedValue(fakeDraft({ deletedAt: NOW }))
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
-    await service.delete({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: DRAFT_ID })
+    await service.delete({
+      workspaceId: WORKSPACE_ID,
+      userId: USER_ID,
+      id: DRAFT_ID,
+      supersededWriteIds: ["write_inflight"],
+    })
 
+    // The discarding device's in-flight write ids ride onto the tombstone so a
+    // late-landing push of the discarded content is dropped, not resurrected.
+    expect(softDelete).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, USER_ID, DRAFT_ID, ["write_inflight"])
     expect(outbox).toHaveBeenCalledWith(
       expect.anything(),
       "draft:deleted",

--- a/apps/backend/src/features/drafts/service.test.ts
+++ b/apps/backend/src/features/drafts/service.test.ts
@@ -83,30 +83,25 @@ describe("DraftsService.upsert", () => {
     )
   })
 
-  it("applies a lost-ack retry in place through the write-lineage CAS (no split, content not discarded)", async () => {
-    // The row's last accepted write is the incoming writeId (our own push whose
-    // ack was lost). The retry may carry NEWER content (the queue re-reads at
-    // drain), so it must flow through the CAS update — keyed on the lineage,
-    // not the stale expectedVersion — rather than being acked-and-discarded.
+  it("returns the row unchanged on an EXACT lost-ack retry (same writeId) — true idempotency, no version churn", async () => {
+    // An exact writeId match implies identical content: a retry reuses its op's
+    // writeId, and any typing since the attempt replaces the op with a fresh
+    // one. So the accepted write can be acked as-is — no re-apply, no bump, no
+    // redundant outbox echo.
     const service = setupService()
     spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
     spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
       fakeDraft({ version: 4, lastClientWriteId: "write_retry" })
     )
-    const casUpdate = spyOn(DraftsRepository, "casUpdate").mockResolvedValue(
-      fakeDraft({ version: 5, lastClientWriteId: "write_retry" })
-    )
+    const casUpdate = spyOn(DraftsRepository, "casUpdate")
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_retry", expectedVersion: 3 })
 
     expect(result.split).toBe(false)
-    expect(result.draft.version).toBe(5)
-    expect(casUpdate).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ expectedVersion: 3, ownWriteIds: ["write_retry"] })
-    )
-    expect(outbox).toHaveBeenCalledWith(expect.anything(), "draft:upserted", expect.objectContaining({}))
+    expect(result.draft.version).toBe(4)
+    expect(casUpdate).not.toHaveBeenCalled()
+    expect(outbox).not.toHaveBeenCalled()
   })
 
   it("passes the full write lineage (writeId + priorWriteIds) into the CAS", async () => {
@@ -171,11 +166,13 @@ describe("DraftsService.upsert", () => {
     expect(result.keptDraft).toMatchObject({ id: DRAFT_ID, version: 5 })
   })
 
-  it("drops a fresh insert landing on a tombstone without splitting", async () => {
+  it("drops a late first insert whose lineage the negative tombstone superseded (discard raced the insert)", async () => {
+    // The discard's `enqueueDraftDelete` collected the pending push's writeId
+    // into the tombstone, so the late insert is provably discarded content.
     const service = setupService()
     const insertIfAbsent = spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValue(null)
     spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
-      fakeDraft({ version: 1, lastClientWriteId: null, deletedAt: NOW })
+      fakeDraft({ version: 1, lastClientWriteId: null, supersededWriteIds: ["write_late"], deletedAt: NOW })
     )
     const casUpdate = spyOn(DraftsRepository, "casUpdate")
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
@@ -188,6 +185,51 @@ describe("DraftsService.upsert", () => {
     expect(insertIfAbsent).toHaveBeenCalledTimes(1)
     expect(casUpdate).not.toHaveBeenCalled()
     expect(outbox).not.toHaveBeenCalled()
+  })
+
+  it("SPLITS a version-0 push onto a tombstone with no lineage evidence (no-loss default)", async () => {
+    // Without an exact-retry or persisted-lineage match the tombstone cannot
+    // prove the content was sent or discarded — dropping it here was the old
+    // behavior and could destroy a tail typed after a lost first ack.
+    const service = setupService()
+    const splitRow = fakeDraft({ id: "draft_split", version: 1 })
+    spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValueOnce(null).mockResolvedValueOnce(splitRow)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 2, lastClientWriteId: "write_other", supersededWriteIds: null, deletedAt: NOW })
+    )
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({ ...baseUpsertParams(), writeId: "write_late", expectedVersion: 0 })
+
+    expect(result.split).toBe(true)
+    expect(result.originalId).toBe(DRAFT_ID)
+    expect(result.draft.id).toBe("draft_split")
+  })
+
+  it("SPLITS when only a PRIOR write id matches the tombstone's last accepted write (unsent tail survives)", async () => {
+    // Device A: push W1 lands, ack lost; A types a tail offline (op replaced,
+    // priors [W1]). Device B sends the draft (version CAS, empty superseded
+    // list) — the tombstone's last accepted write is W1, but B's send contained
+    // only W1's content. A's push carries the tail B never saw: a prefix-only
+    // lineage match must NOT drop it. Split preserves the tail as a new draft.
+    const service = setupService()
+    const splitRow = fakeDraft({ id: "draft_split", version: 1 })
+    spyOn(DraftsRepository, "insertIfAbsent").mockResolvedValueOnce(null).mockResolvedValueOnce(splitRow)
+    spyOn(DraftsRepository, "findByIdForUpdate").mockResolvedValue(
+      fakeDraft({ version: 3, lastClientWriteId: "write_1", supersededWriteIds: [], deletedAt: NOW })
+    )
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await service.upsert({
+      ...baseUpsertParams(),
+      writeId: "write_2",
+      priorWriteIds: ["write_1"],
+      expectedVersion: 1,
+    })
+
+    expect(result.split).toBe(true)
+    expect(result.originalId).toBe(DRAFT_ID)
+    expect(result.draft.id).toBe("draft_split")
   })
 
   it("drops a lost-ack retry landing on its own tombstone (resolve raced the write) — no zombie split", async () => {
@@ -289,9 +331,10 @@ describe("DraftsService.resolve", () => {
     )
   })
 
-  it("declines on version drift — the drifted copy survives and nothing is published", async () => {
+  it("declines on version drift — the drifted copy survives, nothing published, lineage still merged onto a tombstone", async () => {
     const service = setupService()
     spyOn(DraftsRepository, "softDeleteCas").mockResolvedValue(null)
+    const merge = spyOn(DraftsRepository, "mergeTombstoneSupersededWriteIds").mockResolvedValue()
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
     const result = await service.resolve({
@@ -299,10 +342,18 @@ describe("DraftsService.resolve", () => {
       userId: USER_ID,
       id: DRAFT_ID,
       expectedVersion: 1,
+      supersededWriteIds: ["write_sent"],
     })
 
     expect(result.resolved).toBe(false)
     expect(outbox).not.toHaveBeenCalled()
+    // If the decline was "already tombstoned" (second resolver), this device's
+    // lineage must still land on the tombstone so its late push can't zombie.
+    // The merge no-ops on a live row, so calling it unconditionally is safe.
+    expect(merge).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: DRAFT_ID, supersededWriteIds: ["write_sent"] })
+    )
   })
 })
 
@@ -331,13 +382,23 @@ describe("DraftsService.delete", () => {
     )
   })
 
-  it("does not publish when the row was already tombstoned", async () => {
+  it("does not publish when already tombstoned, but merges this device's lineage onto the tombstone", async () => {
     const service = setupService()
     spyOn(DraftsRepository, "softDelete").mockResolvedValue(null)
+    const merge = spyOn(DraftsRepository, "mergeTombstoneSupersededWriteIds").mockResolvedValue()
     const outbox = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
 
-    await service.delete({ workspaceId: WORKSPACE_ID, userId: USER_ID, id: DRAFT_ID })
+    await service.delete({
+      workspaceId: WORKSPACE_ID,
+      userId: USER_ID,
+      id: DRAFT_ID,
+      supersededWriteIds: ["write_inflight"],
+    })
 
     expect(outbox).not.toHaveBeenCalled()
+    expect(merge).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: DRAFT_ID, supersededWriteIds: ["write_inflight"] })
+    )
   })
 })

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -18,6 +18,13 @@ export interface UpsertDraftParams {
   rootStreamId: string | null
   expectedVersion: number
   writeId: string
+  /**
+   * This device's earlier write ids for this draft that were superseded before
+   * their ack was observed. Together with `writeId` they form the device's
+   * write lineage: a row last written by any of them has no other writer since,
+   * so it is updated in place rather than split.
+   */
+  priorWriteIds: string[]
   clientUpdatedAt: Date
   contentJson: JSONContent | null
   contentMarkdown: string | null
@@ -33,6 +40,8 @@ export interface UpsertDraftResult {
   draft: DraftView
   split: boolean
   originalId?: string
+  /** On a split against a live row: that untouched row, so the client can seed it. */
+  keptDraft?: DraftView
 }
 
 export interface ResolveDraftParams {
@@ -47,6 +56,8 @@ export interface DeleteDraftParams {
   workspaceId: string
   userId: string
   id: string
+  /** The discarding device's in-flight write ids, persisted on the tombstone. */
+  supersededWriteIds?: string[]
 }
 
 /**
@@ -73,20 +84,30 @@ export class DraftsService {
    * serialize:
    *
    *  a. `insertIfAbsent` — brand-new id lands at version 1. Done, no split.
-   *  b. else lock the existing row. If its `last_client_write_id` matches the
-   *     incoming `writeId`, this is a lost-ack retry of an already-accepted
-   *     write — return the row unchanged, no split.
-   *  c. else CAS-update on `expectedVersion`. Match → version+1, no split.
-   *  d. else (version drift, or the original id is a resolved tombstone) →
-   *     SPLIT: leave the existing row untouched, insert a fresh `draft_` id
-   *     carrying the incoming content at version 1. Return `originalId` so the
-   *     client migrates its local state to the new id.
+   *  b. else lock the existing row. Tombstoned rows: a first push
+   *     (`expectedVersion` 0), or any write whose lineage the tombstone
+   *     superseded (its `last_client_write_id` / persisted
+   *     `superseded_write_ids` intersect the incoming write ids), is a late
+   *     push of content the user already sent or discarded — drop it, no
+   *     split, no zombie.
+   *  c. else CAS-update: `expectedVersion` match, OR the row's last accepted
+   *     write is one of the caller's own write ids (a lost ack — no other
+   *     device wrote since, so updating in place IS "update the one that is
+   *     live"). Match → version+1 and the incoming content applies, no split.
+   *  d. else (genuine drift: another device wrote since, or an unrelated
+   *     tombstone) → SPLIT: leave the existing row untouched, insert a fresh
+   *     `draft_` id carrying the incoming content at version 1. Return
+   *     `originalId` so the client migrates its local state to the new id, and
+   *     `keptDraft` (when live) so it can seed the other device's copy.
    *
    * Every branch that changes state writes a `draft:upserted` outbox row so the
    * author's other devices converge (INV-4/7, INV-53).
    */
   async upsert(params: UpsertDraftParams): Promise<UpsertDraftResult> {
     return withTransaction(this.pool, async (client) => {
+      // This device's write lineage since its last observed ack. If the row's
+      // last accepted write is any of these, no other device has written since.
+      const ownWriteIds = [params.writeId, ...params.priorWriteIds]
       const insertParams = {
         workspaceId: params.workspaceId,
         userId: params.userId,
@@ -113,32 +134,37 @@ export class DraftsService {
       // The id already exists — lock it and decide update vs split.
       const existing = await DraftsRepository.findByIdForUpdate(client, params.workspaceId, params.userId, params.id)
 
-      // (a2) A never-confirmed draft's first push can land after resolve/discard
-      // planted a negative tombstone for the id. The content was already sent or
-      // thrown away, so drop the late insert rather than splitting it into a live
-      // zombie. Confirmed drift (expectedVersion > 0) still splits below.
-      if (existing && existing.deletedAt && params.expectedVersion === 0) {
-        return { draft: toDraftView(existing), split: false }
-      }
-
-      // (b) Lost-ack retry of a write we already accepted — return as-is. Gated
-      // on a LIVE row: if the draft was resolved (tombstoned) after this write
-      // landed, the writeId still matches but the row is gone, so we must not
-      // hand back a deleted draft as live (it would contradict the draft:deleted
-      // already on the wire). A tombstoned match falls through to the split.
-      if (existing && !existing.deletedAt && existing.lastClientWriteId === params.writeId) {
-        return { draft: toDraftView(existing), split: false }
-      }
-
-      // (c) Happy path — CAS update on the version the edit was based on. The
-      // CAS guards `deleted_at IS NULL`, so a tombstoned row returns null here
-      // and drops to the split.
-      if (existing && !existing.deletedAt) {
+      if (existing?.deletedAt) {
+        // (b) A never-confirmed draft's first push landing after resolve/discard
+        // planted a negative tombstone: the content was already sent or thrown
+        // away — drop the late insert rather than splitting it into a live zombie.
+        if (params.expectedVersion === 0) {
+          return { draft: toDraftView(existing), split: false }
+        }
+        // (b) A write from a lineage this tombstone superseded: the resolve or
+        // discard that tombstoned the row recorded the device's in-flight write
+        // ids, and the tombstone's own last accepted write counts too. Either
+        // way this push carries content the user already sent/discarded — drop
+        // it. Only a lineage the tombstone does NOT know (another device's
+        // unpushed edits) falls through to the no-loss split.
+        const superseded = new Set(existing.supersededWriteIds ?? [])
+        if (existing.lastClientWriteId) superseded.add(existing.lastClientWriteId)
+        if (ownWriteIds.some((id) => superseded.has(id))) {
+          return { draft: toDraftView(existing), split: false }
+        }
+      } else if (existing) {
+        // (c) In-place update: version match, or a lost-ack write lineage match
+        // (both checked race-safely inside the UPDATE, INV-20). Applying the
+        // incoming content on a lineage match matters: a retry can carry NEWER
+        // content than the write whose ack was lost (the queue re-reads the
+        // draft at drain), and acking without applying would strand that
+        // content locally until a cross-device edit overwrote it.
         const updated = await DraftsRepository.casUpdate(client, {
           workspaceId: params.workspaceId,
           userId: params.userId,
           id: params.id,
           expectedVersion: params.expectedVersion,
+          ownWriteIds,
           rootStreamId: params.rootStreamId,
           contentJson: params.contentJson,
           contentMarkdown: params.contentMarkdown,
@@ -156,7 +182,7 @@ export class DraftsService {
         }
       }
 
-      // (d) Drift (or a tombstoned original) → split into a fresh draft.
+      // (d) Genuine drift (or an unrelated tombstone) → split into a fresh draft.
       const newRow = await DraftsRepository.insertIfAbsent(client, { id: draftId(), ...insertParams })
       if (!newRow) {
         // The split id is a freshly minted ULID, so the insert lands unless the
@@ -164,7 +190,10 @@ export class DraftsService {
         throw new Error("draft split insert returned no row (id collision)")
       }
       const result = await this.finishUpsert(client, newRow, true)
-      return { ...result, originalId: params.id }
+      // The pushing device ignored the kept row's socket echo while it was
+      // dirty; returning the live row lets it seed the copy immediately.
+      const keptDraft = existing && !existing.deletedAt ? toDraftView(existing) : undefined
+      return { ...result, originalId: params.id, ...(keptDraft ? { keptDraft } : {}) }
     })
   }
 
@@ -196,11 +225,19 @@ export class DraftsService {
   /**
    * Explicit discard — the user threw the draft away, so drift doesn't matter.
    * Unconditional soft-delete, idempotent on an already-gone row. Emits
-   * `draft:deleted` so other devices drop it too.
+   * `draft:deleted` so other devices drop it too. The device's superseded write
+   * ids ride onto the tombstone so its own late-landing push is dropped by the
+   * upsert path instead of resurrecting the discarded content.
    */
   async delete(params: DeleteDraftParams): Promise<void> {
     return withTransaction(this.pool, async (client) => {
-      const deleted = await DraftsRepository.softDelete(client, params.workspaceId, params.userId, params.id)
+      const deleted = await DraftsRepository.softDelete(
+        client,
+        params.workspaceId,
+        params.userId,
+        params.id,
+        params.supersededWriteIds ?? []
+      )
       if (deleted) {
         await this.publishDelete(client, params.workspaceId, params.userId, params.id)
       }

--- a/apps/backend/src/features/drafts/service.ts
+++ b/apps/backend/src/features/drafts/service.ts
@@ -135,24 +135,31 @@ export class DraftsService {
       const existing = await DraftsRepository.findByIdForUpdate(client, params.workspaceId, params.userId, params.id)
 
       if (existing?.deletedAt) {
-        // (b) A never-confirmed draft's first push landing after resolve/discard
-        // planted a negative tombstone: the content was already sent or thrown
-        // away — drop the late insert rather than splitting it into a live zombie.
-        if (params.expectedVersion === 0) {
-          return { draft: toDraftView(existing), split: false }
-        }
-        // (b) A write from a lineage this tombstone superseded: the resolve or
-        // discard that tombstoned the row recorded the device's in-flight write
-        // ids, and the tombstone's own last accepted write counts too. Either
-        // way this push carries content the user already sent/discarded — drop
-        // it. Only a lineage the tombstone does NOT know (another device's
-        // unpushed edits) falls through to the no-loss split.
+        // (b) Drop the push — no split, no zombie — only when the tombstone can
+        // PROVE the content was already sent or discarded:
+        //  - an exact `writeId` retry of the tombstone's last accepted write. A
+        //    retry reuses its op's writeId, and any typing since replaces the op
+        //    with a fresh writeId, so an exact match implies identical content.
+        //  - a lineage intersecting the PERSISTED `superseded_write_ids` — the
+        //    resolving/discarding device asserted those writes' content was
+        //    covered by the send/discard.
+        // A priors-only match against `last_client_write_id` proves only that a
+        // PREFIX of the caller's lineage landed; the push may carry a newer tail
+        // typed after that write (offline edit racing another device's send), so
+        // it falls through to the no-loss split — a duplicate is acceptable,
+        // destroying the tail is not.
+        const exactRetry = existing.lastClientWriteId !== null && existing.lastClientWriteId === params.writeId
         const superseded = new Set(existing.supersededWriteIds ?? [])
-        if (existing.lastClientWriteId) superseded.add(existing.lastClientWriteId)
-        if (ownWriteIds.some((id) => superseded.has(id))) {
+        if (exactRetry || ownWriteIds.some((id) => superseded.has(id))) {
           return { draft: toDraftView(existing), split: false }
         }
       } else if (existing) {
+        // (c0) Exact lost-ack retry: the row's last accepted write IS this push
+        // (same writeId ⇒ identical content, see above) — return it unchanged.
+        // True idempotency: no version churn, no redundant outbox echo.
+        if (existing.lastClientWriteId === params.writeId) {
+          return { draft: toDraftView(existing), split: false }
+        }
         // (c) In-place update: version match, or a lost-ack write lineage match
         // (both checked race-safely inside the UPDATE, INV-20). Applying the
         // incoming content on a lineage match matters: a retry can carry NEWER
@@ -206,15 +213,25 @@ export class DraftsService {
    */
   async resolve(params: ResolveDraftParams): Promise<{ resolved: boolean }> {
     return withTransaction(this.pool, async (client) => {
+      const supersededWriteIds = params.supersededWriteIds ?? []
       const deleted = await DraftsRepository.softDeleteCas(client, {
         workspaceId: params.workspaceId,
         userId: params.userId,
         id: params.id,
         expectedVersion: params.expectedVersion,
-        supersededWriteIds: params.supersededWriteIds ?? [],
+        supersededWriteIds,
       })
       if (!deleted) {
-        // Either drifted (version moved on) or already gone — keep the row.
+        // Drifted (version moved on — keep the live row) or already tombstoned.
+        // In the tombstoned case this resolve's lineage must still be recorded:
+        // its device's late-landing push would otherwise carry write ids the
+        // tombstone doesn't know and split into a zombie.
+        await DraftsRepository.mergeTombstoneSupersededWriteIds(client, {
+          workspaceId: params.workspaceId,
+          userId: params.userId,
+          id: params.id,
+          supersededWriteIds,
+        })
         return { resolved: false }
       }
       await this.publishDelete(client, params.workspaceId, params.userId, params.id)
@@ -231,15 +248,25 @@ export class DraftsService {
    */
   async delete(params: DeleteDraftParams): Promise<void> {
     return withTransaction(this.pool, async (client) => {
+      const supersededWriteIds = params.supersededWriteIds ?? []
       const deleted = await DraftsRepository.softDelete(
         client,
         params.workspaceId,
         params.userId,
         params.id,
-        params.supersededWriteIds ?? []
+        supersededWriteIds
       )
       if (deleted) {
         await this.publishDelete(client, params.workspaceId, params.userId, params.id)
+      } else {
+        // Already tombstoned by another device — still merge this device's
+        // lineage so its own late-landing push is dropped, not zombie-split.
+        await DraftsRepository.mergeTombstoneSupersededWriteIds(client, {
+          workspaceId: params.workspaceId,
+          userId: params.userId,
+          id: params.id,
+          supersededWriteIds,
+        })
       }
     })
   }

--- a/apps/frontend/src/api/drafts.ts
+++ b/apps/frontend/src/api/drafts.ts
@@ -1,5 +1,6 @@
 import { api } from "./client"
 import type {
+  DeleteDraftInput,
   DraftListResponse,
   ResolveDraftInput,
   ResolveDraftResponse,
@@ -44,8 +45,14 @@ export const draftsApi = {
     return api.post<ResolveDraftResponse>(`/api/workspaces/${workspaceId}/drafts/${id}/resolve`, input)
   },
 
-  /** Unconditional soft-delete (idempotent on an already-gone draft). */
-  async delete(workspaceId: string, id: string): Promise<void> {
-    await api.delete<{ ok: true }>(`/api/workspaces/${workspaceId}/drafts/${id}`)
+  /**
+   * Unconditional soft-delete (idempotent on an already-gone draft). The body
+   * carries this device's in-flight write ids so a push that lands after the
+   * tombstone is recognized as discarded content and dropped, not resurrected.
+   */
+  async delete(workspaceId: string, id: string, input?: DeleteDraftInput): Promise<void> {
+    await api.delete<{ ok: true }>(`/api/workspaces/${workspaceId}/drafts/${id}`, {
+      body: input ? JSON.stringify(input) : undefined,
+    })
   },
 }

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -347,6 +347,13 @@ export interface PendingOperation {
   createdAt: number
   retryCount: number
   retryAfter?: number
+  /**
+   * Set by the queue right before the op's first execution attempt. An op that
+   * ever started may have reached the server even if its result was lost, so a
+   * coalescing replace must carry its idempotency lineage forward (see
+   * `enqueueDraftUpsert`); an op that never started can be reused in place.
+   */
+  startedAt?: number
 }
 
 export interface SyncCursor {

--- a/apps/frontend/src/hooks/use-draft-message.test.ts
+++ b/apps/frontend/src/hooks/use-draft-message.test.ts
@@ -953,3 +953,91 @@ describe("draft staging (synchronous reload safety)", () => {
     expect(readStagedDraft(workspaceId, draftKey)).toBeNull()
   })
 })
+
+describe("upsertLoadedDraft — save races the sync engine (in-transaction revalidation)", () => {
+  const sealContext = { senderId: "user_1", streamId: "stream_e2e_root" }
+  const sealedPayload = {
+    ciphertext: "ct_sealed",
+    envelope: { v: 2 },
+    e2eVersion: 2,
+    contentMarkdown: "typed",
+    attachmentRefs: [],
+  }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    resetDraftStoreCache()
+    resetDraftResolutionGuard()
+    await db.drafts.clear()
+    await db.composerLoaded.clear()
+    await db.pendingOperations.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function putLoaded(id: string, baseVersion: number) {
+    await db.drafts.put({
+      id,
+      workspaceId,
+      scope: draftKey,
+      contentJson: EMPTY_DOC,
+      attachments: [],
+      ciphertext: "ct_old",
+      envelope: { v: 2 },
+      e2eVersion: 2,
+      baseVersion,
+      clientUpdatedAt: Date.now(),
+    })
+    await db.composerLoaded.put({ scope: draftKey, workspaceId, draftId: id })
+  }
+
+  it("retargets to the migrated id when a split ack moves the draft mid-save (no old-id resurrection)", async () => {
+    await putLoaded("draft_old", 1)
+    // The seal is the save's awaited gap; a split ack migrating the id lands
+    // exactly there. The save must NOT write the pre-migration id back (that
+    // row would re-push, re-split server-side, and breed duplicates) — it
+    // retries against the new identity.
+    const { migrateLocalDraftId } = await import("@/sync/draft-sync")
+    let firstCall = true
+    vi.spyOn(sealDraft, "sealDraftContent").mockImplementation(async () => {
+      if (firstCall) {
+        firstCall = false
+        const current = await db.drafts.get("draft_old")
+        await migrateLocalDraftId(workspaceId, "draft_old", { ...current!, id: "draft_new", baseVersion: 5 })
+      }
+      return sealedPayload
+    })
+
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("typed"), attachments: [] }, sealContext)
+
+    expect(await db.drafts.get("draft_old")).toBeUndefined()
+    const migrated = await db.drafts.get("draft_new")
+    // The save landed on the migrated row, preserving its post-split basis.
+    expect(migrated).toMatchObject({ ciphertext: "ct_sealed", baseVersion: 5 })
+    expect((await db.composerLoaded.get(draftKey))?.draftId).toBe("draft_new")
+    const ops = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    expect(ops.map((op) => op.payload.draftId)).toEqual(["draft_new"])
+  })
+
+  it("keeps a baseVersion advanced by a push ack mid-save (stale basis would split the next push)", async () => {
+    await putLoaded("draft_x", 1)
+    let firstCall = true
+    vi.spyOn(sealDraft, "sealDraftContent").mockImplementation(async () => {
+      if (firstCall) {
+        firstCall = false
+        // A push ack confirms version 7 while the save is sealing.
+        const current = await db.drafts.get("draft_x")
+        await db.drafts.put({ ...current!, baseVersion: 7 })
+      }
+      return sealedPayload
+    })
+
+    await upsertLoadedDraft(workspaceId, draftKey, { contentJson: makeDoc("typed"), attachments: [] }, sealContext)
+
+    // The freshly confirmed basis survives the save; writing the stale 1 back
+    // would make the next push CAS against an old version and split.
+    expect((await db.drafts.get("draft_x"))?.baseVersion).toBe(7)
+  })
+})

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -104,8 +104,8 @@ export async function upsertLoadedDraft(
   // stale identity would resurrect the pre-split id as a duplicate row — one
   // that re-pushes, re-splits, and breeds copies — so on a mismatch we retry
   // against the new identity instead. Two retries bound the loop; a save that
-  // still conflicts is dropped (the content stands in the editor and the
-  // staging buffer, and the next keystroke re-saves).
+  // still conflicts is dropped — the content stands in the editor (and, for
+  // plaintext scopes, the staging buffer) until the next keystroke re-saves.
   let row!: CachedDraft
   for (let attempt = 0; attempt < 3; attempt++) {
     const loadedId = await getLoadedDraftId(scope)
@@ -421,10 +421,14 @@ export async function rescopeScopeDrafts(workspaceId: string, fromScope: string,
   const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, fromScope]).toArray()
   for (const row of rows) {
     // Move + enqueue in one txn so the re-scoped row is never visible without
-    // its dirty bit (an inbound echo in that gap could overwrite the move).
+    // its dirty bit (an inbound echo in that gap could overwrite the move). The
+    // row is re-read inside the txn — writing the pre-read copy would drop a
+    // save that committed in between.
     await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
-      await migrateLocalDraftScope(workspaceId, fromScope, { ...row, scope: toScope })
-      await enqueueDraftUpsert(workspaceId, row.id)
+      const live = await db.drafts.get(row.id)
+      if (!live || live.scope !== fromScope) return
+      await migrateLocalDraftScope(workspaceId, fromScope, { ...live, scope: toScope })
+      await enqueueDraftUpsert(workspaceId, live.id)
     })
   }
 }

--- a/apps/frontend/src/hooks/use-draft-message.ts
+++ b/apps/frontend/src/hooks/use-draft-message.ts
@@ -98,135 +98,160 @@ export async function upsertLoadedDraft(
    */
   opts?: { observedResolveSeq?: number }
 ): Promise<CachedDraft> {
-  const loadedId = await getLoadedDraftId(scope)
-  const existing = loadedId ? await db.drafts.get(loadedId) : undefined
-  // The draft id binds the seal AAD (in the message-id slot), so resolve it
-  // before sealing — a re-seal of the same draft reuses the id.
-  const id = existing?.id ?? generateLocalDraftId()
+  // The save's target identity is re-validated INSIDE the write transaction:
+  // a split ack can migrate the loaded draft's id (and a push ack can advance
+  // its baseVersion) between our reads and our write. Writing against the
+  // stale identity would resurrect the pre-split id as a duplicate row — one
+  // that re-pushes, re-splits, and breeds copies — so on a mismatch we retry
+  // against the new identity instead. Two retries bound the loop; a save that
+  // still conflicts is dropped (the content stands in the editor and the
+  // staging buffer, and the next keystroke re-saves).
+  let row!: CachedDraft
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const loadedId = await getLoadedDraftId(scope)
+    const existing = loadedId ? await db.drafts.get(loadedId) : undefined
+    // The draft id binds the seal AAD (in the message-id slot), so resolve it
+    // before sealing — a re-seal of the same draft reuses the id.
+    const id = existing?.id ?? generateLocalDraftId()
 
-  let row: CachedDraft
-  // The attachment refs the seal embedded — re-seeded into the decrypt cache
-  // below so the composer reads attachments back without a self-decrypt.
-  let sealedAttachmentRefs: SealedDraftFields["attachmentRefs"] = []
-  if (seal) {
-    const sealed = await sealDraftContent({
-      workspaceId,
-      senderId: seal.senderId,
-      streamId: seal.streamId,
-      draftId: id,
-      contentJson: fields.contentJson,
-      attachmentIds: fields.attachments.map((a) => a.id),
-    })
-    row = {
-      id,
-      workspaceId,
-      scope,
-      // E2EE-4: neither the plaintext body nor the plaintext attachment linkage
-      // lands on disk — the sealed `ciphertext` is the at-rest copy of both (the
-      // attachment key/iv/filename ride inside it as `attachmentRefs`), and
-      // `contentJson`/`attachments` are only empty placeholders. The composer
-      // reads body + attachments back from the seeded/decrypted in-memory cache.
-      contentJson: EMPTY_DOC,
-      attachments: [],
-      clientUpdatedAt: Date.now(),
-      baseVersion: existing?.baseVersion,
-      ciphertext: sealed.ciphertext,
-      envelope: sealed.envelope,
-      e2eVersion: sealed.e2eVersion,
+    // The attachment refs the seal embedded — re-seeded into the decrypt cache
+    // below so the composer reads attachments back without a self-decrypt.
+    let sealedAttachmentRefs: SealedDraftFields["attachmentRefs"] = []
+    if (seal) {
+      // Seal outside the transaction (async crypto would break a Dexie txn);
+      // the AAD binds `id`, which the txn re-validates before persisting.
+      const sealed = await sealDraftContent({
+        workspaceId,
+        senderId: seal.senderId,
+        streamId: seal.streamId,
+        draftId: id,
+        contentJson: fields.contentJson,
+        attachmentIds: fields.attachments.map((a) => a.id),
+      })
+      row = {
+        id,
+        workspaceId,
+        scope,
+        // E2EE-4: neither the plaintext body nor the plaintext attachment linkage
+        // lands on disk — the sealed `ciphertext` is the at-rest copy of both (the
+        // attachment key/iv/filename ride inside it as `attachmentRefs`), and
+        // `contentJson`/`attachments` are only empty placeholders. The composer
+        // reads body + attachments back from the seeded/decrypted in-memory cache.
+        contentJson: EMPTY_DOC,
+        attachments: [],
+        clientUpdatedAt: Date.now(),
+        baseVersion: existing?.baseVersion,
+        ciphertext: sealed.ciphertext,
+        envelope: sealed.envelope,
+        e2eVersion: sealed.e2eVersion,
+      }
+      sealedAttachmentRefs = sealed.attachmentRefs
+    } else {
+      const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
+      row = {
+        id,
+        workspaceId,
+        scope,
+        contentJson: fields.contentJson,
+        attachments: fields.attachments,
+        contextRefs,
+        clientUpdatedAt: Date.now(),
+        // Carry the sync bookkeeping forward. Without this, editing a confirmed
+        // draft would reset baseVersion to undefined, and the next push
+        // (expectedVersion 0) would collide with the server's existing row and the
+        // server would SPLIT it into a duplicate — once per keystroke after the
+        // first sync. Preserve it so the push CAS-updates in place instead.
+        baseVersion: existing?.baseVersion,
+        attachmentIds: existing?.attachmentIds,
+      }
     }
-    sealedAttachmentRefs = sealed.attachmentRefs
-  } else {
-    const contextRefs = fields.contextRefs && fields.contextRefs.length > 0 ? fields.contextRefs : undefined
-    row = {
-      id,
-      workspaceId,
-      scope,
-      contentJson: fields.contentJson,
-      attachments: fields.attachments,
-      contextRefs,
-      clientUpdatedAt: Date.now(),
-      // Carry the sync bookkeeping forward. Without this, editing a confirmed
-      // draft would reset baseVersion to undefined, and the next push
-      // (expectedVersion 0) would collide with the server's existing row and the
-      // server would SPLIT it into a duplicate — once per keystroke after the
-      // first sync. Preserve it so the push CAS-updates in place instead.
-      baseVersion: existing?.baseVersion,
-      attachmentIds: existing?.attachmentIds,
+
+    // One transaction for the row write, the pointer, AND the queued push: the
+    // pending op IS the dirty bit, so committing the row without it opens a
+    // window where an inbound echo reads this device as clean and overwrites
+    // the just-typed content.
+    //
+    // The resolve-seq guard runs inside too: if a resolve-on-send advanced the
+    // scope's sequence since this (debounced) save began, the save is a stale
+    // echo of just-sent content — creating a draft from it would resurrect the
+    // sent message into the composer. `recordScopeResolved` runs before the
+    // resolve clears the pointer, so by the time the cleared pointer routes a
+    // stale save into the create branch the bumped seq is visible.
+    const outcome = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+      if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return "dropped"
+      const livePointer = (await db.composerLoaded.get(scope))?.draftId ?? null
+      if (livePointer !== loadedId) return "conflict"
+      if (existing) {
+        const liveRow = await db.drafts.get(id)
+        if (!liveRow) return "conflict"
+        // Freshest sync bookkeeping wins: a push ack can advance baseVersion
+        // between our read and this txn, and writing the stale value back would
+        // make the next push CAS against an old version and split.
+        row = seal
+          ? { ...row, baseVersion: liveRow.baseVersion }
+          : { ...row, baseVersion: liveRow.baseVersion, attachmentIds: liveRow.attachmentIds }
+        await db.drafts.put(row)
+      } else {
+        await db.drafts.put(row)
+        await db.composerLoaded.put({ scope, workspaceId, draftId: id })
+      }
+      // Mirror to the backend: a coalesced push that retries silently. The
+      // caller kicks the queue so it drains promptly.
+      await enqueueDraftUpsert(workspaceId, id)
+      return "persisted"
+    })
+
+    if (outcome === "conflict") continue
+    if (outcome === "dropped") return row
+    if (existing) {
+      upsertDraftInCache(workspaceId, row)
+    } else {
+      upsertLoadedDraftInCache(workspaceId, row, scope)
     }
-  }
 
-  let persisted = false
-  if (existing) {
-    await db.transaction("rw", db.drafts, async () => {
-      if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return
-      await db.drafts.put(row)
-      persisted = true
-    })
-    if (!persisted || isStaleObservedResolve(scope, opts?.observedResolveSeq)) return row
-    upsertDraftInCache(workspaceId, row)
-  } else {
-    // No loaded draft for this scope → this save would CREATE one and check it
-    // into the composer. If a resolve-on-send advanced the scope's resolve
-    // sequence since this (debounced) save began, the save is stale — a keystroke
-    // that predates the send — and creating a draft here would resurrect the
-    // just-sent content into the composer (the "it came back, so I sent it twice"
-    // race). `recordScopeResolved` runs before the resolve clears the pointer, so
-    // by the time the cleared pointer routes us here the bumped seq is visible.
-    // Only the debounced save passes `observedResolveSeq`; every other create
-    // path (share-target, attachments, fresh first keystroke) is unaffected.
-    // Check inside the write transaction too: a stale save may have already read
-    // the old loaded row before resolve-on-send deleted it, and writing that row
-    // afterward would stash an identical copy of the sent message.
-    await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
-      if (isStaleObservedResolve(scope, opts?.observedResolveSeq)) return
-      await db.drafts.put(row)
-      await db.composerLoaded.put({ scope, workspaceId, draftId: id })
-      persisted = true
-    })
-    if (!persisted || isStaleObservedResolve(scope, opts?.observedResolveSeq)) return row
-    upsertLoadedDraftInCache(workspaceId, row, scope)
+    if (seal) {
+      // Keep the read path serving the live plaintext: invalidate the reused
+      // id's stale entry, then seed the fresh body AND the attachment refs just
+      // sealed, so the next decrypt-on-read (and any remount) serves THIS
+      // edit's body + attachments, not a prior one. The refs carry the
+      // filename/mime/size the composer renders and the key/iv a later send
+      // re-seals.
+      invalidateDecryption(id)
+      seedDecryption(id, {
+        contentMarkdown: serializeToMarkdown(fields.contentJson),
+        contentJson: fields.contentJson,
+        attachmentRefs: sealedAttachmentRefs,
+        sources: [],
+      })
+    }
+    return row
   }
-
-  if (seal) {
-    // Keep the read path serving the live plaintext (see the doc comment above):
-    // invalidate the reused id's stale entry, then seed the fresh body AND the
-    // attachment refs just sealed, so the next decrypt-on-read (and any remount)
-    // serves THIS edit's body + attachments, not a prior one. The refs carry the
-    // filename/mime/size the composer renders and the key/iv a later send re-seals.
-    invalidateDecryption(id)
-    seedDecryption(id, {
-      contentMarkdown: serializeToMarkdown(fields.contentJson),
-      contentJson: fields.contentJson,
-      attachmentRefs: sealedAttachmentRefs,
-      sources: [],
-    })
-  }
-
-  // Mirror to the backend: a coalesced, debounced push that retries silently.
-  // The caller kicks the queue so it drains promptly.
-  await enqueueDraftUpsert(workspaceId, id)
   return row
 }
 
 /**
  * Remove the loaded draft for `scope` locally (IDB row + pointer + cache) and
- * report what was removed. Shared by `clearLoadedDraft` (discard) and
- * `resolveLoadedDraft` (send) — they differ only in how the removal is mirrored
- * to the backend, so the local teardown lives on one path (INV-43).
+ * mirror the removal to the backend via `mirror`. Shared by `clearLoadedDraft`
+ * (discard) and `resolveLoadedDraft` (send) — they differ only in how the
+ * removal is mirrored, so the local teardown lives on one path (INV-43).
  *
- * The row delete AND the pointer clear happen in ONE transaction. Reading
- * `baseVersion` here also keeps a mid-clear server confirmation from slipping
- * between read and delete (the "ghost draft" race). Crucially the pointer clear
- * is inside the txn too: otherwise a `draft:upserted` echo landing between the
- * row delete and the pointer clear would find no local row and re-insert the
- * just-cleared draft as an orphan stash entry (resurrection race).
+ * The pointer read, the row delete, the pointer clear, AND the mirror enqueue
+ * happen in ONE transaction. Reading `baseVersion` inside keeps a mid-clear
+ * server confirmation from slipping between read and delete (the "ghost draft"
+ * race); the pointer clear inside stops a `draft:upserted` echo landing
+ * mid-teardown from re-inserting the just-cleared draft as an orphan stash
+ * entry; and the enqueue inside means there is no instant where the row is
+ * gone but no queued op yet marks it as deleted/resolved (an echo in that gap
+ * would resurrect it).
  */
 async function removeLoadedDraftLocally(
   workspaceId: string,
-  scope: string
-): Promise<{ loadedId: string | null; baseVersion: number | undefined }> {
-  const loadedId = await getLoadedDraftId(scope)
-  const baseVersion = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+  scope: string,
+  mirror: (loadedId: string, baseVersion: number | undefined) => Promise<void>
+): Promise<void> {
+  let removedId: string | null = null
+  await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+    const loadedId = (await db.composerLoaded.get(scope))?.draftId ?? null
     let version: number | undefined
     if (loadedId) {
       const row = await db.drafts.get(loadedId)
@@ -234,11 +259,11 @@ async function removeLoadedDraftLocally(
       await db.drafts.delete(loadedId)
     }
     await db.composerLoaded.delete(scope)
-    return version
+    if (loadedId) await mirror(loadedId, version)
+    removedId = loadedId
   })
-  if (loadedId) deleteDraftFromCache(workspaceId, loadedId)
+  if (removedId) deleteDraftFromCache(workspaceId, removedId)
   setComposerLoadedInCache(workspaceId, scope, null)
-  return { loadedId, baseVersion }
 }
 
 /**
@@ -250,9 +275,9 @@ export async function clearLoadedDraft(workspaceId: string, scope: string): Prom
   // Drop the staging buffer first (synchronous) so a racing flush or a reload
   // can't recover the discarded content back into the composer.
   clearStagedDraft(workspaceId, scope)
-  const { loadedId, baseVersion } = await removeLoadedDraftLocally(workspaceId, scope)
-  // Sync side-effect after the local state is fully cleared.
-  if (loadedId) await syncDraftRemoval(workspaceId, loadedId, baseVersion)
+  await removeLoadedDraftLocally(workspaceId, scope, (loadedId, baseVersion) =>
+    syncDraftRemoval(workspaceId, loadedId, baseVersion)
+  )
 }
 
 /**
@@ -273,15 +298,14 @@ export async function resolveLoadedDraft(workspaceId: string, scope: string): Pr
   // that would route a racing save into the create path — so the save sees the
   // advanced seq and drops its create.
   recordScopeResolved(scope)
-  const { loadedId, baseVersion } = await removeLoadedDraftLocally(workspaceId, scope)
-  if (loadedId) {
+  await removeLoadedDraftLocally(workspaceId, scope, async (loadedId, baseVersion) => {
     // Remember this draft's (id, version) so an inbound echo of our own push, or a
     // reconnect bootstrap that re-seeds the still-present server row before the
     // resolve op drains, is dropped rather than resurrected as a stash entry. A
     // strictly newer version from another device is NOT suppressed (no-loss).
     markDraftResolved(loadedId, baseVersion ?? 0)
     await syncDraftResolution(workspaceId, loadedId, baseVersion)
-  }
+  })
 }
 
 /**
@@ -290,20 +314,20 @@ export async function resolveLoadedDraft(workspaceId: string, scope: string): Pr
  */
 export async function purgeScopeDrafts(workspaceId: string, scope: string): Promise<void> {
   clearStagedDraft(workspaceId, scope)
-  // Read + delete the rows AND clear the loaded pointer atomically: `baseVersion`
-  // reflects any server confirmation that landed before the delete (ghost-draft
-  // race), and clearing the pointer inside the txn prevents an inbound echo from
-  // re-inserting a just-purged draft as an orphan (resurrection race).
-  const rows = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+  // Read + delete the rows, clear the loaded pointer, AND enqueue the server
+  // deletes atomically: `baseVersion` reflects any server confirmation that
+  // landed before the delete (ghost-draft race), and an inbound echo can never
+  // land in an instant where a row is gone with no queued delete to suppress
+  // its resurrection.
+  const rows = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
     const found = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
     for (const row of found) await db.drafts.delete(row.id)
     await db.composerLoaded.delete(scope)
+    for (const row of found) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
     return found
   })
   for (const row of rows) deleteDraftFromCache(workspaceId, row.id)
   setComposerLoadedInCache(workspaceId, scope, null)
-  // Sync side-effects after the local state is fully cleared.
-  for (const row of rows) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
 }
 
 /**
@@ -320,7 +344,7 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
   // only ever clears a stray entry written before the stream was known to be E2E.
   clearStagedDraft(workspaceId, scope)
   let clearedPointer = false
-  const removed = await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
+  const removed = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
     const found = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, scope]).toArray()
     const plaintext = found.filter((row) => !row.ciphertext)
     const loaded = await db.composerLoaded.get(scope)
@@ -329,12 +353,13 @@ export async function purgePlaintextScopeDrafts(workspaceId: string, scope: stri
       await db.composerLoaded.delete(scope)
       clearedPointer = true
     }
+    // Mirror the removal of any plaintext copy that reached the server, inside
+    // the same txn so an echo can't resurrect a row mid-purge.
+    for (const row of plaintext) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
     return plaintext
   })
   for (const row of removed) deleteDraftFromCache(workspaceId, row.id)
   if (clearedPointer) setComposerLoadedInCache(workspaceId, scope, null)
-  // Mirror the removal of any plaintext copy that reached the server too.
-  for (const row of removed) await syncDraftRemoval(workspaceId, row.id, row.baseVersion)
 }
 
 /**
@@ -395,8 +420,12 @@ export async function restoreStashedDraftToComposer(
 export async function rescopeScopeDrafts(workspaceId: string, fromScope: string, toScope: string): Promise<void> {
   const rows = await db.drafts.where("[workspaceId+scope]").equals([workspaceId, fromScope]).toArray()
   for (const row of rows) {
-    await migrateLocalDraftScope(workspaceId, fromScope, { ...row, scope: toScope })
-    await enqueueDraftUpsert(workspaceId, row.id)
+    // Move + enqueue in one txn so the re-scoped row is never visible without
+    // its dirty bit (an inbound echo in that gap could overwrite the move).
+    await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+      await migrateLocalDraftScope(workspaceId, fromScope, { ...row, scope: toScope })
+      await enqueueDraftUpsert(workspaceId, row.id)
+    })
   }
 }
 

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -564,6 +564,29 @@ describe("executeDraftUpsert", () => {
     expect(await db.composerLoaded.get(scope)).toBeUndefined()
   })
 
+  it("seeds a drifted kept row even while this push's own op row is still in the table (sent mid-push)", async () => {
+    // In production the executing op is deleted by the QUEUE only after
+    // executeDraftUpsert returns — it must not trip the seed's dirty guard.
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 2 }))
+    await enqueueDraftUpsert(workspaceId, "draft_x") // the op being executed
+    await enqueueDraftResolve(workspaceId, "draft_x", 3) // the send
+    const upsert = vi.fn(async (_w: string, id: string): Promise<UpsertDraftResponse> => {
+      await db.drafts.delete("draft_x")
+      return {
+        draft: wireDraft({ id: "draft_new", version: 1 }),
+        split: true,
+        originalId: id,
+        // Strictly newer than the pending resolve (3) — genuine foreign drift.
+        keptDraft: wireDraft({ id: "draft_x", version: 4, contentJson: makeDoc("their newer edits") }),
+      }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    const kept = await db.drafts.get("draft_x")
+    expect(kept).toMatchObject({ baseVersion: 4, contentJson: makeDoc("their newer edits") })
+  })
+
   it("does not seed a kept row this device just resolved (send raced the split)", async () => {
     await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 2 }))
     await enqueueDraftResolve(workspaceId, "draft_x", 3)
@@ -847,6 +870,40 @@ describe("resolve-on-send is authoritative against inbound echoes (no resurrecti
     expect(
       resolves.filter((op) => op.payload.draftId === "draft_split" && op.payload.expectedVersion === 1)
     ).toHaveLength(1)
+  })
+
+  it("deletes a split echo whose write id belongs to a DISCARDED draft (no stash zombie)", async () => {
+    // The user discarded the draft while its push was in flight; the push split
+    // server-side and its echo arrives under a fresh id carrying our writeId.
+    // That's the discarded body — remove it, don't stash it.
+    await enqueueDraftUpsert(workspaceId, "draft_server1")
+    const upserts = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    const writeId = upserts.find((o) => o.payload.draftId === "draft_server1")?.payload.writeId as string
+    await enqueueDraftDelete(workspaceId, "draft_server1") // collects the lineage
+
+    await applyDraftUpserted(
+      {
+        workspaceId,
+        targetUserId: userId,
+        draft: wireDraft({ id: "draft_split", version: 1, lastClientWriteId: writeId }),
+      },
+      workspaceId
+    )
+
+    expect(await db.drafts.get("draft_split")).toBeUndefined()
+    const deletes = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+    expect(deletes.filter((op) => op.payload.draftId === "draft_split")).toHaveLength(1)
+  })
+
+  it("bootstrap does not resurrect a split row from a discarded draft's lineage", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_server1")
+    const upserts = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    const writeId = upserts.find((o) => o.payload.draftId === "draft_server1")?.payload.writeId as string
+    await enqueueDraftDelete(workspaceId, "draft_server1")
+
+    await applyDraftsBootstrap(workspaceId, [wireDraft({ id: "draft_split", version: 1, lastClientWriteId: writeId })])
+
+    expect(await db.drafts.get("draft_split")).toBeUndefined()
   })
 })
 

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import type { Draft, JSONContent, UpsertDraftInput, UpsertDraftResponse } from "@threa/types"
 import { db, type CachedDraft } from "@/db"
-import { resetDraftStoreCache } from "@/stores/draft-store"
+import * as draftStore from "@/stores/draft-store"
+import { resetDraftStoreCache, seedDraftCacheFromIdb } from "@/stores/draft-store"
 import { markDraftResolved, resetDraftResolutionGuard } from "./draft-resolution-guard"
 import {
   applyDraftDeleted,
@@ -16,6 +17,7 @@ import {
   executeDraftResolve,
   executeDraftUpsert,
   hasPendingDraftUpsert,
+  migrateLocalDraftId,
   reconcileStagedDrafts,
   syncDraftResolution,
   type DraftsServiceLike,
@@ -960,6 +962,44 @@ describe("deleteDraftById — the single user-initiated delete path", () => {
     await deleteDraftById(workspaceId, "draft_missing")
 
     expect(await db.pendingOperations.where("type").equals("delete_draft").toArray()).toHaveLength(0)
+  })
+})
+
+describe("cache signals defer to the surrounding transaction (no cache/IDB divergence on abort)", () => {
+  it("drops the cache update when the outer transaction aborts after an id migration", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1 }))
+    await seedDraftCacheFromIdb(workspaceId)
+    const migrateInCache = vi.spyOn(draftStore, "migrateLoadedDraftInCache")
+
+    await expect(
+      db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+        await migrateLocalDraftId(workspaceId, "draft_x", localDraft({ id: "draft_new", baseVersion: 0 }))
+        throw new Error("abort")
+      })
+    ).rejects.toThrow("abort")
+
+    // IDB rolled back — the cache must not have been told about the migration,
+    // or it would render a draft id that no longer exists.
+    expect(await db.drafts.get("draft_x")).toBeDefined()
+    expect(await db.drafts.get("draft_new")).toBeUndefined()
+    expect(migrateInCache).not.toHaveBeenCalled()
+    migrateInCache.mockRestore()
+  })
+
+  it("emits the cache update only after the outer transaction commits", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1 }))
+    await seedDraftCacheFromIdb(workspaceId)
+    const migrateInCache = vi.spyOn(draftStore, "migrateLoadedDraftInCache")
+
+    await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+      await migrateLocalDraftId(workspaceId, "draft_x", localDraft({ id: "draft_new", baseVersion: 0 }))
+      // Not yet — the write isn't durable until the outer transaction commits.
+      expect(migrateInCache).not.toHaveBeenCalled()
+    })
+
+    await vi.waitFor(() => expect(migrateInCache).toHaveBeenCalledTimes(1))
+    expect(await db.drafts.get("draft_new")).toBeDefined()
+    migrateInCache.mockRestore()
   })
 })
 

--- a/apps/frontend/src/sync/draft-sync.test.ts
+++ b/apps/frontend/src/sync/draft-sync.test.ts
@@ -318,9 +318,25 @@ describe("applyDraftsBootstrap", () => {
 
     expect(await db.drafts.get("draft_dirty")).toBeDefined()
   })
+
+  it("does not drop confirmed-absent locals when the snapshot is truncated at the server cap", async () => {
+    // A snapshot at the cap proves nothing about rows beyond it — absence is
+    // truncation, not deletion elsewhere.
+    await db.drafts.put(localDraft({ id: "draft_beyond_cap", baseVersion: 4 }))
+    const capped = Array.from({ length: 500 }, (_, i) => wireDraft({ id: `draft_s${i}` }))
+
+    await applyDraftsBootstrap(workspaceId, capped)
+
+    expect(await db.drafts.get("draft_beyond_cap")).toBeDefined()
+  })
 })
 
 describe("enqueueDraftUpsert / enqueueDraftDelete", () => {
+  async function upsertOp(draftId: string) {
+    const ops = await db.pendingOperations.where("type").equals("upsert_draft").toArray()
+    return ops.find((o) => o.payload.draftId === draftId)
+  }
+
   it("coalesces to a single upsert op per draft id", async () => {
     await enqueueDraftUpsert(workspaceId, "draft_x")
     await enqueueDraftUpsert(workspaceId, "draft_x")
@@ -331,6 +347,42 @@ describe("enqueueDraftUpsert / enqueueDraftDelete", () => {
     expect(ops.filter((o) => o.payload.draftId === "draft_y")).toHaveLength(1)
   })
 
+  it("keeps a never-attempted op untouched — its writeId (idempotency key) stays stable", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const first = await upsertOp("draft_x")
+
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const second = await upsertOp("draft_x")
+
+    // The op reads content fresh at drain, so re-enqueueing has nothing to add;
+    // churning the writeId here is what used to break lost-ack recognition.
+    expect(second?.id).toBe(first?.id)
+    expect(second?.payload.writeId).toBe(first?.payload.writeId)
+  })
+
+  it("replaces an attempted op with a successor that carries its write lineage", async () => {
+    // The op attempted a push (startedAt set by the queue): it may have reached
+    // the server even though the client never saw the ack. A save arriving now
+    // must chain the old writeId so the server can recognize the lineage and
+    // update in place instead of splitting a same-device duplicate.
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const first = await upsertOp("draft_x")
+    await db.pendingOperations.update(first!.id, { startedAt: Date.now() })
+
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const second = await upsertOp("draft_x")
+
+    expect(second?.id).not.toBe(first?.id)
+    expect(second?.payload.writeId).not.toBe(first?.payload.writeId)
+    expect(second?.payload.priorWriteIds).toEqual([first?.payload.writeId])
+
+    // A third replacement accumulates the whole chain.
+    await db.pendingOperations.update(second!.id, { startedAt: Date.now() })
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const third = await upsertOp("draft_x")
+    expect(third?.payload.priorWriteIds).toEqual([second?.payload.writeId, first?.payload.writeId])
+  })
+
   it("enqueueDraftDelete drops a queued push and adds a delete", async () => {
     await enqueueDraftUpsert(workspaceId, "draft_x")
     await enqueueDraftDelete(workspaceId, "draft_x")
@@ -338,6 +390,20 @@ describe("enqueueDraftUpsert / enqueueDraftDelete", () => {
     expect(await hasPendingDraftUpsert("draft_x")).toBe(false)
     const dels = await db.pendingOperations.where("type").equals("delete_draft").toArray()
     expect(dels.filter((o) => o.payload.draftId === "draft_x")).toHaveLength(1)
+  })
+
+  it("enqueueDraftDelete carries the dropped push's write lineage onto the delete", async () => {
+    await enqueueDraftUpsert(workspaceId, "draft_x")
+    const op = await upsertOp("draft_x")
+    const writeId = op?.payload.writeId as string
+
+    await enqueueDraftDelete(workspaceId, "draft_x")
+
+    // If that push already left the device, its late landing must read as
+    // discarded content — the tombstone needs the lineage to drop it.
+    const dels = await db.pendingOperations.where("type").equals("delete_draft").toArray()
+    const del = dels.find((o) => o.payload.draftId === "draft_x")
+    expect(del?.payload.supersededWriteIds).toEqual([writeId])
   })
 
   it("enqueueDraftResolve keeps a queued push as the in-flight echo marker", async () => {
@@ -428,6 +494,19 @@ describe("executeDraftUpsert", () => {
     expect((await db.drafts.get("draft_e2e"))?.baseVersion).toBe(2)
   })
 
+  it("pushes the op's carried write lineage (priorWriteIds) on the wire", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 2 }))
+    const calls: UpsertDraftInput[] = []
+    const upsert = vi.fn(async (_w: string, id: string, input: UpsertDraftInput): Promise<UpsertDraftResponse> => {
+      calls.push(input)
+      return { draft: wireDraft({ id, version: 3 }), split: false }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_b", service(upsert), ["write_a"])
+
+    expect(calls[0]).toMatchObject({ writeId: "write_b", priorWriteIds: ["write_a"] })
+  })
+
   it("migrates the local id to the server-minted id on a split", async () => {
     await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1, contentJson: makeDoc("mine") }))
     await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_x" })
@@ -445,6 +524,64 @@ describe("executeDraftUpsert", () => {
     const migrated = await db.drafts.get("draft_new")
     expect(migrated).toMatchObject({ contentJson: makeDoc("mine"), baseVersion: 1 })
     expect((await db.composerLoaded.get(scope))?.draftId).toBe("draft_new")
+  })
+
+  it("keeps keystrokes typed during the in-flight split push (id migration re-reads the live row)", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1, contentJson: makeDoc("pushed") }))
+    await db.composerLoaded.put({ scope, workspaceId, draftId: "draft_x" })
+    const upsert = vi.fn(async (_w: string, id: string): Promise<UpsertDraftResponse> => {
+      // A debounced save commits newer content while the PUT is in flight.
+      await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1, contentJson: makeDoc("pushed plus more") }))
+      return { draft: wireDraft({ id: "draft_new", version: 1 }), split: true, originalId: id }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    // The migration must carry the LIVE row's content, not the stale pre-push
+    // snapshot — otherwise the newer keystrokes vanish from IDB.
+    expect((await db.drafts.get("draft_new"))?.contentJson).toEqual(makeDoc("pushed plus more"))
+  })
+
+  it("seeds the server-kept row (the other copy) as a stash entry on a split", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 1, contentJson: makeDoc("mine") }))
+    const upsert = vi.fn(
+      async (_w: string, id: string): Promise<UpsertDraftResponse> => ({
+        draft: wireDraft({ id: "draft_new", version: 1, contentJson: makeDoc("mine") }),
+        split: true,
+        originalId: id,
+        keptDraft: wireDraft({ id: "draft_x", version: 3, contentJson: makeDoc("theirs") }),
+      })
+    )
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    // Our content moved to the new id; the other device's kept row seeds locally
+    // (its socket echo was ignored while this device was dirty).
+    expect((await db.drafts.get("draft_new"))?.contentJson).toEqual(makeDoc("mine"))
+    const kept = await db.drafts.get("draft_x")
+    expect(kept).toMatchObject({ baseVersion: 3, contentJson: makeDoc("theirs") })
+    // Seeding never activates the composer.
+    expect(await db.composerLoaded.get(scope)).toBeUndefined()
+  })
+
+  it("does not seed a kept row this device just resolved (send raced the split)", async () => {
+    await db.drafts.put(localDraft({ id: "draft_x", baseVersion: 2 }))
+    await enqueueDraftResolve(workspaceId, "draft_x", 3)
+    const upsert = vi.fn(async (_w: string, id: string): Promise<UpsertDraftResponse> => {
+      await db.drafts.delete("draft_x")
+      return {
+        draft: wireDraft({ id: "draft_new", version: 1 }),
+        split: true,
+        originalId: id,
+        keptDraft: wireDraft({ id: "draft_x", version: 3 }),
+      }
+    })
+
+    await executeDraftUpsert(workspaceId, "draft_x", "write_a", service(upsert))
+
+    // The kept row is at the version the pending resolve targets — re-seeding it
+    // would resurrect the just-sent draft as a stash entry.
+    expect(await db.drafts.get("draft_x")).toBeUndefined()
   })
 
   it("re-routes the queued push to the migrated id on a split (mid-push edits aren't stranded)", async () => {
@@ -552,10 +689,12 @@ describe("executeDraftUpsert", () => {
 })
 
 describe("executeDraftDelete", () => {
-  it("delegates to the service", async () => {
+  it("delegates to the service, carrying the superseded write lineage for the tombstone", async () => {
     const del = vi.fn(async () => {})
-    await executeDraftDelete(workspaceId, "draft_x", { upsert: vi.fn(), delete: del } as unknown as DraftsServiceLike)
-    expect(del).toHaveBeenCalledWith(workspaceId, "draft_x")
+    await executeDraftDelete(workspaceId, "draft_x", { upsert: vi.fn(), delete: del } as unknown as DraftsServiceLike, [
+      "write_inflight",
+    ])
+    expect(del).toHaveBeenCalledWith(workspaceId, "draft_x", { supersededWriteIds: ["write_inflight"] })
   })
 })
 

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -224,6 +224,11 @@ function operationId(): string {
 }
 
 function writeId(): string {
+  // The write id gates in-place overwrites server-side (lineage CAS), so a
+  // cross-device collision must be out of the question — use real entropy.
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `write_${crypto.randomUUID()}`
+  }
   return `write_${Date.now()}_${Math.random().toString(36).slice(2)}`
 }
 
@@ -269,15 +274,23 @@ export async function pendingDraftResolveVersion(draftId: string): Promise<numbe
   return version
 }
 
-async function hasPendingSupersededWriteId(writeId: string): Promise<boolean> {
-  // Intentionally scan all pending resolves, not only the inbound draft id: a
-  // server-side split echo arrives under a fresh draft id, but carries the
-  // original resolve op's superseded write id.
-  const ops = await db.pendingOperations.where("type").equals("resolve_draft").toArray()
-  return ops.some(
-    (op) =>
-      Array.isArray(op.payload.supersededWriteIds) && op.payload.supersededWriteIds.some((value) => value === writeId)
-  )
+/**
+ * Which kind of queued cleanup superseded this write id, if any. A "resolve"
+ * match means the write belongs to a draft this device sent; a "delete" match
+ * means the user discarded it. Scans all pending resolve/delete ops, not only
+ * the inbound draft id: a server-side split echo arrives under a fresh draft
+ * id, but carries the original op's superseded write id.
+ */
+async function pendingSupersededWriteKind(writeId: string): Promise<"resolve" | "delete" | null> {
+  const [resolves, deletes] = await Promise.all([
+    db.pendingOperations.where("type").equals("resolve_draft").toArray(),
+    db.pendingOperations.where("type").equals("delete_draft").toArray(),
+  ])
+  const carries = (op: PendingOperation) =>
+    Array.isArray(op.payload.supersededWriteIds) && op.payload.supersededWriteIds.some((value) => value === writeId)
+  if (resolves.some(carries)) return "resolve"
+  if (deletes.some(carries)) return "delete"
+  return null
 }
 
 /**
@@ -493,7 +506,8 @@ export async function applyDraftUpserted(
   pendingUpsertIds?: ReadonlySet<string>,
   pendingDeleteIds?: ReadonlySet<string>,
   pendingResolveVersions?: ReadonlyMap<string, number>,
-  pendingSupersededWriteIds?: ReadonlySet<string>
+  pendingResolveSupersededWriteIds?: ReadonlySet<string>,
+  pendingDeleteSupersededWriteIds?: ReadonlySet<string>
 ): Promise<void> {
   const { draft } = payload
   if (draft.workspaceId !== expectedWorkspaceId) return
@@ -514,14 +528,26 @@ export async function applyDraftUpserted(
   if (pendingResolveVersion !== undefined && draft.version <= pendingResolveVersion) return
 
   // A version-newer row with one of our superseded write ids is not another
-  // device's drift; it is this device's sent draft write landing late (possibly
-  // under a split id). CAS-resolve it at the version we observed.
+  // device's drift; it is this device's own write landing late (possibly under
+  // a split id). A resolve-superseded write is a SENT draft: CAS-resolve it at
+  // the version we observed. A delete-superseded write is DISCARDED content:
+  // remove it unconditionally rather than stash-zombie it.
   const lastWriteId = draft.lastClientWriteId ?? null
-  const ownSentWrite = lastWriteId
-    ? (pendingSupersededWriteIds?.has(lastWriteId) ?? (await hasPendingSupersededWriteId(lastWriteId)))
-    : false
-  if (ownSentWrite) {
+  let ownWriteKind: "resolve" | "delete" | null = null
+  if (lastWriteId) {
+    if (pendingResolveSupersededWriteIds || pendingDeleteSupersededWriteIds) {
+      if (pendingResolveSupersededWriteIds?.has(lastWriteId)) ownWriteKind = "resolve"
+      else if (pendingDeleteSupersededWriteIds?.has(lastWriteId)) ownWriteKind = "delete"
+    } else {
+      ownWriteKind = await pendingSupersededWriteKind(lastWriteId)
+    }
+  }
+  if (ownWriteKind === "resolve") {
     await enqueueDraftResolve(expectedWorkspaceId, draft.id, draft.version)
+    return
+  }
+  if (ownWriteKind === "delete") {
+    await enqueueDraftDelete(expectedWorkspaceId, draft.id)
     return
   }
 
@@ -571,20 +597,25 @@ export async function applyDraftUpserted(
 export async function applyDraftDeleted(payload: DraftDeletedPayload, expectedWorkspaceId: string): Promise<void> {
   if (payload.workspaceId !== expectedWorkspaceId) return
 
-  if (await hasPendingDraftUpsert(payload.draftId)) {
+  // The check-preserve-re-enqueue sequence runs in ONE transaction: done as
+  // separate steps, the gap after the cancel leaves the row clean (no dirty
+  // bit), so an interleaved newer-version echo would be accepted over the very
+  // edits this branch exists to preserve.
+  const preserved = await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+    if (!(await hasPendingDraftUpsert(payload.draftId))) return false
     const current = await db.drafts.get(payload.draftId)
-    if (current) {
-      const replacementId = generateLocalDraftId()
-      await cancelPendingDraftUpsert(payload.draftId)
-      await migrateLocalDraftId(payload.workspaceId, payload.draftId, {
-        ...current,
-        id: replacementId,
-        baseVersion: 0,
-      })
-      await enqueueDraftUpsert(payload.workspaceId, replacementId)
-      return
-    }
-  }
+    if (!current) return false
+    const replacementId = generateLocalDraftId()
+    await cancelPendingDraftUpsert(payload.draftId)
+    await migrateLocalDraftId(payload.workspaceId, payload.draftId, {
+      ...current,
+      id: replacementId,
+      baseVersion: 0,
+    })
+    await enqueueDraftUpsert(payload.workspaceId, replacementId)
+    return true
+  })
+  if (preserved) return
 
   await cancelPendingDraftUpsert(payload.draftId)
   await deleteLocalDraft(payload.workspaceId, payload.draftId)
@@ -613,19 +644,23 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
   const pendingUpsertIds = new Set(upsertOps.map((op) => op.payload.draftId as string))
   const pendingDeleteIds = new Set(deleteOps.map((op) => op.payload.draftId as string))
   const pendingResolveVersions = new Map<string, number>()
-  const pendingSupersededWriteIds = new Set<string>()
+  const collectSuperseded = (op: PendingOperation, into: Set<string>) => {
+    if (!Array.isArray(op.payload.supersededWriteIds)) return
+    for (const value of op.payload.supersededWriteIds) {
+      if (typeof value === "string") into.add(value)
+    }
+  }
+  const pendingResolveSupersededWriteIds = new Set<string>()
+  const pendingDeleteSupersededWriteIds = new Set<string>()
   for (const op of resolveOps) {
     const draftId = op.payload.draftId as string
     const expectedVersion = Number(op.payload.expectedVersion)
     if (Number.isFinite(expectedVersion)) {
       pendingResolveVersions.set(draftId, Math.max(pendingResolveVersions.get(draftId) ?? 0, expectedVersion))
     }
-    if (Array.isArray(op.payload.supersededWriteIds)) {
-      for (const value of op.payload.supersededWriteIds) {
-        if (typeof value === "string") pendingSupersededWriteIds.add(value)
-      }
-    }
+    collectSuperseded(op, pendingResolveSupersededWriteIds)
   }
+  for (const op of deleteOps) collectSuperseded(op, pendingDeleteSupersededWriteIds)
   for (const draft of drafts) {
     await applyDraftUpserted(
       { workspaceId: draft.workspaceId, targetUserId: draft.userId, draft },
@@ -633,7 +668,8 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
       pendingUpsertIds,
       pendingDeleteIds,
       pendingResolveVersions,
-      pendingSupersededWriteIds
+      pendingResolveSupersededWriteIds,
+      pendingDeleteSupersededWriteIds
     )
   }
 
@@ -808,6 +844,10 @@ export async function executeDraftUpsert(
       } else {
         await enqueueDraftDelete(workspaceId, res.draft.id)
       }
+      // This push's own op row is still in the table while we run (the queue
+      // deletes it only after we return), and it would trip the kept-row seed's
+      // dirty guard — it is terminal here, so drop it before seeding.
+      await cancelPendingDraftUpsert(draftId)
       await seedKeptDraft(res, workspaceId)
       return
     }

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -1,3 +1,4 @@
+import Dexie from "dexie"
 import { db, generateLocalDraftId, type CachedDraft, type PendingOperation } from "@/db"
 import type { DraftContextRef } from "@/lib/context-bag/types"
 import {
@@ -94,6 +95,21 @@ export function cachedDraftFromWire(draft: Draft): CachedDraft {
 // Local persistence primitives (IDB + in-memory draft-store cache)
 // ============================================================================
 
+/**
+ * Emit an in-memory cache update only once the surrounding Dexie transaction
+ * (if any) has committed. The persistence helpers below run their cache signal
+ * after their own transaction, but they are also composed inside larger ones
+ * (`deleteDraftById`, `applyDraftDeleted`'s preserve flow, `rescopeScopeDrafts`)
+ * — there the inner sub-transaction resolving does NOT mean the write is
+ * durable, and emitting immediately would leave the cache holding state that
+ * IDB rolls back if the outer transaction aborts.
+ */
+function emitCacheAfterTxn(emit: () => void): void {
+  const txn = Dexie.currentTransaction
+  if (txn) txn.on("complete", emit)
+  else emit()
+}
+
 /** Write a draft to IDB and (when the workspace cache is live) the store cache. */
 export async function putLocalDraft(row: CachedDraft): Promise<void> {
   await db.drafts.put(row)
@@ -122,10 +138,11 @@ export async function deleteLocalDraft(workspaceId: string, id: string): Promise
     }
     await db.drafts.delete(id)
   })
-  if (hasSeededDraftCache(workspaceId)) {
+  emitCacheAfterTxn(() => {
+    if (!hasSeededDraftCache(workspaceId)) return
     deleteDraftFromCache(workspaceId, id)
     if (clearedScope) setComposerLoadedInCache(workspaceId, clearedScope, null)
-  }
+  })
   return removed
 }
 
@@ -175,9 +192,10 @@ export async function migrateLocalDraftScope(
       movedToScope = toRow.scope
     }
   })
-  if (hasSeededDraftCache(workspaceId)) {
+  emitCacheAfterTxn(() => {
+    if (!hasSeededDraftCache(workspaceId)) return
     migrateDraftScopeInCache(workspaceId, fromScope, toRow, movedToScope)
-  }
+  })
 }
 
 /**
@@ -210,9 +228,10 @@ export async function migrateLocalDraftId(workspaceId: string, fromId: string, t
   // One cache signal (delete-old + insert-new + repoint) so a reader never sees
   // the loaded draft missing mid-migration — i.e. the composer never flashes
   // empty during a server split or a remote-delete preserve.
-  if (hasSeededDraftCache(workspaceId)) {
+  emitCacheAfterTxn(() => {
+    if (!hasSeededDraftCache(workspaceId)) return
     migrateLoadedDraftInCache(workspaceId, fromId, finalRow, repointedScope)
-  }
+  })
 }
 
 // ============================================================================

--- a/apps/frontend/src/sync/draft-sync.ts
+++ b/apps/frontend/src/sync/draft-sync.ts
@@ -8,14 +8,16 @@ import {
   setComposerLoadedInCache,
   upsertDraftInCache,
 } from "@/stores/draft-store"
-import type {
-  Draft,
-  DraftDeletedPayload,
-  DraftUpsertedPayload,
-  ResolveDraftInput,
-  ResolveDraftResponse,
-  UpsertDraftInput,
-  UpsertDraftResponse,
+import {
+  MAX_DRAFTS_PER_USER,
+  type DeleteDraftInput,
+  type Draft,
+  type DraftDeletedPayload,
+  type DraftUpsertedPayload,
+  type ResolveDraftInput,
+  type ResolveDraftResponse,
+  type UpsertDraftInput,
+  type UpsertDraftResponse,
 } from "@threa/types"
 import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
 import { clearStagedDraft, listStagedDrafts, type StagedDraft } from "@/lib/drafts/draft-staging"
@@ -51,7 +53,7 @@ import { isResolvedDraftEcho } from "./draft-resolution-guard"
 export interface DraftsServiceLike {
   upsert: (workspaceId: string, id: string, input: UpsertDraftInput) => Promise<UpsertDraftResponse>
   resolve: (workspaceId: string, id: string, input: ResolveDraftInput) => Promise<ResolveDraftResponse>
-  delete: (workspaceId: string, id: string) => Promise<void>
+  delete: (workspaceId: string, id: string, input?: DeleteDraftInput) => Promise<void>
 }
 
 // ============================================================================
@@ -136,10 +138,16 @@ export async function deleteLocalDraft(workspaceId: string, id: string): Promise
  * pointer when it pointed here) and queues an unconditional, idempotent server
  * delete so the removal propagates to the author's other devices. No-op on an
  * already-gone row. Callers kick the operation queue so the delete drains now.
+ *
+ * Row removal and the delete-op enqueue share ONE transaction: an inbound
+ * upsert echo landing between them would see neither the row nor the queued
+ * delete and resurrect the draft the user just removed.
  */
 export async function deleteDraftById(workspaceId: string, id: string): Promise<void> {
-  const removed = await deleteLocalDraft(workspaceId, id)
-  if (removed) await syncDraftRemoval(workspaceId, id, removed.baseVersion)
+  await db.transaction("rw", db.drafts, db.composerLoaded, db.pendingOperations, async () => {
+    const removed = await deleteLocalDraft(workspaceId, id)
+    if (removed) await syncDraftRemoval(workspaceId, id, removed.baseVersion)
+  })
 }
 
 /**
@@ -178,15 +186,24 @@ export async function migrateLocalDraftScope(
  * optimistic-message id-swap in `stream-sync.ts`: the new row is written before
  * the old one is removed, so a live Dexie query never observes a frame with
  * neither present.
+ *
+ * The source row is re-read INSIDE the transaction: a composer save can commit
+ * between the caller's read (before its network round-trip) and this
+ * transaction, and building the target from that stale copy would silently
+ * drop the newer keystrokes from IDB. Only the identity fields (`id`,
+ * `baseVersion`) come from `toRow`; content is whatever is live at commit time.
  */
 export async function migrateLocalDraftId(workspaceId: string, fromId: string, toRow: CachedDraft): Promise<void> {
   let repointedScope: string | null = null
+  let finalRow: CachedDraft = toRow
   await db.transaction("rw", db.drafts, db.composerLoaded, async () => {
-    await db.drafts.put(toRow)
-    const loaded = await db.composerLoaded.get(toRow.scope)
+    const live = await db.drafts.get(fromId)
+    finalRow = live ? { ...live, id: toRow.id, baseVersion: toRow.baseVersion } : toRow
+    await db.drafts.put(finalRow)
+    const loaded = await db.composerLoaded.get(finalRow.scope)
     if (loaded?.draftId === fromId) {
-      await db.composerLoaded.put({ ...loaded, draftId: toRow.id })
-      repointedScope = toRow.scope
+      await db.composerLoaded.put({ ...loaded, draftId: finalRow.id })
+      repointedScope = finalRow.scope
     }
     await db.drafts.delete(fromId)
   })
@@ -194,7 +211,7 @@ export async function migrateLocalDraftId(workspaceId: string, fromId: string, t
   // the loaded draft missing mid-migration — i.e. the composer never flashes
   // empty during a server split or a remote-delete preserve.
   if (hasSeededDraftCache(workspaceId)) {
-    migrateLoadedDraftInCache(workspaceId, fromId, toRow, repointedScope)
+    migrateLoadedDraftInCache(workspaceId, fromId, finalRow, repointedScope)
   }
 }
 
@@ -264,21 +281,55 @@ async function hasPendingSupersededWriteId(writeId: string): Promise<boolean> {
 }
 
 /**
+ * Bound on the accumulated write lineage carried by one op. The chain only
+ * grows when a save replaces an op that already ATTEMPTED a push (at most one
+ * in flight at a time), so real chains are 1-2 long; the cap is a backstop
+ * matched to the server schema's bound, keeping the most recent ids (the ones
+ * most likely to be the server's last accepted write).
+ */
+const MAX_PRIOR_WRITE_IDS = 64
+
+/** The op's full idempotency lineage: its writeId plus all carried prior ids. */
+function opWriteLineage(op: PendingOperation): string[] {
+  const ids: string[] = []
+  if (typeof op.payload.writeId === "string") ids.push(op.payload.writeId)
+  if (Array.isArray(op.payload.priorWriteIds)) {
+    for (const id of op.payload.priorWriteIds) {
+      if (typeof id === "string") ids.push(id)
+    }
+  }
+  return ids
+}
+
+/**
  * Enqueue a debounced background push for a draft. Coalesces to at most one
- * queued `upsert_draft` op per id: the op reads the draft's current content
- * fresh at drain time, so a superseded op would only re-push identical state.
- * A fresh `writeId` (per-push idempotency key, reused across that op's retries)
- * means a lost ack never causes a spurious server-side split.
+ * queued `upsert_draft` op per id — the op reads the draft's current content
+ * fresh at drain time, so a queued-but-never-attempted op is simply KEPT: its
+ * `writeId` (per-push idempotency key, reused across retries) stays stable and
+ * a lost ack can never read as drift.
+ *
+ * An op that already attempted a push (`startedAt` set) may have reached the
+ * server even though its result was lost, so it is replaced by a fresh op that
+ * carries the old lineage in `priorWriteIds`. The server treats a row whose
+ * last accepted write is any of those ids as "no other device wrote since" and
+ * updates in place — without this, a committed-but-unacked push followed by
+ * more typing splits the draft on a single device.
  */
 export async function enqueueDraftUpsert(workspaceId: string, draftId: string): Promise<void> {
   await db.transaction("rw", db.pendingOperations, async () => {
     const dupes = await pendingDraftOps("upsert_draft", draftId)
+    if (dupes.length > 0 && dupes.every((op) => op.startedAt === undefined)) {
+      // Never attempted — the op will read the latest content at drain, and its
+      // writeId must stay stable. Nothing to do.
+      return
+    }
+    const priorWriteIds = [...new Set(dupes.flatMap(opWriteLineage))].slice(0, MAX_PRIOR_WRITE_IDS)
     if (dupes.length > 0) await db.pendingOperations.bulkDelete(dupes.map((op) => op.id))
     await db.pendingOperations.add({
       id: operationId(),
       workspaceId,
       type: "upsert_draft",
-      payload: { draftId, writeId: writeId() },
+      payload: { draftId, writeId: writeId(), priorWriteIds },
       createdAt: Date.now(),
       retryCount: 0,
     })
@@ -291,19 +342,33 @@ export async function enqueueDraftUpsert(workspaceId: string, draftId: string): 
  * never-confirmed local drafts: their queued upsert may already be in-flight, so
  * an idempotent delete is the durable cleanup/suppression marker that prevents a
  * late server insert from reappearing on the next socket/bootstrap pass.
+ *
+ * The write lineage of every dropped upsert (and of any delete op being
+ * replaced) rides along as `supersededWriteIds`, persisted onto the server
+ * tombstone: a push from that lineage landing AFTER the delete is discarded
+ * content and gets dropped instead of splitting into a zombie.
  */
 export async function enqueueDraftDelete(workspaceId: string, draftId: string): Promise<void> {
   await db.transaction("rw", db.pendingOperations, async () => {
-    const stale = [
-      ...(await pendingDraftOps("upsert_draft", draftId)),
-      ...(await pendingDraftOps("delete_draft", draftId)),
-    ]
+    const upserts = await pendingDraftOps("upsert_draft", draftId)
+    const deletes = await pendingDraftOps("delete_draft", draftId)
+    const supersededWriteIds = [
+      ...new Set([
+        ...upserts.flatMap(opWriteLineage),
+        ...deletes.flatMap((op) =>
+          Array.isArray(op.payload.supersededWriteIds)
+            ? op.payload.supersededWriteIds.filter((id): id is string => typeof id === "string")
+            : []
+        ),
+      ]),
+    ].slice(0, MAX_PRIOR_WRITE_IDS)
+    const stale = [...upserts, ...deletes]
     if (stale.length > 0) await db.pendingOperations.bulkDelete(stale.map((op) => op.id))
     await db.pendingOperations.add({
       id: operationId(),
       workspaceId,
       type: "delete_draft",
-      payload: { draftId },
+      payload: { draftId, supersededWriteIds },
       createdAt: Date.now(),
       retryCount: 0,
     })
@@ -330,13 +395,22 @@ export async function enqueueDraftResolve(
 ): Promise<void> {
   await db.transaction("rw", db.pendingOperations, async () => {
     const pendingUpserts = await pendingDraftOps("upsert_draft", draftId)
-    const supersededWriteIds = pendingUpserts
-      .map((op) => op.payload.writeId)
-      .filter((value): value is string => typeof value === "string" && value.length > 0)
-    const stale = [
-      ...(await pendingDraftOps("resolve_draft", draftId)),
-      ...(await pendingDraftOps("delete_draft", draftId)),
-    ]
+    const staleResolves = await pendingDraftOps("resolve_draft", draftId)
+    // The full lineage of every pending push (writeId + carried priors), merged
+    // with any replaced resolve op's list — a replaced resolve may reference an
+    // op the queue has since consumed, and every id in it still names this
+    // device's own sent-draft writes.
+    const supersededWriteIds = [
+      ...new Set([
+        ...pendingUpserts.flatMap(opWriteLineage),
+        ...staleResolves.flatMap((op) =>
+          Array.isArray(op.payload.supersededWriteIds)
+            ? op.payload.supersededWriteIds.filter((id): id is string => typeof id === "string")
+            : []
+        ),
+      ]),
+    ].slice(0, MAX_PRIOR_WRITE_IDS)
+    const stale = [...staleResolves, ...(await pendingDraftOps("delete_draft", draftId))]
     if (stale.length > 0) await db.pendingOperations.bulkDelete(stale.map((op) => op.id))
     await db.pendingOperations.add({
       id: operationId(),
@@ -563,6 +637,10 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
     )
   }
 
+  // A snapshot at the server cap may be truncated: absence no longer proves a
+  // draft was deleted elsewhere, so the sweep below must not drop local rows.
+  const snapshotTruncated = drafts.length >= MAX_DRAFTS_PER_USER
+
   const localDrafts = await db.drafts.where("workspaceId").equals(workspaceId).toArray()
   for (const local of localDrafts) {
     if (serverIds.has(local.id)) continue
@@ -571,7 +649,7 @@ export async function applyDraftsBootstrap(workspaceId: string, drafts: Draft[])
     if (confirmed) {
       // Tombstoned on another device — drop it, unless we have unpushed edits
       // (those re-upsert and split server-side rather than vanish).
-      if (!queued) await deleteLocalDraft(workspaceId, local.id)
+      if (!queued && !snapshotTruncated) await deleteLocalDraft(workspaceId, local.id)
     } else if (!queued) {
       // Never synced (incl. pre-Stage-3 rows) — mirror it up.
       await enqueueDraftUpsert(workspaceId, local.id)
@@ -670,14 +748,17 @@ async function applyStagedDraft(workspaceId: string, entry: StagedDraft): Promis
 /**
  * Push a draft's current local state to the backend (operation-queue replay of
  * `upsert_draft`). Reads the draft fresh so a coalesced op always mirrors the
- * latest content, and pushes `expectedVersion = baseVersion`. Throws on failure
- * so the queue retries with backoff — never surfaced to the user.
+ * latest content, and pushes `expectedVersion = baseVersion` plus the op's
+ * carried write lineage (`priorWriteIds`) so a lost ack of a superseded push
+ * updates in place instead of splitting. Throws on failure so the queue
+ * retries with backoff — never surfaced to the user.
  */
 export async function executeDraftUpsert(
   workspaceId: string,
   draftId: string,
   writeIdValue: string,
-  service: DraftsServiceLike
+  service: DraftsServiceLike,
+  priorWriteIds: string[] = []
 ): Promise<void> {
   const row = await db.drafts.get(draftId)
   if (!row) return // discarded locally after the op was enqueued — nothing to push
@@ -699,6 +780,7 @@ export async function executeDraftUpsert(
     rootStreamId: null,
     expectedVersion: row.baseVersion ?? 0,
     writeId: writeIdValue,
+    priorWriteIds,
     clientUpdatedAt: new Date(row.clientUpdatedAt).toISOString(),
     // An E2E draft pushes its sealed body, never plaintext — the server stores
     // the ciphertext opaquely and the upsert schema rejects carrying both.
@@ -715,7 +797,6 @@ export async function executeDraftUpsert(
   if (res.split) {
     // The server kept the existing row (the other device's content) under
     // `draftId` and minted `res.draft.id` for ours — migrate our local id to it.
-    // The original id's divergent server row arrives via its own socket event.
     const current = await db.drafts.get(draftId)
     if (!current) {
       // Removed locally while the push was in flight. A sent draft gets a CAS
@@ -727,6 +808,7 @@ export async function executeDraftUpsert(
       } else {
         await enqueueDraftDelete(workspaceId, res.draft.id)
       }
+      await seedKeptDraft(res, workspaceId)
       return
     }
     await migrateLocalDraftId(workspaceId, draftId, {
@@ -739,6 +821,7 @@ export async function executeDraftUpsert(
     // the new id — push them so they reach the server instead of stranding locally.
     await cancelPendingDraftUpsert(draftId)
     await enqueueDraftUpsert(workspaceId, res.draft.id)
+    await seedKeptDraft(res, workspaceId)
     return
   }
 
@@ -768,6 +851,18 @@ export async function executeDraftUpsert(
 }
 
 /**
+ * Seed the row the server kept on a split (the other copy's content). This
+ * device ignored that row's socket echo while it was dirty, so without the
+ * seed it would stay invisible until the next reconnect bootstrap. Routed
+ * through the normal inbound apply so every suppression guard (resolved echo,
+ * pending delete/resolve, dirty) still holds.
+ */
+async function seedKeptDraft(res: UpsertDraftResponse, workspaceId: string): Promise<void> {
+  if (!res.keptDraft) return
+  await applyDraftUpserted({ workspaceId, targetUserId: res.keptDraft.userId, draft: res.keptDraft }, workspaceId)
+}
+
+/**
  * Resolve a draft on the backend after its message sent (operation-queue replay
  * of `resolve_draft`). CAS-guarded by `expectedVersion` plus superseded write
  * ids: the server keeps unrelated drift (`resolved: false`) rather than deleting
@@ -787,11 +882,17 @@ export async function executeDraftResolve(
   await service.resolve(workspaceId, draftId, { expectedVersion, supersededWriteIds })
 }
 
-/** Push a draft deletion to the backend (operation-queue replay of `delete_draft`). */
+/**
+ * Push a draft deletion to the backend (operation-queue replay of
+ * `delete_draft`). `supersededWriteIds` is the discarding device's in-flight
+ * write lineage, persisted onto the tombstone so a late-landing push of the
+ * discarded content is dropped rather than resurrected as a zombie.
+ */
 export async function executeDraftDelete(
   workspaceId: string,
   draftId: string,
-  service: DraftsServiceLike
+  service: DraftsServiceLike,
+  supersededWriteIds: string[] = []
 ): Promise<void> {
-  await service.delete(workspaceId, draftId)
+  await service.delete(workspaceId, draftId, { supersededWriteIds })
 }

--- a/apps/frontend/src/sync/operation-queue.ts
+++ b/apps/frontend/src/sync/operation-queue.ts
@@ -111,6 +111,11 @@ export async function processOperationQueue(
       if (!next) break
 
       try {
+        // Mark the attempt BEFORE executing: once a request may have left the
+        // device, a coalescing replace of this op must carry its idempotency
+        // lineage (writeId) forward instead of minting a fresh one — otherwise
+        // a committed-but-unacked write reads as drift and splits server-side.
+        await db.pendingOperations.update(next.id, { startedAt: Date.now() })
         await executeOperation(next, messageService, reactionService, scheduledService, draftsService)
         await db.pendingOperations.delete(next.id)
       } catch {
@@ -224,7 +229,16 @@ async function executeOperation(
       // Without a drafts service this context is local-only: drop the op rather
       // than throw (a throw would retry forever, never reaching a service).
       if (!draftsService) break
-      await executeDraftUpsert(workspaceId, payload.draftId as string, payload.writeId as string, draftsService)
+      const priorWriteIds = Array.isArray(payload.priorWriteIds)
+        ? payload.priorWriteIds.filter((id): id is string => typeof id === "string")
+        : []
+      await executeDraftUpsert(
+        workspaceId,
+        payload.draftId as string,
+        payload.writeId as string,
+        draftsService,
+        priorWriteIds
+      )
       break
     }
 
@@ -249,7 +263,10 @@ async function executeOperation(
 
     case "delete_draft": {
       if (!draftsService) break
-      await executeDraftDelete(workspaceId, payload.draftId as string, draftsService)
+      const supersededWriteIds = Array.isArray(payload.supersededWriteIds)
+        ? payload.supersededWriteIds.filter((id): id is string => typeof id === "string")
+        : []
+      await executeDraftDelete(workspaceId, payload.draftId as string, draftsService, supersededWriteIds)
       break
     }
   }

--- a/docs/features/architecture/drafts.md
+++ b/docs/features/architecture/drafts.md
@@ -45,10 +45,12 @@ drafts are not.** Everything below is in service of that rule holding under reco
 lost acks, sends, and offline edits.
 
 Concurrency rides on an integer `version` with compare-and-swap, the same primitive
-`scheduled_messages` uses (INV-20). Delivery rides on the outbox (INV-4/7) into the
-author-scoped socket room, and the client reconciles a fresh snapshot on every
-reconnect (INV-53). The feature reuses those three proven subsystems and adds only the
-split behavior on top.
+`scheduled_messages` uses (INV-20) — plus a per-device **write lineage** (the push's
+`writeId` and the superseded `priorWriteIds` before it) that lets the server distinguish
+"my own write whose ack I lost" from "another device wrote": only the latter is drift,
+so only the latter splits. Delivery rides on the outbox (INV-4/7) into the author-scoped
+socket room, and the client reconciles a fresh snapshot on every reconnect (INV-53). The
+feature reuses those proven subsystems and adds only the split behavior on top.
 
 If you only need the mental model, you can stop here.
 
@@ -77,20 +79,34 @@ the device that just sent a draft can recognize its own late echo.
 ### The split-on-drift upsert
 
 The one endpoint that matters is `PUT /drafts/:id`, served by `DraftsService.upsert`
-(`apps/backend/src/features/drafts/service.ts:87`). It runs in a single transaction and
-locks the row by id so concurrent pushes serialize:
+(`apps/backend/src/features/drafts/service.ts`). It runs in a single transaction and
+locks the row by id so concurrent pushes serialize. The decisive question at every
+branch is **"who wrote this row last?"** — answered by the device's _write lineage_:
+the push's `writeId` plus the `priorWriteIds` of its own earlier pushes whose acks were
+never observed (see below).
 
 1. `insertIfAbsent` (`ON CONFLICT (id) DO NOTHING`). A brand-new id lands at version 1.
    Done.
-2. Otherwise lock the existing row. If its `last_client_write_id` equals the incoming
-   `writeId`, this is a lost-ack retry of a write the server already accepted, so it
-   returns the row unchanged (no spurious split).
-3. Otherwise compare-and-swap on `expectedVersion`. A match bumps the version and
-   updates in place: the happy path.
-4. Otherwise (the version drifted, or the original id is a resolved tombstone) it
+2. Otherwise lock the existing row. A **tombstoned** row drops the push (no split, no
+   zombie) when the push is a never-confirmed first insert (`expectedVersion` 0), or
+   when the tombstone's `last_client_write_id` / persisted `superseded_write_ids`
+   intersect the incoming lineage — that content was already sent or discarded, and a
+   late-landing copy of it must not resurrect. Only a lineage the tombstone does not
+   know (another device's unpushed edits) falls through to the split.
+3. Otherwise compare-and-swap: `version = expectedVersion` **or**
+   `last_client_write_id ∈ lineage`. The version match is the happy path; the lineage
+   match is the lost-ack path — the last accepted write was this same device's, no one
+   else wrote in between, so applying the incoming content in place IS "update the one
+   that is live". Both bump the version. The lineage match applies the content rather
+   than acking-and-discarding it, because a retry can carry newer keystrokes than the
+   write whose ack was lost.
+4. Otherwise (genuine drift: another device wrote since, or an unrelated tombstone) it
    **splits**: the existing row is left untouched and the incoming content is inserted
    under a freshly minted `draft_` id at version 1. The response carries
-   `{ split: true, originalId }` so the client migrates its local state to the new id.
+   `{ split: true, originalId }` so the client migrates its local state to the new id,
+   plus `keptDraft` (the untouched row, when live) so the pushing device — which ignored
+   that row's socket echo while it was dirty — can seed the other copy as a stash entry
+   immediately instead of waiting for the next bootstrap.
 
 Every state-changing branch writes a `draft:upserted` outbox row in the same transaction
 (INV-4/7), targeted at the owner's user id. There is no 409 and no merge UI: drift always
@@ -104,18 +120,28 @@ in-memory draft-store cache immediately, then enqueues an `upsert_draft` operati
 offline queue. The queue drains serially under a Web Lock, retries silently with backoff,
 and never surfaces a failure to the user.
 
-Two ideas make the push safe:
+Three ideas make the push safe:
 
 - **The dirty bit is a queued op, not a row flag.** A draft has unpushed edits exactly
   when a pending `upsert_draft` op exists for its id (`hasPendingDraftUpsert`). Read live
   from the op table, it cannot drift out of sync with reality the way a stored flag could.
+  Every write path commits the row **and** its op in one IDB transaction, so there is no
+  instant where an inbound echo could read a just-edited draft as clean and overwrite it.
 - **Content is read fresh at drain, and ops coalesce to one per id.** `executeDraftUpsert`
-  (`apps/frontend/src/sync/draft-sync.ts:548`) re-reads the draft when the op runs and
+  (`apps/frontend/src/sync/draft-sync.ts`) re-reads the draft when the op runs and
   pushes `expectedVersion = baseVersion` (the last server-confirmed version). On a clean
   ack it advances only `baseVersion`, never clobbering content typed since the push; on
   `split: true` it migrates the local id to the server-minted one. Because the queue is
   single-flighted, a user's own rapid sequential edits confirm in order and never
   self-split.
+- **The write lineage survives coalescing.** A queued op that never attempted a push is
+  simply kept — its `writeId` stays stable, so a retry is always recognizable. An op
+  that _did_ attempt (`startedAt`, stamped by the queue before execution) may have
+  reached the server even though the client never saw the ack; replacing it chains its
+  writeId (and its own priors) into the successor's `priorWriteIds`. That chain is what
+  lets the server tell "my own unacked write" from "another device wrote" — without it,
+  typing during a flaky push splits the draft on a single device, which was the root
+  cause of the spurious-duplicate bug this section used to hide.
 
 Inbound events arrive on the `user:{userId}` room and go through `applyDraftUpserted`
 (`draft-sync.ts:395`), which mirrors the server's rule client-side. No local row means
@@ -129,12 +155,13 @@ edits, in which case it preserves them under a new id rather than losing them.
 ### Bootstrap on every reconnect
 
 `SyncEngine.syncDrafts` calls `GET /drafts` and feeds the snapshot through
-`applyDraftsBootstrap` (`draft-sync.ts:491`) on every connect and reconnect (INV-53).
+`applyDraftsBootstrap` (`draft-sync.ts`) on every connect and reconnect (INV-53).
 Each server draft goes through the same drift-aware apply. Locally-confirmed drafts
 absent from the snapshot were resolved or deleted elsewhere and are dropped, _unless_
-they still carry unpushed edits. Never-confirmed local drafts (including any authored
-before sync existed) are queued for their first push. The whole pass is idempotent, so
-re-running it on reconnect is always safe.
+they still carry unpushed edits, or the snapshot is truncated at the shared
+`MAX_DRAFTS_PER_USER` cap (absence then proves nothing). Never-confirmed local drafts
+(including any authored before sync existed) are queued for their first push. The whole
+pass is idempotent, so re-running it on reconnect is always safe.
 
 That is the core. The rest is reference for when you are working on the edges.
 
@@ -188,15 +215,25 @@ edited the draft after this send started, an unconditional delete would destroy 
 work. So the send path calls `resolve`, not `delete`:
 `POST /drafts/:id/resolve` soft-deletes **only if** `version` still matches
 `expectedVersion`, or if the row's `last_client_write_id` is one this send already
-superseded (`DraftsService.resolve`, `service.ts:169`). On unrelated drift the server
-keeps the row and reports `resolved: false`, and the drifted copy survives as a stash
-entry. Explicit discard (stashing away, emptying the composer, deleting from the Drafts
-view) keeps the unconditional `delete`, which is idempotent on an already-gone row.
-Never-confirmed drafts (`baseVersion = 0`) also use `delete`: there is no server version
-to CAS against. To make delete-before-insert ordering safe, `DraftsRepository.softDelete`
-plants a negative tombstone even when the row is absent; a late first upsert
-(`expectedVersion = 0`) that collides with that tombstone is dropped rather than split
-into a live zombie.
+superseded (`DraftsService.resolve`). On unrelated drift the server keeps the row and
+reports `resolved: false`, and the drifted copy survives as a stash entry.
+
+The superseded write ids are **persisted on the tombstone** (`superseded_write_ids`),
+not just checked at resolve time. That covers the nastiest ordering: a push that left
+the device before the send but reaches the server _after_ the tombstone (the client
+aborted the request; the server processed it anyway). Without the persisted set, that
+late write hit "tombstoned + version drift" and split into a live duplicate of content
+the user had already sent — the zombie-draft bug. With it, the upsert path recognizes
+the lineage and drops the write.
+
+Explicit discard (stashing away, emptying the composer, deleting from the Drafts view)
+keeps the unconditional `delete`, which is idempotent on an already-gone row and now
+carries the same `supersededWriteIds` (collected from the upsert ops it cancels) for the
+same reason. Never-confirmed drafts (`baseVersion = 0`) also use `delete`: there is no
+server version to CAS against. To make delete-before-insert ordering safe,
+`DraftsRepository.softDelete` plants a negative tombstone even when the row is absent; a
+late first upsert (`expectedVersion = 0`) that collides with that tombstone is dropped
+rather than split into a live zombie.
 
 ### The resolution guard stops a sent draft from coming back
 
@@ -305,9 +342,11 @@ contiguity / `broadcastSequence` machinery (INV-61) correctly does not apply to 
 ## Entry points
 
 - `apps/backend/src/db/migrations/20260613130739_drafts.sql`: the `drafts` table and its
-  two partial indexes.
-- `apps/backend/src/features/drafts/service.ts`: split-on-drift `upsert`, CAS `resolve`,
-  unconditional `delete`, bootstrap `list`; outbox-in-transaction.
+  two partial indexes; `20260703082208_drafts_superseded_write_ids.sql` adds the
+  tombstone's persisted `superseded_write_ids`.
+- `apps/backend/src/features/drafts/service.ts`: split-on-drift `upsert` (write-lineage
+  aware), CAS `resolve`, unconditional `delete`, bootstrap `list`;
+  outbox-in-transaction.
 - `apps/backend/src/features/drafts/repository.ts`: `insertIfAbsent` / `casUpdate` /
   `softDeleteCas` / `rescopeByScope` / `listByUser`.
 - `apps/frontend/src/sync/draft-sync.ts`: wire-to-local mapping, the coalesced

--- a/docs/features/architecture/drafts.md
+++ b/docs/features/architecture/drafts.md
@@ -88,18 +88,23 @@ never observed (see below).
 1. `insertIfAbsent` (`ON CONFLICT (id) DO NOTHING`). A brand-new id lands at version 1.
    Done.
 2. Otherwise lock the existing row. A **tombstoned** row drops the push (no split, no
-   zombie) when the push is a never-confirmed first insert (`expectedVersion` 0), or
-   when the tombstone's `last_client_write_id` / persisted `superseded_write_ids`
-   intersect the incoming lineage — that content was already sent or discarded, and a
-   late-landing copy of it must not resurrect. Only a lineage the tombstone does not
-   know (another device's unpushed edits) falls through to the split.
-3. Otherwise compare-and-swap: `version = expectedVersion` **or**
-   `last_client_write_id ∈ lineage`. The version match is the happy path; the lineage
-   match is the lost-ack path — the last accepted write was this same device's, no one
-   else wrote in between, so applying the incoming content in place IS "update the one
-   that is live". Both bump the version. The lineage match applies the content rather
-   than acking-and-discarding it, because a retry can carry newer keystrokes than the
-   write whose ack was lost.
+   zombie) only when the tombstone can _prove_ the content was already sent or
+   discarded: an **exact `writeId` retry** of the tombstone's last accepted write (an
+   exact match implies identical content — typing since the attempt would have replaced
+   the op with a fresh writeId), or a lineage intersecting the **persisted**
+   `superseded_write_ids` (the resolving/discarding device asserted those writes were
+   covered by the send/discard). A priors-only match against `last_client_write_id`
+   proves only that a _prefix_ of the lineage landed — the push may carry a newer tail
+   typed after that write — so it falls through to the no-loss split, as does any
+   lineage the tombstone does not know.
+3. Otherwise, for a live row: an exact `writeId` match returns the row unchanged (true
+   idempotency — no version churn, no redundant echo). Else compare-and-swap:
+   `version = expectedVersion` **or** `last_client_write_id ∈ lineage`. The version
+   match is the happy path; the lineage match is the lost-ack path — the last accepted
+   write was this same device's, no one else wrote in between, so applying the incoming
+   content in place IS "update the one that is live". Both bump the version. The
+   lineage match applies the content rather than acking-and-discarding it, because a
+   coalesced successor push carries newer keystrokes than the write whose ack was lost.
 4. Otherwise (genuine drift: another device wrote since, or an unrelated tombstone) it
    **splits**: the existing row is left untouched and the incoming content is inserted
    under a freshly minted `draft_` id at version 1. The response carries
@@ -107,6 +112,10 @@ never observed (see below).
    plus `keptDraft` (the untouched row, when live) so the pushing device — which ignored
    that row's socket echo while it was dirty — can seed the other copy as a stash entry
    immediately instead of waiting for the next bootstrap.
+
+A resolve or delete that arrives after the row is already tombstoned still **merges**
+its `supersededWriteIds` onto the tombstone (`mergeTombstoneSupersededWriteIds`), so
+the second device's own late-landing push is recognized too.
 
 Every state-changing branch writes a `draft:upserted` outbox row in the same transaction
 (INV-4/7), targeted at the owner's user id. There is no 409 and no merge UI: drift always
@@ -232,8 +241,10 @@ carries the same `supersededWriteIds` (collected from the upsert ops it cancels)
 same reason. Never-confirmed drafts (`baseVersion = 0`) also use `delete`: there is no
 server version to CAS against. To make delete-before-insert ordering safe,
 `DraftsRepository.softDelete` plants a negative tombstone even when the row is absent; a
-late first upsert (`expectedVersion = 0`) that collides with that tombstone is dropped
-rather than split into a live zombie.
+late first upsert that collides with that tombstone is dropped when its writeId is in
+the tombstone's persisted lineage (the delete collected it from the ops it canceled) —
+and preserved via the split when it isn't, because an unproven drop could destroy a
+tail typed after a lost first ack.
 
 ### The resolution guard stops a sent draft from coming back
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1999,6 +1999,15 @@ export interface UpsertDraftInput {
   rootStreamId?: string | null
   expectedVersion: number
   writeId: string
+  /**
+   * Write ids of this device's earlier pushes for this draft that were
+   * superseded before their ack was observed (a coalesced save replaced a push
+   * that had already been attempted). If the server row's
+   * `last_client_write_id` is any of these, the last accepted write was this
+   * device's own — no other device has written since — so the server updates in
+   * place instead of splitting a lost ack into a duplicate draft.
+   */
+  priorWriteIds?: string[]
   clientUpdatedAt: string
   contentJson?: JSONContent | null
   attachmentIds?: string[]
@@ -2014,11 +2023,15 @@ export interface UpsertDraftInput {
  * drift: `draft.id` is a freshly minted entity carrying the incoming content,
  * `originalId` is the id the client pushed under (whose row was left untouched
  * for the other device), and the client migrates its local state to `draft.id`.
+ * `keptDraft` is that untouched row when it is still live: the pushing device
+ * ignored its socket echo while dirty, so the response carries it and the
+ * client seeds it as a stash entry instead of waiting for the next bootstrap.
  */
 export interface UpsertDraftResponse {
   draft: Draft
   split: boolean
   originalId?: string
+  keptDraft?: Draft
 }
 
 /**
@@ -2041,6 +2054,25 @@ export interface ResolveDraftResponse {
   /** False when the version no longer matched — the draft drifted and was kept. */
   resolved: boolean
 }
+
+/**
+ * Optional wire body for `DELETE /drafts/:id` (explicit discard). Like resolve,
+ * a discard can race this device's own in-flight upsert: a push that left the
+ * client but lands after the tombstone must be dropped, not split into a live
+ * zombie of the discarded content. The tombstone remembers these write ids so
+ * the late write is recognized as superseded.
+ */
+export interface DeleteDraftInput {
+  supersededWriteIds?: string[]
+}
+
+/**
+ * Defensive cap on the drafts bootstrap read (`GET /drafts`). Shared so the
+ * client can tell a complete snapshot from a truncated one: when the snapshot
+ * hits the cap, absence from it no longer proves a local draft was deleted
+ * elsewhere, so the bootstrap sweep must not drop local rows.
+ */
+export const MAX_DRAFTS_PER_USER = 500
 
 export interface DraftListResponse {
   drafts: Draft[]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -516,6 +516,7 @@ export type {
   UpsertDraftResponse,
   ResolveDraftInput,
   ResolveDraftResponse,
+  DeleteDraftInput,
   DraftListResponse,
   DraftUpsertedPayload,
   DraftDeletedPayload,
@@ -565,7 +566,8 @@ export { DEVICE_KEY_LENGTH } from "./api"
 export { CommandKinds, CommandScopes } from "./api"
 
 // Draft scope builders (single source of truth for the scope string format)
-export { draftStreamScope, draftThreadScope } from "./api"
+// and the shared bootstrap cap (the client must know when a snapshot is truncated)
+export { draftStreamScope, draftThreadScope, MAX_DRAFTS_PER_USER } from "./api"
 
 // Discuss-with-Ariadne client-action id (single source of truth)
 export const DISCUSS_WITH_ARIADNE_COMMAND = "discuss-with-ariadne" as const


### PR DESCRIPTION
## Problem

The centralized draft system (`docs/features/architecture/drafts.md`) promises "local wins, split on drift, never overwrite" — but the version accounting decided *update vs. split* by asking "did the version move?" when the correct question is **"who wrote this row last?"**. That gap produced user-visible failures on a *single* device, no cross-device drift involved:

1. **Same-device spurious splits.** `enqueueDraftUpsert` coalesced by deleting the pending op — including one currently in flight — and minting a fresh `writeId` per save. A push that committed server-side with a lost ack (mobile network flake, backgrounded tab) left `last_client_write_id` holding the old id; the successor push then CAS'd a stale `expectedVersion` with a writeId the server had never seen → split. Typing through one flaky push was enough to duplicate a draft.
2. **Zombie drafts of already-sent content.** `supersededWriteIds` were only *checked* at resolve time, never persisted. A push that left the device before the send but reached the server after the tombstone (client-aborted request the server still processed; or retry ordering inversion via the op queue's `skipped` set) hit "tombstoned + version drift" and split into a live duplicate of the sent message. Client-side cleanup only worked while the resolve op was still queued — past that, the zombie seeded every device as a mystery stash draft. Explicit discards had no superseded tracking at all.
3. **Silent divergence → real loss.** The lost-ack branch returned the row *unchanged*. A coalesced successor push carries newer content than the write whose ack was lost (`executeDraftUpsert` re-reads at drain), so the server acked-and-discarded those keystrokes: local ended up "confirmed + clean" holding content the server didn't have. A later edit from another device (`version > baseVersion`, no pending op) then cleanly **overwrote** it — violating the cardinal no-loss rule.
4. **Composer save races.** `upsertLoadedDraft` resolved the target id and `baseVersion` *outside* its write transaction. A split-ack id migration landing in between resurrected the pre-split id as a duplicate row (which re-pushed, re-split, and bred copies) and reverted the composer's visible content; a push ack landing in between got its `baseVersion` clobbered, making the next push CAS stale → another split. The op-enqueue also lived outside the row-write transaction, so an inbound echo in the gap read the device as clean and overwrote just-typed content (unrecoverable for E2E drafts, which have no staging buffer).

## Solution

Make the device's **write lineage** — the push's `writeId` plus the superseded `priorWriteIds` before it — the thing the protocol reasons about, so the server can distinguish "my own write whose ack I lost" (update in place) from "another device wrote" (split), and so tombstones remember which writes a send/discard superseded (drop the proven-late copy, split the unproven one).

### How it works

**Backend (`apps/backend/src/features/drafts/`):**

1. `casUpdate` predicate becomes `deleted_at IS NULL AND (version = expectedVersion OR last_client_write_id = ANY(ownWriteIds))` where `ownWriteIds = [writeId, ...priorWriteIds]`. `last_client_write_id` names the last accepted writer; if that's this device's own unacked lineage, nobody else wrote since, so applying the incoming content in place *is* "update the one that is live". Version still bumps; content is **applied**, not acked-and-discarded (fixes defect 3). An *exact* `writeId` match short-circuits and returns the row unchanged — true idempotency with no version churn, safe because an exact match implies identical content (any typing since the attempt replaces the op with a fresh writeId).
2. Migration `20260703082208_drafts_superseded_write_ids.sql` adds `superseded_write_ids JSONB`. `softDeleteCas` (resolve-on-send) and `softDelete` (discard, incl. the negative tombstone) persist the superseded set; a resolve/delete that finds the row *already* tombstoned merges its lineage in (`mergeTombstoneSupersededWriteIds`, FOR UPDATE + dedupe, capped at 128) so the second device's late push is covered too. The upsert's tombstone branch drops a push only on **proof**: an exact `writeId` retry of the tombstone's last accepted write, or lineage ∩ the *persisted* superseded set (fixes defect 2). Anything unproven — including a priors-only match against `last_client_write_id`, which shows only that a *prefix* of the lineage landed — falls through to the no-loss split.
3. The split response gains `keptDraft` (the untouched live row): the pushing device ignored that row's socket echo while dirty, so it now seeds the other copy immediately instead of waiting for the next bootstrap — routed through `applyDraftUpserted` so every suppression guard still applies.
4. `PUT /drafts/:id` accepts `priorWriteIds`; `DELETE /drafts/:id` accepts an optional `{ supersededWriteIds }` body (Zod: max 64 ids, 128 chars each).

**Frontend (`apps/frontend/src/sync/`, `hooks/use-draft-message.ts`):**

5. The op queue stamps `startedAt` on an op right before its first execution attempt (`operation-queue.ts`). `enqueueDraftUpsert` now *keeps* a never-attempted op untouched — content is read fresh at drain anyway, and its `writeId` (the idempotency key) stays stable. Only an attempted op — one that may have reached the wire — is replaced, with its writeId (and its own priors) chained into the successor's `priorWriteIds` (fixes defect 1). Offline typing therefore never grows the chain; it grows one link per actual network attempt, capped at 64. Write ids use `crypto.randomUUID()` (they now gate in-place overwrites, so collision must be out of the question).
6. `enqueueDraftResolve` and `enqueueDraftDelete` collect the full lineage of the ops they supersede (writeIds + priors, merged with any replaced op's list). Inbound split echoes carrying a lineage id are routed by kind: resolve-superseded → CAS-resolve (sent content), delete-superseded → unconditional delete (discarded content) — previously the discard case was accepted as a stash zombie.
7. `upsertLoadedDraft` re-validates the composer pointer and re-reads `baseVersion` **inside** one Dexie transaction spanning `drafts + composerLoaded + pendingOperations`, retrying (three attempts) when the identity moved mid-save — a save racing a split-ack migration now lands on the migrated row instead of resurrecting the old id. The push enqueue commits atomically with the row write, closing the clean-window echo overwrite (fixes defect 4). The E2E seal stays outside the transaction (async crypto can't live in a Dexie txn); the AAD-bound id is what the txn re-validates, and a conflict re-seals on retry.
8. Teardown paths (`removeLoadedDraftLocally`, `purgeScopeDrafts`, `purgePlaintextScopeDrafts`, `deleteDraftById`, `rescopeScopeDrafts`) and `applyDraftDeleted`'s preserve branch run their read–mutate–enqueue sequence in one transaction — no instant exists where a row is gone (or clean) with no queued op to suppress an echo.
9. `migrateLocalDraftId` re-reads the live source row inside its transaction, so keystrokes committed while the split push was in flight survive the id swap (only `id`/`baseVersion` come from the caller); `rescopeScopeDrafts` re-reads per row for the same reason.
10. `applyDraftsBootstrap` skips the absent-local delete sweep when the snapshot length hits the shared `MAX_DRAFTS_PER_USER` (500, now exported from `@threa/types`) — a truncated snapshot proves nothing about rows beyond the cap.

### Key design decisions

**1. Lineage on the write path, not content diffing.** The alternative for defect 1 was content-equality dedupe on CAS failure (treat an identical-content push as an ack). Rejected as the primary fix: it never converges for E2E drafts (every re-seal produces fresh ciphertext) and it papers over divergence instead of preventing it. `last_client_write_id ∈ ownWriteIds` is exact: it is true iff the last accepted write came from this device's unacked chain, which is precisely the safe-to-overwrite condition.

**2. Tombstone drops require proof; the default is split.** The persisted superseded set is an assertion by the resolving/discarding device that those writes' content was covered by the send/discard. Anything short of that — including the tombstone's own `last_client_write_id` matching a *prior* id in the incoming lineage — only proves a prefix landed, and the push may carry a tail typed after it. Worst case of splitting is a duplicate; worst case of dropping is destroyed content. Per the feature's cardinal rule, the tie always breaks toward split. (This also removed the old unconditional `expectedVersion = 0` tombstone drop: the discard's collected lineage now covers its legitimate case with proof.)

**3. Keep-if-unattempted instead of always-replace in the coalescer.** Always-replacing with chained priors would work but grows the chain unboundedly while offline (one link per debounced save). An op that never started cannot have reached the server, so keeping it (stable writeId) is both simpler and correct; `startedAt` is stamped by the queue *before* execution, so every interleaving of stamp/save/drain converges (traced in review: the save either lands in the kept op's fresh drain read, or chains the lineage).

**4. Splits still exist — deliberately.** Genuine cross-device drift (two devices editing offline, a tombstone with an unproven lineage) still splits, per the feature's rule that duplicates are acceptable and loss is not. This PR removes the *spurious* splits (same-device lost-ack, sent/discarded zombies), not the mechanism. Thread-conversion re-scoping of a dirty draft also still splits — that is the documented, intended behavior (`rescopeByScope` doc comment), not a regression.

### Design evolution (self-review)

The first version of the tombstone branch counted the tombstone's `last_client_write_id` itself as superseded. A pre-PR reviewer agent constructed the loss case: device A's push W1 lands with a lost ack, A types a tail offline (successor op carries `priorWriteIds: [W1]`), device B sends the draft (version CAS, empty superseded list) — the tombstone's last accepted write is W1, so A's reconnect push matched on the prefix and was **dropped, destroying the tail B never saw**. Fixed in the second commit: the drop now requires an exact `writeId` retry or a persisted-set intersection, and the priors-only match splits. The same review pass motivated the already-tombstoned lineage merge and the removal of the unconditional version-0 drop (same prefix-vs-proof reasoning).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260703082208_drafts_superseded_write_ids.sql` | `superseded_write_ids JSONB` on `drafts` tombstones (append-only, INV-17) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts`, `index.ts` | `priorWriteIds` on `UpsertDraftInput`, `keptDraft` on `UpsertDraftResponse`, new `DeleteDraftInput`, shared `MAX_DRAFTS_PER_USER` |
| `apps/backend/src/features/drafts/repository.ts` | Lineage CAS predicate; tombstones persist `superseded_write_ids`; `mergeTombstoneSupersededWriteIds`; `softDelete` takes the superseded set |
| `apps/backend/src/features/drafts/service.ts` | Decision tree: exact-retry idempotency, proof-gated tombstone drop, lineage CAS, tombstone lineage merge on declined resolve/delete, `keptDraft` on split |
| `apps/backend/src/features/drafts/handlers.ts` | Zod: `priorWriteIds`, optional DELETE body, write-id length caps |
| `apps/frontend/src/sync/draft-sync.ts` | Keep-vs-chain coalescer, lineage collection on resolve/delete, kind-routed lineage echoes, `keptDraft` seeding, in-txn migrate re-read, atomic `deleteDraftById` / `applyDraftDeleted`, truncation guard, UUID write ids |
| `apps/frontend/src/sync/operation-queue.ts` | `startedAt` stamp before execution; threads `priorWriteIds` / `supersededWriteIds` into the executors |
| `apps/frontend/src/hooks/use-draft-message.ts` | Transactional `upsertLoadedDraft` with in-txn revalidation + retry; teardown paths enqueue in-txn; rescope re-reads live rows |
| `apps/frontend/src/db/database.ts` | `PendingOperation.startedAt` (no index → no Dexie version bump) |
| `apps/frontend/src/api/drafts.ts` | DELETE carries the superseded body |
| `docs/features/architecture/drafts.md` | Protocol doc rewritten around the write lineage, proof-gated tombstone drops, `keptDraft`, truncation guard |
| `*.test.ts` (backend service/repository, frontend draft-sync, use-draft-message) | Coverage for every new branch; regression tests for each race class, including the reviewer-found loss sequence |

## Out of scope (deliberate)

- **Tombstone GC** — unchanged; `superseded_write_ids` rides on rows that were already retained post-v1.
- **Conflict/merge UI** — the duplicate-then-let-the-user-pick model stands; this PR only removes duplicates that never represented real divergence.
- **Residual duplicate windows** (documented, accepted): a remote *delete* racing this device's in-flight push whose ack is lost, and a thread-conversion re-scope of a dirty draft, can each still produce one content-preserving duplicate. Duplicates on genuine cross-device races are within the feature's contract; loss is not, and no traced interleaving loses content.

## Test plan

- [x] Backend `bun test src/features/drafts/` — 27 pass (lineage CAS, exact-retry idempotency, proof-gated tombstone drops incl. the prefix-match loss regression, superseded persistence + merge, `keptDraft`)
- [x] Backend full unit suite (`bun run test:unit`) — 2233 pass
- [x] Frontend draft/sync sweep (17 files: `src/sync/` + draft hooks) — 417 pass, incl. new regressions: stable writeId on keep, lineage chain on replace, mid-push keystroke survival, `keptDraft` seed + suppression + executing-op case, discard-lineage zombie suppression (socket + bootstrap), save-vs-split-migration retarget, mid-save baseVersion ack preserved, truncated-snapshot sweep guard
- [x] Frontend full suite — 3470 pass
- [x] `tsc --noEmit` clean across types / backend / frontend; pre-commit hooks ran the full monorepo lint + typecheck + migration checks + OpenAPI drift check on both commits
- [ ] Backend e2e (`bun run test:e2e`) — not run: no docker/postgres in this session's environment; the new SQL is exercised via the stubbed-querier repository tests like its siblings, and the migration is a single idempotent `ADD COLUMN IF NOT EXISTS`
- [x] Pre-PR review (2 reviewer agents: backend protocol soundness, frontend Dexie/race correctness) — 1 critical fixed (tombstone prefix-match loss, see Design evolution), 1 major fixed (unconditional version-0 tombstone drop), 5 minor fixed (tombstone lineage merge, suppressed `keptDraft` seed, discard-lineage zombies, rescope stale re-read, `applyDraftDeleted` atomicity), 2 nits fixed (writeId entropy, Zod length caps), 2 declined as intended behavior (dirty-draft split on thread re-scope, per the documented design) or pre-existing-benign (`startedAt` on never-sent ops)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2tyxA2W98kfTDDHgXT9kV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663202&installation_id=129946197&pr_number=1149&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1149&signature=883b4b626362a9a95bd21ad4eaa6f753dbc482a80410b77da7d9f38b2938ed2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->