### PR TITLE
feat(harness-daemon): attached-session targeting, stable window ids, session-scoped MCP wiring

### DIFF
--- a/extensions/harness-daemon/bun.lock
+++ b/extensions/harness-daemon/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@threa/harness-daemon",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/extensions/harness-daemon/src/commands.ts
+++ b/extensions/harness-daemon/src/commands.ts
@@ -4,8 +4,8 @@ import { die } from "./errors"
 import { findAgent, inventoryPath, readInventory, upsertAgent } from "./inventory"
 import { commandExists, commandPath, output } from "./shell"
 import { ClaudeRuntimeSpawner, PiRuntimeSpawner } from "./spawners"
-import { sendKeys } from "./tmux"
-import type { SpawnOptions } from "./types"
+import { attachedTmuxSession, sendKeys } from "./tmux"
+import type { ManagedAgent, SpawnOptions } from "./types"
 
 function spawnCommand(options: SpawnOptions): string[] {
   const command = ["threa-harnessd", "spawn", options.runtime, "--name", options.name]
@@ -47,6 +47,7 @@ export async function spawnAgent(options: SpawnOptions): Promise<void> {
       branch: result.branch,
       tmuxSession: result.tmuxSession,
       tmuxWindow: result.tmuxWindow,
+      tmuxWindowId: result.tmuxWindowId,
       scratchpadUrl: result.scratchpadUrl,
       status: "online",
       updatedAt: now(),
@@ -74,54 +75,54 @@ export function listAgents(): void {
 
 export function stopAgent(ref: string): void {
   const agent = findAgent(ref)
-  if (!agent.tmuxSession || !agent.tmuxWindow) die(`${agent.name} has no tmux target recorded`)
-  const target = `${agent.tmuxSession}:${agent.tmuxWindow}`
+  const target = tmuxTarget(agent)
   const result = output(["tmux", "kill-window", "-t", target], { allowFailure: true })
   if (result.exitCode !== 0) die(result.stderr.trim() || `tmux kill-window failed for ${target}`)
   upsertAgent({ ...agent, status: "stopped", updatedAt: now() })
   console.log(`harnessd: stopped ${agent.name} (${target})`)
 }
 
-function tmuxTarget(ref: string): { session: string; window: string } {
-  const agent = findAgent(ref)
-  if (!agent.tmuxSession || !agent.tmuxWindow) die(`${agent.name} has no tmux target recorded`)
-  return { session: agent.tmuxSession, window: agent.tmuxWindow }
+/** Window id when recorded (durable across renames/collisions), else the legacy session:name target. */
+function tmuxTarget(agent: ManagedAgent): string {
+  if (agent.tmuxWindowId) return agent.tmuxWindowId
+  if (agent.tmuxSession && agent.tmuxWindow) return `${agent.tmuxSession}:${agent.tmuxWindow}`
+  return die(`${agent.name} has no tmux target recorded`)
 }
 
 /** Send Esc to interrupt the agent's current turn (Claude Code / Pi) without killing the window. */
 export function interruptAgent(ref: string): void {
-  const { session, window } = tmuxTarget(ref)
-  sendKeys(session, window, ["Escape"])
-  console.log(`harnessd: interrupted ${session}:${window}`)
+  const target = tmuxTarget(findAgent(ref))
+  sendKeys(target, ["Escape"])
+  console.log(`harnessd: interrupted ${target}`)
 }
 
 /** Interrupt the current turn, then (if given) type a follow-up and submit it. */
 export function steerAgent(ref: string, text: string): void {
-  const { session, window } = tmuxTarget(ref)
-  sendKeys(session, window, ["Escape"])
+  const target = tmuxTarget(findAgent(ref))
+  sendKeys(target, ["Escape"])
   if (text) {
     // Esc restores the interrupted message into the input box; clear it (Ctrl-U)
     // before typing so the follow-up doesn't concatenate with that residue and
     // submit as a plain prompt.
-    sendKeys(session, window, ["C-u"])
-    sendKeys(session, window, ["-l", text])
-    sendKeys(session, window, ["Enter"])
+    sendKeys(target, ["C-u"])
+    sendKeys(target, ["-l", text])
+    sendKeys(target, ["Enter"])
   }
-  console.log(`harnessd: steered ${session}:${window}`)
+  console.log(`harnessd: steered ${target}`)
 }
 
 /** Raw `tmux send-keys` passthrough to the agent's window (tokens follow tmux rules). */
 export function sendKeysToAgent(ref: string, keys: string[]): void {
   if (keys.length === 0) die("keys requires at least one key or token")
-  const { session, window } = tmuxTarget(ref)
-  sendKeys(session, window, keys)
-  console.log(`harnessd: sent keys to ${session}:${window}`)
+  const target = tmuxTarget(findAgent(ref))
+  sendKeys(target, keys)
+  console.log(`harnessd: sent keys to ${target}`)
 }
 
 export function attachAgent(ref: string): void {
   const agent = findAgent(ref)
-  if (!agent.tmuxSession || !agent.tmuxWindow) die(`${agent.name} has no tmux target recorded`)
-  const target = `${agent.tmuxSession}:${agent.tmuxWindow}`
+  if (!agent.tmuxSession) die(`${agent.name} has no tmux session recorded`)
+  const target = tmuxTarget(agent)
   if (process.env.TMUX) {
     const result = Bun.spawnSync(["tmux", "switch-client", "-t", target], { stdout: "inherit", stderr: "pipe" })
     if (result.exitCode !== 0) die(result.stderr.toString().trim() || `tmux switch-client failed for ${target}`)
@@ -148,9 +149,16 @@ export function doctor(): void {
     ["pi", Boolean(process.env.THREA_HARNESSD_PI_BIN || commandPath("pi")), "needed for Pi agents"],
     ["claude", Boolean(process.env.THREA_HARNESSD_CLAUDE_BIN || commandPath("claude")), "needed for Claude agents"],
     [
-      "tmux session 0",
+      "tmux attached session",
+      Boolean(attachedTmuxSession()),
+      attachedTmuxSession()
+        ? `windows spawn into '${attachedTmuxSession()}'`
+        : "no attached session; falls back to session '0'",
+    ],
+    [
+      "tmux session 0 (fallback)",
       output(["tmux", "has-session", "-t", "0"], { allowFailure: true }).exitCode === 0,
-      "default target",
+      "used when nothing is attached",
     ],
   ]
   for (const [name, ok, note] of checks) {

--- a/extensions/harness-daemon/src/inventory.ts
+++ b/extensions/harness-daemon/src/inventory.ts
@@ -16,6 +16,7 @@ interface ManagedAgentRow {
   branch: string | null
   tmux_session: string | null
   tmux_window: string | null
+  tmux_window_id: string | null
   scratchpad_url: string | null
   command_json: string
   created_at: string
@@ -48,6 +49,12 @@ function openInventory(): Database {
       last_output TEXT
     )
   `)
+  // Inventories predating the window-id column: CREATE TABLE IF NOT EXISTS
+  // won't extend an existing table, so add the column in place.
+  const columns = db.query("PRAGMA table_info(managed_agents)").all() as Array<{ name: string }>
+  if (!columns.some((column) => column.name === "tmux_window_id")) {
+    db.exec("ALTER TABLE managed_agents ADD COLUMN tmux_window_id TEXT")
+  }
   return db
 }
 
@@ -61,6 +68,7 @@ function rowToAgent(row: ManagedAgentRow): ManagedAgent {
     branch: row.branch ?? undefined,
     tmuxSession: row.tmux_session ?? undefined,
     tmuxWindow: row.tmux_window ?? undefined,
+    tmuxWindowId: row.tmux_window_id ?? undefined,
     scratchpadUrl: row.scratchpad_url ?? undefined,
     command: JSON.parse(row.command_json) as string[],
     createdAt: row.created_at,
@@ -86,8 +94,8 @@ export function upsertAgent(agent: ManagedAgent): void {
       `
       INSERT INTO managed_agents (
         id, name, runtime, status, worktree, branch, tmux_session, tmux_window,
-        scratchpad_url, command_json, created_at, updated_at, last_output
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        tmux_window_id, scratchpad_url, command_json, created_at, updated_at, last_output
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         runtime = excluded.runtime,
@@ -96,6 +104,7 @@ export function upsertAgent(agent: ManagedAgent): void {
         branch = excluded.branch,
         tmux_session = excluded.tmux_session,
         tmux_window = excluded.tmux_window,
+        tmux_window_id = excluded.tmux_window_id,
         scratchpad_url = excluded.scratchpad_url,
         command_json = excluded.command_json,
         updated_at = excluded.updated_at,
@@ -110,6 +119,7 @@ export function upsertAgent(agent: ManagedAgent): void {
       agent.branch ?? null,
       agent.tmuxSession ?? null,
       agent.tmuxWindow ?? null,
+      agent.tmuxWindowId ?? null,
       agent.scratchpadUrl ?? null,
       JSON.stringify(agent.command),
       agent.createdAt,

--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -1,10 +1,10 @@
 import { createHash } from "node:crypto"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir, hostname } from "node:os"
 import { basename, join } from "node:path"
 import { die } from "./errors"
 import { commandExists, commandPath, run, shellQuote } from "./shell"
-import { capturePane, ensureTmuxSession, pickTmuxWindow, tmuxSession } from "./tmux"
+import { capturePane, createWindow, ensureTmuxSession, pickTmuxWindow, sendKeys, tmuxSession } from "./tmux"
 import type { SpawnOptions, SpawnResult, ThreaChannelConfig } from "./types"
 import { ensureWorktree } from "./worktree"
 
@@ -32,26 +32,34 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
     ensureTmuxSession(session)
     const { worktree, branch } = this.createWorktree(options)
     const window = pickTmuxWindow(session, options.name)
-    console.log(`harnessd: launching Pi in tmux ${session}:${window}`)
-    run(["tmux", "new-window", "-t", session, "-a", "-n", window, "-c", worktree, piBin])
+    const windowId = createWindow(session, window, worktree, piBin)
+    console.log(`harnessd: launched Pi in tmux ${session}:${window} (${windowId})`)
 
     if (!options.noRemote) {
       await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_BOOT_WAIT_MS ?? 8000))
-      run(["tmux", "send-keys", "-t", `${session}:${window}`, "/remote-control", "Enter"])
+      sendKeys(windowId, ["/remote-control", "Enter"])
       await Bun.sleep(Number(process.env.THREA_HARNESSD_PI_REMOTE_WAIT_MS ?? 6000))
     }
 
-    const outputText = capturePane(session, window)
+    const outputText = capturePane(windowId)
     return {
       worktree,
       branch,
       tmuxSession: session,
       tmuxWindow: window,
+      tmuxWindowId: windowId,
       scratchpadUrl: firstScratchpadUrl(outputText),
       output: outputText,
     }
   }
 }
+
+// Boot dialogs (trust prompt, MCP-server approval, update notices) all end
+// with an "Enter to confirm/continue" hint; the composer's input line is a
+// bare "❯" only once boot has settled (during a dialog that line carries the
+// highlighted option, e.g. "❯ 1. Use this MCP server").
+const BOOT_DIALOG_RE = /Enter to confirm|Enter to continue/
+const IDLE_PROMPT_RE = /^❯\s*$/m
 
 export class ClaudeRuntimeSpawner extends RuntimeSpawner {
   async spawn(options: SpawnOptions): Promise<SpawnResult> {
@@ -75,39 +83,75 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     const scratchpadUrl = await this.prelinkScratchpad(worktree)
     if (scratchpadUrl) console.log(`harnessd: scratchpad: ${scratchpadUrl}`)
 
+    const args = [claudeBin, "--name", `threa.${options.name}`]
     if (!options.noRegister) {
-      console.log(`harnessd: registering Claude MCP server '${channel}'`)
-      run([claudeBin, "mcp", "remove", channel, "--scope", "local"], { cwd: worktree, allowFailure: true })
-      run([claudeBin, "mcp", "add", channel, "--scope", "local", "--", "bun", channelEntry], { cwd: worktree })
+      args.push(
+        "--mcp-config",
+        this.writeMcpConfig(options.name, channel, channelEntry),
+        "--dangerously-load-development-channels",
+        `server:${channel}`
+      )
     }
+    if (!options.noYolo) args.push("--dangerously-skip-permissions")
 
     const window = pickTmuxWindow(session, options.name)
-    const args = [
-      claudeBin,
-      "--name",
-      `threa.${options.name}`,
-      "--dangerously-load-development-channels",
-      `server:${channel}`,
-    ]
-    if (!options.noYolo) args.push("--dangerously-skip-permissions")
-    console.log(`harnessd: launching Claude Code in tmux ${session}:${window}`)
-    run(["tmux", "new-window", "-t", session, "-a", "-n", window, "-c", worktree, args.map(shellQuote).join(" ")])
+    const windowId = createWindow(session, window, worktree, args.map(shellQuote).join(" "))
+    console.log(`harnessd: launched Claude Code in tmux ${session}:${window} (${windowId})`)
 
-    if (!options.noAutoAccept) {
-      await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 5000))
-      run(["tmux", "send-keys", "-t", `${session}:${window}`, "Enter"])
-      await Bun.sleep(Number(process.env.THREA_HARNESSD_CLAUDE_ACCEPT_WAIT_MS ?? 6000))
-    }
+    if (!options.noAutoAccept) await this.acceptBootPrompts(windowId)
 
-    const outputText = capturePane(session, window)
+    const outputText = capturePane(windowId)
     return {
       worktree,
       branch,
       tmuxSession: session,
       tmuxWindow: window,
+      tmuxWindowId: windowId,
       scratchpadUrl: scratchpadUrl ?? firstScratchpadUrl(outputText),
       output: outputText,
     }
+  }
+
+  /**
+   * Session-scoped MCP wiring via `--mcp-config` instead of `claude mcp add
+   * --scope local`: Claude Code resolves every worktree of a repo to the same
+   * project entry, so a persisted local-scope registration from worktree A
+   * silently repoints worktree B's channel at A's code the next time B starts
+   * (and stacks a duplicate channel on top of a user-scope registration). A
+   * config file passed at launch binds this session to this worktree's channel
+   * and leaves global config untouched.
+   */
+  private writeMcpConfig(name: string, channel: string, channelEntry: string): string {
+    const dir = join(homedir(), ".threa", "harnessd", "mcp")
+    mkdirSync(dir, { recursive: true })
+    const path = join(dir, `${name}.json`)
+    writeFileSync(
+      path,
+      JSON.stringify({ mcpServers: { [channel]: { type: "stdio", command: "bun", args: [channelEntry] } } }, null, 2)
+    )
+    return path
+  }
+
+  /**
+   * Walk Claude Code through its boot dialogs by pressing Enter until the
+   * composer prompt is idle. Polling capture-pane beats fixed sleeps: a fast
+   * boot isn't held for the full wait and a slow one isn't abandoned with a
+   * dialog still open (which left the channel half-wired often enough that the
+   * old two-blind-Enters approach needed constant retuning).
+   */
+  private async acceptBootPrompts(windowId: string): Promise<void> {
+    const deadline = Date.now() + Number(process.env.THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS ?? 45_000)
+    while (Date.now() < deadline) {
+      const text = capturePane(windowId)
+      if (BOOT_DIALOG_RE.test(text)) {
+        sendKeys(windowId, ["Enter"])
+        await Bun.sleep(1000)
+        continue
+      }
+      if (IDLE_PROMPT_RE.test(text)) return
+      await Bun.sleep(500)
+    }
+    console.warn("harnessd: Claude Code boot did not settle before the wait deadline; continuing")
   }
 
   private async prelinkScratchpad(worktree: string): Promise<string | undefined> {

--- a/extensions/harness-daemon/src/tmux.ts
+++ b/extensions/harness-daemon/src/tmux.ts
@@ -2,8 +2,30 @@ import { die } from "./errors"
 import { output, run } from "./shell"
 import type { SpawnOptions } from "./types"
 
+/**
+ * The tmux session the user is actually looking at: the enclosing session when
+ * running inside tmux, otherwise the first session with an attached client.
+ * Spawned agent windows land where the user will see them instead of in a
+ * hardcoded background session.
+ */
+export function attachedTmuxSession(): string | undefined {
+  if (process.env.TMUX) {
+    const result = output(["tmux", "display-message", "-p", "#{session_name}"], { allowFailure: true })
+    const name = result.stdout.trim()
+    if (result.exitCode === 0 && name) return name
+  }
+  const sessions = output(["tmux", "list-sessions", "-F", "#{session_attached} #{session_name}"], {
+    allowFailure: true,
+  })
+  for (const line of sessions.stdout.split("\n")) {
+    const match = line.match(/^([1-9]\d*) (.+)$/)
+    if (match) return match[2]
+  }
+  return undefined
+}
+
 export function tmuxSession(options: SpawnOptions): string {
-  return options.tmux ?? "0"
+  return options.tmux ?? attachedTmuxSession() ?? "0"
 }
 
 export function ensureTmuxSession(session: string): void {
@@ -16,16 +38,49 @@ export function pickTmuxWindow(session: string, name: string): string {
     .stdout.split("\n")
     .filter(Boolean)
   if (!existing.includes(name)) return name
+  for (let i = 2; i < 100; i++) {
+    const candidate = `${name}-${i}`
+    if (!existing.includes(candidate)) return candidate
+  }
   return `${name}-${Math.floor(Math.random() * 10000)}`
 }
 
-export function capturePane(session: string, window: string, lines = 30): string {
-  return output(["tmux", "capture-pane", "-t", `${session}:${window}`, "-p", "-S", `-${lines}`], {
+/**
+ * Create a window at the session's first free index (the `session:` target —
+ * no `-a`, which inserts relative to the *current* window and fails when the
+ * next index is taken) and return its window id. The id is the durable handle
+ * for steer/keys/stop: names can collide or be renamed, `@n` ids cannot.
+ * Detached (`-d`) so spawning into the user's attached session never yanks
+ * focus away from what they're doing.
+ */
+export function createWindow(session: string, name: string, cwd: string, command: string): string {
+  const result = output([
+    "tmux",
+    "new-window",
+    "-d",
+    "-P",
+    "-F",
+    "#{window_id}",
+    "-t",
+    `${session}:`,
+    "-n",
+    name,
+    "-c",
+    cwd,
+    command,
+  ])
+  const windowId = result.stdout.trim()
+  if (!windowId) die("tmux new-window did not return a window id")
+  return windowId
+}
+
+export function capturePane(target: string, lines = 30): string {
+  return output(["tmux", "capture-pane", "-t", target, "-p", "-S", `-${lines}`], {
     allowFailure: true,
   }).stdout
 }
 
-/** Send keys/tokens to a window's active program. `tmux send-keys` token rules apply (`Escape`, `Enter`, `-l` for literal text). */
-export function sendKeys(session: string, window: string, keys: string[]): void {
-  run(["tmux", "send-keys", "-t", `${session}:${window}`, ...keys])
+/** Send keys/tokens to a target's active program. `tmux send-keys` token rules apply (`Escape`, `Enter`, `-l` for literal text). */
+export function sendKeys(target: string, keys: string[]): void {
+  run(["tmux", "send-keys", "-t", target, ...keys])
 }

--- a/extensions/harness-daemon/src/types.ts
+++ b/extensions/harness-daemon/src/types.ts
@@ -10,6 +10,8 @@ export interface ManagedAgent {
   branch?: string
   tmuxSession?: string
   tmuxWindow?: string
+  /** Stable tmux window id (`@n`) — the durable target for steer/keys/stop; names can collide or be renamed. */
+  tmuxWindowId?: string
   scratchpadUrl?: string
   command: string[]
   createdAt: string
@@ -36,6 +38,7 @@ export interface SpawnResult {
   branch: string
   tmuxSession: string
   tmuxWindow: string
+  tmuxWindowId: string
   scratchpadUrl?: string
   output: string
 }


### PR DESCRIPTION
## Problem

harnessd's tmux handling had four failure modes hit in daily use, plus one config-corruption bug found while diagnosing why session control "didn't work":

1. Windows spawned into hardcoded session `0` — never the session you're attached to.
2. `tmux new-window -t <session> -a` inserts relative to the *current* window and fails outright when the next index is taken (`create window failed: index 0 in use`).
3. `steer`/`keys`/`stop` targeted `session:window-name`; names collide (`pickTmuxWindow` dedupes only at spawn) and get renamed, after which the daemon drives the wrong window or none.
4. Claude boot acceptance was two blind `Enter`s with tuned sleeps (`THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS` kept needing retuning); a slow boot got abandoned mid-dialog, wedging the channel half-registered.
5. **The registration bug:** `claude mcp add threa --scope local` run from a worktree writes to the *shared* project entry in `~/.claude.json` — Claude Code resolves every worktree of a repo to the same project key. Every spawn silently repointed all other threa sessions' channels at its own worktree's code, and stacked a duplicate on the user-scope `threa` entry. Observed live before the fix: one session (pane `%99`) running **two** channel servers with the same derived `cc-…` identity, fighting over claims.

This PR incorporates the intent of the uncommitted harness-daemon changes from the main worktree (attached-session detection, free-index picking, double-Enter boot, name suffixing), rewritten, plus fixes 3 and 5 which those changes didn't cover.

## Solution

### How it works

- **Attached-session targeting** — `attachedTmuxSession()` (`tmux.ts`) asks tmux directly: `display-message -p '#{session_name}'` when inside tmux, else the first session with `session_attached > 0` from `list-sessions`. `tmuxSession()` resolves `--tmux` flag → attached → `"0"`. `doctor` reports the detection ("windows spawn into '6'") alongside the session-0 fallback.
- **Free-index creation without hunting** — `createWindow()` targets `session:` (trailing colon), which tmux natively resolves to the first free index; no `-a`, no index-scanning loop. Created `-d`etached: windows now land in the user's *attached* session and must not yank focus mid-typing.
- **Stable window ids** — `createWindow` returns `#{window_id}` (`@n`) via `-P -F`; the id is recorded in the inventory (`tmux_window_id`, added to existing DBs by a `PRAGMA table_info`-guarded `ALTER TABLE`) and `steer`/`keys`/`stop`/`attach` target it. Legacy rows without an id fall back to `session:name`.
- **Dialog-aware boot** — `acceptBootPrompts()` polls `capture-pane` every 500ms: while an `Enter to confirm|Enter to continue` dialog is up it presses Enter; done when the composer line is a bare `❯` (during a dialog that line carries the highlighted option, e.g. `❯ 1. Use this MCP server`). Deadline defaults to 45s via the existing `THREA_HARNESSD_CLAUDE_BOOT_WAIT_MS`; `THREA_HARNESSD_CLAUDE_ACCEPT_WAIT_MS` is gone.
- **Session-scoped MCP wiring** — instead of `claude mcp remove/add --scope local`, the spawner writes `~/.threa/harnessd/mcp/<name>.json` (`mcpServers.threa` → the worktree's own channel entry) and launches `claude --mcp-config <file> …`. No global state is touched; `--no-register` now skips the channel flags entirely (previously it still passed `--dangerously-load-development-channels` pointlessly).

### Key design decisions

**Detached spawn (`-d`)** — the pre-existing behavior focused the new window, which was tolerable when everything went to background session `0`. With attached-session targeting it would steal the user's focus at spawn time; `threa-harnessd attach <name>` is the deliberate way in.

**`--mcp-config` over fixing the `mcp add` scope** — there is no per-worktree scope to add to (worktrees collapse to one project key by design in Claude Code), and user-scope registration must survive for non-threa projects. A launch-arg config is the only variant that binds a session to its own worktree's channel without cross-talk. Verified live: a spawned session runs exactly one channel, from its own worktree, with the user-scope `threa` entry present.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/tmux.ts` | `attachedTmuxSession`, `createWindow` (session-colon target, `-d`, returns `@id`), target-string `capturePane`/`sendKeys`, suffix loop in `pickTmuxWindow` |
| `extensions/harness-daemon/src/spawners.ts` | both spawners use `createWindow`; `writeMcpConfig` + launch args; `acceptBootPrompts` poller |
| `extensions/harness-daemon/src/commands.ts` | window-id targeting for steer/keys/stop/attach; doctor attached-session checks |
| `extensions/harness-daemon/src/inventory.ts` | `tmux_window_id` column + guarded ALTER for existing DBs |
| `extensions/harness-daemon/src/types.ts` | `tmuxWindowId` on `ManagedAgent`/`SpawnResult` |
| `extensions/harness-daemon/bun.lock` | committed (was untracked) |

## Test plan

- [x] `tsc --noEmit` clean (harness-daemon)
- [x] Live end-to-end: `spawn claude --name harness-verify --tmux 0 --skip-setup` — worktree created, window at free index (`@103`), boot dialogs auto-accepted to idle prompt, **exactly one** channel process from the new worktree (registration fix verified against the live user-scope entry), `keys`/`interrupt`/`stop` by window id, `ALTER TABLE` migration ran against the real inventory DB; sandbox worktree/branch cleaned up after
- [x] `doctor` detects the live attached session (`6`)
- [ ] No unit tests — the package has none and everything it does is tmux/process side effects; the live spawn above is the coverage

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663290&installation_id=129946197&pr_number=1150&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1150&signature=1b558de760dca6998bdd52eb4cce656fd8fe4950ec754eeb388ba79072606dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->