### PR TITLE
feat(commands): stream-commands endpoint + slash-menu refresh on runtime liveness edges

### DIFF
--- a/apps/backend/src/features/commands/handlers.ts
+++ b/apps/backend/src/features/commands/handlers.ts
@@ -178,5 +178,19 @@ export function createCommandHandlers({ pool, commandAvailabilityService, botRun
     list(_req: Request, res: Response) {
       res.json({ commands: commandAvailabilityService.listWorkspaceCommands() })
     },
+
+    /**
+     * List the commands available in a specific stream — the workspace set plus
+     * any session-control commands the stream's linked runtime advertises. This
+     * is what the composer's slash menu renders.
+     */
+    async listForStream(req: Request, res: Response) {
+      const commands = await commandAvailabilityService.listStreamCommands({
+        workspaceId: req.workspaceId!,
+        userId: req.user!.id,
+        streamId: req.params.streamId!,
+      })
+      res.json({ commands })
+    },
   }
 }

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -503,6 +503,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
   app.post("/api/workspaces/:workspaceId/commands/dispatch", ...authed, rateLimits.commandDispatch, command.dispatch)
   app.get("/api/workspaces/:workspaceId/commands", ...authed, command.list)
+  app.get("/api/workspaces/:workspaceId/streams/:streamId/commands", ...authed, command.listForStream)
 
   // Invitations and member management — gated on members:write
   const requireMembersWrite = requireWorkspacePermission(WORKSPACE_PERMISSION_SCOPES.MEMBERS_WRITE)

--- a/apps/frontend/src/api/commands.ts
+++ b/apps/frontend/src/api/commands.ts
@@ -15,4 +15,12 @@ export const commandsApi = {
     const res = await api.get<{ commands: CommandInfo[] }>(`/api/workspaces/${workspaceId}/commands`)
     return res.commands
   },
+
+  /** Stream-effective commands (workspace set + whatever session-control the stream's linked runtime advertises right now). */
+  async listForStream(workspaceId: string, streamId: string): Promise<CommandInfo[]> {
+    const res = await api.get<{ commands: CommandInfo[] }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/commands`
+    )
+    return res.commands
+  },
 }

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -14,6 +14,7 @@ import {
   type CachedStreamBootstrap,
 } from "./stream-sync"
 import { streamKeys } from "@/hooks/use-streams"
+import { commandsApi } from "@/api"
 import { clearDecryptCache, getCachedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { BotRuntimePresenceSummary, LinkPreviewSummary, StreamBootstrap, StreamEvent } from "@threa/types"
 
@@ -952,6 +953,112 @@ describe("registerStreamSocketHandlers — bot_runtime:presence cache patching",
     expect(after).toBe(before)
 
     cleanup()
+  })
+
+  // The stream's command set is computed server-side at bootstrap time, so a
+  // runtime liveness edge (coming online / going away / instance swap) must
+  // refetch it — otherwise a scratchpad opened before its agent connected keeps
+  // an empty slash menu until the next full bootstrap. Available↔busy flips
+  // happen on every turn and must NOT refetch.
+  describe("command-set refresh on liveness edges", () => {
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+    it("refetches and patches commands when a runtime comes online", async () => {
+      const queryClient = new QueryClient()
+      const streamId = "stream_cmd_online"
+      seedBootstrap(queryClient, streamId, { bot_1: null })
+      const steer = { name: "steer", description: "Steer the linked session" }
+      const listForStream = vi.spyOn(commandsApi, "listForStream").mockResolvedValue([steer])
+
+      const { socket, emit } = createTestSocket()
+      const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+      emit("bot_runtime:presence", {
+        workspaceId: "ws_1",
+        streamId,
+        botId: "bot_1",
+        presence: makePresence({ status: "available", acceptingInvocations: true }),
+      })
+      await flush()
+
+      expect(listForStream).toHaveBeenCalledWith("ws_1", streamId)
+      const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+      expect(after?.commands).toEqual([steer])
+
+      listForStream.mockRestore()
+      cleanup()
+    })
+
+    it("refetches when a runtime goes offline (commands drop)", async () => {
+      const queryClient = new QueryClient()
+      const streamId = "stream_cmd_offline"
+      seedBootstrap(queryClient, streamId, { bot_1: makePresence({ status: "available" }) })
+      const listForStream = vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+
+      const { socket, emit } = createTestSocket()
+      const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+      emit("bot_runtime:presence", {
+        workspaceId: "ws_1",
+        streamId,
+        botId: "bot_1",
+        presence: makePresence({ status: "offline", acceptingInvocations: false }),
+      })
+      await flush()
+
+      expect(listForStream).toHaveBeenCalledTimes(1)
+      const after = queryClient.getQueryData<CachedStreamBootstrap>(streamKeys.bootstrap("ws_1", streamId))
+      expect(after?.commands).toEqual([])
+
+      listForStream.mockRestore()
+      cleanup()
+    })
+
+    it("does not refetch on an available↔busy flip of the same instance", async () => {
+      const queryClient = new QueryClient()
+      const streamId = "stream_cmd_busy"
+      seedBootstrap(queryClient, streamId, { bot_1: makePresence({ status: "available" }) })
+      const listForStream = vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+
+      const { socket, emit } = createTestSocket()
+      const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+      emit("bot_runtime:presence", {
+        workspaceId: "ws_1",
+        streamId,
+        botId: "bot_1",
+        presence: makePresence({ status: "busy", statusText: "Working in Claude Code…" }),
+      })
+      await flush()
+
+      expect(listForStream).not.toHaveBeenCalled()
+
+      listForStream.mockRestore()
+      cleanup()
+    })
+
+    it("refetches when the serving instance is swapped out", async () => {
+      const queryClient = new QueryClient()
+      const streamId = "stream_cmd_swap"
+      seedBootstrap(queryClient, streamId, { bot_1: makePresence({ status: "available", instanceId: "inst_1" }) })
+      const listForStream = vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+
+      const { socket, emit } = createTestSocket()
+      const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+      emit("bot_runtime:presence", {
+        workspaceId: "ws_1",
+        streamId,
+        botId: "bot_1",
+        presence: makePresence({ status: "available", instanceId: "inst_2" }),
+      })
+      await flush()
+
+      expect(listForStream).toHaveBeenCalledTimes(1)
+
+      listForStream.mockRestore()
+      cleanup()
+    })
   })
 })
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -14,6 +14,7 @@ import {
 import { seedDecryption } from "@/lib/crypto/decrypt-cache"
 import type { AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import type { SyncEventSource } from "./socket-event-gate"
+import { commandsApi } from "@/api"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import type { QueryClient } from "@tanstack/react-query"
@@ -26,6 +27,11 @@ import { dropReactionActivity, rehomeActivities } from "./unread-counters"
 
 export interface CachedStreamBootstrap extends StreamBootstrap {
   windowVersion: number
+}
+
+/** True when a runtime in this state contributes session-control commands to the stream's command set (mirrors the backend's available/busy gate). */
+function commandsLive(presence: BotRuntimePresenceSummary | null | undefined): boolean {
+  return presence?.status === "available" || presence?.status === "busy"
 }
 
 function preserveDmDisplayName(nextStream: Stream, previousStream?: Stream): Stream {
@@ -1035,6 +1041,14 @@ export function registerStreamSocketHandlers(
     presence: BotRuntimePresenceSummary | null
   }) => {
     if (payload.streamId !== streamId) return
+    // The stream's effective command set follows runtime liveness: a runtime
+    // coming online adds its session-control commands (/steer, /stop, /model…),
+    // one going away removes them. `commands` was computed server-side at
+    // bootstrap time, so on a liveness edge refresh it — otherwise a scratchpad
+    // opened before its agent connected keeps an empty slash menu until the
+    // next full bootstrap. Available↔busy flips (every turn) don't change the
+    // set and must not trigger refetches.
+    let commandsAffected = false
     queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (old) => {
       if (!old) return old
       const current = old.botRuntimePresence ?? {}
@@ -1050,11 +1064,24 @@ export function registerStreamSocketHandlers(
       ) {
         return old
       }
+      commandsAffected = commandsLive(previous) !== commandsLive(next) || previous?.instanceId !== next?.instanceId
       return {
         ...old,
         botRuntimePresence: { ...current, [payload.botId]: next },
       }
     })
+    if (commandsAffected) void refreshStreamCommands()
+  }
+
+  const refreshStreamCommands = async () => {
+    try {
+      const commands = await commandsApi.listForStream(workspaceId, streamId)
+      queryClient.setQueryData<CachedStreamBootstrap>(streamKeys.bootstrap(workspaceId, streamId), (old) =>
+        old ? { ...old, commands } : old
+      )
+    } catch {
+      // Best-effort freshness — the next bootstrap converges the command set.
+    }
   }
 
   socket.on("message:created", handleMessageCreated)


### PR DESCRIPTION
## Problem

The stream-effective slash-command set — including session control (`/steer`, `/stop`, `/model`) for a linked Claude Code/Pi runtime — is computed server-side **only** inside `GET /streams/:id/bootstrap` (`apps/backend/src/features/streams/handlers.ts` → `commandAvailabilityService.listStreamCommands`). The composer (`use-command-suggestion.tsx`) reads `streamBootstrap.commands` from the cached bootstrap and never refreshes it.

So the normal harnessd flow — scratchpad already open in the app, agent spawns, channel connects — leaves the slash menu **empty until the next full bootstrap** (reload/reconnect). Typing `/` offers nothing, which reads as "session control doesn't work". This was the last unexplained piece of the "I have no steer/stop/model control" report: the whole pipeline (catalog → availability → dispatch → busy-claim routing → tmux actuation, PR #1091) was live and working; the menu was just frozen at page-load state. `handleBotRuntimePresence` (`stream-sync.ts`) already patches presence into the cached bootstrap on the `bot_runtime:presence` socket event — but not `commands`.

## Solution

Refresh the command set exactly when it can change: on a runtime **liveness edge**.

### How it works

1. New endpoint `GET /api/workspaces/:workspaceId/streams/:streamId/commands` (`command.listForStream`) returning the same stream-effective list bootstrap embeds — the availability resolution is shared, no new logic.
2. `commandsApi.listForStream` in `apps/frontend/src/api/commands.ts`.
3. In `handleBotRuntimePresence`, when the presence patch changes **liveness** — `commandsLive(prev) !== commandsLive(next)` where live = `status ∈ {available, busy}` (mirroring the backend's gate in `resolveRuntimeCommandTarget`), or the serving `instanceId` swapped — fire `refreshStreamCommands()`: fetch the list and patch `commands` into the cached bootstrap. Best-effort; a failed fetch converges on the next bootstrap.
4. Available↔busy flips happen on **every turn** and don't change the command set — they deliberately do not refetch (the same reason `lastSeenAt` is excluded from the presence equality check: an active runtime would otherwise hammer the endpoint).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/commands/handlers.ts` | `listForStream` handler |
| `apps/backend/src/routes.ts` | route registration |
| `apps/frontend/src/api/commands.ts` | `commandsApi.listForStream` |
| `apps/frontend/src/sync/stream-sync.ts` | liveness-edge detection + `refreshStreamCommands` cache patch |
| `apps/frontend/src/sync/stream-sync.test.ts` | 4 new cases (below) |

## Out of scope (deliberate)

- No change to how the composer *reads* commands (`resolveEffectiveCommandInfos` stays bootstrap-cache-first) — this PR only keeps that cache truthful.
- Workspace-level command list in `WorkspaceBootstrap` untouched.

## Test plan

- [x] `stream-sync.test.ts` — 60 pass (4 new: refetch on runtime-online with cache patch, refetch on runtime-offline, **no** refetch on available↔busy flip, refetch on instance swap)
- [x] `tsc --noEmit` backend + frontend clean; full repo lint/typecheck via pre-commit hook
- [x] Live against prod: the dispatch path this menu feeds was exercised end-to-end (dispatched `/steer` to a fresh harnessd-spawned scratchpad via `POST /commands/dispatch`; the tmux Claude Code session was interrupted and produced the steered reply)
- [ ] The presence-edge refresh itself wasn't visually verified in a browser session (needs an open scratchpad + a runtime connecting mid-session); covered by the 4 unit cases above

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663292&installation_id=129946197&pr_number=1151&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1151&signature=98dc3a9f858e94ad2a6241df301ee64eb192c29bdd2c500732201a8cd1008bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->