### PR TITLE
feat(channel): /thinking→/effort control, discovered model catalog with display names

### DIFF
--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -177,8 +177,13 @@ The channel advertises in its `bot:hello` / presence `capabilities` **only when 
   "supportsActiveScratchpad": true,
   "supportsPersistentSessions": true,
   "supportsSessionControlCommands": true,
-  "sessionControlCommands": ["stop", "steer", "model", "compact", "run"],
-  "modelSuggestions": [{ "value": "sonnet" }, { "value": "opus" }, { "value": "default" }, { "value": "opusplan" }],
+  "sessionControlCommands": ["stop", "steer", "model", "thinking", "compact", "run", "reload"],
+  "modelSuggestions": [
+    { "value": "opus", "label": "Opus", "description": "Opus 4.8 with 1M context · Best for everyday, complex tasks" },
+    // …built-in aliases (default/opus/sonnet/haiku) plus models discovered from the
+    // local client's ~/.claude.json additionalModelOptionsCache (see model-catalog.ts)
+  ],
+  "thinkingLevels": ["low", "medium", "high", "xhigh", "max", "ultracode"],
 }
 ```
 
@@ -191,9 +196,12 @@ Commands chosen for v1: **stop, steer, model, compact, run, reload**. `reload` m
 Code's `/reload-skills` (v2.1.152+) — picks up skills + custom commands added on disk mid-session;
 verified live ("16 skills available"). Newly `claude mcp add`'d MCP servers still can't hot-reload
 (Claude Code limitation — restart only); `/reload-plugins` is reachable via the generic `run`.
-Dropped from Pi's set: `thinking` (no Claude Code slash equivalent), `skill` (needs the skill list
-the channel doesn't have — fold into generic `run`). `shell` could be added later as a direct exec
-in the channel (like Pi's `runShellCommand`), independent of tmux.
+`thinking` joined later: Claude Code v2.1.x grew `/effort <low|medium|high|xhigh|max|ultracode>`,
+so Threa's canonical `/thinking` now actuates as `/effort` (verified live on v2.1.199, which also
+dropped the old mid-session "Switch model?" confirm dialog — `/model <alias>` sets directly).
+Still dropped from Pi's set: `skill` (needs the skill list the channel doesn't have — fold into
+generic `run`). `shell` could be added later as a direct exec in the channel (like Pi's
+`runShellCommand`), independent of tmux.
 
 `run` is a **new generic command** (arg = slash command to type, e.g. `run /remote-control`),
 added to the canonical name list + catalog. Open UX question for Kris: `run` vs surfacing named

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 import { downloadInboundAttachments, formatInboundAttachmentManifest, uploadReplyAttachments } from "./attachments"
 import type { ThreaChannelConfig } from "./config"
 import { ThreaClient, type ClaimedInvocation, type RuntimeSessionLink } from "./threa-client"
+import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
 import { interrupt, STEER_SETTLE_MS, submitLine, tmuxAvailable } from "./tmux-control"
 
 const RUNTIME_KIND = "claude-code-channel"
@@ -15,10 +16,13 @@ const SESSION_CONTROL_CAPABILITY = "session-control"
 // advertised when running inside tmux. `run` types an arbitrary slash command
 // (e.g. /remote-control); `compact` is sugar for `run /compact`; `reload` maps
 // to Claude Code's `/reload-skills` (pick up skills + custom commands added on
-// disk this session — `/reload-plugins` is reachable via `run` for the plugin case).
-const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "compact", "run", "reload"] as const
-// Claude Code `/model` aliases offered as autocomplete in the composer's arg picker.
-const MODEL_SUGGESTIONS = [{ value: "default" }, { value: "sonnet" }, { value: "opus" }, { value: "opusplan" }]
+// disk this session — `/reload-plugins` is reachable via `run` for the plugin
+// case); Threa's canonical `thinking` maps to Claude Code's `/effort`.
+const SESSION_CONTROL_COMMANDS = ["stop", "steer", "model", "thinking", "compact", "run", "reload"] as const
+// Model options for the composer's arg picker: built-in /model aliases plus
+// whatever the local client's own picker cache discovers (see model-catalog).
+// Resolved once at startup — new models arrive with the next spawned session.
+const MODEL_SUGGESTIONS = modelSuggestions()
 // Mirror Pi's STEER_DRAIN_LIMIT: how many queued messages a single /steer folds
 // into one combined turn before stopping (a backstop, not an expected count).
 const STEER_DRAIN_LIMIT = 10
@@ -165,6 +169,7 @@ export function runtimeCapabilitiesFor(
           supportsSessionControlCommands: true,
           sessionControlCommands: [...SESSION_CONTROL_COMMANDS],
           modelSuggestions: MODEL_SUGGESTIONS,
+          thinkingLevels: [...THINKING_LEVELS],
         }
       : {}),
   }
@@ -502,6 +507,8 @@ export class ChannelServer {
           return await this.runSteer(invocation, command.args)
         case "model":
           return await this.runModelCommand(invocation, command.args)
+        case "thinking":
+          return await this.runThinkingCommand(invocation, command.args)
         case "compact":
           return await this.runSlashCommand(invocation, command.args ? `/compact ${command.args}` : "/compact")
         case "reload":
@@ -550,7 +557,15 @@ export class ChannelServer {
       return
     }
     await Bun.sleep(STEER_SETTLE_MS)
-    await this.completeInterruptedTurns("Superseded by /steer.")
+    // Always leave a visible marker carrying the steer text: a bare
+    // "Superseded by /steer." followed by working silence reads as "the steer
+    // was lost", which is exactly how it got reported. The note doubles as the
+    // delivery acknowledgement.
+    const preview = text.length > 120 ? `${text.slice(0, 120)}…` : text
+    await this.completeInterruptedTurns(
+      preview ? `Superseded by /steer — now handling: “${preview}”` : "Superseded by /steer.",
+      { alwaysNote: true }
+    )
 
     const parts: string[] = []
     const swept: ClaimedInvocation[] = []
@@ -585,15 +600,33 @@ export class ChannelServer {
   private async runModelCommand(invocation: ClaimedInvocation, args: string): Promise<void> {
     const alias = args.trim()
     if (!alias) {
-      await this.completeAck(invocation, "Usage: `/model <name>` (e.g. sonnet, opus, default).")
+      await this.completeAck(invocation, "Usage: `/model <name>` (e.g. fable, opus, sonnet, haiku, default).")
       return
     }
-    // `confirm`: a mid-session model switch pops a "Switch model?" dialog (default
-    // "Yes") — the second Enter accepts it; harmless no-op when no dialog appears.
-    const ok = await submitLine(`/model ${alias}`, { confirm: true })
+    // `/model <name>` sets directly in current Claude Code (v2.1.199 dropped the
+    // old "Switch model?" confirm dialog), so a plain submit is the whole action.
+    const ok = await submitLine(`/model ${alias}`)
     await this.completeAck(
       invocation,
       ok ? `Set Claude Code model to \`${alias}\`.` : "Could not send /model (no tmux control)."
+    )
+  }
+
+  /**
+   * Threa's canonical `/thinking <level>` actuated as Claude Code's `/effort`.
+   * Levels are validated against the advertised set so a typo gets usage help
+   * instead of an Enter submitted into the TUI's effort slider.
+   */
+  private async runThinkingCommand(invocation: ClaimedInvocation, args: string): Promise<void> {
+    const level = args.trim().toLowerCase()
+    if (!(THINKING_LEVELS as readonly string[]).includes(level)) {
+      await this.completeAck(invocation, `Usage: \`/thinking <level>\` — one of ${THINKING_LEVELS.join(", ")}.`)
+      return
+    }
+    const ok = await submitLine(`/effort ${level}`)
+    await this.completeAck(
+      invocation,
+      ok ? `Set Claude Code effort to \`${level}\`.` : "Could not send /effort (no tmux control)."
     )
   }
 
@@ -646,8 +679,13 @@ export class ChannelServer {
       .catch((error) => log(`session-control fail failed: ${this.summarize(error)}`))
   }
 
-  /** Close every in-flight turn that an interrupt just aborted, so none idle-hangs for an hour. */
-  private async completeInterruptedTurns(note: string): Promise<void> {
+  /**
+   * Close every in-flight turn that an interrupt just aborted, so none
+   * idle-hangs for an hour. By default a turn that already posted interim
+   * messages closes silently (the user has heard from it); `alwaysNote` posts
+   * the note regardless — steers use it so delivery is always visible.
+   */
+  private async completeInterruptedTurns(note: string, opts: { alwaysNote?: boolean } = {}): Promise<void> {
     // Clear every entry's timer and drop it from the map BEFORE the first await.
     // If we cleared-and-completed one at a time, a sibling's idle-timeout could
     // fire at a `complete()` yield point, find itself still in the map, and
@@ -659,7 +697,8 @@ export class ChannelServer {
     }
     await Promise.all(
       entries.map(([id, entry]) => {
-        const body = entry.sentCount > 0 ? { noResponse: true } : { finalMessageMarkdown: `_${note}_` }
+        const body =
+          entry.sentCount > 0 && !opts.alwaysNote ? { noResponse: true } : { finalMessageMarkdown: `_${note}_` }
         return this.client
           .complete(id, {
             instanceId: this.config.instanceId,

--- a/extensions/claude-code-remote/src/model-catalog.test.ts
+++ b/extensions/claude-code-remote/src/model-catalog.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { discoverAdditionalModels, modelSuggestions, THINKING_LEVELS } from "./model-catalog"
+
+function writeConfig(contents: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "model-catalog-"))
+  const path = join(dir, "claude.json")
+  writeFileSync(path, typeof contents === "string" ? contents : JSON.stringify(contents))
+  return path
+}
+
+describe("discoverAdditionalModels", () => {
+  it("reads value/label/description entries from the client's cache", () => {
+    const path = writeConfig({
+      additionalModelOptionsCache: [
+        { value: "claude-fable-5[1m]", label: "Fable", description: "Fable 5 · Most capable" },
+      ],
+    })
+    expect(discoverAdditionalModels(path)).toEqual([
+      { value: "claude-fable-5[1m]", label: "Fable", description: "Fable 5 · Most capable" },
+    ])
+  })
+
+  it("drops malformed entries but keeps valid ones", () => {
+    const path = writeConfig({
+      additionalModelOptionsCache: [
+        null,
+        "nope",
+        { label: "no-value" },
+        { value: "  " },
+        { value: "claude-x", label: 42, description: "desc" },
+      ],
+    })
+    expect(discoverAdditionalModels(path)).toEqual([{ value: "claude-x", description: "desc" }])
+  })
+
+  it("returns empty for a missing file, invalid JSON, or a non-array cache", () => {
+    expect(discoverAdditionalModels("/nonexistent/claude.json")).toEqual([])
+    expect(discoverAdditionalModels(writeConfig("{not json"))).toEqual([])
+    expect(discoverAdditionalModels(writeConfig({ additionalModelOptionsCache: "fable" }))).toEqual([])
+  })
+})
+
+describe("modelSuggestions", () => {
+  it("appends discovered models after the baseline aliases", () => {
+    const path = writeConfig({
+      additionalModelOptionsCache: [{ value: "claude-fable-5[1m]", label: "Fable", description: "Fable 5" }],
+    })
+    const suggestions = modelSuggestions(path)
+    const values = suggestions.map((suggestion) => suggestion.value)
+    expect(values).toEqual(["default", "opus", "sonnet", "haiku", "claude-fable-5[1m]"])
+    // Every entry carries display copy for the composer's arg picker.
+    expect(suggestions.every((suggestion) => suggestion.label && suggestion.description)).toBe(true)
+  })
+
+  it("dedupes a discovered model whose label collides with a baseline alias", () => {
+    const path = writeConfig({
+      additionalModelOptionsCache: [{ value: "claude-opus-9", label: "Opus", description: "future" }],
+    })
+    expect(modelSuggestions(path).filter((suggestion) => suggestion.label === "Opus")).toHaveLength(1)
+  })
+
+  it("falls back to baseline-only when discovery finds nothing", () => {
+    expect(modelSuggestions("/nonexistent/claude.json").map((suggestion) => suggestion.value)).toEqual([
+      "default",
+      "opus",
+      "sonnet",
+      "haiku",
+    ])
+  })
+})
+
+describe("THINKING_LEVELS", () => {
+  it("matches the /effort levels Claude Code accepts", () => {
+    expect([...THINKING_LEVELS]).toEqual(["low", "medium", "high", "xhigh", "max", "ultracode"])
+  })
+})

--- a/extensions/claude-code-remote/src/model-catalog.ts
+++ b/extensions/claude-code-remote/src/model-catalog.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export interface ModelSuggestion {
+  value: string
+  label?: string
+  description?: string
+}
+
+/**
+ * Effort levels the Claude Code TUI accepts as `/effort <level>` (verified
+ * against v2.1.199 — the slider steps, plus `ultracode` = xhigh + workflows).
+ * Advertised as `thinkingLevels` so Threa's canonical `/thinking` command
+ * surfaces them as picker options; the channel actuates the pick as `/effort`.
+ */
+export const THINKING_LEVELS = ["low", "medium", "high", "xhigh", "max", "ultracode"] as const
+
+/**
+ * The TUI's built-in `/model` aliases with the display copy its picker shows
+ * (v2.1.199). Only the stable aliases live here — models beyond them (e.g.
+ * Fable) arrive via `discoverAdditionalModels`, so a new release shows up
+ * without a code change.
+ */
+const BASELINE_MODELS: ModelSuggestion[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Recommended · Opus 4.8 with 1M context",
+  },
+  {
+    value: "opus",
+    label: "Opus",
+    description: "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+  },
+  {
+    value: "sonnet",
+    label: "Sonnet",
+    description: "Sonnet 5 · Efficient for routine tasks",
+  },
+  {
+    value: "haiku",
+    label: "Haiku",
+    description: "Haiku 4.5 · Fastest for quick answers",
+  },
+]
+
+/**
+ * Claude Code caches the extra model options its own /model picker offers in
+ * `~/.claude.json` as `additionalModelOptionsCache: [{ value, label,
+ * description }]`. Reading that cache keeps the advertised model list in step
+ * with what the local client can actually switch to. The `value` is what the
+ * client itself uses for model selection, so it round-trips through
+ * `/model <value>` unchanged (verified live: `/model claude-fable-5[1m]`).
+ */
+export function discoverAdditionalModels(configPath = join(homedir(), ".claude.json")): ModelSuggestion[] {
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8")) as { additionalModelOptionsCache?: unknown }
+    if (!Array.isArray(parsed.additionalModelOptionsCache)) return []
+    const result: ModelSuggestion[] = []
+    for (const entry of parsed.additionalModelOptionsCache) {
+      if (!entry || typeof entry !== "object") continue
+      const candidate = entry as Record<string, unknown>
+      if (typeof candidate.value !== "string" || !candidate.value.trim()) continue
+      result.push({
+        value: candidate.value,
+        ...(typeof candidate.label === "string" && { label: candidate.label }),
+        ...(typeof candidate.description === "string" && { description: candidate.description }),
+      })
+    }
+    return result
+  } catch {
+    return []
+  }
+}
+
+/** Baseline aliases plus discovered models, deduped by display label so a model never lists twice. */
+export function modelSuggestions(configPath?: string): ModelSuggestion[] {
+  const seen = new Set(BASELINE_MODELS.map((model) => (model.label ?? model.value).toLowerCase()))
+  const discovered = discoverAdditionalModels(configPath).filter((model) => {
+    const key = (model.label ?? model.value).toLowerCase()
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  return [...BASELINE_MODELS, ...discovered]
+}

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -102,12 +102,29 @@ describe("capability selection", () => {
   it("only publishes session-control command capabilities when control is available", () => {
     const enabled = runtimeCapabilitiesFor("ccs_1", true)
     expect(enabled.supportsSessionControlCommands).toBe(true)
-    expect(enabled.sessionControlCommands).toEqual(["stop", "steer", "model", "compact", "run", "reload"])
+    expect(enabled.sessionControlCommands).toEqual(["stop", "steer", "model", "thinking", "compact", "run", "reload"])
     expect(enabled.runtimeSessionId).toBe("ccs_1")
 
     const disabled = runtimeCapabilitiesFor("ccs_1", false)
     expect(disabled.supportsSessionControlCommands).toBeUndefined()
     expect(disabled.sessionControlCommands).toBeUndefined()
     expect(disabled.runtimeSessionId).toBe("ccs_1")
+  })
+
+  it("advertises effort levels and display-labelled model suggestions with control enabled", () => {
+    const enabled = runtimeCapabilitiesFor("ccs_1", true)
+    expect(enabled.thinkingLevels).toEqual(["low", "medium", "high", "xhigh", "max", "ultracode"])
+    const suggestions = enabled.modelSuggestions as Array<{ value: string; label?: string }>
+    expect(suggestions.map((suggestion) => suggestion.value)).toContain("opus")
+    expect(suggestions.every((suggestion) => suggestion.label)).toBe(true)
+
+    const disabled = runtimeCapabilitiesFor("ccs_1", false)
+    expect(disabled.thinkingLevels).toBeUndefined()
+    expect(disabled.modelSuggestions).toBeUndefined()
+  })
+
+  it("parses /thinking with a level argument", () => {
+    const inv = invocation({ trigger: "session-control", promptMarkdown: "/thinking xhigh", metadata: {} })
+    expect(parseSessionControlCommand(inv)).toEqual({ name: "thinking", args: "xhigh" })
   })
 })

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -45,39 +45,22 @@ export function interrupt(): boolean {
  * Clears the input line first (Ctrl-U): an Esc-interrupt restores the interrupted
  * message back into Claude Code's input box, so a stale line would concatenate
  * with the command and get submitted as a plain prompt (the command silently
- * doesn't run). Verified live against Claude Code v2.1.193.
+ * doesn't run).
  *
  * `-l` sends the text verbatim so `/`, spaces, and punctuation aren't parsed as
  * tmux key names. A short settle between the text and Enter lets the slash-command
  * autocomplete resolve, so `/model sonnet` submits instead of the menu eating the
- * Enter.
- *
- * With `confirm`, a second Enter is sent after a longer settle to accept a modal
- * Claude Code may raise — `/model <x>` mid-session pops a "Switch model?" dialog
- * whose default option is "Yes"; without the confirm the session wedges at the
- * dialog. The trailing Enter is a harmless empty submit when no modal appears.
+ * Enter. Commands with an argument set directly in current Claude Code (v2.1.199
+ * dropped the old mid-session "Switch model?" confirm dialog), so one submit is
+ * the whole actuation.
  */
-export async function submitLine(text: string, opts: { settleMs?: number; confirm?: boolean } = {}): Promise<boolean> {
+export async function submitLine(text: string, opts: { settleMs?: number } = {}): Promise<boolean> {
   const settleMs = opts.settleMs ?? 150
   if (!sendKeys(["C-u"])) return false
   if (!sendKeys(["-l", text])) return false
   if (settleMs > 0) await Bun.sleep(settleMs)
-  if (!sendKeys(["Enter"])) return false
-  if (opts.confirm) {
-    // A modal Claude Code raises (e.g. "/model" mid-session pops "Switch model?")
-    // may render slightly after the first Enter. Send two guarded, spaced Enters
-    // so a late-rendering modal is still confirmed; an Enter on an empty prompt is
-    // a harmless no-op. Guarded (unlike a fire-and-forget Enter) so a pane that
-    // vanished mid-confirm reports failure instead of acking a false success.
-    await Bun.sleep(CONFIRM_SETTLE_MS)
-    if (!sendKeys(["Enter"])) return false
-    await Bun.sleep(CONFIRM_SETTLE_MS)
-    if (!sendKeys(["Enter"])) return false
-  }
-  return true
+  return sendKeys(["Enter"])
 }
 
 /** Milliseconds to wait after an interrupt before delivering the steer turn, so Claude has returned to idle. */
 export const STEER_SETTLE_MS = 250
-/** Wait for a modal (e.g. "Switch model?") to render before sending the confirming Enter. */
-const CONFIRM_SETTLE_MS = 350


### PR DESCRIPTION
## Problem

Three gaps in the Claude Code channel's session control, all reported from live use:

1. **No effort/thinking control.** The channel advertised `stop/steer/model/compact/run/reload` only; Threa's canonical `/thinking` command (already in the backend catalog with runtime-advertised level suggestions) had no Claude actuation. Claude Code 2.1.x grew `/effort <level>` — probed live on v2.1.199: `low/medium/high/xhigh/max/ultracode`, direct argument form works.
2. **Stale, unlabeled model suggestions.** `MODEL_SUGGESTIONS` was `default/sonnet/opus/opusplan` — `opusplan` no longer exists, Fable/Haiku missing, and bare alias values rendered raw in the composer's arg picker ("I don't know what model that is. It would be really nice if we could show a display name").
3. **Steers read as lost.** A `/steer` superseding a turn that had posted interim sends closed it *silently* (`noResponse`), and one that hadn't showed only a bare "_Superseded by /steer._" — then working silence. Live consequence: a delivered steer was assumed broken and escalated to `/stop`.

## Solution

### How it works

- **`/thinking` → `/effort`** — `thinking` joins `SESSION_CONTROL_COMMANDS`; `thinkingLevels: [low, medium, high, xhigh, max, ultracode]` is advertised in capabilities, so `availability.ts`'s existing `applyAdvertisedSuggestions` fills the composer's level picker with **zero backend changes**. The handler validates the level against the set (a typo gets usage help instead of an Enter poked into the TUI's effort slider) and submits `/effort <level>`.
- **Model discovery instead of hardcoding** — new `model-catalog.ts`. Baseline = the TUI's stable aliases (`default/opus/sonnet/haiku`) with the display copy its own picker shows. On top, `discoverAdditionalModels()` reads `~/.claude.json` → `additionalModelOptionsCache: [{value, label, description}]` — the same cache Claude Code's own `/model` picker uses — so a new release (Fable today) appears with its label and description without a code change. Deduped by label; defensive parsing, empty on any malformed input. The discovered `value` round-trips: verified live that `/model claude-fable-5[1m]` → "Set model to Fable 5".
- **Visible steer supersede** — `completeInterruptedTurns` gains `alwaysNote`; the steer path always posts `_Superseded by /steer — now handling: "<first 120 chars>"_`, doubling as the delivery acknowledgement.
- **Confirm dance removed** — v2.1.199 sets `/model <alias>` directly (the mid-session "Switch model?" modal is gone); the guarded double-Enter `confirm` path in `tmux-control.ts` is deleted (INV-38).

### Key design decisions

**Catalog resolved once at startup** — capabilities are re-sent on every presence update and must stay consistent with `bot:hello` (the server replaces, not merges); a static per-process list keeps that trivially true. New models arrive with the next spawned session, which matches how the daemon runs sessions anyway.

**Baseline display copy is hardcoded to the v2.1.199 picker text** — the built-in aliases live in the client binary and aren't discoverable; only additions flow through the cache. Accepted staleness risk, noted in the module comment.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/model-catalog.ts` | baseline aliases + display copy, `discoverAdditionalModels`, `THINKING_LEVELS` |
| `extensions/claude-code-remote/src/model-catalog.test.ts` | discovery parsing, dedupe, fallback |

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/channel-server.ts` | `thinking` command + handler, catalog-backed suggestions, `thinkingLevels` capability, always-visible steer note |
| `extensions/claude-code-remote/src/tmux-control.ts` | drop `confirm` option + `CONFIRM_SETTLE_MS` |
| `extensions/claude-code-remote/src/session-control.test.ts` | capability expectations incl. levels/labels, `/thinking` parse |
| `docs/claude-channel-session-control.md` | capability example + command-set rationale updated |

## Test plan

- [x] `bun test` (claude-code-remote) — 80 pass
- [x] Live on prod, fresh sandbox session: capabilities row shows `thinking` + levels + Fable suggestion with label/description; composer-facing availability confirmed via authenticated `GET /streams/:id/bootstrap` (`thinkingSuggestions: [low…ultracode]`, `modelLabels: [Default, Opus, Sonnet, Haiku, Fable]`)
- [x] Live actuation: dispatched `/thinking high` → TUI ran `/effort high` ("Set effort level to high"); `/thinking xhigh` restored; `/model claude-fable-5[1m]` → "Set model to Fable 5"
- [x] Live steer supersede: second `/steer` onto a running turn posted `_Superseded by /steer — now handling: "Never mind the poem — reply with exactly the word SECOND…"_` and the steered reply landed

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663294&installation_id=129946197&pr_number=1152&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1152&signature=6d7119ab4c503120cd6a9d2fdbb16ef85becc187d5def6d5b36891335009ed28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->