### PR TITLE
feat(drafts): bulk-select delete on the drafts explorer

### DIFF
--- a/apps/frontend/src/components/drafts/delete-draft-confirm-dialog.tsx
+++ b/apps/frontend/src/components/drafts/delete-draft-confirm-dialog.tsx
@@ -16,25 +16,35 @@ interface DeleteDraftConfirmDialogProps {
   onOpenChange: (open: boolean) => void
   /** Confirmed delete — the caller runs the actual removal. */
   onConfirm: () => void
+  /**
+   * Number of drafts being removed. Omit (or `1`) for the single-draft delete;
+   * pass the batch size for the Drafts explorer's bulk delete so the copy reads
+   * "Delete N drafts?".
+   */
+  count?: number
 }
 
 /**
  * The single "Delete this draft?" confirmation for every draft-delete entry
- * point — the Drafts explorer (`pages/drafts.tsx`) and the in-composer stash
- * picker (`stashed-drafts-picker.tsx`). The delete itself is unified in
- * `deleteDraftById`; keeping the confirm shell on one path too means the two
- * surfaces can't drift (INV-35/INV-43). Renders an AlertDialog on desktop and a
- * Drawer on mobile via `ResponsiveAlertDialog`.
+ * point — the Drafts explorer (`pages/drafts.tsx`, single and bulk delete) and
+ * the in-composer stash picker (`stashed-drafts-picker.tsx`). The delete itself
+ * is unified in `deleteDraftById`; keeping the confirm shell on one path too
+ * means the surfaces can't drift (INV-35/INV-43). Renders an AlertDialog on
+ * desktop and a Drawer on mobile via `ResponsiveAlertDialog`.
  */
-export function DeleteDraftConfirmDialog({ open, onOpenChange, onConfirm }: DeleteDraftConfirmDialogProps) {
+export function DeleteDraftConfirmDialog({ open, onOpenChange, onConfirm, count }: DeleteDraftConfirmDialogProps) {
+  const isBulk = count != null && count > 1
+  const title = isBulk ? `Delete ${count} drafts?` : "Delete this draft?"
+  const description = isBulk
+    ? `This action cannot be undone. ${count} drafts will be permanently deleted.`
+    : "This action cannot be undone. The draft will be permanently deleted."
+
   return (
     <ResponsiveAlertDialog open={open} onOpenChange={onOpenChange}>
       <ResponsiveAlertDialogContent>
         <ResponsiveAlertDialogHeader>
-          <ResponsiveAlertDialogTitle>Delete this draft?</ResponsiveAlertDialogTitle>
-          <ResponsiveAlertDialogDescription>
-            This action cannot be undone. The draft will be permanently deleted.
-          </ResponsiveAlertDialogDescription>
+          <ResponsiveAlertDialogTitle>{title}</ResponsiveAlertDialogTitle>
+          <ResponsiveAlertDialogDescription>{description}</ResponsiveAlertDialogDescription>
         </ResponsiveAlertDialogHeader>
         <ResponsiveAlertDialogFooter>
           <ResponsiveAlertDialogCancel>Cancel</ResponsiveAlertDialogCancel>

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -96,9 +96,23 @@ export function ItemList({
 
   const selectionEnabled = selection?.enabled ?? false
 
-  const focusRow = (index: number) => {
-    const el = listRef.current?.querySelector<HTMLElement>(`[data-index="${index}"]`)
-    el?.focus()
+  // Move focus relative to the option that currently holds it, in RENDER order.
+  // Rows render grouped, so the flat `data-index` is not visual order — a group
+  // can own non-adjacent indices. Walking the live `[data-index]` node list
+  // keeps Up/Down matching what the user sees.
+  const focusOptionFrom = (currentIndex: number, to: "next" | "prev" | "first" | "last") => {
+    const list = listRef.current
+    if (!list) return
+    const options = Array.from(list.querySelectorAll<HTMLElement>("[data-index]"))
+    if (options.length === 0) return
+    const pos = options.findIndex((el) => el.dataset.index === String(currentIndex))
+    const target = {
+      next: Math.min(pos + 1, options.length - 1),
+      prev: Math.max(pos - 1, 0),
+      first: 0,
+      last: options.length - 1,
+    }[to]
+    options[target]?.focus()
   }
 
   // Roving arrow-key navigation for selection mode: the listbox is one tab stop
@@ -115,22 +129,22 @@ export function ItemList({
       case "ArrowDown":
         e.preventDefault()
         e.stopPropagation()
-        focusRow(Math.min(index + 1, items.length - 1))
+        focusOptionFrom(index, "next")
         break
       case "ArrowUp":
         e.preventDefault()
         e.stopPropagation()
-        focusRow(Math.max(index - 1, 0))
+        focusOptionFrom(index, "prev")
         break
       case "Home":
         e.preventDefault()
         e.stopPropagation()
-        focusRow(0)
+        focusOptionFrom(index, "first")
         break
       case "End":
         e.preventDefault()
         e.stopPropagation()
-        focusRow(items.length - 1)
+        focusOptionFrom(index, "last")
         break
     }
   }
@@ -272,7 +286,10 @@ export function ItemList({
                 // focusable.
                 tabIndex={rowTabIndex}
                 className={className}
-                onMouseEnter={() => onSelectIndex(index)}
+                // In selection mode the roving anchor follows focus, not hover,
+                // so the sole tab stop can't drift out from under the focused
+                // row (hover highlight is CSS-only via focus:/hover:bg-muted).
+                onMouseEnter={selectionEnabled ? undefined : () => onSelectIndex(index)}
                 onFocus={selectionEnabled ? () => onSelectIndex(index) : undefined}
                 onClick={(e) => handleClick(e, item)}
                 onKeyDown={selectionEnabled ? (e) => handleSelectionKeyDown(e, index, item.id) : undefined}

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -32,20 +32,22 @@ interface ItemListProps {
 }
 
 /**
- * Leading check circle shown in a row's icon slot while batch selection is on.
- * Sized to the icon footprint (`h-4 w-4`) so entering select mode swaps the
- * icon for the toggle without shifting the row (INV-21).
+ * Leading check circle shown in a row's leading slot while batch selection is
+ * on. Sized to the footprint of the visual it replaces — the `h-7 w-7` avatar
+ * on avatar rows, the `h-4 w-4` icon otherwise — so entering select mode swaps
+ * in place without shifting the row (INV-21).
  */
-function SelectionToggle({ checked }: { checked: boolean }) {
+function SelectionToggle({ checked, large }: { checked: boolean; large?: boolean }) {
   return (
     <span
       aria-hidden
       className={cn(
-        "grid h-4 w-4 shrink-0 place-content-center rounded-full border transition-colors",
+        "grid shrink-0 place-content-center border transition-colors",
+        large ? "h-7 w-7 rounded-md" : "h-4 w-4 rounded-full",
         checked ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/40 bg-transparent"
       )}
     >
-      {checked && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+      {checked && <Check className={large ? "h-3.5 w-3.5" : "h-2.5 w-2.5"} strokeWidth={3} />}
     </span>
   )
 }
@@ -137,7 +139,7 @@ export function ItemList({
 
             let leadingVisual: React.ReactNode = null
             if (selectionEnabled) {
-              leadingVisual = <SelectionToggle checked={isChecked} />
+              leadingVisual = <SelectionToggle checked={isChecked} large={!!item.avatarUrl} />
             } else if (item.avatarUrl) {
               leadingVisual = (
                 <Avatar className="h-7 w-7 rounded-md">
@@ -218,9 +220,26 @@ export function ItemList({
                 role="option"
                 aria-selected={selectionEnabled ? isChecked : isHighlighted}
                 data-index={index}
+                // Selection rows are focusable toggles so the list is operable
+                // by keyboard alone (Enter/Space); plain nav rows are not.
+                tabIndex={selectionEnabled ? 0 : undefined}
                 className={className}
                 onMouseEnter={() => onSelectIndex(index)}
                 onClick={(e) => handleClick(e, item)}
+                onKeyDown={
+                  selectionEnabled
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault()
+                          // Stop the row's Enter from also reaching a container
+                          // keydown handler (e.g. the drafts page's) and toggling
+                          // the highlighted index — that would double-fire.
+                          e.stopPropagation()
+                          selection?.onToggle(item.id)
+                        }
+                      }
+                    : undefined
+                }
               >
                 {itemContent}
               </div>

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -192,7 +192,11 @@ export function ItemList({
               selectionEnabled ? "cursor-pointer" : "cursor-default",
               // ring-inset keeps the checked outline from nudging neighbours (INV-21).
               isChecked && "bg-primary/[0.07] ring-1 ring-primary/45 ring-inset",
-              !isChecked && (isHighlighted ? "bg-muted" : "hover:bg-muted")
+              // In selection mode the highlight tracks real DOM focus, so a
+              // keyboard user sees which focusable row Enter/Space will toggle,
+              // and it can never desync from a separate index-based highlight.
+              !isChecked && selectionEnabled && "hover:bg-muted focus:bg-muted",
+              !isChecked && !selectionEnabled && (isHighlighted ? "bg-muted" : "hover:bg-muted")
             )
 
             // In batch mode a row never navigates, so it renders as a toggle
@@ -231,9 +235,8 @@ export function ItemList({
                     ? (e) => {
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault()
-                          // Stop the row's Enter from also reaching a container
-                          // keydown handler (e.g. the drafts page's) and toggling
-                          // the highlighted index — that would double-fire.
+                          // Keep the toggle from bubbling to an ancestor keydown
+                          // handler that might act on the same key.
                           e.stopPropagation()
                           selection?.onToggle(item.id)
                         }

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -96,6 +96,45 @@ export function ItemList({
 
   const selectionEnabled = selection?.enabled ?? false
 
+  const focusRow = (index: number) => {
+    const el = listRef.current?.querySelector<HTMLElement>(`[data-index="${index}"]`)
+    el?.focus()
+  }
+
+  // Roving arrow-key navigation for selection mode: the listbox is one tab stop
+  // (only the active option has tabIndex 0), and Up/Down/Home/End move focus
+  // between options, per the WAI-ARIA listbox pattern. Enter/Space toggle.
+  const handleSelectionKeyDown = (e: React.KeyboardEvent, index: number, itemId: string) => {
+    switch (e.key) {
+      case "Enter":
+      case " ":
+        e.preventDefault()
+        e.stopPropagation()
+        selection?.onToggle(itemId)
+        break
+      case "ArrowDown":
+        e.preventDefault()
+        e.stopPropagation()
+        focusRow(Math.min(index + 1, items.length - 1))
+        break
+      case "ArrowUp":
+        e.preventDefault()
+        e.stopPropagation()
+        focusRow(Math.max(index - 1, 0))
+        break
+      case "Home":
+        e.preventDefault()
+        e.stopPropagation()
+        focusRow(0)
+        break
+      case "End":
+        e.preventDefault()
+        e.stopPropagation()
+        focusRow(items.length - 1)
+        break
+    }
+  }
+
   const handleClick = (e: React.MouseEvent, item: QuickSwitcherItem) => {
     if (selectionEnabled) {
       // In batch mode the whole row is a selection toggle — never navigate.
@@ -127,6 +166,9 @@ export function ItemList({
             const ActionIcon = item.actionIcon
             const isHighlighted = index === selectedIndex
             const isChecked = selection?.selectedIds.has(item.id) ?? false
+            // Roving tabindex in selection mode: active option is the tab stop.
+            let rowTabIndex: number | undefined
+            if (selectionEnabled) rowTabIndex = isHighlighted ? 0 : -1
             const iconFallback = Icon ? (
               <Icon className="h-3.5 w-3.5 opacity-60" />
             ) : (
@@ -224,25 +266,16 @@ export function ItemList({
                 role="option"
                 aria-selected={selectionEnabled ? isChecked : isHighlighted}
                 data-index={index}
-                // Selection rows are focusable toggles so the list is operable
-                // by keyboard alone (Enter/Space); plain nav rows are not.
-                tabIndex={selectionEnabled ? 0 : undefined}
+                // Roving tabindex: only the active option is a tab stop, so the
+                // list is one Tab stop and Arrow keys move between options
+                // (handled in handleSelectionKeyDown). Plain nav rows aren't
+                // focusable.
+                tabIndex={rowTabIndex}
                 className={className}
                 onMouseEnter={() => onSelectIndex(index)}
+                onFocus={selectionEnabled ? () => onSelectIndex(index) : undefined}
                 onClick={(e) => handleClick(e, item)}
-                onKeyDown={
-                  selectionEnabled
-                    ? (e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault()
-                          // Keep the toggle from bubbling to an ancestor keydown
-                          // handler that might act on the same key.
-                          e.stopPropagation()
-                          selection?.onToggle(item.id)
-                        }
-                      }
-                    : undefined
-                }
+                onKeyDown={selectionEnabled ? (e) => handleSelectionKeyDown(e, index, item.id) : undefined}
               >
                 {itemContent}
               </div>

--- a/apps/frontend/src/components/quick-switcher/item-list.tsx
+++ b/apps/frontend/src/components/quick-switcher/item-list.tsx
@@ -1,11 +1,25 @@
 import { useEffect, useRef } from "react"
 import { Link } from "react-router-dom"
+import { Check } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { MentionIndicator } from "@/components/mention-indicator"
 import { URGENCY_COLORS } from "@/components/layout/sidebar/config"
 import type { QuickSwitcherItem } from "./types"
+
+/**
+ * Optional batch-selection layer. While `enabled`, every row becomes a toggle
+ * (its leading icon/avatar swaps in place for a check circle — same footprint,
+ * no layout shift per INV-21), navigation is suppressed, and per-row actions
+ * hide. Mirrors the message timeline's batch-select look (`bg-primary/[0.07]`
+ * ring-inset on the checked row).
+ */
+export interface ItemListSelection {
+  enabled: boolean
+  selectedIds: Set<string>
+  onToggle: (id: string) => void
+}
 
 interface ItemListProps {
   items: QuickSwitcherItem[]
@@ -14,6 +28,26 @@ interface ItemListProps {
   onSelectItem: (item: QuickSwitcherItem, withModifier: boolean) => void
   isLoading?: boolean
   emptyMessage?: string
+  selection?: ItemListSelection
+}
+
+/**
+ * Leading check circle shown in a row's icon slot while batch selection is on.
+ * Sized to the icon footprint (`h-4 w-4`) so entering select mode swaps the
+ * icon for the toggle without shifting the row (INV-21).
+ */
+function SelectionToggle({ checked }: { checked: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "grid h-4 w-4 shrink-0 place-content-center rounded-full border transition-colors",
+        checked ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/40 bg-transparent"
+      )}
+    >
+      {checked && <Check className="h-2.5 w-2.5" strokeWidth={3} />}
+    </span>
+  )
 }
 
 export function ItemList({
@@ -23,6 +57,7 @@ export function ItemList({
   onSelectItem,
   isLoading,
   emptyMessage,
+  selection,
 }: ItemListProps) {
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -57,7 +92,15 @@ export function ItemList({
     {} as Record<string, Array<{ item: QuickSwitcherItem; index: number }>>
   )
 
+  const selectionEnabled = selection?.enabled ?? false
+
   const handleClick = (e: React.MouseEvent, item: QuickSwitcherItem) => {
+    if (selectionEnabled) {
+      // In batch mode the whole row is a selection toggle — never navigate.
+      e.preventDefault()
+      selection?.onToggle(item.id)
+      return
+    }
     const isModifier = e.metaKey || e.ctrlKey
     if (isModifier && item.href) {
       // Let the browser handle Cmd+click on links natively (opens in new tab)
@@ -71,6 +114,7 @@ export function ItemList({
     <div
       ref={listRef}
       role="listbox"
+      aria-multiselectable={selectionEnabled || undefined}
       className="max-h-[400px] overflow-y-auto p-2 max-sm:max-h-none max-sm:flex-1 max-sm:min-h-0"
     >
       {Object.entries(groups).map(([groupName, groupItems]) => (
@@ -79,7 +123,8 @@ export function ItemList({
           {groupItems.map(({ item, index }) => {
             const Icon = item.icon
             const ActionIcon = item.actionIcon
-            const isSelected = index === selectedIndex
+            const isHighlighted = index === selectedIndex
+            const isChecked = selection?.selectedIds.has(item.id) ?? false
             const iconFallback = Icon ? (
               <Icon className="h-3.5 w-3.5 opacity-60" />
             ) : (
@@ -90,6 +135,20 @@ export function ItemList({
             const urgency = item.urgency ?? "quiet"
             const showUrgencyStrip = urgency !== "quiet"
 
+            let leadingVisual: React.ReactNode = null
+            if (selectionEnabled) {
+              leadingVisual = <SelectionToggle checked={isChecked} />
+            } else if (item.avatarUrl) {
+              leadingVisual = (
+                <Avatar className="h-7 w-7 rounded-md">
+                  <AvatarImage src={item.avatarUrl} alt={item.label} />
+                  <AvatarFallback className="rounded-md">{iconFallback}</AvatarFallback>
+                </Avatar>
+              )
+            } else if (Icon) {
+              leadingVisual = <Icon className="h-4 w-4 opacity-50" />
+            }
+
             const itemContent = (
               <>
                 {showUrgencyStrip && (
@@ -99,14 +158,7 @@ export function ItemList({
                   />
                 )}
                 <div className="flex items-center gap-3 flex-1 min-w-0 px-3 py-3">
-                  {item.avatarUrl ? (
-                    <Avatar className="h-7 w-7 rounded-md">
-                      <AvatarImage src={item.avatarUrl} alt={item.label} />
-                      <AvatarFallback className="rounded-md">{iconFallback}</AvatarFallback>
-                    </Avatar>
-                  ) : (
-                    Icon && <Icon className="h-4 w-4 opacity-50" />
-                  )}
+                  {leadingVisual}
                   <div className="flex flex-col flex-1 min-w-0">
                     <span className={cn("truncate", hasUnread ? "font-semibold" : "font-normal")}>{item.label}</span>
                     {item.description && (
@@ -114,7 +166,7 @@ export function ItemList({
                     )}
                   </div>
                   {(item.mentionCount ?? 0) > 0 && <MentionIndicator count={item.mentionCount!} className="ml-auto" />}
-                  {item.onAction && ActionIcon && (
+                  {!selectionEnabled && item.onAction && ActionIcon && (
                     <Button
                       variant="ghost"
                       size="icon"
@@ -134,17 +186,22 @@ export function ItemList({
             )
 
             const className = cn(
-              "group reveal-host relative flex cursor-default select-none items-stretch rounded-[10px] text-sm outline-none transition-colors",
-              isSelected ? "bg-muted" : "hover:bg-muted"
+              "group reveal-host relative flex select-none items-stretch rounded-[10px] text-sm outline-none transition-colors",
+              selectionEnabled ? "cursor-pointer" : "cursor-default",
+              // ring-inset keeps the checked outline from nudging neighbours (INV-21).
+              isChecked && "bg-primary/[0.07] ring-1 ring-primary/45 ring-inset",
+              !isChecked && (isHighlighted ? "bg-muted" : "hover:bg-muted")
             )
 
-            if (item.href) {
+            // In batch mode a row never navigates, so it renders as a toggle
+            // <div> even when it carries an href.
+            if (item.href && !selectionEnabled) {
               return (
                 <Link
                   key={item.id}
                   to={item.href}
                   role="option"
-                  aria-selected={isSelected}
+                  aria-selected={isHighlighted}
                   data-index={index}
                   className={className}
                   onMouseEnter={() => onSelectIndex(index)}
@@ -159,7 +216,7 @@ export function ItemList({
               <div
                 key={item.id}
                 role="option"
-                aria-selected={isSelected}
+                aria-selected={selectionEnabled ? isChecked : isHighlighted}
                 data-index={index}
                 className={className}
                 onMouseEnter={() => onSelectIndex(index)}

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -85,6 +85,23 @@ describe("DraftsPage batch delete", () => {
     expect(row).toHaveAttribute("aria-selected", "true")
   })
 
+  it("moves focus between rows with arrow keys and toggles the focused row", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    const alpha = screen.getByRole("option", { name: /Alpha/ })
+    const bravo = screen.getByRole("option", { name: /Bravo/ })
+    alpha.focus()
+
+    await userEvent.keyboard("{ArrowDown}")
+    expect(bravo).toHaveFocus()
+
+    await userEvent.keyboard("{Enter}")
+    // Enter acts on the focused (Bravo) row, not the originally-focused Alpha.
+    expect(bravo).toHaveAttribute("aria-selected", "true")
+    expect(alpha).toHaveAttribute("aria-selected", "false")
+  })
+
   it("select-all then delete confirms with the batch count and removes every draft", async () => {
     renderPage()
 

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -58,13 +58,13 @@ describe("DraftsPage batch delete", () => {
   it("hides the Select control when there are no drafts", () => {
     mockDrafts([])
     renderPage()
-    expect(screen.queryByRole("button", { name: "Select" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Select drafts" })).not.toBeInTheDocument()
   })
 
   it("enters batch mode, selects rows by tapping, and reflects the count", async () => {
     renderPage()
 
-    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
     // Rows are now toggles (no navigation): tap two of them.
     await userEvent.click(screen.getByRole("option", { name: /Alpha/ }))
     await userEvent.click(screen.getByRole("option", { name: /Charlie/ }))
@@ -74,12 +74,23 @@ describe("DraftsPage batch delete", () => {
     expect(screen.getByRole("option", { name: /Bravo/ })).toHaveAttribute("aria-selected", "false")
   })
 
+  it("toggles a row selection with the keyboard (Enter)", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    const row = screen.getByRole("option", { name: /Alpha/ })
+    row.focus()
+    await userEvent.keyboard("{Enter}")
+
+    expect(row).toHaveAttribute("aria-selected", "true")
+  })
+
   it("select-all then delete confirms with the batch count and removes every draft", async () => {
     renderPage()
 
-    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
     await userEvent.click(screen.getByRole("button", { name: "Select all" }))
-    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+    await userEvent.click(screen.getByRole("button", { name: "Delete selected drafts" }))
 
     // Confirmation carries the count, not a singular string.
     const dialog = await screen.findByRole("alertdialog")
@@ -88,19 +99,31 @@ describe("DraftsPage batch delete", () => {
     await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }))
 
     expect(deleteDraft).toHaveBeenCalledTimes(3)
-    expect(deleteDraft.mock.calls.map((c) => c[0])).toEqual(["a", "b", "c"])
+    expect(deleteDraft.mock.calls.map((c) => c[0]).sort()).toEqual(["a", "b", "c"])
     // Batch mode exits after the delete — the Select control returns.
-    expect(await screen.findByRole("button", { name: "Select" })).toBeInTheDocument()
+    expect(await screen.findByRole("button", { name: "Select drafts" })).toBeInTheDocument()
   })
 
   it("leaves batch mode via Cancel without deleting anything", async () => {
     renderPage()
 
-    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
     await userEvent.click(screen.getByRole("option", { name: /Alpha/ }))
     await userEvent.click(screen.getByRole("button", { name: "Cancel selection" }))
 
     expect(deleteDraft).not.toHaveBeenCalled()
-    expect(screen.getByRole("button", { name: "Select" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Select drafts" })).toBeInTheDocument()
+  })
+
+  it("exits batch mode on Escape from anywhere", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    expect(screen.getByRole("button", { name: "Cancel selection" })).toBeInTheDocument()
+
+    await userEvent.keyboard("{Escape}")
+
+    expect(screen.getByRole("button", { name: "Select drafts" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Cancel selection" })).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -115,6 +115,23 @@ describe("DraftsPage batch delete", () => {
     expect(screen.getByRole("button", { name: "Select drafts" })).toBeInTheDocument()
   })
 
+  it("Escape while the confirm dialog is open dismisses only the dialog, keeping the selection", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }))
+    await userEvent.click(screen.getByRole("button", { name: "Delete selected drafts" }))
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument()
+
+    await userEvent.keyboard("{Escape}")
+
+    // Dialog gone, but still in batch mode with the selection intact.
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Cancel selection" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute("aria-selected", "true")
+    expect(deleteDraft).not.toHaveBeenCalled()
+  })
+
   it("exits batch mode on Escape from anywhere", async () => {
     renderPage()
 

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -102,6 +102,27 @@ describe("DraftsPage batch delete", () => {
     expect(alpha).toHaveAttribute("aria-selected", "false")
   })
 
+  it("arrow nav follows visual render order when a group owns non-adjacent rows", async () => {
+    // Recency order interleaves group "Stream A" (rows 0 and 2) around "Stream B"
+    // (row 1); rows render grouped, so visually A-one is above A-two above Bravo.
+    mockDrafts([
+      draft({ id: "a1", displayName: "Alpha one", groupLabel: "Stream A" }),
+      draft({ id: "b", displayName: "Bravo", groupLabel: "Stream B" }),
+      draft({ id: "a2", displayName: "Alpha two", groupLabel: "Stream A" }),
+    ])
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    const aOne = screen.getByRole("option", { name: /Alpha one/ })
+    const aTwo = screen.getByRole("option", { name: /Alpha two/ })
+    aOne.focus()
+
+    // Down goes to the next row on screen (Alpha two, same group), not the
+    // next flat index (Bravo).
+    await userEvent.keyboard("{ArrowDown}")
+    expect(aTwo).toHaveFocus()
+  })
+
   it("select-all then delete confirms with the batch count and removes every draft", async () => {
     renderPage()
 

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -1,6 +1,7 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import { describe, expect, it, vi, beforeEach } from "vitest"
-import { render, screen, userEvent, within } from "@/test"
+import { toast } from "sonner"
+import { render, screen, userEvent, within, waitFor } from "@/test"
 import { DraftsPage } from "./drafts"
 import { SidebarProvider } from "@/contexts"
 import * as hooksModule from "@/hooks"
@@ -47,7 +48,8 @@ function renderPage() {
 describe("DraftsPage batch delete", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
-    deleteDraft.mockClear()
+    deleteDraft.mockReset()
+    deleteDraft.mockResolvedValue(undefined)
     mockDrafts([
       draft({ id: "a", displayName: "Alpha" }),
       draft({ id: "b", displayName: "Bravo" }),
@@ -140,6 +142,25 @@ describe("DraftsPage batch delete", () => {
     expect(deleteDraft.mock.calls.map((c) => c[0]).sort()).toEqual(["a", "b", "c"])
     // Batch mode exits after the delete — the Select control returns.
     expect(await screen.findByRole("button", { name: "Select drafts" })).toBeInTheDocument()
+  })
+
+  it("reports the count of drafts that failed to delete", async () => {
+    const errorToast = vi.spyOn(toast, "error").mockImplementation(() => "err")
+    deleteDraft.mockImplementation(async (id: string) => {
+      if (id === "b") throw new Error("boom")
+    })
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select drafts" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }))
+    await userEvent.click(screen.getByRole("button", { name: "Delete selected drafts" }))
+    const dialog = await screen.findByRole("alertdialog")
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }))
+
+    // Every draft is still attempted (allSettled); the toast reports the real
+    // failed count, not a generic message.
+    expect(deleteDraft).toHaveBeenCalledTimes(3)
+    await waitFor(() => expect(errorToast).toHaveBeenCalledWith("Failed to delete 1 of 3 drafts"))
   })
 
   it("leaves batch mode via Cancel without deleting anything", async () => {

--- a/apps/frontend/src/pages/drafts.test.tsx
+++ b/apps/frontend/src/pages/drafts.test.tsx
@@ -1,0 +1,106 @@
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, userEvent, within } from "@/test"
+import { DraftsPage } from "./drafts"
+import { SidebarProvider } from "@/contexts"
+import * as hooksModule from "@/hooks"
+import type { UnifiedDraft } from "@/hooks"
+
+const WS = "ws_1"
+
+function draft(overrides: Partial<UnifiedDraft> & { id: string; displayName: string }): UnifiedDraft {
+  return {
+    type: "channel",
+    streamId: `stream_${overrides.id}`,
+    preview: "some text",
+    attachmentCount: 0,
+    updatedAt: 0,
+    href: `/w/${WS}/s/stream_${overrides.id}`,
+    groupLabel: overrides.displayName,
+    isStashed: false,
+    ...overrides,
+  }
+}
+
+const deleteDraft = vi.fn(async (_id: string) => {})
+
+function mockDrafts(drafts: UnifiedDraft[]) {
+  vi.spyOn(hooksModule, "useAllDrafts").mockReturnValue({
+    drafts,
+    draftCount: drafts.length,
+    deleteDraft,
+  } as unknown as ReturnType<typeof hooksModule.useAllDrafts>)
+}
+
+function renderPage() {
+  return render(
+    <SidebarProvider>
+      <MemoryRouter initialEntries={[`/w/${WS}/drafts`]}>
+        <Routes>
+          <Route path="/w/:workspaceId/drafts" element={<DraftsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </SidebarProvider>
+  )
+}
+
+describe("DraftsPage batch delete", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    deleteDraft.mockClear()
+    mockDrafts([
+      draft({ id: "a", displayName: "Alpha" }),
+      draft({ id: "b", displayName: "Bravo" }),
+      draft({ id: "c", displayName: "Charlie" }),
+    ])
+  })
+
+  it("hides the Select control when there are no drafts", () => {
+    mockDrafts([])
+    renderPage()
+    expect(screen.queryByRole("button", { name: "Select" })).not.toBeInTheDocument()
+  })
+
+  it("enters batch mode, selects rows by tapping, and reflects the count", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    // Rows are now toggles (no navigation): tap two of them.
+    await userEvent.click(screen.getByRole("option", { name: /Alpha/ }))
+    await userEvent.click(screen.getByRole("option", { name: /Charlie/ }))
+
+    expect(screen.getByRole("option", { name: /Alpha/ })).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByRole("option", { name: /Charlie/ })).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByRole("option", { name: /Bravo/ })).toHaveAttribute("aria-selected", "false")
+  })
+
+  it("select-all then delete confirms with the batch count and removes every draft", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    await userEvent.click(screen.getByRole("button", { name: "Select all" }))
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }))
+
+    // Confirmation carries the count, not a singular string.
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).getByText("Delete 3 drafts?")).toBeInTheDocument()
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Delete" }))
+
+    expect(deleteDraft).toHaveBeenCalledTimes(3)
+    expect(deleteDraft.mock.calls.map((c) => c[0])).toEqual(["a", "b", "c"])
+    // Batch mode exits after the delete — the Select control returns.
+    expect(await screen.findByRole("button", { name: "Select" })).toBeInTheDocument()
+  })
+
+  it("leaves batch mode via Cancel without deleting anything", async () => {
+    renderPage()
+
+    await userEvent.click(screen.getByRole("button", { name: "Select" }))
+    await userEvent.click(screen.getByRole("option", { name: /Alpha/ }))
+    await userEvent.click(screen.getByRole("button", { name: "Cancel selection" }))
+
+    expect(deleteDraft).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "Select" })).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -96,15 +96,18 @@ export function DraftsPage() {
 
   // Escape exits batch mode from anywhere. A document listener (not <main>'s
   // onKeyDown) so it fires no matter where focus landed — clicking the header
-  // "Select" button moves focus to <body>, outside <main>'s subtree.
+  // "Select" button moves focus to <body>, outside <main>'s subtree. Suspended
+  // while the confirm dialog is open: Radix closes it on Escape via a
+  // capture-phase preventDefault without stopPropagation, so an unguarded
+  // listener here would also fire and drop the whole selection.
   useEffect(() => {
-    if (!batchMode) return
+    if (!batchMode || bulkConfirmOpen) return
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") exitBatchMode()
     }
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
-  }, [batchMode, exitBatchMode])
+  }, [batchMode, bulkConfirmOpen, exitBatchMode])
 
   const allSelected = drafts.length > 0 && selectedIds.size === drafts.length
   const toggleSelectAll = useCallback(() => {

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -53,6 +53,14 @@ export function DraftsPage() {
     })
   }, [drafts])
 
+  // Keep the roving-tabindex anchor in range when the list shrinks. If
+  // selectedIndex pointed past the new end, no option would be the tab stop and
+  // (since <main> is not a tab stop in batch mode) the list would be
+  // unreachable by keyboard until a mouse click.
+  useEffect(() => {
+    setSelectedIndex((prev) => (drafts.length === 0 ? 0 : Math.min(prev, drafts.length - 1)))
+  }, [drafts.length])
+
   const handleSelectDraft = useCallback(
     (href: string | null) => {
       if (href) {

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -287,7 +287,10 @@ export function DraftsPage() {
               }
             }
           }}
-          tabIndex={0}
+          // Not a tab stop in batch mode — the option list owns keyboard focus
+          // there (roving tabindex), so <main> shouldn't sit between the header
+          // controls and the first row.
+          tabIndex={batchMode ? -1 : 0}
         >
           <ItemList
             items={items}

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -94,6 +94,18 @@ export function DraftsPage() {
     setSelectedIds(new Set())
   }, [])
 
+  // Escape exits batch mode from anywhere. A document listener (not <main>'s
+  // onKeyDown) so it fires no matter where focus landed — clicking the header
+  // "Select" button moves focus to <body>, outside <main>'s subtree.
+  useEffect(() => {
+    if (!batchMode) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") exitBatchMode()
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [batchMode, exitBatchMode])
+
   const allSelected = drafts.length > 0 && selectedIds.size === drafts.length
   const toggleSelectAll = useCallback(() => {
     setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts.map((draft) => draft.id))))
@@ -105,11 +117,11 @@ export function DraftsPage() {
     const ids = drafts.filter((draft) => selectedIds.has(draft.id)).map((draft) => draft.id)
     setBulkConfirmOpen(false)
     exitBatchMode()
-    try {
-      for (const id of ids) await deleteDraft(id)
-    } catch {
-      toast.error("Failed to delete some drafts")
-    }
+    // allSettled, not a for-await loop: one failing delete must not abort the
+    // rest, and the toast reports the real failed count (INV-11, fail loudly).
+    const results = await Promise.allSettled(ids.map((id) => deleteDraft(id)))
+    const failed = results.filter((result) => result.status === "rejected").length
+    if (failed > 0) toast.error(`Failed to delete ${failed} of ${ids.length} drafts`)
   }, [drafts, selectedIds, deleteDraft, exitBatchMode])
 
   // Convert drafts to QuickSwitcherItem format. Stashed rows render under the
@@ -166,7 +178,7 @@ export function DraftsPage() {
   const countPill = (
     <span
       className={cn(
-        "inline-flex h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-xs font-medium tabular-nums tracking-tight transition-colors",
+        "inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full px-1.5 text-xs font-medium tabular-nums tracking-tight transition-colors",
         selectedCount > 0 ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
       )}
       aria-live="polite"
@@ -184,23 +196,33 @@ export function DraftsPage() {
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8"
+                className="h-8 w-8 shrink-0"
                 onClick={exitBatchMode}
                 aria-label="Cancel selection"
               >
                 <X className="h-4 w-4" />
               </Button>
               {countPill}
-              <span className="text-sm font-medium">selected</span>
+              {/* Label hidden on phones to keep the control row from overflowing
+                  narrow viewports — mirrors the timeline's BatchSelectionBar. */}
+              <span className="hidden text-sm font-medium sm:inline">selected</span>
               <div className="ml-auto flex items-center gap-1">
-                <Button variant="ghost" size="sm" onClick={toggleSelectAll} disabled={drafts.length === 0}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={toggleSelectAll}
+                  disabled={drafts.length === 0}
+                >
                   {allSelected ? "Deselect all" : "Select all"}
                 </Button>
                 <Button
                   variant="destructive"
                   size="sm"
+                  className="shrink-0"
                   onClick={() => setBulkConfirmOpen(true)}
                   disabled={selectedCount === 0}
+                  aria-label="Delete selected drafts"
                 >
                   <Trash2 className="h-4 w-4 sm:mr-1.5" />
                   <span className="hidden sm:inline">Delete</span>
@@ -220,7 +242,13 @@ export function DraftsPage() {
                 <h1 className="font-semibold">Drafts</h1>
               </div>
               {drafts.length > 0 && (
-                <Button variant="ghost" size="sm" className="ml-auto" onClick={enterBatchMode}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto"
+                  onClick={enterBatchMode}
+                  aria-label="Select drafts"
+                >
                   <ListChecks className="h-4 w-4 sm:mr-1.5" />
                   <span className="hidden sm:inline">Select</span>
                 </Button>
@@ -243,12 +271,6 @@ export function DraftsPage() {
               case "ArrowUp":
                 e.preventDefault()
                 setSelectedIndex((prev) => Math.max(prev - 1, 0))
-                break
-              case "Escape":
-                if (batchMode) {
-                  e.preventDefault()
-                  exitBatchMode()
-                }
                 break
               case "Enter": {
                 e.preventDefault()

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -262,7 +262,11 @@ export function DraftsPage() {
         <main
           className="flex-1 overflow-hidden"
           onKeyDown={(e) => {
-            if (drafts.length === 0) return
+            // Batch mode is driven entirely by row focus — each option is
+            // focusable and handles Enter/Space itself, so the highlight is
+            // always the focused row. The page-level arrow/Enter nav below is
+            // the browse-and-open model, active only when not selecting.
+            if (drafts.length === 0 || batchMode) return
 
             const isMod = e.metaKey || e.ctrlKey
 
@@ -278,12 +282,7 @@ export function DraftsPage() {
               case "Enter": {
                 e.preventDefault()
                 const item = items[selectedIndex]
-                if (!item) break
-                if (batchMode) {
-                  toggleSelect(item.id)
-                } else {
-                  handleSelectItem(item, isMod)
-                }
+                if (item) handleSelectItem(item, isMod)
                 break
               }
             }

--- a/apps/frontend/src/pages/drafts.tsx
+++ b/apps/frontend/src/pages/drafts.tsx
@@ -1,11 +1,24 @@
-import { useState, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo, useEffect } from "react"
 import { useParams, useNavigate, Link } from "react-router-dom"
-import { FileText, Hash, MessageSquare, Trash2, FileEdit, ArrowLeft, Bookmark, StickyNote } from "lucide-react"
+import {
+  FileText,
+  Hash,
+  MessageSquare,
+  Trash2,
+  FileEdit,
+  ArrowLeft,
+  Bookmark,
+  StickyNote,
+  ListChecks,
+  X,
+} from "lucide-react"
+import { toast } from "sonner"
 import { CompanionModes } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import { DeleteDraftConfirmDialog } from "@/components/drafts/delete-draft-confirm-dialog"
 import { ItemList, type QuickSwitcherItem } from "@/components/quick-switcher"
 import { SidebarToggle } from "@/components/layout"
+import { cn } from "@/lib/utils"
 import { useAllDrafts, type UnifiedDraft, type DraftType } from "@/hooks"
 
 const TYPE_ICONS: Record<DraftType, React.ComponentType<{ className?: string }>> = {
@@ -21,6 +34,24 @@ export function DraftsPage() {
   const { drafts, deleteDraft } = useAllDrafts(workspaceId ?? "")
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [draftToDelete, setDraftToDelete] = useState<UnifiedDraft | null>(null)
+
+  // Batch-select mode: the whole list becomes tappable toggles (desktop + mobile)
+  // with a single bulk-delete action, mirroring the message timeline's selection.
+  const [batchMode, setBatchMode] = useState(false)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false)
+
+  // Drop selections whose draft has since disappeared (sync delete on another
+  // device) so the count and select-all state stay truthful.
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev
+      const valid = new Set(drafts.map((draft) => draft.id))
+      const next = new Set<string>()
+      for (const id of prev) if (valid.has(id)) next.add(id)
+      return next.size === prev.size ? prev : next
+    })
+  }, [drafts])
 
   const handleSelectDraft = useCallback(
     (href: string | null) => {
@@ -46,6 +77,40 @@ export function DraftsPage() {
   const handleCancelDelete = useCallback(() => {
     setDraftToDelete(null)
   }, [])
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const enterBatchMode = useCallback(() => setBatchMode(true), [])
+
+  const exitBatchMode = useCallback(() => {
+    setBatchMode(false)
+    setSelectedIds(new Set())
+  }, [])
+
+  const allSelected = drafts.length > 0 && selectedIds.size === drafts.length
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => (prev.size === drafts.length ? new Set() : new Set(drafts.map((draft) => draft.id))))
+  }, [drafts])
+
+  const selectedCount = selectedIds.size
+
+  const handleConfirmBulkDelete = useCallback(async () => {
+    const ids = drafts.filter((draft) => selectedIds.has(draft.id)).map((draft) => draft.id)
+    setBulkConfirmOpen(false)
+    exitBatchMode()
+    try {
+      for (const id of ids) await deleteDraft(id)
+    } catch {
+      toast.error("Failed to delete some drafts")
+    }
+  }, [drafts, selectedIds, deleteDraft, exitBatchMode])
 
   // Convert drafts to QuickSwitcherItem format. Stashed rows render under the
   // same per-stream `group` as their ambient-draft sibling, so the explorer
@@ -98,20 +163,70 @@ export function DraftsPage() {
     return null
   }
 
+  const countPill = (
+    <span
+      className={cn(
+        "inline-flex h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-xs font-medium tabular-nums tracking-tight transition-colors",
+        selectedCount > 0 ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+      )}
+      aria-live="polite"
+    >
+      {selectedCount}
+    </span>
+  )
+
   return (
     <>
       <div className="flex h-full flex-col">
         <header className="flex h-12 items-center gap-2 border-b px-4">
-          <SidebarToggle location="page" />
-          <Link to={`/w/${workspaceId}`}>
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <ArrowLeft className="h-4 w-4" />
-            </Button>
-          </Link>
-          <div className="flex items-center gap-2">
-            <FileEdit className="h-5 w-5 text-muted-foreground" />
-            <h1 className="font-semibold">Drafts</h1>
-          </div>
+          {batchMode ? (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={exitBatchMode}
+                aria-label="Cancel selection"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              {countPill}
+              <span className="text-sm font-medium">selected</span>
+              <div className="ml-auto flex items-center gap-1">
+                <Button variant="ghost" size="sm" onClick={toggleSelectAll} disabled={drafts.length === 0}>
+                  {allSelected ? "Deselect all" : "Select all"}
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => setBulkConfirmOpen(true)}
+                  disabled={selectedCount === 0}
+                >
+                  <Trash2 className="h-4 w-4 sm:mr-1.5" />
+                  <span className="hidden sm:inline">Delete</span>
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <SidebarToggle location="page" />
+              <Link to={`/w/${workspaceId}`}>
+                <Button variant="ghost" size="icon" className="h-8 w-8">
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+              </Link>
+              <div className="flex items-center gap-2">
+                <FileEdit className="h-5 w-5 text-muted-foreground" />
+                <h1 className="font-semibold">Drafts</h1>
+              </div>
+              {drafts.length > 0 && (
+                <Button variant="ghost" size="sm" className="ml-auto" onClick={enterBatchMode}>
+                  <ListChecks className="h-4 w-4 sm:mr-1.5" />
+                  <span className="hidden sm:inline">Select</span>
+                </Button>
+              )}
+            </>
+          )}
         </header>
         <main
           className="flex-1 overflow-hidden"
@@ -129,10 +244,19 @@ export function DraftsPage() {
                 e.preventDefault()
                 setSelectedIndex((prev) => Math.max(prev - 1, 0))
                 break
+              case "Escape":
+                if (batchMode) {
+                  e.preventDefault()
+                  exitBatchMode()
+                }
+                break
               case "Enter": {
                 e.preventDefault()
                 const item = items[selectedIndex]
-                if (item) {
+                if (!item) break
+                if (batchMode) {
+                  toggleSelect(item.id)
+                } else {
                   handleSelectItem(item, isMod)
                 }
                 break
@@ -146,6 +270,7 @@ export function DraftsPage() {
             selectedIndex={selectedIndex}
             onSelectIndex={setSelectedIndex}
             onSelectItem={handleSelectItem}
+            selection={batchMode ? { enabled: true, selectedIds, onToggle: toggleSelect } : undefined}
             emptyMessage="No drafts"
           />
         </main>
@@ -155,6 +280,13 @@ export function DraftsPage() {
         open={!!draftToDelete}
         onOpenChange={(open) => !open && handleCancelDelete()}
         onConfirm={handleConfirmDelete}
+      />
+
+      <DeleteDraftConfirmDialog
+        open={bulkConfirmOpen}
+        onOpenChange={setBulkConfirmOpen}
+        onConfirm={handleConfirmBulkDelete}
+        count={selectedCount}
       />
     </>
   )


### PR DESCRIPTION
## Problem

The Drafts explorer (`apps/frontend/src/pages/drafts.tsx`) could only delete drafts one at a time — each row's trash action opened a single-item confirm. Clearing out a pile of stale drafts meant tapping through the same confirm N times, which is especially painful on mobile.

## Solution

A batch-select mode on the Drafts page, modeled on the message timeline's selection look-and-feel. A **Select** button in the header turns every row into a tappable toggle (desktop and touch); a single **Delete** removes all selected drafts behind one count-aware confirmation ("Delete N drafts?"). The hard constraint throughout was **no layout shift** — entering select mode must not move anything, rows just become selectable.

### How it works

- **Shared `ItemList` grows an optional `selection` layer** (`apps/frontend/src/components/quick-switcher/item-list.tsx`). When present and enabled, the row's leading icon swaps in place for a `SelectionToggle` check circle sized to the exact footprint it replaces (`h-7` for avatar rows, `h-4` for icon rows), navigation is suppressed, per-row actions hide, and the checked row gets the timeline's `bg-primary/[0.07] ring-1 ring-primary/45 ring-inset` styling (ring-inset, so no reflow — INV-21). The quick-switcher and share-picker never pass `selection`, so their behavior is byte-identical.
- **Header swaps within the same `h-12` shell** — not a new bar — into `[✕ cancel] [count pill] "selected" … [Select all/Deselect all] [Delete]`, so the list below never moves. On phones the "selected" label is `hidden sm:inline` and the controls carry `shrink-0`, mirroring the timeline's `BatchSelectionBar`, so the row can't overflow a 320px viewport.
- **Bulk delete** (`handleConfirmBulkDelete`) snapshots the selected ids, exits batch mode, then `Promise.allSettled(ids.map(deleteDraft))` so one failing delete never aborts the rest; on failure `toast.error("Failed to delete N of M drafts")` reports the real count (INV-11). Success is silent (INV-63). Single-item delete via the per-row trash is untouched.
- **`DeleteDraftConfirmDialog` takes an optional `count`** so single- and bulk-delete stay on one confirm path (INV-35/43); `count > 1` renders the plural copy, `undefined`/`1` keeps the existing singular.
- **Keyboard model is a WAI-ARIA roving-tabindex listbox.** In select mode the list is one Tab stop (only the active option has `tabIndex 0`); Up/Down/Home/End move focus between options via `focusOptionFrom`, which walks the live `[data-index]` node list in **render order** (rows render grouped, so the flat index is not visual order); Enter/Space toggle the focused row. The highlight is `focus:bg-muted`, so the visibly-focused row is always the one Enter acts on. Escape exits from anywhere via a document listener, suspended while the confirm dialog is open so its own Escape only closes the dialog. `<main>` drops out of the tab order in batch mode. `selectedIndex` is clamped when the list shrinks so the roving anchor always lands on a real option and the list stays keyboard-reachable.

### Key design decisions

**1. Extend the shared `ItemList`, don't fork a drafts-only list.** The drafts explorer already renders through `ItemList`; a parallel selectable list would drift from it (INV-35/37). The `selection` prop is opt-in and defaults off, so the two other consumers are unaffected.

**2. Reuse `DeleteDraftConfirmDialog` with a `count` rather than a second dialog.** One confirm shell for single and bulk delete keeps the copy and behavior from diverging (INV-35/43).

**3. Icon-swap-in-place for the toggle, not a leading checkbox column.** A new column would shift every row's text on mode entry. Swapping the existing leading visual for a same-footprint circle is the zero-shift path the user asked for (INV-21), and matches the timeline's avatar-as-toggle.

**4. Nouns are "drafts", not "messages".** The user described these as messages, but the rows are drafts; the confirmation and labels say "drafts" for accuracy.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/drafts.tsx` | Batch-select state, header selection controls, bulk-delete flow, selection/roving-anchor pruning + clamping effects, guarded Escape listener |
| `apps/frontend/src/components/quick-switcher/item-list.tsx` | Optional `selection` layer: `SelectionToggle`, checked styling, roving-tabindex keyboard nav (`focusOptionFrom`/`handleSelectionKeyDown`), focus-driven highlight |
| `apps/frontend/src/components/drafts/delete-draft-confirm-dialog.tsx` | Optional `count` for bulk copy |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/pages/drafts.test.tsx` | Batch-select coverage: tap-to-select, select-all → count confirm → per-draft delete, cancel, keyboard Enter/arrow-roving (incl. interleaved-group render order), Escape-exit, Escape-over-dialog, partial-failure toast |

## Out of scope (deliberate)

- Bulk actions other than delete (move, mark-read) — delete-only per the request.
- Backend batch-delete endpoint — `deleteDraft` is the existing per-draft IDB + queued-server path; there's no batch API, so the bulk path calls it per id.

## Test plan

- [x] `apps/frontend` — `drafts.test.tsx` (10) + quick-switcher suites, 271 pass
- [x] `tsc --noEmit` (frontend) clean; eslint + prettier clean on changed files
- [x] Pre-PR review (6 rounds, sonnet spec+design / correctness+data-flow / UX / mobile): 10 findings fixed across rounds (allSettled bulk delete, footprint-sized toggle, keyboard focus model, roving-tabindex render-order nav, selectedIndex clamp, dialog-Escape guard, mobile overflow, aria-labels), final two rounds returned no issues (7/7)
- [ ] No live app/E2E run in this session — behavior is covered by the mounted-component tests above, not a browser click-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHZJntNLA3tgY7GcDCb4FC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785663595&installation_id=129946197&pr_number=1154&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1154&signature=010e0146678dba997e40703421f771c33258918a802f76f53fc385093c16d9b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->