### PR TITLE
feat(agents): turn-purpose union consolidation (roadmap 1.5)

### DIFF
--- a/apps/backend/evals/suites/companion/suite.ts
+++ b/apps/backend/evals/suites/companion/suite.ts
@@ -69,7 +69,7 @@ import type { StorageProvider } from "../../../src/lib/storage/s3-client"
 import { EventService } from "../../../src/features/messaging"
 import type { Server } from "socket.io"
 import { parseMarkdown } from "@threa/prosemirror"
-import { AuthorTypes, AgentTriggers, StreamTypes } from "@threa/types"
+import { AuthorTypes, StreamTypes } from "@threa/types"
 import { ulid } from "ulid"
 import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
 
@@ -447,7 +447,7 @@ async function runCompanionTask(input: CompanionInput, ctx: EvalContext): Promis
       messageId,
       personaId,
       serverId: `eval-server-${ulid()}`,
-      trigger: input.trigger === "mention" ? AgentTriggers.MENTION : undefined,
+      purpose: input.trigger === "mention" ? { kind: "mention" } : { kind: "catch_up" },
       currentTime: input.currentTime ? new Date(input.currentTime) : undefined,
     }
 

--- a/apps/backend/evals/suites/multimodal-vision/suite.ts
+++ b/apps/backend/evals/suites/multimodal-vision/suite.ts
@@ -427,7 +427,7 @@ async function runVisionTask(input: MultimodalVisionInput, ctx: EvalContext): Pr
       messageId,
       personaId,
       serverId: `eval-server-${ulid()}`,
-      trigger: undefined, // Companion mode
+      purpose: { kind: "catch_up" }, // Companion mode
     }
 
     // Run the agent!

--- a/apps/backend/src/features/agents/companion/context.ts
+++ b/apps/backend/src/features/agents/companion/context.ts
@@ -2,7 +2,7 @@ import type { Pool } from "pg"
 import type { ModelMessage } from "ai"
 import type { AgentTool } from "@threa/agent-runtime"
 import type { UserPreferences } from "@threa/types"
-import { AgentTriggers, AuthorTypes, StreamTypes } from "@threa/types"
+import { AuthorTypes, StreamTypes } from "@threa/types"
 import type { UserPreferencesService } from "../../user-preferences"
 import { MessageRepository, SharedMessageRepository, collectSharedMessageIds, type Message } from "../../messaging"
 import { UserRepository } from "../../workspaces"
@@ -21,6 +21,7 @@ import { loadCrossSurfaceStitch, formatSpawnedFromContext, type CrossSurfaceStit
 import { formatMessagesWithTemporal } from "./prompt/message-format"
 import { resolveQuoteReplies, renderMessageWithQuoteContext, DEFAULT_MAX_QUOTE_DEPTH } from "../quote-resolver"
 import { computeAgentAccessSpec } from "../researcher/access-spec"
+import type { TurnPurpose } from "../turn-purpose"
 import { SearchRepository } from "../../search"
 import { logger } from "../../../lib/logger"
 import { escapeXmlAttr } from "../../../lib/xml"
@@ -37,7 +38,8 @@ export interface ContextParams {
   stream: Stream
   messageId: string
   persona: Persona
-  trigger?: typeof AgentTriggers.MENTION
+  /** Why this turn is running (roadmap 1.5) — drives mentionerName resolution here. */
+  purpose: TurnPurpose
   /**
    * Per-turn hydration policy, resolved at the dispatch (`Hydrate`) seam by
    * `resolveContextWindowPolicy`. Fixes the window budget and whether prior
@@ -62,8 +64,13 @@ export interface AgentContext {
    * access, integrations, researcher callbacks — come from this context), and
    * the prompt's tool sections must reflect exactly what was wired, never a
    * parallel enabled-tools list (INV-44-adjacent: one source of truth).
+   *
+   * Takes the *effective* purpose at call time — a supersede rerun whose target
+   * session vanished, or a follow-up whose row failed to load, is passed as
+   * `catch_up` so its prompt section (and derived flags) match the behavior the
+   * turn actually takes. The plan/row aren't known until after context build.
    */
-  composeSystemPrompt: (tools: AgentTool[]) => string
+  composeSystemPrompt: (tools: AgentTool[], purpose: TurnPurpose) => string
   messages: ModelMessage[]
   triggerMessage: Message | null
   invokingUserId: string | undefined
@@ -109,7 +116,7 @@ async function resolveScratchpadCustomPrompt(
  */
 export async function buildAgentContext(deps: ContextDeps, params: ContextParams): Promise<AgentContext> {
   const { db, userPreferencesService, conversationSummaryService } = deps
-  const { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime, followUp } = params
+  const { workspaceId, streamId, stream, messageId, persona, purpose, policy, currentTime, followUp } = params
 
   const triggerMessage = await MessageRepository.findById(db, messageId)
   const invokingUserId = triggerMessage?.authorType === AuthorTypes.USER ? triggerMessage.authorId : undefined
@@ -233,7 +240,7 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
   for (const [id, name] of resolvedNames) authorNames.set(id, name)
 
   let mentionerName: string | undefined
-  if (trigger === AgentTriggers.MENTION && triggerMessage?.authorType === AuthorTypes.USER) {
+  if (purpose.kind === "mention" && triggerMessage?.authorType === AuthorTypes.USER) {
     const mentioner = await UserRepository.findById(db, workspaceId, triggerMessage.authorId)
     mentionerName = mentioner?.name ?? undefined
   }
@@ -371,12 +378,12 @@ export async function buildAgentContext(deps: ContextDeps, params: ContextParams
       ? formatSpawnedFromContext(crossSurfaceStitch, authorNames, streamContext.temporal)
       : null
 
-  const composeSystemPrompt = (tools: AgentTool[]): string => {
+  const composeSystemPrompt = (tools: AgentTool[], effectivePurpose: TurnPurpose): string => {
     let systemPrompt = buildSystemPrompt(
       persona,
       streamContext,
       scratchpadCustomPrompt,
-      trigger,
+      effectivePurpose,
       mentionerName,
       rollingConversationSummary,
       tools,

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -159,7 +159,7 @@ describe("buildSystemPrompt", () => {
         },
       },
       null,
-      undefined,
+      { kind: "follow_up", followUpId: "agfu_01" },
       undefined,
       null,
       [],
@@ -195,6 +195,45 @@ describe("buildSystemPrompt", () => {
 
     expect(provided).not.toContain("## Scheduled follow-up firing now")
     expect(explicitNull).not.toContain("## Scheduled follow-up firing now")
+  })
+
+  test("injects the mention invocation section, naming the mentioner, for a mention turn", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null, { kind: "mention" }, "Kris")
+
+    expect(prompt).toContain("## Invocation Context")
+    expect(prompt).toContain("You were explicitly @mentioned by **Kris**")
+  })
+
+  test("omits the mention invocation section for a catch-up turn", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null, { kind: "catch_up" })
+
+    expect(prompt).not.toContain("## Invocation Context")
+  })
+
+  test("injects the supersede reconciliation section last for a supersede rerun", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null, {
+      kind: "supersede_rerun",
+      supersedesSessionId: "agsess_prev",
+      rerunContext: {
+        cause: "invoking_message_edited",
+        editedMessageId: "msg_edited",
+        editedMessageBefore: "book me a flight",
+        editedMessageAfter: "book me a train",
+      },
+    })
+
+    expect(prompt).toContain("## Superseded Session Reconciliation")
+    expect(prompt).toContain("Edited message ID: msg_edited")
+    expect(prompt).toContain('After edit: "book me a train"')
+    expect(prompt).toContain("exactly one of `keep_response` or `send_message`")
+    // Reconciliation lands last so its final-decision directive is most salient.
+    expect(prompt.indexOf("## Superseded Session Reconciliation")).toBeGreaterThan(prompt.indexOf("## Response Style"))
+  })
+
+  test("omits the supersede reconciliation section for a catch-up turn", () => {
+    const prompt = buildSystemPrompt(persona, scratchpadContext, null, { kind: "catch_up" })
+
+    expect(prompt).not.toContain("## Superseded Session Reconciliation")
   })
 
   test("web search recency guidance references Current Time when the tool is temporally grounded", () => {

--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.ts
@@ -1,14 +1,16 @@
-import { AgentTriggers, StreamTypes } from "@threa/types"
 import { buildToolPromptSections, formatConversationMemoryForPrompt, type AgentTool } from "@threa/agent-runtime"
-import { buildTemporalPromptSection, formatCurrentTime } from "../../../../lib/temporal"
+import { buildTemporalPromptSection } from "../../../../lib/temporal"
 import type { Persona } from "../../persona-repository"
 import type { StreamContext } from "../../context-builder"
+import type { TurnPurpose } from "../../turn-purpose"
 import { WORKSPACE_RESEARCH_TOOL_NAME } from "../../tools"
 import { buildPromptSectionForStreamType } from "./stream-context-sections"
+import { buildEarlyPurposeSection, buildLatePurposeSection } from "./turn-purpose-prompt"
 
 /**
  * Build the system prompt for the persona agent.
- * Produces stream-type-specific context and optional mention invocation context.
+ * Produces stream-type-specific context and the turn's purpose section (mention,
+ * scheduled follow-up, or supersede reconciliation — dispatched in turn-purpose-prompt).
  *
  * `tools` is the ACTUAL built toolset for the turn: each tool's prose rides its
  * definition (`AgentToolConfig.promptBlock`) and is assembled here in toolset
@@ -20,7 +22,7 @@ export function buildSystemPrompt(
   persona: Persona,
   context: StreamContext,
   scratchpadCustomPrompt?: string | null,
-  trigger?: typeof AgentTriggers.MENTION,
+  purpose: TurnPurpose = { kind: "catch_up" },
   mentionerName?: string,
   rollingConversationSummary?: string | null,
   tools: AgentTool[] = [],
@@ -47,40 +49,10 @@ Apply them in scratchpads and scratchpad-root threads unless they conflict with 
 ${scratchpadCustomPrompt.trim()}`
   }
 
-  if (trigger === AgentTriggers.MENTION) {
-    const mentionerDesc = mentionerName ? `**${mentionerName}**` : "a user"
-    prompt += `
-
-## Invocation Context
-
-You were explicitly @mentioned by ${mentionerDesc} who wants your assistance.`
-
-    if (context.streamType === StreamTypes.CHANNEL) {
-      prompt += ` This conversation is happening in a thread created specifically for your response.`
-    }
-  }
-
-  if (followUp) {
-    const scheduledForDisplay = context.temporal
-      ? formatCurrentTime(
-          followUp.scheduledFor,
-          context.temporal.timezone,
-          context.temporal.dateFormat,
-          context.temporal.timeFormat
-        )
-      : followUp.scheduledFor.toISOString()
-
-    prompt += `
-
-## Scheduled follow-up firing now
-
-This turn is a follow-up you scheduled for yourself — not a new message from anyone. You are waking up on your own timer to revisit this stream.
-
-- You set this reminder (at ${scheduledForDisplay}) to: "${followUp.note.trim()}"
-- This IS that reminder firing. Act on it now — look at what has happened in the stream since you scheduled it and, if there's something worth saying, post your check-in with \`send_message\`. Do not decline or promise to check back later; later is now.
-- Do NOT schedule another follow-up for the same thing. The note above is what this turn is already handling — re-reading it as a fresh instruction and scheduling again just loops forever. Only schedule a new follow-up if genuinely new future work has surfaced.
-- If nothing needs saying (the matter resolved itself, nothing changed, or you're still waiting on someone), call \`keep_response\` with a brief reason and stay silent. Do not post filler.`
-  }
+  // Why-this-turn-is-running section, dispatched by purpose. Mention and
+  // follow-up describe the invocation up front; supersede reconciliation lands
+  // last (below) for salience. `followUp` carries the note the fired row held.
+  prompt += buildEarlyPurposeSection(purpose, { context, mentionerName, followUp })
 
   prompt += buildPromptSectionForStreamType(context, workspaceResearchEnabled)
 
@@ -178,6 +150,11 @@ Safety rules:
   if (context.temporal) {
     prompt += buildTemporalPromptSection(context.temporal, context.participantTimezones)
   }
+
+  // Supersede reconciliation lands last so its "call exactly one of
+  // keep_response / send_message" directive is the most salient instruction
+  // before the model acts. Empty for every other purpose.
+  prompt += buildLatePurposeSection(purpose)
 
   return prompt
 }

--- a/apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts
@@ -1,0 +1,110 @@
+import { StreamTypes, type AgentSessionRerunContext } from "@threa/types"
+import { formatCurrentTime } from "../../../../lib/temporal"
+import type { StreamContext } from "../../context-builder"
+import type { TurnPurpose } from "../../turn-purpose"
+
+/**
+ * Per-purpose system-prompt sections. Each invocation kind self-describes why
+ * the turn is running, mirroring how each tool carries its own `promptBlock`
+ * (roadmap 1.5). One switch here is the single place a new kind adds its
+ * prose — no scattered `if (trigger === …)` / `if (followUp)` branches.
+ *
+ * Two insertion points, both dispatched from the same purpose:
+ * - "early" (mention, follow-up) — announces the invocation before the stream
+ *   context, matching where these have always sat.
+ * - "late" (supersede reconciliation) — appended after everything else so its
+ *   final-decision directive is the most salient instruction.
+ */
+
+interface EarlyPurposeContext {
+  context: StreamContext
+  mentionerName?: string
+  /** The note the fired follow-up carried; present only for a follow-up turn. */
+  followUp?: { note: string; scheduledFor: Date } | null
+}
+
+export function buildEarlyPurposeSection(purpose: TurnPurpose, ctx: EarlyPurposeContext): string {
+  switch (purpose.kind) {
+    case "mention":
+      return buildMentionSection(ctx.context, ctx.mentionerName)
+    case "follow_up":
+      return ctx.followUp ? buildFollowUpSection(ctx.context, ctx.followUp) : ""
+    case "catch_up":
+    case "supersede_rerun":
+      return ""
+  }
+}
+
+export function buildLatePurposeSection(purpose: TurnPurpose): string {
+  return purpose.kind === "supersede_rerun" ? buildSupersedeSection(purpose.rerunContext) : ""
+}
+
+function buildMentionSection(context: StreamContext, mentionerName?: string): string {
+  const mentionerDesc = mentionerName ? `**${mentionerName}**` : "a user"
+  let section = `
+
+## Invocation Context
+
+You were explicitly @mentioned by ${mentionerDesc} who wants your assistance.`
+
+  if (context.streamType === StreamTypes.CHANNEL) {
+    section += ` This conversation is happening in a thread created specifically for your response.`
+  }
+
+  return section
+}
+
+function buildFollowUpSection(context: StreamContext, followUp: { note: string; scheduledFor: Date }): string {
+  const scheduledForDisplay = context.temporal
+    ? formatCurrentTime(followUp.scheduledFor, context.temporal.timezone, context.temporal.dateFormat, context.temporal.timeFormat)
+    : followUp.scheduledFor.toISOString()
+
+  return `
+
+## Scheduled follow-up firing now
+
+This turn is a follow-up you scheduled for yourself — not a new message from anyone. You are waking up on your own timer to revisit this stream.
+
+- You set this reminder (at ${scheduledForDisplay}) to: "${followUp.note.trim()}"
+- This IS that reminder firing. Act on it now — look at what has happened in the stream since you scheduled it and, if there's something worth saying, post your check-in with \`send_message\`. Do not decline or promise to check back later; later is now.
+- Do NOT schedule another follow-up for the same thing. The note above is what this turn is already handling — re-reading it as a fresh instruction and scheduling again just loops forever. Only schedule a new follow-up if genuinely new future work has surfaced.
+- If nothing needs saying (the matter resolved itself, nothing changed, or you're still waiting on someone), call \`keep_response\` with a brief reason and stay silent. Do not post filler.`
+}
+
+function buildSupersedeSection(rerunContext?: AgentSessionRerunContext): string {
+  const cause =
+    rerunContext?.cause === "referenced_message_edited"
+      ? "a follow-up (referenced) message was edited"
+      : "the invoking message was edited"
+  const editedBefore = rerunContext?.editedMessageBefore?.trim()
+  const editedAfter = rerunContext?.editedMessageAfter?.trim()
+
+  const changeBlock = [
+    `Rerun cause: ${cause}.`,
+    `Edited message ID: ${rerunContext?.editedMessageId ?? "unknown"}.`,
+    editedBefore ? `Before edit: "${editedBefore}"` : null,
+    editedAfter ? `After edit: "${editedAfter}"` : null,
+    rerunContext?.editedMessageRevision ? `Edited message revision: ${rerunContext.editedMessageRevision}.` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n")
+
+  return `
+
+## Superseded Session Reconciliation
+
+This run supersedes a previous completed session because conversation context changed after completion.
+${changeBlock}
+
+For the final outcome:
+- Compare the previous response(s) against the edited context and current conversation state.
+- Treat the edited message text as the authoritative user intent. The prior wording is obsolete.
+- If any previous response is now incorrect, contradictory, or misses a new constraint, call \`send_message\` with the revised response.
+- When updating, answer the edited request directly with concrete help. Do not ask the user to reconfirm the edited intent unless the edited prompt is genuinely ambiguous or missing required constraints.
+- For "best" or singular requests, provide one clear recommendation first (with practical details), then optional alternatives.
+- If the edited request is concrete (for example noun/topic substitutions), do not reply with only a clarification question.
+- Avoid meta narration about the edit itself (for example "I see your message was edited") unless the user explicitly asks about that process.
+- If the previous response should stay exactly as-is, call \`keep_response\` with a specific reason that references what changed and why no update is needed.
+- Never use both \`keep_response\` and \`send_message\` for the same final decision.
+- Do not end your turn without calling exactly one of \`keep_response\` or \`send_message\`.`
+}

--- a/apps/backend/src/features/agents/index.ts
+++ b/apps/backend/src/features/agents/index.ts
@@ -3,6 +3,9 @@ export { createAgentSessionHandlers } from "./session-handlers"
 export { PersonaAgent } from "./persona-agent"
 export type { PersonaAgentDeps, PersonaAgentInput, PersonaAgentResult, WithSessionResult } from "./persona-agent"
 
+export { resolveTurnPurpose, deriveTurnFlags } from "./turn-purpose"
+export type { TurnPurpose, TurnPurposeKind } from "./turn-purpose"
+
 export { defineAgentTool, toVercelToolDefs, AgentRuntime, createSessionTraceProjector, OtelObserver } from "./runtime"
 export type {
   AgentTool,

--- a/apps/backend/src/features/agents/persona-agent-worker.test.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.test.ts
@@ -16,7 +16,7 @@ function makeAgent(capture: (input: PersonaAgentInput) => void): PersonaAgentLik
 }
 
 describe("createPersonaAgentWorker", () => {
-  it("forwards followUpId from the fired-follow-up job to agent.run", async () => {
+  it("maps a fired-follow-up job payload to a follow_up purpose", async () => {
     let captured: PersonaAgentInput | undefined
     const worker = createPersonaAgentWorker({
       agent: makeAgent((input) => (captured = input)),
@@ -35,11 +35,11 @@ describe("createPersonaAgentWorker", () => {
     }
     await worker({ id: "job_1", name: "persona.agent", data })
 
-    expect(captured?.followUpId).toBe("agfu_01")
+    expect(captured?.purpose).toEqual({ kind: "follow_up", followUpId: "agfu_01" })
     expect(captured?.messageId).toBe("followup_agfu_01")
   })
 
-  it("leaves followUpId undefined for a normal companion job", async () => {
+  it("maps a plain companion job payload to a catch_up purpose", async () => {
     let captured: PersonaAgentInput | undefined
     const worker = createPersonaAgentWorker({
       agent: makeAgent((input) => (captured = input)),
@@ -57,6 +57,6 @@ describe("createPersonaAgentWorker", () => {
     }
     await worker({ id: "job_2", name: "persona.agent", data })
 
-    expect(captured?.followUpId).toBeUndefined()
+    expect(captured?.purpose).toEqual({ kind: "catch_up" })
   })
 })

--- a/apps/backend/src/features/agents/persona-agent-worker.ts
+++ b/apps/backend/src/features/agents/persona-agent-worker.ts
@@ -4,6 +4,7 @@ import { JobQueues } from "../../lib/queue"
 import { AgentTriggers } from "@threa/types"
 import type { QueueManager } from "../../lib/queue"
 import type { PersonaAgentInput, PersonaAgentResult } from "./persona-agent"
+import { resolveTurnPurpose } from "./turn-purpose"
 import { StreamEventRepository } from "../streams"
 import { logger } from "../../lib/logger"
 
@@ -35,21 +36,19 @@ export function createPersonaAgentWorker(deps: PersonaAgentWorkerDeps): JobHandl
   const { agent, serverId, pool, jobQueue } = deps
 
   return async (job) => {
-    const { workspaceId, streamId, messageId, personaId, trigger, supersedesSessionId, rerunContext, followUpId } =
-      job.data
+    const { workspaceId, streamId, messageId, personaId, trigger, followUpId } = job.data
 
     logger.info({ jobId: job.id, streamId, messageId, personaId, trigger, followUpId }, "Processing persona agent job")
 
+    // Map the in-flight wire payload to the turn's purpose at the boundary — the
+    // job fields stay as-is so already-enqueued rows still decode (roadmap 1.5).
     const result = await agent.run({
       workspaceId,
       streamId,
       messageId,
       personaId,
       serverId,
-      trigger,
-      supersedesSessionId,
-      rerunContext,
-      followUpId,
+      purpose: resolveTurnPurpose(job.data),
     })
 
     if (result.status === "failed") {

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -4,7 +4,6 @@ import { withClient, type Querier } from "../../db"
 import {
   AgentStepTypes,
   AgentToolNames,
-  AgentTriggers,
   AuthorTypes,
   StreamTypes,
   type AgentSessionRerunContext,
@@ -35,6 +34,7 @@ import { WorkspaceAgent, type WorkspaceAgentResult } from "./researcher"
 import { GeneralResearcher, GENERAL_RESEARCH_TOOL_POLICY, type GeneralResearchResult } from "./general-researcher"
 import { logger } from "../../lib/logger"
 import { buildAgentContext, buildToolSet, withCompanionSession, type WithSessionResult } from "./companion"
+import { deriveTurnFlags, type TurnPurpose } from "./turn-purpose"
 import { resolveContextWindowPolicy } from "./context-window-policy"
 import { resolveBagForStream, persistSnapshot, appendBagToSystemPrompt, type ResolvedBag } from "./context-bag"
 import { createMemoizedGithubClient, createMemoizedLinearClient, type RunGeneralResearchOptions } from "./tools"
@@ -168,15 +168,14 @@ export interface PersonaAgentInput {
   messageId: string
   personaId: string
   serverId: string
-  trigger?: typeof AgentTriggers.MENTION
-  supersedesSessionId?: string
-  rerunContext?: AgentSessionRerunContext
   /**
-   * Set when this run was enqueued by a fired follow-up. `messageId` is then
-   * synthetic (no real trigger message); the agent loads the follow-up's context
-   * and injects the "why you woke up" prompt section (roadmap 1.2).
+   * Why this turn is running (roadmap 1.5). One discriminated union replaces the
+   * four orthogonal optional signals that used to accumulate here — mention,
+   * supersede rerun, fired follow-up, and plain companion catch-up. A fired
+   * follow-up carries a synthetic `messageId` (no real trigger message); the
+   * agent loads its row and injects the "why you woke up" prompt section.
    */
-  followUpId?: string
+  purpose: TurnPurpose
   /** Invocation time override for deterministic evals/tests. Production leaves this unset. */
   currentTime?: Date
 }
@@ -236,18 +235,11 @@ export class PersonaAgent {
       scheduleFollowUp,
       loadFollowUp,
     } = this.deps
-    const {
-      workspaceId,
-      streamId,
-      messageId,
-      personaId,
-      serverId,
-      trigger,
-      supersedesSessionId,
-      rerunContext,
-      followUpId,
-      currentTime,
-    } = input
+    const { workspaceId, streamId, messageId, personaId, serverId, purpose, currentTime } = input
+    // Supersede-rerun payload, extracted once from the purpose (roadmap 1.5) and
+    // threaded through the session setup, reconciliation, trace, and validator.
+    const supersedesSessionId = purpose.kind === "supersede_rerun" ? purpose.supersedesSessionId : undefined
+    const rerunContext = purpose.kind === "supersede_rerun" ? purpose.rerunContext : undefined
 
     const precheck = await withClient(pool, async (client) => {
       const persona = await PersonaRepository.findById(client, personaId, workspaceId)
@@ -298,13 +290,13 @@ export class PersonaAgent {
     // catch-up — the two live staging bugs (declining the check-in, re-scheduling
     // in a loop) stem from exactly that context-less path, so this is the fix.
     let followUpContext: { note: string; scheduledFor: Date } | undefined
-    if (followUpId) {
-      const followUp = loadFollowUp ? await loadFollowUp({ workspaceId, followUpId }) : null
+    if (purpose.kind === "follow_up") {
+      const followUp = loadFollowUp ? await loadFollowUp({ workspaceId, followUpId: purpose.followUpId }) : null
       if (followUp) {
         followUpContext = { note: followUp.note, scheduledFor: followUp.scheduledFor }
       } else {
         logger.warn(
-          { workspaceId, followUpId, streamId },
+          { workspaceId, followUpId: purpose.followUpId, streamId },
           "Fired follow-up row not found or loader unbound; running as a plain catch-up turn"
         )
       }
@@ -312,7 +304,7 @@ export class PersonaAgent {
     const isFollowUp = followUpContext !== undefined
 
     // Create the thread eagerly so session events go there for channel mentions.
-    const isChannelMention = trigger === AgentTriggers.MENTION && stream.type === StreamTypes.CHANNEL
+    const isChannelMention = purpose.kind === "mention" && stream.type === StreamTypes.CHANNEL
     let sessionStreamId = streamId
     let channelStreamId: string | undefined
     if (isChannelMention) {
@@ -364,7 +356,7 @@ export class PersonaAgent {
 
         const agentContext = await buildAgentContext(
           { db: pool, userPreferencesService, conversationSummaryService },
-          { workspaceId, streamId, stream, messageId, persona, trigger, policy, currentTime, followUp: followUpContext }
+          { workspaceId, streamId, stream, messageId, persona, purpose, policy, currentTime, followUp: followUpContext }
         )
 
         // Resolve an attached ContextBag (if any) so `stable + delta` flow into
@@ -474,6 +466,16 @@ export class PersonaAgent {
           triggerMessageId: messageId,
         })
         const isSupersedeRerun = !!supersededMessagePlan
+
+        // The purpose as it effectively behaves this turn: a supersede rerun
+        // whose target session vanished (no reusable plan), or a follow-up whose
+        // row failed to load, degrades to a plain catch-up. The purpose prompt
+        // section and the derived runtime flags both key off this, so wording and
+        // behavior match what the turn actually does.
+        let effectivePurpose: TurnPurpose = purpose
+        if (purpose.kind === "supersede_rerun" && !isSupersedeRerun) effectivePurpose = { kind: "catch_up" }
+        else if (purpose.kind === "follow_up" && !isFollowUp) effectivePurpose = { kind: "catch_up" }
+        const turnFlags = deriveTurnFlags(effectivePurpose)
 
         // `sources` is required on the commit payload (empty array = none) so a
         // caller can't silently drop citations — see TurnCommit.
@@ -721,21 +723,20 @@ export class PersonaAgent {
             sessionId: session.id,
             origin: agentContext.invokingUserId ? "user" : "system",
           },
-          systemPrompt: appendBagToSystemPrompt(
-            isSupersedeRerun
-              ? buildSupersedeRerunSystemPrompt(agentContext.composeSystemPrompt(tools), rerunContext)
-              : agentContext.composeSystemPrompt(tools),
-            resolvedBag
-          ),
+          // The purpose's prompt section (mention/follow-up early, supersede
+          // reconciliation last) is composed here from the effective purpose —
+          // one dispatch, no bespoke supersede wrap at the call site (roadmap 1.5).
+          systemPrompt: appendBagToSystemPrompt(agentContext.composeSystemPrompt(tools, effectivePurpose), resolvedBag),
           messages: agentContext.messages,
           initialContext,
           tools,
           maxTokens: persona.maxTokens,
           temperature: persona.temperature,
-          // Follow-up turns may legitimately conclude "nothing to add" — enabling
-          // this exposes `keep_response` so they can end silently instead of the
-          // runtime auto-committing filler or throwing (roadmap 1.2).
-          allowNoMessageOutput: isSupersedeRerun || isFollowUp,
+          // Supersede reruns and fired follow-ups may legitimately conclude
+          // "nothing to add" — this exposes `keep_response` so they end silently
+          // instead of the runtime auto-committing filler. Derived from the
+          // purpose kind, never set ad hoc (roadmap 1.5).
+          allowNoMessageOutput: turnFlags.allowNoMessageOutput,
           validateFinalResponse: isSupersedeRerun
             ? buildSupersedeResponseValidator({
                 ai,
@@ -1232,44 +1233,6 @@ function toTraceRerunContext(rerunContext?: AgentSessionRerunContext): Record<st
     editedMessageAfter: rerunContext.editedMessageAfter ?? null,
     editedMessageRevision: rerunContext.editedMessageRevision ?? null,
   }
-}
-
-function buildSupersedeRerunSystemPrompt(basePrompt: string, rerunContext?: AgentSessionRerunContext): string {
-  const cause =
-    rerunContext?.cause === "referenced_message_edited"
-      ? "a follow-up (referenced) message was edited"
-      : "the invoking message was edited"
-  const editedBefore = rerunContext?.editedMessageBefore?.trim()
-  const editedAfter = rerunContext?.editedMessageAfter?.trim()
-
-  const changeBlock = [
-    `Rerun cause: ${cause}.`,
-    `Edited message ID: ${rerunContext?.editedMessageId ?? "unknown"}.`,
-    editedBefore ? `Before edit: "${editedBefore}"` : null,
-    editedAfter ? `After edit: "${editedAfter}"` : null,
-    rerunContext?.editedMessageRevision ? `Edited message revision: ${rerunContext.editedMessageRevision}.` : null,
-  ]
-    .filter((line): line is string => line !== null)
-    .join("\n")
-
-  return `${basePrompt}
-
-## Superseded Session Reconciliation
-
-This run supersedes a previous completed session because conversation context changed after completion.
-${changeBlock}
-
-For the final outcome:
-- Compare the previous response(s) against the edited context and current conversation state.
-- Treat the edited message text as the authoritative user intent. The prior wording is obsolete.
-- If any previous response is now incorrect, contradictory, or misses a new constraint, call \`send_message\` with the revised response.
-- When updating, answer the edited request directly with concrete help. Do not ask the user to reconfirm the edited intent unless the edited prompt is genuinely ambiguous or missing required constraints.
-- For "best" or singular requests, provide one clear recommendation first (with practical details), then optional alternatives.
-- If the edited request is concrete (for example noun/topic substitutions), do not reply with only a clarification question.
-- Avoid meta narration about the edit itself (for example "I see your message was edited") unless the user explicitly asks about that process.
-- If the previous response should stay exactly as-is, call \`keep_response\` with a specific reason that references what changed and why no update is needed.
-- Never use both \`keep_response\` and \`send_message\` for the same final decision.
-- Do not end your turn without calling exactly one of \`keep_response\` or \`send_message\`.`
 }
 
 const SupersedeResponseValidationSchema = z.object({

--- a/apps/backend/src/features/agents/turn-purpose.test.ts
+++ b/apps/backend/src/features/agents/turn-purpose.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test"
+import { AgentTriggers, type AgentSessionRerunContext } from "@threa/types"
+import { resolveTurnPurpose, deriveTurnFlags, type TurnPurpose } from "./turn-purpose"
+
+describe("resolveTurnPurpose", () => {
+  it("maps a bare companion payload to catch_up", () => {
+    expect(resolveTurnPurpose({})).toEqual({ kind: "catch_up" })
+  })
+
+  it("maps a mention payload to mention", () => {
+    expect(resolveTurnPurpose({ trigger: AgentTriggers.MENTION })).toEqual({ kind: "mention" })
+  })
+
+  it("maps a fired-follow-up payload to follow_up carrying the id", () => {
+    expect(resolveTurnPurpose({ followUpId: "agfu_01" })).toEqual({ kind: "follow_up", followUpId: "agfu_01" })
+  })
+
+  it("maps a supersede payload to supersede_rerun carrying its rerun context", () => {
+    const rerunContext: AgentSessionRerunContext = {
+      cause: "invoking_message_edited",
+      editedMessageId: "msg_edited",
+    }
+    expect(resolveTurnPurpose({ supersedesSessionId: "agsess_prev", rerunContext })).toEqual({
+      kind: "supersede_rerun",
+      supersedesSessionId: "agsess_prev",
+      rerunContext,
+    })
+  })
+})
+
+describe("deriveTurnFlags", () => {
+  const cases: Array<{ purpose: TurnPurpose; allow: boolean }> = [
+    { purpose: { kind: "catch_up" }, allow: false },
+    { purpose: { kind: "mention" }, allow: false },
+    { purpose: { kind: "follow_up", followUpId: "agfu_01" }, allow: true },
+    { purpose: { kind: "supersede_rerun", supersedesSessionId: "agsess_prev" }, allow: true },
+  ]
+
+  for (const { purpose, allow } of cases) {
+    it(`${purpose.kind} → allowNoMessageOutput=${allow}`, () => {
+      expect(deriveTurnFlags(purpose)).toEqual({ allowNoMessageOutput: allow })
+    })
+  }
+})

--- a/apps/backend/src/features/agents/turn-purpose.ts
+++ b/apps/backend/src/features/agents/turn-purpose.ts
@@ -1,0 +1,65 @@
+import { AgentTriggers, type AgentSessionRerunContext } from "@threa/types"
+
+/**
+ * Why a persona turn is running. One first-class answer replaces the four
+ * orthogonal optional signals that used to accumulate on `PersonaAgentInput`
+ * (`trigger`, `supersedesSessionId`, `rerunContext`, `followUpId`), each with
+ * scattered if-branches, a bespoke prompt section, and repurposed runtime
+ * flags (roadmap 1.5). Adding an invocation kind = one union member + its
+ * prompt block, not another optional field.
+ *
+ * The kinds are mutually exclusive at every enqueue site: a mention sets only
+ * `trigger`, a supersede rerun only `supersedesSessionId`/`rerunContext`, a
+ * fired follow-up only `followUpId`, and companion catch-up none of them.
+ */
+export type TurnPurpose =
+  | { kind: "catch_up" }
+  | { kind: "mention" }
+  | { kind: "follow_up"; followUpId: string }
+  | { kind: "supersede_rerun"; supersedesSessionId: string; rerunContext?: AgentSessionRerunContext }
+
+export type TurnPurposeKind = TurnPurpose["kind"]
+
+/**
+ * Map an in-flight queue payload to the turn's purpose at the worker boundary.
+ * The wire payload keeps its original fields (rows already enqueued must still
+ * decode), so the union is derived here rather than carried on the job.
+ *
+ * Precedence matches how the enqueue sites are wired — the fields never co-occur,
+ * so any order that keeps the four kinds distinct is equivalent; this one reads
+ * most-specific first.
+ */
+export function resolveTurnPurpose(payload: {
+  trigger?: typeof AgentTriggers.MENTION
+  supersedesSessionId?: string
+  rerunContext?: AgentSessionRerunContext
+  followUpId?: string
+}): TurnPurpose {
+  if (payload.followUpId) {
+    return { kind: "follow_up", followUpId: payload.followUpId }
+  }
+  if (payload.supersedesSessionId) {
+    return { kind: "supersede_rerun", supersedesSessionId: payload.supersedesSessionId, rerunContext: payload.rerunContext }
+  }
+  if (payload.trigger === AgentTriggers.MENTION) {
+    return { kind: "mention" }
+  }
+  return { kind: "catch_up" }
+}
+
+/**
+ * Runtime flags derived from the purpose kind — never set ad hoc at the turn
+ * request. `allowNoMessageOutput` exposes `keep_response` so a turn can end
+ * silently instead of the runtime auto-committing filler; supersede reruns and
+ * fired follow-ups both legitimately conclude "nothing to add", plain catch-up
+ * and mention turns do not.
+ *
+ * The caller passes the *effective* purpose: a supersede rerun whose target
+ * session vanished, or a follow-up whose row failed to load, degrades to
+ * `catch_up` before this runs, so the flag tracks the behavior actually taken.
+ */
+export function deriveTurnFlags(purpose: TurnPurpose): { allowNoMessageOutput: boolean } {
+  return {
+    allowNoMessageOutput: purpose.kind === "supersede_rerun" || purpose.kind === "follow_up",
+  }
+}

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -38,7 +38,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #1142 |
 | 1.3  | Follow-up visibility: timeline card + cancel         | ☐      |       |
 | 1.4  | Configurable follow-up limits (workspace setting)    | ☐      |       |
-| 1.5  | Turn-purpose consolidation (invocation variants)     | ☐      |       |
+| 1.5  | Turn-purpose consolidation (invocation variants)     | ☑      | #TBD  |
 | 2.1  | Generalized session abort                            | ☐      |       |
 | 2.2  | Stop/Redirect affordances on the activity card       | ☐      |       |
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |
@@ -151,6 +151,13 @@ The cheapest team-member behavior ("I'll check back tomorrow") and the pathfinde
 **Files:** `persona-agent.ts` (input type + variant readers), `persona-agent-worker.ts` (payload→purpose mapping), `companion/context.ts`, `companion/prompt/system-prompt.ts` (per-purpose sections), `packages/agent-runtime` `TurnRequest` if flag derivation moves there.
 
 **Tests:** existing per-variant tests pass unchanged (behavioral no-op); one test per purpose kind asserting derived flags + prompt-section presence.
+
+**Deviations (shipped):**
+
+- `TurnPurpose` union + `resolveTurnPurpose` (payload→purpose at the worker boundary) + `deriveTurnFlags` live in a new `features/agents/turn-purpose.ts`. Flag derivation stayed backend-side (`deriveTurnFlags`), not moved onto `TurnRequest` — cleaner than plumbing purpose into the generic runtime.
+- Per-purpose prompt sections unified in `companion/prompt/turn-purpose-prompt.ts`: `buildEarlyPurposeSection` (mention, follow-up — before stream context) and `buildLatePurposeSection` (supersede reconciliation — last, for final-decision salience). The supersede section moved out of persona-agent's `buildSupersedeRerunSystemPrompt` wrap into `buildSystemPrompt` at its exact prior position (after temporal), so composition is byte-identical to the old wrap.
+- The continuation-wording leak is fixed at the source: the runtime's `allowNoMessageOutput` continuation prompt (`agent-runtime.ts`) is now edit-neutral, since that phrasing already misapplied to fired-follow-up *and* research turns. The supersede system-prompt section still carries the edit-comparison instructions where they belong.
+- Degradation preserves behavior via `effectivePurpose`: a supersede rerun whose target session vanished, or a follow-up whose row failed to load, resolves to `catch_up` — so its prompt section and derived flags match the plain-catch-up turn it already ran as (true no-op).
 
 **Done when:** adding a new invocation kind = one union member + its prompt block — no new optional field on `PersonaAgentInput`, no ad-hoc flag setting.
 

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -38,7 +38,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #1142 |
 | 1.3  | Follow-up visibility: timeline card + cancel         | ☐      |       |
 | 1.4  | Configurable follow-up limits (workspace setting)    | ☐      |       |
-| 1.5  | Turn-purpose consolidation (invocation variants)     | ☑      | #TBD  |
+| 1.5  | Turn-purpose consolidation (invocation variants)     | ☑      | #1155 |
 | 2.1  | Generalized session abort                            | ☐      |       |
 | 2.2  | Stop/Redirect affordances on the activity card       | ☐      |       |
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -765,8 +765,13 @@ export class AgentRuntime {
       return conversation
     }
 
+    // Neutral wording for the may-end-silently case: this fires for supersede
+    // reruns, fired follow-ups, and research alike, so it must not assume an
+    // "updated context" edit (that phrasing leaked supersede framing onto
+    // follow-up turns). The supersede system-prompt section carries the
+    // edit-comparison instructions where they actually belong.
     const continuationPrompt = this.config.allowNoMessageOutput
-      ? "Review the conversation above and follow the system instructions. Compare the latest assistant response against the updated context, then call keep_response or send_message."
+      ? "Review the conversation above and follow the system instructions, then call keep_response or send_message."
       : "Continue from the conversation above and follow the system instructions."
 
     return [...conversation, { role: "user", content: continuationPrompt }]


### PR DESCRIPTION
**Roadmap:** [`docs/plans/ariadne-collaborator-roadmap.md`](docs/plans/ariadne-collaborator-roadmap.md) — step **1.5** (Turn-purpose consolidation). Hard prerequisite for Phase 8 (ambient turns = invocation kind #5).

## Problem

`PersonaAgentInput` had accumulated **four orthogonal optional variant signals** — `trigger?: MENTION`, `supersedesSessionId?`, `rerunContext?`, and (from #1142) `followUpId?` — each read through its own scattered `if`-branch, each contributing a bespoke prompt section, each repurposing runtime flags. `allowNoMessageOutput` went from supersede-only to also-follow-up by an inline `isSupersedeRerun || isFollowUp`. The supersede prompt section was a post-composition wrap in `persona-agent.ts` while the mention and follow-up sections lived inside `buildSystemPrompt`. And #1142 left a recorded leak: the runtime's `allowNoMessageOutput` continuation prompt carried supersede-flavored wording ("compare against the updated context") onto fired-follow-up turns, which have no edit.

Every new invocation kind widened this. Phase 8's ambient turns are kind #5; landing them on top of four ad-hoc signals would multiply the branches again.

## Solution

One first-class answer to "why is this turn running": a discriminated `TurnPurpose` union, resolved in one place into three derived behaviors — the purpose's prompt section, its runtime flags, and its context-assembly hints. The wire payload is untouched; the worker maps payload → purpose at the boundary.

### How it works

1. **`features/agents/turn-purpose.ts`** — `TurnPurpose = catch_up | mention | follow_up{followUpId} | supersede_rerun{supersedesSessionId, rerunContext?}`. `resolveTurnPurpose(payload)` maps an in-flight `PersonaAgentJobData` to the union (most-specific first: `followUpId` → `supersedesSessionId` → `trigger === MENTION` → `catch_up`); the four fields never co-occur across the enqueue sites, so the precedence is unambiguous. `deriveTurnFlags(purpose)` returns `{ allowNoMessageOutput }` (true for `supersede_rerun` and `follow_up`).
2. **`persona-agent-worker.ts`** maps `job.data` → `purpose` at the boundary and passes it to `agent.run`. The payload keeps `trigger`/`supersedesSessionId`/`rerunContext`/`followUpId`, so queue rows already in flight still decode; the worker still reads `job.data.trigger` for its own post-completion `checkForUnseenMessages` gate.
3. **`companion/prompt/turn-purpose-prompt.ts`** — per-purpose sections in one switch, mirroring how each tool carries its own `promptBlock`. `buildEarlyPurposeSection` (mention, follow-up) renders before the stream context; `buildLatePurposeSection` (supersede reconciliation) renders last. The supersede section text moved verbatim out of `persona-agent.ts`'s `buildSupersedeRerunSystemPrompt`.
4. **`persona-agent.ts`** computes an `effectivePurpose`: a `supersede_rerun` whose target session vanished (no reusable message plan), or a `follow_up` whose row failed to load, degrades to `catch_up`. The prompt section and derived flags both key off `effectivePurpose`, so a degraded turn's prompt and flags match the plain catch-up it already ran as. `composeSystemPrompt(tools, effectivePurpose)` now composes the supersede section internally at its exact prior position — the turn-request `systemPrompt` is a single `appendBagToSystemPrompt(composeSystemPrompt(...), resolvedBag)` with no special-case wrap.
5. **`agent-runtime.ts`** — the `allowNoMessageOutput` continuation prompt is now edit-neutral (`"Review the conversation above and follow the system instructions, then call keep_response or send_message."`). That wording fires for supersede reruns, fired follow-ups, and research alike, so it must not assume an edit; the supersede system-prompt section still carries the edit-comparison instructions where they belong.

### Key design decisions

**1. Wire payload unchanged; map at the worker boundary.** The union is a runtime concern, not a queue contract. Keeping `PersonaAgentJobData`'s fields means no migration and no drain of in-flight rows — the same deviation #1142 took for `followUpId`, now the place the union finally lands.

**2. `effectivePurpose` degradation instead of purpose-kind-only flags.** The pre-existing behavior is that a supersede rerun whose target session is missing runs as a plain turn (no supersede prompt, no `allowNoMessageOutput`, no validator). Deriving flags purely from `purpose.kind` would have changed that. Folding the "target resolved?" fact into an `effectivePurpose` keeps `deriveTurnFlags` a pure function of the union *and* preserves the degrade path exactly — `deriveTurnFlags(effectivePurpose).allowNoMessageOutput` is identical to the old `isSupersedeRerun || isFollowUp`.

**3. Fix the continuation-wording leak at the source, not by plumbing purpose into the runtime.** `@threa/agent-runtime` is a generic runtime; teaching it "supersede" vs "follow_up" would be the wrong layer. The leaked phrase was supersede-specific text that already misapplied to research turns (which also set `allowNoMessageOutput`). Neutralizing it removes the leak for every caller at once; the supersede-specific comparison instructions remain in the supersede prompt section. No test asserted the old phrasing; the tested substring (`keep_response or send_message`) is preserved.

**4. Supersede section stays last.** Its "call exactly one of `keep_response` / `send_message`" directive is the most salient instruction before the model acts. `buildLatePurposeSection` renders it after the temporal block — the exact position the old wrap produced, so the composed prompt for a supersede rerun is unchanged.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/turn-purpose.ts` | `TurnPurpose` union, `resolveTurnPurpose` (payload→purpose), `deriveTurnFlags` |
| `apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts` | Per-purpose prompt sections (`buildEarlyPurposeSection`, `buildLatePurposeSection`) |
| `apps/backend/src/features/agents/turn-purpose.test.ts` | Resolver + derived-flags coverage per kind |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/persona-agent.ts` | `PersonaAgentInput.purpose` replaces the four fields; `effectivePurpose`; supersede locals derived from purpose; `buildSupersedeRerunSystemPrompt` removed (moved) |
| `apps/backend/src/features/agents/persona-agent-worker.ts` | Maps payload → purpose via `resolveTurnPurpose` |
| `apps/backend/src/features/agents/companion/context.ts` | `ContextParams.purpose` replaces `trigger`; `composeSystemPrompt(tools, purpose)` |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.ts` | `purpose` replaces `trigger`; dispatches early/late purpose sections |
| `apps/backend/src/features/agents/index.ts` | Barrel exports `TurnPurpose`, `resolveTurnPurpose`, `deriveTurnFlags` |
| `packages/agent-runtime/src/runtime/agent-runtime.ts` | Edit-neutral `allowNoMessageOutput` continuation prompt (leak fix) |
| `apps/backend/evals/suites/{companion,multimodal-vision}/suite.ts` | Construct `purpose` instead of `trigger` |
| `apps/backend/src/features/agents/**/*.test.ts` | Worker payload→purpose mapping; per-purpose section presence |
| `docs/plans/ariadne-collaborator-roadmap.md` | Step 1.5 checked + shipped-deviations note |

## Out of scope (deliberate)

- **The wire payload / `PersonaAgentJobData` fields** stay as-is (decision 1) — not consolidated onto the queue.
- **Flag derivation did not move onto `TurnRequest`** (the roadmap's "if flag derivation moves there"). It stayed backend-side in `deriveTurnFlags`; the runtime got only the neutral-wording fix. Cleaner than plumbing purpose into the generic runtime.
- **The two deeper supersede-flavored runtime strings** (the empty-draft "[Final decision required]" retry prompt and the `noMessageReason` fallback) are untouched — the documented leak was the continuation prompt, and those edge paths aren't reached on a normal follow-up turn.

## Test plan

- [x] `bun test` — `turn-purpose` + `persona-agent-worker` + `system-prompt` — 26 pass
- [x] `bun test` — `agent-runtime` (continuation-wording change) — 13 pass
- [x] `bun test` — `mention-invoke` + `message-mutation` + `companion` outbox handlers — 26 pass
- [x] `bun run --cwd apps/backend typecheck` (prod + `tsconfig.tests.json` + evals) — clean
- [x] Pre-commit hook (full monorepo lint + typecheck + prettier + OpenAPI-check) — passed
- [ ] Full fired-turn → live turn path (DB + queue + AI) — exercised on staging like 1.2, not in unit scope

Self-review (2 passes, correctness + claim-verification): the composed prompt for each existing kind is unchanged (supersede section same text + same last position; mention/follow-up unchanged); `deriveTurnFlags(effectivePurpose)` proven identical to the old `isSupersedeRerun || isFollowUp`; `resolveTurnPurpose` precedence checked against all five `PERSONA_AGENT` enqueue sites (fields mutually exclusive).

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTLwyfATXZckUapeudc1Hu)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785664917&installation_id=129946197&pr_number=1155&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1155&signature=b9f5b5f02598597c6e325df3e9e34f7ba0eaddde4de85c6cbf23e7c457d3005a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->