### PR TITLE
perf(edge): stop idle agent fleets from burning the KV quota

### DIFF
--- a/apps/workspace-router/src/index.test.ts
+++ b/apps/workspace-router/src/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, mock } from "bun:test"
+import { beforeEach, describe, test, expect, mock } from "bun:test"
 import { ORIGINAL_HOST_HEADER } from "@threa/types"
-import worker from "./index"
+import worker, { clearRegionCache } from "./index"
 
 const REGIONS_JSON = JSON.stringify({
   "eu-north-1": {
@@ -66,6 +66,10 @@ async function getJson<T>(response: Response): Promise<T> {
 }
 
 describe("workspace-router", () => {
+  // The in-isolate region cache is module-level state; without a reset, one
+  // test's resolved region leaks into the next test's identically-named ws id.
+  beforeEach(() => clearRegionCache())
+
   describe("health check", () => {
     test("GET /readyz returns 200 OK", async () => {
       const res = await worker.fetch(makeRequest("/readyz"), makeEnv())
@@ -167,6 +171,54 @@ describe("workspace-router", () => {
         const env = makeEnvWithKv("eu-north-1")
         await worker.fetch(makeRequest("/api/workspaces/ws_123"), env)
         expect(getProxiedUrl(fn)).toBe("http://eu-north-1.backend:3002/api/workspaces/ws_123")
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+  })
+
+  describe("in-isolate region caching", () => {
+    test("second request for the same workspace skips the KV read", async () => {
+      const originalFetch = globalThis.fetch
+      mockFetchFn(new Response('{"ok":true}', { status: 200 }))
+      try {
+        const env = makeEnvWithKv("eu-north-1")
+        await worker.fetch(makeRequest("/api/workspaces/ws_cached/a"), env)
+        await worker.fetch(makeRequest("/api/workspaces/ws_cached/b"), env)
+        expect(env.WORKSPACE_REGIONS.get).toHaveBeenCalledTimes(1)
+      } finally {
+        globalThis.fetch = originalFetch
+      }
+    })
+
+    test("caches a control-plane resolution and a miss", async () => {
+      const originalFetch = globalThis.fetch
+      const fn = mock((url: string) =>
+        Promise.resolve(
+          String(url).includes("/internal/workspaces/ws_known/region")
+            ? new Response(JSON.stringify({ region: "eu-north-1" }), { status: 200 })
+            : String(url).includes("/internal/workspaces/")
+              ? new Response("not found", { status: 404 })
+              : new Response('{"ok":true}', { status: 200 })
+        )
+      )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      globalThis.fetch = fn as any
+      try {
+        const env = makeEnv({ CONTROL_PLANE_URL: "http://cp", INTERNAL_API_KEY: "k" })
+        await worker.fetch(makeRequest("/api/workspaces/ws_known/a"), env)
+        await worker.fetch(makeRequest("/api/workspaces/ws_known/b"), env)
+        // one control-plane resolve + two proxied requests (not two resolves)
+        const cpCalls = fn.mock.calls.filter((c) => String(c[0]).includes("/internal/workspaces/")).length
+        expect(cpCalls).toBe(1)
+        expect(env.WORKSPACE_REGIONS.get).toHaveBeenCalledTimes(1)
+
+        const missA = await worker.fetch(makeRequest("/api/workspaces/ws_gone/a"), env)
+        const missB = await worker.fetch(makeRequest("/api/workspaces/ws_gone/b"), env)
+        expect(missA.status).toBe(404)
+        expect(missB.status).toBe(404)
+        // the negative result is cached too: KV consulted once for ws_gone
+        expect(env.WORKSPACE_REGIONS.get).toHaveBeenCalledTimes(2)
       } finally {
         globalThis.fetch = originalFetch
       }

--- a/apps/workspace-router/src/index.ts
+++ b/apps/workspace-router/src/index.ts
@@ -240,10 +240,46 @@ function parseRegions(raw: string): RegionsMap {
   }
 }
 
+/**
+ * In-isolate cache for the workspace→region lookup. Every workspace-scoped API
+ * request resolves the region, and each `KV.get` is a billed read — with a
+ * fleet of agent sessions polling through the Worker all day, those reads alone
+ * ate a meaningful slice of the daily KV quota, despite the mapping being
+ * written once and never changed. The TTL bounds staleness if region migration
+ * ever becomes real; isolate recycling clears it anyway. Misses are cached
+ * briefly too, so an unknown id can't turn every request into a KV read + a
+ * control-plane round-trip.
+ */
+const REGION_CACHE_TTL_MS = 5 * 60 * 1000
+const REGION_NEGATIVE_TTL_MS = 30 * 1000
+const REGION_CACHE_MAX_ENTRIES = 5000
+const regionCache = new Map<string, { region: string | null; expiresAt: number }>()
+
+/** Test hook: module-level state would otherwise leak between test cases. */
+export function clearRegionCache(): void {
+  regionCache.clear()
+}
+
+function cacheRegion(workspaceId: string, region: string | null): void {
+  // Ids come from request URLs, so the key space is attacker-controlled; a hard
+  // cap with full reset beats unbounded growth (entries re-warm in one lookup).
+  if (regionCache.size >= REGION_CACHE_MAX_ENTRIES) regionCache.clear()
+  regionCache.set(workspaceId, {
+    region,
+    expiresAt: Date.now() + (region ? REGION_CACHE_TTL_MS : REGION_NEGATIVE_TTL_MS),
+  })
+}
+
 async function resolveRegion(workspaceId: string, env: Env): Promise<string | null> {
-  // Fast path: KV cache hit
+  const held = regionCache.get(workspaceId)
+  if (held && held.expiresAt > Date.now()) return held.region
+
+  // KV hit: the durable cache shared across isolates/colos
   const cached = await env.WORKSPACE_REGIONS.get(workspaceId)
-  if (cached) return cached
+  if (cached) {
+    cacheRegion(workspaceId, cached)
+    return cached
+  }
 
   // Slow path: ask the control-plane (source of truth) and cache the result
   if (!env.CONTROL_PLANE_URL || !env.INTERNAL_API_KEY) return null
@@ -251,10 +287,14 @@ async function resolveRegion(workspaceId: string, env: Env): Promise<string | nu
   const res = await fetch(`${env.CONTROL_PLANE_URL}/internal/workspaces/${workspaceId}/region`, {
     headers: { [INTERNAL_API_KEY_HEADER]: env.INTERNAL_API_KEY },
   })
-  if (!res.ok) return null
+  if (!res.ok) {
+    cacheRegion(workspaceId, null)
+    return null
+  }
 
   const { region } = (await res.json()) as { region: string }
   await env.WORKSPACE_REGIONS.put(workspaceId, region)
+  cacheRegion(workspaceId, region)
   return region
 }
 

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -394,8 +394,10 @@ describe("Pi remote trace safety", () => {
     expect(migrated.linkedSessions?.session_1.wsCursor).toBe("2026-05-27T12:34:56.000Z")
   })
 
-  test("WS_BACKSTOP_POLL_MS is the 30s safety cadence described in the plan", () => {
-    expect(__testing.WS_BACKSTOP_POLL_MS).toBe(30_000)
+  test("WS_BACKSTOP_POLL_MS is the 15-minute edge-billed safety cadence", () => {
+    // Every backstop tick is an HTTP claim through the billed edge Worker; the
+    // socket push is the real delivery path. See the constant's comment.
+    expect(__testing.WS_BACKSTOP_POLL_MS).toBe(15 * 60 * 1000)
   })
 })
 

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -30,8 +30,12 @@ const MAX_FAILURE_POLL_MS = 60_000
 const BUSY_HEARTBEAT_MS = 15_000
 // Cadence the safety-backstop poll runs at while a `/bot` WebSocket is up.
 // Pushes deliver new invocations within a frame; the poll is only there to
-// catch the rare missed-emit / mid-flight-disconnect case (plan §5).
-const WS_BACKSTOP_POLL_MS = 30_000
+// catch the rare missed-emit / mid-flight-disconnect case (plan §5). Every
+// tick is an HTTP claim through the billed edge Worker, so it runs at 15 min
+// — an idle fleet at the old 30s cadence burned thousands of edge requests a
+// day doing nothing; reconnects still drain immediately via the hello
+// bootstrap, so only a silently dropped push waits this long.
+const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
 const WS_RECONNECTION_DELAY_MAX_MS = 30_000
 const TRACE_CONTENT_MAX_CHARS = 9_500
 const MAX_AUTO_RETRY_MS = 4 * 60 * 60 * 1000

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -15,7 +15,14 @@ const CLAIM_TTL_SECONDS = 120
 // Renew at a third of the lease so a single transient renew failure can't let
 // the claim expire (two misses still leaves a full interval of margin).
 const RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
-const WS_BACKSTOP_POLL_MS = 30_000
+// While the /bot socket is healthy the server PUSHES work (bot_invocation:available,
+// plus the hello bootstrap on every connect/resync), so this poll is only
+// insurance against a silently dropped push. Every tick is an HTTP claim through
+// the billed edge Worker — at 30s an idle fleet of sessions burned thousands of
+// requests/day doing nothing. 15 min bounds a lost push's worst-case latency at
+// ~100 requests/day/session; reconnects still drain immediately via the hello
+// bootstrap callback.
+const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
 const MAX_CLAIMS_PER_DRAIN = 20
 const MAX_CONTEXT_MESSAGES = 12
 const MAX_MESSAGE_CHARS = 2_000


### PR DESCRIPTION
## Problem

A handful of *idle* agent sessions eat ~half the daily Cloudflare KV quota ("you used 50% of the KV quota — and that's just me and a couple of bots idling"). Two compounding causes:

1. **Every workspace-scoped API request does a billed KV read.** `resolveRegion` (`apps/workspace-router/src/index.ts`) calls `WORKSPACE_REGIONS.get(workspaceId)` per request with no in-isolate caching — for a mapping that is written once at provisioning and never changed.
2. **Idle runtimes poll claims over HTTP every 30 seconds.** Both `RemoteSession` (`WS_BACKSTOP_POLL_MS` in `extensions/remote-session/src/session.ts`) and pi-remote run a 30s claim backstop *while the /bot socket is healthy*. Each tick is a `POST /bot-invocations/claim` through the billed edge Worker: **2,880 requests/day per idle session**, each also paying cause 1's KV read. Ten idle sessions ≈ 29k requests/day of pure nothing.

The socket itself is free — it's a direct CNAME to the regional backend (`ws-eu.threa.io`), and presence/renew/steps already ride it (#1067). The claim poll is the last chatty HTTP path.

## Solution

### How it works

- **workspace-router:** an in-isolate `Map` cache in front of the KV read. 5-minute positive TTL; 30-second negative TTL (an unknown workspace id can't turn every request into a KV read + control-plane round-trip); 5,000-entry hard cap with full reset, since ids arrive from attacker-controlled URLs. The KV entry is itself an immutable forever-cache, so in-memory staleness adds no correctness risk; the TTL just bounds it if region migration ever becomes real. Exported `clearRegionCache()` keeps module-level state out of test cross-talk.
- **remote-session + pi-remote:** `WS_BACKSTOP_POLL_MS` 30s → **15 minutes**. While the socket is up the server *pushes* work (`bot_invocation:available`, plus the `bot:hello` bootstrap replays available invocations + owned claims on every connect/resync), so the poll only insures against a silently dropped push. 15 min bounds that worst case at 96 requests/day/session — and with the Worker cache the residual KV cost of those is ~zero. The 3s degraded-mode poll when the socket is *down* is unchanged.

### Key design decision

**Stretch the backstop rather than move claims onto the socket.** Claims are deliberately durable HTTP writes ("durable, low-frequency writes stay on each extension's own HTTP client" — the transport's own contract from #1067). The quota burn came from the *frequency*, not the transport; a 20× cadence cut plus Worker-side caching removes the cost without growing the socket protocol's write surface. Claims-over-WS remains open as a further step if ever needed.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/workspace-router/src/index.ts` | in-isolate region cache (positive + negative TTL, cap), `clearRegionCache` test hook |
| `apps/workspace-router/src/index.test.ts` | `beforeEach` cache reset + 2 cache-behavior tests |
| `extensions/remote-session/src/session.ts` | backstop 30s → 15 min, rationale comment |
| `extensions/pi-remote/src/threa-remote.ts` | same |
| `extensions/pi-remote/src/threa-remote.test.ts` | cadence-constant test updated to the new contract |

## Test plan

- [x] workspace-router — 54 pass (2 new: same-workspace second request skips KV; control-plane resolution + not-found both cached), `tsc` clean (app + test configs)
- [x] remote-session — 61 pass; pi-remote — 76 pass
- [x] Full repo lint/typecheck via pre-commit hook
- [ ] Quota impact is only measurable in the CF dashboard over a day of real idling — expect workspace-scoped KV reads to drop by roughly the idle-poll volume (≈3k/day/session) plus the per-request read amplification from the web app

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785671838&installation_id=129946197&pr_number=1156&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1156&signature=5b611577dd24657f9943d26cbc220f785d5c701a8949366d5482e7883d11b7f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->