### PR TITLE
feat(harness): archiving a scratchpad gracefully shuts down its linked agent

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -3,7 +3,12 @@ import { AuthorTypes, StreamTypes, botHasCapability } from "@threa/types"
 import { resolveDeliveryVerdict, TrustTiers, TurnDeliveries } from "@threa/agent-runtime"
 import { collectMentionActorRefs, parseMarkdown, type JSONContent } from "@threa/prosemirror"
 import { CursorLock, DebounceWithMaxWait, ensureListenerFromLatest, type ProcessResult } from "@threa/backend-common"
-import { OutboxRepository, parseMessagePayload, type OutboxHandler } from "../../lib/outbox"
+import {
+  OutboxRepository,
+  parseMessagePayload,
+  type OutboxHandler,
+  type StreamArchivedOutboxPayload,
+} from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { StreamRepository } from "../streams"
 import { resolveSealingContext } from "../e2e-streams"
@@ -95,10 +100,25 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
       for (const event of events) {
         if (event.eventType === "message:created") {
           await this.processMessageCreated(event.payload)
+        } else if (event.eventType === "stream:archived") {
+          await this.processStreamArchived(event.payload as StreamArchivedOutboxPayload)
         }
         seen.push(event.id)
       }
       return { status: "processed", processedIds: seen }
+    })
+  }
+
+  /**
+   * Archiving a scratchpad ends its runtime session links and notifies each
+   * linked runtime so it can shut itself down. The service call is idempotent
+   * (set-based end of still-active links), so a retried batch is a no-op.
+   */
+  private async processStreamArchived(payload: StreamArchivedOutboxPayload): Promise<void> {
+    if (!payload?.workspaceId || !payload?.streamId) return
+    await this.service.endSessionsForArchivedStream({
+      workspaceId: payload.workspaceId,
+      rootStreamId: payload.streamId,
     })
   }
 

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -480,6 +480,24 @@ export const BotRuntimeSessionLinkRepository = {
     return mapSessionLink(result.rows[0]!)
   },
 
+  /**
+   * End every active link rooted at a stream (its scratchpad was archived) and
+   * return the ended rows so the caller can notify each runtime. One set-based
+   * UPDATE … RETURNING so concurrent archive/consumer retries can't double-end
+   * or race a link back to life (INV-20, INV-56).
+   */
+  async endActiveByRootStream(
+    db: Querier,
+    params: { workspaceId: string; rootStreamId: string }
+  ): Promise<BotRuntimeSessionLink[]> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`UPDATE bot_runtime_session_links SET status = 'ended', updated_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND root_stream_id = ${params.rootStreamId} AND status = 'active'
+      RETURNING *`
+    )
+    return result.rows.map(mapSessionLink)
+  },
+
   async findActiveByStream(
     db: Querier,
     params: { workspaceId: string; botId: string; rootStreamId: string; activeStreamId: string }

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -413,6 +413,36 @@ export class BotRuntimeService {
     })
   }
 
+  /**
+   * A scratchpad was archived: end every active runtime link rooted at it and
+   * tell each linked runtime over the /bot socket so it can wind itself down
+   * (the Claude channel pushes its branch and kills its own tmux window). Link
+   * ending and the notify events commit together (INV-4/INV-7); the set-based
+   * UPDATE makes consumer retries idempotent — already-ended links return no
+   * rows, so nothing re-notifies.
+   */
+  async endSessionsForArchivedStream(params: { workspaceId: string; rootStreamId: string }): Promise<number> {
+    return withTransaction(this.pool, async (db) => {
+      const ended = await BotRuntimeSessionLinkRepository.endActiveByRootStream(db, params)
+      for (const link of ended) {
+        await OutboxRepository.insert(db, "bot:session_archived", {
+          workspaceId: params.workspaceId,
+          botId: link.botId,
+          instanceId: link.instanceId,
+          runtimeSessionId: link.runtimeSessionId,
+          rootStreamId: params.rootStreamId,
+        })
+      }
+      if (ended.length > 0) {
+        logger.info(
+          { workspaceId: params.workspaceId, rootStreamId: params.rootStreamId, endedLinks: ended.length },
+          "Ended runtime session links for archived stream"
+        )
+      }
+      return ended.length
+    })
+  }
+
   async createInvocation(params: {
     workspaceId: string
     rootStreamId: string

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -8,6 +8,7 @@ import {
   type BotInvocationClaimedOutboxPayload,
   type BotActiveActorChangedOutboxPayload,
   type BotResyncOutboxPayload,
+  type BotSessionArchivedOutboxPayload,
 } from "./repository"
 import { resolveDeliveryGroups, emitToGroups } from "./delivery-groups"
 import { logger } from "../logger"
@@ -266,6 +267,17 @@ export class BroadcastHandler implements OutboxHandler {
       } else {
         botNs.to(`bot:${workspaceId}`).emit(event.eventType, payload)
       }
+      return
+    }
+
+    if (isOutboxEventType(event, "bot:session_archived")) {
+      const payload = event.payload as BotSessionArchivedOutboxPayload
+      // Narrow session room first (the link identifies one session); instance
+      // room as fallback for runtimes that registered without a session id.
+      botNs
+        .to(`bot:${workspaceId}:bot:${payload.botId}:session:${payload.runtimeSessionId}`)
+        .to(`bot:${workspaceId}:bot:${payload.botId}:instance:${payload.instanceId}`)
+        .emit(event.eventType, payload)
       return
     }
 

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -96,6 +96,7 @@ export type OutboxEventType =
   | "bot_invocation:claimed"
   | "bot:active_actor_changed"
   | "bot:resync"
+  | "bot:session_archived"
   | "label:created"
   | "label:updated"
   | "label:deleted"
@@ -732,6 +733,18 @@ export interface BotResyncOutboxPayload extends WorkspaceScopedPayload {
   reason: string
 }
 
+/**
+ * The scratchpad a runtime session was linked to has been archived; the link is
+ * already `ended` server-side. The runtime should wind itself down (the Claude
+ * channel pushes its branch and kills its own tmux window on receipt).
+ */
+export interface BotSessionArchivedOutboxPayload extends WorkspaceScopedPayload {
+  botId: string
+  instanceId: string
+  runtimeSessionId: string
+  rootStreamId: string
+}
+
 // Label event payloads. Labels are owner-scoped, so `targetUserId` is always the
 // owning actor and the broadcast handler delivers to that actor's user room only.
 export interface LabelUpsertedOutboxPayload extends WorkspaceScopedPayload {
@@ -854,6 +867,7 @@ export interface OutboxEventPayloadMap {
   "bot_invocation:claimed": BotInvocationClaimedOutboxPayload
   "bot:active_actor_changed": BotActiveActorChangedOutboxPayload
   "bot:resync": BotResyncOutboxPayload
+  "bot:session_archived": BotSessionArchivedOutboxPayload
   "label:created": LabelUpsertedOutboxPayload
   "label:updated": LabelUpsertedOutboxPayload
   "label:deleted": LabelDeletedOutboxPayload
@@ -999,12 +1013,14 @@ export type BotScopedEventType =
   | "bot_invocation:claimed"
   | "bot:active_actor_changed"
   | "bot:resync"
+  | "bot:session_archived"
 
 const BOT_SCOPED_EVENTS: BotScopedEventType[] = [
   "bot_invocation:available",
   "bot_invocation:claimed",
   "bot:active_actor_changed",
   "bot:resync",
+  "bot:session_archived",
 ]
 
 /**

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -120,6 +120,7 @@ export class BotRuntimeTransport {
     socket.on("bot_invocation:available", () => this.callbacks.onInvocationAvailable?.())
     socket.on("bot_invocation:claimed", (payload: unknown) => this.callbacks.onInvocationClaimed?.(payload))
     socket.on("bot:active_actor_changed", (payload: unknown) => this.callbacks.onActiveActorChanged?.(payload))
+    socket.on("bot:session_archived", (payload: unknown) => this.callbacks.onSessionArchived?.(payload))
     socket.on("bot:resync", () => {
       this.sendHello()
       this.callbacks.onResync?.()

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -53,6 +53,8 @@ export interface BotRuntimeTransportCallbacks {
   onActiveActorChanged?: (payload: unknown) => void
   /** The server asked the runtime to re-announce itself; the transport re-sends hello automatically and also fires this. */
   onResync?: () => void
+  /** The scratchpad this runtime session is linked to was archived; the link is ended server-side. Wind down. */
+  onSessionArchived?: (payload: unknown) => void
   /** The `bot:hello` ack landed; carries the bootstrap snapshot. */
   onBootstrap?: (bootstrap: BotHelloBootstrap) => void
 }

--- a/extensions/claude-code-remote/src/archive-cleanup.test.ts
+++ b/extensions/claude-code-remote/src/archive-cleanup.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pushBranchAndScheduleRemoval } from "./archive-cleanup"
+
+const noLog = () => undefined
+
+function sh(cwd: string, command: string): string {
+  const result = Bun.spawnSync(["sh", "-c", command], { cwd, stdout: "pipe", stderr: "pipe" })
+  if (result.exitCode !== 0) {
+    throw new Error(`'${command}' failed: ${result.stderr.toString()}`)
+  }
+  return result.stdout.toString().trim()
+}
+
+/** A main repo on a feature branch with a bare `origin`, plus a linked worktree. */
+function makeFixture(): { main: string; worktree: string; origin: string } {
+  const root = mkdtempSync(join(tmpdir(), "archive-cleanup-"))
+  const origin = join(root, "origin.git")
+  const main = join(root, "main")
+  sh(root, `git init --bare origin.git`)
+  sh(root, `git init -b main main`)
+  sh(main, `git config user.email t@t && git config user.name t`)
+  writeFileSync(join(main, "a.txt"), "a\n")
+  sh(main, `git add -A && git commit -m init`)
+  sh(main, `git remote add origin ${origin}`)
+  sh(main, `git push -u origin main`)
+  const worktree = join(root, "wt-feature")
+  sh(main, `git worktree add -b feature/archive-test ${worktree}`)
+  sh(worktree, `git config user.email t@t && git config user.name t`)
+  return { main, worktree, origin }
+}
+
+function originHasBranch(origin: string, branch: string): boolean {
+  const result = Bun.spawnSync(["git", "-C", origin, "rev-parse", "--verify", `refs/heads/${branch}`], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  return result.exitCode === 0
+}
+
+describe("pushBranchAndScheduleRemoval", () => {
+  test("commits dirty work, pushes the branch, and schedules removal of a linked worktree", async () => {
+    const { worktree, origin } = makeFixture()
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+
+    expect(report).toMatchObject({ committed: true, pushed: true, removalScheduled: true })
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(true)
+    const pushedMessage = sh(origin, `git log -1 --format=%s feature/archive-test`)
+    expect(pushedMessage).toBe("wip: auto-commit — scratchpad archived")
+    // The detached remover fires after its 5s grace; poll briefly for it.
+    const { existsSync } = await import("node:fs")
+    const deadline = Date.now() + 10_000
+    while (existsSync(worktree) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+    expect(existsSync(worktree)).toBe(false)
+  }, 20_000)
+
+  test("pushes a clean worktree without inventing a commit", () => {
+    const { worktree, origin } = makeFixture()
+    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+    expect(report.committed).toBe(false)
+    expect(report.pushed).toBe(true)
+    expect(originHasBranch(origin, "feature/archive-test")).toBe(true)
+  })
+
+  test("leaves the worktree when the push fails (no remote)", async () => {
+    const { main, worktree } = makeFixture()
+    sh(main, `git remote remove origin`)
+    writeFileSync(join(worktree, "wip.txt"), "unsaved work\n")
+
+    const report = pushBranchAndScheduleRemoval(worktree, noLog)
+
+    expect(report.pushed).toBe(false)
+    expect(report.removalScheduled).toBe(false)
+    expect(report.reason).toContain("push failed")
+    // Committed (preserving the work) but still on disk well past any grace delay.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    const { existsSync } = await import("node:fs")
+    expect(existsSync(join(worktree, "wip.txt"))).toBe(true)
+  })
+
+  test("refuses to touch main and never removes the main checkout", () => {
+    const { main } = makeFixture()
+    const report = pushBranchAndScheduleRemoval(main, noLog)
+    expect(report.pushed).toBe(false)
+    expect(report.removalScheduled).toBe(false)
+    expect(report.reason).toContain("protected")
+  })
+
+  test("pushes from the main checkout on a feature branch but does not remove it", () => {
+    const { main, origin } = makeFixture()
+    sh(main, `git checkout -b feature/from-main`)
+    const report = pushBranchAndScheduleRemoval(main, noLog)
+    expect(report.pushed).toBe(true)
+    expect(report.removalScheduled).toBe(false)
+    expect(report.reason).toContain("main repository checkout")
+    expect(originHasBranch(origin, "feature/from-main")).toBe(true)
+  })
+
+  test("reports a non-repo directory without doing anything", () => {
+    const dir = mkdtempSync(join(tmpdir(), "not-a-repo-"))
+    const report = pushBranchAndScheduleRemoval(dir, noLog)
+    expect(report).toMatchObject({ committed: false, pushed: false, removalScheduled: false })
+    expect(report.reason).toContain("not a git worktree")
+  })
+})

--- a/extensions/claude-code-remote/src/archive-cleanup.ts
+++ b/extensions/claude-code-remote/src/archive-cleanup.ts
@@ -1,0 +1,102 @@
+import { spawn } from "node:child_process"
+import { dirname, resolve } from "node:path"
+
+/**
+ * Wind-down for an archived scratchpad: preserve the work on the remote, then
+ * clean up the local footprint. The safety ladder is strict — each rung only
+ * runs when the one before it succeeded, and anything short of a successful
+ * push leaves the worktree untouched on disk:
+ *
+ *   1. dirty tree → `git add -A` + a wip commit (uncommitted work must never
+ *      die with the worktree)
+ *   2. `git push origin HEAD:<branch>`
+ *   3. push succeeded AND this is a linked worktree → schedule removal via a
+ *      detached shell (this process dies with its tmux window moments later,
+ *      so the removal must outlive it)
+ *
+ * Never touches `main`/`master`/detached HEAD, and never removes the main
+ * repository checkout — only linked worktrees.
+ */
+
+export interface ArchiveCleanupReport {
+  committed: boolean
+  pushed: boolean
+  removalScheduled: boolean
+  reason?: string
+}
+
+const PROTECTED_BRANCHES = new Set(["main", "master", "HEAD"])
+const GIT_TIMEOUT_MS = 30_000
+const PUSH_TIMEOUT_MS = 120_000
+
+function git(cwd: string, args: string[], timeoutMs = GIT_TIMEOUT_MS): { ok: boolean; stdout: string } {
+  try {
+    const result = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", timeout: timeoutMs })
+    return { ok: result.exitCode === 0, stdout: result.stdout.toString().trim() }
+  } catch {
+    return { ok: false, stdout: "" }
+  }
+}
+
+export function pushBranchAndScheduleRemoval(cwd: string, log: (message: string) => void): ArchiveCleanupReport {
+  const report: ArchiveCleanupReport = { committed: false, pushed: false, removalScheduled: false }
+
+  if (!git(cwd, ["rev-parse", "--is-inside-work-tree"]).ok) {
+    report.reason = "not a git worktree"
+    return report
+  }
+  const branch = git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout
+  if (!branch || PROTECTED_BRANCHES.has(branch)) {
+    report.reason = `branch '${branch || "?"}' is protected or detached — leaving everything as is`
+    return report
+  }
+
+  const dirty = git(cwd, ["status", "--porcelain"]).stdout.length > 0
+  if (dirty) {
+    const added = git(cwd, ["add", "-A"])
+    const commit = added.ok ? git(cwd, ["commit", "-m", "wip: auto-commit — scratchpad archived"]) : added
+    if (!commit.ok) {
+      report.reason = "could not commit dirty work — leaving the worktree"
+      return report
+    }
+    report.committed = true
+  }
+
+  const push = git(cwd, ["push", "-u", "origin", `HEAD:${branch}`], PUSH_TIMEOUT_MS)
+  if (!push.ok) {
+    report.reason = "push failed — leaving the worktree so nothing is lost"
+    return report
+  }
+  report.pushed = true
+  log(`pushed ${branch} to origin`)
+
+  // Linked worktree ⇔ its .git dir differs from the repo's common dir. The
+  // main checkout's dir IS the common dir, so this can never remove it.
+  const gitDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-dir"]).stdout
+  const commonDir = git(cwd, ["rev-parse", "--path-format=absolute", "--git-common-dir"]).stdout
+  if (!gitDir || !commonDir || resolve(gitDir) === resolve(commonDir)) {
+    report.reason = "main repository checkout — not removing"
+    return report
+  }
+
+  const mainRepo = dirname(resolve(commonDir))
+  try {
+    // Detached with a grace delay: this process dies with its tmux window
+    // moments after returning, and a directory can't be removed out from under
+    // the processes still holding it.
+    const child = spawn(
+      "sh",
+      ["-c", `sleep 5; git -C ${shellQuote(mainRepo)} worktree remove --force ${shellQuote(cwd)}`],
+      { detached: true, stdio: "ignore" }
+    )
+    child.unref()
+    report.removalScheduled = true
+  } catch {
+    report.reason = "could not schedule worktree removal (branch is pushed; remove manually)"
+  }
+  return report
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -13,7 +13,8 @@ import {
 } from "@threa/remote-session"
 import { z } from "zod"
 import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
-import { interrupt, submitLine, tmuxAvailable } from "./tmux-control"
+import { pushBranchAndScheduleRemoval } from "./archive-cleanup"
+import { interrupt, killOwnWindow, submitLine, tmuxAvailable } from "./tmux-control"
 
 const RUNTIME_KIND = "claude-code-channel"
 export const CHANNEL_SOURCE = "threa"
@@ -191,6 +192,7 @@ export class ChannelServer {
       delegate: {
         deliverTurn: (turn) => this.deliverToClaude(turn),
         sessionControl: createClaudeSessionControl(),
+        onArchived: () => this.windDownForArchive(),
         ...(config.permissionRelay
           ? { interceptClaimed: (invocation: ClaimedInvocation) => this.interceptVerdict(invocation) }
           : {}),
@@ -212,6 +214,23 @@ export class ChannelServer {
     for (const [, open] of this.openPermissions) clearTimeout(open.cleanup)
     this.openPermissions.clear()
     await this.session.shutdown()
+  }
+
+  /**
+   * The scratchpad was archived (SDK is already offline). Preserve the work on
+   * the remote, then take the whole tmux window down — Claude Code, this
+   * channel, and the shell die together; a detached helper removes the
+   * worktree afterwards. Recovery is `git fetch` + the pushed branch, never a
+   * local revival. Outside tmux there is nothing to kill but ourselves.
+   */
+  private windDownForArchive(): void {
+    log("scratchpad archived — preserving work and shutting down")
+    const report = pushBranchAndScheduleRemoval(process.cwd(), log)
+    log(
+      `archive cleanup: committed=${report.committed} pushed=${report.pushed} removal=${report.removalScheduled}` +
+        (report.reason ? ` (${report.reason})` : "")
+    )
+    if (!killOwnWindow()) process.exit(0)
   }
 
   // --- Turn delivery ----------------------------------------------------------

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -62,5 +62,20 @@ export async function submitLine(text: string, opts: { settleMs?: number } = {})
   return sendKeys(["Enter"])
 }
 
+/**
+ * Kill the tmux window this channel (and its Claude Code parent) lives in —
+ * deliberate self-termination for the archived-scratchpad wind-down. The
+ * channel dies with the window; callers do any last writes first.
+ */
+export function killOwnWindow(): boolean {
+  const target = paneTarget()
+  if (!target) return false
+  try {
+    return Bun.spawnSync(["tmux", "kill-window", "-t", target], { stdout: "pipe", stderr: "pipe" }).exitCode === 0
+  } catch {
+    return false
+  }
+}
+
 /** Milliseconds to wait after an interrupt before delivering the steer turn, so Claude has returned to idle. */
 export const STEER_SETTLE_MS = 250

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -355,6 +355,45 @@ describe("RemoteSession.onReplyTimeout", () => {
   })
 })
 
+describe("RemoteSession session-archived handling", () => {
+  test("goes offline, fails in-flight turns, and hands the connector the final word", async () => {
+    const failed: string[] = []
+    const client = {
+      fail: async (id: string) => {
+        failed.push(id)
+      },
+    } as unknown as ThreaClient
+    const { transport, presence } = makeFakeTransport()
+    const archived: Array<{ rootStreamId: string }> = []
+    const session = makeSession(client, transport, { onArchived: (payload) => void archived.push(payload) })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+
+    await (session as unknown as { handleSessionArchived: (p: unknown) => Promise<void> }).handleSessionArchived({
+      runtimeSessionId: "rts-test",
+      rootStreamId: "stream_root",
+    })
+
+    expect(presence.at(-1)?.status).toBe("offline")
+    expect(failed).toEqual(["binv_running"])
+    expect(archived).toEqual([{ rootStreamId: "stream_root" }])
+  })
+
+  test("ignores an event for a different runtime session (stale re-registration)", async () => {
+    const { client } = makeFakeClient()
+    const { transport, presence } = makeFakeTransport()
+    const archived: unknown[] = []
+    const session = makeSession(client, transport, { onArchived: (payload) => void archived.push(payload) })
+
+    await (session as unknown as { handleSessionArchived: (p: unknown) => Promise<void> }).handleSessionArchived({
+      runtimeSessionId: "rts-someone-else",
+      rootStreamId: "stream_root",
+    })
+
+    expect(archived).toEqual([])
+    expect(presence).toEqual([])
+  })
+})
+
 describe("RemoteSession.shutdown", () => {
   test("marks presence offline and fails every in-flight claim", async () => {
     const failed: Array<{ id: string; body: Record<string, unknown> }> = []

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -80,6 +80,13 @@ export interface RemoteSessionDelegate {
   interceptClaimed?(invocation: ClaimedInvocation): Promise<boolean>
   /** Present iff the connector can drive the runtime. Gates advertising session control (fail-safe). */
   sessionControl?: SessionControlActuator
+  /**
+   * The linked scratchpad was archived (the server already ended the session
+   * link). Called after the SDK has gone offline and failed its in-flight
+   * turns; the connector finishes the wind-down — the Claude channel pushes
+   * its branch and kills its own tmux window, so this hook may never return.
+   */
+  onArchived?: (payload: { rootStreamId: string }) => Promise<void> | void
 }
 
 /** The connector's runtime identity and user-facing wording. */
@@ -265,6 +272,7 @@ export class RemoteSession {
           onBootstrap: (bootstrap) => {
             if (bootstrap.availableInvocations.length > 0 || bootstrap.ownedClaims.length > 0) void this.claimDrain()
           },
+          onSessionArchived: (payload) => void this.handleSessionArchived(payload),
         },
         log: this.log,
       })
@@ -779,6 +787,27 @@ export class RemoteSession {
     if (!entry) return
     clearTimeout(entry.deadline)
     entry.deadline = this.scheduleIdleTimeout(invocationId)
+  }
+
+  /**
+   * The linked scratchpad was archived. The server has already ended the
+   * session link, so no more work can arrive; go offline (shutdown also fails
+   * any in-flight turn) and hand the connector the final word. Scoped to this
+   * session: the event is room-targeted, but a runtime that re-registered
+   * under a new session id must not die to a stale event for the old one.
+   */
+  private async handleSessionArchived(payload: unknown): Promise<void> {
+    const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
+    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
+    if (this.stopped) return
+    const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : (this.link?.rootStreamId ?? "")
+    this.log(`scratchpad ${rootStreamId} archived — winding down`)
+    await this.shutdown()
+    try {
+      await this.delegate.onArchived?.({ rootStreamId })
+    } catch (error) {
+      this.log(`onArchived hook failed: ${this.summarize(error)}`)
+    }
   }
 
   // --- Timers ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

Archiving a scratchpad in the UI does nothing to the agent behind it. The tmux window keeps running Claude Code, the channel keeps its presence alive, the worktree lingers, and any work on the branch stays local-only. Kris's ruling: archive should propagate all the way down — the agent pushes its branch gracefully, kills its own session, and cleans up locally; recovery is fetching the pushed branch from the remote, **not** local revival.

Nothing existed for this: the archive flow wrote `stream:archived` to the outbox but no bot-runtimes consumer handled it, `bot_runtime_session_links` had no code path that ever set `ended`, and there was no bot-socket event for session termination.

## Solution

Archive → end links → push one socket event per linked runtime → the agent preserves its work and removes itself.

### How it works

1. **Consumer** — `BotInvocationOutboxHandler` (the existing bot-runtimes outbox consumer) now handles `stream:archived` alongside `message:created`, calling `BotRuntimeService.endSessionsForArchivedStream`.
2. **Service** — one transaction (INV-4/7): `endActiveByRootStream` flips every active link rooted at the archived stream to `ended` via a single set-based `UPDATE … RETURNING` (INV-20/56 — a retried outbox batch finds no active rows and re-notifies nobody), then inserts one `bot:session_archived` outbox event per ended link (`botId`, `instanceId`, `runtimeSessionId`, `rootStreamId`).
3. **Routing** — `BroadcastHandler.dispatchBotEvent` emits it to the narrow session room (`bot:{ws}:bot:{botId}:session:{runtimeSessionId}`) with the instance room as fallback, same scheme as `bot_invocation:available`.
4. **SDK** — `BotRuntimeTransport` surfaces `onSessionArchived`; `RemoteSession.handleSessionArchived` drops events whose `runtimeSessionId` isn't this session's (a runtime that re-registered must not die to a stale event for its predecessor), then runs `shutdown()` (presence offline, in-flight turns failed) and calls the new delegate hook `onArchived`.
5. **Claude connector** — `windDownForArchive`: `pushBranchAndScheduleRemoval(cwd)` then `killOwnWindow()` (tmux `kill-window` on its own pane — Claude Code, channel, and shell die together; `process.exit(0)` outside tmux).

### The safety ladder (`archive-cleanup.ts`)

Each rung runs only if the previous one succeeded; anything short of a successful push leaves the worktree on disk:

1. dirty tree → `git add -A` + `wip: auto-commit — scratchpad archived` (uncommitted work must never die with the worktree)
2. `git push -u origin HEAD:<branch>` (120s timeout)
3. push OK **and** the cwd is a *linked* worktree (its `--git-dir` ≠ `--git-common-dir`) → schedule `git worktree remove --force` via a **detached** shell with a 5s grace — the scheduling process dies with its tmux window moments later, so the remover must outlive it

Never touches `main`/`master`/detached HEAD; can never remove the main checkout (the main checkout's git dir *is* the common dir).

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/archive-cleanup.ts` | the safety ladder |
| `extensions/claude-code-remote/src/archive-cleanup.test.ts` | 6 real-git integration tests |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/lib/outbox/repository.ts` | `bot:session_archived` event type + payload + bot-scoped registration |
| `apps/backend/src/lib/outbox/broadcast-handler.ts` | session-room routing branch |
| `apps/backend/src/features/bot-runtimes/repository.ts` | `endActiveByRootStream` (set-based UPDATE…RETURNING) |
| `apps/backend/src/features/bot-runtimes/service.ts` | `endSessionsForArchivedStream` |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | consume `stream:archived` |
| `extensions/bot-runtime-client/src/{transport,types}.ts` | `onSessionArchived` callback |
| `extensions/remote-session/src/session.ts` | `handleSessionArchived` + `onArchived` delegate hook |
| `extensions/claude-code-remote/src/channel-server.ts` | `windDownForArchive` wiring |
| `extensions/claude-code-remote/src/tmux-control.ts` | `killOwnWindow` |

## Out of scope (deliberate)

- **Unarchive does not revive** the agent (link stays `ended`) — per Kris, recovery is `git fetch` of the pushed branch.
- **pi-remote** doesn't get the wind-down (it hasn't adopted the SDK yet); its links still end server-side, so it stops receiving work.
- **harnessd inventory** rows aren't reaped when a window self-destructs; `list` shows them until pruned — candidate for a follow-up `harnessd list` liveness check.

## Test plan

- [x] archive-cleanup — 6 pass against real temp git repos: dirty→wip-commit→push→actual detached worktree removal observed; push-failure leaves everything; protected-branch refusal; main-checkout-never-removed; non-repo no-op
- [x] remote-session — 63 pass (2 new: archived → offline + in-flight failed + hook fired; stale session id ignored); bot-runtime-client — 12 pass; claude-code-remote — 30 pass
- [x] Backend `tsc` (app + tests) clean; full repo lint/typecheck via pre-commit hook
- [ ] The backend chain (consumer → link ending → socket delivery to the session room) has no unit harness here — it mirrors the existing `bot_invocation:available` routing exactly, and I'll run the full live loop (spawn agent via harnessd → archive in the UI → watch the window die, branch appear on origin, worktree vanish, link flip to `ended`) right after this deploys, the same way the session-control stack was verified

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785671841&installation_id=129946197&pr_number=1157&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1157&signature=56ae48bb7de11c338bc7ee0ac3ae6d2b239c9f977af5ac5a84885226df9122af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->