### PR TITLE
fix(pi-remote): surface model errors instead of a fake 'Done.' reply

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -297,6 +297,67 @@ describe("Pi remote trace safety", () => {
     ).toBe("Error: model provider rate-limited the request.")
   })
 
+  // The 2026-07-03 Pi-Orchestrator failure: opencode's gateway 502'd every
+  // call, the client THREW (so `after_provider_response` never fired and
+  // providerError stayed unset), and each errored assistant message had empty
+  // content plus `stopReason: "error"`. The turn fell through every branch to
+  // the "Done." fallback — the user asked "Did I mess up?" and got "Done.".
+  test("surfaces a model error carried on an errored assistant message instead of Done.", () => {
+    const messages = [
+      { role: "user", content: "Hi" },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "502 status code (no body)",
+        provider: "opencode-go",
+        model: "deepseek-v4-flash",
+      },
+    ]
+    expect(__testing.resolveFinalText({ messages }, { assistantTexts: [], otherTexts: [] })).toBe(
+      "⚠️ Model call failed (opencode-go/deepseek-v4-flash): 502 status code (no body). Try /model to switch models."
+    )
+  })
+
+  test("prefers the modelError captured at message_end when agent_end carries no messages", () => {
+    const modelError =
+      "⚠️ Model call failed (opencode-go/deepseek-v4-flash): 502 status code (no body). Try /model to switch models."
+    expect(__testing.resolveFinalText({}, { assistantTexts: [], otherTexts: [], modelError })).toBe(modelError)
+  })
+
+  test("a successful assistant message after an errored one means the retry recovered", () => {
+    const messages = [
+      { role: "assistant", content: [], stopReason: "error", errorMessage: "502 status code (no body)" },
+      { role: "assistant", content: "Recovered on retry — here is the answer." },
+    ]
+    expect(__testing.trailingModelError(messages)).toBeUndefined()
+    expect(__testing.resolveFinalText({ messages }, { assistantTexts: [], otherTexts: [] })).toBe(
+      "Recovered on retry — here is the answer."
+    )
+  })
+
+  test("appends the model error when narration exists but the final model call died", () => {
+    const messages = [
+      { role: "assistant", content: "Let me rebase the branch first." },
+      { role: "assistant", content: [], stopReason: "error", errorMessage: "502 status code (no body)" },
+    ]
+    expect(
+      __testing.resolveFinalText({ messages }, { assistantTexts: ["Let me rebase the branch first."], otherTexts: [] })
+    ).toBe(
+      "Let me rebase the branch first.\n\n⚠️ Model call failed: 502 status code (no body). Try /model to switch models."
+    )
+  })
+
+  test("extractModelError formats without a provider/model pair and defaults a blank message", () => {
+    expect(__testing.extractModelError({ role: "assistant", stopReason: "error", errorMessage: "  " })).toBe(
+      "⚠️ Model call failed: unknown error. Try /model to switch models."
+    )
+    expect(
+      __testing.extractModelError({ role: "assistant", stopReason: "stop", errorMessage: "irrelevant" })
+    ).toBeUndefined()
+    expect(__testing.extractModelError({ role: "user", stopReason: "error" })).toBeUndefined()
+  })
+
   test("parseRetryAfter understands the seconds form of Retry-After", () => {
     expect(__testing.parseRetryAfter({ "retry-after": "120" })).toBe(120_000)
     expect(__testing.parseRetryAfter({ "Retry-After": "0.5" })).toBe(500)

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -166,6 +166,7 @@ let pendingAssistantTexts: string[] = []
 let pendingNonAssistantTexts: Array<{ role: string; text: string }> = []
 let pendingToolCalls = new Map<string, { headline: string }>()
 let pendingProviderError: string | undefined
+let pendingModelError: string | undefined
 let pendingRetryAfterMs: number | undefined
 let pendingInvocationPrompt: string | undefined
 let pendingRetry: { timer: ReturnType<typeof setTimeout>; retryAt: number; attempts: number } | undefined
@@ -1503,6 +1504,7 @@ function beginPendingInvocation(invocation: ClaimedInvocation, cursor?: string):
   pendingNonAssistantTexts = []
   pendingToolCalls = new Map()
   pendingProviderError = undefined
+  pendingModelError = undefined
   pendingRetryAfterMs = undefined
   pendingInvocationPrompt = undefined
   clearPendingRetry()
@@ -1521,6 +1523,7 @@ function resetPendingTurnTexts(): void {
   pendingNonAssistantTexts = []
   pendingToolCalls = new Map()
   pendingProviderError = undefined
+  pendingModelError = undefined
   pendingRetryAfterMs = undefined
   lastTraceHeartbeat = undefined
 }
@@ -2083,6 +2086,48 @@ function captureMessageText(message: unknown): { role: string; text: string } | 
   return text ? { role, text } : null
 }
 
+/**
+ * An assistant message whose model call died carries the failure on the
+ * message itself (`stopReason: "error"` + `errorMessage`) and usually has no
+ * text content — so the text-capture path drops it entirely and the turn
+ * "completes" silently. This is the only place that error is visible when the
+ * provider throws instead of returning an HTTP response (a thrown 502 never
+ * fires `after_provider_response`, so `pendingProviderError` stays unset).
+ */
+function extractModelError(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") return undefined
+  const raw = message as {
+    role?: unknown
+    stopReason?: unknown
+    errorMessage?: unknown
+    provider?: unknown
+    model?: unknown
+  }
+  if (raw.role !== "assistant" || raw.stopReason !== "error") return undefined
+  const detail =
+    typeof raw.errorMessage === "string" && raw.errorMessage.trim().length > 0
+      ? raw.errorMessage.trim()
+      : "unknown error"
+  const source =
+    typeof raw.provider === "string" && typeof raw.model === "string" ? ` (${raw.provider}/${raw.model})` : ""
+  return `⚠️ Model call failed${source}: ${detail}. Try /model to switch models.`
+}
+
+/**
+ * Did the turn END in a model error? Scanning backwards, an error only counts
+ * if no assistant message with real text came after it — a later successful
+ * message means a retry recovered and the error is history, not the outcome.
+ */
+function trailingModelError(messages: unknown): string | undefined {
+  if (!Array.isArray(messages)) return undefined
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const error = extractModelError(messages[i])
+    if (error) return error
+    if (captureMessageText(messages[i])?.role === "assistant") return undefined
+  }
+  return undefined
+}
+
 function textFromAgentMessages(messages: unknown): string {
   if (!Array.isArray(messages)) return "Done."
   const captured = messages
@@ -2208,12 +2253,25 @@ function resolveFinalText(
     assistantTexts: string[]
     otherTexts: Array<{ role: string; text: string }>
     providerError?: string
+    modelError?: string
   }
 ): string {
-  if (state.assistantTexts.length > 0) return state.assistantTexts[state.assistantTexts.length - 1]
+  // Captured at `message_end` when the errored message streamed through, with
+  // a scan of the turn's messages as backup for paths that bypass the pending
+  // state. Either way, a turn that ended in a model error must say so — the
+  // old behavior fell through to the "Done." fallback and posted a confident
+  // no-op while every model call was failing.
+  const modelError = state.modelError ?? trailingModelError((event as { messages?: unknown } | undefined)?.messages)
+  if (state.assistantTexts.length > 0) {
+    const answer = state.assistantTexts[state.assistantTexts.length - 1]
+    // Narration followed by a dead final model call: posting the narration
+    // alone reads as a finished answer, so carry the failure with it.
+    return modelError ? `${answer}\n\n${modelError}` : answer
+  }
   if (state.providerError) return state.providerError
   const eventError = extractAgentEndError(event)
   if (eventError) return eventError
+  if (modelError) return modelError
   if (state.otherTexts.length > 0) return state.otherTexts.map((item) => item.text).join("\n\n")
   return textFromAgentMessages((event as { messages?: unknown } | undefined)?.messages)
 }
@@ -2398,6 +2456,7 @@ async function completePending(markdown: string, ctx: ExtensionContext): Promise
   pendingNonAssistantTexts = []
   pendingToolCalls = new Map()
   pendingProviderError = undefined
+  pendingModelError = undefined
   pendingRetryAfterMs = undefined
   pendingInvocationPrompt = undefined
   clearPendingRetry()
@@ -2420,6 +2479,7 @@ async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void
   pendingNonAssistantTexts = []
   pendingToolCalls = new Map()
   pendingProviderError = undefined
+  pendingModelError = undefined
   pendingRetryAfterMs = undefined
   pendingInvocationPrompt = undefined
   clearPendingRetry()
@@ -2447,6 +2507,8 @@ export const __testing = {
   captureMessageText,
   textFromAgentMessages,
   extractAgentEndError,
+  extractModelError,
+  trailingModelError,
   resolveFinalText,
   parseRetryAfter,
   describeProviderError,
@@ -2643,9 +2705,18 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("message_end", async (event) => {
     if (!pending) return
+    const modelError = extractModelError(event.message)
+    if (modelError) {
+      pendingModelError = modelError
+      await recordTraceStep("tool_error", modelError, "Model call failed")
+      return
+    }
     const captured = captureMessageText(event.message)
     if (!captured) return
     if (captured.role === "assistant") {
+      // A successful assistant message after an errored one means the retry
+      // recovered — the earlier error is history, not the turn's outcome.
+      pendingModelError = undefined
       pendingAssistantTexts.push(captured.text)
       // Surface the model's running narration as a `thinking` trace step so
       // the scratchpad trace shows what the agent reasoned between tool
@@ -2691,6 +2762,7 @@ export default function (pi: ExtensionAPI): void {
         assistantTexts: pendingAssistantTexts,
         otherTexts: pendingNonAssistantTexts,
         providerError: pendingProviderError,
+        modelError: pendingModelError,
       })
       // When the reply is the model's final assistant message, it was already
       // recorded as the last `thinking` trace step in `message_end` — recording


### PR DESCRIPTION
## Problem

A Pi turn whose model calls all fail posts a confident **"Done."** to the scratchpad. Live occurrence (2026-07-03, Pi - orchestrator): opencode's zen gateway started 502ing `deepseek-v4-flash`; every turn produced assistant messages with empty content, `stopReason: "error"`, `errorMessage: "502 status code (no body)"` — and the user's "Did I mess up?" got "Done." back.

Why every existing error path missed it, in `resolveFinalText`'s branch order:

1. `assistantTexts` — empty (errored messages have no text; `captureMessageText` drops them).
2. `providerError` — unset: the client **threw** rather than returning a response, so `after_provider_response` (which needs a numeric `status`) never fired.
3. `extractAgentEndError` — the turn "completed", `event.error` unset.
4. Fallback `textFromAgentMessages` → literal `"Done."`.

The error was visible in exactly one place — the errored assistant message itself — and that's the one shape nothing read.

## Solution

Read the failure off the errored assistant message and make it the reply.

- `extractModelError(message)` — `role: "assistant"` + `stopReason: "error"` → `⚠️ Model call failed (provider/model): <errorMessage>. Try /model to switch models.` (provider/model tag only when both fields are strings; blank `errorMessage` → "unknown error").
- `trailingModelError(messages)` — backward scan answering "did the turn END in an error?": an error only counts if no assistant message with real text came after it, so a recovered retry posts its answer with no stale warning.
- Capture at `message_end` into `pendingModelError` (reset at all four pending-reset sites, cleared when a later assistant message succeeds) — guarantees the error survives even if `agent_end`'s `event.messages` is absent; the trailing scan is the backup for paths that bypass pending state. Errored messages also get a `tool_error` trace step ("Model call failed") instead of vanishing from the trace.
- `resolveFinalText` order: real assistant text still wins, but a trailing error is **appended** to it (narration followed by a dead final call must not read as a finished answer); `providerError`/`event.error` keep precedence over the message-derived error since they carry retry context; the model error slots in before the `otherTexts`/`"Done."` fallbacks.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/pi-remote/src/threa-remote.ts` | `extractModelError` + `trailingModelError`; `pendingModelError` capture/clear in `message_end` + four reset sites; `resolveFinalText` gains `modelError` with append-to-narration behavior |
| `extensions/pi-remote/src/threa-remote.test.ts` | 5 tests: the exact live 502 shape → ⚠️ reply, `modelError` without `event.messages`, retry-recovery suppression, narration+append, `extractModelError` field handling |

## Test plan

- [x] `bun test` in `extensions/pi-remote` — 81 pass (76 existing + 5 new), 0 fail
- [x] Pre-commit gauntlet: eslint all apps, `tsc --noEmit` all packages/apps, migration + Dockerfile checks — clean
- [x] Root-cause verified against prod: the errored message shape in the fixture is copied verbatim from the orchestrator's session log; gateway probed directly (dead model → 500, sibling model same key → 200)
- [ ] Not live-tested through a real dead provider end-to-end — requires opencode's gateway to still be broken at install time; the fixture reproduces the exact captured message shape instead

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785676793&installation_id=129946197&pr_number=1160&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1160&signature=4459d920d1c7f413615e831a5de1cf4799cea321796425b144833532605b2347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->