### PR TITLE
feat(conversations): thread-follow routing for "Reply in conversation"

### DIFF
--- a/apps/frontend/src/auth/account-scope.tsx
+++ b/apps/frontend/src/auth/account-scope.tsx
@@ -12,6 +12,7 @@ import { resetStreamStoreCache } from "@/stores/stream-store"
 import { resetDraftStoreCache } from "@/stores/draft-store"
 import { resetShareHandoffStoreCache } from "@/stores/share-handoff-store"
 import { resetSnippetRequestStoreCache } from "@/stores/snippet-request-store"
+import { resetConversationReplyOpenStoreCache } from "@/stores/conversation-reply-open-store"
 import { resetE2eSessionStoreCache } from "@/stores/e2e-session-store"
 import { resetRevealGate } from "@/sync/reveal-gate"
 import { useAuth } from "./hooks"
@@ -70,6 +71,7 @@ function flushModuleStoreCaches(): void {
   resetDraftStoreCache()
   resetShareHandoffStoreCache()
   resetSnippetRequestStoreCache()
+  resetConversationReplyOpenStoreCache()
   resetE2eSessionStoreCache()
   resetRevealGate()
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -41,13 +41,13 @@ interface BoardReplyComposerProps {
    *  continuation (a reply follows the conversation into its thread). */
   lastActiveStreamId: string | null
   /**
-   * When it turns true, expand the resting affordance into the live composer and
-   * focus it — the conversation panel raises this after being opened via "Reply
-   * in conversation" so the user lands straight in the reply editor. Left false
-   * on board cards (they open on tap). One-shot: a manual collapse afterwards is
-   * respected because the flag doesn't change again.
+   * Monotonic nonce: each increment expands the resting affordance into the live
+   * composer and focuses it — the conversation panel bumps it after being opened
+   * via "Reply in conversation" so the user lands straight in the reply editor. A
+   * counter (not a boolean) so a second request re-opens the composer after a
+   * manual collapse; `0`/absent leaves it collapsed (board cards open on tap).
    */
-  autoOpenReply?: boolean
+  openReplySignal?: number
 }
 
 /**
@@ -72,13 +72,14 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   // "Reply in conversation" opened the panel and asked it to land in the editor.
-  // Deps on the flag alone, so a later manual collapse isn't reopened.
-  const { autoOpenReply } = props
+  // Keyed on the nonce so each request re-opens the composer even after a manual
+  // collapse; `0`/absent is the resting default.
+  const { openReplySignal } = props
   useEffect(() => {
-    if (!autoOpenReply) return
+    if (!openReplySignal) return
     setResting("idle")
     setOpen(true)
-  }, [autoOpenReply])
+  }, [openReplySignal])
 
   // Quote reply from a message row in this conversation lands here. The resting
   // affordance leaves the form unmounted while collapsed, so this always-mounted

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -40,6 +40,14 @@ interface BoardReplyComposerProps {
   /** The conversation's most-recently-active stream, for recency-biased
    *  continuation (a reply follows the conversation into its thread). */
   lastActiveStreamId: string | null
+  /**
+   * When it turns true, expand the resting affordance into the live composer and
+   * focus it — the conversation panel raises this after being opened via "Reply
+   * in conversation" so the user lands straight in the reply editor. Left false
+   * on board cards (they open on tap). One-shot: a manual collapse afterwards is
+   * respected because the flag doesn't change again.
+   */
+  autoOpenReply?: boolean
 }
 
 /**
@@ -62,6 +70,15 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
   const [resting, setResting] = useState<RestingState>("idle")
   const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // "Reply in conversation" opened the panel and asked it to land in the editor.
+  // Deps on the flag alone, so a later manual collapse isn't reopened.
+  const { autoOpenReply } = props
+  useEffect(() => {
+    if (!autoOpenReply) return
+    setResting("idle")
+    setOpen(true)
+  }, [autoOpenReply])
 
   // Quote reply from a message row in this conversation lands here. The resting
   // affordance leaves the form unmounted while collapsed, so this always-mounted

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor, fireEvent } from "@testing-library/react"
+import { act, render, screen, waitFor, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -165,29 +165,46 @@ describe("ConversationPanel", () => {
     expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
   })
 
-  it("raises autoOpenReply on the composer when opened via 'Reply in conversation' (queued request)", async () => {
+  it("bumps openReplySignal on the composer when opened via 'Reply in conversation' (queued request)", async () => {
     // The message-row action queues this before opening the panel; the panel picks
-    // it up on mount and asks its composer to expand instead of resting collapsed.
-    let capturedAutoOpen: boolean | undefined
+    // it up on mount and bumps its composer's open signal instead of resting collapsed.
+    let captured: number | undefined
     vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
-      capturedAutoOpen = props.autoOpenReply
+      captured = props.openReplySignal
       return <></>
     })
     requestConversationReplyOpen(CONVERSATION_ID)
     mountPanel({ cached: asCached(makePost()) })
     await screen.findByText("Opening message body.")
-    await waitFor(() => expect(capturedAutoOpen).toBe(true))
+    await waitFor(() => expect(captured ?? 0).toBeGreaterThan(0))
   })
 
   it("leaves the composer collapsed on a plain open (no queued request)", async () => {
-    let capturedAutoOpen: boolean | undefined
+    let captured: number | undefined
     vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
-      capturedAutoOpen = props.autoOpenReply
+      captured = props.openReplySignal
       return <></>
     })
     mountPanel({ cached: asCached(makePost()) })
     await screen.findByText("Opening message body.")
-    expect(capturedAutoOpen).toBe(false)
+    expect(captured).toBe(0)
+  })
+
+  it("re-bumps openReplySignal on a repeat request while the panel is already open", async () => {
+    // A boolean handoff would no-op here (already true); the nonce increments so
+    // the composer reopens after a manual collapse on a second "Reply in conversation".
+    let captured: number | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      captured = props.openReplySignal
+      return <></>
+    })
+    requestConversationReplyOpen(CONVERSATION_ID)
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    await waitFor(() => expect(captured).toBe(1))
+
+    act(() => requestConversationReplyOpen(CONVERSATION_ID))
+    await waitFor(() => expect(captured).toBe(2))
   })
 
   it("fetches the post by id when the store has no row (deep-link / in-stream list)", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -22,6 +22,11 @@ import * as contextsModule from "@/contexts"
 import * as touchCapableModule from "@/hooks/use-touch-capable"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as shareHandoffModule from "@/stores/share-handoff-store"
+import * as boardReplyComposerModule from "@/components/board/board-reply-composer"
+import {
+  requestConversationReplyOpen,
+  resetConversationReplyOpenStoreCache,
+} from "@/stores/conversation-reply-open-store"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 const WORKSPACE_ID = "ws_1"
@@ -140,7 +145,10 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof contextsModule.usePreferences>)
 })
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  resetConversationReplyOpenStoreCache()
+  vi.restoreAllMocks()
+})
 
 describe("ConversationPanel", () => {
   it("renders the conversation from the reactive store row without a by-id fetch", async () => {
@@ -155,6 +163,31 @@ describe("ConversationPanel", () => {
     mountPanel({ cached: asCached(makePost()) })
     await screen.findByText("Opening message body.")
     expect(screen.getByRole("button", { name: "Write a reply…" })).toBeTruthy()
+  })
+
+  it("raises autoOpenReply on the composer when opened via 'Reply in conversation' (queued request)", async () => {
+    // The message-row action queues this before opening the panel; the panel picks
+    // it up on mount and asks its composer to expand instead of resting collapsed.
+    let capturedAutoOpen: boolean | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      capturedAutoOpen = props.autoOpenReply
+      return <></>
+    })
+    requestConversationReplyOpen(CONVERSATION_ID)
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    await waitFor(() => expect(capturedAutoOpen).toBe(true))
+  })
+
+  it("leaves the composer collapsed on a plain open (no queued request)", async () => {
+    let capturedAutoOpen: boolean | undefined
+    vi.spyOn(boardReplyComposerModule, "BoardReplyComposer").mockImplementation((props) => {
+      capturedAutoOpen = props.autoOpenReply
+      return <></>
+    })
+    mountPanel({ cached: asCached(makePost()) })
+    await screen.findByText("Opening message body.")
+    expect(capturedAutoOpen).toBe(false)
   })
 
   it("fetches the post by id when the store has no row (deep-link / in-stream list)", async () => {

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -61,15 +61,17 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   // "Reply in conversation" opened this panel with the intent to reply, not just
   // read — pick up its one-shot signal (queued before this panel mounted, or
   // arriving while it's already open for the same conversation) and land the user
-  // in the composer. Consumed on mount so a plain deep-link/"Show in conversation"
-  // open (no queued request) leaves it collapsed.
-  const [autoOpenReply, setAutoOpenReply] = useState(false)
+  // in the composer. A monotonic nonce, not a boolean, so a repeat request while
+  // the panel is already open re-opens the composer after a manual collapse.
+  // Stays 0 on a plain deep-link/"Show in conversation" open (no queued request).
+  const [openReplySignal, setOpenReplySignal] = useState(0)
   useEffect(() => {
     if (!conversationId) return
-    if (consumeConversationReplyOpen(conversationId)) setAutoOpenReply(true)
-    return subscribeConversationReplyOpen(conversationId, () => {
-      if (consumeConversationReplyOpen(conversationId)) setAutoOpenReply(true)
-    })
+    const bump = () => {
+      if (consumeConversationReplyOpen(conversationId)) setOpenReplySignal((n) => n + 1)
+    }
+    bump()
+    return subscribeConversationReplyOpen(conversationId, bump)
   }, [conversationId])
 
   // Keep the conversation's streams (root + threads) caught up + joined while the
@@ -134,7 +136,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
         workspaceId={workspaceId}
         post={post}
         hostStreamType={hostStreamType}
-        autoOpenReply={autoOpenReply}
+        openReplySignal={openReplySignal}
       />
     )
   } else if (isLoading) {
@@ -222,8 +224,8 @@ interface ConversationPanelBodyProps {
   workspaceId: string
   post: BoardViewPost
   hostStreamType: string | undefined
-  /** Raised when the panel was opened via "Reply in conversation" — opens the composer. */
-  autoOpenReply: boolean
+  /** Bumped each time the panel is opened via "Reply in conversation" — opens the composer. */
+  openReplySignal: number
 }
 
 /**
@@ -233,7 +235,7 @@ interface ConversationPanelBodyProps {
  * replies, backfilled with the complete ordered list when the local rail is
  * incomplete — the same merge the board card runs on expand.
  */
-function ConversationPanelBody({ workspaceId, post, hostStreamType, autoOpenReply }: ConversationPanelBodyProps) {
+function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySignal }: ConversationPanelBodyProps) {
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
@@ -335,7 +337,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, autoOpenRepl
           post={post}
           hostStreamType={hostStreamType}
           lastActiveStreamId={lastActiveStreamId}
-          autoOpenReply={autoOpenReply}
+          openReplySignal={openReplySignal}
         />
       </div>
     </QuoteReplyProvider>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -25,6 +25,7 @@ import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useConversationService, usePanel, parseConversationPanel, useSidebar } from "@/contexts"
 import { useStreamFromStore } from "@/stores/stream-store"
+import { consumeConversationReplyOpen, subscribeConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { conversationKeys, useConversationBoardPost } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
@@ -56,6 +57,20 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   const { panelId } = usePanel()
   const conversationId = panelId ? parseConversationPanel(panelId) : null
   const { post, isLoading, notFound, refetch } = useConversationBoardPost(workspaceId, conversationId)
+
+  // "Reply in conversation" opened this panel with the intent to reply, not just
+  // read — pick up its one-shot signal (queued before this panel mounted, or
+  // arriving while it's already open for the same conversation) and land the user
+  // in the composer. Consumed on mount so a plain deep-link/"Show in conversation"
+  // open (no queued request) leaves it collapsed.
+  const [autoOpenReply, setAutoOpenReply] = useState(false)
+  useEffect(() => {
+    if (!conversationId) return
+    if (consumeConversationReplyOpen(conversationId)) setAutoOpenReply(true)
+    return subscribeConversationReplyOpen(conversationId, () => {
+      if (consumeConversationReplyOpen(conversationId)) setAutoOpenReply(true)
+    })
+  }, [conversationId])
 
   // Keep the conversation's streams (root + threads) caught up + joined while the
   // panel is open, so the rail is live and offline-first. Its own SyncEngine slot,
@@ -114,7 +129,14 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
 
   let body: React.ReactNode
   if (post) {
-    body = <ConversationPanelBody workspaceId={workspaceId} post={post} hostStreamType={hostStreamType} />
+    body = (
+      <ConversationPanelBody
+        workspaceId={workspaceId}
+        post={post}
+        hostStreamType={hostStreamType}
+        autoOpenReply={autoOpenReply}
+      />
+    )
   } else if (isLoading) {
     body = (
       <div className="flex flex-col gap-3 p-4">
@@ -200,6 +222,8 @@ interface ConversationPanelBodyProps {
   workspaceId: string
   post: BoardViewPost
   hostStreamType: string | undefined
+  /** Raised when the panel was opened via "Reply in conversation" — opens the composer. */
+  autoOpenReply: boolean
 }
 
 /**
@@ -209,7 +233,7 @@ interface ConversationPanelBodyProps {
  * replies, backfilled with the complete ordered list when the local rail is
  * incomplete — the same merge the board card runs on expand.
  */
-function ConversationPanelBody({ workspaceId, post, hostStreamType }: ConversationPanelBodyProps) {
+function ConversationPanelBody({ workspaceId, post, hostStreamType, autoOpenReply }: ConversationPanelBodyProps) {
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
@@ -311,6 +335,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType }: Conversati
           post={post}
           hostStreamType={hostStreamType}
           lastActiveStreamId={lastActiveStreamId}
+          autoOpenReply={autoOpenReply}
         />
       </div>
     </QuoteReplyProvider>

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -651,6 +651,57 @@ describe("MessageInput", () => {
       // The panel's composer is asked to open, and no inline strip is left behind.
       expect(consumeConversationReplyOpen("conv_1")).toBe(true)
       expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      // The channel composer is never focused — focus would pop the mobile keyboard
+      // on the composer we're about to leave for the panel.
+      expect(mockComposerFocus).not.toHaveBeenCalled()
+    })
+
+    it("hands off to the panel instead of filing flat when the projection isn't resolved at send time", async () => {
+      // The board-post projection hasn't loaded (post null), so the last-active
+      // stream is unknown. A flat `{intent:"existing"}` send could re-interleave the
+      // channel if the conversation is actually thread-live — so the send is routed
+      // to the panel instead, and nothing is filed inline.
+      vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({
+        post: null,
+        isLoading: true,
+        notFound: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>)
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("late pizza take")
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await userEvent.click(screen.getByRole("button", { name: /send/i }))
+
+      expect(mockOpenPanel).toHaveBeenCalledWith(contextsModule.createConversationPanelId("conv_1"))
+      expect(consumeConversationReplyOpen("conv_1")).toBe(true)
+      // No flat send — routing was unresolved, so the directive send never fired.
+      expect(mockSendMessage).not.toHaveBeenCalled()
+    })
+
+    it("does not open the panel when navigating away from an armed same-stream reply", () => {
+      // Arm a same-stream reply (mock last-active === rendered stream) — inline strip,
+      // no redirect. Switching streams must disarm quietly, never redirect the
+      // now-stale armed conversation into the panel.
+      const { rerender } = render(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      expect(screen.getByTestId("conversation-reply-strip")).toBeInTheDocument()
+      expect(mockOpenPanel).not.toHaveBeenCalled()
+
+      rerender(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId="stream_other" />
+        </Wrapper>
+      )
+
+      expect(mockOpenPanel).not.toHaveBeenCalled()
+      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
     })
   })
 

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -11,6 +11,10 @@ import * as authModule from "@/auth"
 import * as quoteReplyModule from "./quote-reply-context"
 import * as conversationReplyModule from "./conversation-reply-context"
 import * as useConversationsModule from "@/hooks/use-conversations"
+import {
+  consumeConversationReplyOpen,
+  resetConversationReplyOpenStoreCache,
+} from "@/stores/conversation-reply-open-store"
 import * as composerModule from "@/components/composer"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
@@ -56,6 +60,7 @@ const mockNavigate = vi.fn()
 let mockMessageSendMode: "enter" | "cmdEnter" = "enter"
 
 const mockSendMessage = vi.fn()
+const mockOpenPanel = vi.fn()
 const mockClearDraft = vi.fn()
 const mockResolveDraft = vi.fn()
 const mockClearAttachments = vi.fn()
@@ -103,6 +108,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockSendMessage.mockReset()
   mockSendMessage.mockResolvedValue({})
+  mockOpenPanel.mockReset()
+  resetConversationReplyOpenStoreCache()
   mockNavigate.mockReset()
   mockMessageSendMode = "enter"
   mockComposerState = {
@@ -180,15 +187,27 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof conversationReplyModule.useConversationReply>)
   // The armed-reply strip resolves its topic label via the board-post hook,
   // which needs the services context + query client; stub it with a fixed topic.
+  // `recentMessages`/`conversation.streamId` default the conversation's last-active
+  // stream to the rendered stream ("stream_456"), so the inline strip stays put —
+  // the thread-follow redirect only fires when they point elsewhere (own test).
   vi.spyOn(useConversationsModule, "useConversationBoardPost").mockImplementation(
     (_workspaceId: string, conversationId: string | null) =>
       ({
-        post: conversationId ? { conversation: { id: conversationId, topicSummary: "Pizza plans" } } : null,
+        post: conversationId
+          ? {
+              conversation: { id: conversationId, streamId: "stream_456", topicSummary: "Pizza plans" },
+              recentMessages: [],
+            }
+          : null,
         isLoading: false,
         notFound: false,
         refetch: vi.fn(),
       }) as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>
   )
+
+  vi.spyOn(contextsModule, "usePanel").mockReturnValue({
+    openPanel: mockOpenPanel,
+  } as unknown as ReturnType<typeof contextsModule.usePanel>)
 
   vi.spyOn(hooksModule, "useStreamOrDraft").mockReturnValue({
     sendMessage: mockSendMessage,
@@ -603,6 +622,35 @@ describe("MessageInput", () => {
       await userEvent.click(screen.getByRole("button", { name: /send/i }))
 
       expect(mockSendMessage).toHaveBeenCalledWith(expect.objectContaining({ conversation: undefined }))
+    })
+
+    it("hands off to the conversation panel when the conversation is live in a thread (thread-follow)", () => {
+      // The conversation's most-recently-active stream is a thread (`thread_789`),
+      // not the rendered channel (`stream_456`) — a flat send here would
+      // re-interleave the channel, so the composer redirects to the conversation
+      // panel and asks it to open its reply composer instead of arming inline.
+      vi.spyOn(useConversationsModule, "useConversationBoardPost").mockImplementation(
+        (_workspaceId: string, conversationId: string | null) =>
+          ({
+            post: conversationId
+              ? {
+                  conversation: { id: conversationId, streamId, topicSummary: "Pizza plans" },
+                  recentMessages: [{ streamId: "thread_789" }],
+                }
+              : null,
+            isLoading: false,
+            notFound: false,
+            refetch: vi.fn(),
+          }) as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>
+      )
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      expect(mockOpenPanel).toHaveBeenCalledWith(contextsModule.createConversationPanelId("conv_1"))
+      // The panel's composer is asked to open, and no inline strip is left behind.
+      expect(consumeConversationReplyOpen("conv_1")).toBe(true)
+      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
     })
   })
 

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -18,6 +18,7 @@ import {
 import * as composerModule from "@/components/composer"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as streamContextBagModule from "@/hooks/use-stream-context-bag"
+import { toast } from "sonner"
 import { MessageInput, materializePendingAttachmentReferences } from "./message-input"
 import type { JSONContent } from "@threa/types"
 
@@ -61,6 +62,7 @@ let mockMessageSendMode: "enter" | "cmdEnter" = "enter"
 
 const mockSendMessage = vi.fn()
 const mockOpenPanel = vi.fn()
+let infoToastSpy: ReturnType<typeof vi.spyOn>
 const mockClearDraft = vi.fn()
 const mockResolveDraft = vi.fn()
 const mockClearAttachments = vi.fn()
@@ -109,6 +111,7 @@ beforeEach(() => {
   mockSendMessage.mockReset()
   mockSendMessage.mockResolvedValue({})
   mockOpenPanel.mockReset()
+  infoToastSpy = vi.spyOn(toast, "info").mockImplementation(() => "toast-id")
   resetConversationReplyOpenStoreCache()
   mockNavigate.mockReset()
   mockMessageSendMode = "enter"
@@ -679,6 +682,41 @@ describe("MessageInput", () => {
       expect(consumeConversationReplyOpen("conv_1")).toBe(true)
       // No flat send — routing was unresolved, so the directive send never fired.
       expect(mockSendMessage).not.toHaveBeenCalled()
+      // The redirect is signalled — the panel can cover this view, so the kept
+      // draft needs a word or the message reads as vanished (INV-63).
+      expect(infoToastSpy).toHaveBeenCalled()
+    })
+
+    it("keeps the inline reply put when a background update later moves the conversation to a thread", () => {
+      // Armed and resolved same-stream (strip shown, composer focused). A live
+      // board-post update then reports the conversation living in a thread — the
+      // route is latched at arm time, so it must NOT evict the user to the panel
+      // mid-composition without any action from them.
+      const { rerender } = render(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      expect(mockComposerFocus).toHaveBeenCalledTimes(1)
+      expect(mockOpenPanel).not.toHaveBeenCalled()
+
+      vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({
+        post: {
+          conversation: { id: "conv_1", streamId, topicSummary: "Pizza plans" },
+          recentMessages: [{ streamId: "thread_789" }],
+        },
+        isLoading: false,
+        notFound: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>)
+      rerender(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+
+      expect(mockOpenPanel).not.toHaveBeenCalled()
     })
 
     it("does not open the panel when navigating away from an armed same-stream reply", () => {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -28,7 +28,7 @@ import { serializeToMarkdown, parseMarkdown } from "@threa/prosemirror"
 import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quote-reply-context"
 import { useConversationReply, type ConversationReplyData } from "./conversation-reply-context"
-import { useConversationBoardPost } from "@/hooks/use-conversations"
+import { useConversationBoardPost, boardPostLastActiveStreamId } from "@/hooks/use-conversations"
 import { usePanel, createConversationPanelId } from "@/contexts"
 import { Layers, X } from "lucide-react"
 import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
@@ -303,9 +303,11 @@ function MessageInputComponent({
   const [conversationReply, setConversationReply] = useState<ConversationReplyData | null>(null)
   useEffect(() => {
     if (!conversationReplyCtx) return
+    // Arm only. Focus is deferred to the resolve effect below: focusing the
+    // channel composer here would pop the mobile keyboard on it a beat before a
+    // thread-follow reply redirects to the conversation panel.
     return conversationReplyCtx.registerHandler((data: ConversationReplyData) => {
       setConversationReply(data)
-      composerFocusRef.current?.focus()
     })
   }, [conversationReplyCtx])
   useEffect(() => {
@@ -321,25 +323,44 @@ function MessageInputComponent({
   )
   const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
   const conversationReplyLastActiveStreamId = conversationReplyPost
-    ? (conversationReplyPost.recentMessages.at(-1)?.streamId ?? conversationReplyPost.conversation.streamId)
+    ? boardPostLastActiveStreamId(conversationReplyPost)
     : null
 
-  // Thread-follow: when the armed conversation is currently live in a thread (its
-  // most-recently-active stream isn't this one), a flat send here would
-  // re-interleave the channel — the mess recency-biased continuation avoids
-  // (board-view-design.md). Hand off to the conversation panel instead: it renders
-  // the conversation across its root + threads and its composer routes the reply
-  // into the live thread. A same-stream conversation keeps the inline strip/send
-  // below. Fires once — disarming makes `conversationReply` null so the guard holds.
+  // Hand the armed conversation off to its side panel (Mechanism B), which renders
+  // it across its root + threads and routes the reply recency-biased into the live
+  // thread. Shared by the resolve effect (proactive, once the projection loads) and
+  // the send guard (the race where the user sends before it loads).
+  const redirectReplyToPanel = useCallback(
+    (conversationId: string) => {
+      requestConversationReplyOpen(conversationId)
+      openPanel(createConversationPanelId(conversationId))
+      setConversationReply(null)
+    },
+    [openPanel]
+  )
+
+  // Current stream read through a ref so the routing effect doesn't take `streamId`
+  // as a dep: on a plain stream switch, `streamId` changes while `conversationReply`
+  // still holds the previous stream's armed value (the `[streamId]` reset effect
+  // hasn't committed yet), and a streamId-driven re-run would misread that as a
+  // thread-follow and spuriously open the panel. The reset effect nulls the arm,
+  // which re-runs this effect to a clean no-op.
+  const streamIdRef = useRef(streamId)
+  streamIdRef.current = streamId
+
+  // Thread-follow: once the projection resolves, route the armed reply. A
+  // conversation live in THIS stream keeps the inline strip and focuses the
+  // composer to type; one that has moved into a thread hands off to the panel — a
+  // flat send here would re-interleave the channel, the mess recency-biased
+  // continuation avoids (board-view-design.md). Waits while unresolved (`target`
+  // null); fires once, since disarming nulls `conversationReply`.
   useEffect(() => {
     if (!conversationReply) return
     const target = conversationReplyLastActiveStreamId
-    if (!target || target === streamId) return
-    const { conversationId } = conversationReply
-    requestConversationReplyOpen(conversationId)
-    openPanel(createConversationPanelId(conversationId))
-    setConversationReply(null)
-  }, [conversationReply, conversationReplyLastActiveStreamId, streamId, openPanel])
+    if (!target) return
+    if (target === streamIdRef.current) composerFocusRef.current?.focus()
+    else redirectReplyToPanel(conversationReply.conversationId)
+  }, [conversationReply, conversationReplyLastActiveStreamId, redirectReplyToPanel])
 
   // Consume any pending share handoff for this stream, pre-inserting the
   // shared-message pointer into the composer and leaving the cursor after it.
@@ -590,6 +611,18 @@ function MessageInputComponent({
         return
       }
 
+      // Armed for "Reply in conversation" but not confirmed live in THIS stream
+      // (thread-live, or the board-post projection hasn't resolved yet): filing
+      // flat here would re-interleave the channel. Hand off to the conversation
+      // panel and keep the composer content — nothing typed is lost, the user
+      // continues in the panel. The inline flat send below only runs once the
+      // conversation is confirmed same-stream.
+      if (conversationReply && conversationReplyLastActiveStreamId !== streamId) {
+        redirectReplyToPanel(conversationReply.conversationId)
+        composer.setIsSending(false)
+        return
+      }
+
       const attachments = extractUploadedAttachments(normalizedContent)
       const attachmentIds = attachments.map((attachment) => attachment.id)
 
@@ -641,6 +674,8 @@ function MessageInputComponent({
       queueCommand,
       availableCommandByName,
       conversationReply,
+      conversationReplyLastActiveStreamId,
+      redirectReplyToPanel,
     ]
   )
 

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -29,9 +29,11 @@ import { useEditLastMessage } from "./edit-last-message-context"
 import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "./quote-reply-context"
 import { useConversationReply, type ConversationReplyData } from "./conversation-reply-context"
 import { useConversationBoardPost } from "@/hooks/use-conversations"
+import { usePanel, createConversationPanelId } from "@/contexts"
 import { Layers, X } from "lucide-react"
 import { consumeShareHandoff, consumePlaintextShareHandoff, subscribeShareHandoff } from "@/stores/share-handoff-store"
 import { consumeSnippetRequest, subscribeSnippetRequest } from "@/stores/snippet-request-store"
+import { requestConversationReplyOpen } from "@/stores/conversation-reply-open-store"
 import { useDiscussWithAriadne } from "@/hooks/use-discuss-with-ariadne"
 import { useCommandDispatchQueue } from "@/hooks/use-command-dispatch-queue"
 import { DISCUSS_WITH_ARIADNE_COMMAND, type JSONContent, type CommandInfo } from "@threa/types"
@@ -297,6 +299,7 @@ function MessageInputComponent({
   // reload would silently misfile whatever is typed next, so it resets with the
   // session and with the stream.
   const conversationReplyCtx = useConversationReply()
+  const { openPanel } = usePanel()
   const [conversationReply, setConversationReply] = useState<ConversationReplyData | null>(null)
   useEffect(() => {
     if (!conversationReplyCtx) return
@@ -308,12 +311,35 @@ function MessageInputComponent({
   useEffect(() => {
     setConversationReply(null)
   }, [streamId])
-  // Topic label for the strip — cached board card or a one-shot by-id fetch.
+  // Topic label for the strip — cached board card or a one-shot by-id fetch. The
+  // same projection carries the conversation's most-recently-active stream: the
+  // latest reply's own stream (a thread under the root), falling back to the
+  // conversation's anchor.
   const { post: conversationReplyPost } = useConversationBoardPost(
     workspaceId,
     conversationReply?.conversationId ?? null
   )
   const conversationReplyTopic = conversationReplyPost?.conversation.topicSummary ?? null
+  const conversationReplyLastActiveStreamId = conversationReplyPost
+    ? (conversationReplyPost.recentMessages.at(-1)?.streamId ?? conversationReplyPost.conversation.streamId)
+    : null
+
+  // Thread-follow: when the armed conversation is currently live in a thread (its
+  // most-recently-active stream isn't this one), a flat send here would
+  // re-interleave the channel — the mess recency-biased continuation avoids
+  // (board-view-design.md). Hand off to the conversation panel instead: it renders
+  // the conversation across its root + threads and its composer routes the reply
+  // into the live thread. A same-stream conversation keeps the inline strip/send
+  // below. Fires once — disarming makes `conversationReply` null so the guard holds.
+  useEffect(() => {
+    if (!conversationReply) return
+    const target = conversationReplyLastActiveStreamId
+    if (!target || target === streamId) return
+    const { conversationId } = conversationReply
+    requestConversationReplyOpen(conversationId)
+    openPanel(createConversationPanelId(conversationId))
+    setConversationReply(null)
+  }, [conversationReply, conversationReplyLastActiveStreamId, streamId, openPanel])
 
   // Consume any pending share handoff for this stream, pre-inserting the
   // shared-message pointer into the composer and leaving the cursor after it.

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -1,5 +1,6 @@
 import { memo, useState, useCallback, useEffect, useMemo, useRef } from "react"
 import { createPortal } from "react-dom"
+import { toast } from "sonner"
 import { useNavigate } from "react-router-dom"
 import {
   useDraftComposer,
@@ -348,16 +349,27 @@ function MessageInputComponent({
   const streamIdRef = useRef(streamId)
   streamIdRef.current = streamId
 
-  // Thread-follow: once the projection resolves, route the armed reply. A
-  // conversation live in THIS stream keeps the inline strip and focuses the
-  // composer to type; one that has moved into a thread hands off to the panel — a
-  // flat send here would re-interleave the channel, the mess recency-biased
-  // continuation avoids (board-view-design.md). Waits while unresolved (`target`
-  // null); fires once, since disarming nulls `conversationReply`.
+  // Thread-follow: route the armed reply ONCE, at first resolution of the
+  // projection. A conversation live in THIS stream keeps the inline strip and
+  // focuses the composer to type; one that has moved into a thread hands off to
+  // the panel — a flat send there would re-interleave the channel, the mess
+  // recency-biased continuation avoids (board-view-design.md).
+  //
+  // The route is latched per arm (`routedArmIdRef`): `conversationReplyLastActive-
+  // StreamId` is a live Dexie value, so without the latch a background reply that
+  // later moves the conversation into a thread would re-fire this effect and evict
+  // the user from the channel mid-composition, unsolicited. Once routed, only an
+  // explicit send re-checks routing. The latch resets when the arm is cleared.
+  const routedArmIdRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!conversationReply) return
+    if (!conversationReply) {
+      routedArmIdRef.current = null
+      return
+    }
+    if (routedArmIdRef.current === conversationReply.conversationId) return
     const target = conversationReplyLastActiveStreamId
     if (!target) return
+    routedArmIdRef.current = conversationReply.conversationId
     if (target === streamIdRef.current) composerFocusRef.current?.focus()
     else redirectReplyToPanel(conversationReply.conversationId)
   }, [conversationReply, conversationReplyLastActiveStreamId, redirectReplyToPanel])
@@ -616,9 +628,13 @@ function MessageInputComponent({
       // flat here would re-interleave the channel. Hand off to the conversation
       // panel and keep the composer content — nothing typed is lost, the user
       // continues in the panel. The inline flat send below only runs once the
-      // conversation is confirmed same-stream.
+      // conversation is confirmed same-stream. A toast because the send didn't do
+      // the obvious thing (post here): the panel can cover this view on mobile, so
+      // the kept draft needs a word or the message reads as vanished (INV-63:
+      // deferred action, no other on-screen signal).
       if (conversationReply && conversationReplyLastActiveStreamId !== streamId) {
         redirectReplyToPanel(conversationReply.conversationId)
+        toast.info("Opening the conversation to reply — your draft was kept here.")
         composer.setIsSending(false)
         return
       }

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -35,6 +35,19 @@ export interface CreateBoardPostInput {
 /** Shared stable empty list so a disabled/loading query returns one identity. */
 const EMPTY_CONVERSATIONS: ConversationWithStaleness[] = []
 
+/**
+ * The conversation's most-recently-active stream from its board projection: the
+ * newest recent-message's own stream (a thread under the root — recency-biased
+ * continuation, board-view-design.md), falling back to the conversation anchor.
+ * `recentMessages` is optional-chained because older cached `conversations` IDB
+ * rows predate the field. This is the projection-derived answer used where the
+ * live message rail isn't loaded (the timeline composer); the conversation panel
+ * refines it from its live merged `displayedReplies` once the rail is present.
+ */
+export function boardPostLastActiveStreamId(post: Pick<BoardPost, "recentMessages" | "conversation">): string {
+  return post.recentMessages?.at(-1)?.streamId ?? post.conversation.streamId
+}
+
 export const conversationKeys = {
   all: ["conversations"] as const,
   list: (workspaceId: string, streamId: string, options?: { status?: string; limit?: number }) =>

--- a/apps/frontend/src/stores/conversation-reply-open-store.test.ts
+++ b/apps/frontend/src/stores/conversation-reply-open-store.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  consumeConversationReplyOpen,
+  requestConversationReplyOpen,
+  resetConversationReplyOpenStoreCache,
+  subscribeConversationReplyOpen,
+} from "./conversation-reply-open-store"
+
+afterEach(() => {
+  resetConversationReplyOpenStoreCache()
+  vi.useRealTimers()
+})
+
+describe("conversation reply-open store", () => {
+  it("returns false when nothing is queued for the conversation", () => {
+    expect(consumeConversationReplyOpen("conv_a")).toBe(false)
+  })
+
+  it("returns true once and clears the entry on consume", () => {
+    requestConversationReplyOpen("conv_a")
+    expect(consumeConversationReplyOpen("conv_a")).toBe(true)
+    expect(consumeConversationReplyOpen("conv_a")).toBe(false)
+  })
+
+  it("queues independently per conversation", () => {
+    requestConversationReplyOpen("conv_a")
+    expect(consumeConversationReplyOpen("conv_b")).toBe(false)
+    expect(consumeConversationReplyOpen("conv_a")).toBe(true)
+  })
+
+  it("evicts entries whose TTL has expired", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-23T12:00:00Z"))
+    requestConversationReplyOpen("conv_a")
+
+    vi.setSystemTime(new Date("2026-04-23T12:01:00Z")) // 60s later, past 30s TTL
+    expect(consumeConversationReplyOpen("conv_a")).toBe(false)
+  })
+
+  it("notifies a subscriber when a request is queued for the matching conversation", () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeConversationReplyOpen("conv_a", listener)
+
+    requestConversationReplyOpen("conv_a")
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    requestConversationReplyOpen("conv_a")
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("scopes notifications by conversation — listeners on other conversations are not called", () => {
+    const onA = vi.fn()
+    const onB = vi.fn()
+    subscribeConversationReplyOpen("conv_a", onA)
+    subscribeConversationReplyOpen("conv_b", onB)
+
+    requestConversationReplyOpen("conv_a")
+    expect(onA).toHaveBeenCalledTimes(1)
+    expect(onB).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/stores/conversation-reply-open-store.ts
+++ b/apps/frontend/src/stores/conversation-reply-open-store.ts
@@ -1,0 +1,65 @@
+/**
+ * Ephemeral per-conversation signal asking a conversation side panel to open its
+ * reply composer as soon as it mounts. "Reply in conversation" fires from a
+ * message row (in the stream-content tree) but the reply lands in the conversation
+ * panel (a separate React tree in the panel slot), so the row queues a request
+ * here keyed by conversation id and the mounted panel picks it up — the same
+ * hand-off shape used for snippet requests and share nodes. Content-less: the
+ * panel just opens its already-scoped {@link BoardReplyComposer} and focuses it.
+ */
+
+const HANDOFF_TTL_MS = 30 * 1000
+
+const cache = new Map<string, number>()
+const listeners = new Map<string, Set<() => void>>()
+
+/**
+ * Ask the conversation panel for `conversationId` to open its reply composer. A
+ * panel already mounted for this conversation is notified immediately; otherwise
+ * the request waits (briefly) to be consumed on the panel's next mount.
+ */
+export function requestConversationReplyOpen(conversationId: string): void {
+  cache.set(conversationId, Date.now() + HANDOFF_TTL_MS)
+  const subs = listeners.get(conversationId)
+  if (subs) {
+    for (const listener of subs) listener()
+  }
+}
+
+/** Read + clear a pending reply-open request for the conversation (respecting the TTL). */
+export function consumeConversationReplyOpen(conversationId: string): boolean {
+  const expiresAt = cache.get(conversationId)
+  if (expiresAt === undefined) return false
+  cache.delete(conversationId)
+  return expiresAt >= Date.now()
+}
+
+/**
+ * Subscribe to reply-open events for a conversation. Returns an unsubscribe
+ * function. A mounted panel pairs this with an on-mount
+ * {@link consumeConversationReplyOpen} read so it catches a request queued before
+ * it subscribed, and reacts to one that arrives while it's already open.
+ */
+export function subscribeConversationReplyOpen(conversationId: string, listener: () => void): () => void {
+  let subs = listeners.get(conversationId)
+  if (!subs) {
+    subs = new Set()
+    listeners.set(conversationId, subs)
+  }
+  subs.add(listener)
+  return () => {
+    const set = listeners.get(conversationId)
+    if (!set) return
+    set.delete(listener)
+    if (set.size === 0) listeners.delete(conversationId)
+  }
+}
+
+/**
+ * Clears every queued request and subscriber. Module-level cache survives an
+ * account-switch remount, so AccountScope clears it on switch.
+ */
+export function resetConversationReplyOpenStoreCache(): void {
+  cache.clear()
+  listeners.clear()
+}


### PR DESCRIPTION
Follow-up to #1146 (Mechanism C). Design basis: `docs/board-view-design.md` "Continuation is recency-biased" + `INV-62` (access inherited through the root).

## Problem

"Reply in conversation" (#1146) arms the current stream's composer and files the send flat into it via `{ intent: "existing" }` (`message-input.tsx`). When the conversation has since **moved into a thread**, that flat send re-interleaves the channel — the exact mess `board-view-design.md` ("Continuation is recency-biased") says to avoid: "posting into the anchor root would re-interleave the channel, the exact mess convert-to-thread avoids."

The board card and conversation panel already route replies recency-biased (`useReplyToBoardPost` + `lastActiveStreamId`). The timeline's inline arm was the one reply surface that didn't follow the conversation.

## Solution

When the armed conversation is live in a thread, hand off to the conversation panel (Mechanism B) instead of filing inline: the panel renders the conversation flattened across its root + threads, and its `BoardReplyComposer` already routes the reply recency-biased into the live thread. Kris's ruling — open the conversation view to reply, so it isn't weird wherever the reply lands — and keep the inline arm for the common same-stream case. The result is **adaptive**:

- Conversation live in the **current stream** → inline strip/send, unchanged from #1146.
- Conversation live in a **thread** → open the conversation panel + land the user in its composer.

### How it works

1. **`conversation-reply-open-store`** — a one-shot request/consume signal keyed by conversation id, mirroring `snippet-request-store` exactly (30s TTL, per-key subscribers). "Reply in conversation" fires from a message row (stream-content React tree) but the reply lands in the conversation panel (a separate panel-slot tree), so the row queues a request and the mounted panel consumes it. Registered for reset in `AccountScope.flushModuleStoreCaches` so it clears on account switch.

2. **`message-input.tsx`** — the armed strip already fetches the conversation's `BoardPost` for its topic label (`useConversationBoardPost`, cached row or one-shot by-id fetch). The same projection carries the most-recently-active stream: `recentMessages.at(-1)?.streamId ?? conversation.streamId`. An effect fires when that resolves to a stream **other than** the current one — `requestConversationReplyOpen(conversationId)`, `openPanel(createConversationPanelId(conversationId))`, then disarm. Same-stream (or unresolved) keeps the inline path. Fires once: disarming nulls `conversationReply`, and the guard holds.

3. **`conversation-panel.tsx`** — consumes the signal on mount (catching a request queued before it existed) and subscribes (catching one that arrives while it's already open for this conversation), raising `autoOpenReply`. Threaded through `ConversationPanelBody` to `BoardReplyComposer`, which expands its resting affordance into the live editor and focuses it (`autoFocus`).

### Key design decisions

**1. Projection-derived last-active stream, not a new wire field.** The redirect reads `BoardPost.recentMessages` (already fetched for the label), not a denormalized `lastActiveStreamId` on the conversation event. This matches #1146's deliberate choice not to denormalize the topic label onto the wire. Tradeoff (below in Out of scope): `recentMessages` can lag a just-landed thread reply, so a single reply can re-interleave before the projection catches up; the steady state (a conversation sitting in a thread) resolves correctly.

**2. Keep the inline arm (Kris's call).** The panel handoff replaces the inline arm only when the conversation is elsewhere. A same-stream reply stays inline and snappy — no panel, no fetch-gated delay. The inline strip renders immediately on arm; the redirect only supersedes it once the projection resolves to a thread.

**3. One-shot store, not a URL param or context.** The message row and the panel live in different React trees, so a shared context can't bridge them; a URL param would leak "open the composer" intent into the panel's shareable link. The transient store is the established pattern here (`snippet-request-store`, `share-handoff-store`).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/stores/conversation-reply-open-store.ts` | One-shot per-conversation "open the reply composer" signal bridging the message row → conversation panel |
| `apps/frontend/src/stores/conversation-reply-open-store.test.ts` | Unit coverage: request/consume, per-conversation scoping, TTL eviction, subscriber notify/scope |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-input.tsx` | Derive last-active stream from the fetched `BoardPost`; redirect to the conversation panel + queue reply-open + disarm when it isn't the current stream |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Consume the reply-open signal (mount + subscribe), thread `autoOpenReply` to the composer |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | Optional `autoOpenReply` prop; effect expands + focuses the composer when raised (default false on board cards) |
| `apps/frontend/src/auth/account-scope.tsx` | Reset the new store on account switch |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | `usePanel` spy; board-post mock carries `recentMessages`; new thread-follow redirect test |
| `apps/frontend/src/components/conversations/conversation-panel.test.tsx` | `autoOpenReply` raised on a queued request, collapsed on a plain open |

## Out of scope (deliberate)

- **Exact recency via a wire field.** `recentMessages.at(-1).streamId` is a projection snapshot; a very-recent thread reply not yet in the projection can route a single reply into the channel. A denormalized `lastActiveStreamId` (assigner signature + transaction-order change) would make it exact — same denormalization declined in #1146, deferred here for the same reason.
- **E2E streams.** `BoardReplyComposer` already refuses E2E hosts ("open the note to reply there"); unchanged.
- **`docs/board-view-design.md` open-decision #2** ("lean: content node") is still stale vs the shipped hidden-field design — a #1146 doc cleanup, not this PR.

## Test plan

- [x] `vitest run` — store + message-input + conversation-panel + message-actions: **120 pass**
- [x] `vitest run` — board + event-list + auth suites (regression sweep of touched components): **17 pass**
- [x] `tsc --noEmit -p tsconfig.json` (frontend) — clean
- [x] Pre-commit hook (full monorepo lint / tsc / astro / api-docs) — passed on commit
- [ ] No manual browser pass — verified via the component tests (redirect fires on a thread-live conversation, inline arm on same-stream, panel raises `autoOpenReply`); the live handoff timing (strip → panel) isn't exercised end-to-end

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fn3ieJe79LdC27D5WWixQD)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785679080&installation_id=129946197&pr_number=1161&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1161&signature=df1c87ea0174f8f0cb5bc65c79797305d6d4cfa36d6333a74633659bc1a077b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->