### PR TITLE
feat(claude-channel): trace steps tailed from the session transcript

### DIFF
--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -15,6 +15,7 @@ import { z } from "zod"
 import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
 import { pushBranchAndScheduleRemoval } from "./archive-cleanup"
 import { interrupt, killOwnWindow, submitLine, tmuxAvailable } from "./tmux-control"
+import { TranscriptTracer } from "./transcript-trace"
 
 const RUNTIME_KIND = "claude-code-channel"
 export const CHANNEL_SOURCE = "threa"
@@ -159,6 +160,7 @@ function log(message: string): void {
 export class ChannelServer {
   private readonly mcp: Server
   readonly session: RemoteSession
+  private readonly tracer: TranscriptTracer
   private readonly openPermissions = new Map<string, { cleanup: ReturnType<typeof setTimeout> }>()
 
   constructor(
@@ -198,6 +200,12 @@ export class ChannelServer {
           : {}),
       },
     })
+    // Steps ship only while the SDK holds the turn in flight — recordSteps
+    // returns false once the invocation closes, which stops the tail.
+    this.tracer = new TranscriptTracer({
+      emit: (invocationId, frames, statusText) => this.session.recordSteps(invocationId, frames, statusText),
+      log,
+    })
     this.registerHandlers()
   }
 
@@ -211,6 +219,7 @@ export class ChannelServer {
   }
 
   async shutdown(): Promise<void> {
+    this.tracer.stop()
     for (const [, open] of this.openPermissions) clearTimeout(open.cleanup)
     this.openPermissions.clear()
     await this.session.shutdown()
@@ -236,6 +245,9 @@ export class ChannelServer {
   // --- Turn delivery ----------------------------------------------------------
 
   private async deliverToClaude(turn: DeliveredTurn): Promise<void> {
+    // Window the transcript tail BEFORE the content is pushed, so the tracer's
+    // start offset precedes the prompt echo it binds on.
+    this.tracer.beginTurn(turn.invocationId)
     await this.notify("notifications/claude/channel", {
       content: turn.content,
       meta: {
@@ -303,6 +315,7 @@ export class ChannelServer {
         req.params.name === "send"
           ? await this.session.sendInterim(invocationId, text)
           : await this.session.reply(invocationId, text)
+      if (req.params.name === "reply" && result.ok) this.tracer.endTurn(invocationId)
       return toToolResult(result)
     })
 

--- a/extensions/claude-code-remote/src/transcript-trace.test.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test"
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  TranscriptTracer,
+  describeClaudeTool,
+  encodeProjectDir,
+  mapTranscriptLine,
+  type MapContext,
+  type TraceFrame,
+} from "./transcript-trace"
+
+function ctx(mode: "headline" | "full" = "headline"): MapContext {
+  return { mode, toolHeadlines: new Map() }
+}
+
+function assistantLine(parts: unknown[]): string {
+  return JSON.stringify({ type: "assistant", message: { role: "assistant", content: parts } })
+}
+
+function toolResultLine(toolUseId: string, content: unknown, isError = false): string {
+  return JSON.stringify({
+    type: "user",
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, content, is_error: isError }] },
+  })
+}
+
+describe("encodeProjectDir", () => {
+  test("matches Claude Code's projects-dir encoding", () => {
+    expect(encodeProjectDir("/Users/k/dev/personal/threa.improve-harness-tmux")).toBe(
+      "-Users-k-dev-personal-threa-improve-harness-tmux"
+    )
+  })
+})
+
+describe("mapTranscriptLine redaction (headline mode)", () => {
+  test("a Bash tool_use ships the headline and never the command", () => {
+    const secret = "cat .env && curl -H 'Authorization: Bearer sk-test-secret-token' https://example.com"
+    const steps = mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_1", name: "Bash", input: { command: secret } }]),
+      ctx()
+    )
+    expect(steps).toHaveLength(1)
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Running shell command")
+    expect(serialized).toContain("Shell command omitted for safety.")
+    expect(serialized).not.toContain("sk-test-secret-token")
+    expect(serialized).not.toContain("cat .env")
+    expect(steps[0]!.statusText).toBe("Running shell command…")
+  })
+
+  test("file edits ship the basename only, never contents or patches", () => {
+    const steps = mapTranscriptLine(
+      assistantLine([
+        {
+          type: "tool_use",
+          id: "toolu_2",
+          name: "Edit",
+          input: { file_path: "/repo/src/handlers.ts", old_string: "password = 'hunter2'", new_string: "..." },
+        },
+      ]),
+      ctx()
+    )
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Editing file handlers.ts")
+    expect(serialized).toContain("File contents and patches omitted for safety.")
+    expect(serialized).not.toContain("hunter2")
+    expect(serialized).not.toContain("old_string")
+  })
+
+  test("reading a credentials-looking path is reported as a sensitive file without the path", () => {
+    const steps = mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_3", name: "Read", input: { file_path: "/repo/.env" } }]),
+      ctx()
+    )
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Reading sensitive file")
+    expect(serialized).not.toContain(".env")
+  })
+
+  test("a tool_result pairs with its call's headline and ships size telemetry, not output", () => {
+    const context = ctx()
+    mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_4", name: "Bash", input: { command: "printenv" } }]),
+      context
+    )
+    const steps = mapTranscriptLine(
+      toolResultLine("toolu_4", "DATABASE_URL=postgres://user:password@host/db\nAPI_KEY=sk-oops"),
+      context
+    )
+    expect(steps).toHaveLength(1)
+    expect(steps[0]!.stepType).toBe("tool_call")
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Running shell command")
+    expect(serialized).toContain("characters across 2 lines")
+    expect(serialized).not.toContain("DATABASE_URL")
+    expect(serialized).not.toContain("sk-oops")
+  })
+
+  test("an errored tool_result becomes tool_error and withholds error details", () => {
+    const context = ctx()
+    mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_5", name: "Bash", input: { command: "false" } }]),
+      context
+    )
+    const steps = mapTranscriptLine(toolResultLine("toolu_5", "secret traceback", true), context)
+    expect(steps[0]!.stepType).toBe("tool_error")
+    expect(steps[0]!.statusText).toBe("Tool failed")
+    expect(JSON.stringify(steps)).toContain("Error details omitted for safety.")
+    expect(JSON.stringify(steps)).not.toContain("secret traceback")
+  })
+
+  test("thinking and narration ship size only, never the body", () => {
+    const steps = mapTranscriptLine(
+      assistantLine([
+        { type: "thinking", thinking: "the user's token is sk-hidden, better not repeat it", signature: "x" },
+        { type: "text", text: "Now I'll check the config." },
+      ]),
+      ctx()
+    )
+    expect(steps).toHaveLength(2)
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Thinking content omitted for safety. Captured locally: 51 characters.")
+    expect(serialized).toContain("Assistant narration omitted for safety.")
+    expect(serialized).not.toContain("sk-hidden")
+    expect(serialized).not.toContain("check the config")
+  })
+
+  test("the channel's own send/reply tools and their results are skipped entirely", () => {
+    const context = ctx()
+    const callSteps = mapTranscriptLine(
+      assistantLine([
+        { type: "tool_use", id: "toolu_6", name: "mcp__threa__send", input: { invocation_id: "binv_1", text: "hi" } },
+      ]),
+      context
+    )
+    expect(callSteps).toHaveLength(0)
+    const resultSteps = mapTranscriptLine(toolResultLine("toolu_6", "sent"), context)
+    expect(resultSteps).toHaveLength(0)
+  })
+
+  test("MCP tools ship server:tool names only", () => {
+    const steps = mapTranscriptLine(
+      assistantLine([
+        { type: "tool_use", id: "toolu_7", name: "mcp__github__create_pull_request", input: { title: "private" } },
+      ]),
+      ctx()
+    )
+    const serialized = JSON.stringify(steps)
+    expect(serialized).toContain("Using github:create_pull_request")
+    expect(serialized).not.toContain("private")
+  })
+
+  test("session metadata, prompts, and malformed lines map to nothing", () => {
+    expect(mapTranscriptLine(JSON.stringify({ type: "file-history-snapshot", data: {} }), ctx())).toHaveLength(0)
+    expect(
+      mapTranscriptLine(JSON.stringify({ type: "user", message: { role: "user", content: "the prompt" } }), ctx())
+    ).toHaveLength(0)
+    expect(mapTranscriptLine("not json at all", ctx())).toHaveLength(0)
+    expect(mapTranscriptLine("", ctx())).toHaveLength(0)
+  })
+
+  test("oversized structured sections stay under the content budget", () => {
+    const context = ctx("full")
+    const steps = mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_8", name: "Bash", input: { command: "x".repeat(40_000) } }]),
+      context
+    )
+    expect(steps[0]!.content.length).toBeLessThanOrEqual(9_500)
+  })
+})
+
+describe("mapTranscriptLine (full mode, E2EE-ready)", () => {
+  test("ships real bodies when explicitly enabled", () => {
+    const context = ctx("full")
+    const steps = mapTranscriptLine(
+      assistantLine([{ type: "tool_use", id: "toolu_9", name: "Bash", input: { command: "echo hello" } }]),
+      context
+    )
+    expect(JSON.stringify(steps)).toContain("echo hello")
+    const thinking = mapTranscriptLine(assistantLine([{ type: "thinking", thinking: "full reasoning body" }]), context)
+    expect(thinking[0]!.content).toBe("full reasoning body")
+  })
+})
+
+describe("describeClaudeTool", () => {
+  test("covers the built-in tool vocabulary", () => {
+    expect(describeClaudeTool("Read", { file_path: "/a/b.ts" }).headline).toBe("Reading file b.ts")
+    expect(describeClaudeTool("Grep", {}).headline).toBe("Searching files")
+    expect(describeClaudeTool("Task", {}).headline).toBe("Delegating to a subagent")
+    expect(describeClaudeTool("WebSearch", {}).headline).toBe("Searching the web")
+    expect(describeClaudeTool("Weird$Name!!", {}).headline).toBe("Using tool")
+  })
+})
+
+describe("TranscriptTracer", () => {
+  test("binds to the transcript that echoes the invocation id and emits only its steps", async () => {
+    const root = mkdtempSync(join(tmpdir(), "trace-projects-"))
+    const cwd = "/tmp/fake-worktree"
+    const projectDir = join(root, encodeProjectDir(cwd))
+    mkdirSync(projectDir, { recursive: true })
+    const decoy = join(projectDir, "aaaa-decoy.jsonl")
+    const real = join(projectDir, "bbbb-real.jsonl")
+    writeFileSync(decoy, `${JSON.stringify({ type: "system", note: "old session" })}\n`)
+    writeFileSync(real, `${JSON.stringify({ type: "system", note: "current session" })}\n`)
+
+    const batches: Array<{ invocationId: string; frames: TraceFrame[] }> = []
+    const tracer = new TranscriptTracer({
+      projectsRoot: root,
+      cwd,
+      pollMs: 20,
+      emit: async (invocationId, frames) => {
+        batches.push({ invocationId, frames })
+        return true
+      },
+    })
+
+    tracer.beginTurn("binv_trace_test")
+    // The decoy gets unrelated traffic; the real file echoes the invocation id
+    // (as Claude Code does when the channel prompt lands) and then does work.
+    appendFileSync(decoy, `${assistantLine([{ type: "text", text: "decoy work" }])}\n`)
+    appendFileSync(
+      real,
+      `${JSON.stringify({ type: "user", message: { role: "user", content: 'channel event invocation_id="binv_trace_test"' } })}\n`
+    )
+    appendFileSync(
+      real,
+      `${assistantLine([{ type: "tool_use", id: "t1", name: "Bash", input: { command: "make secret" } }])}\n`
+    )
+
+    const deadline = Date.now() + 3_000
+    while (batches.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    tracer.stop()
+
+    expect(batches.length).toBeGreaterThan(0)
+    const all = JSON.stringify(batches)
+    expect(all).toContain("Running shell command")
+    expect(all).not.toContain("decoy work")
+    expect(all).not.toContain("make secret")
+    expect(batches.every((batch) => batch.invocationId === "binv_trace_test")).toBe(true)
+  }, 10_000)
+
+  test("stops the turn when emit reports the invocation closed", async () => {
+    const root = mkdtempSync(join(tmpdir(), "trace-projects-"))
+    const cwd = "/tmp/fake-worktree-2"
+    const projectDir = join(root, encodeProjectDir(cwd))
+    mkdirSync(projectDir, { recursive: true })
+    const file = join(projectDir, "session.jsonl")
+    writeFileSync(file, "")
+
+    let calls = 0
+    const tracer = new TranscriptTracer({
+      projectsRoot: root,
+      cwd,
+      pollMs: 20,
+      emit: async () => {
+        calls += 1
+        return false
+      },
+    })
+    tracer.beginTurn("binv_closed")
+    appendFileSync(file, `id echo binv_closed\n${assistantLine([{ type: "text", text: "one" }])}\n`)
+    const deadline = Date.now() + 3_000
+    while (calls === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    // Give it a couple more polls to prove it stopped.
+    appendFileSync(file, `${assistantLine([{ type: "text", text: "two" }])}\n`)
+    await new Promise((resolve) => setTimeout(resolve, 120))
+    tracer.stop()
+    expect(calls).toBe(1)
+  }, 10_000)
+})

--- a/extensions/claude-code-remote/src/transcript-trace.test.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.test.ts
@@ -244,6 +244,48 @@ describe("TranscriptTracer", () => {
     expect(batches.every((batch) => batch.invocationId === "binv_trace_test")).toBe(true)
   }, 10_000)
 
+  test("binds a transcript created after the turn starts (fresh session, empty project dir)", async () => {
+    // The harnessd-spawn case that failed live: Claude Code creates the
+    // session's .jsonl at its FIRST turn, so the file never exists in the
+    // beginTurn baseline and the prompt echo has already landed by the time a
+    // rescan sees it. Discovered-late files must read from offset 0.
+    const root = mkdtempSync(join(tmpdir(), "trace-projects-"))
+    const cwd = "/tmp/fake-worktree-fresh"
+    const projectDir = join(root, encodeProjectDir(cwd))
+    mkdirSync(projectDir, { recursive: true })
+
+    const batches: TraceFrame[][] = []
+    const tracer = new TranscriptTracer({
+      projectsRoot: root,
+      cwd,
+      pollMs: 20,
+      emit: async (_invocationId, frames) => {
+        batches.push(frames)
+        return true
+      },
+    })
+    tracer.beginTurn("binv_fresh_session")
+    // File is born after the turn started, echo + work already inside it.
+    const file = join(projectDir, "newborn.jsonl")
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: 'event invocation_id="binv_fresh_session"' },
+        }),
+        assistantLine([{ type: "tool_use", id: "t1", name: "Read", input: { file_path: "/x/notes.md" } }]),
+        "",
+      ].join("\n")
+    )
+    const deadline = Date.now() + 3_000
+    while (batches.length === 0 && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25))
+    }
+    tracer.stop()
+    expect(JSON.stringify(batches)).toContain("Reading file notes.md")
+  }, 10_000)
+
   test("stops the turn when emit reports the invocation closed", async () => {
     const root = mkdtempSync(join(tmpdir(), "trace-projects-"))
     const cwd = "/tmp/fake-worktree-2"

--- a/extensions/claude-code-remote/src/transcript-trace.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.ts
@@ -456,7 +456,16 @@ export class TranscriptTracer {
   private async tryBind(): Promise<void> {
     const turn = this.turn
     if (!turn) return
-    if (this.candidates.length === 0) this.candidates = this.scanCandidates()
+    // Rescan on every unbound poll: a fresh session's transcript is BORN at
+    // its first turn — i.e. mid-window — so it can never be in the beginTurn
+    // baseline. A file discovered after turn start reads from offset 0 (its
+    // entire content belongs to the window, including the echo that already
+    // landed); baseline files keep their turn-start snapshot so another
+    // session's history is never read.
+    const known = new Set(this.candidates.map((candidate) => candidate.path))
+    for (const found of this.scanCandidates()) {
+      if (!known.has(found.path)) this.candidates.push({ ...found, offset: 0 })
+    }
     for (const candidate of this.candidates) {
       const appended = this.readAppended(candidate)
       if (appended) {

--- a/extensions/claude-code-remote/src/transcript-trace.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.ts
@@ -393,6 +393,10 @@ export class TranscriptTracer {
   /** Start (or re-window) tailing for a delivered turn. Call BEFORE the turn content is pushed to the runtime. */
   beginTurn(invocationId: string): void {
     this.stopTimer()
+    // Orphaned tool_use ids (a call whose result never streamed before the
+    // turn ended) must not accumulate across a long-lived session; pairing is
+    // per-turn, so a fresh turn starts with an empty map.
+    this.toolHeadlines.clear()
     this.turn = { invocationId, emitted: 0, truncationNoted: false, bindDeadline: Date.now() + this.bindTimeoutMs }
     if (this.bound) {
       const fresh = this.snapshotCandidate(this.bound.path)

--- a/extensions/claude-code-remote/src/transcript-trace.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.ts
@@ -1,0 +1,597 @@
+import { closeSync, openSync, readSync, readdirSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { basename, join } from "node:path"
+
+/**
+ * Trace steps for a Claude Code turn, sourced from the session transcript.
+ *
+ * Claude Code appends every event of a session — thinking blocks, tool calls,
+ * tool results, assistant text — as one JSON line to
+ * `~/.claude/projects/<encoded-cwd>/<session>.jsonl`. Tailing that file gives
+ * a structured, terminal-free view of what the session is doing, which this
+ * module maps to Threa trace steps and ships through the SDK's `recordSteps`
+ * (over the /bot socket) while a turn is in flight.
+ *
+ * Privacy model (mirrors pi-remote's, one notch stricter): in the default
+ * `headline` mode nothing user-generated leaves the machine — tool calls ship
+ * a category headline plus at most a file *basename*; shell commands, file
+ * contents, tool outputs, and thinking bodies are replaced with "omitted for
+ * safety" markers carrying only size telemetry. Thinking is withheld entirely
+ * (pi ships its narration because pi's narration is stream-bound anyway;
+ * Claude's thinking is internal and can quote file contents wholesale). The
+ * `full` mode exists for E2EE-backed session links, where complete steps can
+ * ship encrypted — nothing wires it up until then.
+ */
+
+// Wire format shared with pi-remote and parsed by the frontend trace dialog
+// (`apps/frontend/src/components/trace/trace-step.tsx`; canonical constants in
+// `packages/types`). Duplicated here for the same reason pi-remote duplicates
+// it: this package installs standalone (install-local vendoring), so it cannot
+// depend on @threa/types.
+const TOOL_TRACE_FORMAT = "pi_tool_trace"
+const SECTION_LABELS = {
+  ARGUMENTS: "Arguments",
+  OUTPUT: "Output",
+  ERROR_OUTPUT: "Error output",
+  DETAILS: "Details",
+} as const
+type SectionLabel = (typeof SECTION_LABELS)[keyof typeof SECTION_LABELS]
+
+const TRACE_CONTENT_MAX_CHARS = 9_500
+const DEFAULT_POLL_MS = 500
+const DEFAULT_BIND_TIMEOUT_MS = 60_000
+const DEFAULT_MAX_FRAMES_PER_TURN = 400
+// While unbound, appended text is buffered per candidate so the whole turn can
+// be replayed once the right file identifies itself. Turn prefixes are small;
+// the cap only guards against a runaway writer in a candidate we never bind.
+const MAX_UNBOUND_BUFFER_CHARS = 4_000_000
+const MAX_LINE_CHARS = 2_000_000
+// Only the most recently touched transcripts are worth watching — a project
+// dir accumulates every historical session, and dead files never append.
+const MAX_CANDIDATES = 12
+
+export type RedactionMode = "headline" | "full"
+
+export interface TraceFrame {
+  stepType: string
+  content: string
+}
+
+export interface MappedStep extends TraceFrame {
+  /** Presence status line for the strip (already from the fixed allowlist below — never free text). */
+  statusText: string
+}
+
+export interface MapContext {
+  mode: RedactionMode
+  /**
+   * tool_use id → headline, so a result renders under the same headline as its
+   * call. An empty-string sentinel marks a call whose result must be skipped
+   * (the channel's own send/reply tools).
+   */
+  toolHeadlines: Map<string, string>
+}
+
+/** Claude Code's project-dir encoding: every non-alphanumeric character becomes '-'. */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-")
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function isSensitivePath(path: unknown): boolean {
+  if (typeof path !== "string") return false
+  return /(^|[\\/.])(?:env|npmrc|netrc|pypirc|pgpass|aws|credentials|config|secrets?|tokens?|keys?)(?:$|[.\\/-])/i.test(
+    path
+  )
+}
+
+function safeFileSummary(path: unknown): string {
+  if (isSensitivePath(path)) return "sensitive file"
+  const name = typeof path === "string" && path.trim() ? basename(path.trim()) : ""
+  return name ? `file ${name}` : "file"
+}
+
+function safeToolName(toolName: string): string {
+  return /^[A-Za-z0-9_-]{1,64}$/.test(toolName) ? toolName : "tool"
+}
+
+function truncateForTrace(text: string, max = TRACE_CONTENT_MAX_CHARS): string {
+  if (text.length <= max) return text
+  const omitted = text.length - max
+  return `${text.slice(0, max).trimEnd()}\n\n…[truncated; ${omitted} more characters]`
+}
+
+/**
+ * Serialize a structured tool trace under the content budget, trimming the
+ * largest section first (ported from pi-remote so both runtimes emit the same
+ * shape the trace dialog parses).
+ */
+function formatStructuredToolTrace(params: {
+  headline: string
+  sections: Array<{ label: SectionLabel; body: string; lang: string | null }>
+}): string {
+  const sections = params.sections.map((section) => ({ ...section, originalBody: section.body }))
+
+  for (let attempt = 0; attempt < 24; attempt++) {
+    const payload = JSON.stringify({
+      format: TOOL_TRACE_FORMAT,
+      headline: params.headline,
+      sections: sections.map(({ originalBody: _originalBody, ...section }) => section),
+    })
+    if (payload.length <= TRACE_CONTENT_MAX_CHARS) return payload
+
+    const largestIndex = sections.reduce(
+      (largest, section, index) => (section.body.length > sections[largest]!.body.length ? index : largest),
+      0
+    )
+    const largest = sections[largestIndex]
+    if (!largest || largest.originalBody.length === 0) break
+
+    const overflow = payload.length - TRACE_CONTENT_MAX_CHARS
+    const currentVisibleLength = largest.body.includes("…[section truncated;")
+      ? largest.body.indexOf("\n\n…[section truncated;")
+      : largest.body.length
+    const nextVisibleLength = Math.max(0, currentVisibleLength - Math.max(overflow + 256, 512))
+    const omitted = largest.originalBody.length - nextVisibleLength
+    largest.body = `${largest.originalBody.slice(0, nextVisibleLength).trimEnd()}\n\n…[section truncated; ${omitted} more characters]`
+  }
+
+  return JSON.stringify({
+    format: TOOL_TRACE_FORMAT,
+    headline: params.headline,
+    sections: [{ label: SECTION_LABELS.DETAILS, body: "Trace content was too large to serialize safely.", lang: null }],
+  })
+}
+
+function toolInputPath(input: unknown): unknown {
+  if (!isObject(input)) return undefined
+  return input.file_path ?? input.path ?? input.notebook_path
+}
+
+export function describeClaudeTool(name: string, input: unknown): { headline: string; statusText: string } {
+  const lower = name.toLowerCase()
+  const path = toolInputPath(input)
+  switch (lower) {
+    case "bash":
+      return { headline: "Running shell command", statusText: "Running shell command…" }
+    case "read":
+      if (isSensitivePath(path)) return { headline: "Reading sensitive file", statusText: "Reading sensitive file…" }
+      return { headline: `Reading ${safeFileSummary(path)}`, statusText: "Reading file…" }
+    case "write":
+      return { headline: `Writing ${safeFileSummary(path)}`, statusText: "Writing file…" }
+    case "edit":
+    case "notebookedit":
+      return { headline: `Editing ${safeFileSummary(path)}`, statusText: "Editing file…" }
+    case "grep":
+    case "glob":
+      return { headline: "Searching files", statusText: "Searching files…" }
+    case "task":
+    case "agent":
+      return { headline: "Delegating to a subagent", statusText: "Using tool…" }
+    case "webfetch":
+      return { headline: "Fetching a web page", statusText: "Using tool…" }
+    case "websearch":
+      return { headline: "Searching the web", statusText: "Using tool…" }
+    case "todowrite":
+    case "taskcreate":
+    case "taskupdate":
+      return { headline: "Updating the task list", statusText: "Using tool…" }
+    default: {
+      const mcp = /^mcp__([A-Za-z0-9_-]+)__([A-Za-z0-9_-]+)$/.exec(name)
+      if (mcp) return { headline: `Using ${mcp[1]}:${mcp[2]}`, statusText: "Using tool…" }
+      return { headline: `Using ${safeToolName(name)}`, statusText: "Using tool…" }
+    }
+  }
+}
+
+function safeToolArgumentSummary(name: string, input: unknown): string {
+  const lower = name.toLowerCase()
+  if (lower === "bash") return "Shell command omitted for safety."
+  if (lower === "read" || lower === "write" || lower === "edit" || lower === "notebookedit") {
+    const action = lower === "read" ? "Read" : lower === "write" ? "Write" : "Edit"
+    return `${action} target: ${safeFileSummary(toolInputPath(input))}. File contents and patches omitted for safety.`
+  }
+  if (lower === "grep" || lower === "glob") return "Search arguments omitted for safety."
+  return `Arguments for ${safeToolName(name)} omitted for safety.`
+}
+
+function textFromToolResult(content: unknown): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part
+      if (!isObject(part) || !("type" in part)) return ""
+      if (part.type === "text" && typeof part.text === "string") return part.text
+      if (part.type === "image") return "[image output]"
+      return ""
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
+function summarizeToolOutput(output: string): string {
+  const text = output.trim()
+  if (!text) return "Tool produced no textual output."
+  const lines = text.split("\n").length
+  return `Tool output omitted for safety. Captured locally: ${text.length} characters across ${lines} ${lines === 1 ? "line" : "lines"}.`
+}
+
+function withheldBody(kind: "Thinking content" | "Assistant narration", length: number): string {
+  return `${kind} omitted for safety. Captured locally: ${length} characters.`
+}
+
+/** The channel's own MCP tools — their payloads land in the stream as real messages, so trace rows would be noise. */
+const OWN_TOOL_RE = /^mcp__threa__(send|reply)$/i
+
+function toolUseStep(part: Record<string, unknown>, ctx: MapContext): MappedStep | null {
+  const name = typeof part.name === "string" ? part.name : ""
+  const id = typeof part.id === "string" ? part.id : ""
+  if (!name) return null
+  if (OWN_TOOL_RE.test(name)) {
+    if (id) ctx.toolHeadlines.set(id, "")
+    return null
+  }
+  const { headline, statusText } = describeClaudeTool(name, part.input)
+  if (id) ctx.toolHeadlines.set(id, headline)
+  const body =
+    ctx.mode === "full"
+      ? truncateForTrace(JSON.stringify(part.input ?? {}, null, 1))
+      : safeToolArgumentSummary(name, part.input)
+  return {
+    stepType: "tool_call",
+    content: formatStructuredToolTrace({
+      headline,
+      sections: [{ label: SECTION_LABELS.ARGUMENTS, body, lang: ctx.mode === "full" ? "json" : null }],
+    }),
+    statusText,
+  }
+}
+
+function toolResultStep(part: Record<string, unknown>, ctx: MapContext): MappedStep | null {
+  const id = typeof part.tool_use_id === "string" ? part.tool_use_id : ""
+  const headline = ctx.toolHeadlines.get(id)
+  ctx.toolHeadlines.delete(id)
+  if (headline === "") return null
+  const isError = part.is_error === true
+  const output = textFromToolResult(part.content)
+  const body =
+    ctx.mode === "full"
+      ? truncateForTrace(output.trim() || "(no textual output)")
+      : `${summarizeToolOutput(output)}${isError ? " Error details omitted for safety." : ""}`
+  return {
+    stepType: isError ? "tool_error" : "tool_call",
+    content: formatStructuredToolTrace({
+      headline: headline ?? "Used tool",
+      sections: [{ label: isError ? SECTION_LABELS.ERROR_OUTPUT : SECTION_LABELS.OUTPUT, body, lang: null }],
+    }),
+    statusText: isError ? "Tool failed" : "Tool finished",
+  }
+}
+
+/**
+ * Map one transcript JSONL line to trace steps. Unknown/irrelevant line types
+ * (session metadata, snapshots, the echoed user prompt) map to nothing.
+ */
+export function mapTranscriptLine(raw: string, ctx: MapContext): MappedStep[] {
+  if (raw.length === 0 || raw.length > MAX_LINE_CHARS) return []
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!isObject(parsed)) return []
+  const type = parsed.type
+  if (type !== "assistant" && type !== "user") return []
+  const message = parsed.message
+  if (!isObject(message)) return []
+  const content = message.content
+  if (!Array.isArray(content)) return []
+
+  const steps: MappedStep[] = []
+  for (const part of content) {
+    if (!isObject(part)) continue
+    if (type === "assistant" && part.type === "thinking" && typeof part.thinking === "string") {
+      // Current Claude Code persists thinking blocks with an empty body (only
+      // the opaque signature), so this usually skips — the branch matters for
+      // transcripts that do carry bodies.
+      const text = part.thinking.trim()
+      if (!text) continue
+      steps.push({
+        stepType: "thinking",
+        content: ctx.mode === "full" ? truncateForTrace(text) : withheldBody("Thinking content", text.length),
+        statusText: "Thinking…",
+      })
+    } else if (type === "assistant" && part.type === "text" && typeof part.text === "string") {
+      const text = part.text.trim()
+      if (!text) continue
+      steps.push({
+        stepType: "thinking",
+        content: ctx.mode === "full" ? truncateForTrace(text) : withheldBody("Assistant narration", text.length),
+        statusText: "Composing response…",
+      })
+    } else if (type === "assistant" && part.type === "tool_use") {
+      const step = toolUseStep(part, ctx)
+      if (step) steps.push(step)
+    } else if (type === "user" && part.type === "tool_result") {
+      const step = toolResultStep(part, ctx)
+      if (step) steps.push(step)
+    }
+  }
+  return steps
+}
+
+interface Candidate {
+  path: string
+  offset: number
+  /** Partial trailing line carried between reads. */
+  remainder: string
+  /** Appended text accumulated while unbound, replayed on bind. */
+  buffered: string
+}
+
+export interface TranscriptTracerOptions {
+  /** Defaults to `~/.claude/projects`. */
+  projectsRoot?: string
+  /** Defaults to `process.cwd()`. */
+  cwd?: string
+  mode?: RedactionMode
+  pollMs?: number
+  bindTimeoutMs?: number
+  maxFramesPerTurn?: number
+  /**
+   * Ship a batch of frames for the in-flight turn. Return false when the turn
+   * is no longer open — the tracer stops tailing for it.
+   */
+  emit: (invocationId: string, frames: TraceFrame[], statusText?: string) => Promise<boolean>
+  log?: (message: string) => void
+}
+
+/**
+ * Tails the session transcript while a turn is in flight and ships mapped
+ * steps through `emit`.
+ *
+ * Binding: a cwd's project dir can hold transcripts of several live sessions
+ * (two Claude sessions in one directory is the known identity-collision case),
+ * so newest-mtime is not trusted. Instead, every candidate is watched from the
+ * turn-start offset, and the file that echoes the delivered turn's
+ * invocation id — Claude Code writes the injected prompt into the transcript —
+ * is bound for the tracer's lifetime. Until binding, nothing is emitted;
+ * the bound file's buffered prefix is replayed so no step is lost.
+ */
+export class TranscriptTracer {
+  private readonly projectDir: string
+  private readonly mode: RedactionMode
+  private readonly pollMs: number
+  private readonly bindTimeoutMs: number
+  private readonly maxFramesPerTurn: number
+  private readonly emit: TranscriptTracerOptions["emit"]
+  private readonly log: (message: string) => void
+
+  private bound: Candidate | undefined
+  private candidates: Candidate[] = []
+  private turn: { invocationId: string; emitted: number; truncationNoted: boolean; bindDeadline: number } | undefined
+  private readonly toolHeadlines = new Map<string, string>()
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private polling = false
+
+  constructor(options: TranscriptTracerOptions) {
+    const root = options.projectsRoot ?? join(homedir(), ".claude", "projects")
+    this.projectDir = join(root, encodeProjectDir(options.cwd ?? process.cwd()))
+    this.mode = options.mode ?? "headline"
+    this.pollMs = options.pollMs ?? DEFAULT_POLL_MS
+    this.bindTimeoutMs = options.bindTimeoutMs ?? DEFAULT_BIND_TIMEOUT_MS
+    this.maxFramesPerTurn = options.maxFramesPerTurn ?? DEFAULT_MAX_FRAMES_PER_TURN
+    this.emit = options.emit
+    this.log = options.log ?? (() => undefined)
+  }
+
+  /** Start (or re-window) tailing for a delivered turn. Call BEFORE the turn content is pushed to the runtime. */
+  beginTurn(invocationId: string): void {
+    this.stopTimer()
+    this.turn = { invocationId, emitted: 0, truncationNoted: false, bindDeadline: Date.now() + this.bindTimeoutMs }
+    if (this.bound) {
+      const fresh = this.snapshotCandidate(this.bound.path)
+      if (fresh) {
+        this.bound = fresh
+      } else {
+        // Bound file vanished (worktree cleanup, manual delete) — rebind.
+        this.bound = undefined
+      }
+    }
+    if (!this.bound) this.candidates = this.scanCandidates()
+    this.schedule(this.pollMs)
+  }
+
+  /** The turn was answered; stop tailing (frames for a closed invocation are rejected server-side anyway). */
+  endTurn(invocationId: string): void {
+    if (this.turn?.invocationId !== invocationId) return
+    this.turn = undefined
+    this.stopTimer()
+  }
+
+  stop(): void {
+    this.turn = undefined
+    this.stopTimer()
+  }
+
+  private stopTimer(): void {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  private schedule(delayMs: number): void {
+    this.stopTimer()
+    if (!this.turn) return
+    this.timer = setTimeout(() => void this.poll(), delayMs)
+  }
+
+  private async poll(): Promise<void> {
+    if (this.polling || !this.turn) return
+    this.polling = true
+    try {
+      if (this.bound) await this.drainBound()
+      else await this.tryBind()
+    } catch (error) {
+      this.log(`transcript trace poll failed: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      this.polling = false
+      this.schedule(this.pollMs)
+    }
+  }
+
+  private async drainBound(): Promise<void> {
+    const turn = this.turn
+    const bound = this.bound
+    if (!turn || !bound) return
+    const lines = this.readLines(bound)
+    if (lines.length === 0) return
+    await this.emitLines(lines)
+  }
+
+  private async tryBind(): Promise<void> {
+    const turn = this.turn
+    if (!turn) return
+    if (this.candidates.length === 0) this.candidates = this.scanCandidates()
+    for (const candidate of this.candidates) {
+      const appended = this.readAppended(candidate)
+      if (appended) {
+        candidate.buffered = (candidate.buffered + appended).slice(-MAX_UNBOUND_BUFFER_CHARS)
+      }
+      if (candidate.buffered.includes(turn.invocationId)) {
+        this.bound = candidate
+        this.candidates = []
+        this.log(`transcript bound: ${basename(candidate.path)}`)
+        // Replay the buffered prefix through the line splitter so the steps
+        // that landed before binding are not lost.
+        const replay = candidate.buffered
+        candidate.buffered = ""
+        const lines = this.splitLines(candidate, replay)
+        if (lines.length > 0) await this.emitLines(lines)
+        return
+      }
+    }
+    if (Date.now() > turn.bindDeadline) {
+      this.log(`transcript bind timed out for ${turn.invocationId} — tracing disabled for this turn`)
+      this.turn = undefined
+    }
+  }
+
+  private async emitLines(lines: string[]): Promise<void> {
+    const turn = this.turn
+    if (!turn) return
+    const ctx: MapContext = { mode: this.mode, toolHeadlines: this.toolHeadlines }
+    let frames: TraceFrame[] = []
+    let statusText: string | undefined
+    for (const line of lines) {
+      for (const step of mapTranscriptLine(line, ctx)) {
+        frames.push({ stepType: step.stepType, content: step.content })
+        statusText = step.statusText
+      }
+    }
+    if (frames.length === 0) return
+    if (turn.emitted >= this.maxFramesPerTurn) {
+      if (!turn.truncationNoted) {
+        turn.truncationNoted = true
+        frames = [
+          {
+            stepType: "thinking",
+            content: "Trace truncated for this turn: further steps omitted (still captured locally).",
+          },
+        ]
+      } else {
+        return
+      }
+    } else if (turn.emitted + frames.length > this.maxFramesPerTurn) {
+      frames = frames.slice(0, this.maxFramesPerTurn - turn.emitted)
+    }
+    turn.emitted += frames.length
+    const open = await this.emit(turn.invocationId, frames, statusText)
+    if (!open && this.turn?.invocationId === turn.invocationId) {
+      // Turn closed server-side (reply landed, timeout, or supersede).
+      this.turn = undefined
+    }
+  }
+
+  private scanCandidates(): Candidate[] {
+    let names: string[]
+    try {
+      names = readdirSync(this.projectDir)
+    } catch {
+      return []
+    }
+    // Subagent transcripts (agent-*.jsonl) narrate delegated work, not this
+    // session's turn — the Task tool_use row already marks the delegation.
+    const files = names.filter((name) => name.endsWith(".jsonl") && !name.startsWith("agent-"))
+    const withMtime = files
+      .map((name) => {
+        const path = join(this.projectDir, name)
+        try {
+          const stats = statSync(path)
+          return { path, mtimeMs: stats.mtimeMs, size: stats.size }
+        } catch {
+          return undefined
+        }
+      })
+      .filter((entry): entry is { path: string; mtimeMs: number; size: number } => entry !== undefined)
+      .sort((a, b) => b.mtimeMs - a.mtimeMs)
+      .slice(0, MAX_CANDIDATES)
+    return withMtime.map((entry) => ({ path: entry.path, offset: entry.size, remainder: "", buffered: "" }))
+  }
+
+  private snapshotCandidate(path: string): Candidate | undefined {
+    try {
+      const stats = statSync(path)
+      return { path, offset: stats.size, remainder: "", buffered: "" }
+    } catch {
+      return undefined
+    }
+  }
+
+  /** Read text appended since the candidate's offset. A shrunk file (rotation) resets the offset. */
+  private readAppended(candidate: Candidate): string {
+    let size: number
+    try {
+      size = statSync(candidate.path).size
+    } catch {
+      return ""
+    }
+    if (size < candidate.offset) candidate.offset = size
+    if (size === candidate.offset) return ""
+    let fd: number
+    try {
+      fd = openSync(candidate.path, "r")
+    } catch {
+      return ""
+    }
+    try {
+      const length = Math.min(size - candidate.offset, 8_000_000)
+      const buffer = Buffer.alloc(length)
+      const read = readSync(fd, buffer, 0, length, candidate.offset)
+      candidate.offset += read
+      // A read can split a multibyte character at the boundary; the mangled
+      // character lands inside a line whose body is redacted to a size anyway.
+      return buffer.toString("utf8", 0, read)
+    } finally {
+      closeSync(fd)
+    }
+  }
+
+  private readLines(candidate: Candidate): string[] {
+    const appended = this.readAppended(candidate)
+    if (!appended) return []
+    return this.splitLines(candidate, appended)
+  }
+
+  /** Split appended text into complete lines, carrying a partial trailing line in the candidate's remainder. */
+  private splitLines(candidate: Candidate, appended: string): string[] {
+    const text = candidate.remainder + appended
+    const parts = text.split("\n")
+    candidate.remainder = parts.pop() ?? ""
+    return parts.map((line) => line.trim()).filter((line) => line.length > 0)
+  }
+}

--- a/extensions/remote-session/src/index.ts
+++ b/extensions/remote-session/src/index.ts
@@ -51,3 +51,4 @@ export {
   type SelectedAttachment,
 } from "./attachments"
 export { wireLifecycle, type LifecycleOptions, type LifecycleProcess } from "./lifecycle"
+export type { StepFrame } from "@threa/bot-runtime-client"

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -753,6 +753,10 @@ export class RemoteSession {
       await this.transport
         .recordSteps(invocationId, entry.invocation.claimToken, chunk, statusText ?? this.runtime.busyStatusText)
         .catch((error) => this.log(`recordSteps failed: ${this.summarize(error)}`))
+      // The turn can close during an awaited send (reply, /stop, idle timeout)
+      // — exactly the long multi-chunk replays this loop exists for. Recheck so
+      // the returned boolean stays an honest stop signal for the tailer.
+      if (!this.inflight.has(invocationId)) return false
     }
     return true
   }

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -1,4 +1,4 @@
-import { BotRuntimeTransport, type BotRuntimeHello } from "@threa/bot-runtime-client"
+import { BotRuntimeTransport, type BotRuntimeHello, type StepFrame } from "@threa/bot-runtime-client"
 import { downloadInboundAttachments, formatInboundAttachmentManifest, uploadReplyAttachments } from "./attachments"
 import type { RemoteSessionConfig } from "./identity"
 import { ThreaClient, type ClaimedInvocation, type RuntimeSessionLink } from "./client"
@@ -730,6 +730,25 @@ export class RemoteSession {
     if (this.activeTurnStream === entry.invocation.responseStreamId) this.activeTurnStream = undefined
     await this.syncPresence()
     return { ok: true, message: "sent" }
+  }
+
+  /**
+   * Record trace steps against an in-flight turn. Fire-and-forget: a failed
+   * frame is logged and dropped, not retried — steps are ephemeral progress,
+   * not state. Returns false when the invocation is no longer in flight
+   * (answered, expired, superseded), which a transcript tailer uses as its
+   * stop signal. Frames must arrive already redacted; this method ships them
+   * verbatim.
+   */
+  async recordSteps(invocationId: string, frames: StepFrame[], statusText?: string): Promise<boolean> {
+    const entry = this.inflight.get(invocationId)
+    if (!entry) return false
+    if (frames.length > 0) {
+      await this.transport
+        .recordSteps(invocationId, entry.invocation.claimToken, frames, statusText ?? this.runtime.busyStatusText)
+        .catch((error) => this.log(`recordSteps failed: ${this.summarize(error)}`))
+    }
+    return true
   }
 
   /** Post a message into a stream outside the turn flow (e.g. a relayed approval prompt). */

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -24,6 +24,9 @@ const RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
 // bootstrap callback.
 const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
 const MAX_CLAIMS_PER_DRAIN = 20
+// Server-side cap on frames per bot:invocation:steps call (`stepsFrameSchema`
+// in apps/backend/src/features/bot-runtimes/socket-handler.ts).
+const MAX_STEP_FRAMES_PER_CALL = 50
 const MAX_CONTEXT_MESSAGES = 12
 const MAX_MESSAGE_CHARS = 2_000
 // Recent messages to scan for inbound attachments. The trigger message is always
@@ -743,9 +746,12 @@ export class RemoteSession {
   async recordSteps(invocationId: string, frames: StepFrame[], statusText?: string): Promise<boolean> {
     const entry = this.inflight.get(invocationId)
     if (!entry) return false
-    if (frames.length > 0) {
+    // The server rejects >50 frames per bot:invocation:steps call, so a large
+    // batch (e.g. a transcript replay after late binding) ships in chunks.
+    for (let start = 0; start < frames.length; start += MAX_STEP_FRAMES_PER_CALL) {
+      const chunk = frames.slice(start, start + MAX_STEP_FRAMES_PER_CALL)
       await this.transport
-        .recordSteps(invocationId, entry.invocation.claimToken, frames, statusText ?? this.runtime.busyStatusText)
+        .recordSteps(invocationId, entry.invocation.claimToken, chunk, statusText ?? this.runtime.busyStatusText)
         .catch((error) => this.log(`recordSteps failed: ${this.summarize(error)}`))
     }
     return true


### PR DESCRIPTION
## Problem

Claude-channel sessions are a black box between the prompt and the reply. pi-remote streams a live trace (thinking, tool calls, tool results) into the scratchpad's trace dialog; the Claude connector ships exactly one step per turn — the "Forwarded to Claude Code." note — because it has no view into what the session is doing. Scraping tmux output was the only obvious source, and it's the wrong one (unstructured, fragile, full of TUI noise).

Kris's rulings: source the steps from the session transcript, not tmux; and follow pi-remote's privacy model — high-level steps only, nothing that could carry secrets to the server, with full steps reserved for E2EE-backed links later.

## Solution

Tail Claude Code's own session transcript — `~/.claude/projects/<encoded-cwd>/<session>.jsonl`, one typed JSON line per event — while a turn is in flight, map lines to redacted trace steps, and ship them through the SDK's step channel over the /bot socket (free: no Worker, no KV).

### How it works

1. **SDK** (`extensions/remote-session`): `RemoteSession.recordSteps(invocationId, frames, statusText?)` — public, bound to the in-flight claim (`inflight.get(...).claimToken`), fire-and-forget with logging. Returns **false when the invocation is no longer open**, which doubles as the tailer's stop signal (reply landed, idle timeout, steer supersede — all covered without new plumbing). `StepFrame` re-exported.
2. **Binding** (`transcript-trace.ts`): a cwd's project dir can hold several live sessions (the known identity-collision case), so newest-mtime is not trusted. On `beginTurn` every candidate `*.jsonl` (newest 12, `agent-*` subagent transcripts excluded) is watched from its turn-start offset; the file that **echoes the delivered invocation id** — Claude Code writes the injected channel prompt into the transcript — is bound for the tracer's lifetime. Until binding, appended text is buffered (4 MB cap) and replayed on bind so no step is lost; a 60s bind timeout disables tracing for that turn instead of guessing.
3. **Tailing**: 500ms poll of appended bytes (local `statSync`/`readSync`, partial-line remainder carried between reads), windowed per turn: `beginTurn` is called before the content is pushed (so the offset precedes the echo), `endTurn` on a successful `reply`. 400-frames-per-turn cap with an explicit "Trace truncated" marker — never a silent drop.
4. **Mapping** (pi's wire shape): tool steps serialize as the same `pi_tool_trace` structured JSON pi-remote emits (headline + labeled sections, 9,500-char budget with largest-section-first trimming ported verbatim), so `apps/frontend/src/components/trace/trace-step.tsx` renders them with zero frontend changes. `tool_use` → `tool_call`, errored `tool_result` → `tool_error`, thinking/text → `thinking`. Presence `statusText` comes from a fixed allowlist ("Running shell command…", "Reading file…", …), never free text — so the presence strip shows live activity too.

### Key design decisions

**1. Redaction: pi's model, one notch stricter.** Headline mode ships tool category + at most a file *basename* ("Editing file handlers.ts"); commands, patches, arguments, and outputs become pi's exact "…omitted for safety" markers with size telemetry ("Captured locally: N characters across M lines"). Paths matching pi's sensitive-path regex (env/credentials/config/keys…) collapse to "sensitive file". Thinking and narration ship **size only, no body** — stricter than pi on purpose: pi's narration steps are assistant messages that were stream-bound anyway, while Claude's thinking is internal and can quote file contents wholesale. (Empirically, current Claude Code persists thinking bodies as empty strings — signature only — so these usually skip entirely; the redaction matters for transcripts that do carry bodies.)

**2. `redactionMode: "headline" | "full"`.** The full mode (real bodies, budget-truncated) exists and is tested but nothing wires it up — it's the switch the E2EE work flips when a session link is enclave-backed, per Kris's ruling. Default is headline everywhere.

**3. The channel's own `mcp__threa__send`/`reply` calls are skipped** (empty-headline sentinel also suppresses their results): their payloads land in the stream as real messages, so trace rows would be duplicates.

**4. Trace constants duplicated locally, not imported from `@threa/types`.** Same reason pi-remote duplicates them: the extension installs standalone via `install-local.ts` vendoring, and vendoring the whole types package for two string constants is worse. Comment points at the canonical source.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/transcript-trace.ts` | Project-dir encoding, redacting line mapper, structured-trace budgeter, and the `TranscriptTracer` (bind → tail → emit lifecycle) |
| `extensions/claude-code-remote/src/transcript-trace.test.ts` | 15 tests: leak guards (command/patch/output/thinking bodies never serialize), sensitive paths, result pairing, own-tool skipping, full-mode bodies, budget cap, and two live-tail tests against real temp transcripts (decoy + echo binding; emit-false stop) |

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/remote-session/src/session.ts` | Public `recordSteps` (in-flight lookup, claim token, false-when-closed) |
| `extensions/remote-session/src/index.ts` | Re-export `StepFrame` |
| `extensions/claude-code-remote/src/channel-server.ts` | `TranscriptTracer` construction (emit → `session.recordSteps`), `beginTurn` before turn delivery, `endTurn` on successful reply, `stop()` on shutdown |

## Design evolution (live verification)

Ran the full loop pre-merge — spawned a sandbox agent from this branch via harnessd, triggered a real turn from the authenticated app, and read what landed in prod. Two real bugs surfaced and are fixed in this branch:

1. **Server caps steps at 50 frames per call** (`stepsFrameSchema` in `socket-handler.ts`) — a transcript replay after late binding can batch hundreds, and the whole call bounced as INVALID_PAYLOAD. `RemoteSession.recordSteps` now chunks to 50.
2. **Transcripts are born mid-turn** — Claude Code creates the session's `.jsonl` at its *first* user turn, so the file never exists in the `beginTurn` baseline and the invocation-id echo is already behind any later size snapshot; binding only fired on the final `reply` tool call, after the invocation closed (zero steps shipped — the exact harnessd-spawn case). The tracer now rescans on every unbound poll, and files discovered after turn start read from offset 0.

Also confirmed during verification: the backend's own `public-api/sanitize.ts` force-rewrites Arguments/Output section bodies server-side regardless of what a runtime sends — so headline redaction here is layered *under* an existing defense-in-depth boundary, and both held.

## Out of scope (deliberate)

- Subagent transcripts (`agent-*.jsonl` from the Task tool) — the "Delegating to a subagent" row marks the delegation; tailing the child transcripts is a follow-up.
- Wiring `full` mode — waits for E2EE-backed session links.
- Steps for the final assistant text written between the last poll and the reply may be missed (≤500ms window); the reply itself carries that content anyway.

## Test plan

- [x] `bun test` in `extensions/claude-code-remote` — 46 pass (30 existing + 16 new), 0 fail
- [x] `bun test` in `extensions/remote-session` — 63 pass, 0 fail
- [x] Real-transcript smoke test: mapper run over this working session's own 2,523-line transcript → 1,090 frames (983 tool_call / 80 thinking / 27 tool_error), all statusTexts from the allowlist, and **zero hits** on leak probes for values known to be in that transcript (prod DB connection string env var, `threa_bk_` API keys, bearer headers, edit patch bodies, SQL text)
- [x] Pre-commit gauntlet (eslint all apps, `tsc --noEmit` all packages/apps, migration/Dockerfile checks) — clean
- [x] **Live end-to-end on prod**: harnessd-spawned sandbox from this branch → real message → 5 steps persisted in `agent_session_steps` (paired call/result headlines: "Running shell command", "Reading file package.json"), trace dialog renders them, presence strip live — and the DB rows contain only redaction markers, no command/output text. Before/after contrast on record: the pre-fix spawn shipped 1 step (the forwarded note) for the same turn shape; the fixed spawn shipped 5.
- [x] Archive self-destruct re-exercised on the test sandbox during cleanup (window died, worktree removed, branch pushed)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
