### PR TITLE
feat(reads): sparse read overlay — conversation-aware read state on board/panel + phantom-unread fixes

### DIFF
--- a/apps/backend/src/db/migrations/20260703090000_stream_member_message_reads.sql
+++ b/apps/backend/src/db/migrations/20260703090000_stream_member_message_reads.sql
@@ -1,0 +1,28 @@
+-- Sparse read overlay: individually-read messages ABOVE a member's watermark.
+-- A message is effectively read iff sequence <= watermark OR id in this overlay.
+-- See docs/sparse-read-overlay-design.md. No FKs (INV-1); workspace-scoped (INV-8);
+-- member_id is the stream-membership identity surface (INV-50). event_id/sequence
+-- are denormalized at write (stream_events keys messages inside payload->>'messageId')
+-- and refreshed only by a message move.
+
+CREATE TABLE IF NOT EXISTS stream_member_message_reads (
+  workspace_id TEXT NOT NULL,
+  stream_id    TEXT NOT NULL,
+  member_id    TEXT NOT NULL,
+  message_id   TEXT NOT NULL,
+  event_id     TEXT NOT NULL,
+  sequence     BIGINT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (stream_id, member_id, message_id)
+);
+
+-- Compaction window scan + prune-at/above-watermark run over (stream, member)
+-- ordered by sequence; the PK prefix (stream_id, member_id) is not sorted on
+-- sequence, so give those range deletes/scans a sorted path.
+CREATE INDEX IF NOT EXISTS idx_smmr_stream_member_sequence
+  ON stream_member_message_reads (stream_id, member_id, sequence);
+
+-- Move rehome rewrites every member's overlay row for the moved message ids by
+-- (stream_id, message_id); the PK can't serve that (message_id isn't a prefix).
+CREATE INDEX IF NOT EXISTS idx_smmr_stream_message
+  ON stream_member_message_reads (stream_id, message_id);

--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -351,6 +351,25 @@ export const ActivityRepository = {
     `)
   },
 
+  /**
+   * Mark a user's unread activity rows read for specific messages — the
+   * message-granular coupling for conversation reads: marking a conversation
+   * read clears exactly its messages' activity, never the stream's other
+   * topics (contrast `markStreamAsRead`, the whole-stream open coupling).
+   */
+  async markMessagesAsRead(db: Querier, workspaceId: string, userId: string, messageIds: string[]): Promise<number> {
+    if (messageIds.length === 0) return 0
+    const result = await db.query(sql`
+      UPDATE user_activity
+      SET read_at = NOW()
+      WHERE workspace_id = ${workspaceId}
+        AND user_id = ${userId}
+        AND message_id = ANY(${messageIds}::text[])
+        AND read_at IS NULL
+    `)
+    return result.rowCount ?? 0
+  },
+
   async markStreamAsRead(db: Querier, userId: string, streamId: string): Promise<number> {
     const result = await db.query(sql`
       UPDATE user_activity

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -36,6 +36,14 @@ const reassignMessageParamsSchema = z.object({
   messageId: z.string().min(1),
 })
 
+const markReadSchema = z.object({
+  throughMessageId: z.string().min(1),
+})
+
+const markUnreadSchema = z.object({
+  fromMessageId: z.string().min(1),
+})
+
 interface Dependencies {
   conversationService: ConversationService
   streamService: StreamService
@@ -196,6 +204,47 @@ export function createConversationHandlers({ conversationService, streamService,
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const result = await conversationService.reassignMessage({ workspaceId, conversationId, messageId, userId })
+      res.json(result)
+    },
+
+    /**
+     * Mark a conversation read through a message (inclusive). Applies a sparse
+     * read overlay across every stream the conversation spans; returns the
+     * per-stream absolute read-state snapshots. Access via the conversation's root
+     * stream (INV-62), matching the other conversation reads.
+     */
+    async markRead(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { conversationId } = req.params
+
+      const { throughMessageId } = validateRequest(markReadSchema, req.body)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.markRead({ workspaceId, conversationId, throughMessageId, userId })
+      res.json(result)
+    },
+
+    /** Mark a conversation unread from a message (inclusive). Inverse of {@link markRead}. */
+    async markUnread(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { conversationId } = req.params
+
+      const { fromMessageId } = validateRequest(markUnreadSchema, req.body)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.markUnread({ workspaceId, conversationId, fromMessageId, userId })
       res.json(result)
     },
   }

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -1,9 +1,9 @@
 import { Pool } from "pg"
-import { withClient, withTransaction } from "../../db"
+import { withClient, withTransaction, type Querier } from "../../db"
 import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageRepository, type Message } from "../messaging"
-import { StreamRepository } from "../streams"
+import { StreamRepository, applySparseRead, applySparseUnread, type ReadStateSnapshot } from "../streams"
 import { AttachmentRepository, toAttachmentSummary } from "../attachments"
 import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
@@ -419,6 +419,132 @@ export class ConversationService {
         previousConversation: updatedPrevious ? addStalenessFields(updatedPrevious) : null,
       }
     })
+  }
+
+  /**
+   * Mark a conversation read through `throughMessageId` (inclusive). Read truth is
+   * message-granular and stream-anchored (docs/sparse-read-overlay-design.md):
+   * the conversation's member messages are snapshotted to concrete ids at write
+   * time (immune to later re-clustering), grouped by each message's own stream (a
+   * conversation spans root + threads), and applied as a sparse-read overlay per
+   * stream — compacting into the watermark where contiguous. One transaction
+   * (INV-6), one `stream:read_messages` per touched stream (INV-4/7).
+   */
+  async markRead(params: {
+    workspaceId: string
+    conversationId: string
+    throughMessageId: string
+    userId: string
+  }): Promise<{ streams: ReadStateSnapshot[] }> {
+    return withTransaction(this.pool, async (client) => {
+      const groups = await this.resolveConversationReadTargets(
+        client,
+        params.workspaceId,
+        params.conversationId,
+        params.throughMessageId,
+        "read"
+      )
+      const streams: ReadStateSnapshot[] = []
+      for (const [streamId, messageIds] of groups) {
+        streams.push(
+          await applySparseRead(client, {
+            workspaceId: params.workspaceId,
+            streamId,
+            memberId: params.userId,
+            messageIds,
+          })
+        )
+      }
+      return { streams }
+    })
+  }
+
+  /**
+   * Mark a conversation unread from `fromMessageId` (inclusive). Per spanned
+   * stream: drop the affected member ids from the overlay and regress the
+   * watermark to just before the earliest affected message when it sits at/past
+   * it (existing `stream:read_set` semantics, accepting collateral un-reading).
+   */
+  async markUnread(params: {
+    workspaceId: string
+    conversationId: string
+    fromMessageId: string
+    userId: string
+  }): Promise<{ streams: ReadStateSnapshot[] }> {
+    return withTransaction(this.pool, async (client) => {
+      const groups = await this.resolveConversationReadTargets(
+        client,
+        params.workspaceId,
+        params.conversationId,
+        params.fromMessageId,
+        "unread"
+      )
+      const streams: ReadStateSnapshot[] = []
+      for (const [streamId, messageIds] of groups) {
+        streams.push(
+          await applySparseUnread(client, {
+            workspaceId: params.workspaceId,
+            streamId,
+            memberId: params.userId,
+            messageIds,
+          })
+        )
+      }
+      return { streams }
+    })
+  }
+
+  /**
+   * Resolve a conversation's member messages to the concrete ids to apply per
+   * stream: `message_ids ∪ secondary_message_ids` plus the thread-anchored
+   * opening's parent message, filtered by the target message's `createdAt`
+   * (timestamps are the card's cross-stream merge key — sequences aren't
+   * comparable across streams). Returns `[streamId, messageIds]` entries in
+   * sorted stream-id order so two concurrent conversation-reads take the same
+   * per-stream lock order and can't deadlock.
+   */
+  private async resolveConversationReadTargets(
+    client: Querier,
+    workspaceId: string,
+    conversationId: string,
+    targetMessageId: string,
+    direction: "read" | "unread"
+  ): Promise<Array<[string, string[]]>> {
+    const conversation = await ConversationRepository.findById(client, conversationId)
+    if (!conversation || conversation.workspaceId !== workspaceId) {
+      throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+    }
+
+    const memberSet = new Set<string>([...conversation.messageIds, ...conversation.secondaryMessageIds])
+    const stream = await StreamRepository.findById(client, conversation.streamId)
+    if (stream?.type === StreamTypes.THREAD && stream.parentMessageId) {
+      memberSet.add(stream.parentMessageId)
+    }
+
+    const fetchIds = new Set(memberSet)
+    fetchIds.add(targetMessageId)
+    const messagesMap = await MessageRepository.findByIds(client, [...fetchIds])
+
+    const target = messagesMap.get(targetMessageId)
+    if (!target) {
+      throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+    }
+    const cutoff = target.createdAt.getTime()
+
+    const groups = new Map<string, string[]>()
+    for (const id of memberSet) {
+      const message = messagesMap.get(id)
+      if (!message) continue
+      const at = message.createdAt.getTime()
+      const include = direction === "read" ? at <= cutoff : at >= cutoff
+      if (!include) continue
+      const list = groups.get(message.streamId)
+      if (list) list.push(id)
+      else groups.set(message.streamId, [id])
+    }
+
+    // Map keys are unique, so a strict less-than comparator totally orders them.
+    return [...groups.entries()].sort(([a], [b]) => (a < b ? -1 : 1))
   }
 }
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -4,6 +4,7 @@ import { ConversationRepository, type Conversation } from "./repository"
 import { ConversationFeedbackRepository } from "./feedback-repository"
 import { MessageRepository, type Message } from "../messaging"
 import { StreamRepository, applySparseRead, applySparseUnread, type ReadStateSnapshot } from "../streams"
+import { ActivityRepository } from "../activity"
 import { AttachmentRepository, toAttachmentSummary } from "../attachments"
 import { LinkPreviewRepository, toLinkPreviewSummary } from "../link-previews"
 import { OutboxRepository } from "../../lib/outbox"
@@ -455,6 +456,15 @@ export class ConversationService {
           })
         )
       }
+      // Message-granular activity coupling: reading these messages clears their
+      // activity rows (mention/reply badges) — and only theirs, so the stream's
+      // other topics keep their badges. One batched update across all streams.
+      await ActivityRepository.markMessagesAsRead(
+        client,
+        params.workspaceId,
+        params.userId,
+        groups.flatMap(([, messageIds]) => messageIds)
+      )
       return { streams }
     })
   }

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -1,8 +1,8 @@
 import type { Pool, PoolClient } from "pg"
-import { withTransaction, withClient } from "../../db"
+import { withTransaction, withClient, sql } from "../../db"
 import { StreamEventRepository, type StreamEvent, type MoveEventIdSequenceUpdate } from "../streams"
 import { StreamRepository } from "../streams"
-import { StreamMemberRepository } from "../streams"
+import { StreamMemberRepository, SparseReadRepository } from "../streams"
 import { checkStreamAccess, resolveEffectiveAccessStream } from "../streams"
 import { MessageRepository, type Message, type MoveMessageSequenceUpdate } from "./repository"
 import { ShareService, type ResolveEffectiveStream } from "./sharing"
@@ -958,6 +958,18 @@ export class EventService {
 
       const message = await MessageRepository.softDelete(client, params.messageId)
 
+      // A2 (sparse-read design): a deleted message's unread activity rows would
+      // otherwise survive forever unless the user opens that exact stream, keeping
+      // a phantom badge. Mark them read in the delete transaction; clients drop
+      // held rows for the id on the `message_deleted` stream event.
+      await client.query(sql`
+        UPDATE user_activity
+        SET read_at = NOW()
+        WHERE workspace_id = ${params.workspaceId}
+          AND message_id = ${params.messageId}
+          AND read_at IS NULL
+      `)
+
       if (message) {
         await OutboxRepository.insert(client, "message:deleted", {
           workspaceId: params.workspaceId,
@@ -1195,6 +1207,24 @@ export class EventService {
       })
       await MessageRepository.moveToStream(client, destinationThread.id, updates)
 
+      // Sparse-read follow-through (docs/sparse-read-overlay-design.md), run AFTER
+      // the events are relocated so the destination sequences are readable:
+      //  - rehome every member's overlay rows for the moved messages to the
+      //    destination (stream_id/event_id/sequence refreshed), and
+      //  - A3: repoint any SOURCE membership whose watermark was one of the moved
+      //    events to the nearest surviving prior source event — otherwise it counts
+      //    unread against a foreign thread-space sequence (survives reload).
+      await SparseReadRepository.rehomeReads(client, {
+        sourceStreamId: params.sourceStreamId,
+        destinationStreamId: destinationThread.id,
+        messageIds: uniqueMessageIds,
+      })
+      await StreamMemberRepository.repointWatermarksForMovedEvents(
+        client,
+        params.sourceStreamId,
+        movableEvents.map((entry) => ({ eventId: entry.event.id, sequence: entry.event.sequence }))
+      )
+
       // Thread re-pointing: the target message just became a thread, so any reply
       // draft composed against it (scope `thread:{targetMessageId}`) follows the
       // message into the new thread stream (`stream:{destinationThread.id}`).
@@ -1348,6 +1378,14 @@ export class EventService {
       const removedEventIds = [...movedEvents, ...movedAgentSessionEvents].map((event) => event.id)
       const serializedSourceTombstone = serializeBigInt(sourceTombstone) as unknown as WireStreamEvent
 
+      // A1 (sparse-read design): the move dropped the source's true message count.
+      // Ship the post-move source ordinal so the client SETs `latestOrdinals` down
+      // (no applier corrects it downward otherwise → sticky phantom unread).
+      const sourceMessageCounts = await StreamEventRepository.countMessagesByStreamBatch(client, [
+        params.sourceStreamId,
+      ])
+      const sourceMessageOrdinal = sourceMessageCounts.get(params.sourceStreamId) ?? 0
+
       await OutboxRepository.insert(client, "messages:moved", {
         workspaceId: params.workspaceId,
         streamId: params.sourceStreamId,
@@ -1361,6 +1399,7 @@ export class EventService {
         sourceTombstoneEvent: serializedSourceTombstone,
         parentReplyCount,
         parentThreadSummary,
+        sourceMessageOrdinal,
       })
 
       return {

--- a/apps/backend/src/features/streams/event-repository.ts
+++ b/apps/backend/src/features/streams/event-repository.ts
@@ -384,6 +384,25 @@ export const StreamEventRepository = {
   },
 
   /**
+   * The lowest-sequence `message_created` event among `messageIds` in a stream —
+   * the earliest affected message for a conversation mark-unread regress. Null
+   * when none of the ids resolve to a message event in the stream.
+   */
+  async findEarliestMessageEvent(db: Querier, streamId: string, messageIds: string[]): Promise<StreamEvent | null> {
+    if (messageIds.length === 0) return null
+    const result = await db.query<StreamEventRow>(sql`
+      SELECT id, stream_id, sequence, broadcast_sequence, event_type, payload, actor_id, actor_type, created_at
+      FROM stream_events
+      WHERE stream_id = ${streamId}
+        AND event_type = 'message_created'
+        AND payload->>'messageId' = ANY(${messageIds}::text[])
+      ORDER BY sequence ASC
+      LIMIT 1
+    `)
+    return result.rows[0] ? mapRowToEvent(result.rows[0]) : null
+  },
+
+  /**
    * The message_created event immediately before `sequence` in viewer order.
    * Used as the read pointer for "mark unread" — set the membership here so the
    * message at `sequence` and everything after it count as unread. Returns null
@@ -688,33 +707,46 @@ export const StreamEventRepository = {
    */
   async countUnreadByStreamBatch(
     db: Querier,
-    memberships: Array<{ streamId: string; lastReadEventId: string | null }>
+    memberships: Array<{ streamId: string; memberId: string; lastReadEventId: string | null }>
   ): Promise<Map<string, { unreadCount: number; totalCount: number }>> {
     if (memberships.length === 0) return new Map()
 
     const streamIds = memberships.map((m) => m.streamId)
+    const memberIds = memberships.map((m) => m.memberId)
     const lastReadEventIds = memberships.map((m) => m.lastReadEventId)
 
+    // Effective unread = messages above the watermark − the sparse overlay count
+    // (individually-read messages above the watermark). The overlay invariant
+    // keeps those rows strictly above the watermark, so the two sets are disjoint
+    // and the subtraction can't go negative; GREATEST guards a torn read anyway.
     const result = await db.query<{ stream_id: string; unread_count: string; total_count: string }>(
       `
       WITH memberships AS (
         SELECT
           m.stream_id,
+          m.member_id,
           COALESCE(se.sequence, 0) as last_read_seq
         FROM (
-          SELECT unnest($1::text[]) as stream_id, unnest($2::text[]) as last_read_event_id
+          SELECT unnest($1::text[]) as stream_id, unnest($2::text[]) as member_id, unnest($3::text[]) as last_read_event_id
         ) m
         LEFT JOIN stream_events se ON se.id = m.last_read_event_id
       )
       SELECT
         m.stream_id,
-        COUNT(*) FILTER (WHERE e.sequence > m.last_read_seq)::text as unread_count,
+        GREATEST(
+          COUNT(*) FILTER (WHERE e.sequence > m.last_read_seq)
+          - COALESCE((
+              SELECT COUNT(*) FROM stream_member_message_reads r
+              WHERE r.stream_id = m.stream_id AND r.member_id = m.member_id
+            ), 0),
+          0
+        )::text as unread_count,
         COUNT(e.id)::text as total_count
       FROM memberships m
       LEFT JOIN stream_events e ON e.stream_id = m.stream_id AND e.event_type = 'message_created'
-      GROUP BY m.stream_id
+      GROUP BY m.stream_id, m.member_id
     `,
-      [streamIds, lastReadEventIds]
+      [streamIds, memberIds, lastReadEventIds]
     )
 
     const map = new Map<string, { unreadCount: number; totalCount: number }>()
@@ -772,6 +804,23 @@ export const StreamEventRepository = {
     const row = result.rows[0]
     if (!row) return null
     return { sequence: BigInt(row.sequence), messageOrdinal: parseInt(row.message_ordinal, 10) }
+  },
+
+  /**
+   * Resolve a batch of event ids to their per-stream `sequence` (bigint as
+   * string). Missing ids are absent from the map. Backs the bootstrap membership
+   * `lastReadSequence` — the client needs the watermark's sequence to place its
+   * read frontier against the sparse overlay.
+   */
+  async getSequencesByEventIds(db: Querier, eventIds: string[]): Promise<Map<string, string>> {
+    if (eventIds.length === 0) return new Map()
+    const result = await db.query<{ id: string; sequence: string }>(sql`
+      SELECT id, sequence FROM stream_events
+      WHERE id = ANY(${eventIds}::text[])
+    `)
+    const map = new Map<string, string>()
+    for (const row of result.rows) map.set(row.id, row.sequence)
+    return map
   },
 
   /**

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -961,7 +961,9 @@ export function createStreamHandlers({
         })
       )
 
-      const unreadCount = membership ? await streamService.getUnreadCount(streamId, membership.lastReadEventId) : 0
+      const unreadCount = membership
+        ? await streamService.getUnreadCount(streamId, userId, membership.lastReadEventId)
+        : 0
 
       let events = await eventService.listEvents(streamId, {
         limit: afterSequence !== undefined ? EVENTS_DEFAULT_LIMIT + 1 : EVENTS_DEFAULT_LIMIT,

--- a/apps/backend/src/features/streams/index.ts
+++ b/apps/backend/src/features/streams/index.ts
@@ -61,5 +61,11 @@ export type { MemoStreamState, StreamReadyToProcess } from "./state-repository"
 
 export { StreamPoliciesRepository } from "./policy-repository"
 
+export { SparseReadRepository } from "./sparse-read-repository"
+export type { CompactionTarget } from "./sparse-read-repository"
+
+export { applySparseRead, applySparseUnread } from "./sparse-read"
+export type { ReadStateSnapshot, ApplySparseReadParams } from "./sparse-read"
+
 export { getEffectiveDisplayName, formatParticipantNames, needsAutoNaming } from "./display-name"
 export type { DisplayNameSource, DisplayNameContext, EffectiveDisplayName } from "./display-name"

--- a/apps/backend/src/features/streams/member-repository.ts
+++ b/apps/backend/src/features/streams/member-repository.ts
@@ -47,6 +47,24 @@ export const StreamMemberRepository = {
     return result.rows[0] ? mapRowToMember(result.rows[0]) : null
   },
 
+  /**
+   * Locked read of one membership row (`FOR UPDATE`). Returns null when the
+   * member has no row on the stream — the sparse-read core relies on this to tell
+   * a member stream (watermark + compaction) apart from a non-member thread leg
+   * (overlay-only, no row to lock). Serializes concurrent read/unread writes for
+   * the same (stream, member) behind the lock (INV-20).
+   */
+  async findByStreamAndMemberForUpdate(db: Querier, streamId: string, memberId: string): Promise<StreamMember | null> {
+    const result = await db.query<StreamMemberRow>(sql`
+      SELECT stream_id, member_id, notification_level,
+             last_read_event_id, last_read_at, joined_at
+      FROM stream_members
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+      FOR UPDATE
+    `)
+    return result.rows[0] ? mapRowToMember(result.rows[0]) : null
+  },
+
   async findByStreamsAndMember(db: Querier, streamIds: string[], memberId: string): Promise<StreamMember[]> {
     if (streamIds.length === 0) return []
 
@@ -225,12 +243,7 @@ export const StreamMemberRepository = {
    * whose source message the recipient has already read — closing the race where
    * the read-time activity clear runs before the async activity row is written.
    */
-  async membersReadThrough(
-    db: Querier,
-    streamId: string,
-    memberIds: string[],
-    sequence: bigint
-  ): Promise<Set<string>> {
+  async membersReadThrough(db: Querier, streamId: string, memberIds: string[], sequence: bigint): Promise<Set<string>> {
     if (memberIds.length === 0) return new Set()
     const result = await db.query<{ member_id: string }>(sql`
       SELECT sm.member_id
@@ -241,6 +254,47 @@ export const StreamMemberRepository = {
         AND se.sequence >= ${sequence.toString()}
     `)
     return new Set(result.rows.map((row) => row.member_id))
+  },
+
+  /**
+   * A3 fix (sparse-read design): after a move relocates events out of a source
+   * stream, any source membership whose `last_read_event_id` is one of those
+   * moved events now counts unread against a foreign thread-space sequence. Repoint
+   * each such watermark to the nearest surviving prior event in the source stream
+   * (greatest sequence strictly below the moved event's original source sequence),
+   * or null when nothing prior survives. Set-based (INV-56); MUST run AFTER the
+   * move so the moved rows are already gone from the source and can't be chosen as
+   * their own predecessor.
+   */
+  async repointWatermarksForMovedEvents(
+    db: Querier,
+    sourceStreamId: string,
+    movedEvents: Array<{ eventId: string; sequence: bigint }>
+  ): Promise<void> {
+    if (movedEvents.length === 0) return
+    const eventIds = movedEvents.map((e) => e.eventId)
+    const sequences = movedEvents.map((e) => e.sequence.toString())
+    await db.query(
+      `
+      WITH moved AS (
+        SELECT unnest($2::text[]) AS event_id, unnest($3::bigint[]) AS src_seq
+      ),
+      repoint AS (
+        SELECT sm.member_id,
+          (SELECT e.id FROM stream_events e
+             WHERE e.stream_id = $1 AND e.sequence < moved.src_seq
+             ORDER BY e.sequence DESC LIMIT 1) AS new_event_id
+        FROM stream_members sm
+        JOIN moved ON moved.event_id = sm.last_read_event_id
+        WHERE sm.stream_id = $1
+      )
+      UPDATE stream_members sm
+      SET last_read_event_id = repoint.new_event_id, last_read_at = NOW()
+      FROM repoint
+      WHERE sm.stream_id = $1 AND sm.member_id = repoint.member_id
+      `,
+      [sourceStreamId, eventIds, sequences]
+    )
   },
 
   async delete(db: Querier, streamId: string, memberId: string): Promise<boolean> {

--- a/apps/backend/src/features/streams/member-repository.ts
+++ b/apps/backend/src/features/streams/member-repository.ts
@@ -264,7 +264,10 @@ export const StreamMemberRepository = {
    * (greatest sequence strictly below the moved event's original source sequence),
    * or null when nothing prior survives. Set-based (INV-56); MUST run AFTER the
    * move so the moved rows are already gone from the source and can't be chosen as
-   * their own predecessor.
+   * their own predecessor. `last_read_at` is deliberately left untouched: this is
+   * an automated correction, not a read, and the timestamp feeds the conversation
+   * card's time fallback — bumping it to NOW() would falsely mark every older
+   * sequenceless/non-member-thread row as read.
    */
   async repointWatermarksForMovedEvents(
     db: Querier,
@@ -289,7 +292,7 @@ export const StreamMemberRepository = {
         WHERE sm.stream_id = $1
       )
       UPDATE stream_members sm
-      SET last_read_event_id = repoint.new_event_id, last_read_at = NOW()
+      SET last_read_event_id = repoint.new_event_id
       FROM repoint
       WHERE sm.stream_id = $1 AND sm.member_id = repoint.member_id
       `,

--- a/apps/backend/src/features/streams/service.test.ts
+++ b/apps/backend/src/features/streams/service.test.ts
@@ -4,6 +4,7 @@ import { StreamService } from "./service"
 import { StreamRepository } from "./repository"
 import { StreamMemberRepository, type StreamMember } from "./member-repository"
 import { StreamEventRepository } from "./event-repository"
+import { SparseReadRepository } from "./sparse-read-repository"
 import { OutboxRepository } from "../../lib/outbox"
 import { UserRepository } from "../workspaces"
 import { MessageRepository } from "../messaging"
@@ -27,6 +28,12 @@ const mockInsertStream = spyOn(StreamRepository, "insert")
 const mockMarkStreamE2e = spyOn(E2eStreamsRepository, "markStreamE2e")
 const mockUpdate = spyOn(StreamRepository, "update")
 const mockUpdateSealedName = spyOn(E2eStreamsRepository, "updateSealedName")
+// Sparse read overlay pruning/listing runs inside the watermark write paths;
+// stub against the fake `{}` client so unit tests never touch a real DB.
+const mockPruneAtOrBelow = spyOn(SparseReadRepository, "pruneAtOrBelow").mockResolvedValue(undefined)
+const mockDeleteAtOrAbove = spyOn(SparseReadRepository, "deleteAtOrAbove").mockResolvedValue(undefined)
+const mockDeleteAllForStreams = spyOn(SparseReadRepository, "deleteAllForStreams").mockResolvedValue(undefined)
+const mockListOverlayIds = spyOn(SparseReadRepository, "listOverlayIds").mockResolvedValue([])
 
 spyOn(idModule, "eventId").mockReturnValue("evt_1")
 spyOn(idModule, "streamId").mockReturnValue("stream_new")
@@ -1290,6 +1297,7 @@ describe("StreamService.markAsRead", () => {
       lastReadEventId: "evt_9",
       lastReadSequence: "42",
       lastReadOrdinal: 7,
+      readMessageIds: [],
     })
   })
 
@@ -1355,7 +1363,9 @@ describe("StreamService.markUnread", () => {
       lastReadEventId: "evt_4",
       lastReadSequence: "40",
       lastReadOrdinal: 4,
+      readMessageIds: [],
     })
+    expect(mockDeleteAtOrAbove).toHaveBeenCalledWith({}, "stream_1", "usr_1", 50n)
   })
 
   test("clears the read pointer when the target is the first message", async () => {
@@ -1442,6 +1452,7 @@ describe("StreamService.markAllAsRead", () => {
     const updated = await service.markAllAsRead("ws_1", "usr_1")
 
     expect(updated).toEqual(["stream_1", "stream_2"])
+    expect(mockDeleteAllForStreams).toHaveBeenCalledWith({}, "usr_1", ["stream_1", "stream_2"])
     expect(mockCountMessages).toHaveBeenCalledWith({}, ["stream_1", "stream_2"])
     expect(mockInsertOutbox).toHaveBeenCalledWith({}, "stream:read_all", {
       workspaceId: "ws_1",

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1610,6 +1610,11 @@ export class StreamService {
     const deleted = await StreamMemberRepository.delete(client, stream.id, memberId)
     if (!deleted) return null
 
+    // The overlay leaves with the membership: a rejoin born-reads the watermark
+    // at latest, and any surviving row would sit below it — violating the
+    // strictly-above invariant and double-subtracting in the unread count.
+    await SparseReadRepository.deleteAllForStreams(client, memberId, [stream.id])
+
     const event = await StreamEventRepository.insert(client, {
       id: eventId(),
       streamId: stream.id,
@@ -1655,6 +1660,7 @@ export class StreamService {
       if (event) {
         // Batch-remove from all descendant threads the member is in (single recursive CTE)
         const removedStreamIds = await StreamMemberRepository.deleteByMemberInDescendants(client, memberId, streamId)
+        await SparseReadRepository.deleteAllForStreams(client, memberId, removedStreamIds)
         for (const removedStreamId of removedStreamIds) {
           const threadEvent = await StreamEventRepository.insert(client, {
             id: eventId(),

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -1881,9 +1881,15 @@ export class StreamService {
       if (membership) {
         // Mark-unread means "this message and everything after it is unread", so
         // overlay rows at/above the target contradict the intent — drop them. The
-        // watermark already regressed below the target; the remaining overlay is
-        // the holes still above it.
+        // pointer lands just before the target, which can also ADVANCE it (target
+        // above the old watermark, e.g. after board reads left holes): overlay
+        // rows now at/below the new watermark must go too, or they double-subtract
+        // in the effective unread count. `previous` is the message immediately
+        // before the target, so together the two deletes clear the whole overlay.
         await SparseReadRepository.deleteAtOrAbove(client, streamId, memberId, messageEvent.sequence)
+        if (previous) {
+          await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, previous.sequence)
+        }
         const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
         await OutboxRepository.insert(client, "stream:read_set", {
           workspaceId,

--- a/apps/backend/src/features/streams/service.ts
+++ b/apps/backend/src/features/streams/service.ts
@@ -11,6 +11,7 @@ import {
 } from "./repository"
 import { StreamMemberRepository, StreamMember } from "./member-repository"
 import { StreamEventRepository, type StreamEvent } from "./event-repository"
+import { SparseReadRepository } from "./sparse-read-repository"
 import { MessageRepository } from "../messaging"
 import { OutboxRepository } from "../../lib/outbox"
 import { streamId, eventId } from "../../lib/id"
@@ -1827,6 +1828,12 @@ export class StreamService {
 
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId: eventId })
       if (membership) {
+        // Overlay invariant: every overlay row sits strictly above the watermark.
+        // Advancing the watermark absorbs the run at/below it, so prune those rows
+        // in the same transaction; the remaining overlay is the absolute set the
+        // client keeps.
+        await SparseReadRepository.pruneAtOrBelow(client, streamId, memberId, position.sequence)
+        const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
         // Absolute read position (sync phase 2c): clients derive unread as
         // latestOrdinal - lastReadOrdinal, so the event carries where this read
         // lands in message-ordinal space.
@@ -1837,6 +1844,7 @@ export class StreamService {
           lastReadEventId: eventId,
           lastReadSequence: position.sequence.toString(),
           lastReadOrdinal: position.messageOrdinal,
+          readMessageIds,
         })
       }
       return membership
@@ -1871,6 +1879,12 @@ export class StreamService {
 
       const membership = await StreamMemberRepository.update(client, streamId, memberId, { lastReadEventId })
       if (membership) {
+        // Mark-unread means "this message and everything after it is unread", so
+        // overlay rows at/above the target contradict the intent — drop them. The
+        // watermark already regressed below the target; the remaining overlay is
+        // the holes still above it.
+        await SparseReadRepository.deleteAtOrAbove(client, streamId, memberId, messageEvent.sequence)
+        const readMessageIds = await SparseReadRepository.listOverlayIds(client, streamId, memberId)
         await OutboxRepository.insert(client, "stream:read_set", {
           workspaceId,
           authorId: memberId,
@@ -1878,6 +1892,7 @@ export class StreamService {
           lastReadEventId,
           lastReadSequence: (previous?.sequence ?? 0n).toString(),
           lastReadOrdinal,
+          readMessageIds,
         })
       }
       return membership
@@ -1913,6 +1928,10 @@ export class StreamService {
       const updatedStreamIds = Array.from(updatesToApply.keys())
 
       if (updatedStreamIds.length > 0) {
+        // Read-all pins each membership to its stream's latest event, so nothing
+        // can remain above the watermark — wipe every absorbed overlay row (the
+        // client clears each read stream's set on `stream:read_all`).
+        await SparseReadRepository.deleteAllForStreams(client, memberId, updatedStreamIds)
         // Read-all sets each membership to its stream's latest event, so the
         // absolute read position per stream is the stream's total message
         // count (sync phase 2c).
@@ -1933,14 +1952,24 @@ export class StreamService {
   }
 
   async getUnreadCounts(
-    memberships: Array<{ streamId: string; lastReadEventId: string | null }>
+    memberships: Array<{ streamId: string; memberId: string; lastReadEventId: string | null }>
   ): Promise<Map<string, { unreadCount: number; totalCount: number }>> {
     return StreamEventRepository.countUnreadByStreamBatch(this.pool, memberships)
   }
 
-  async getUnreadCount(streamId: string, lastReadEventId: string | null): Promise<number> {
-    const unreadCounts = await this.getUnreadCounts([{ streamId, lastReadEventId }])
+  async getUnreadCount(streamId: string, memberId: string, lastReadEventId: string | null): Promise<number> {
+    const unreadCounts = await this.getUnreadCounts([{ streamId, memberId, lastReadEventId }])
     return unreadCounts.get(streamId)?.unreadCount ?? 0
+  }
+
+  /** The member's sparse read overlay across `streamIds`, keyed by stream id (bootstrap). */
+  async getReadOverlayForMember(memberId: string, streamIds: string[]): Promise<Map<string, string[]>> {
+    return SparseReadRepository.listOverlayIdsForMember(this.pool, memberId, streamIds)
+  }
+
+  /** Resolve watermark event ids to per-stream sequences (bootstrap membership `lastReadSequence`). */
+  async getSequencesByEventIds(eventIds: string[]): Promise<Map<string, string>> {
+    return StreamEventRepository.getSequencesByEventIds(this.pool, eventIds)
   }
 
   async getThreadsForMessages(streamId: string): Promise<Map<string, string>> {

--- a/apps/backend/src/features/streams/sparse-read-repository.test.ts
+++ b/apps/backend/src/features/streams/sparse-read-repository.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, mock } from "bun:test"
+import { SparseReadRepository } from "./sparse-read-repository"
+import type { Querier } from "../../db"
+
+function makeDb(rows: Record<string, unknown>[]) {
+  const query = mock(() => Promise.resolve({ rows, rowCount: rows.length }))
+  return { query, _query: query } as unknown as Querier & { _query: ReturnType<typeof mock> }
+}
+
+describe("SparseReadRepository row mapping", () => {
+  test("listOverlayIds returns message ids in row order", async () => {
+    const db = makeDb([{ message_id: "msg_a" }, { message_id: "msg_b" }])
+    const ids = await SparseReadRepository.listOverlayIds(db, "stream_1", "usr_1")
+    expect(ids).toEqual(["msg_a", "msg_b"])
+    expect(db._query).toHaveBeenCalledTimes(1)
+  })
+
+  test("listOverlayIdsForMember groups ids by stream id, preserving order", async () => {
+    const db = makeDb([
+      { stream_id: "stream_1", message_id: "msg_a" },
+      { stream_id: "stream_1", message_id: "msg_b" },
+      { stream_id: "stream_2", message_id: "msg_c" },
+    ])
+    const map = await SparseReadRepository.listOverlayIdsForMember(db, "usr_1", ["stream_1", "stream_2"])
+    expect(Object.fromEntries(map)).toEqual({ stream_1: ["msg_a", "msg_b"], stream_2: ["msg_c"] })
+  })
+
+  test("findCompactionTarget maps the row to an event id + bigint sequence", async () => {
+    const db = makeDb([{ event_id: "evt_9", sequence: "42" }])
+    const target = await SparseReadRepository.findCompactionTarget(db, "stream_1", "usr_1", 0n)
+    expect(target).toEqual({ eventId: "evt_9", sequence: 42n })
+  })
+
+  test("findCompactionTarget returns null when nothing above the watermark is covered", async () => {
+    const db = makeDb([])
+    expect(await SparseReadRepository.findCompactionTarget(db, "stream_1", "usr_1", 5n)).toBeNull()
+  })
+
+  test("countOverlay parses the count", async () => {
+    const db = makeDb([{ count: "3" }])
+    expect(await SparseReadRepository.countOverlay(db, "stream_1", "usr_1")).toBe(3)
+  })
+
+  test("empty-input guards short-circuit without a query", async () => {
+    const db = makeDb([])
+    await SparseReadRepository.insertReads(db, { workspaceId: "ws", streamId: "s", memberId: "m", messageIds: [] })
+    await SparseReadRepository.deleteReads(db, "s", "m", [])
+    await SparseReadRepository.rehomeReads(db, { sourceStreamId: "s", destinationStreamId: "d", messageIds: [] })
+    expect(await SparseReadRepository.listOverlayIdsForMember(db, "m", [])).toEqual(new Map())
+    expect(db._query).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/streams/sparse-read-repository.ts
+++ b/apps/backend/src/features/streams/sparse-read-repository.ts
@@ -1,0 +1,202 @@
+import type { Querier } from "../../db"
+import { sql } from "../../db"
+
+/**
+ * The result of a compaction probe: the greatest message_created event above a
+ * member's watermark such that EVERY message from just-above-watermark up to and
+ * including it is in the overlay. `null` when the first message above the
+ * watermark isn't covered (nothing to absorb).
+ */
+export interface CompactionTarget {
+  eventId: string
+  sequence: bigint
+}
+
+/**
+ * Data access for the sparse read overlay (`stream_member_message_reads`) —
+ * individually-read messages above a (stream, member) watermark. Every method
+ * is a composable primitive (INV-27); the ordering/transaction guarantees live
+ * in the sparse-read application core, not here.
+ */
+export const SparseReadRepository = {
+  /**
+   * Bulk-insert overlay rows for `messageIds`, resolving each message's
+   * `event_id`/`sequence` from its `message_created` event in `streamId` via the
+   * unnest-join on `payload->>'messageId'` (the move flow's house pattern). Ids
+   * with no message_created event in the stream are silently dropped (the join
+   * yields no row). `ON CONFLICT DO NOTHING` (INV-20/56) — concurrent double
+   * apply is idempotent.
+   */
+  async insertReads(
+    db: Querier,
+    params: { workspaceId: string; streamId: string; memberId: string; messageIds: string[] }
+  ): Promise<void> {
+    if (params.messageIds.length === 0) return
+    await db.query(sql`
+      INSERT INTO stream_member_message_reads (workspace_id, stream_id, member_id, message_id, event_id, sequence)
+      SELECT ${params.workspaceId}, ${params.streamId}, ${params.memberId}, e.payload->>'messageId', e.id, e.sequence
+      FROM unnest(${params.messageIds}::text[]) AS ids(message_id)
+      JOIN stream_events e
+        ON e.stream_id = ${params.streamId}
+       AND e.event_type = 'message_created'
+       AND e.payload->>'messageId' = ids.message_id
+      ON CONFLICT (stream_id, member_id, message_id) DO NOTHING
+    `)
+  },
+
+  /** Remove specific overlay rows by (stream, member, messageIds). */
+  async deleteReads(db: Querier, streamId: string, memberId: string, messageIds: string[]): Promise<void> {
+    if (messageIds.length === 0) return
+    await db.query(sql`
+      DELETE FROM stream_member_message_reads
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+        AND message_id = ANY(${messageIds}::text[])
+    `)
+  },
+
+  /** The overlay message ids for one (stream, member), ascending by sequence. */
+  async listOverlayIds(db: Querier, streamId: string, memberId: string): Promise<string[]> {
+    const result = await db.query<{ message_id: string }>(sql`
+      SELECT message_id FROM stream_member_message_reads
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+      ORDER BY sequence ASC
+    `)
+    return result.rows.map((r) => r.message_id)
+  },
+
+  /**
+   * Overlay message ids for one member across many streams — the bootstrap
+   * `readMessageIds` map in a single batch. Streams with no overlay row are
+   * absent from the map (the caller omits empty streams anyway).
+   */
+  async listOverlayIdsForMember(db: Querier, memberId: string, streamIds: string[]): Promise<Map<string, string[]>> {
+    const map = new Map<string, string[]>()
+    if (streamIds.length === 0) return map
+    const result = await db.query<{ stream_id: string; message_id: string }>(sql`
+      SELECT stream_id, message_id FROM stream_member_message_reads
+      WHERE member_id = ${memberId} AND stream_id = ANY(${streamIds}::text[])
+      ORDER BY stream_id, sequence ASC
+    `)
+    for (const row of result.rows) {
+      const list = map.get(row.stream_id)
+      if (list) list.push(row.message_id)
+      else map.set(row.stream_id, [row.message_id])
+    }
+    return map
+  },
+
+  /** Prune overlay rows at or below `sequence` — the watermark-advance invariant. */
+  async pruneAtOrBelow(db: Querier, streamId: string, memberId: string, sequence: bigint): Promise<void> {
+    await db.query(sql`
+      DELETE FROM stream_member_message_reads
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+        AND sequence <= ${sequence.toString()}
+    `)
+  },
+
+  /**
+   * Delete overlay rows at or above `sequence` — mark-unread's inverse. Regressing
+   * to before message M means M and everything after it is unread, so overlay rows
+   * for messages at/after M contradict the intent and are dropped.
+   */
+  async deleteAtOrAbove(db: Querier, streamId: string, memberId: string, sequence: bigint): Promise<void> {
+    await db.query(sql`
+      DELETE FROM stream_member_message_reads
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+        AND sequence >= ${sequence.toString()}
+    `)
+  },
+
+  /** Wipe all overlay rows for a member across the given streams (mark-all-as-read). */
+  async deleteAllForStreams(db: Querier, memberId: string, streamIds: string[]): Promise<void> {
+    if (streamIds.length === 0) return
+    await db.query(sql`
+      DELETE FROM stream_member_message_reads
+      WHERE member_id = ${memberId} AND stream_id = ANY(${streamIds}::text[])
+    `)
+  },
+
+  /**
+   * The compaction target for (stream, member, watermarkSeq): the greatest
+   * message_created event W such that every message with `watermarkSeq < sequence
+   * <= W` is in the overlay. A window `bool_and(covered)` over ascending sequence
+   * flips false at the first uncovered message and stays false, so the last row
+   * still `true` is exactly W. `null` when the first message above the watermark
+   * isn't covered (no absorbable run).
+   */
+  async findCompactionTarget(
+    db: Querier,
+    streamId: string,
+    memberId: string,
+    watermarkSeq: bigint
+  ): Promise<CompactionTarget | null> {
+    const result = await db.query<{ event_id: string; sequence: string }>(sql`
+      WITH bound AS (
+        SELECT MAX(sequence) AS max_seq FROM stream_member_message_reads
+        WHERE stream_id = ${streamId} AND member_id = ${memberId}
+      ),
+      ordered AS (
+        SELECT
+          e.id AS event_id,
+          e.sequence,
+          (r.message_id IS NOT NULL) AS covered
+        FROM stream_events e
+        LEFT JOIN stream_member_message_reads r
+          ON r.stream_id = e.stream_id
+         AND r.member_id = ${memberId}
+         AND r.message_id = e.payload->>'messageId'
+        WHERE e.stream_id = ${streamId}
+          AND e.event_type = 'message_created'
+          AND e.sequence > ${watermarkSeq.toString()}
+          -- The target must itself be covered, so the run can never extend past
+          -- the overlay's max sequence; bounding here keeps the window scan
+          -- proportional to the conversation span, not the member's whole unread
+          -- backlog (a never-read busy channel would otherwise scan every event).
+          AND e.sequence <= (SELECT max_seq FROM bound)
+      ),
+      runs AS (
+        SELECT event_id, sequence, bool_and(covered) OVER (ORDER BY sequence ASC) AS contiguous
+        FROM ordered
+      )
+      SELECT event_id, sequence FROM runs
+      WHERE contiguous
+      ORDER BY sequence DESC
+      LIMIT 1
+    `)
+    const row = result.rows[0]
+    return row ? { eventId: row.event_id, sequence: BigInt(row.sequence) } : null
+  },
+
+  /** Overlay row count for one (stream, member). */
+  async countOverlay(db: Querier, streamId: string, memberId: string): Promise<number> {
+    const result = await db.query<{ count: string }>(sql`
+      SELECT COUNT(*)::text AS count FROM stream_member_message_reads
+      WHERE stream_id = ${streamId} AND member_id = ${memberId}
+    `)
+    return parseInt(result.rows[0].count, 10)
+  },
+
+  /**
+   * Rehome overlay rows for moved messages: refresh `stream_id`, `event_id`, and
+   * `sequence` to the destination values. Runs AFTER the move relocated the
+   * `message_created` rows, so the destination stream_events already carry the new
+   * sequence; the join reads it back. Every member's overlay row for a moved
+   * message follows the message.
+   */
+  async rehomeReads(
+    db: Querier,
+    params: { sourceStreamId: string; destinationStreamId: string; messageIds: string[] }
+  ): Promise<void> {
+    if (params.messageIds.length === 0) return
+    await db.query(sql`
+      UPDATE stream_member_message_reads r
+      SET stream_id = ${params.destinationStreamId}, event_id = e.id, sequence = e.sequence
+      FROM stream_events e
+      WHERE r.stream_id = ${params.sourceStreamId}
+        AND r.message_id = ANY(${params.messageIds}::text[])
+        AND e.stream_id = ${params.destinationStreamId}
+        AND e.event_type = 'message_created'
+        AND e.payload->>'messageId' = r.message_id
+    `)
+  },
+}

--- a/apps/backend/src/features/streams/sparse-read-repository.ts
+++ b/apps/backend/src/features/streams/sparse-read-repository.ts
@@ -139,12 +139,16 @@ export const SparseReadRepository = {
         SELECT
           e.id AS event_id,
           e.sequence,
-          (r.message_id IS NOT NULL) AS covered
+          -- Covered = individually read OR soft-deleted: a deleted message can
+          -- never be read by anyone, so it must not hold the watermark down.
+          (r.message_id IS NOT NULL OR m.deleted_at IS NOT NULL) AS covered
         FROM stream_events e
         LEFT JOIN stream_member_message_reads r
           ON r.stream_id = e.stream_id
          AND r.member_id = ${memberId}
          AND r.message_id = e.payload->>'messageId'
+        LEFT JOIN messages m
+          ON m.id = e.payload->>'messageId'
         WHERE e.stream_id = ${streamId}
           AND e.event_type = 'message_created'
           AND e.sequence > ${watermarkSeq.toString()}
@@ -161,6 +165,38 @@ export const SparseReadRepository = {
       SELECT event_id, sequence FROM runs
       WHERE contiguous
       ORDER BY sequence DESC
+      LIMIT 1
+    `)
+    const row = result.rows[0]
+    return row ? { eventId: row.event_id, sequence: BigInt(row.sequence) } : null
+  },
+
+  /**
+   * The end of the contiguous run of soft-deleted messages immediately above
+   * `afterSeq`, or null when the first message above it is alive (or none
+   * exists). The compaction window is bounded by the overlay's max sequence, so
+   * a deleted run ABOVE the last overlay row escapes it — this probe lets the
+   * watermark absorb that trailing dead water too. A missing `messages` row
+   * counts as alive (conservative: stops the run).
+   */
+  async findTrailingDeletedRunEnd(db: Querier, streamId: string, afterSeq: bigint): Promise<CompactionTarget | null> {
+    const result = await db.query<{ event_id: string; sequence: string }>(sql`
+      WITH first_alive AS (
+        SELECT MIN(e.sequence) AS seq
+        FROM stream_events e
+        LEFT JOIN messages m ON m.id = e.payload->>'messageId'
+        WHERE e.stream_id = ${streamId}
+          AND e.event_type = 'message_created'
+          AND e.sequence > ${afterSeq.toString()}
+          AND m.deleted_at IS NULL
+      )
+      SELECT e.id AS event_id, e.sequence
+      FROM stream_events e
+      WHERE e.stream_id = ${streamId}
+        AND e.event_type = 'message_created'
+        AND e.sequence > ${afterSeq.toString()}
+        AND e.sequence < COALESCE((SELECT seq FROM first_alive), 9223372036854775807)
+      ORDER BY e.sequence DESC
       LIMIT 1
     `)
     const row = result.rows[0]

--- a/apps/backend/src/features/streams/sparse-read.ts
+++ b/apps/backend/src/features/streams/sparse-read.ts
@@ -1,0 +1,167 @@
+import type { Querier } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
+import { StreamEventRepository } from "./event-repository"
+import { StreamMemberRepository } from "./member-repository"
+import { SparseReadRepository } from "./sparse-read-repository"
+
+/**
+ * The absolute post-write read-state for one stream — the shape both the socket
+ * snapshot (`stream:read_messages`) and the conversation read/unread HTTP
+ * responses carry. `readMessageIds` is the ENTIRE sparse overlay after the write.
+ */
+export interface ReadStateSnapshot {
+  streamId: string
+  readMessageIds: string[]
+  lastReadEventId: string | null
+  lastReadSequence: string
+  lastReadOrdinal: number
+}
+
+export interface ApplySparseReadParams {
+  workspaceId: string
+  streamId: string
+  memberId: string
+  /** Message ids to add to the overlay (already scoped to this stream). */
+  messageIds: string[]
+}
+
+async function resolveWatermarkSequence(db: Querier, streamId: string, eventId: string | null): Promise<bigint> {
+  if (!eventId) return 0n
+  const pos = await StreamEventRepository.getMessageOrdinalForEvent(db, streamId, eventId)
+  return pos ? pos.sequence : 0n
+}
+
+async function ordinalFor(db: Querier, streamId: string, sequence: bigint): Promise<number> {
+  return sequence > 0n ? StreamEventRepository.countMessagesThrough(db, streamId, sequence) : 0
+}
+
+/**
+ * Apply a conversation "mark read" to one stream: lock the membership row if it
+ * exists, insert the overlay rows, compact the contiguous run above the watermark
+ * into the watermark (pruning absorbed rows), and emit `stream:read_messages` with
+ * the absolute snapshot — all on the caller's transaction (INV-6/7). A non-member
+ * thread leg (no membership row) is overlay-only: no watermark, no compaction.
+ * Returns the post-write snapshot.
+ */
+export async function applySparseRead(db: Querier, params: ApplySparseReadParams): Promise<ReadStateSnapshot> {
+  const { workspaceId, streamId, memberId } = params
+
+  const membership = await StreamMemberRepository.findByStreamAndMemberForUpdate(db, streamId, memberId)
+
+  await SparseReadRepository.insertReads(db, {
+    workspaceId,
+    streamId,
+    memberId,
+    messageIds: params.messageIds,
+  })
+
+  let watermarkEventId = membership?.lastReadEventId ?? null
+  let watermarkSeq = await resolveWatermarkSequence(db, streamId, watermarkEventId)
+
+  if (membership) {
+    const target = await SparseReadRepository.findCompactionTarget(db, streamId, memberId, watermarkSeq)
+    if (target) {
+      await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: target.eventId })
+      await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, target.sequence)
+      watermarkEventId = target.eventId
+      watermarkSeq = target.sequence
+    }
+  }
+
+  const lastReadOrdinal = await ordinalFor(db, streamId, watermarkSeq)
+  const overlay = await SparseReadRepository.listOverlayIds(db, streamId, memberId)
+
+  const snapshot: ReadStateSnapshot = {
+    streamId,
+    readMessageIds: overlay,
+    lastReadEventId: watermarkEventId,
+    lastReadSequence: watermarkSeq.toString(),
+    lastReadOrdinal,
+  }
+
+  await OutboxRepository.insert(db, "stream:read_messages", {
+    workspaceId,
+    authorId: memberId,
+    streamId,
+    readMessageIds: overlay,
+    lastReadEventId: watermarkEventId,
+    lastReadSequence: watermarkSeq.toString(),
+    lastReadOrdinal,
+  })
+
+  return snapshot
+}
+
+/**
+ * Apply a conversation "mark unread" to one stream: drop the affected messages
+ * from the overlay, and — only when the watermark sits at/past the earliest
+ * affected message — regress it to just before that message (existing
+ * `stream:read_set` semantics, accepting collateral un-reading of interleaved
+ * messages). When the watermark is already behind the affected run, or there's no
+ * membership row (thread leg), the overlay delete alone suffices and the absolute
+ * `stream:read_messages` snapshot is emitted. Returns the post-write snapshot.
+ */
+export async function applySparseUnread(db: Querier, params: ApplySparseReadParams): Promise<ReadStateSnapshot> {
+  const { workspaceId, streamId, memberId, messageIds } = params
+
+  const membership = await StreamMemberRepository.findByStreamAndMemberForUpdate(db, streamId, memberId)
+
+  await SparseReadRepository.deleteReads(db, streamId, memberId, messageIds)
+
+  const earliest = await StreamEventRepository.findEarliestMessageEvent(db, streamId, messageIds)
+  const watermarkEventId = membership?.lastReadEventId ?? null
+  const watermarkSeq = await resolveWatermarkSequence(db, streamId, watermarkEventId)
+
+  if (membership && earliest && watermarkSeq >= earliest.sequence) {
+    const previous = await StreamEventRepository.findPreviousMessageEvent(db, streamId, earliest.sequence)
+    const newWatermarkEventId = previous?.id ?? null
+    const newWatermarkSeq = previous?.sequence ?? 0n
+    await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: newWatermarkEventId })
+
+    const lastReadOrdinal = await ordinalFor(db, streamId, newWatermarkSeq)
+    const overlay = await SparseReadRepository.listOverlayIds(db, streamId, memberId)
+
+    const snapshot: ReadStateSnapshot = {
+      streamId,
+      readMessageIds: overlay,
+      lastReadEventId: newWatermarkEventId,
+      lastReadSequence: newWatermarkSeq.toString(),
+      lastReadOrdinal,
+    }
+
+    await OutboxRepository.insert(db, "stream:read_set", {
+      workspaceId,
+      authorId: memberId,
+      streamId,
+      lastReadEventId: newWatermarkEventId,
+      lastReadSequence: newWatermarkSeq.toString(),
+      lastReadOrdinal,
+      readMessageIds: overlay,
+    })
+
+    return snapshot
+  }
+
+  const lastReadOrdinal = await ordinalFor(db, streamId, watermarkSeq)
+  const overlay = await SparseReadRepository.listOverlayIds(db, streamId, memberId)
+
+  const snapshot: ReadStateSnapshot = {
+    streamId,
+    readMessageIds: overlay,
+    lastReadEventId: watermarkEventId,
+    lastReadSequence: watermarkSeq.toString(),
+    lastReadOrdinal,
+  }
+
+  await OutboxRepository.insert(db, "stream:read_messages", {
+    workspaceId,
+    authorId: memberId,
+    streamId,
+    readMessageIds: overlay,
+    lastReadEventId: watermarkEventId,
+    lastReadSequence: watermarkSeq.toString(),
+    lastReadOrdinal,
+  })
+
+  return snapshot
+}

--- a/apps/backend/src/features/streams/sparse-read.ts
+++ b/apps/backend/src/features/streams/sparse-read.ts
@@ -15,6 +15,12 @@ export interface ReadStateSnapshot {
   lastReadEventId: string | null
   lastReadSequence: string
   lastReadOrdinal: number
+  /**
+   * The message ids this write marked read (pre-compaction, this stream's
+   * slice) — set on the read path only. Drives the client's message-granular
+   * activity drop; absent on unread/regress snapshots.
+   */
+  markedMessageIds?: string[]
 }
 
 export interface ApplySparseReadParams {
@@ -69,10 +75,21 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
   if (membership) {
     const target = await SparseReadRepository.findCompactionTarget(db, streamId, memberId, watermarkSeq)
     if (target) {
-      await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: target.eventId })
-      await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, target.sequence)
       watermarkEventId = target.eventId
       watermarkSeq = target.sequence
+    }
+    // The tide also rises over sunken rocks: a trailing run of DELETED messages
+    // just above the (possibly compacted) watermark can never be read by anyone,
+    // so absorb it too — otherwise agent-deleted transients above the watermark
+    // stall it forever and the stream can never fully read from the board.
+    const deletedRun = await SparseReadRepository.findTrailingDeletedRunEnd(db, streamId, watermarkSeq)
+    if (deletedRun) {
+      watermarkEventId = deletedRun.eventId
+      watermarkSeq = deletedRun.sequence
+    }
+    if (watermarkEventId !== (membership.lastReadEventId ?? null)) {
+      await StreamMemberRepository.update(db, streamId, memberId, { lastReadEventId: watermarkEventId })
+      await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
     }
   }
 
@@ -85,6 +102,7 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
     lastReadEventId: watermarkEventId,
     lastReadSequence: watermarkSeq.toString(),
     lastReadOrdinal,
+    markedMessageIds: params.messageIds,
   }
 
   await OutboxRepository.insert(db, "stream:read_messages", {
@@ -95,6 +113,7 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
     lastReadEventId: watermarkEventId,
     lastReadSequence: watermarkSeq.toString(),
     lastReadOrdinal,
+    markedMessageIds: params.messageIds,
   })
 
   return snapshot

--- a/apps/backend/src/features/streams/sparse-read.ts
+++ b/apps/backend/src/features/streams/sparse-read.ts
@@ -58,6 +58,14 @@ export async function applySparseRead(db: Querier, params: ApplySparseReadParams
   let watermarkEventId = membership?.lastReadEventId ?? null
   let watermarkSeq = await resolveWatermarkSequence(db, streamId, watermarkEventId)
 
+  // The conversation cutoff filters by createdAt only, so member ids at/below
+  // the watermark reach the insert; drop them unconditionally (not just in the
+  // compaction branch) or they double-subtract in the effective unread count —
+  // the overlay invariant is "every row strictly above the watermark".
+  if (watermarkSeq > 0n) {
+    await SparseReadRepository.pruneAtOrBelow(db, streamId, memberId, watermarkSeq)
+  }
+
   if (membership) {
     const target = await SparseReadRepository.findCompactionTarget(db, streamId, memberId, watermarkSeq)
     if (target) {

--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -201,7 +201,7 @@ export function createWorkspaceHandlers({
 
       const [unreadCountsMap, activityCounts, unreadActivities] = await Promise.all([
         streamService.getUnreadCounts(
-          streamMemberships.map((m) => ({ streamId: m.streamId, lastReadEventId: m.lastReadEventId }))
+          streamMemberships.map((m) => ({ streamId: m.streamId, memberId: userId, lastReadEventId: m.lastReadEventId }))
         ),
         activityService?.getUnreadCounts(userId, workspaceId),
         activityService?.listFeed(userId, workspaceId, { unreadOnly: true, othersOnly: true, limit: 200 }),
@@ -212,6 +212,27 @@ export function createWorkspaceHandlers({
         unreadCounts[streamId] = counts.unreadCount
         messageCounts[streamId] = counts.totalCount
       }
+
+      // Sparse read overlay (docs/sparse-read-overlay-design.md): the per-stream
+      // set of individually-read messages above each watermark. `unreadCounts`
+      // above is already net of the overlay; the client also needs the raw ids
+      // (to render row read state) and each watermark's sequence (to place the
+      // read frontier against the overlay).
+      const membershipStreamIds = streamMemberships.map((m) => m.streamId)
+      const [readOverlayMap, watermarkSequences] = await Promise.all([
+        streamService.getReadOverlayForMember(userId, membershipStreamIds),
+        streamService.getSequencesByEventIds(
+          streamMemberships.map((m) => m.lastReadEventId).filter((id): id is string => Boolean(id))
+        ),
+      ])
+      const readMessageIds: Record<string, string[]> = {}
+      for (const [streamId, ids] of readOverlayMap) {
+        if (ids.length > 0) readMessageIds[streamId] = ids
+      }
+      const serializedMemberships = streamMemberships.map((m) => ({
+        ...m,
+        lastReadSequence: m.lastReadEventId ? (watermarkSequences.get(m.lastReadEventId) ?? null) : null,
+      }))
 
       const mentionCounts: Record<string, number> = {}
       const activityCountsPerStream: Record<string, number> = {}
@@ -256,7 +277,8 @@ export function createWorkspaceHandlers({
           workspace,
           users,
           streams: resolvedStreams,
-          streamMemberships,
+          streamMemberships: serializedMemberships,
+          readMessageIds,
           personas,
           bots: bots.map(serializeBot),
           emojis: getEmojiList(),

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -42,6 +42,7 @@ export type OutboxEventType =
   | "stream:read"
   | "stream:read_set"
   | "stream:read_all"
+  | "stream:read_messages"
   | "stream:notification_level_updated"
   | "stream:activity"
   | "attachment:uploaded"
@@ -203,6 +204,15 @@ export interface MessagesMovedOutboxPayload extends StreamScopedPayload {
    * land alongside the move without waiting for a second event.
    */
   parentThreadSummary: import("@threa/types").ThreadSummary | null
+  /**
+   * The SOURCE stream's `message_created` count AFTER the move relocated rows
+   * out of it. The move drops the source's true message ordinal, but no client
+   * applier ever corrects `latestOrdinals` downward (max-merge only), so stale
+   * inflated unread sticks for the session. The client SETs
+   * `latestOrdinals[source]` to this value and recomputes unread — the one
+   * sanctioned non-monotonic latest write (fix A1, sparse-read design).
+   */
+  sourceMessageOrdinal: number
 }
 
 export interface MessageUpdatedOutboxPayload extends StreamScopedPayload {
@@ -478,6 +488,28 @@ export interface StreamReadOutboxPayload extends WorkspaceScopedPayload {
    * unread as latestOrdinal - lastReadOrdinal.
    */
   lastReadOrdinal: number
+  /**
+   * The member's ENTIRE sparse read overlay for this stream after the watermark
+   * advance + prune (usually empty — the advance absorbs the run below it). The
+   * client SETs its overlay to this absolute snapshot. See the sparse-read design.
+   */
+  readMessageIds: string[]
+}
+
+/**
+ * The absolute post-write read-state snapshot for one stream, emitted by every
+ * sparse-read overlay write (conversation read/unread). `readMessageIds` is the
+ * ENTIRE overlay after the write (post-compaction) — absolute state, not a delta,
+ * so application is idempotent under the sync log's total order. Author-scoped.
+ */
+export interface StreamReadMessagesOutboxPayload extends WorkspaceScopedPayload {
+  authorId: string
+  streamId: string
+  readMessageIds: string[]
+  lastReadEventId: string | null
+  /** The watermark's per-stream sequence (bigint as string; "0" when no watermark). */
+  lastReadSequence: string
+  lastReadOrdinal: number
 }
 
 /**
@@ -495,6 +527,11 @@ export interface StreamReadSetOutboxPayload extends WorkspaceScopedPayload {
   lastReadSequence: string
   /** Message ordinal of the read pointer; clients derive unread as latestOrdinal - lastReadOrdinal. */
   lastReadOrdinal: number
+  /**
+   * The member's ENTIRE sparse read overlay for this stream after the pointer
+   * SET + overlay delete. The client SETs its overlay to this absolute snapshot.
+   */
+  readMessageIds: string[]
 }
 
 // Notification-level event payload (author-scoped — the mute/notify choice is
@@ -818,6 +855,7 @@ export interface OutboxEventPayloadMap {
   "stream:read": StreamReadOutboxPayload
   "stream:read_set": StreamReadSetOutboxPayload
   "stream:read_all": StreamsReadAllOutboxPayload
+  "stream:read_messages": StreamReadMessagesOutboxPayload
   "stream:notification_level_updated": StreamNotificationLevelUpdatedOutboxPayload
   "stream:activity": StreamActivityOutboxPayload
   "attachment:uploaded": AttachmentUploadedOutboxPayload
@@ -947,6 +985,7 @@ export type AuthorScopedEventType =
   | "stream:read"
   | "stream:read_set"
   | "stream:read_all"
+  | "stream:read_messages"
   | "stream:notification_level_updated"
   | "user_preferences:updated"
   | "sidebar_config:updated"
@@ -956,6 +995,7 @@ const AUTHOR_SCOPED_EVENTS: AuthorScopedEventType[] = [
   "stream:read",
   "stream:read_set",
   "stream:read_all",
+  "stream:read_messages",
   "stream:notification_level_updated",
   "link_preview:dismissed",
   "user_preferences:updated",

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -510,6 +510,9 @@ export interface StreamReadMessagesOutboxPayload extends WorkspaceScopedPayload 
   /** The watermark's per-stream sequence (bigint as string; "0" when no watermark). */
   lastReadSequence: string
   lastReadOrdinal: number
+  /** The ids this write marked read (pre-compaction) — drives the client's
+   * message-granular activity drop. Absent on unread/regress writes. */
+  markedMessageIds?: string[]
 }
 
 /**

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -500,6 +500,8 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     conversation.reassignMessage
   )
+  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/read", ...authed, conversation.markRead)
+  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/unread", ...authed, conversation.markUnread)
 
   app.post("/api/workspaces/:workspaceId/commands/dispatch", ...authed, rateLimits.commandDispatch, command.dispatch)
   app.get("/api/workspaces/:workspaceId/commands", ...authed, command.list)

--- a/apps/backend/tests/integration/conversation-read.test.ts
+++ b/apps/backend/tests/integration/conversation-read.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../src/features/streams"
 import { EventService } from "../../src/features/messaging"
 import { ConversationService } from "../../src/features/conversations"
+import { ActivityRepository } from "../../src/features/activity"
 import { streamId, userId, workspaceId, conversationId } from "../../src/lib/id"
 
 describe("ConversationService read/unread", () => {
@@ -30,6 +31,7 @@ describe("ConversationService read/unread", () => {
 
   beforeEach(async () => {
     await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM user_activity")
     await pool.query("DELETE FROM conversations")
     await pool.query("DELETE FROM messages")
     await pool.query("DELETE FROM stream_events")
@@ -129,6 +131,7 @@ describe("ConversationService read/unread", () => {
       lastReadEventId: rootEvents.get(msg2)!.id,
       lastReadSequence: rootEvents.get(msg2)!.sequence.toString(),
       lastReadOrdinal: 2,
+      markedMessageIds: [msg1, msg2],
     })
 
     // Thread: non-member leg → overlay-only, only tmsg1 (tmsg2 excluded by cutoff).
@@ -136,6 +139,59 @@ describe("ConversationService read/unread", () => {
     expect(threadSnap.lastReadEventId).toBeNull()
     expect(threadSnap.readMessageIds).toEqual([tmsg1])
     expect(await StreamMemberRepository.findByStreamAndMember(pool, thread, reader)).toBeNull()
+  })
+
+  test("markRead clears activity for exactly the marked messages, never the stream's other topics", async () => {
+    const wid = workspaceId()
+    const root = streamId()
+    const author = userId()
+    const reader = userId()
+    await withTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+        [root, wid, author]
+      )
+      await StreamMemberRepository.insert(client, root, reader)
+    })
+    const msg1 = await send(wid, root, author, "topic A opener")
+    const msg2 = await send(wid, root, author, "topic B — stays unread")
+    await setCreatedAt(msg1, 1000)
+    await setCreatedAt(msg2, 2000)
+    const convId = await insertConversation(wid, root, [msg1])
+
+    // A mention badge on each message; only the marked conversation's clears.
+    for (const messageId of [msg1, msg2]) {
+      await ActivityRepository.insert(pool, {
+        workspaceId: wid,
+        userId: reader,
+        activityType: "mention",
+        streamId: root,
+        messageId,
+        actorId: author,
+        actorType: "user",
+        context: {},
+      })
+    }
+
+    const { streams } = await conversationService.markRead({
+      workspaceId: wid,
+      conversationId: convId,
+      throughMessageId: msg1,
+      userId: reader,
+    })
+
+    expect(streams[0]?.markedMessageIds).toEqual([msg1])
+    const rows = await pool.query(
+      `SELECT message_id, (read_at IS NOT NULL) AS is_read FROM user_activity
+       WHERE workspace_id = $1 AND user_id = $2 ORDER BY message_id`,
+      [wid, reader]
+    )
+    expect(new Map(rows.rows.map((r) => [r.message_id, r.is_read]))).toEqual(
+      new Map([
+        [msg1, true],
+        [msg2, false],
+      ])
+    )
   })
 
   test("markUnread regresses the watermark on the affected stream and drops overlay-only thread reads", async () => {

--- a/apps/backend/tests/integration/conversation-read.test.ts
+++ b/apps/backend/tests/integration/conversation-read.test.ts
@@ -1,0 +1,235 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, setupTestDatabase, testMessageContent } from "./setup"
+import {
+  StreamService,
+  StreamEventRepository,
+  StreamMemberRepository,
+  SparseReadRepository,
+} from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { ConversationService } from "../../src/features/conversations"
+import { streamId, userId, workspaceId, conversationId } from "../../src/lib/id"
+
+describe("ConversationService read/unread", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let eventService: EventService
+  let conversationService: ConversationService
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    eventService = new EventService(pool)
+    conversationService = new ConversationService(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM conversations")
+    await pool.query("DELETE FROM messages")
+    await pool.query("DELETE FROM stream_events")
+    await pool.query("DELETE FROM stream_sequences")
+    await pool.query("DELETE FROM stream_members")
+    await pool.query("DELETE FROM streams")
+    await pool.query(
+      "DELETE FROM outbox WHERE id > (SELECT COALESCE(MAX(last_processed_id), 0) FROM outbox_listeners WHERE listener_id = 'broadcast')"
+    )
+  })
+
+  async function send(wid: string, sid: string, authorId: string, text: string): Promise<string> {
+    const m = await eventService.createMessage({
+      workspaceId: wid,
+      streamId: sid,
+      authorId,
+      authorType: "user",
+      ...testMessageContent(text),
+    })
+    return m.id
+  }
+
+  async function setCreatedAt(messageId: string, epochMs: number): Promise<void> {
+    await pool.query(`UPDATE messages SET created_at = to_timestamp($1::double precision / 1000.0) WHERE id = $2`, [
+      epochMs,
+      messageId,
+    ])
+  }
+
+  async function insertConversation(wid: string, anchorStreamId: string, messageIds: string[]): Promise<string> {
+    const id = conversationId()
+    await pool.query(
+      `INSERT INTO conversations (id, stream_id, workspace_id, message_ids, participant_ids, secondary_message_ids, status, last_activity_at)
+       VALUES ($1, $2, $3, $4, '{}'::text[], '{}'::text[], 'active', NOW())`,
+      [id, anchorStreamId, wid, messageIds]
+    )
+    return id
+  }
+
+  async function eventByMessage(sid: string): Promise<Map<string, { id: string; sequence: bigint }>> {
+    const events = await StreamEventRepository.list(pool, sid)
+    return new Map(
+      events.map((e) => [(e.payload as { messageId: string }).messageId, { id: e.id, sequence: e.sequence }])
+    )
+  }
+
+  test("markRead fans out across the streams a conversation spans, bounded by the target's createdAt", async () => {
+    const wid = workspaceId()
+    const root = streamId()
+    const author = userId()
+    const reader = userId()
+    await withTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+        [root, wid, author]
+      )
+      await StreamMemberRepository.insert(client, root, reader)
+    })
+    const msg1 = await send(wid, root, author, "root 1")
+
+    // Thread under root; reader has root access but no thread membership row.
+    const thread = streamId()
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, created_by, parent_stream_id, parent_message_id, root_stream_id)
+       VALUES ($1, $2, 'thread', 'private', $3, $4, $5, $4)`,
+      [thread, wid, author, root, msg1]
+    )
+    const tmsg1 = await send(wid, thread, author, "thread 1")
+    const msg2 = await send(wid, root, author, "root 2")
+    const tmsg2 = await send(wid, thread, author, "thread 2")
+
+    // Deterministic cross-stream ordering by created_at (the card merge key).
+    await setCreatedAt(msg1, 1000)
+    await setCreatedAt(tmsg1, 2000)
+    await setCreatedAt(msg2, 3000)
+    await setCreatedAt(tmsg2, 4000)
+
+    const convId = await insertConversation(wid, root, [msg1, tmsg1, msg2, tmsg2])
+
+    const { streams } = await conversationService.markRead({
+      workspaceId: wid,
+      conversationId: convId,
+      throughMessageId: msg2,
+      userId: reader,
+    })
+
+    const rootEvents = await eventByMessage(root)
+    const byStream = new Map(streams.map((s) => [s.streamId, s]))
+
+    // Two streams touched (tmsg2 is past the cutoff, excluded).
+    expect([...byStream.keys()].sort()).toEqual([root, thread].sort())
+
+    // Root: msg1+msg2 contiguous from the watermark → compacted, overlay empty.
+    expect(byStream.get(root)).toEqual({
+      streamId: root,
+      readMessageIds: [],
+      lastReadEventId: rootEvents.get(msg2)!.id,
+      lastReadSequence: rootEvents.get(msg2)!.sequence.toString(),
+      lastReadOrdinal: 2,
+    })
+
+    // Thread: non-member leg → overlay-only, only tmsg1 (tmsg2 excluded by cutoff).
+    const threadSnap = byStream.get(thread)!
+    expect(threadSnap.lastReadEventId).toBeNull()
+    expect(threadSnap.readMessageIds).toEqual([tmsg1])
+    expect(await StreamMemberRepository.findByStreamAndMember(pool, thread, reader)).toBeNull()
+  })
+
+  test("markUnread regresses the watermark on the affected stream and drops overlay-only thread reads", async () => {
+    const wid = workspaceId()
+    const root = streamId()
+    const author = userId()
+    const reader = userId()
+    await withTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+        [root, wid, author]
+      )
+      await StreamMemberRepository.insert(client, root, reader)
+    })
+    const msg1 = await send(wid, root, author, "root 1")
+    const thread = streamId()
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, created_by, parent_stream_id, parent_message_id, root_stream_id)
+       VALUES ($1, $2, 'thread', 'private', $3, $4, $5, $4)`,
+      [thread, wid, author, root, msg1]
+    )
+    const tmsg1 = await send(wid, thread, author, "thread 1")
+    const msg2 = await send(wid, root, author, "root 2")
+    await setCreatedAt(msg1, 1000)
+    await setCreatedAt(tmsg1, 2000)
+    await setCreatedAt(msg2, 3000)
+
+    const convId = await insertConversation(wid, root, [msg1, tmsg1, msg2])
+    const rootEvents = await eventByMessage(root)
+
+    // Read the whole conversation first.
+    await conversationService.markRead({
+      workspaceId: wid,
+      conversationId: convId,
+      throughMessageId: msg2,
+      userId: reader,
+    })
+    expect(await SparseReadRepository.countOverlay(pool, thread, reader)).toBe(1)
+
+    // Now mark unread from tmsg1 (cutoff 2000): tmsg1 + msg2 affected.
+    const { streams } = await conversationService.markUnread({
+      workspaceId: wid,
+      conversationId: convId,
+      fromMessageId: tmsg1,
+      userId: reader,
+    })
+    const byStream = new Map(streams.map((s) => [s.streamId, s]))
+
+    // Root: watermark was at msg2 (>= msg2's own seq), regress to just before msg2 → msg1.
+    expect(byStream.get(root)!.lastReadEventId).toBe(rootEvents.get(msg1)!.id)
+    // Thread: overlay-only, tmsg1 dropped from the overlay.
+    expect(byStream.get(thread)!.readMessageIds).toEqual([])
+    expect(await SparseReadRepository.countOverlay(pool, thread, reader)).toBe(0)
+
+    // Effective root unread: msg2 is unread again (msg1 read).
+    const membership = await streamService.getMembership(root, reader)
+    const counts = await streamService.getUnreadCounts([
+      { streamId: root, memberId: reader, lastReadEventId: membership?.lastReadEventId ?? null },
+    ])
+    expect(counts.get(root)?.unreadCount).toBe(1)
+  })
+
+  test("read truth is snapshotted — cutoff uses the target message's own createdAt", async () => {
+    const wid = workspaceId()
+    const root = streamId()
+    const author = userId()
+    const reader = userId()
+    await withTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+        [root, wid, author]
+      )
+      await StreamMemberRepository.insert(client, root, reader)
+    })
+    const a = await send(wid, root, author, "a")
+    const b = await send(wid, root, author, "b")
+    const c = await send(wid, root, author, "c")
+    await setCreatedAt(a, 1000)
+    await setCreatedAt(b, 2000)
+    await setCreatedAt(c, 3000)
+    const convId = await insertConversation(wid, root, [a, b, c])
+
+    // Through b → a,b read; c stays unread.
+    const { streams } = await conversationService.markRead({
+      workspaceId: wid,
+      conversationId: convId,
+      throughMessageId: b,
+      userId: reader,
+    })
+    expect(streams).toHaveLength(1)
+    const membership = await streamService.getMembership(root, reader)
+    const counts = await streamService.getUnreadCounts([
+      { streamId: root, memberId: reader, lastReadEventId: membership?.lastReadEventId ?? null },
+    ])
+    expect(counts.get(root)?.unreadCount).toBe(1)
+  })
+})

--- a/apps/backend/tests/integration/phantom-unread-fixes.test.ts
+++ b/apps/backend/tests/integration/phantom-unread-fixes.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { Pool } from "pg"
+import { setupTestDatabase, testMessageContent, addTestMember } from "./setup"
+import {
+  StreamEventRepository,
+  StreamMemberRepository,
+  StreamRepository,
+  StreamService,
+} from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { streamId, userId, workspaceId, activityId } from "../../src/lib/id"
+
+describe("Phantom-unread drift fixes", () => {
+  let pool: Pool
+  let eventService: EventService
+  let streamService: StreamService
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    eventService = new EventService(pool)
+    streamService = new StreamService(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM user_activity")
+    await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM messages")
+    await pool.query("DELETE FROM stream_events")
+    await pool.query("DELETE FROM stream_sequences")
+    await pool.query("DELETE FROM stream_members")
+    await pool.query("DELETE FROM streams")
+    await pool.query(
+      "DELETE FROM outbox WHERE id > (SELECT COALESCE(MAX(last_processed_id), 0) FROM outbox_listeners WHERE listener_id = 'broadcast')"
+    )
+  })
+
+  async function send(wid: string, sid: string, authorId: string, text: string): Promise<string> {
+    const m = await eventService.createMessage({
+      workspaceId: wid,
+      streamId: sid,
+      authorId,
+      authorType: "user",
+      ...testMessageContent(text),
+    })
+    return m.id
+  }
+
+  test("A1: messages:moved carries the post-move source message ordinal", async () => {
+    const wid = workspaceId()
+    const source = streamId()
+    const actor = await addTestMember(pool, wid, userId())
+    await StreamRepository.insert(pool, {
+      id: source,
+      workspaceId: wid,
+      type: "channel",
+      visibility: "private",
+      createdBy: actor.id,
+    })
+    await StreamMemberRepository.insert(pool, source, actor.id)
+
+    const target = await send(wid, source, actor.id, "target")
+    const keep = await send(wid, source, actor.id, "keep")
+    const movedA = await send(wid, source, actor.id, "moved a")
+    const movedB = await send(wid, source, actor.id, "moved b")
+
+    const validation = await eventService.validateMoveMessagesToThread({
+      workspaceId: wid,
+      sourceStreamId: source,
+      targetMessageId: target,
+      messageIds: [movedA, movedB],
+      actorId: actor.id,
+    })
+    await eventService.moveMessagesToThread({
+      workspaceId: wid,
+      sourceStreamId: source,
+      targetMessageId: target,
+      messageIds: [movedA, movedB],
+      actorId: actor.id,
+      leaseKey: validation.leaseKey,
+    })
+
+    const moved = await pool.query(
+      `SELECT payload FROM outbox WHERE event_type = 'messages:moved' AND payload->>'sourceStreamId' = $1 ORDER BY id DESC LIMIT 1`,
+      [source]
+    )
+    // Source keeps target + keep; movedA/movedB relocated → 2 remain.
+    expect(moved.rows[0].payload.sourceMessageOrdinal).toBe(2)
+    void keep
+  })
+
+  test("A3: a source watermark on a moved event is repointed to the nearest surviving prior event", async () => {
+    const wid = workspaceId()
+    const source = streamId()
+    const actor = await addTestMember(pool, wid, userId())
+    const reader = await addTestMember(pool, wid, userId())
+    await StreamRepository.insert(pool, {
+      id: source,
+      workspaceId: wid,
+      type: "channel",
+      visibility: "private",
+      createdBy: actor.id,
+    })
+    await StreamMemberRepository.insert(pool, source, actor.id)
+    await StreamMemberRepository.insert(pool, source, reader.id)
+
+    const target = await send(wid, source, actor.id, "target")
+    const m1 = await send(wid, source, actor.id, "m1")
+    const m2 = await send(wid, source, actor.id, "m2")
+    const m3 = await send(wid, source, actor.id, "m3")
+
+    const events = await StreamEventRepository.list(pool, source)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // Reader's watermark sits on m2 — which is about to be moved away.
+    await streamService.markAsRead(wid, source, reader.id, eventByMsg.get(m2)!.id)
+    const before = await streamService.getMembership(source, reader.id)
+    expect(before?.lastReadEventId).toBe(eventByMsg.get(m2)!.id)
+
+    const validation = await eventService.validateMoveMessagesToThread({
+      workspaceId: wid,
+      sourceStreamId: source,
+      targetMessageId: target,
+      messageIds: [m2, m3],
+      actorId: actor.id,
+    })
+    await eventService.moveMessagesToThread({
+      workspaceId: wid,
+      sourceStreamId: source,
+      targetMessageId: target,
+      messageIds: [m2, m3],
+      actorId: actor.id,
+      leaseKey: validation.leaseKey,
+    })
+
+    // After the fix: the watermark repoints to m1 (nearest surviving prior source
+    // event); without it, it would still point at m2 (now in the thread) and the
+    // unread count would resolve against a foreign thread-space sequence.
+    const after = await streamService.getMembership(source, reader.id)
+    expect(after?.lastReadEventId).toBe(eventByMsg.get(m1)!.id)
+
+    // Source now holds target + m1; nothing unread above m1.
+    const counts = await streamService.getUnreadCounts([
+      { streamId: source, memberId: reader.id, lastReadEventId: after?.lastReadEventId ?? null },
+    ])
+    expect(counts.get(source)).toEqual({ unreadCount: 0, totalCount: 2 })
+  })
+
+  test("A2: deleting a message marks its unread activity rows read in the same transaction", async () => {
+    const wid = workspaceId()
+    const source = streamId()
+    const actor = await addTestMember(pool, wid, userId())
+    const recipient = await addTestMember(pool, wid, userId())
+    await StreamRepository.insert(pool, {
+      id: source,
+      workspaceId: wid,
+      type: "channel",
+      visibility: "private",
+      createdBy: actor.id,
+    })
+    await StreamMemberRepository.insert(pool, source, actor.id)
+
+    const msg = await send(wid, source, actor.id, "@mention you")
+
+    // An unread mention activity row for the recipient.
+    await pool.query(
+      `INSERT INTO user_activity (id, workspace_id, user_id, activity_type, stream_id, message_id, actor_id, actor_type, context, read_at)
+       VALUES ($1, $2, $3, 'mention', $4, $5, $6, 'user', '{}'::jsonb, NULL)`,
+      [activityId(), wid, recipient.id, source, msg, actor.id]
+    )
+
+    await eventService.deleteMessage({
+      workspaceId: wid,
+      streamId: source,
+      messageId: msg,
+      actorId: actor.id,
+      actorType: "user",
+    })
+
+    const row = await pool.query(`SELECT read_at FROM user_activity WHERE message_id = $1`, [msg])
+    expect(row.rows).toHaveLength(1)
+    expect(row.rows[0].read_at).not.toBeNull()
+  })
+})

--- a/apps/backend/tests/integration/phantom-unread-fixes.test.ts
+++ b/apps/backend/tests/integration/phantom-unread-fixes.test.ts
@@ -141,6 +141,10 @@ describe("Phantom-unread drift fixes", () => {
     // unread count would resolve against a foreign thread-space sequence.
     const after = await streamService.getMembership(source, reader.id)
     expect(after?.lastReadEventId).toBe(eventByMsg.get(m1)!.id)
+    // The repoint is an automated correction, not a read: last_read_at must be
+    // preserved — it feeds the conversation card's time fallback, and bumping it
+    // to NOW() would falsely mark older sequenceless rows as read.
+    expect(after?.lastReadAt).toEqual(before!.lastReadAt)
 
     // Source now holds target + m1; nothing unread above m1.
     const counts = await streamService.getUnreadCounts([

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -301,6 +301,27 @@ describe("Sparse read overlay", () => {
     expect(await effectiveUnread(sid, reader)).toBe(1)
   })
 
+  test("removing a member purges their overlay so a born-read rejoin can't undercount", async () => {
+    const reader = userId()
+    const other = userId()
+    const { wid, sid, authorId } = await seedChannel([reader, other])
+    const [, , msg3] = await sendMessages(wid, sid, authorId, 3)
+
+    // Board-read hole, then the member is removed. The overlay must go with the
+    // membership: a rejoin born-reads the watermark at latest, and a surviving
+    // row below it would double-subtract in the effective unread count.
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(1)
+
+    await streamService.removeMember(sid, reader)
+
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    // The other member's overlay state is untouched by reader's removal.
+    expect(await effectiveUnread(sid, other)).toBe(3)
+  })
+
   test("applySparseUnread drops the affected ids and regresses when the watermark is past them", async () => {
     const reader = userId()
     const { wid, sid, authorId } = await seedChannel([reader])

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -250,6 +250,57 @@ describe("Sparse read overlay", () => {
     expect(await effectiveUnread(sid, reader)).toBe(2)
   })
 
+  test("members at/below the watermark never survive in the overlay (no double-subtract)", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, , msg4] = await sendMessages(wid, sid, authorId, 4)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // Timeline read through msg2, then a conversation whose members straddle the
+    // watermark ({msg1, msg4}) is marked read while msg3 (another conversation)
+    // stays a hole above the watermark — so no compaction fires. msg1 sits below
+    // the watermark and must be pruned, not inserted: a surviving row would
+    // double-subtract and hide msg3's genuine unread.
+    await streamService.markAsRead(wid, sid, reader, eventByMsg.get(msg2)!.id)
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1, msg4] })
+    )
+
+    expect(snapshot.readMessageIds).toEqual([msg4])
+    const belowWatermark = await pool.query(
+      `SELECT message_id FROM stream_member_message_reads
+       WHERE stream_id = $1 AND member_id = $2 AND sequence <= $3`,
+      [sid, reader, eventByMsg.get(msg2)!.sequence.toString()]
+    )
+    expect(belowWatermark.rows).toEqual([])
+    // msg3 is the one genuinely unread message.
+    expect(await effectiveUnread(sid, reader)).toBe(1)
+  })
+
+  test("mark-unread that ADVANCES the watermark past overlay holes clears them too", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, , msg3, msg4] = await sendMessages(wid, sid, authorId, 4)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // Watermark at msg1, board-read hole at msg3. Mark-unread from msg4 lands the
+    // pointer on msg3 — an ADVANCE, not a regress. The absorbed hole (msg3) is now
+    // at the watermark and must be pruned or it double-subtracts, reporting the
+    // just-marked-unread msg4 as read.
+    await streamService.markAsRead(wid, sid, reader, eventByMsg.get(msg1)!.id)
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    await streamService.markUnread(wid, sid, reader, msg4)
+
+    const membership = await streamService.getMembership(sid, reader)
+    expect(membership?.lastReadEventId).toBe(eventByMsg.get(msg3)!.id)
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    expect(await effectiveUnread(sid, reader)).toBe(1)
+  })
+
   test("applySparseUnread drops the affected ids and regresses when the watermark is past them", async () => {
     const reader = userId()
     const { wid, sid, authorId } = await seedChannel([reader])

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -1,0 +1,277 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test"
+import { Pool } from "pg"
+import { withTransaction, setupTestDatabase, testMessageContent } from "./setup"
+import {
+  StreamService,
+  StreamEventRepository,
+  StreamMemberRepository,
+  SparseReadRepository,
+  applySparseRead,
+  applySparseUnread,
+} from "../../src/features/streams"
+import { EventService } from "../../src/features/messaging"
+import { streamId, userId, workspaceId } from "../../src/lib/id"
+
+describe("Sparse read overlay", () => {
+  let pool: Pool
+  let streamService: StreamService
+  let eventService: EventService
+
+  beforeAll(async () => {
+    pool = await setupTestDatabase()
+    streamService = new StreamService(pool)
+    eventService = new EventService(pool)
+  })
+
+  afterAll(async () => {
+    await pool.end()
+  })
+
+  beforeEach(async () => {
+    await pool.query("DELETE FROM stream_member_message_reads")
+    await pool.query("DELETE FROM messages")
+    await pool.query("DELETE FROM stream_events")
+    await pool.query("DELETE FROM stream_sequences")
+    await pool.query("DELETE FROM stream_members")
+    await pool.query("DELETE FROM streams")
+    await pool.query(
+      "DELETE FROM outbox WHERE id > (SELECT COALESCE(MAX(last_processed_id), 0) FROM outbox_listeners WHERE listener_id = 'broadcast')"
+    )
+  })
+
+  async function seedChannel(memberIds: string[]): Promise<{ wid: string; sid: string; authorId: string }> {
+    const wid = workspaceId()
+    const sid = streamId()
+    const authorId = userId()
+    await withTransaction(pool, async (client) => {
+      await client.query(
+        `INSERT INTO streams (id, workspace_id, type, visibility, created_by) VALUES ($1, $2, 'channel', 'private', $3)`,
+        [sid, wid, authorId]
+      )
+      for (const m of memberIds) await StreamMemberRepository.insert(client, sid, m)
+    })
+    return { wid, sid, authorId }
+  }
+
+  async function sendMessages(wid: string, sid: string, authorId: string, count: number): Promise<string[]> {
+    const ids: string[] = []
+    for (let i = 1; i <= count; i++) {
+      const m = await eventService.createMessage({
+        workspaceId: wid,
+        streamId: sid,
+        authorId,
+        authorType: "user",
+        ...testMessageContent(`Message ${i}`),
+      })
+      ids.push(m.id)
+    }
+    return ids
+  }
+
+  async function outboxFor(eventType: string, sid: string): Promise<Array<Record<string, unknown>>> {
+    const result = await pool.query(
+      `SELECT payload FROM outbox WHERE event_type = $1 AND payload->>'streamId' = $2 ORDER BY id`,
+      [eventType, sid]
+    )
+    return result.rows.map((r) => r.payload)
+  }
+
+  async function effectiveUnread(sid: string, memberId: string): Promise<number> {
+    const membership = await streamService.getMembership(sid, memberId)
+    const counts = await streamService.getUnreadCounts([
+      { streamId: sid, memberId, lastReadEventId: membership?.lastReadEventId ?? null },
+    ])
+    return counts.get(sid)?.unreadCount ?? 0
+  }
+
+  test("a non-contiguous overlay read drops effective unread without advancing the watermark", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [, , msg3] = await sendMessages(wid, sid, authorId, 3)
+
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+
+    // msg1 above the (null) watermark isn't covered, so no compaction: the
+    // watermark stays put and the overlay holds the single hole.
+    expect(snapshot).toEqual({
+      streamId: sid,
+      readMessageIds: [msg3],
+      lastReadEventId: null,
+      lastReadSequence: "0",
+      lastReadOrdinal: 0,
+    })
+    expect(await effectiveUnread(sid, reader)).toBe(2)
+
+    const emitted = await outboxFor("stream:read_messages", sid)
+    expect(emitted).toEqual([
+      {
+        workspaceId: wid,
+        authorId: reader,
+        streamId: sid,
+        readMessageIds: [msg3],
+        lastReadEventId: null,
+        lastReadSequence: "0",
+        lastReadOrdinal: 0,
+      },
+    ])
+  })
+
+  test("compaction absorbs the contiguous run into the watermark and prunes the overlay", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // Read the hole first (msg3), then the run below it (msg1, msg2): the whole
+    // 1..3 run is now contiguous from the watermark, so compaction advances to
+    // msg3 and prunes every absorbed row.
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1, msg2] })
+    )
+
+    expect(snapshot).toEqual({
+      streamId: sid,
+      readMessageIds: [],
+      lastReadEventId: eventByMsg.get(msg3)!.id,
+      lastReadSequence: eventByMsg.get(msg3)!.sequence.toString(),
+      lastReadOrdinal: 3,
+    })
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    expect(await effectiveUnread(sid, reader)).toBe(0)
+  })
+
+  test("a non-member thread leg is overlay-only — no membership row, no watermark", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [parentMsg] = await sendMessages(wid, sid, authorId, 1)
+
+    // A thread under the channel root; reader has access via the root but no
+    // thread membership row.
+    const threadId = streamId()
+    await pool.query(
+      `INSERT INTO streams (id, workspace_id, type, visibility, created_by, parent_stream_id, parent_message_id, root_stream_id)
+       VALUES ($1, $2, 'thread', 'private', $3, $4, $5, $4)`,
+      [threadId, wid, authorId, sid, parentMsg]
+    )
+    const threadMsgs = await sendMessages(wid, threadId, authorId, 2)
+
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: threadId, memberId: reader, messageIds: threadMsgs })
+    )
+
+    expect(snapshot.lastReadEventId).toBeNull()
+    expect(snapshot.lastReadSequence).toBe("0")
+    expect(snapshot.readMessageIds.sort()).toEqual([...threadMsgs].sort())
+    // Overlay-only: no membership row was upserted (membership ≠ access, INV-62).
+    expect(await StreamMemberRepository.findByStreamAndMember(pool, threadId, reader)).toBeNull()
+    expect(await SparseReadRepository.countOverlay(pool, threadId, reader)).toBe(2)
+  })
+
+  test("double-applying the same read is idempotent (ON CONFLICT) and order-convergent", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [, , msg3] = await sendMessages(wid, sid, authorId, 3)
+
+    const first = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    const second = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+
+    expect(second).toEqual(first)
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(1)
+  })
+
+  test("overlay rows are workspace-tagged and member-scoped (INV-8)", async () => {
+    const reader = userId()
+    const other = userId()
+    const { wid, sid, authorId } = await seedChannel([reader, other])
+    const [, , msg3] = await sendMessages(wid, sid, authorId, 3)
+
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+
+    const row = await pool.query(
+      `SELECT workspace_id, member_id FROM stream_member_message_reads WHERE stream_id = $1 AND message_id = $2`,
+      [sid, msg3]
+    )
+    expect(row.rows).toEqual([{ workspace_id: wid, member_id: reader }])
+    // The other member's count is untouched by reader's overlay.
+    expect(await effectiveUnread(sid, other)).toBe(3)
+    expect(await effectiveUnread(sid, reader)).toBe(2)
+  })
+
+  test("markAsRead advancing past a hole prunes it and reports the empty overlay", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [, , msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    // Timeline mark-as-read up to the latest event absorbs the hole.
+    await streamService.markAsRead(wid, sid, reader, eventByMsg.get(msg3)!.id)
+
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    const readPayloads = await outboxFor("stream:read", sid)
+    expect(readPayloads.at(-1)?.readMessageIds).toEqual([])
+    expect(await effectiveUnread(sid, reader)).toBe(0)
+  })
+
+  test("mark-unread from a message regresses the watermark and clears overlay at/above it", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // Read everything, then a conversation-style unread from msg2 via the stream
+    // watermark path: overlay above msg2 is dropped and the pointer regresses.
+    await streamService.markAsRead(wid, sid, reader, eventByMsg.get(msg3)!.id)
+    await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg3] })
+    )
+    await streamService.markUnread(wid, sid, reader, msg2)
+
+    const membership = await streamService.getMembership(sid, reader)
+    expect(membership?.lastReadEventId).toBe(eventByMsg.get(msg1)!.id)
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    // msg2, msg3 unread again.
+    expect(await effectiveUnread(sid, reader)).toBe(2)
+  })
+
+  test("applySparseUnread drops the affected ids and regresses when the watermark is past them", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    await streamService.markAsRead(wid, sid, reader, eventByMsg.get(msg3)!.id)
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseUnread(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg2, msg3] })
+    )
+
+    // Earliest affected is msg2; the watermark regresses to just before it (msg1).
+    expect(snapshot).toEqual({
+      streamId: sid,
+      readMessageIds: [],
+      lastReadEventId: eventByMsg.get(msg1)!.id,
+      lastReadSequence: eventByMsg.get(msg1)!.sequence.toString(),
+      lastReadOrdinal: 1,
+    })
+    const setPayloads = await outboxFor("stream:read_set", sid)
+    expect(setPayloads.at(-1)?.lastReadEventId).toBe(eventByMsg.get(msg1)!.id)
+    expect(await effectiveUnread(sid, reader)).toBe(2)
+  })
+})

--- a/apps/backend/tests/integration/sparse-read-overlay.test.ts
+++ b/apps/backend/tests/integration/sparse-read-overlay.test.ts
@@ -101,6 +101,7 @@ describe("Sparse read overlay", () => {
       lastReadEventId: null,
       lastReadSequence: "0",
       lastReadOrdinal: 0,
+      markedMessageIds: [msg3],
     })
     expect(await effectiveUnread(sid, reader)).toBe(2)
 
@@ -114,6 +115,7 @@ describe("Sparse read overlay", () => {
         lastReadEventId: null,
         lastReadSequence: "0",
         lastReadOrdinal: 0,
+        markedMessageIds: [msg3],
       },
     ])
   })
@@ -141,6 +143,7 @@ describe("Sparse read overlay", () => {
       lastReadEventId: eventByMsg.get(msg3)!.id,
       lastReadSequence: eventByMsg.get(msg3)!.sequence.toString(),
       lastReadOrdinal: 3,
+      markedMessageIds: [msg1, msg2],
     })
     expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
     expect(await effectiveUnread(sid, reader)).toBe(0)
@@ -248,6 +251,48 @@ describe("Sparse read overlay", () => {
     expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
     // msg2, msg3 unread again.
     expect(await effectiveUnread(sid, reader)).toBe(2)
+  })
+
+  test("a deleted message inside the run counts as covered — the tide rises over sunken rocks", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // msg2 deleted: nobody can ever read it, so it must not hold the watermark
+    // down. Reading msg1 + msg3 compacts the whole run.
+    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1, msg3] })
+    )
+
+    expect(snapshot.lastReadEventId).toBe(eventByMsg.get(msg3)!.id)
+    expect(snapshot.readMessageIds).toEqual([])
+    expect(await effectiveUnread(sid, reader)).toBe(0)
+  })
+
+  test("a trailing deleted run above the last read is absorbed into the watermark", async () => {
+    const reader = userId()
+    const { wid, sid, authorId } = await seedChannel([reader])
+    const [msg1, msg2, msg3] = await sendMessages(wid, sid, authorId, 3)
+    const events = await StreamEventRepository.list(pool, sid)
+    const eventByMsg = new Map(events.map((e) => [(e.payload as { messageId: string }).messageId, e]))
+
+    // msg2 and msg3 deleted AFTER msg1 is the only live content: reading msg1
+    // must lift the watermark over the dead tail to msg3, or the stream can
+    // never fully read from the board (the compaction window is bounded by the
+    // overlay's max sequence, which sits below the deleted run).
+    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg2, actorId: authorId })
+    await eventService.deleteMessage({ workspaceId: wid, streamId: sid, messageId: msg3, actorId: authorId })
+    const snapshot = await withTransaction(pool, (client) =>
+      applySparseRead(client, { workspaceId: wid, streamId: sid, memberId: reader, messageIds: [msg1] })
+    )
+
+    expect(snapshot.lastReadEventId).toBe(eventByMsg.get(msg3)!.id)
+    expect(snapshot.readMessageIds).toEqual([])
+    expect(await SparseReadRepository.countOverlay(pool, sid, reader)).toBe(0)
+    expect(await effectiveUnread(sid, reader)).toBe(0)
   })
 
   test("members at/below the watermark never survive in the overlay (no double-subtract)", async () => {

--- a/apps/backend/tests/integration/unread-counts.test.ts
+++ b/apps/backend/tests/integration/unread-counts.test.ts
@@ -65,7 +65,9 @@ describe("Unread Counts", () => {
       const lastEventId = events[0].id
 
       // Count unreads with lastReadEventId = latest event
-      const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: lastEventId }])
+      const counts = await streamService.getUnreadCounts([
+        { streamId: testStreamId, memberId: testUserId, lastReadEventId: lastEventId },
+      ])
 
       expect(counts.get(testStreamId)).toEqual({ unreadCount: 0, totalCount: 1 })
     })
@@ -113,7 +115,9 @@ describe("Unread Counts", () => {
       const firstEventId = events[0].id
 
       // Should have 2 unread (messages 2 and 3)
-      const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: firstEventId }])
+      const counts = await streamService.getUnreadCounts([
+        { streamId: testStreamId, memberId: testUserId, lastReadEventId: firstEventId },
+      ])
 
       expect(counts.get(testStreamId)).toEqual({ unreadCount: 2, totalCount: 3 })
     })
@@ -143,7 +147,9 @@ describe("Unread Counts", () => {
       }
 
       // Count with null lastReadEventId (never read)
-      const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: null }])
+      const counts = await streamService.getUnreadCounts([
+        { streamId: testStreamId, memberId: testUserId, lastReadEventId: null },
+      ])
 
       expect(counts.get(testStreamId)).toEqual({ unreadCount: 3, totalCount: 3 })
     })
@@ -179,7 +185,7 @@ describe("Unread Counts", () => {
 
       // Author should have 0 unread
       const authorCounts = await streamService.getUnreadCounts([
-        { streamId: testStreamId, lastReadEventId: authorMembership!.lastReadEventId },
+        { streamId: testStreamId, memberId: authorId, lastReadEventId: authorMembership!.lastReadEventId },
       ])
       expect(authorCounts.get(testStreamId)).toEqual({ unreadCount: 0, totalCount: 1 })
 
@@ -188,7 +194,7 @@ describe("Unread Counts", () => {
       expect(otherMembership?.lastReadEventId).toBeNull()
 
       const otherCounts = await streamService.getUnreadCounts([
-        { streamId: testStreamId, lastReadEventId: otherMembership!.lastReadEventId },
+        { streamId: testStreamId, memberId: otherUserId, lastReadEventId: otherMembership!.lastReadEventId },
       ])
       expect(otherCounts.get(testStreamId)).toEqual({ unreadCount: 1, totalCount: 1 })
     })
@@ -244,8 +250,8 @@ describe("Unread Counts", () => {
       const events2 = await StreamEventRepository.list(pool, stream2)
 
       const counts = await streamService.getUnreadCounts([
-        { streamId: stream1, lastReadEventId: events1[0].id }, // Read 1, unread 1
-        { streamId: stream2, lastReadEventId: events2[2].id }, // Read all 3, unread 0
+        { streamId: stream1, memberId: testUserId, lastReadEventId: events1[0].id }, // Read 1, unread 1
+        { streamId: stream2, memberId: testUserId, lastReadEventId: events2[2].id }, // Read all 3, unread 0
       ])
 
       expect(counts.get(stream1)).toEqual({ unreadCount: 1, totalCount: 2 })
@@ -308,8 +314,8 @@ describe("Unread Counts", () => {
 
       // Verify unread counts are now 0
       const counts = await streamService.getUnreadCounts([
-        { streamId: stream1, lastReadEventId: membership1!.lastReadEventId },
-        { streamId: stream2, lastReadEventId: membership2!.lastReadEventId },
+        { streamId: stream1, memberId: testUserId, lastReadEventId: membership1!.lastReadEventId },
+        { streamId: stream2, memberId: testUserId, lastReadEventId: membership2!.lastReadEventId },
       ])
 
       expect(counts.get(stream1)).toEqual({ unreadCount: 0, totalCount: 1 })
@@ -544,10 +550,13 @@ describe("Unread Counts", () => {
         lastReadEventId: events[1].id,
         lastReadSequence: events[1].sequence.toString(),
         lastReadOrdinal: 2,
+        readMessageIds: [],
       })
 
       // The derived unread matches the authoritative count: 3 - 2 = 1.
-      const counts = await streamService.getUnreadCounts([{ streamId: testStreamId, lastReadEventId: events[1].id }])
+      const counts = await streamService.getUnreadCounts([
+        { streamId: testStreamId, memberId: readerId, lastReadEventId: events[1].id },
+      ])
       expect(counts.get(testStreamId)).toEqual({ unreadCount: 1, totalCount: 3 })
     })
 

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -1,5 +1,6 @@
 import { api } from "./client"
 import type { ConversationWithStaleness, ConversationStatus, Message, BoardPost, BoardPostMessage } from "@threa/types"
+import type { ReadStateSnapshot } from "@/sync/read-state"
 
 export interface ListConversationsParams {
   status?: ConversationStatus
@@ -89,6 +90,35 @@ export const conversationsApi = {
       `/api/workspaces/${workspaceId}/conversations/${conversationId}/board-post`
     )
     return res.post
+  },
+
+  /**
+   * Mark the conversation read through `throughMessageId` (inclusive). The
+   * server expands the cutoff to concrete member-message ids per spanned stream
+   * (snapshot semantics — immune to re-clustering) and returns the absolute
+   * post-write read state for each touched stream. See
+   * docs/sparse-read-overlay-design.md.
+   */
+  async markRead(
+    workspaceId: string,
+    conversationId: string,
+    throughMessageId: string
+  ): Promise<{ streams: ReadStateSnapshot[] }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/read`, { throughMessageId })
+  },
+
+  /**
+   * Mark the conversation unread from `fromMessageId` (inclusive) onward — the
+   * asymmetric inverse of {@link markRead}. Above the watermark this deletes
+   * overlay rows; below it the server regresses the watermark. Returns the
+   * absolute post-write read state per touched stream.
+   */
+  async markUnread(
+    workspaceId: string,
+    conversationId: string,
+    fromMessageId: string
+  ): Promise<{ streams: ReadStateSnapshot[] }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/unread`, { fromMessageId })
   },
 
   /**

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { BoardPostMessage } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+
+const WS = "ws_1"
+const STREAM = "stream_1"
+
+function openingMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
+  return {
+    id: "m_open",
+    streamId: STREAM,
+    authorId: "usr_other",
+    authorType: "user",
+    contentMarkdown: "Opening body.",
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-06-22T12:00:00.000Z",
+    editedAt: null,
+    ...overrides,
+  }
+}
+
+function makePost(): BoardViewPost {
+  const opening = openingMessage()
+  return {
+    id: "conv_1",
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    conversation: {
+      id: "conv_1",
+      streamId: STREAM,
+      messageIds: ["m_open"],
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+    },
+    openingMessage: opening,
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as BoardViewPost
+}
+
+function mountCard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <PanelProvider>
+              <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
+            </PanelProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+beforeEach(() => {
+  __clearBoardRailRegistry()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard unread dot", () => {
+  it("shows the unread dot when the conversation has an effectively-unread member message", async () => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => true,
+    })
+    mountCard()
+    expect(await screen.findByLabelText("Unread")).toBeTruthy()
+  })
+
+  it("hides the unread dot when nothing is effectively unread", async () => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => false,
+    })
+    mountCard()
+    await screen.findByText("Opening body.")
+    expect(screen.queryByLabelText("Unread")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type LucideIcon } from "lucide-react"
@@ -6,6 +6,7 @@ import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
@@ -66,6 +67,24 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
 
   const streamId = conversation.streamId
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
+
+  // Conversation read state: per-row gating + actions for the message rows, plus
+  // the card's effectively-unread signal for the header dot. Both derive live
+  // from the overlay + per-stream watermarks, so the dot clears the moment a
+  // read lands (docs/sparse-read-overlay-design.md).
+  const { value: conversationReadValue, hasUnread } = useConversationReadController(
+    workspaceId,
+    conversation.id,
+    streamId,
+    currentUserId
+  )
+  // Over the card's known local messages (opening + the full local reply rail);
+  // own-authored rows are excluded inside `hasUnread`.
+  const knownMessages = useMemo(
+    () => (openingMessage ? [openingMessage, ...railReplies] : railReplies),
+    [openingMessage, railReplies]
+  )
+  const cardHasUnread = hasUnread(knownMessages)
 
   // The rail carries every locally-synced reply; older ones (or a wholly unsynced
   // stream — `source === "projection"`) may be missing, so on expand we backfill
@@ -129,90 +148,103 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   return (
     // Scope quote reply to this card: a message row's "Quote reply" routes into
     // this card's own reply composer, not another card's.
-    <QuoteReplyProvider>
-      {/* Desktop text-selection → floating "Quote" button, scoped to this card. */}
-      <TextSelectionQuote streamId={streamId} containerRef={cardRef} />
-      <div ref={cardRef} className="rounded-xl border bg-card p-3 sm:p-4">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          {/* The stream the post lives in — a real link back into it (INV-40). */}
-          <Link
-            to={`/w/${workspaceId}/s/${streamId}`}
-            className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
-          >
-            <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
-            <span className="truncate font-medium">{contextLabel}</span>
-          </Link>
-          <RelativeTime date={conversation.lastActivityAt} terse className="ml-auto shrink-0" />
-          {/* Open the whole conversation in the side panel (Mechanism B) — reads it
+    <ConversationReadProvider value={conversationReadValue}>
+      <QuoteReplyProvider>
+        {/* Desktop text-selection → floating "Quote" button, scoped to this card. */}
+        <TextSelectionQuote streamId={streamId} containerRef={cardRef} />
+        <div ref={cardRef} className="rounded-xl border bg-card p-3 sm:p-4">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            {/* The stream the post lives in — a real link back into it (INV-40). */}
+            <Link
+              to={`/w/${workspaceId}/s/${streamId}`}
+              className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
+            >
+              <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate font-medium">{contextLabel}</span>
+            </Link>
+            {/* Quiet unread dot: the conversation holds an effectively-unread member
+              message. Reserved fixed footprint (no layout shift, INV-21); clears
+              live as read state changes. */}
+            <span
+              className="ml-auto flex h-2 w-2 shrink-0 items-center justify-center"
+              aria-label={cardHasUnread ? "Unread" : undefined}
+            >
+              {cardHasUnread && <span className="h-2 w-2 rounded-full bg-primary" />}
+            </span>
+            <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
+            {/* Open the whole conversation in the side panel (Mechanism B) — reads it
             coherently and replies scoped to it, peer to a thread. */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Open conversation"
-                onClick={() => openPanel(createConversationPanelId(conversation.id))}
-              >
-                <PanelRight className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Open conversation</TooltipContent>
-          </Tooltip>
-        </div>
-
-        <div className="mt-3 [&>*:first-child]:mt-0">
-          {contiguous ? (
-            (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).map((message, i, all) =>
-              renderMessage(message, i > 0 && isContinuation(all[i - 1], message))
-            )
-          ) : (
-            <>
-              {openingMessage && renderMessage(openingMessage, false)}
-              {!expanded && hiddenCount > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setExpanded(true)}
-                  className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Open conversation"
+                  onClick={() => openPanel(createConversationPanelId(conversation.id))}
                 >
-                  <ChevronDown className="h-3.5 w-3.5" />
-                  {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
-                </button>
-              )}
-              {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>}
-              {/* The backfill loads the older/full window; the recent replies the
+                  <PanelRight className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open conversation</TooltipContent>
+            </Tooltip>
+          </div>
+
+          <div className="mt-3 [&>*:first-child]:mt-0">
+            {contiguous ? (
+              (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).map((message, i, all) =>
+                renderMessage(message, i > 0 && isContinuation(all[i - 1], message))
+              )
+            ) : (
+              <>
+                {openingMessage && renderMessage(openingMessage, false)}
+                {!expanded && hiddenCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setExpanded(true)}
+                    className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ChevronDown className="h-3.5 w-3.5" />
+                    {hiddenCount} more {hiddenCount === 1 ? "message" : "messages"}
+                  </button>
+                )}
+                {loadingMore && (
+                  <span className="mt-3 block text-xs text-muted-foreground">Loading older messages…</span>
+                )}
+                {/* The backfill loads the older/full window; the recent replies the
                 rail carried are already shown above, so the error names "older"
                 rather than contradicting visible content. */}
-              {expanded && expandFailed && (
-                <button
-                  type="button"
-                  onClick={() => void refetchMessages()}
-                  className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
-                >
-                  Couldn't load older messages. Retry.
-                </button>
-              )}
-              {displayedReplies.map((message, i) =>
-                renderMessage(message, i > 0 && isContinuation(displayedReplies[i - 1], message))
-              )}
-            </>
-          )}
-        </div>
+                {expanded && expandFailed && (
+                  <button
+                    type="button"
+                    onClick={() => void refetchMessages()}
+                    className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+                  >
+                    Couldn't load older messages. Retry.
+                  </button>
+                )}
+                {displayedReplies.map((message, i) =>
+                  renderMessage(message, i > 0 && isContinuation(displayedReplies[i - 1], message))
+                )}
+              </>
+            )}
+          </div>
 
-        <BoardReplyComposer
-          workspaceId={workspaceId}
-          post={post}
-          hostStreamType={streamType}
-          // The conversation's most-recently-active stream — the latest displayed
-          // reply's own stream (a thread under the root), INCLUDING the viewer's own
-          // pending reply and any expand-backfilled rows, so a continuation follows
-          // the conversation into the thread it moved to instead of re-interleaving
-          // the channel. `displayedReplies` is chronological; its last entry is the
-          // freshest activity. Falls back to the conversation's own stream — NOT the
-          // opening message's, which for a thread post is the parent-stream message.
-          lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? streamId}
-        />
-      </div>
-    </QuoteReplyProvider>
+          <BoardReplyComposer
+            workspaceId={workspaceId}
+            post={post}
+            hostStreamType={streamType}
+            // The conversation's most-recently-active stream — the latest displayed
+            // reply's own stream (a thread under the root), INCLUDING the viewer's own
+            // pending reply and any expand-backfilled rows, so a continuation follows
+            // the conversation into the thread it moved to instead of re-interleaving
+            // the channel. `displayedReplies` is chronological; its last entry is the
+            // freshest activity. Falls back to the conversation's own stream — NOT the
+            // opening message's, which for a thread post is the parent-stream message.
+            lastActiveStreamId={displayedReplies.at(-1)?.streamId ?? streamId}
+          />
+        </div>
+      </QuoteReplyProvider>
+    </ConversationReadProvider>
   )
 }

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -15,6 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
@@ -240,6 +241,15 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const { conversation } = post
+  // Per-row read state + the mark-read/unread actions for this conversation's
+  // rows (docs/sparse-read-overlay-design.md). The panel has no unread dot, so
+  // only the provider value is used.
+  const { value: conversationReadValue } = useConversationReadController(
+    workspaceId,
+    conversation.id,
+    conversation.streamId,
+    currentUserId
+  )
   // Deep-link target from `?m=` — the row to scroll to + flash. Shared with the
   // host page's `m` param, but only the conversation panel reads it here (the
   // board page, the panel's host for a conversation link, ignores it), so a
@@ -298,48 +308,50 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
 
   return (
     // Quote reply from a row routes into this conversation's reply composer.
-    <QuoteReplyProvider>
-      {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
-      <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
-      <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
-        {all.map((message, i) => (
-          <MessageItem
-            key={message.id}
+    <ConversationReadProvider value={conversationReadValue}>
+      <QuoteReplyProvider>
+        {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
+        <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
+          {all.map((message, i) => (
+            <MessageItem
+              key={message.id}
+              workspaceId={workspaceId}
+              // Each row renders against its own stream so reactions and the
+              // permalink target where the message actually lives (one root, many
+              // streams); fall back to the anchor.
+              streamId={message.streamId ?? conversation.streamId}
+              message={message}
+              authorName={getActorName(message.authorId, message.authorType)}
+              currentUserId={currentUserId}
+              continuation={i > 0 && isContinuation(all[i - 1], message)}
+              conversationId={conversation.id}
+              conversationRootStreamId={conversation.streamId}
+              isHighlighted={message.id === highlightMessageId}
+              surfaceClassName="bg-background"
+            />
+          ))}
+          {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
+          {backfillFailed && (
+            <button
+              type="button"
+              onClick={() => void refetchMessages()}
+              className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
+            >
+              Couldn't load the full conversation. Retry.
+            </button>
+          )}
+        </div>
+        <div className="border-t px-4 py-3">
+          <BoardReplyComposer
             workspaceId={workspaceId}
-            // Each row renders against its own stream so reactions and the
-            // permalink target where the message actually lives (one root, many
-            // streams); fall back to the anchor.
-            streamId={message.streamId ?? conversation.streamId}
-            message={message}
-            authorName={getActorName(message.authorId, message.authorType)}
-            currentUserId={currentUserId}
-            continuation={i > 0 && isContinuation(all[i - 1], message)}
-            conversationId={conversation.id}
-            conversationRootStreamId={conversation.streamId}
-            isHighlighted={message.id === highlightMessageId}
-            surfaceClassName="bg-background"
+            post={post}
+            hostStreamType={hostStreamType}
+            lastActiveStreamId={lastActiveStreamId}
+            openReplySignal={openReplySignal}
           />
-        ))}
-        {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
-        {backfillFailed && (
-          <button
-            type="button"
-            onClick={() => void refetchMessages()}
-            className="mt-3 block w-fit text-xs text-destructive underline underline-offset-2"
-          >
-            Couldn't load the full conversation. Retry.
-          </button>
-        )}
-      </div>
-      <div className="border-t px-4 py-3">
-        <BoardReplyComposer
-          workspaceId={workspaceId}
-          post={post}
-          hostStreamType={hostStreamType}
-          lastActiveStreamId={lastActiveStreamId}
-          openReplySignal={openReplySignal}
-        />
-      </div>
-    </QuoteReplyProvider>
+        </div>
+      </QuoteReplyProvider>
+    </ConversationReadProvider>
   )
 }

--- a/apps/frontend/src/components/message/conversation-read-context.test.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.test.tsx
@@ -44,11 +44,14 @@ function msg(overrides: Partial<RenderableMessage> & Pick<RenderableMessage, "id
   }
 }
 
-async function seedReadState(overlay: Record<string, string[]> = {}) {
+async function seedReadState(
+  overlay: Record<string, string[]> = {},
+  unreadCounts: Record<string, number> = { [ROOT]: 1 }
+) {
   await db.unreadState.put({
     id: WS,
     workspaceId: WS,
-    unreadCounts: { [ROOT]: 1 },
+    unreadCounts,
     mentionCounts: {},
     activityCounts: {},
     unreadActivityCount: 0,
@@ -101,6 +104,20 @@ describe("useConversationReadController", () => {
     await waitFor(() =>
       expect(result.current.value.state(ROOT, "m_reply", "5", "2026-06-22T12:00:00.000Z")).toBe("read")
     )
+  })
+
+  it("treats a stream with zero effective unread as fully read despite a stale sequence frontier", async () => {
+    // Mark-all-read advances counts to 0 without a per-stream sequence payload,
+    // so the membership's lastReadSequence (3) goes stale. The count-0
+    // short-circuit must win over the sequence comparison — a row at sequence 5
+    // would otherwise re-derive as unread (phantom card dot).
+    await seedReadState({}, { [ROOT]: 0 })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    await waitFor(() =>
+      expect(result.current.value.state(ROOT, "m_reply", "5", "2026-06-22T13:00:00.000Z")).toBe("read")
+    )
+    expect(result.current.hasUnread([msg({ id: "m_reply", sequence: "5" })])).toBe(false)
   })
 
   it("falls back to the root read-through time for a non-member thread leg", async () => {

--- a/apps/frontend/src/components/message/conversation-read-context.test.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.test.tsx
@@ -1,0 +1,169 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ServicesProvider, type ConversationService } from "@/contexts"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real store-hook read path
+import { clearAllCachedData, db } from "@/db"
+import type { RenderableMessage } from "@/components/message/message-item"
+import { useConversationReadController } from "./conversation-read-context"
+
+const WS = "ws_1"
+const CONV = "conv_1"
+const ROOT = "stream_root"
+const THREAD = "stream_thread"
+const ME = "usr_me"
+const OTHER = "usr_other"
+
+const markRead = vi.fn<ConversationService["markRead"]>()
+const markUnread = vi.fn<ConversationService["markUnread"]>()
+
+function wrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ServicesProvider, {
+        services: { conversations: { markRead, markUnread } as unknown as ConversationService },
+        children,
+      })
+    )
+  }
+}
+
+function msg(overrides: Partial<RenderableMessage> & Pick<RenderableMessage, "id">): RenderableMessage {
+  return {
+    streamId: ROOT,
+    authorId: OTHER,
+    authorType: "user",
+    contentMarkdown: "body",
+    reactions: {},
+    createdAt: "2026-06-22T12:00:00.000Z",
+    ...overrides,
+  }
+}
+
+async function seedReadState(overlay: Record<string, string[]> = {}) {
+  await db.unreadState.put({
+    id: WS,
+    workspaceId: WS,
+    unreadCounts: { [ROOT]: 1 },
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    unreadActivities: [],
+    latestOrdinals: { [ROOT]: 5 },
+    readMessageIds: overlay,
+    mutedStreamIds: [],
+    _cachedAt: Date.now(),
+  })
+  // Root membership: watermark at sequence 3, read-through timestamp T0.
+  await db.streamMemberships.put({
+    id: `${WS}:${ROOT}`,
+    workspaceId: WS,
+    streamId: ROOT,
+    memberId: "member_me",
+    notificationLevel: "everything",
+    lastReadEventId: "evt_3",
+    lastReadSequence: "3",
+    lastReadAt: "2026-06-22T12:00:00.000Z",
+    joinedAt: "2026-06-01T00:00:00.000Z",
+    _cachedAt: Date.now(),
+  })
+}
+
+beforeEach(async () => {
+  markRead.mockReset()
+  markUnread.mockReset()
+  await clearAllCachedData()
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("useConversationReadController", () => {
+  it("derives per-row read state against the stream watermark", async () => {
+    await seedReadState()
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    // Strictly past the watermark sequence (3) → unread.
+    await waitFor(() =>
+      expect(result.current.value.state(ROOT, "m_reply", "5", "2026-06-22T12:00:00.000Z")).toBe("unread")
+    )
+    // At/before the watermark sequence → read.
+    expect(result.current.value.state(ROOT, "m_open", "1", "2026-06-22T12:00:00.000Z")).toBe("read")
+  })
+
+  it("treats an overlay-read row as effectively read even past the watermark", async () => {
+    await seedReadState({ [ROOT]: ["m_reply"] })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    await waitFor(() =>
+      expect(result.current.value.state(ROOT, "m_reply", "5", "2026-06-22T12:00:00.000Z")).toBe("read")
+    )
+  })
+
+  it("falls back to the root read-through time for a non-member thread leg", async () => {
+    await seedReadState()
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+    // A thread with no membership row: compare createdAt to the root's lastReadAt (T0).
+    await waitFor(() =>
+      expect(result.current.value.state(THREAD, "t_old", undefined, "2026-06-22T11:00:00.000Z")).toBe("read")
+    )
+    expect(result.current.value.state(THREAD, "t_new", undefined, "2026-06-22T13:00:00.000Z")).toBe("unread")
+  })
+
+  it("reports the card unread when a non-own member message is effectively unread, excluding own rows", async () => {
+    await seedReadState()
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+
+    const own = msg({ id: "m_own", authorId: ME, sequence: "5" })
+    const other = msg({ id: "m_reply", authorId: OTHER, sequence: "5" })
+    await waitFor(() => expect(result.current.hasUnread([other])).toBe(true))
+    // The viewer's own unread-sequence row must not light the dot.
+    expect(result.current.hasUnread([own])).toBe(false)
+  })
+
+  it("marks read through a message via the client and clears the card unread once the overlay snapshot applies", async () => {
+    await seedReadState()
+    markRead.mockResolvedValue({
+      streams: [
+        {
+          streamId: ROOT,
+          readMessageIds: ["m_reply"],
+          lastReadEventId: "evt_3",
+          lastReadSequence: "3",
+          lastReadOrdinal: 4,
+        },
+      ],
+    })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+    const reply = msg({ id: "m_reply", authorId: OTHER, sequence: "5" })
+
+    await waitFor(() => expect(result.current.hasUnread([reply])).toBe(true))
+
+    result.current.value.markReadUpToHere("m_reply")
+    expect(markRead).toHaveBeenCalledWith(WS, CONV, "m_reply")
+
+    // The absolute snapshot lands in the overlay (IDB), so the row is now
+    // effectively read and the card unread clears live.
+    await waitFor(() => expect(result.current.hasUnread([reply])).toBe(false))
+    expect(result.current.value.state(ROOT, "m_reply", "5", reply.createdAt)).toBe("read")
+  })
+
+  it("marks unread from a message via the client", async () => {
+    await seedReadState({ [ROOT]: ["m_reply"] })
+    markUnread.mockResolvedValue({
+      streams: [
+        { streamId: ROOT, readMessageIds: [], lastReadEventId: "evt_3", lastReadSequence: "3", lastReadOrdinal: 4 },
+      ],
+    })
+    const { result } = renderHook(() => useConversationReadController(WS, CONV, ROOT, ME), { wrapper: wrapper() })
+    const reply = msg({ id: "m_reply", authorId: OTHER, sequence: "5" })
+
+    // Seeded overlay makes it read; mark-unread is offered.
+    await waitFor(() => expect(result.current.value.state(ROOT, "m_reply", "5", reply.createdAt)).toBe("read"))
+    result.current.value.markUnread("m_reply")
+    expect(markUnread).toHaveBeenCalledWith(WS, CONV, "m_reply")
+  })
+})

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -50,10 +50,19 @@ function deriveRowState(
   sequence: string | undefined,
   createdAt: string | Date,
   overlay: Record<string, string[]> | undefined,
+  unreadCounts: Record<string, number> | undefined,
   frontierByStream: Map<string, ReadFrontierRow>,
   rootStreamId: string
 ): RowReadState {
   if (overlay?.[streamId]?.includes(messageId)) return "read"
+
+  // A stream whose effective unread is 0 is fully read — every row in it is at/
+  // below the watermark or in the overlay by definition. This short-circuit is
+  // what keeps the card honest when a watermark advance doesn't carry a
+  // sequence the frontier map can see (mark-all-read advances counts to 0
+  // without a per-stream sequence payload). Strict === 0: a missing entry means
+  // "no data" (non-member thread legs), which must fall through, not read.
+  if (unreadCounts?.[streamId] === 0) return "read"
 
   const membership = frontierByStream.get(streamId)
   if (membership) {
@@ -89,7 +98,9 @@ export function useConversationReadController(
   currentUserId: string | null
 ): { value: ConversationRowRead; hasUnread: (messages: RenderableMessage[]) => boolean } {
   const conversationService = useConversationService()
-  const overlay = useWorkspaceUnreadState(workspaceId)?.readMessageIds
+  const unreadState = useWorkspaceUnreadState(workspaceId)
+  const overlay = unreadState?.readMessageIds
+  const unreadCounts = unreadState?.unreadCounts
   const memberships = useWorkspaceStreamMemberships(workspaceId)
 
   const frontierByStream = useMemo(() => {
@@ -102,8 +113,8 @@ export function useConversationReadController(
 
   const state = useCallback<ConversationRowRead["state"]>(
     (streamId, messageId, sequence, createdAt) =>
-      deriveRowState(streamId, messageId, sequence, createdAt, overlay, frontierByStream, rootStreamId),
-    [overlay, frontierByStream, rootStreamId]
+      deriveRowState(streamId, messageId, sequence, createdAt, overlay, unreadCounts, frontierByStream, rootStreamId),
+    [overlay, unreadCounts, frontierByStream, rootStreamId]
   )
 
   const markReadUpToHere = useCallback(

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -1,0 +1,144 @@
+import { createContext, useCallback, useContext, useMemo } from "react"
+import { toast } from "sonner"
+import { useConversationService } from "@/contexts"
+import { useWorkspaceStreamMemberships, useWorkspaceUnreadState } from "@/stores/workspace-store"
+import { applyReadStateSnapshots } from "@/hooks/use-unread-counts"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/**
+ * Per-row read state + the two read actions for a conversation surface (board
+ * card, conversation panel). Read truth stays message-granular and
+ * stream-anchored (docs/sparse-read-overlay-design.md) — the row gates the
+ * "Mark as read" / "Mark as unread" menu entries by where it sits, and the
+ * actions call the conversation read API and fold the returned snapshots into
+ * the local read state. `null` (no provider — e.g. the label page) hides both
+ * actions, the same field-one-side-sets gate as `conversationId`.
+ */
+export interface ConversationRowRead {
+  state: (streamId: string, messageId: string, sequence: string | undefined, createdAt: string | Date) => RowReadState
+  markReadUpToHere: (messageId: string) => void
+  markUnread: (messageId: string) => void
+}
+
+const ConversationReadContext = createContext<ConversationRowRead | null>(null)
+
+export function useConversationRowRead(): ConversationRowRead | null {
+  return useContext(ConversationReadContext)
+}
+
+export const ConversationReadProvider = ConversationReadContext.Provider
+
+interface ReadFrontierRow {
+  lastReadSequence?: string | null
+  lastReadAt: string | null
+}
+
+/**
+ * Derive one row's effective read state against the conversation's spanned
+ * streams. A member stream compares the row's per-stream `sequence` to the
+ * stream's watermark sequence; a non-member thread leg (no membership row) falls
+ * back to the root watermark's `last_read_at` timestamp (the v1 approximation —
+ * docs/sparse-read-overlay-design.md § "Card unread derivation"). The overlay
+ * makes a row effectively read regardless of sequence. Sequenceless rows
+ * (projection/backfill) fall back to the same timestamp comparison; `ungated`
+ * when nothing can decide (callers show both actions / don't count unread).
+ */
+function deriveRowState(
+  streamId: string,
+  messageId: string,
+  sequence: string | undefined,
+  createdAt: string | Date,
+  overlay: Record<string, string[]> | undefined,
+  frontierByStream: Map<string, ReadFrontierRow>,
+  rootStreamId: string
+): RowReadState {
+  if (overlay?.[streamId]?.includes(messageId)) return "read"
+
+  const membership = frontierByStream.get(streamId)
+  if (membership) {
+    if (sequence != null && membership.lastReadSequence != null) {
+      return BigInt(sequence) > BigInt(membership.lastReadSequence) ? "unread" : "read"
+    }
+    if (membership.lastReadAt != null) {
+      return new Date(createdAt).getTime() > new Date(membership.lastReadAt).getTime() ? "unread" : "read"
+    }
+    return "ungated"
+  }
+
+  const root = frontierByStream.get(rootStreamId)
+  if (root?.lastReadAt != null) {
+    return new Date(createdAt).getTime() > new Date(root.lastReadAt).getTime() ? "unread" : "read"
+  }
+  return "ungated"
+}
+
+/**
+ * Owns a conversation surface's read state: builds the {@link ConversationRowRead}
+ * provider value (per-row gating + the two actions) and a `hasUnread` predicate
+ * for the card's unread dot. Both hosts (board card, panel) call it; it reads the
+ * overlay and per-stream watermarks live from the workspace caches so the derived
+ * state (and the dot) clear the instant a read lands. Own-authored rows never
+ * count toward `hasUnread` — sending a message doesn't make the conversation
+ * unread to yourself.
+ */
+export function useConversationReadController(
+  workspaceId: string,
+  conversationId: string,
+  rootStreamId: string,
+  currentUserId: string | null
+): { value: ConversationRowRead; hasUnread: (messages: RenderableMessage[]) => boolean } {
+  const conversationService = useConversationService()
+  const overlay = useWorkspaceUnreadState(workspaceId)?.readMessageIds
+  const memberships = useWorkspaceStreamMemberships(workspaceId)
+
+  const frontierByStream = useMemo(() => {
+    const map = new Map<string, ReadFrontierRow>()
+    for (const m of memberships) {
+      map.set(m.streamId, { lastReadSequence: m.lastReadSequence, lastReadAt: m.lastReadAt })
+    }
+    return map
+  }, [memberships])
+
+  const state = useCallback<ConversationRowRead["state"]>(
+    (streamId, messageId, sequence, createdAt) =>
+      deriveRowState(streamId, messageId, sequence, createdAt, overlay, frontierByStream, rootStreamId),
+    [overlay, frontierByStream, rootStreamId]
+  )
+
+  const markReadUpToHere = useCallback(
+    (messageId: string) => {
+      conversationService
+        .markRead(workspaceId, conversationId, messageId)
+        .then((res) => applyReadStateSnapshots(workspaceId, res.streams))
+        .catch(() => toast.error("Couldn't mark as read"))
+    },
+    [conversationService, workspaceId, conversationId]
+  )
+
+  const markUnread = useCallback(
+    (messageId: string) => {
+      conversationService
+        .markUnread(workspaceId, conversationId, messageId)
+        .then((res) => applyReadStateSnapshots(workspaceId, res.streams))
+        .catch(() => toast.error("Couldn't mark as unread"))
+    },
+    [conversationService, workspaceId, conversationId]
+  )
+
+  const value = useMemo<ConversationRowRead>(
+    () => ({ state, markReadUpToHere, markUnread }),
+    [state, markReadUpToHere, markUnread]
+  )
+
+  const hasUnread = useCallback(
+    (messages: RenderableMessage[]): boolean =>
+      messages.some(
+        (m) =>
+          m.authorId !== currentUserId && state(m.streamId ?? rootStreamId, m.id, m.sequence, m.createdAt) === "unread"
+      ),
+    [state, currentUserId, rootStreamId]
+  )
+
+  return { value, hasUnread }
+}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -28,6 +28,7 @@ import { MessageHistoryDialog } from "@/components/timeline/message-history-dial
 import { ReminderPickerSheet } from "@/components/timeline/reminder-picker-sheet"
 import { ShareMessageModal } from "@/components/share/share-message-modal"
 import type { MessageActionContext } from "@/components/timeline/message-actions"
+import { useConversationRowRead } from "@/components/message/conversation-read-context"
 import { useQuoteReply } from "@/components/timeline/quote-reply-context"
 import { useMessageReactions, stripColons, reactionShortcodes } from "@/hooks/use-message-reactions"
 import { LabelStack } from "@/components/labels/label-stack"
@@ -70,6 +71,12 @@ export interface RenderableMessage {
    * threads (one root), so a card renders each row against its own stream — the
    * caller passes `message.streamId ?? <card stream>` to {@link MessageItem}. */
   streamId?: string
+  /** This message's per-stream event `sequence` (bigint-as-string), when the row
+   * comes from the live events rail. Gates conversation-surface read state
+   * (a row is unread iff its sequence sits past its stream's read frontier and
+   * it isn't in the overlay). Absent on projection/backfill rows, which fall
+   * back to a timestamp comparison. See docs/sparse-read-overlay-design.md. */
+  sequence?: string
   authorId: string
   authorType: AuthorType
   contentMarkdown: string
@@ -182,6 +189,17 @@ export function MessageItem({
   // label page (no provider, no composer) → `onQuoteReply` stays undefined and the
   // action hides, the same field-one-side-sets gate as `conversationId`.
   const quoteReplyCtx = useQuoteReply()
+
+  // Conversation-surface read state (board card / panel). Absent on the label
+  // page (no provider) → both mark-read actions hide, the same field-one-side-
+  // sets gate as `conversationId`. Gate each action by where the row sits
+  // relative to the effective read frontier, mirroring the in-stream row
+  // (message-event): hide "Mark as read" on read rows, "Mark as unread" on
+  // unread rows; an ungated row (no resolvable frontier) shows both.
+  const conversationRead = useConversationRowRead()
+  const rowRead = conversationRead
+    ? conversationRead.state(streamId, message.id, message.sequence, message.createdAt)
+    : "ungated"
 
   // Own-message edit reuses the timeline's `MessageEditForm` (same save/offline
   // path). The row can host it wherever a message shows — the form only needs
@@ -376,6 +394,9 @@ export function MessageItem({
       label: viewInStreamLabel(rowStream?.type),
     },
     onLabelMessage: () => setLabelPickerOpen(true),
+    onMarkReadUpToHere:
+      conversationRead && rowRead !== "read" ? () => conversationRead.markReadUpToHere(message.id) : undefined,
+    onMarkUnread: conversationRead && rowRead !== "unread" ? () => conversationRead.markUnread(message.id) : undefined,
   }
 
   // Desktop/keyboard only via the shared input-mode reveal model: the row is the

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -922,7 +922,7 @@ function SentMessageEvent({
   // Gate the read-state actions by where this row sits relative to the read
   // pointer: "Mark as read" only on unread rows, "Mark as unread" only on read
   // rows. Ungated (no resolved frontier) shows both.
-  const rowRead = rowReadState(event.sequence, useReadFrontier())
+  const rowRead = rowReadState(event.sequence, payload.messageId, useReadFrontier())
   // For one-level threads, parent === root, so we only show the root entry to
   // avoid two identical menu items. For nested threads (parent is itself a
   // thread), we show both: root for the most useful target (the channel/dm/

--- a/apps/frontend/src/components/timeline/read-frontier-context.test.ts
+++ b/apps/frontend/src/components/timeline/read-frontier-context.test.ts
@@ -1,31 +1,51 @@
 import { describe, it, expect } from "vitest"
-import { rowReadState } from "./read-frontier-context"
+import { rowReadState, type ReadFrontier } from "./read-frontier-context"
+
+const EMPTY: ReadonlySet<string> = new Set()
+const frontier = (sequence: string | null, overlay: ReadonlySet<string> = EMPTY): ReadFrontier => ({
+  sequence,
+  overlay,
+})
 
 describe("rowReadState", () => {
-  it("is ungated when there is no frontier (unresolved / out-of-window)", () => {
-    expect(rowReadState("5", null)).toBe("ungated")
+  it("is ungated when there is no frontier (unresolved / out-of-window) and not overlay-read", () => {
+    expect(rowReadState("5", "msg_1", frontier(null))).toBe("ungated")
   })
 
-  it("is ungated when the row has no sequence yet (optimistic send)", () => {
-    expect(rowReadState(undefined, "5")).toBe("ungated")
-    expect(rowReadState(null, "5")).toBe("ungated")
+  it("is ungated when the row has no sequence yet (optimistic send) and not overlay-read", () => {
+    expect(rowReadState(undefined, "msg_1", frontier("5"))).toBe("ungated")
+    expect(rowReadState(null, "msg_1", frontier("5"))).toBe("ungated")
   })
 
   it("is unread when the row sits strictly past the frontier", () => {
-    expect(rowReadState("6", "5")).toBe("unread")
+    expect(rowReadState("6", "msg_1", frontier("5"))).toBe("unread")
   })
 
   it("is read at or before the frontier (the frontier row is the last read)", () => {
-    expect(rowReadState("5", "5")).toBe("read")
-    expect(rowReadState("4", "5")).toBe("read")
+    expect(rowReadState("5", "msg_1", frontier("5"))).toBe("read")
+    expect(rowReadState("4", "msg_1", frontier("5"))).toBe("read")
   })
 
   it("treats a '0' frontier (nothing read) as everything unread", () => {
-    expect(rowReadState("1", "0")).toBe("unread")
+    expect(rowReadState("1", "msg_1", frontier("0"))).toBe("unread")
   })
 
   it("compares as integers, not lexically (large sequences)", () => {
-    expect(rowReadState("100", "99")).toBe("unread")
-    expect(rowReadState("99", "100")).toBe("read")
+    expect(rowReadState("100", "msg_1", frontier("99"))).toBe("unread")
+    expect(rowReadState("99", "msg_1", frontier("100"))).toBe("read")
+  })
+
+  it("is read when the id is in the overlay even though its sequence is past the frontier", () => {
+    expect(rowReadState("6", "msg_ov", frontier("5", new Set(["msg_ov"])))).toBe("read")
+  })
+
+  it("is read (overlay) even with no resolvable frontier — the overlay is authoritative", () => {
+    expect(rowReadState(undefined, "msg_ov", frontier(null, new Set(["msg_ov"])))).toBe("read")
+  })
+
+  it("still gates by sequence for a row whose id is NOT in the overlay", () => {
+    const ov = new Set(["msg_other"])
+    expect(rowReadState("6", "msg_1", frontier("5", ov))).toBe("unread")
+    expect(rowReadState("5", "msg_1", frontier("5", ov))).toBe("read")
   })
 })

--- a/apps/frontend/src/components/timeline/read-frontier-context.tsx
+++ b/apps/frontend/src/components/timeline/read-frontier-context.tsx
@@ -1,28 +1,45 @@
 import { createContext, useContext } from "react"
 
-/**
- * The read pointer's per-stream `sequence` (bigint-as-string), or `null` when
- * the read state isn't resolved or the pointer sits outside the loaded window.
- * Provided by `stream-content`; message rows read it to gate their read-state
- * actions ("Mark as read" on unread rows, "Mark as unread" on read
- * rows). `null` means "don't gate" — both actions stay visible — so a surface
- * with no provider (e.g. a context with no resolved read state) is unchanged.
- */
-export const ReadFrontierContext = createContext<string | null>(null)
+const EMPTY_OVERLAY: ReadonlySet<string> = new Set()
 
-export function useReadFrontier(): string | null {
+/**
+ * Per-stream read frontier for the open timeline: the read pointer's `sequence`
+ * (bigint-as-string, or `null` when the read state isn't resolved or the pointer
+ * sits outside the loaded window) plus the sparse read overlay — message ids read
+ * individually *above* the watermark (docs/sparse-read-overlay-design.md). A row
+ * is *effectively* read when its id is in the overlay even if its sequence sits
+ * past the frontier. Provided by `stream-content`; message rows read it to gate
+ * their read-state actions. The default (`{ sequence: null, overlay: ∅ }`) means
+ * "don't gate" — both actions stay visible — so a surface with no provider is
+ * unchanged.
+ */
+export interface ReadFrontier {
+  sequence: string | null
+  overlay: ReadonlySet<string>
+}
+
+export const ReadFrontierContext = createContext<ReadFrontier>({ sequence: null, overlay: EMPTY_OVERLAY })
+
+export function useReadFrontier(): ReadFrontier {
   return useContext(ReadFrontierContext)
 }
 
 export type RowReadState = "read" | "unread" | "ungated"
 
 /**
- * Where a row sits relative to the read pointer. A row is `unread` when its
- * sequence is strictly past the frontier; the row AT the frontier (the last
- * read message) counts as `read`. `ungated` when there's no usable frontier or
- * the row has no sequence yet (optimistic send) — callers show both actions.
+ * Where a row sits relative to the *effective* read state. A row is `read` when
+ * its id is in the overlay (individually read above the watermark) or its
+ * sequence is at/before the frontier; `unread` only when its sequence is
+ * strictly past the frontier AND it isn't in the overlay; `ungated` when there's
+ * no usable frontier or the row has no sequence yet (optimistic send) and isn't
+ * overlay-read — callers show both actions.
  */
-export function rowReadState(eventSequence: string | null | undefined, readFrontier: string | null): RowReadState {
-  if (readFrontier === null || eventSequence == null) return "ungated"
-  return BigInt(eventSequence) > BigInt(readFrontier) ? "unread" : "read"
+export function rowReadState(
+  eventSequence: string | null | undefined,
+  messageId: string | null | undefined,
+  frontier: ReadFrontier
+): RowReadState {
+  if (messageId != null && frontier.overlay.has(messageId)) return "read"
+  if (frontier.sequence === null || eventSequence == null) return "ungated"
+  return BigInt(eventSequence) > BigInt(frontier.sequence) ? "unread" : "read"
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -98,7 +98,8 @@ import { stripMarkdownToInline } from "@/lib/markdown"
 import { localStartOfDayMs } from "@/lib/dates"
 import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
 import { addMarkReadUpToHereListener, addMarkUnreadListener } from "@/lib/mark-read-events"
-import { ReadFrontierContext } from "./read-frontier-context"
+import { ReadFrontierContext, type ReadFrontier } from "./read-frontier-context"
+import { useReadMessageIds } from "@/hooks/use-unread-counts"
 
 /** Membership events; suppressed in threads (see displayEvents memo). */
 const THREAD_HIDDEN_EVENT_TYPES = new Set<StreamEvent["eventType"]>(["member_joined", "member_added", "member_left"])
@@ -1684,8 +1685,20 @@ export function StreamContent({
   const { markAsRead, markUnread, getUnreadCount } = useUnreadCounts(workspaceId)
   const unreadCount = getUnreadCount(streamId)
 
+  // The stream's sparse read overlay — message ids read individually above the
+  // watermark (from a conversation-surface read). Threads through the read
+  // frontier so the divider, the "new" flash, and per-row gating all treat an
+  // overlay-read row as effectively read (docs/sparse-read-overlay-design.md).
+  const readOverlay = useReadMessageIds(workspaceId, streamId)
+
   // Track live-arriving messages from other users for brief "new" indicator.
-  const newMessageIds = useNewMessageIndicator(events, currentWorkspaceUserId ?? undefined, streamId, lastReadEventId)
+  const newMessageIds = useNewMessageIndicator(
+    events,
+    currentWorkspaceUserId ?? undefined,
+    streamId,
+    lastReadEventId,
+    readOverlay
+  )
 
   // Unread divider state — a bookmark line at the first unread message. The
   // stream opens at the bottom (no auto-scroll to unread); the viewer reaches
@@ -1706,6 +1719,9 @@ export function StreamContent({
     // session). `idbStream` alone isn't enough — its denormalized copy can be a
     // stale null while the authoritative membership value is still loading.
     readStateResolved: lastReadEventId !== undefined,
+    // Skip overlay-read events so the divider anchors on the first *effectively*
+    // unread row, not one already read from a conversation surface.
+    overlayReadIds: readOverlay,
   })
 
   // The divider is red while unread still sits at/after it, and turns muted-gray
@@ -1953,6 +1969,11 @@ export function StreamContent({
     return events.find((event) => event.id === lastReadEventId)?.sequence ?? null
   }, [events, lastReadEventId])
 
+  const readFrontier = useMemo<ReadFrontier>(
+    () => ({ sequence: readFrontierSequence, overlay: readOverlay }),
+    [readFrontierSequence, readOverlay]
+  )
+
   // Hard load error with nothing cached to fall back on. Placed after every
   // hook so the hook order stays stable: `error`/`idbStream` can toggle (a
   // failed fetch that later succeeds, or IDB resolving a beat after first
@@ -1969,7 +1990,7 @@ export function StreamContent({
   }
 
   return (
-    <ReadFrontierContext.Provider value={readFrontierSequence}>
+    <ReadFrontierContext.Provider value={readFrontier}>
       <EditLastMessageContext.Provider value={editLastMessageCtxWithScroll}>
         <QuoteReplyProvider>
           <ConversationReplyProvider>

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -69,6 +69,8 @@ export interface ConversationService {
   getMessages: typeof conversationsApi.getMessages
   getBoardMessages: typeof conversationsApi.getBoardMessages
   getBoardPost: typeof conversationsApi.getBoardPost
+  markRead: typeof conversationsApi.markRead
+  markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
 }
 

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -138,6 +138,14 @@ export interface CachedStreamMembership {
   memberId: string
   notificationLevel: NotificationLevel | null
   lastReadEventId: string | null
+  /**
+   * The watermark event's per-stream sequence (stringified bigint), mirrored
+   * from the membership row / read events. Lets board-card unread derivation
+   * compare a row's sequence against the read frontier without holding the
+   * watermark event. Optional during rollout / for rows cached before it
+   * shipped. See docs/sparse-read-overlay-design.md.
+   */
+  lastReadSequence?: string | null
   lastReadAt: string | null
   joinedAt: string
   _cachedAt: number
@@ -477,6 +485,14 @@ export interface CachedUnreadState {
    * rows cached before the field shipped; see sync/unread-counters.ts.
    */
   latestOrdinals?: Record<string, number>
+  /**
+   * Sparse read overlay per stream (docs/sparse-read-overlay-design.md): message
+   * ids read individually above each stream's watermark. Rides this singleton
+   * row (no index). Effective unread stays `latestOrdinals[s] − read(s) −
+   * |readMessageIds[s]|`. Absent for rows cached before the field shipped;
+   * readers normalize with `?.`. See sync/unread-counters.ts.
+   */
+  readMessageIds?: Record<string, string[]>
   mutedStreamIds: string[]
   _cachedAt: number
 }
@@ -1236,6 +1252,12 @@ export class ThreaDatabase extends Dexie {
     this.version(36).stores({
       conversations: "id, workspaceId, [workspaceId+_lastActivityMs], _cachedAt",
     })
+
+    // v37: sparse read overlay (docs/sparse-read-overlay-design.md). The overlay
+    // (`unreadState.readMessageIds`) and the membership watermark sequence
+    // (`streamMemberships.lastReadSequence`) are unindexed value fields on
+    // existing rows, so the bump only guards the added shape — no schema delta.
+    this.version(37).stores({})
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }

--- a/apps/frontend/src/hooks/use-activity.ts
+++ b/apps/frontend/src/hooks/use-activity.ts
@@ -12,6 +12,14 @@ export const activityKeys = {
     ["activity", workspaceId, filters] as const,
 }
 
+/**
+ * One page of the activity feed. Exported because the unread-tab reconcile
+ * backstop must know whether a fetched page is the COMPLETE unread set
+ * (rows < limit) — reconciling the held badge set against a truncated page
+ * would clamp the count to the page size.
+ */
+export const ACTIVITY_FEED_PAGE_LIMIT = 50
+
 export function useActivityFeed(
   workspaceId: string,
   opts?: { unreadOnly?: boolean; mineOnly?: boolean; othersOnly?: boolean }
@@ -23,7 +31,8 @@ export function useActivityFeed(
 
   return useQuery({
     queryKey: activityKeys.listFiltered(workspaceId, { unreadOnly, mineOnly, othersOnly }),
-    queryFn: () => activityService.list(workspaceId, { limit: 50, unreadOnly, mineOnly, othersOnly }),
+    queryFn: () =>
+      activityService.list(workspaceId, { limit: ACTIVITY_FEED_PAGE_LIMIT, unreadOnly, mineOnly, othersOnly }),
     // Subscribe-then-bootstrap: socket events invalidate; refetchOnMount picks up
     // the invalidation, staleTime: Infinity suppresses other auto-refetches.
     staleTime: Infinity,

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -29,6 +29,7 @@ function eventToRenderable(event: CachedEvent): RenderableMessage | null {
   return {
     id: p.messageId,
     streamId: event.streamId,
+    sequence: event.sequence,
     authorId: event.actorId ?? "",
     authorType: (event.actorType ?? "user") as AuthorType,
     contentMarkdown: p.contentMarkdown ?? "",

--- a/apps/frontend/src/hooks/use-new-message-indicator.ts
+++ b/apps/frontend/src/hooks/use-new-message-indicator.ts
@@ -19,7 +19,8 @@ export function useNewMessageIndicator(
   events: StreamEvent[],
   currentUserId: string | undefined,
   streamId: string,
-  lastReadEventId?: string | null
+  lastReadEventId?: string | null,
+  overlayReadIds?: ReadonlySet<string>
 ): Set<string> {
   const [newIds, setNewIds] = useState<Set<string>>(new Set())
   /** Event IDs present when the stream was opened. With the eventCache removed,
@@ -61,11 +62,13 @@ export function useNewMessageIndicator(
       const event = events[i]
       if (lastReadIndex >= 0 && i <= lastReadIndex) break
       if (knownEventIdsRef.current.has(event.id)) break
+      const messageId = (event.payload as { messageId?: string } | null)?.messageId
       if (
         !trackedIdsRef.current.has(event.id) &&
         event.actorId !== currentUserId &&
         event.actorType === "user" &&
-        (event.eventType === "message_created" || event.eventType === "companion_response")
+        (event.eventType === "message_created" || event.eventType === "companion_response") &&
+        !(messageId && overlayReadIds?.has(messageId))
       ) {
         freshIds.push(event.id)
       }
@@ -93,7 +96,7 @@ export function useNewMessageIndicator(
       })
     }, 2000)
     timersRef.current.add(timer)
-  }, [events, currentUserId, lastReadEventId])
+  }, [events, currentUserId, lastReadEventId, overlayReadIds])
 
   return newIds
 }

--- a/apps/frontend/src/hooks/use-unread-counts.ts
+++ b/apps/frontend/src/hooks/use-unread-counts.ts
@@ -6,8 +6,56 @@ import { streamKeys } from "./use-streams"
 import { useWorkspaceUnreadState } from "@/stores/workspace-store"
 import { db } from "@/db"
 import { deriveActivityCounts } from "@/sync/unread-counters"
+import { applyReadStateSnapshotsIdb, type ReadStateSnapshot } from "@/sync/read-state"
 import { SW_MSG_CLEAR_NOTIFICATIONS } from "@/lib/sw-messages"
 import type { WorkspaceBootstrap } from "@threa/types"
+
+export type { ReadStateSnapshot }
+
+const EMPTY_READ_SET: ReadonlySet<string> = new Set()
+
+/** Drop one stream's entry from a sparse-overlay map, returning the same
+ *  reference when there is nothing to remove. */
+function withoutOverlay(
+  map: Record<string, string[]> | undefined,
+  streamId: string
+): Record<string, string[]> | undefined {
+  if (!map || !(streamId in map)) return map
+  const next = { ...map }
+  delete next[streamId]
+  return next
+}
+
+/**
+ * The sparse read overlay for one stream as a referentially-stable set: the
+ * message ids read individually above the stream's watermark
+ * (docs/sparse-read-overlay-design.md). Reads IDB via `useLiveQuery`; the
+ * returned set keeps its identity while the overlay's contents are unchanged, so
+ * consumers can use it as a stable dependency.
+ */
+export function useReadMessageIds(workspaceId: string, streamId: string): ReadonlySet<string> {
+  const unreadState = useWorkspaceUnreadState(workspaceId)
+  const ids = unreadState?.readMessageIds?.[streamId]
+  // `useLiveQuery` structured-clones a fresh array on every IDB write, so key on
+  // the overlay's CONTENT (not the array reference) to keep the returned set
+  // referentially stable while the stream's overlay is unchanged.
+  const key = ids && ids.length ? ids.join(" ") : ""
+  const stable = useRef<{ key: string; set: ReadonlySet<string> }>({ key: "", set: EMPTY_READ_SET })
+  if (stable.current.key !== key) {
+    stable.current = { key, set: key === "" ? EMPTY_READ_SET : new Set(ids) }
+  }
+  return stable.current.set
+}
+
+/**
+ * Optimistically apply sparse-read snapshots (from a conversation-surface read)
+ * straight to IDB so the timeline overlay, board card, and badge update at once;
+ * the authoritative `stream:read_messages` socket echo reconciles the query
+ * cache. One apply path with the socket handler (`sync/read-state.ts`).
+ */
+export function applyReadStateSnapshots(workspaceId: string, snapshots: ReadStateSnapshot[]): Promise<void> {
+  return applyReadStateSnapshotsIdb(workspaceId, snapshots)
+}
 
 export function useUnreadCounts(workspaceId: string) {
   const queryClient = useQueryClient()
@@ -52,7 +100,15 @@ export function useUnreadCounts(workspaceId: string) {
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
         const rows = (old.unreadActivities ?? []).filter((a) => a.streamId !== streamId)
-        const messageCounters = partial ? {} : { unreadCounts: { ...old.unreadCounts, [streamId]: 0 } }
+        // A full read advances the watermark to latest, so every overlay message
+        // for this stream is now below it and pruned server-side — clear the set
+        // optimistically to keep the invariant (the server echo re-SETs it).
+        const messageCounters = partial
+          ? {}
+          : {
+              unreadCounts: { ...old.unreadCounts, [streamId]: 0 },
+              readMessageIds: withoutOverlay(old.readMessageIds, streamId),
+            }
         return {
           ...old,
           unreadActivities: rows,
@@ -85,7 +141,12 @@ export function useUnreadCounts(workspaceId: string) {
             ...state,
             unreadActivities: rows,
             ...deriveActivityCounts(rows),
-            ...(partial ? {} : { unreadCounts: { ...state.unreadCounts, [streamId]: 0 } }),
+            ...(partial
+              ? {}
+              : {
+                  unreadCounts: { ...state.unreadCounts, [streamId]: 0 },
+                  readMessageIds: withoutOverlay(state.readMessageIds, streamId),
+                }),
             _cachedAt: now,
           })
         }
@@ -179,12 +240,15 @@ export function useUnreadCounts(workspaceId: string) {
       queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
         if (!old) return old
         const newUnread = { ...old.unreadCounts }
+        const newReadMessageIds = { ...old.readMessageIds }
         for (const streamId of updatedStreamIds) {
           newUnread[streamId] = 0
+          delete newReadMessageIds[streamId]
         }
         return {
           ...old,
           unreadCounts: newUnread,
+          readMessageIds: newReadMessageIds,
           unreadActivities: [],
           ...deriveActivityCounts([]),
         }
@@ -194,12 +258,15 @@ export function useUnreadCounts(workspaceId: string) {
         const state = await db.unreadState.get(workspaceId)
         if (!state) return
         const newUnread = { ...state.unreadCounts }
+        const newReadMessageIds = { ...state.readMessageIds }
         for (const streamId of updatedStreamIds) {
           newUnread[streamId] = 0
+          delete newReadMessageIds[streamId]
         }
         await db.unreadState.put({
           ...state,
           unreadCounts: newUnread,
+          readMessageIds: newReadMessageIds,
           unreadActivities: [],
           ...deriveActivityCounts([]),
           _cachedAt: Date.now(),

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -263,6 +263,40 @@ describe("useUnreadDivider", () => {
 
     expect(enabledCalls[enabledCalls.length - 1]).toBe(true)
   })
+
+  it("skips an overlay-read event and anchors the divider on the first effectively-unread row", () => {
+    const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadEventId: null,
+        currentUserId: "me",
+        streamId: "stream_1",
+        readStateResolved: true,
+        // event_1 was read individually above the watermark (a conversation-
+        // surface read) → the divider skips it and lands on event_2.
+        overlayReadIds: new Set(["msg_event_1"]),
+      })
+    )
+
+    expect(result.current.dividerEventId).toBe("event_2")
+  })
+
+  it("shows no divider when every candidate unread row is overlay-read", () => {
+    const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
+    const { result } = renderHook(() =>
+      useUnreadDivider({
+        events,
+        lastReadEventId: null,
+        currentUserId: "me",
+        streamId: "stream_1",
+        readStateResolved: true,
+        overlayReadIds: new Set(["msg_event_1", "msg_event_2"]),
+      })
+    )
+
+    expect(result.current.dividerEventId).toBeUndefined()
+  })
 })
 
 describe("isDividerReadPast", () => {

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -29,6 +29,13 @@ interface UseUnreadDividerOptions {
    * affirmatively say the read position is resolved before any divider latches.
    */
   readStateResolved?: boolean
+  /**
+   * Message ids read individually above the watermark (the sparse read overlay).
+   * The divider anchors on the first *effectively* unread event — one whose
+   * message id isn't in this set — so a row already read from a conversation
+   * surface is skipped. See docs/sparse-read-overlay-design.md.
+   */
+  overlayReadIds?: ReadonlySet<string>
 }
 
 interface UseUnreadDividerResult {
@@ -80,6 +87,7 @@ export function useUnreadDivider({
   highlightMessageId,
   isLoading = false,
   readStateResolved = false,
+  overlayReadIds,
 }: UseUnreadDividerOptions): UseUnreadDividerResult {
   const firstUnreadEventId = useMemo(() => {
     if (events.length === 0 || !readStateResolved) return undefined
@@ -91,16 +99,20 @@ export function useUnreadDivider({
       return undefined
     }
 
-    // Find first visible event from another user after the last read position.
-    // Skip event types that don't render as timeline items (e.g. reactions).
+    // Find the first *effectively* unread visible event from another user after
+    // the last read position. Skip event types that don't render as timeline
+    // items (e.g. reactions) and rows already in the overlay (individually read
+    // from a conversation surface).
     for (let i = startIndex; i < events.length; i++) {
-      if (events[i].actorId !== currentUserId && !INVISIBLE_EVENT_TYPES.has(events[i].eventType)) {
-        return events[i].id
-      }
+      const event = events[i]
+      if (event.actorId === currentUserId || INVISIBLE_EVENT_TYPES.has(event.eventType)) continue
+      const messageId = (event.payload as { messageId?: string } | null)?.messageId
+      if (messageId && overlayReadIds?.has(messageId)) continue
+      return event.id
     }
 
     return undefined
-  }, [events, lastReadEventId, currentUserId, readStateResolved])
+  }, [events, lastReadEventId, currentUserId, readStateResolved, overlayReadIds])
 
   // Latch the first unread position for this stream and hold it for the whole
   // reading session. Done in render (not an effect) so it's immune to effect

--- a/apps/frontend/src/pages/activity.tsx
+++ b/apps/frontend/src/pages/activity.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import { Navigate, useParams } from "react-router-dom"
+import { useQueryClient } from "@tanstack/react-query"
 import { Bell, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -12,6 +13,8 @@ import { ActivityItem } from "@/components/activity/activity-item"
 import { ActivityEmpty } from "@/components/activity/activity-empty"
 import { ActivitySkeleton } from "@/components/activity/activity-skeleton"
 import { PageHeaderTabs } from "@/components/layout"
+import { commitCounterMutation } from "@/sync/catch-up-batch"
+import { reconcileActivities } from "@/sync/unread-counters"
 import type { AuthorType, Activity } from "@threa/types"
 
 type ActivityFilter = "all" | "unread" | "me"
@@ -54,6 +57,7 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
   })
   const markRead = useMarkActivityRead(workspaceId)
   const markAllRead = useMarkAllActivityRead(workspaceId)
+  const queryClient = useQueryClient()
   const { getActorName, getActorAvatar } = useActors(workspaceId)
   const { toEmoji } = useWorkspaceEmoji(workspaceId)
   const idbStreams = useWorkspaceStreams(workspaceId)
@@ -62,6 +66,16 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
   const streamById = useMemo(() => {
     return new Map(idbStreams.map((s) => [s.id, s]))
   }, [idbStreams])
+
+  // Fix A4 backstop (docs/sparse-read-overlay-design.md): when the unread feed
+  // resolves, reconcile the held activity set to exactly the rows the server
+  // shows unread, so the badge can never disagree with the open feed (mops up
+  // residual drift like a move-rehomed row under an unvisited root). Folds
+  // through commitCounter so a live row spliced mid-fetch applies on top.
+  useEffect(() => {
+    if (filter !== "unread" || isLoading || !activities) return
+    commitCounterMutation(queryClient, workspaceId, (s) => reconcileActivities(s, activities))
+  }, [filter, isLoading, activities, queryClient, workspaceId])
 
   // Filter tabs are links, not buttons (INV-40). The Tabs primitive is still
   // used for the visual "active" styling — controlled via `value` — but each

--- a/apps/frontend/src/pages/activity.tsx
+++ b/apps/frontend/src/pages/activity.tsx
@@ -5,6 +5,7 @@ import { Bell, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useActivityFeed, useMarkActivityRead, useMarkAllActivityRead, useActors } from "@/hooks"
+import { ACTIVITY_FEED_PAGE_LIMIT } from "@/hooks/use-activity"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
 import { useActivityCounts } from "@/hooks/use-activity-counts"
@@ -72,8 +73,13 @@ function ActivityPageInner({ workspaceId, filter }: InnerProps) {
   // shows unread, so the badge can never disagree with the open feed (mops up
   // residual drift like a move-rehomed row under an unvisited root). Folds
   // through commitCounter so a live row spliced mid-fetch applies on top.
+  // Only when the page is the COMPLETE unread set (rows < limit): replacing the
+  // held set with a truncated page would clamp an honest 80-unread badge to 50.
+  // The drift this backstop targets is a handful of orphaned rows, so the
+  // full-page case can safely skip.
   useEffect(() => {
     if (filter !== "unread" || isLoading || !activities) return
+    if (activities.length >= ACTIVITY_FEED_PAGE_LIMIT) return
     commitCounterMutation(queryClient, workspaceId, (s) => reconcileActivities(s, activities))
   }, [filter, isLoading, activities, queryClient, workspaceId])
 

--- a/apps/frontend/src/sync/catch-up-batch.ts
+++ b/apps/frontend/src/sync/catch-up-batch.ts
@@ -54,7 +54,7 @@ function applyPreviewsToCache(
 
 /** Fold the counter mutations onto the IDB unread-state singleton. Must run
  *  inside an open `rw` transaction that includes `db.unreadState`. */
-async function putCountersIdb(workspaceId: string, mutators: CounterMutator[]): Promise<void> {
+export async function putCountersIdb(workspaceId: string, mutators: CounterMutator[]): Promise<void> {
   if (mutators.length === 0) return
   const state = await db.unreadState.get(workspaceId)
   if (!state) return

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { QueryClient } from "@tanstack/react-query"
+import { db } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { commitCounterMutation } from "./catch-up-batch"
+import { applyReadStateSnapshotsIdb, commitReadStateSnapshot, type ReadStateSnapshot } from "./read-state"
+
+function snapshot(overrides: Partial<ReadStateSnapshot> = {}): ReadStateSnapshot {
+  return {
+    streamId: "stream_1",
+    readMessageIds: ["msg_5", "msg_7"],
+    lastReadEventId: "evt_4",
+    lastReadSequence: "40",
+    lastReadOrdinal: 4,
+    ...overrides,
+  }
+}
+
+async function seedUnreadState() {
+  await db.unreadState.put({
+    id: "ws_1",
+    workspaceId: "ws_1",
+    unreadCounts: { stream_1: 6 },
+    mentionCounts: {},
+    activityCounts: {},
+    unreadActivityCount: 0,
+    unreadActivities: [],
+    latestOrdinals: { stream_1: 10 },
+    mutedStreamIds: [],
+    _cachedAt: Date.now(),
+  })
+}
+
+async function seedMembership() {
+  await db.streamMemberships.put({
+    id: "ws_1:stream_1",
+    workspaceId: "ws_1",
+    streamId: "stream_1",
+    memberId: "member_1",
+    notificationLevel: null,
+    lastReadEventId: "evt_0",
+    lastReadAt: null,
+    joinedAt: new Date().toISOString(),
+    _cachedAt: Date.now(),
+  })
+}
+
+describe("applyReadStateSnapshotsIdb", () => {
+  beforeEach(async () => {
+    await Promise.all([db.unreadState.clear(), db.streamMemberships.clear(), db.streams.clear()])
+  })
+
+  it("SETs the overlay, recomputes unread by the invariant, and mirrors the watermark", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()])
+
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toEqual(["msg_5", "msg_7"])
+    expect(state?.unreadCounts.stream_1).toBe(4) // 10 - 4 - 2
+
+    const membership = await db.streamMemberships.get("ws_1:stream_1")
+    expect(membership?.lastReadEventId).toBe("evt_4")
+    expect(membership?.lastReadSequence).toBe("40")
+  })
+
+  it("is idempotent — a duplicate snapshot converges to the same state", async () => {
+    await seedUnreadState()
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()])
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot()])
+
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toEqual(["msg_5", "msg_7"])
+    expect(state?.unreadCounts.stream_1).toBe(4)
+  })
+
+  it("no-ops when there are no snapshots", async () => {
+    await seedUnreadState()
+    await applyReadStateSnapshotsIdb("ws_1", [])
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds).toBeUndefined()
+    expect(state?.unreadCounts.stream_1).toBe(6)
+  })
+})
+
+describe("commitReadStateSnapshot", () => {
+  beforeEach(async () => {
+    await Promise.all([db.unreadState.clear(), db.streamMemberships.clear(), db.streams.clear()])
+  })
+
+  it("mirrors the watermark into the workspace bootstrap cache and folds the counter", async () => {
+    await seedUnreadState()
+    await seedMembership()
+
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), {
+      unreadCounts: { stream_1: 6 },
+      messageCounts: { stream_1: 10 },
+      readMessageIds: {},
+      unreadActivities: [],
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      streamMemberships: [{ streamId: "stream_1", lastReadEventId: "evt_0", lastReadSequence: "0" }],
+    })
+
+    commitReadStateSnapshot(queryClient, "ws_1", snapshot(), (m) => commitCounterMutation(queryClient, "ws_1", m))
+
+    const cached = queryClient.getQueryData<{
+      unreadCounts: Record<string, number>
+      readMessageIds: Record<string, string[]>
+      streamMemberships: Array<{ streamId: string; lastReadEventId: string | null; lastReadSequence?: string | null }>
+    }>(workspaceKeys.bootstrap("ws_1"))
+    expect(cached?.unreadCounts.stream_1).toBe(4)
+    expect(cached?.readMessageIds.stream_1).toEqual(["msg_5", "msg_7"])
+    expect(cached?.streamMemberships[0].lastReadEventId).toBe("evt_4")
+    expect(cached?.streamMemberships[0].lastReadSequence).toBe("40")
+  })
+})

--- a/apps/frontend/src/sync/read-state.test.ts
+++ b/apps/frontend/src/sync/read-state.test.ts
@@ -31,6 +31,24 @@ async function seedUnreadState() {
   })
 }
 
+function makeActivity(id: string, messageId: string) {
+  return {
+    id,
+    workspaceId: "ws_1",
+    userId: "usr_1",
+    activityType: "mention",
+    streamId: "stream_1",
+    messageId,
+    actorId: "usr_2",
+    actorType: "user" as const,
+    context: {},
+    isSelf: false,
+    readAt: null,
+    emoji: null,
+    createdAt: new Date().toISOString(),
+  }
+}
+
 async function seedMembership() {
   await db.streamMemberships.put({
     id: "ws_1:stream_1",
@@ -48,6 +66,29 @@ async function seedMembership() {
 describe("applyReadStateSnapshotsIdb", () => {
   beforeEach(async () => {
     await Promise.all([db.unreadState.clear(), db.streamMemberships.clear(), db.streams.clear()])
+  })
+
+  it("drops held activity for exactly the marked messages (message-granular badge coupling)", async () => {
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 6 },
+      mentionCounts: { stream_1: 2 },
+      activityCounts: { stream_1: 2 },
+      unreadActivityCount: 2,
+      unreadActivities: [makeActivity("act_1", "msg_5"), makeActivity("act_2", "msg_9")],
+      latestOrdinals: { stream_1: 10 },
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+    await seedMembership()
+
+    // msg_5 was marked read; msg_9 belongs to another topic and keeps its badge.
+    await applyReadStateSnapshotsIdb("ws_1", [snapshot({ markedMessageIds: ["msg_5"] })])
+
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.unreadActivities?.map((a) => a.id)).toEqual(["act_2"])
+    expect(state?.unreadActivityCount).toBe(1)
   })
 
   it("SETs the overlay, recomputes unread by the invariant, and mirrors the watermark", async () => {

--- a/apps/frontend/src/sync/read-state.ts
+++ b/apps/frontend/src/sync/read-state.ts
@@ -1,0 +1,119 @@
+import type { QueryClient } from "@tanstack/react-query"
+import type { StreamBootstrap, WorkspaceBootstrap } from "@threa/types"
+import { db } from "@/db"
+import { workspaceKeys } from "@/hooks/use-workspaces"
+import { streamKeys } from "@/hooks/use-streams"
+import { applyStreamReadMessages } from "./unread-counters"
+import { putCountersIdb, type CounterMutator } from "./catch-up-batch"
+
+/**
+ * The absolute post-write read state for one stream produced by a sparse-read
+ * write (`stream:read_messages` socket echo, or a conversation-surface optimistic
+ * apply). `readMessageIds` is the ENTIRE overlay for that (stream, member) after
+ * the write (post-compaction) — absolute, not a delta — so application is
+ * idempotent and order-convergent. See docs/sparse-read-overlay-design.md.
+ */
+export interface ReadStateSnapshot {
+  streamId: string
+  readMessageIds: string[]
+  lastReadEventId: string | null
+  lastReadSequence: string
+  lastReadOrdinal: number
+}
+
+/** The pure counter fold for one snapshot — the single math authority both the
+ *  socket echo and the optimistic apply route through. */
+export function snapshotCounterMutator(snapshot: ReadStateSnapshot): CounterMutator {
+  return (state) =>
+    applyStreamReadMessages(state, snapshot.streamId, {
+      readMessageIds: snapshot.readMessageIds,
+      lastReadOrdinal: snapshot.lastReadOrdinal,
+    })
+}
+
+/** Mirror a snapshot's watermark fields into the query cache (workspace +
+ *  stream bootstrap membership rows) so the unread divider tracks immediately. */
+function mirrorSnapshotToCache(queryClient: QueryClient, workspaceId: string, snapshot: ReadStateSnapshot): void {
+  queryClient.setQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId), (old) => {
+    if (!old) return old
+    return {
+      ...old,
+      streamMemberships: old.streamMemberships.map((membership) =>
+        membership.streamId === snapshot.streamId
+          ? { ...membership, lastReadEventId: snapshot.lastReadEventId, lastReadSequence: snapshot.lastReadSequence }
+          : membership
+      ),
+    }
+  })
+
+  queryClient.setQueryData<StreamBootstrap | undefined>(streamKeys.bootstrap(workspaceId, snapshot.streamId), (old) => {
+    if (!old?.membership) return old
+    return {
+      ...old,
+      membership: {
+        ...old.membership,
+        lastReadEventId: snapshot.lastReadEventId,
+        lastReadSequence: snapshot.lastReadSequence,
+      },
+    }
+  })
+}
+
+/** Write a snapshot's watermark mirrors to IDB. Must run inside an open `rw`
+ *  transaction that includes `db.streams` and `db.streamMemberships`. */
+async function writeSnapshotWatermarkIdb(workspaceId: string, snapshot: ReadStateSnapshot): Promise<void> {
+  const now = Date.now()
+  await db.streams.update(snapshot.streamId, { lastReadEventId: snapshot.lastReadEventId, _cachedAt: now })
+
+  const membershipId = `${workspaceId}:${snapshot.streamId}`
+  const membership = await db.streamMemberships.get(membershipId)
+  if (membership) {
+    await db.streamMemberships.put({
+      ...membership,
+      lastReadEventId: snapshot.lastReadEventId,
+      lastReadSequence: snapshot.lastReadSequence,
+      id: membershipId,
+      workspaceId,
+      _cachedAt: now,
+    })
+  }
+}
+
+/**
+ * THE single apply path for a sparse-read snapshot on the socket side: mirror
+ * the watermark into the query cache, fold the counter through the caller's
+ * commit (batch-aware during catch-up, immediate live), and persist the
+ * watermark mirrors to IDB. The counter's own IDB write (`db.unreadState`) is
+ * owned by `commitCounter`; the watermark mirror is a separate transaction, as
+ * with the other read handlers.
+ */
+export function commitReadStateSnapshot(
+  queryClient: QueryClient,
+  workspaceId: string,
+  snapshot: ReadStateSnapshot,
+  commitCounter: (mutate: CounterMutator) => void
+): void {
+  mirrorSnapshotToCache(queryClient, workspaceId, snapshot)
+  commitCounter(snapshotCounterMutator(snapshot))
+  void db.transaction("rw", [db.streams, db.streamMemberships], () => writeSnapshotWatermarkIdb(workspaceId, snapshot))
+}
+
+/**
+ * Optimistic apply of one or more snapshots straight to IDB (no query cache):
+ * the badge (`db.unreadState`), the timeline overlay, and the board card read
+ * state all read IDB via `useLiveQuery`, so this drives the live UI instantly.
+ * The authoritative `stream:read_messages` echo reconciles the query cache
+ * through `commitReadStateSnapshot`. Counter math + watermark persistence share
+ * the same helpers as the socket path (`snapshotCounterMutator`,
+ * `writeSnapshotWatermarkIdb`), so there is one apply path per surface (INV-35).
+ */
+export async function applyReadStateSnapshotsIdb(workspaceId: string, snapshots: ReadStateSnapshot[]): Promise<void> {
+  if (snapshots.length === 0) return
+  const mutators = snapshots.map(snapshotCounterMutator)
+  await db.transaction("rw", [db.unreadState, db.streams, db.streamMemberships], async () => {
+    await putCountersIdb(workspaceId, mutators)
+    for (const snapshot of snapshots) {
+      await writeSnapshotWatermarkIdb(workspaceId, snapshot)
+    }
+  })
+}

--- a/apps/frontend/src/sync/read-state.ts
+++ b/apps/frontend/src/sync/read-state.ts
@@ -3,7 +3,7 @@ import type { StreamBootstrap, WorkspaceBootstrap } from "@threa/types"
 import { db } from "@/db"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
-import { applyStreamReadMessages } from "./unread-counters"
+import { applyStreamReadMessages, dropMessageActivities } from "./unread-counters"
 import { putCountersIdb, type CounterMutator } from "./catch-up-batch"
 
 /**
@@ -19,16 +19,25 @@ export interface ReadStateSnapshot {
   lastReadEventId: string | null
   lastReadSequence: string
   lastReadOrdinal: number
+  /** The ids this write marked read (pre-compaction) — set on the read path
+   * only. Their held activity rows (mention/reply badges) drop on apply:
+   * message-granular, so the stream's other topics keep their badges. */
+  markedMessageIds?: string[]
 }
 
 /** The pure counter fold for one snapshot — the single math authority both the
  *  socket echo and the optimistic apply route through. */
 export function snapshotCounterMutator(snapshot: ReadStateSnapshot): CounterMutator {
-  return (state) =>
-    applyStreamReadMessages(state, snapshot.streamId, {
+  return (state) => {
+    let next = applyStreamReadMessages(state, snapshot.streamId, {
       readMessageIds: snapshot.readMessageIds,
       lastReadOrdinal: snapshot.lastReadOrdinal,
     })
+    for (const messageId of snapshot.markedMessageIds ?? []) {
+      next = dropMessageActivities(next, messageId)
+    }
+    return next
+  }
 }
 
 /** Mirror a snapshot's watermark fields into the query cache (workspace +

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1820,3 +1820,96 @@ describe("preserveBakedInAppData", () => {
     expect(merged).toBe(incoming)
   })
 })
+
+describe("registerStreamSocketHandlers — read-state counter wiring", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      emit(event: string, payload: unknown) {
+        handlers.get(event)?.forEach((handler) => handler(payload))
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await Promise.all([db.unreadState.clear(), db.events.clear()])
+  })
+
+  it("drops the deleted message's held activity rows on message_deleted (fix A2)", async () => {
+    const streamId = "stream_del"
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: {},
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [
+        {
+          id: "act_del",
+          workspaceId: "ws_1",
+          userId: "usr_1",
+          activityType: "mention",
+          streamId,
+          messageId: "msg_del",
+          actorId: "usr_2",
+          actorType: "user",
+          context: {},
+          readAt: null,
+          createdAt: new Date().toISOString(),
+          isSelf: false,
+          emoji: null,
+        },
+        {
+          id: "act_keep",
+          workspaceId: "ws_1",
+          userId: "usr_1",
+          activityType: "mention",
+          streamId,
+          messageId: "msg_keep",
+          actorId: "usr_2",
+          actorType: "user",
+          context: {},
+          readAt: null,
+          createdAt: new Date().toISOString(),
+          isSelf: false,
+          emoji: null,
+        },
+      ],
+      latestOrdinals: {},
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, queryClient)
+
+    emit("message:deleted", {
+      workspaceId: "ws_1",
+      streamId,
+      messageId: "msg_del",
+      deletedAt: new Date().toISOString(),
+    })
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.unreadActivities?.map((a) => a.id)).toEqual(["act_keep"])
+    })
+
+    cleanup()
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -19,7 +19,12 @@ import { workspaceKeys } from "@/hooks/use-workspaces"
 import { streamKeys } from "@/hooks/use-streams"
 import type { QueryClient } from "@tanstack/react-query"
 import { commitCounterMutation } from "./catch-up-batch"
-import { dropReactionActivity, rehomeActivities } from "./unread-counters"
+import {
+  applyMovedSourceOrdinal,
+  dropMessageActivities,
+  dropReactionActivity,
+  rehomeActivities,
+} from "./unread-counters"
 
 // ============================================================================
 // Bootstrap application — writes stream bootstrap data to IndexedDB
@@ -398,6 +403,11 @@ interface MessagesMovedPayload {
   parentReplyCount: number
   /** Recomputed thread summary for the drop-target — same shape as `message:updated` ships. */
   parentThreadSummary: ThreadSummary | null
+  /** Source stream's post-move `message_created` count. Fix A1: SET onto the
+   *  source `latestOrdinals` so the count that dropped when rows relocated heals
+   *  (max-merge alone never corrects it). Optional during rollout → absent keeps
+   *  today's behavior. See docs/sparse-read-overlay-design.md. */
+  sourceMessageOrdinal?: number
 }
 
 interface ReactionPayload {
@@ -805,6 +815,10 @@ export function registerStreamSocketHandlers(
       ...p,
       deletedAt: payload.deletedAt,
     }))
+
+    // Fix A2: the delete transaction marks the message's activity rows read
+    // server-side with no counter event, so drop the held rows here to match.
+    commitCounterMutation(queryClient, workspaceId, (s) => dropMessageActivities(s, payload.messageId))
   }
 
   const handleMessagesMoved = async (payload: MessagesMovedPayload) => {
@@ -876,11 +890,19 @@ export function registerStreamSocketHandlers(
     // Re-home held activity rows from the source stream to the destination (D4):
     // the server UPDATEs user_activity.stream_id on a move with no counter event.
     // This handler fires once per subscribed stream (source AND destination), so
-    // gate on the source to apply the workspace-wide rehome exactly once.
+    // gate on the source to apply the workspace-wide rehome exactly once. Fix A1:
+    // the same gate SETs the source's latest ordinal to its post-move count so
+    // the phantom unread from vacated `message_created` rows heals.
     if (payload.sourceStreamId === streamId) {
       commitCounterMutation(queryClient, workspaceId, (s) =>
         rehomeActivities(s, payload.sourceStreamId, payload.destinationStreamId, payload.movedMessageIds)
       )
+      if (payload.sourceMessageOrdinal !== undefined) {
+        const sourceOrdinal = payload.sourceMessageOrdinal
+        commitCounterMutation(queryClient, workspaceId, (s) =>
+          applyMovedSourceOrdinal(s, payload.sourceStreamId, sourceOrdinal)
+        )
+      }
     }
   }
 

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -900,7 +900,7 @@ export function registerStreamSocketHandlers(
       if (payload.sourceMessageOrdinal !== undefined) {
         const sourceOrdinal = payload.sourceMessageOrdinal
         commitCounterMutation(queryClient, workspaceId, (s) =>
-          applyMovedSourceOrdinal(s, payload.sourceStreamId, sourceOrdinal)
+          applyMovedSourceOrdinal(s, payload.sourceStreamId, sourceOrdinal, payload.movedMessageIds)
         )
       }
     }

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -4,11 +4,15 @@ import {
   applyStreamActivityOrdinal,
   applyStreamReadOrdinal,
   applyStreamReadSet,
+  applyStreamReadMessages,
   applyStreamsReadAllOrdinals,
+  applyMovedSourceOrdinal,
   deriveActivityCounts,
   upsertActivity,
   dropActivitiesForStream,
+  dropMessageActivities,
   dropReactionActivity,
+  reconcileActivities,
   rehomeActivities,
   clearActivities,
   type UnreadCounterState,
@@ -321,6 +325,239 @@ describe("clearActivities", () => {
     const next = clearActivities(state)
     expect(next.unreadActivities).toEqual([])
     expect(next.activityCounts).toEqual({})
+    expect(next.unreadActivityCount).toBe(0)
+  })
+})
+
+describe("sparse read overlay invariant", () => {
+  describe("applyStreamActivityOrdinal (overlay-aware)", () => {
+    it("subtracts the overlay when reconstructing the read position", () => {
+      // latest 5, unread 1, overlay of 2 above the watermark → watermark = 5-1-2 = 2.
+      const seeded = makeState({
+        unreadCounts: { s1: 1 },
+        latestOrdinals: { s1: 5 },
+        readMessageIds: { s1: ["m8", "m9"] },
+      })
+      // A new other-message arrives: unread rises by one, overlay unchanged.
+      const next = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+      expect(next.unreadCounts.s1).toBe(2)
+      expect(next.latestOrdinals?.s1).toBe(6)
+      expect(next.readMessageIds?.s1).toEqual(["m8", "m9"])
+    })
+
+    it("converges on duplicate apply with an overlay present", () => {
+      const seeded = makeState({
+        unreadCounts: { s1: 1 },
+        latestOrdinals: { s1: 5 },
+        readMessageIds: { s1: ["m9"] },
+      })
+      const once = applyStreamActivityOrdinal(seeded, "s1", 6, { isOwnMessage: false, isViewing: false })
+      const twice = applyStreamActivityOrdinal(once, "s1", 6, { isOwnMessage: false, isViewing: false })
+      expect(twice).toEqual(once)
+    })
+  })
+
+  describe("applyStreamReadMessages", () => {
+    it("SETs the overlay, max-merges the watermark, and recomputes unread", () => {
+      // latest 10, watermark at 4 (unread 6), no overlay yet.
+      const seeded = makeState({ unreadCounts: { s1: 6 }, latestOrdinals: { s1: 10 } })
+      // A conversation read covers 3 messages above the watermark; watermark unmoved.
+      const next = applyStreamReadMessages(seeded, "s1", { readMessageIds: ["m5", "m7", "m9"], lastReadOrdinal: 4 })
+      expect(next.readMessageIds?.s1).toEqual(["m5", "m7", "m9"])
+      expect(next.unreadCounts.s1).toBe(3) // 10 - 4 - 3
+      expect(next.latestOrdinals?.s1).toBe(10)
+    })
+
+    it("is idempotent on duplicate apply (absolute snapshot)", () => {
+      const seeded = makeState({ unreadCounts: { s1: 6 }, latestOrdinals: { s1: 10 } })
+      const once = applyStreamReadMessages(seeded, "s1", { readMessageIds: ["m5", "m7"], lastReadOrdinal: 4 })
+      const twice = applyStreamReadMessages(once, "s1", { readMessageIds: ["m5", "m7"], lastReadOrdinal: 4 })
+      expect(twice.unreadCounts.s1).toBe(once.unreadCounts.s1)
+      expect(twice.readMessageIds?.s1).toEqual(["m5", "m7"])
+    })
+
+    it("converges under out-of-order snapshots (later snapshot wins the set)", () => {
+      const seeded = makeState({ unreadCounts: { s1: 6 }, latestOrdinals: { s1: 10 } })
+      // Snapshot B (watermark 4, overlay 2) then stale snapshot A (watermark 2, overlay 1):
+      // the overlay SETs to A's set but the watermark max-merges, so it stays at 4.
+      const b = applyStreamReadMessages(seeded, "s1", { readMessageIds: ["m6", "m8"], lastReadOrdinal: 4 })
+      const then = applyStreamReadMessages(b, "s1", { readMessageIds: ["m6"], lastReadOrdinal: 2 })
+      expect(then.latestOrdinals?.s1).toBe(10)
+      expect(then.readMessageIds?.s1).toEqual(["m6"])
+      expect(then.unreadCounts.s1).toBe(5) // 10 - 4 - 1 (watermark held at 4)
+    })
+
+    it("seeds from no baseline (overlay + watermark, unread derived)", () => {
+      const noBaseline = makeState({ unreadCounts: { s1: 3 }, latestOrdinals: undefined })
+      const next = applyStreamReadMessages(noBaseline, "s1", { readMessageIds: ["m5"], lastReadOrdinal: 4 })
+      expect(next.latestOrdinals?.s1).toBe(4)
+      expect(next.readMessageIds?.s1).toEqual(["m5"])
+      expect(next.unreadCounts.s1).toBe(0)
+    })
+
+    it("drops the overlay key when the snapshot is empty", () => {
+      const seeded = makeState({
+        unreadCounts: { s1: 3 },
+        latestOrdinals: { s1: 10 },
+        readMessageIds: { s1: ["m5", "m7"] },
+      })
+      const next = applyStreamReadMessages(seeded, "s1", { readMessageIds: [], lastReadOrdinal: 5 })
+      expect(next.readMessageIds?.s1).toBeUndefined()
+      expect(next.unreadCounts.s1).toBe(5) // 10 - 5 - 0
+    })
+  })
+
+  describe("applyStreamReadOrdinal readMessageIds param", () => {
+    it("SETs the overlay when carried and folds it into unread", () => {
+      const seeded = makeState({ unreadCounts: { s1: 6 }, latestOrdinals: { s1: 10 } })
+      const next = applyStreamReadOrdinal(seeded, "s1", 5, ["m8"])
+      expect(next.readMessageIds?.s1).toEqual(["m8"])
+      expect(next.unreadCounts.s1).toBe(4) // 10 - 5 - 1
+    })
+
+    it("leaves the overlay untouched when the field is absent (rollout compat)", () => {
+      const seeded = makeState({
+        unreadCounts: { s1: 4 },
+        latestOrdinals: { s1: 10 },
+        readMessageIds: { s1: ["m8", "m9"] },
+      })
+      const next = applyStreamReadOrdinal(seeded, "s1", 6)
+      expect(next.readMessageIds?.s1).toEqual(["m8", "m9"])
+      expect(next.unreadCounts.s1).toBe(2) // 10 - 6 - 2
+    })
+
+    it("preserves the D2 activity-drop coupling overlay-aware", () => {
+      // watermark = latest - unread - overlay = 10 - 4 - 2 = 4. A read AT the
+      // reconstructed watermark still clears held activity (D5 heal); a strictly
+      // stale read below it does not.
+      const seeded = makeState({
+        unreadCounts: { s1: 4 },
+        latestOrdinals: { s1: 10 },
+        readMessageIds: { s1: ["m8", "m9"] },
+        unreadActivities: [act("a1", "s1", "mention")],
+      })
+      expect(applyStreamReadOrdinal(seeded, "s1", 4, ["m8", "m9"]).unreadActivityCount).toBe(0)
+      expect(applyStreamReadOrdinal(seeded, "s1", 3, ["m8", "m9"]).unreadActivityCount).toBe(1)
+    })
+  })
+
+  describe("applyStreamReadSet readMessageIds param", () => {
+    it("SETs the overlay (including empty) alongside the backward pointer", () => {
+      const seeded = makeState({
+        unreadCounts: { s1: 0 },
+        latestOrdinals: { s1: 10 },
+        readMessageIds: { s1: ["m8"] },
+      })
+      // Mark-unread regresses the watermark to 5 and deletes overlay ids above it.
+      const next = applyStreamReadSet(seeded, "s1", 5, [])
+      expect(next.readMessageIds?.s1).toBeUndefined()
+      expect(next.unreadCounts.s1).toBe(5) // 10 - 5 - 0
+    })
+
+    it("leaves the overlay untouched when the field is absent", () => {
+      const seeded = makeState({
+        unreadCounts: { s1: 0 },
+        latestOrdinals: { s1: 10 },
+        readMessageIds: { s1: ["m8"] },
+      })
+      const next = applyStreamReadSet(seeded, "s1", 5)
+      expect(next.readMessageIds?.s1).toEqual(["m8"])
+      expect(next.unreadCounts.s1).toBe(4) // 10 - 5 - 1
+    })
+  })
+
+  describe("applyStreamsReadAllOrdinals clears overlays", () => {
+    it("wipes each read stream's overlay set", () => {
+      const state = makeState({
+        unreadCounts: { s1: 2, s2: 5 },
+        latestOrdinals: { s1: 4, s2: 10 },
+        readMessageIds: { s1: ["m3"], s2: ["m9", "m10"] },
+      })
+      const next = applyStreamsReadAllOrdinals(state, [
+        { streamId: "s1", lastReadOrdinal: 4 },
+        { streamId: "s2", lastReadOrdinal: 10 },
+      ])
+      expect(next.readMessageIds).toEqual({})
+      expect(next.unreadCounts).toEqual({ s1: 0, s2: 0 })
+    })
+  })
+})
+
+describe("applyMovedSourceOrdinal", () => {
+  it("SETs the source latest ordinal downward and keeps the read position stable", () => {
+    // latest 5, unread 2 → watermark 3. Move drops the source count to 4.
+    const state = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: { s1: 5 } })
+    const next = applyMovedSourceOrdinal(state, "s1", 4)
+    expect(next.latestOrdinals?.s1).toBe(4)
+    expect(next.unreadCounts.s1).toBe(1) // 4 - 3
+  })
+
+  it("clamps unread at zero when the drop lands at or below the read position", () => {
+    const state = makeState({ unreadCounts: { s1: 2 }, latestOrdinals: { s1: 5 } })
+    const next = applyMovedSourceOrdinal(state, "s1", 3)
+    expect(next.latestOrdinals?.s1).toBe(3)
+    expect(next.unreadCounts.s1).toBe(0) // 3 - 3, clamped
+  })
+
+  it("heals the phantom-unread move sequence (activity 2 → move to 1 → read 1 → 0)", () => {
+    let state = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 1 } })
+    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false, isViewing: false })
+    expect(state.unreadCounts.s1).toBe(2)
+    state = applyMovedSourceOrdinal(state, "s1", 1)
+    expect(state.latestOrdinals?.s1).toBe(1)
+    state = applyStreamReadOrdinal(state, "s1", 1)
+    expect(state.unreadCounts.s1).toBe(0)
+  })
+
+  it("without the source-ordinal fix the read cannot clear the phantom (regression guard)", () => {
+    let state = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 1 } })
+    state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false, isViewing: false })
+    // Skip applyMovedSourceOrdinal: latest stays inflated at 2 (max-merge only).
+    const read = applyStreamReadOrdinal(state, "s1", 1)
+    expect(read.unreadCounts.s1).toBe(1) // stuck — the exact bug the fix removes
+  })
+})
+
+describe("dropMessageActivities", () => {
+  const state = makeState({
+    unreadActivities: [
+      act("a1", "s1", "reaction", { messageId: "m1" }),
+      act("a2", "s1", "mention", { messageId: "m2" }),
+    ],
+  })
+
+  it("drops every held row for the deleted message", () => {
+    const next = dropMessageActivities(state, "m1")
+    expect(next.unreadActivities.map((a) => a.id)).toEqual(["a2"])
+    expect(next.unreadActivityCount).toBe(1)
+  })
+
+  it("is a no-op (same reference) when no row matches", () => {
+    expect(dropMessageActivities(state, "m_absent")).toBe(state)
+  })
+})
+
+describe("reconcileActivities", () => {
+  it("replaces the held set wholesale with the server rows", () => {
+    const state = makeState({ unreadActivities: [act("a1", "s1"), act("a2", "s2")] })
+    const next = reconcileActivities(state, [act("a2", "s2"), act("a3", "s3", "mention")])
+    expect(next.unreadActivities.map((a) => a.id)).toEqual(["a2", "a3"])
+    expect(next.activityCounts).toEqual({ s2: 1, s3: 1 })
+    expect(next.mentionCounts).toEqual({ s3: 1 })
+    expect(next.unreadActivityCount).toBe(2)
+  })
+
+  it("drops self rows from the server set", () => {
+    const state = makeState()
+    const next = reconcileActivities(state, [act("a1", "s1"), act("a2", "s1", "message", { isSelf: true })])
+    expect(next.unreadActivities.map((a) => a.id)).toEqual(["a1"])
+    expect(next.unreadActivityCount).toBe(1)
+  })
+
+  it("empties the held set when the server shows nothing unread", () => {
+    const state = makeState({ unreadActivities: [act("a1", "s1")] })
+    const next = reconcileActivities(state, [])
+    expect(next.unreadActivities).toEqual([])
     expect(next.unreadActivityCount).toBe(0)
   })
 })

--- a/apps/frontend/src/sync/unread-counters.test.ts
+++ b/apps/frontend/src/sync/unread-counters.test.ts
@@ -509,6 +509,32 @@ describe("applyMovedSourceOrdinal", () => {
     expect(state.unreadCounts.s1).toBe(0)
   })
 
+  it("drops moved ids from the source overlay so a stale entry can't hide genuine unread", () => {
+    // Messages 1..5, watermark at 1, m2 overlay-read → unread 3 ({m3,m4,m5}).
+    // m2 (overlay-read) + m3 (unread) move to a thread → source count 3.
+    // True post-move state: watermark 1, overlay empty, unread 2 ({m4,m5}).
+    // With a stale m2 entry the math yields 1 — hiding a genuinely unread row.
+    const state = makeState({
+      unreadCounts: { s1: 3 },
+      latestOrdinals: { s1: 5 },
+      readMessageIds: { s1: ["m2"] },
+    })
+    const next = applyMovedSourceOrdinal(state, "s1", 3, ["m2", "m3"])
+    expect(next.readMessageIds).toEqual({})
+    expect(next.unreadCounts.s1).toBe(2)
+  })
+
+  it("leaves the overlay untouched when no moved id is in it", () => {
+    const state = makeState({
+      unreadCounts: { s1: 2 },
+      latestOrdinals: { s1: 5 },
+      readMessageIds: { s1: ["m4"] },
+    })
+    const next = applyMovedSourceOrdinal(state, "s1", 4, ["m2"])
+    expect(next.readMessageIds).toEqual({ s1: ["m4"] })
+    expect(next.unreadCounts.s1).toBe(1)
+  })
+
   it("without the source-ordinal fix the read cannot clear the phantom (regression guard)", () => {
     let state = makeState({ unreadCounts: { s1: 1 }, latestOrdinals: { s1: 1 } })
     state = applyStreamActivityOrdinal(state, "s1", 2, { isOwnMessage: false, isViewing: false })

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -315,16 +315,31 @@ export function applyStreamReadMessages(
 export function applyMovedSourceOrdinal(
   state: UnreadCounterState,
   streamId: string,
-  sourceMessageOrdinal: number
+  sourceMessageOrdinal: number,
+  movedMessageIds: readonly string[] = []
 ): UnreadCounterState {
-  const ov = overlaySize(state, streamId)
+  // Reconstruct the read position with the PRE-move overlay, then drop the moved
+  // ids from the source set before recomputing — the server rehomed their rows
+  // to the destination, so a stale entry here keeps subtracting for a message
+  // the shrunk latest no longer counts, silently hiding genuine unread. One
+  // fold for both writes so no reader sees the ordinal without the drop.
+  // (Destination overlay is deliberately NOT topped up: destination `latest`
+  // isn't bumped on move either, so omitting both keeps its arithmetic
+  // consistent-stale until the next snapshot/bootstrap heals it.)
+  const ovBefore = overlaySize(state, streamId)
   const prevUnread = state.unreadCounts[streamId] ?? 0
   const base = state.latestOrdinals?.[streamId] ?? sourceMessageOrdinal
-  const read = Math.max(0, base - prevUnread - ov)
+  const read = Math.max(0, base - prevUnread - ovBefore)
+
+  const moved = new Set(movedMessageIds)
+  const remaining = (state.readMessageIds?.[streamId] ?? []).filter((id) => !moved.has(id))
+  const next = setOverlay(state, streamId, remaining)
+  const ovAfter = overlaySize(next, streamId)
+
   return {
-    ...state,
-    latestOrdinals: { ...state.latestOrdinals, [streamId]: sourceMessageOrdinal },
-    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, sourceMessageOrdinal - read - ov) },
+    ...next,
+    latestOrdinals: { ...next.latestOrdinals, [streamId]: sourceMessageOrdinal },
+    unreadCounts: { ...next.unreadCounts, [streamId]: Math.max(0, sourceMessageOrdinal - read - ovAfter) },
   }
 }
 

--- a/apps/frontend/src/sync/unread-counters.ts
+++ b/apps/frontend/src/sync/unread-counters.ts
@@ -37,6 +37,39 @@ export interface UnreadCounterState {
    * from the first absolute event they see.
    */
   latestOrdinals?: Record<string, number>
+  /**
+   * Sparse read overlay per stream (docs/sparse-read-overlay-design.md): the
+   * message ids read individually ABOVE that stream's watermark via a
+   * conversation surface. The effective unread invariant everywhere is
+   * `unreadCounts[s] = max(0, latestOrdinals[s] − read(s) − |overlay(s)|)`, with
+   * the watermark reconstructed as `read = latest − unread − |overlay|`. An
+   * absent entry means an empty overlay. `stream:read_messages` and the
+   * `readMessageIds`-carrying read events SET the set absolutely (idempotent
+   * under sync-log order); a `stream:read_all` clears it.
+   */
+  readMessageIds?: Record<string, string[]>
+}
+
+/** Size of a stream's sparse read overlay (0 when absent). */
+function overlaySize(state: UnreadCounterState, streamId: string): number {
+  return state.readMessageIds?.[streamId]?.length ?? 0
+}
+
+/**
+ * SET a stream's overlay to an absolute snapshot. An empty snapshot drops the
+ * key (empty overlays are omitted); a no-op returns the same reference so
+ * unrelated appliers stay referentially stable.
+ */
+function setOverlay(state: UnreadCounterState, streamId: string, ids: string[]): UnreadCounterState {
+  const current = state.readMessageIds?.[streamId]
+  if (ids.length === 0) {
+    if (current === undefined) return state
+    const next = { ...state.readMessageIds }
+    delete next[streamId]
+    return { ...state, readMessageIds: next }
+  }
+  if (current === ids) return state
+  return { ...state, readMessageIds: { ...state.readMessageIds, [streamId]: ids } }
 }
 
 /** Per-stream activity + mention counts (and total) derived from the held unread rows. */
@@ -142,14 +175,16 @@ export function applyStreamActivityOrdinal(
   messageOrdinal: number,
   opts: { isOwnMessage: boolean; isViewing: boolean }
 ): UnreadCounterState {
+  const ov = overlaySize(state, streamId)
   const prevLatest = state.latestOrdinals?.[streamId]
   let latest: number
   let read: number
   if (prevLatest === undefined) {
     latest = messageOrdinal
-    read = opts.isOwnMessage || opts.isViewing ? latest : Math.max(0, latest - (state.unreadCounts[streamId] ?? 0) - 1)
+    read =
+      opts.isOwnMessage || opts.isViewing ? latest : Math.max(0, latest - (state.unreadCounts[streamId] ?? 0) - 1 - ov)
   } else {
-    const prevRead = Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0))
+    const prevRead = Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0) - ov)
     latest = Math.max(prevLatest, messageOrdinal)
     read = opts.isOwnMessage ? Math.max(prevRead, messageOrdinal) : prevRead
     if (opts.isViewing) read = latest
@@ -157,7 +192,7 @@ export function applyStreamActivityOrdinal(
   return {
     ...state,
     latestOrdinals: { ...state.latestOrdinals, [streamId]: latest },
-    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, latest - read) },
+    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, latest - read - ov) },
   }
 }
 
@@ -172,23 +207,29 @@ export function applyStreamActivityOrdinal(
 export function applyStreamReadOrdinal(
   state: UnreadCounterState,
   streamId: string,
-  lastReadOrdinal: number
+  lastReadOrdinal: number,
+  readMessageIds?: string[]
 ): UnreadCounterState {
+  // Reconstruct the OLD watermark against the OLD overlay before the SET below,
+  // since the stored unread was computed with the old overlay size.
+  const prevOv = overlaySize(state, streamId)
   const prevLatest = state.latestOrdinals?.[streamId]
   const latest = Math.max(prevLatest ?? 0, lastReadOrdinal)
   const prevRead =
-    prevLatest === undefined ? lastReadOrdinal : Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0))
+    prevLatest === undefined ? lastReadOrdinal : Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0) - prevOv)
   const read = Math.max(prevRead, lastReadOrdinal)
+  const withOverlay = readMessageIds !== undefined ? setOverlay(state, streamId, readMessageIds) : state
+  const ov = overlaySize(withOverlay, streamId)
   // Coupling (D2): drop the stream's held activity on a read that is at or ahead
   // of the current position — this includes the caught-up D5 heal, where the read
   // does not advance (lastReadOrdinal === prevRead). A strictly stale/out-of-order
   // read (lastReadOrdinal < prevRead) must NOT wipe activity that arrived after
   // the real read.
-  const next = lastReadOrdinal >= prevRead ? dropActivitiesForStream(state, streamId) : state
+  const next = lastReadOrdinal >= prevRead ? dropActivitiesForStream(withOverlay, streamId) : withOverlay
   return {
     ...next,
     latestOrdinals: { ...next.latestOrdinals, [streamId]: latest },
-    unreadCounts: { ...next.unreadCounts, [streamId]: Math.max(0, latest - read) },
+    unreadCounts: { ...next.unreadCounts, [streamId]: Math.max(0, latest - read - ov) },
   }
 }
 
@@ -203,26 +244,107 @@ export function applyStreamReadOrdinal(
 export function applyStreamReadSet(
   state: UnreadCounterState,
   streamId: string,
-  lastReadOrdinal: number
+  lastReadOrdinal: number,
+  readMessageIds?: string[]
 ): UnreadCounterState {
-  const latest = Math.max(state.latestOrdinals?.[streamId] ?? 0, lastReadOrdinal)
+  const withOverlay = readMessageIds !== undefined ? setOverlay(state, streamId, readMessageIds) : state
+  const ov = overlaySize(withOverlay, streamId)
+  const latest = Math.max(withOverlay.latestOrdinals?.[streamId] ?? 0, lastReadOrdinal)
   return {
-    ...state,
-    latestOrdinals: { ...state.latestOrdinals, [streamId]: latest },
-    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, latest - lastReadOrdinal) },
+    ...withOverlay,
+    latestOrdinals: { ...withOverlay.latestOrdinals, [streamId]: latest },
+    unreadCounts: { ...withOverlay.unreadCounts, [streamId]: Math.max(0, latest - lastReadOrdinal - ov) },
   }
 }
 
-/** Apply a `stream:read_all` reads array — per-stream `applyStreamReadOrdinal`. */
+/**
+ * Apply a `stream:read_all` reads array — per-stream `applyStreamReadOrdinal`.
+ * The server wipes overlay rows for every updated stream, so each read clears
+ * that stream's overlay set (passing `[]`).
+ */
 export function applyStreamsReadAllOrdinals(
   state: UnreadCounterState,
   reads: Array<{ streamId: string; lastReadOrdinal: number }>
 ): UnreadCounterState {
   let next = state
   for (const read of reads) {
-    next = applyStreamReadOrdinal(next, read.streamId, read.lastReadOrdinal)
+    next = applyStreamReadOrdinal(next, read.streamId, read.lastReadOrdinal, [])
   }
   return next
+}
+
+/**
+ * Apply a `stream:read_messages` snapshot — the absolute post-write read state
+ * for one stream from a conversation-surface read. SETs the overlay to the
+ * snapshot (idempotent under sync-log order), max-merges the watermark ordinal
+ * (a conversation read only advances it), and recomputes effective unread by
+ * the invariant. Held activity is left untouched: a conversation read is a
+ * partial stream read, so it must not wipe other conversations' activity rows —
+ * the activity feed reconcile (`reconcileActivities`) is the badge backstop.
+ */
+export function applyStreamReadMessages(
+  state: UnreadCounterState,
+  streamId: string,
+  snapshot: { readMessageIds: string[]; lastReadOrdinal: number }
+): UnreadCounterState {
+  const prevOv = overlaySize(state, streamId)
+  const prevLatest = state.latestOrdinals?.[streamId]
+  const latest = Math.max(prevLatest ?? 0, snapshot.lastReadOrdinal)
+  const prevRead =
+    prevLatest === undefined
+      ? snapshot.lastReadOrdinal
+      : Math.max(0, prevLatest - (state.unreadCounts[streamId] ?? 0) - prevOv)
+  const read = Math.max(prevRead, snapshot.lastReadOrdinal)
+  const withOverlay = setOverlay(state, streamId, snapshot.readMessageIds)
+  const ov = snapshot.readMessageIds.length
+  return {
+    ...withOverlay,
+    latestOrdinals: { ...withOverlay.latestOrdinals, [streamId]: latest },
+    unreadCounts: { ...withOverlay.unreadCounts, [streamId]: Math.max(0, latest - read - ov) },
+  }
+}
+
+/**
+ * SET `latestOrdinals[streamId]` from a `messages:moved` source count (fix A1).
+ * A move relocates `message_created` rows out of the source, so the source's
+ * true latest ordinal DROPS — the one sanctioned non-monotonic latest write
+ * (precedent: `applyStreamReadSet`). The reconstructed watermark stays put and
+ * unread clamps at ≥ 0, so a phantom unread that stuck on max-merge-only
+ * `latestOrdinals` heals immediately.
+ */
+export function applyMovedSourceOrdinal(
+  state: UnreadCounterState,
+  streamId: string,
+  sourceMessageOrdinal: number
+): UnreadCounterState {
+  const ov = overlaySize(state, streamId)
+  const prevUnread = state.unreadCounts[streamId] ?? 0
+  const base = state.latestOrdinals?.[streamId] ?? sourceMessageOrdinal
+  const read = Math.max(0, base - prevUnread - ov)
+  return {
+    ...state,
+    latestOrdinals: { ...state.latestOrdinals, [streamId]: sourceMessageOrdinal },
+    unreadCounts: { ...state.unreadCounts, [streamId]: Math.max(0, sourceMessageOrdinal - read - ov) },
+  }
+}
+
+/** Drop every held row for a deleted message (fix A2), mirroring `dropReactionActivity`. */
+export function dropMessageActivities(state: UnreadCounterState, messageId: string): UnreadCounterState {
+  const rows = state.unreadActivities.filter((a) => a.messageId !== messageId)
+  if (rows.length === state.unreadActivities.length) return state
+  return withActivities(state, rows)
+}
+
+/**
+ * Wholesale-replace the held activity set with the server's authoritative rows
+ * (fix A4 backstop): opening the unread activity feed reconciles the badge to
+ * exactly what the feed shows. Self rows are dropped to match `upsertActivity`.
+ */
+export function reconcileActivities(state: UnreadCounterState, serverRows: Activity[]): UnreadCounterState {
+  return withActivities(
+    state,
+    serverRows.filter((a) => !a.isSelf)
+  )
 }
 
 /**
@@ -253,6 +375,7 @@ export function toCounterState(bootstrap: WorkspaceBootstrap): UnreadCounterStat
     unreadActivities: rows,
     ...deriveActivityCounts(rows),
     latestOrdinals: bootstrap.messageCounts,
+    readMessageIds: bootstrap.readMessageIds,
   }
 }
 
@@ -266,5 +389,6 @@ export function withCounterState(bootstrap: WorkspaceBootstrap, state: UnreadCou
     activityCounts: state.activityCounts,
     unreadActivityCount: state.unreadActivityCount,
     messageCounts: state.latestOrdinals,
+    readMessageIds: state.readMessageIds,
   }
 }

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -687,6 +687,92 @@ describe("registerWorkspaceSocketHandlers", () => {
     cleanup()
   })
 
+  it("applies a stream:read_messages snapshot to the overlay, counter, and watermark", async () => {
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 6 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { stream_1: 10 },
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+    await db.streamMemberships.put({
+      id: "ws_1:stream_1",
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      memberId: "member_1",
+      notificationLevel: null,
+      lastReadEventId: "evt_0",
+      lastReadAt: null,
+      joinedAt: new Date().toISOString(),
+      _cachedAt: Date.now(),
+    })
+
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("stream:read_messages", {
+      workspaceId: "ws_1",
+      authorId: "member_1",
+      streamId: "stream_1",
+      readMessageIds: ["msg_5", "msg_7"],
+      lastReadEventId: "evt_4",
+      lastReadSequence: "40",
+      lastReadOrdinal: 4,
+    })
+
+    await vi.waitFor(async () => {
+      const state = await db.unreadState.get("ws_1")
+      expect(state?.readMessageIds?.stream_1).toEqual(["msg_5", "msg_7"])
+      expect(state?.unreadCounts.stream_1).toBe(4) // 10 - 4 - 2
+      const membership = await db.streamMemberships.get("ws_1:stream_1")
+      expect(membership?.lastReadSequence).toBe("40")
+      expect(membership?.lastReadEventId).toBe("evt_4")
+    })
+
+    cleanup()
+  })
+
+  it("ignores a stream:read_messages for another workspace", async () => {
+    await db.unreadState.put({
+      id: "ws_1",
+      workspaceId: "ws_1",
+      unreadCounts: { stream_1: 6 },
+      mentionCounts: {},
+      activityCounts: {},
+      unreadActivityCount: 0,
+      unreadActivities: [],
+      latestOrdinals: { stream_1: 10 },
+      mutedStreamIds: [],
+      _cachedAt: Date.now(),
+    })
+
+    const queryClient = new QueryClient()
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerWorkspaceSocketHandlers(socket, "ws_1", queryClient, handlerRefs)
+
+    emit("stream:read_messages", {
+      workspaceId: "ws_other",
+      authorId: "member_1",
+      streamId: "stream_1",
+      readMessageIds: ["msg_5"],
+      lastReadEventId: "evt_4",
+      lastReadSequence: "40",
+      lastReadOrdinal: 4,
+    })
+
+    await new Promise((r) => setTimeout(r, 20))
+    const state = await db.unreadState.get("ws_1")
+    expect(state?.readMessageIds?.stream_1).toBeUndefined()
+    expect(state?.unreadCounts.stream_1).toBe(6)
+    cleanup()
+  })
+
   it("applies gate-dispatched saved/scheduled catch-up replays to IDB", async () => {
     // The coverage the engine-gated `refetchOnReconnect` is traded for: these
     // handlers register on the engine's event gate, so a catch-up replay

--- a/apps/frontend/src/sync/workspace-sync.test.ts
+++ b/apps/frontend/src/sync/workspace-sync.test.ts
@@ -421,6 +421,7 @@ describe("mergeReconnectWorkspaceBootstrap", () => {
           memberId: "user_1",
           notificationLevel: null,
           lastReadEventId: "evt_cached",
+          lastReadSequence: "77",
           lastReadAt: null,
           joinedAt: new Date().toISOString(),
           _cachedAt: Date.now(),
@@ -440,9 +441,10 @@ describe("mergeReconnectWorkspaceBootstrap", () => {
     })
 
     expect(merged.streams.map((stream) => stream.id)).toContain("stream_failed")
-    expect(
-      merged.streamMemberships.find((membership) => membership.streamId === "stream_failed")?.lastReadEventId
-    ).toBe("evt_cached")
+    const failedMembership = merged.streamMemberships.find((membership) => membership.streamId === "stream_failed")
+    // The board-card sequence frontier must survive the cached→bootstrap
+    // conversion — dropping it silently degrades card rows to the time fallback.
+    expect(failedMembership).toMatchObject({ lastReadEventId: "evt_cached", lastReadSequence: "77" })
     expect(merged.unreadCounts.stream_failed).toBe(3)
     expect(merged.mutedStreamIds).toContain("stream_failed")
   })

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -62,6 +62,7 @@ import {
   upsertActivity,
 } from "./unread-counters"
 import { commitCounterMutation, commitStreamPreview, type CatchUpBatch, type CounterMutator } from "./catch-up-batch"
+import { commitReadStateSnapshot } from "./read-state"
 
 /** Workspace user shape from backend user repository. */
 interface WorkspaceUserPayload {
@@ -124,6 +125,23 @@ interface StreamReadPayload {
   lastReadSequence?: string
   /** Message ordinal of the read position. */
   lastReadOrdinal: number
+  /** Post-write sparse overlay for this stream (usually shrunk by compaction).
+   *  Absent = not carried (rollout) → leave the client set unchanged; `[]` =
+   *  overlay now empty. See docs/sparse-read-overlay-design.md. */
+  readMessageIds?: string[]
+}
+
+// The absolute post-write read-state snapshot for one stream from a
+// conversation-surface read (docs/sparse-read-overlay-design.md). readMessageIds
+// is the ENTIRE overlay after the write (post-compaction), applied as a SET.
+interface StreamReadMessagesPayload {
+  workspaceId: string
+  authorId: string
+  streamId: string
+  readMessageIds: string[]
+  lastReadEventId: string | null
+  lastReadSequence: string
+  lastReadOrdinal: number
 }
 
 interface StreamsReadAllPayload {
@@ -145,6 +163,9 @@ interface StreamReadSetPayload {
   lastReadEventId: string | null
   lastReadSequence?: string
   lastReadOrdinal: number
+  /** Post-write sparse overlay for this stream (deleted ids above the pointer
+   *  on a re-unread). Absent = not carried; `[]` = overlay now empty. */
+  readMessageIds?: string[]
 }
 
 // Author-scoped: the user's own mute/notify choice for one stream, mirrored to
@@ -338,6 +359,11 @@ export function mergeReconnectWorkspaceBootstrap({
   // local unread state wins but that have no local ordinal lose their
   // baseline (handlers re-seed from the next absolute event).
   const messageCounts = { ...workspaceBootstrap.messageCounts }
+  // The sparse read overlay (docs/sparse-read-overlay-design.md) is the third
+  // leg of the per-stream triple: effective unread = latest − read − |overlay|,
+  // so a stream's overlay must stay paired with whichever unread/ordinal source
+  // wins for it, exactly as messageCounts does.
+  const readMessageIds = { ...workspaceBootstrap.readMessageIds }
   const mutedStreamIds = new Set(workspaceBootstrap.mutedStreamIds)
   const localStreamById = new Map(localStreams.map((stream) => [stream.id, stream]))
   const localMembershipByStreamId = new Map(localMemberships.map((membership) => [membership.streamId, membership]))
@@ -365,6 +391,12 @@ export function mergeReconnectWorkspaceBootstrap({
         } else {
           delete messageCounts[streamId]
         }
+        const localOverlay = localUnreadState.readMessageIds?.[streamId]
+        if (localOverlay !== undefined) {
+          readMessageIds[streamId] = localOverlay
+        } else {
+          delete readMessageIds[streamId]
+        }
       }
       for (const streamId of localUnreadState.mutedStreamIds) {
         if (successfulStreamIds.has(streamId)) continue
@@ -391,6 +423,12 @@ export function mergeReconnectWorkspaceBootstrap({
         messageCounts[streamId] = localOrdinal
       } else {
         delete messageCounts[streamId]
+      }
+      const localOverlay = localUnreadState.readMessageIds?.[streamId]
+      if (localOverlay !== undefined) {
+        readMessageIds[streamId] = localOverlay
+      } else {
+        delete readMessageIds[streamId]
       }
       if (localUnreadState.mutedStreamIds.includes(streamId)) {
         mutedStreamIds.add(streamId)
@@ -426,6 +464,7 @@ export function mergeReconnectWorkspaceBootstrap({
     membershipsByStreamId.delete(streamId)
     delete unreadCounts[streamId]
     delete messageCounts[streamId]
+    delete readMessageIds[streamId]
     mutedStreamIds.delete(streamId)
   }
 
@@ -439,6 +478,7 @@ export function mergeReconnectWorkspaceBootstrap({
     // fields derive from it.
     ...bootstrapActivityCacheFields(workspaceBootstrap),
     messageCounts,
+    readMessageIds,
     mutedStreamIds: Array.from(mutedStreamIds),
   }
 }
@@ -821,13 +861,19 @@ export function registerWorkspaceSocketHandlers(
         ...old,
         streamMemberships: old.streamMemberships.map((membership) =>
           membership.streamId === payload.streamId
-            ? { ...membership, lastReadEventId: payload.lastReadEventId }
+            ? {
+                ...membership,
+                lastReadEventId: payload.lastReadEventId,
+                ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
+              }
             : membership
         ),
       }
     })
 
-    commitCounter((state) => applyStreamReadOrdinal(state, payload.streamId, payload.lastReadOrdinal))
+    commitCounter((state) =>
+      applyStreamReadOrdinal(state, payload.streamId, payload.lastReadOrdinal, payload.readMessageIds)
+    )
 
     queryClient.setQueryData<import("@threa/types").StreamBootstrap | undefined>(
       streamKeys.bootstrap(workspaceId, payload.streamId),
@@ -835,7 +881,11 @@ export function registerWorkspaceSocketHandlers(
         if (!old?.membership) return old
         return {
           ...old,
-          membership: { ...old.membership, lastReadEventId: payload.lastReadEventId },
+          membership: {
+            ...old.membership,
+            lastReadEventId: payload.lastReadEventId,
+            ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
+          },
         }
       }
     )
@@ -852,6 +902,7 @@ export function registerWorkspaceSocketHandlers(
         await db.streamMemberships.put({
           ...membership,
           lastReadEventId: payload.lastReadEventId,
+          ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
           id: membershipId,
           workspaceId,
           _cachedAt: now,
@@ -880,13 +931,19 @@ export function registerWorkspaceSocketHandlers(
         ...old,
         streamMemberships: old.streamMemberships.map((membership) =>
           membership.streamId === payload.streamId
-            ? { ...membership, lastReadEventId: payload.lastReadEventId }
+            ? {
+                ...membership,
+                lastReadEventId: payload.lastReadEventId,
+                ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
+              }
             : membership
         ),
       }
     })
 
-    commitCounter((state) => applyStreamReadSet(state, payload.streamId, payload.lastReadOrdinal))
+    commitCounter((state) =>
+      applyStreamReadSet(state, payload.streamId, payload.lastReadOrdinal, payload.readMessageIds)
+    )
 
     queryClient.setQueryData<import("@threa/types").StreamBootstrap | undefined>(
       streamKeys.bootstrap(workspaceId, payload.streamId),
@@ -894,7 +951,11 @@ export function registerWorkspaceSocketHandlers(
         if (!old?.membership) return old
         return {
           ...old,
-          membership: { ...old.membership, lastReadEventId: payload.lastReadEventId },
+          membership: {
+            ...old.membership,
+            lastReadEventId: payload.lastReadEventId,
+            ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
+          },
         }
       }
     )
@@ -909,11 +970,38 @@ export function registerWorkspaceSocketHandlers(
         await db.streamMemberships.put({
           ...membership,
           lastReadEventId: payload.lastReadEventId,
+          ...(payload.lastReadSequence !== undefined ? { lastReadSequence: payload.lastReadSequence } : {}),
           id: membershipId,
           workspaceId,
           _cachedAt: now,
         })
       }
+    })
+  }
+
+  // Handle a sparse-read snapshot (`stream:read_messages`) from a conversation
+  // surface — this or another session of the same user. Mirrors the read
+  // watermark, SETs the overlay to the absolute post-write snapshot, and
+  // dismisses this stream's push notification (the user read here).
+  const handleStreamReadMessages = (payload: StreamReadMessagesPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+
+    commitReadStateSnapshot(
+      queryClient,
+      workspaceId,
+      {
+        streamId: payload.streamId,
+        readMessageIds: payload.readMessageIds,
+        lastReadEventId: payload.lastReadEventId,
+        lastReadSequence: payload.lastReadSequence,
+        lastReadOrdinal: payload.lastReadOrdinal,
+      },
+      commitCounter
+    )
+
+    navigator.serviceWorker?.controller?.postMessage({
+      type: SW_MSG_CLEAR_NOTIFICATIONS,
+      streamId: payload.streamId,
     })
   }
 
@@ -1705,6 +1793,7 @@ export function registerWorkspaceSocketHandlers(
   socket.on("workspace_user:updated", handleWorkspaceUserUpdated)
   socket.on("stream:read", handleStreamRead)
   socket.on("stream:read_set", handleStreamReadSet)
+  socket.on("stream:read_messages", handleStreamReadMessages)
   socket.on("stream:read_all", handleStreamReadAll)
   socket.on("stream:notification_level_updated", handleStreamNotificationLevelUpdated)
   socket.on("stream:activity", handleStreamActivity)
@@ -1757,6 +1846,7 @@ export function registerWorkspaceSocketHandlers(
     socket.off("workspace_user:updated", handleWorkspaceUserUpdated)
     socket.off("stream:read", handleStreamRead)
     socket.off("stream:read_set", handleStreamReadSet)
+    socket.off("stream:read_messages", handleStreamReadMessages)
     socket.off("stream:read_all", handleStreamReadAll)
     socket.off("stream:notification_level_updated", handleStreamNotificationLevelUpdated)
     socket.off("stream:activity", handleStreamActivity)
@@ -1919,6 +2009,7 @@ export async function applyWorkspaceBootstrap(
           unreadCounts: bootstrap.unreadCounts,
           ...bootstrapActivityCacheFields(bootstrap),
           latestOrdinals: bootstrap.messageCounts,
+          readMessageIds: bootstrap.readMessageIds,
           mutedStreamIds: bootstrap.mutedStreamIds,
           _cachedAt: now,
         })
@@ -1994,6 +2085,7 @@ export async function applyWorkspaceBootstrap(
       unreadCounts: bootstrap.unreadCounts,
       ...bootstrapActivityCacheFields(bootstrap),
       latestOrdinals: bootstrap.messageCounts,
+      readMessageIds: bootstrap.readMessageIds,
       mutedStreamIds: bootstrap.mutedStreamIds,
       _cachedAt: now,
     },
@@ -2124,6 +2216,7 @@ export async function applyReconnectBootstrapBatch(
           unreadCounts: finalBootstrap.unreadCounts,
           ...bootstrapActivityCacheFields(finalBootstrap),
           latestOrdinals: finalBootstrap.messageCounts,
+          readMessageIds: finalBootstrap.readMessageIds,
           mutedStreamIds: finalBootstrap.mutedStreamIds,
           _cachedAt: now,
         }),
@@ -2208,6 +2301,7 @@ export async function applyReconnectBootstrapBatch(
       unreadCounts: finalBootstrap.unreadCounts,
       ...bootstrapActivityCacheFields(finalBootstrap),
       latestOrdinals: finalBootstrap.messageCounts,
+      readMessageIds: finalBootstrap.readMessageIds,
       mutedStreamIds: finalBootstrap.mutedStreamIds,
       _cachedAt: now,
     },

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -142,6 +142,7 @@ interface StreamReadMessagesPayload {
   lastReadEventId: string | null
   lastReadSequence: string
   lastReadOrdinal: number
+  markedMessageIds?: string[]
 }
 
 interface StreamsReadAllPayload {
@@ -996,6 +997,7 @@ export function registerWorkspaceSocketHandlers(
         lastReadEventId: payload.lastReadEventId,
         lastReadSequence: payload.lastReadSequence,
         lastReadOrdinal: payload.lastReadOrdinal,
+        markedMessageIds: payload.markedMessageIds,
       },
       commitCounter
     )

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -289,6 +289,7 @@ function toWorkspaceBootstrapMembership(membership: CachedStreamMembership): Str
     memberId: membership.memberId,
     notificationLevel: membership.notificationLevel,
     lastReadEventId: membership.lastReadEventId,
+    lastReadSequence: membership.lastReadSequence,
     lastReadAt: membership.lastReadAt,
     joinedAt: membership.joinedAt,
   }

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -1,0 +1,133 @@
+# Sparse read overlay — conversation-aware read state
+
+Status: design, v1 (draft — wire details pending investigation pass). Sibling to
+[`board-view-design.md`](./board-view-design.md); this doc extends the read
+model so the board/conversation surfaces can mark messages read without lying
+about the stream.
+
+## The problem: two read geometries over one ordering
+
+The timeline reads a **contiguous prefix**: one rising watermark per
+(stream, member) — `stream_members.last_read_event_id` — with unread derived as
+`latestOrdinal − readOrdinal` on both sides of the wire
+(`countUnreadByStreamBatch`, `unread-counters.ts`).
+
+The board reads a **filtered projection**: a conversation's member messages are
+interleaved with other conversations' messages in the same stream. Reading card
+A means you saw ordinals {5, 7, 9} while 6 and 8 (card B's) stay genuinely
+unread. A single pointer physically cannot represent that:
+
+- Advance the watermark past 9 → falsely marks B's messages read.
+- Don't move it → the stream still shows A's messages unread. Double-read.
+
+## The trap: per-conversation read pointers
+
+A `conversation_reads(conv_id, user_id, last_read_…)` table is the obvious
+model and it is wrong **as truth**, for a Threa-specific reason: conversation
+membership is mutable. The extractor retitles, merges, splits; reassignment is
+a first-class correction. If read-truth hangs on the cluster label, a message
+moving between conversations silently flips read state, merges double-count,
+splits lose state.
+
+> **Invariant (this doc's core rule): read truth is message-granular and
+> stream-anchored. Conversation read state is always derived, never stored.**
+> You read messages, not cluster assignments.
+
+## The model: watermark + sparse overlay + compaction
+
+Two layers of truth, one derivation:
+
+1. **The watermark — unchanged.** `last_read_event_id`, contiguous-prefix
+   semantics. All existing events (`stream:read` max-merge, `stream:read_set`,
+   `stream:read_all`) keep their exact meaning. The timeline keeps owning it.
+
+2. **A sparse overlay above the watermark.** New workspace-scoped table
+   (working name `stream_member_message_reads`): individually-read messages
+   _above_ the watermark, keyed `(workspace_id, stream_id, user_id,
+message_id)`. A message is **effectively read** iff
+   `ordinal ≤ watermark OR id ∈ overlay`.
+
+   Writes come from the conversation surfaces. "Mark conversation read up to
+   message X" **expands to concrete member-message ids at write time**
+   (snapshot semantics — immune to later re-clustering, closing the trap
+   above), grouped by each member's own stream (a conversation spans root +
+   threads), bulk-inserted `ON CONFLICT DO NOTHING` (INV-20, INV-56).
+
+3. **Compaction makes the layers complementary.** In the same transaction as
+   any overlay write (and any watermark advance): if the overlay covers the
+   contiguous run of messages immediately above the watermark, advance the
+   watermark over that run and delete the absorbed rows — one set-based SQL
+   statement, race-safe. Reading the frontier on the board just moves the
+   watermark; the overlay only holds _holes_, and most reading happens in the
+   timeline (wholesale watermark advance), so the overlay stays small and
+   self-erasing. (Zulip's pure per-message-flag model with no watermark is the
+   cautionary tale; the hybrid keeps the sparse set bounded to gaps in recent
+   history.)
+
+### Derived state per surface
+
+- **Stream unread count** = messages above watermark − overlay size.
+  Touches `countUnreadByStreamBatch` (LEFT JOIN the overlay), bootstrap
+  `unreadCounts`, and the frontend ordinal math (`unread = latest − read −
+overlayAbove`).
+- **Card unread** = "does this conversation contain any effectively-unread
+  message", computed at read time against _current_ membership. Merge/split/
+  reassign only changes what the question ranges over; no stored state to
+  corrupt.
+- **Timeline**: an overlay-read row above the divider renders as read; the
+  "new messages" divider means "first _effectively_ unread".
+
+### Mark-unread (the asymmetric inverse)
+
+- **Above the watermark**: delete the conversation's member ids from the
+  overlay. Clean.
+- **Below the watermark**: regress the watermark to just before the
+  conversation's earliest member (existing `stream:read_set` semantics),
+  accepting collateral un-reading of interleaved messages — the same contract
+  the timeline's "mark as unread" already has ("this and everything after").
+  A _negative_ overlay (sparse unread exceptions below the watermark) is
+  explicitly rejected: two overlays with opposite signs is unmaintainable.
+
+### Threads without membership rows
+
+Thread membership is participation, not access (INV-62): a viewer can read a
+thread's messages on a card with no `stream_members` row for that thread. The
+overlay table deliberately does not require a membership row. For non-member
+threads: overlay-only, no watermark compaction (nothing to compact into).
+
+## Sync plan
+
+- New author-scoped outbox event (working name `stream:read_messages`)
+  carrying the stream id + message ids added to the overlay, flowing through
+  the same delivery groups as `stream:read`. Compaction emits a standard
+  `stream:read` alongside — clients already know what that means.
+- Client holds the overlay per stream (IDB + counter state), applies
+  `stream:read_messages` additively, and drops overlay entries at/below the
+  watermark whenever a `stream:read`/`read_set` lands (client-side compaction
+  mirror).
+- Exact count-convergence math (how the client knows overlay∩above-watermark
+  without full ordinal knowledge) is pinned after the read-path investigation:
+  candidates are server-stamped overlay-above-watermark size on each event vs.
+  client-side sequence comparison via IDB events.
+
+## Surfaces shipped with v1
+
+- `MessageItem` (board card / conversation panel) menu: "Mark read up to
+  here" / "Mark as unread" in **conversation geometry** — they operate on the
+  conversation's member messages, not the raw stream prefix.
+- Board card unread indicator, derived per the rule above.
+- Timeline honors the overlay (divider + row bolding = effectively-unread).
+
+Out of scope for v1: viewport-driven auto-read on the board (the "seen"
+question — board-view-design edge 6 territory); restoring activity badges on
+mark-unread (already an accepted gap for the stream path).
+
+## Companion fix: phantom-unread drift (rides the same PR)
+
+Reported: a stream shows unread (sidebar section + green + count 1, activity
+badge 1) but opening the stream and the activity feed shows nothing; the badge
+persists. Root-cause chain under verification (hypothesis: client
+`latestOrdinals` max-merge + ordinals-as-counts means a message deleted/moved
+after its `stream:activity` leaves the client's latest permanently inflated;
+the same staleness guard then blocks the D2 activity-row drop). Findings and
+fix land in this doc when the verification pass completes.

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -1,9 +1,10 @@
 # Sparse read overlay — conversation-aware read state
 
-Status: design, v1 (draft — wire details pending investigation pass). Sibling to
+Status: design, v2 (contracts pinned; implementation in flight). Sibling to
 [`board-view-design.md`](./board-view-design.md); this doc extends the read
 model so the board/conversation surfaces can mark messages read without lying
-about the stream.
+about the stream, and fixes the phantom-unread drift family found while
+verifying the design.
 
 ## The problem: two read geometries over one ordering
 
@@ -38,14 +39,13 @@ splits lose state.
 Two layers of truth, one derivation:
 
 1. **The watermark — unchanged.** `last_read_event_id`, contiguous-prefix
-   semantics. All existing events (`stream:read` max-merge, `stream:read_set`,
-   `stream:read_all`) keep their exact meaning. The timeline keeps owning it.
+   semantics. All existing events keep their meaning. The timeline keeps
+   owning it.
 
-2. **A sparse overlay above the watermark.** New workspace-scoped table
-   (working name `stream_member_message_reads`): individually-read messages
-   _above_ the watermark, keyed `(workspace_id, stream_id, user_id,
-message_id)`. A message is **effectively read** iff
-   `ordinal ≤ watermark OR id ∈ overlay`.
+2. **A sparse overlay above the watermark.** Table
+   `stream_member_message_reads`: individually-read messages *above* the
+   watermark. A message is **effectively read** iff
+   `sequence ≤ watermark OR id ∈ overlay`.
 
    Writes come from the conversation surfaces. "Mark conversation read up to
    message X" **expands to concrete member-message ids at write time**
@@ -54,80 +54,230 @@ message_id)`. A message is **effectively read** iff
    threads), bulk-inserted `ON CONFLICT DO NOTHING` (INV-20, INV-56).
 
 3. **Compaction makes the layers complementary.** In the same transaction as
-   any overlay write (and any watermark advance): if the overlay covers the
-   contiguous run of messages immediately above the watermark, advance the
-   watermark over that run and delete the absorbed rows — one set-based SQL
-   statement, race-safe. Reading the frontier on the board just moves the
-   watermark; the overlay only holds _holes_, and most reading happens in the
-   timeline (wholesale watermark advance), so the overlay stays small and
-   self-erasing. (Zulip's pure per-message-flag model with no watermark is the
-   cautionary tale; the hybrid keeps the sparse set bounded to gaps in recent
-   history.)
+   any overlay write: if the overlay covers the contiguous run of messages
+   immediately above the watermark, advance the watermark over that run and
+   delete the absorbed rows (set-based, under the locked membership row).
+   Reading the frontier on the board just moves the watermark; the overlay
+   only holds *holes*, and most reading happens in the timeline (wholesale
+   watermark advance), so the overlay stays small and self-erasing.
+
+**Overlay invariant: every overlay row sits strictly above its member's
+watermark.** Every watermark advance (`markAsRead`, `markAllAsRead`,
+compaction) prunes rows at/below the new watermark in the same transaction.
+This keeps the client math trivial: the overlay's size is exactly the count to
+subtract.
+
+### Pinned schema
+
+```sql
+CREATE TABLE stream_member_message_reads (
+    workspace_id TEXT NOT NULL,          -- INV-8
+    stream_id    TEXT NOT NULL,
+    member_id    TEXT NOT NULL,          -- INV-50: stream-membership surface
+    message_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,          -- denormalized at write
+    sequence     BIGINT NOT NULL,        -- denormalized at write; refreshed on move
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (stream_id, member_id, message_id)
+);
+```
+
+`event_id`/`sequence` are denormalized because `stream_events` keys messages
+inside `payload->>'messageId'`; resolving once at write (the move flow's
+unnest-join pattern) keeps compaction and pruning index-friendly. A message
+move is the only thing that changes them, and the move transaction rehomes
+overlay rows anyway (below). No FKs (INV-1), no membership-row requirement —
+that is load-bearing for threads (see below).
 
 ### Derived state per surface
 
-- **Stream unread count** = messages above watermark − overlay size.
-  Touches `countUnreadByStreamBatch` (LEFT JOIN the overlay), bootstrap
-  `unreadCounts`, and the frontend ordinal math (`unread = latest − read −
-overlayAbove`).
+- **Stream unread count** = messages above watermark − overlay size (the
+  invariant makes these disjoint-free). Server: `countUnreadByStreamBatch`
+  subtracts a per-(stream, member) overlay count; bootstrap `unreadCounts`
+  becomes this **effective** unread. Client:
+  `unreadCounts[s] = max(0, latestOrdinals[s] − readOrdinal(s) − |overlay(s)|)`
+  with the read position reconstructed as `latest − unread − |overlay|`.
 - **Card unread** = "does this conversation contain any effectively-unread
-  message", computed at read time against _current_ membership. Merge/split/
-  reassign only changes what the question ranges over; no stored state to
-  corrupt.
-- **Timeline**: an overlay-read row above the divider renders as read; the
-  "new messages" divider means "first _effectively_ unread".
+  message", computed at read time against *current* membership.
+- **Timeline**: row read state, the "new messages" divider, and the
+  new-message flash all mean "first/any *effectively* unread" — watermark
+  comparison plus an overlay-set membership check.
 
 ### Mark-unread (the asymmetric inverse)
 
-- **Above the watermark**: delete the conversation's member ids from the
-  overlay. Clean.
+- **Above the watermark**: delete the member ids from the overlay. Clean.
 - **Below the watermark**: regress the watermark to just before the
-  conversation's earliest member (existing `stream:read_set` semantics),
-  accepting collateral un-reading of interleaved messages — the same contract
-  the timeline's "mark as unread" already has ("this and everything after").
-  A _negative_ overlay (sparse unread exceptions below the watermark) is
-  explicitly rejected: two overlays with opposite signs is unmaintainable.
+  conversation's earliest member in that stream (existing `stream:read_set`
+  semantics), accepting collateral un-reading of interleaved messages — the
+  same contract the timeline's "mark as unread" already has. A *negative*
+  overlay (sparse unread exceptions below the watermark) is explicitly
+  rejected: two overlays with opposite signs is unmaintainable.
 
 ### Threads without membership rows
 
 Thread membership is participation, not access (INV-62): a viewer can read a
-thread's messages on a card with no `stream_members` row for that thread. The
-overlay table deliberately does not require a membership row. For non-member
-threads: overlay-only, no watermark compaction (nothing to compact into).
+thread's messages on a card with **no** `stream_members` row
+(`checkStreamAccess` resolves thread→root; `StreamMemberRepository.update`
+no-ops without a row, so the existing `markAsRead` is a silent no-op on such
+threads). The overlay deliberately does not require a membership row:
+non-member thread legs are **overlay-only** — no watermark to advance, no
+compaction target. This is why the overlay, not a membership upsert, is the
+right storage: upserting memberships on read would corrupt the
+membership≠access contract.
 
-## Sync plan
+## Wire contracts (pinned)
 
-- New author-scoped outbox event (working name `stream:read_messages`)
-  carrying the stream id + message ids added to the overlay, flowing through
-  the same delivery groups as `stream:read`. Compaction emits a standard
-  `stream:read` alongside — clients already know what that means.
-- Client holds the overlay per stream (IDB + counter state), applies
-  `stream:read_messages` additively, and drops overlay entries at/below the
-  watermark whenever a `stream:read`/`read_set` lands (client-side compaction
-  mirror).
-- Exact count-convergence math (how the client knows overlay∩above-watermark
-  without full ordinal knowledge) is pinned after the read-path investigation:
-  candidates are server-stamped overlay-above-watermark size on each event vs.
-  client-side sequence comparison via IDB events.
+All read events are author-scoped: register in **both** `AuthorScopedEventType`
+and `AUTHOR_SCOPED_EVENTS` (`lib/outbox/repository.ts` — the two-place gotcha),
+plus `OutboxEventType` and `OutboxEventPayloadMap`. Payload types follow the
+house split (backend `lib/outbox/repository.ts`, frontend inline in
+`workspace-sync.ts`) — no shared `@threa/types` socket type.
 
-## Surfaces shipped with v1
+- **NEW `stream:read_messages`** — the absolute post-write read-state snapshot
+  for one stream:
+  `{ workspaceId, authorId, streamId, readMessageIds: string[],
+  lastReadEventId: string | null, lastReadSequence: string,
+  lastReadOrdinal: number }`.
+  `readMessageIds` is the **entire** overlay for that (stream, member) after
+  the write (post-compaction) — absolute state, not a delta, so application is
+  idempotent and order-convergent under the sync log's per-workspace total
+  order. Emitted by every sparse-read write.
+- **`stream:read` / `stream:read_set`** gain `readMessageIds?: string[]` — the
+  post-write overlay (usually empty/shrunk after pruning). `undefined` means
+  "not carried" (old event during rollout → leave the client set unchanged);
+  `[]` means "overlay now empty". The server always includes it going forward.
+- **`stream:read_all`**: the server wipes overlay rows for every updated
+  stream; the client clears each read stream's set.
+- **`messages:moved`** gains `sourceMessageOrdinal: number` (the source
+  stream's post-move `message_created` count). The move transaction also:
+  (a) rehomes overlay rows for moved messages (`stream_id`, `event_id`,
+  `sequence` refreshed to destination), and (b) repoints any source
+  membership whose `last_read_event_id` is a moved event to the nearest
+  surviving prior source event (set-based) — fix A3 below.
+- **Message delete**: the delete transaction marks the message's
+  `user_activity` rows read (`read_at = NOW() WHERE message_id = … AND
+  read_at IS NULL`). No new socket event: clients already receive the
+  `message_deleted` stream event and drop held activity rows for that
+  message id there (mirror `dropReactionActivity`) — fix A2 below.
 
-- `MessageItem` (board card / conversation panel) menu: "Mark read up to
-  here" / "Mark as unread" in **conversation geometry** — they operate on the
-  conversation's member messages, not the raw stream prefix.
-- Board card unread indicator, derived per the rule above.
-- Timeline honors the overlay (divider + row bolding = effectively-unread).
+### Client counter math
 
-Out of scope for v1: viewport-driven auto-read on the board (the "seen"
-question — board-view-design edge 6 territory); restoring activity badges on
-mark-unread (already an accepted gap for the stream path).
+`CachedUnreadState` gains `readMessageIds?: Record<string, string[]>`
+(IDB version bump). Invariant everywhere:
 
-## Companion fix: phantom-unread drift (rides the same PR)
+```
+unreadCounts[s] = max(0, latestOrdinals[s] − read(s) − |readMessageIds[s]|)
+read(s) is implicit: latest − unread − |overlay|
+```
+
+- `stream:read_messages` / `readMessageIds`-carrying events **SET** the
+  overlay set (absolute snapshot; safe under syncId-ordered application).
+- Watermark ordinals keep their existing merge rules (`stream:read`
+  max-merges, `read_set` SETs).
+- `messages:moved` applier **SETs** `latestOrdinals[source] =
+  sourceMessageOrdinal` and recomputes unread — the one sanctioned
+  non-monotonic latest write (precedent: `applyStreamReadSet`). Fix A1 below.
+- Bootstrap (`toCounterState`/`withCounterState`) carries the overlay;
+  `mergeReconnectWorkspaceBootstrap` must keep the
+  `unreadCounts`/`messageCounts`/`readMessageIds` **triple** paired per
+  stream (today it pairs the first two).
+
+`WorkspaceBootstrap` gains `readMessageIds?: Record<string, string[]>`
+(this one *is* a shared API type in `@threa/types`).
+
+## Conversation read API (pinned)
+
+- `POST /api/workspaces/:workspaceId/conversations/:conversationId/read`
+  body `{ throughMessageId }` (Zod, INV-55)
+- `POST /api/workspaces/:workspaceId/conversations/:conversationId/unread`
+  body `{ fromMessageId }`
+
+`ConversationService.markRead/markUnread` own one transaction each (INV-6):
+
+1. Access check via the conversation's root stream (INV-62 single-root check).
+2. Member set = `message_ids ∪ secondary_message_ids` (+ the thread-anchored
+   opening's parent message), resolved via `MessageRepository.findByIds`.
+3. **Cutoff = the target message's `createdAt`** (inclusive), applied across
+   all spanned streams — timestamps are the card's cross-stream merge key
+   (sequences aren't comparable across streams). Read: members with
+   `createdAt ≤ cutoff`; unread: members with `createdAt ≥ cutoff`.
+4. Group by each member message's own stream; process streams in sorted order
+   (deterministic lock order — two concurrent conversation-reads must not
+   deadlock); lock the membership row `FOR UPDATE` where one exists (INV-20).
+5. Per stream: overlay insert → compaction → prune; or overlay delete →
+   watermark regress. Emit **one** event per touched stream
+   (`stream:read_messages`, or `stream:read_set` on regress), same
+   transaction (INV-4/INV-7).
+
+Frontend: the conversation hosts (`BoardCard`, `ConversationPanelBody`) own
+the mutation + optimistic apply and hand `MessageItem` its row read state and
+the two callbacks; rows stay UI-focused (INV-15). The label page sets neither
+→ the actions hide there (the same field-one-side-sets gate as
+`conversationId`).
+
+### Card unread derivation (v1 scope decision)
+
+Per spanned stream, a member message is unread iff it's past that stream's
+read frontier and not in the overlay. Frontiers: the root and member-threads
+by watermark sequence; **non-member thread legs fall back to the root
+watermark's `last_read_at` timestamp** (no row → no sequence frontier; the
+time fallback bounds false-quiet without a wall of false-unread on ship day).
+Documented approximation — a principled thread frontier is a follow-up. The
+board card rail must retain `sequence` on its rows (`eventToRenderable`
+currently drops it).
+
+The stable-view "N new" pill (`use-stable-board-view`) is ordering-buffer
+state and stays fully independent of read state.
+
+## Phantom-unread drift — verified root causes + fixes (same PR)
 
 Reported: a stream shows unread (sidebar section + green + count 1, activity
-badge 1) but opening the stream and the activity feed shows nothing; the badge
-persists. Root-cause chain under verification (hypothesis: client
-`latestOrdinals` max-merge + ordinals-as-counts means a message deleted/moved
-after its `stream:activity` leaves the client's latest permanently inflated;
-the same staleness guard then blocks the D2 activity-row drop). Findings and
-fix land in this doc when the verification pass completes.
+badge 1) but opening the stream and the activity feed clears nothing.
+Investigated and adversarially re-verified; three real defects:
+
+1. **A1, message half (CONFIRMED)** — `messages:moved` relocates
+   `message_created` rows out of the source stream
+   (`event-service.ts:1153-1171`), so the source's true count drops; no
+   client applier ever corrects `latestOrdinals` downward (max-merge only,
+   `unread-counters.ts:153,178`), so `unread = inflatedLatest − trueRead > 0`
+   sticks for the whole session (heals only on a full network bootstrap;
+   cache-first bootstrap re-serves the drift). **Fix:** the
+   `sourceMessageOrdinal` payload + SET applier above.
+   *(The originally-suspected delete trigger is refuted: deletion soft-deletes
+   and keeps the `message_created` row, so ordinals are delete-stable.)*
+2. **A2 (CONFIRMED, reload-surviving)** — message deletion never touches
+   `user_activity` (`event-service.ts:916-957`): an unread activity row for a
+   deleted message survives server-side forever unless the user opens that
+   exact stream. **Fix:** mark the message's activity rows read in the delete
+   transaction + client-side held-row drop on `message_deleted`.
+3. **A4 (CONFIRMED, reload-surviving)** — on move, the activity row is
+   rehomed to the destination thread on both sides
+   (`messaging/repository.ts:513-519`, `rehomeActivities`); opening the
+   *root* clears nothing under the thread, so the badge persists on a stream
+   the user never visits. Rehoming itself is correct (the row must deep-link
+   to where the message lives). **Fix (backstop):** opening the activity feed
+   reconciles the held set against the server's `unreadOnly` feed — replacing
+   the held rows so the badge can never disagree with what the feed shows.
+   This also mops up any residual variant: the badge converges to feed truth
+   the moment the user looks.
+4. **A3 (verify during implementation)** — a source membership whose
+   `last_read_event_id` points at a since-moved event counts unread against a
+   foreign thread-space sequence in `countUnreadByStreamBatch`
+   (`event-repository.ts:707`) — survives reload. **Fix:** the watermark
+   repoint in the move transaction. Ship with a regression test either way.
+
+*(The activity half's originally-hypothesized D2-guard blockage was refuted
+in verification: `prevRead` collapses to 0 in the canonical scenario and the
+`markAsReadMutation` clears held rows unconditionally on stream open. The D2
+coupling is untouched by this work.)*
+
+## Out of scope for v1
+
+- Viewport-driven auto-read on the board (the "seen" question —
+  board-view-design edge 6 territory).
+- Restoring activity badges on mark-unread (accepted gap, matches the
+  stream path).
+- Offline queueing for read actions (existing read mutations are not queued;
+  the new ones match — parity, not a regression).
+- A principled read frontier for non-member threads (v1 uses the root
+  `last_read_at` time fallback on cards).

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1328,6 +1328,17 @@ export interface WorkspaceBootstrap {
    * Optional during rollout: snapshots cached before the field shipped lack it.
    */
   messageCounts?: Record<string, number>
+  /**
+   * Per-stream sparse read overlay at snapshot time: message ids the viewer
+   * read individually (via a conversation surface) ABOVE that stream's
+   * watermark. `unreadCounts` is already effective (watermark + overlay
+   * subtracted); this set lets the client keep the invariant
+   * `unread = latest − read − |overlay|` as live events fold in, and lets the
+   * timeline render overlay-read rows as read. Streams with an empty overlay
+   * are omitted. Optional: snapshots cached before the field shipped lack it
+   * (absent reads as empty). See docs/sparse-read-overlay-design.md.
+   */
+  readMessageIds?: Record<string, string[]>
   mentionCounts: Record<string, number>
   activityCounts: Record<string, number>
   unreadActivityCount: number

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -331,6 +331,15 @@ export interface StreamMember {
   memberId: string
   notificationLevel: NotificationLevel | null
   lastReadEventId: string | null
+  /**
+   * The watermark event's sequence in its stream (stringified bigint), resolved
+   * server-side where memberships are fetched. Lets clients compare a row's
+   * sequence against the read frontier without holding the watermark event
+   * itself (board-card unread derivation — see
+   * docs/sparse-read-overlay-design.md). Null when the watermark is unset or
+   * dangling; optional during rollout.
+   */
+  lastReadSequence?: string | null
   lastReadAt: string | null
   joinedAt: string
 }


### PR DESCRIPTION
**Design doc:** [`docs/sparse-read-overlay-design.md`](https://github.com/threahq/threa/blob/claude/conversation-aware-share-oiv8wn/docs/sparse-read-overlay-design.md) (in this PR) — continues the board action-parity line (#1124 → #1143).

## Problem

Two problems, one read model.

**1. The board can't mark read without lying.** The read model is one contiguous watermark per (stream, member) — `stream_members.last_read_event_id`, unread = `latestOrdinal − readOrdinal`. The board reads a *filtered projection*: conversation A's member messages interleave with B's in the same stream, so "I read card A" marks ordinals {5, 7, 9} while 6 and 8 stay genuinely unread. A single pointer physically can't represent that — advancing it falsely reads B; not advancing double-reads A. This blocked `onMarkReadUpToHere`/`onMarkUnread` on `MessageItem`, the last tractable context-menu parity gap.

**2. Phantom unread (user-reported: badge shows 1, opening the stream and the activity feed clears nothing).** Investigated and adversarially re-verified; three real defects, all shipping fixes here:

- **A1 (move-driven ordinal inflation)** — `messages:moved` relocates `message_created` rows out of the source (`event-service.ts` `moveMessageCreatedEvents`), shrinking its true count; client `latestOrdinals` only ever max-merge (`unread-counters.ts`), so `unread = inflatedLatest − trueRead` sticks all session. The originally-suspected delete trigger was **refuted** in verification: deletion soft-deletes and keeps the `message_created` row.
- **A2 (delete orphans activity)** — `deleteMessage` never touched `user_activity`; an unread row for a deleted message survived server-side forever. Reload-surviving.
- **A3 (moved watermark corruption)** — a `last_read_event_id` pointing at a since-moved event counts source unread against a foreign thread-space sequence in `countUnreadByStreamBatch`. Reload-surviving.
- **A4 (rehome-orphaned badge)** — move rehomes activity rows to the destination thread on both sides; opening the root clears nothing under a thread the user never visits.

## Solution

Keep the watermark, add a **sparse overlay above it**, and derive everything else — the model's core rule (now an invariant in the design doc): *read truth is message-granular and stream-anchored; conversation read state is always derived, never stored.* Conversation membership is mutable (merge/split/reassign), so read truth keyed on the cluster label would corrupt on every re-cluster; "mark conversation read" instead **expands to concrete member-message ids at write time** (snapshot semantics).

### How it works

1. **Overlay table** `stream_member_message_reads` (`20260703090000` migration): PK `(stream_id, member_id, message_id)`, workspace-tagged (INV-8), `event_id`/`sequence` denormalized at write (events key messages in `payload->>'messageId'`; the move tx refreshes them on rehome). A message is *effectively read* iff `sequence ≤ watermark OR id ∈ overlay`. **Invariant: every overlay row sits strictly above its member's watermark** — every watermark writer prunes at/below in the same transaction, so the overlay's size is exactly the count to subtract.
2. **Compaction** (`SparseReadRepository.findCompactionTarget`): a window `bool_and(covered)` over ascending sequence finds the greatest event where the run just above the watermark is fully overlay-covered; the watermark advances over it and absorbed rows are deleted — reading the frontier on a card just moves the watermark, the overlay only holds *holes*. The scan is bounded by the overlay's own max sequence (proportional to the conversation span, not the member's unread backlog).
3. **Application cores** (`sparse-read.ts` `applySparseRead`/`applySparseUnread`): lock the membership row `FOR UPDATE` where one exists; **non-member thread legs are overlay-only** — thread membership is participation not access (INV-62), a viewer reads thread messages via root access with no `stream_members` row, and the existing `markAsRead` silently no-ops there. The overlay deliberately doesn't require a membership row; no membership upsert (that would corrupt membership≠access).
4. **Conversation API**: `POST /workspaces/:ws/conversations/:id/read` `{throughMessageId}` / `/unread` `{fromMessageId}` (Zod, INV-55) → `ConversationService.markRead/markUnread`, one transaction each (INV-6): member set = `message_ids ∪ secondary_message_ids ∪` thread-anchored opening parent; **cutoff by the target's `createdAt`** (sequences aren't comparable across streams — timestamps are the card's merge key); streams processed in sorted id order (deterministic lock order); one outbox event per touched stream in the same tx (INV-4/7). Response: `{ streams: ReadStateSnapshot[] }`.
5. **Wire**: new author-scoped `stream:read_messages` carrying the **absolute post-write overlay** (idempotent, order-convergent under the sync log's total order — not a delta); `stream:read`/`read_set` gain `readMessageIds?` (absent = not carried, rollout-safe; `[]` = now empty); `messages:moved` gains `sourceMessageOrdinal`.
6. **Client counters** (`unread-counters.ts`): `unreadCounts[s] = max(0, latest − read − |overlay|)` threaded through every applier; overlay SETs, watermark keeps its existing merge rules (`read` max-merges, `read_set` SETs); `applyMovedSourceOrdinal` is the one sanctioned non-monotonic latest write (precedent: `applyStreamReadSet`). Dexie v37; bootstrap and the reconnect merge carry the `unreadCounts`/`messageCounts`/`readMessageIds` **triple** paired per stream. One snapshot-apply path (`sync/read-state.ts`) shared by the socket echo and the HTTP responses.
7. **Surfaces**: `ConversationReadProvider` on the board card + conversation panel derives per-row state (overlay hit → read; member streams by `lastReadSequence` frontier; non-member thread legs by root `lastReadAt` time fallback — documented v1 approximation) and gates the two menu entries exactly like the timeline row; label page sets no provider → actions hide (the same field-one-side-sets gate as `conversationId`). Board card gets a quiet unread dot (fixed footprint, INV-21). Timeline divider, row bolding, and new-message flash become *effectively*-unread aware.

### Key design decisions

**1. Overlay, not per-conversation pointers.** `conversation_reads(conv_id, …)` fails on Threa's own mutability: the extractor merges/splits/reassigns, so read state keyed on the cluster label flips on re-cluster, double-counts on merge, loses state on split. Expand-at-write + stream-anchored rows are immune. (Zulip's pure per-message-flag model with no watermark is the cautionary tale for the other extreme; compaction keeps the sparse set bounded to holes.)

**2. Mark-unread below the watermark regresses with collateral** — same contract as the timeline's "this and everything after". A *negative* overlay (sparse unread exceptions below the watermark) was explicitly rejected: two overlays with opposite signs is unmaintainable. Overlay rows of *other* conversations above the regressed point survive, so their reads aren't collateral damage.

**3. Absolute snapshots on the wire, not deltas.** `readMessageIds` is the entire post-write overlay: application is idempotent and convergent under syncId ordering; no delta-reordering hazards. `undefined` vs `[]` is load-bearing (rollout compat vs cleared).

**4. A4 fixed as a reconcile backstop, not by un-rehoming.** Rehoming is semantically right (the row must deep-link to where the message lives). Instead, opening the activity Unread tab reconciles the held badge set against the server's rows — the badge can never again disagree with the open feed. Guarded to complete pages only (a truncated 50-row page must not clamp an honest 80-unread badge).

### Design evolution (self-review)

Pre-PR adversarial review (4 lenses, every finding independently re-verified: **6 confirmed, 0 refuted**) caught real invariant violations, fixed in `c1b2150` with regression tests:

- `applySparseRead` inserted already-read (below-watermark) members and only pruned in the compaction branch — a surviving row double-subtracted, hiding genuine unread (reload-surviving). Now prunes unconditionally.
- `markUnread` can *advance* the watermark (target above it, board-read holes below); absorbed holes survived at/below the new watermark — reporting the just-marked-unread message as read. Now prunes both sides.
- Mark-all-read zeroes counts without a per-stream sequence payload, so card rows re-derived as unread against the stale frontier — a fresh phantom dot. Card derivation now short-circuits to read on `unreadCounts[s] === 0`.
- The activity reconcile clamped the badge to the 50-row page (regression vs. bootstrap's 200); now gated to complete pages.
- `toWorkspaceBootstrapMembership` dropped `lastReadSequence` through reconnect merges.
- Compaction window scan was unbounded over the member's whole unread backlog; now bounded by the overlay's max sequence.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260703090000_stream_member_message_reads.sql` | Overlay table (pinned schema, two indexes) |
| `apps/backend/src/features/streams/sparse-read-repository.ts` | Overlay primitives: unnest-join insert, compaction probe, prune/rehome (INV-27) |
| `apps/backend/src/features/streams/sparse-read.ts` | `applySparseRead`/`applySparseUnread` cores + `ReadStateSnapshot` |
| `apps/frontend/src/sync/read-state.ts` | One snapshot-apply path (socket echo + HTTP responses + IDB-optimistic) |
| `apps/frontend/src/components/message/conversation-read-context.tsx` | Per-row read derivation + the two actions, provided by card/panel hosts |
| `docs/sparse-read-overlay-design.md` | Pinned model, wire contracts, verified bug root-causes |
| Tests | `sparse-read-overlay.test.ts` (10), `conversation-read.test.ts` (3), `phantom-unread-fixes.test.ts` (3), `sparse-read-repository.test.ts` (6), `read-state.test.ts` (4), `conversation-read-context.test.tsx` (7), `board-card.test.tsx` |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/…/streams/service.ts` | `markAsRead`/`markUnread`/`markAllAsRead` maintain the overlay invariant; events carry `readMessageIds` |
| `apps/backend/…/streams/event-repository.ts` | `countUnreadByStreamBatch` subtracts overlay (effective unread); sequence resolvers |
| `apps/backend/…/streams/member-repository.ts` | `findByStreamAndMemberForUpdate`; `repointWatermarksForMovedEvents` (A3) |
| `apps/backend/…/conversations/{service,handlers}.ts` + `routes.ts` | `markRead`/`markUnread` fan-out + the two routes |
| `apps/backend/…/messaging/event-service.ts` | Move tx: overlay rehome + watermark repoint + `sourceMessageOrdinal` (A1/A3); delete tx: activity cleanup (A2) |
| `apps/backend/…/lib/outbox/repository.ts` | `stream:read_messages` registration (4 places) + payload extensions |
| `apps/backend/…/workspaces/handlers.ts` | Bootstrap: effective `unreadCounts`, `readMessageIds` map, membership `lastReadSequence` |
| `packages/types/{api,domain}.ts` | `WorkspaceBootstrap.readMessageIds`, `StreamMember.lastReadSequence` (optional, rollout-safe) |
| `apps/frontend/src/sync/unread-counters.ts` | Overlay-aware invariant in every applier + `applyStreamReadMessages`/`applyMovedSourceOrdinal`/`dropMessageActivities`/`reconcileActivities` |
| `apps/frontend/src/sync/{workspace-sync,stream-sync,catch-up-batch}.ts` | New handler + registration; `readMessageIds`/`lastReadSequence` persistence; move-ordinal + delete-activity appliers; triple-paired reconnect merge |
| `apps/frontend/src/db/database.ts` | Dexie v37: `CachedUnreadState.readMessageIds`, `CachedStreamMembership.lastReadSequence` |
| `apps/frontend/src/hooks/use-unread-counts.ts` | `useReadMessageIds`, `applyReadStateSnapshots`; full-read/mark-all optimistic overlay clears |
| `apps/frontend/src/components/{board/board-card,conversations/conversation-panel,message/message-item}.tsx` | Provider hosts, unread dot, menu wiring |
| `apps/frontend/src/components/timeline/{read-frontier-context,stream-content,message-event}.tsx` + `hooks/use-unread-divider.ts`, `use-new-message-indicator.ts` | Effective-unread (overlay-aware) row state, divider, flash |
| `apps/frontend/src/{pages/activity,hooks/use-activity}.tsx/.ts` | A4 reconcile backstop, gated to complete pages (`ACTIVITY_FEED_PAGE_LIMIT`) |
| `apps/frontend/src/api/conversations.ts` + `contexts/services-context.tsx` | The two client calls |

## Out of scope (deliberate)

- **Viewport-driven auto-read on the board** (the "seen" question — board-view-design edge 6 territory); v1 is explicit menu actions.
- **Offline queueing for read actions** — existing read mutations aren't queued; the new ones match (parity, not a regression).
- **Restoring activity badges on mark-unread** — accepted gap, matches the stream path.
- **A principled non-member-thread frontier** — v1 uses the root `lastReadAt` time fallback on cards (documented approximation).

## Test plan

- [x] Backend unit: `bun test src/` — **2251 pass** (incl. new sparse-read repo/service cases)
- [x] Backend integration (real Postgres): overlay (10, incl. 2 review regressions), conversation fan-out (3), phantom-unread fixes (3), unread-counts + message-move suites — **all pass**
- [x] Frontend full suite: `vitest run` — **3531 pass / 319 files** (incl. 54 counter-math, 4 read-state, snapshot/socket/merge, divider, conversation-read-context (7), board-card)
- [x] Full monorepo typecheck (`bun run typecheck`) — clean
- [x] Pre-PR review: 4 adversarial lenses, every finding re-verified independently — **6 confirmed / 0 refuted, all fixed** (see Design evolution)
- [ ] Playwright browser e2e — not run in this environment; unit+integration is the house bar for counter/service/menu layers (per repo test conventions), and the full stack (MinIO) isn't available here
- [ ] CI note: integration tests need `pgvector` in the Postgres image (installed locally to run migrations)

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Close the last context-menu parity gap (read pointer on `MessageItem`) without corrupting the stream read model, and kill the user-reported phantom-unread family.

**What was built.** Watermark + sparse overlay + compaction (design doc in this PR pins the model); conversation read/unread API with expand-at-write semantics; wire events with absolute snapshots; overlay-aware client counter math; board/panel read actions + card unread dot; timeline effective-unread; four verified phantom-unread fixes (A1 move-ordinal, A2 delete-activity, A3 watermark repoint, A4 feed reconcile).

**Design decisions.** Read truth message-granular + stream-anchored, conversation read state derived (mutability trap); collateral regress for below-watermark unread (negative overlay rejected); absolute snapshots not deltas; overlay-only for non-member threads (membership ≠ access, INV-62); createdAt cutoff across streams.

**Design evolution.** Adversarial review (6 confirmed findings) hardened the overlay invariant on every watermark path — see the Design evolution section above.

**Schema changes.** One append-only migration: `stream_member_message_reads`.

**What's NOT included.** Viewport auto-read, offline read queueing, mark-unread badge restoration, principled non-member-thread frontier (v1 time fallback).

**Status.** Complete; all suites green; docs updated.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01TBfcsdJofemjUuAqF7idYR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBfcsdJofemjUuAqF7idYR)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785683335&installation_id=129946197&pr_number=1165&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1165&signature=a56e074a1ca42c4b3204c75bcd1d5918ec4ac5e7373150048270df51f3357937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->