### PR TITLE
test(agents): verify per-thread session concurrency (roadmap 3.2)

### DIFF
--- a/apps/backend/src/features/agents/companion/session.test.ts
+++ b/apps/backend/src/features/agents/companion/session.test.ts
@@ -209,3 +209,91 @@ describe("withCompanionSession", () => {
     expect(insertOutboxSpy).not.toHaveBeenCalled()
   })
 })
+
+// The running-session slot is the partial unique index on
+// agent_sessions(stream_id) WHERE status='running'
+// (20260109155152_agent_session_one_running.sql, INV-20). withCompanionSession
+// keys the session on the *addressed* stream id it is handed — persona-agent
+// passes the thread's own id (or, for a channel mention, the freshly created
+// thread's id), never a re-resolved root. So a channel/scratchpad and a thread
+// beneath it hold distinct slots and run concurrently, while two turns targeting
+// the same thread collide on the index and the second serializes to a no-op.
+describe("per-stream session concurrency (roadmap 3.2)", () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("keys each session on its addressed stream id, so a channel and its thread occupy distinct slots and both run", async () => {
+    mockTransactions()
+    spyOn(AgentSessionRepository, "findByTriggerMessage").mockResolvedValue(null)
+    const insertSpy = spyOn(AgentSessionRepository, "insertRunningOrSkip").mockImplementation(async (_db, params) =>
+      makeRunningSession({ id: `session_${params.streamId}`, streamId: params.streamId })
+    )
+    spyOn(AgentSessionRepository, "completeSession").mockImplementation(async (_db, id) =>
+      makeRunningSession({ id, status: SessionStatuses.COMPLETED, completedAt: new Date("2026-02-19T12:01:00.000Z") })
+    )
+    spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([])
+    spyOn(StreamEventRepository, "insert").mockResolvedValue({} as any)
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const base = {
+      pool: {} as any,
+      personaId: "persona_1",
+      personaName: "Ariadne",
+      workspaceId: "ws_1",
+      serverId: "server_1",
+      initialSequence: 10n,
+    }
+    const work = async () => ({ messagesSent: 1, sentMessageIds: ["msg_agent_1"], lastSeenSequence: 11n })
+
+    const channelResult = await withCompanionSession(
+      { ...base, triggerMessageId: "msg_channel", streamId: "stream_channel" },
+      work
+    )
+    const threadResult = await withCompanionSession(
+      { ...base, triggerMessageId: "msg_thread", streamId: "stream_thread_under_channel" },
+      work
+    )
+
+    expect(channelResult.status).toBe("completed")
+    expect(threadResult.status).toBe("completed")
+    expect(insertSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ streamId: "stream_channel" }))
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ streamId: "stream_thread_under_channel" })
+    )
+  })
+
+  it("serializes a second turn in the same stream: the running-index conflict (null insert) skips instead of running a duplicate", async () => {
+    mockTransactions()
+    // No prior session for this trigger message, but a concurrent turn already
+    // holds the thread's running slot, so INSERT ... ON CONFLICT DO NOTHING
+    // returns no row.
+    spyOn(AgentSessionRepository, "findByTriggerMessage").mockResolvedValue(null)
+    spyOn(AgentSessionRepository, "insertRunningOrSkip").mockResolvedValue(null)
+    const eventSpy = spyOn(StreamEventRepository, "insert").mockResolvedValue({} as any)
+    const outboxSpy = spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    const result = await withCompanionSession(
+      {
+        pool: {} as any,
+        triggerMessageId: "msg_second_in_thread",
+        streamId: "stream_thread",
+        personaId: "persona_1",
+        personaName: "Ariadne",
+        workspaceId: "ws_1",
+        serverId: "server_1",
+        initialSequence: 10n,
+      },
+      async () => ({ messagesSent: 1, sentMessageIds: ["msg_agent_1"], lastSeenSequence: 11n })
+    )
+
+    expect(result).toEqual({
+      status: "skipped",
+      sessionId: null,
+      reason: "agent already running for stream",
+    })
+    expect(eventSpy).not.toHaveBeenCalled()
+    expect(outboxSpy).not.toHaveBeenCalled()
+  })
+})

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -44,7 +44,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 2.2  | Stop/Redirect affordances on the activity card       | ☐      |       |
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |
 | 3.1  | Persisted episode summaries                          | ☑      | #1162 |
-| 3.2  | Per-thread session concurrency                       | ☑      | #TBD  |
+| 3.2  | Per-thread session concurrency                       | ☑      | #1167 |
 | 3.3  | Conversation-anchored agent replies                  | ☐      |       |
 | 4.1  | `stream_briefs` storage + endpoints + injection      | ☐      |       |
 | 4.2  | `update_stream_brief` tool + timeline event          | ☐      |       |

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -44,7 +44,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 2.2  | Stop/Redirect affordances on the activity card       | ☐      |       |
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |
 | 3.1  | Persisted episode summaries                          | ☑      | #1162 |
-| 3.2  | Per-thread session concurrency                       | ☐      |       |
+| 3.2  | Per-thread session concurrency                       | ☑      | #TBD  |
 | 3.3  | Conversation-anchored agent replies                  | ☐      |       |
 | 4.1  | `stream_briefs` storage + endpoints + injection      | ☐      |       |
 | 4.2  | `update_stream_brief` tool + timeline event          | ☐      |       |
@@ -269,6 +269,15 @@ Not a duplicate of the two existing summaries: `conversations.topic_summary` nam
 **Tests:** concurrent sessions in a channel and its thread both run; two messages in the _same_ thread still serialize (INV-20 index).
 
 **Done when:** the concurrency semantics are tested, whichever way the investigation lands.
+
+**Investigation outcome (shipped): already concurrent — test-only, no code change.** Sessions key on the _addressed_ stream id end to end, so channel + thread never share a slot:
+
+- The running-session slot is the partial unique index `agent_sessions(stream_id) WHERE status='running'` (`20260109155152_agent_session_one_running.sql`). Threads are their own stream ids.
+- Dispatch keys on the addressed stream: `CompanionHandler` sends the `PERSONA_AGENT` job with the message's own `streamId` — root resolution (`companionSource`) is used only to inherit companion mode + persona, never to re-key the dispatch (`companion-outbox-handler.ts:86-158`).
+- Session insert keys on the addressed stream: `persona-agent.ts` sets `sessionStreamId = streamId` (a channel _mention_ spawns a fresh thread and keys on _that_), and `withCompanionSession` passes it verbatim to `insertRunningOrSkip` (`companion/session.ts:87`). The only root usages in the turn — tool-privacy policy and context-window policy (`persona-agent.ts:288`) — don't touch session keying. The other two `insertRunningOrSkip` callers (public-api bot invocations, enclave claim) likewise key on the invocation's target stream.
+- No advisory lock or other primitive serializes sessions on the root (the `pg_advisory_xact_lock` in `agents/` is the follow-up cap, unrelated).
+
+So a channel/scratchpad and a thread beneath it already run concurrently, and two turns in the same thread serialize on the index. The missing coverage — the concurrency contract as a unit — landed in `companion/session.test.ts` (`per-stream session concurrency (roadmap 3.2)`): distinct addressed streams both complete with their own `stream_id` forwarded to `insertRunningOrSkip`; a same-stream second turn whose insert conflicts (null) skips as "agent already running for stream" with no started event. The existing `companion-outbox-handler.test.ts` already covers threads dispatching on their own id.
 
 ### 3.3 Conversation-anchored agent replies
 


### PR DESCRIPTION
**Roadmap:** [`docs/plans/ariadne-collaborator-roadmap.md`](../blob/main/docs/plans/ariadne-collaborator-roadmap.md) step 3.2 — per-thread session concurrency.

## Problem

Roadmap 3.2 asks whether a busy channel and its threads serialize on one agent slot. The step is written **verify-first**: sessions may already run concurrently per thread, in which case it reduces to "add the missing test and close." The concurrency contract was untested as a unit, so the behavior wasn't pinned against regression.

## Solution

Investigated the session-keying path end to end and confirmed sessions **already** key on the addressed stream id — no code change needed. Added the missing concurrency-contract test and recorded the outcome in the roadmap.

### How it works (investigation outcome)

Sessions key on the addressed stream id at every layer, so a channel/scratchpad and a thread beneath it never share a running-session slot:

1. **The slot** is the partial unique index `agent_sessions(stream_id) WHERE status='running'` (`20260109155152_agent_session_one_running.sql`, INV-20). Threads are their own stream ids.
2. **Dispatch** keys on the addressed stream: `CompanionHandler` sends the `PERSONA_AGENT` job with the message's own `streamId`; root resolution (`companionSource`) is used only to inherit companion mode + persona, never to re-key the dispatch (`companion-outbox-handler.ts:86-158`).
3. **Session insert** keys on the addressed stream: `persona-agent.ts` sets `sessionStreamId = streamId` (a channel *mention* spawns a fresh thread via `createThread` and keys the session on *that* id), and `withCompanionSession` passes it verbatim to `insertRunningOrSkip` (`companion/session.ts:87`). The only root usages in the turn — tool-privacy policy and context-window policy at `persona-agent.ts:288` — don't touch session keying. The other two `insertRunningOrSkip` callers (public-api bot invocations `handlers.ts:1051`, enclave claim `claim-service.ts:473`) likewise key on the invocation's target stream.
4. **No advisory lock** serializes sessions on the root — the `pg_advisory_xact_lock` in `agents/` is the follow-up cap (`follow-up-repository.ts:82`), unrelated.

So a channel and a thread beneath it run concurrently, and two turns in the same thread serialize on the index. The added test in `companion/session.test.ts` (`per-stream session concurrency (roadmap 3.2)`) pins both halves:

- **Concurrent**: two `withCompanionSession` calls with distinct addressed stream ids both complete, each forwarding its own `streamId` to `insertRunningOrSkip`.
- **Serialize**: a same-stream second turn whose insert conflicts (`insertRunningOrSkip` → null, the `ON CONFLICT DO NOTHING` outcome) skips as `agent already running for stream` with no `agent_session:started` event.

The existing `companion-outbox-handler.test.ts` already covers threads dispatching on their own id (channel-rooted threads correctly don't auto-invoke; scratchpad-rooted threads dispatch on the thread's id).

### Why a unit test, not integration

The repo treats partial-unique enforcement as a DB/integration concern and covers the *application control flow* with a fake `Querier` — the pattern is stated verbatim in `append-step-idempotency.test.ts:6-8`. The new test follows it: it asserts the keying contract (`withCompanionSession` forwards the addressed stream id) and the conflict→skip no-op that the index drives, not the index itself.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/companion/session.test.ts` | New `describe("per-stream session concurrency (roadmap 3.2)")` — distinct streams both run; same-stream conflict skips. Load-bearing comment cites the index migration + INV-20. |
| `docs/plans/ariadne-collaborator-roadmap.md` | Check 3.2 box; add the investigation outcome (already concurrent, test-only) with the code citations above. |

## Out of scope (deliberate)

- **No production code change.** The investigation found the concurrency already correct; per the roadmap's own framing this is the "add the missing test and close" branch.
- **No live-DB test of the index itself** — consistent with the repo's harness convention (see above).

## Test plan

- [x] `bun test ./apps/backend/src/features/agents/companion/session.test.ts` — 5 pass (2 new)
- [x] `bun test ./apps/backend/src/features/agents/` — 389 pass, 0 fail
- [x] `bun run --cwd apps/backend typecheck` (prod + `tsconfig.tests.json`) — clean
- [x] Full pre-commit hook (all-workspace typecheck, check-migrations, astro check, `generate-api-docs --check`, prettier) — green
- [x] Self-review: claim-verification pass over the diff — every cited symbol/line (`companion-outbox-handler.ts:86-158`, `persona-agent.ts:288/334-345`, `session.ts:87`, `handlers.ts:1051`, `claim-service.ts:473`, the index migration) opened and confirmed. No `/code-review` agents — test+docs change with no runtime surface.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BY6GVkkqhgRDmZ748jsbhJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785693471&installation_id=129946197&pr_number=1167&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1167&signature=90f37484002dd1a9798152114c923c92d6f85bdd691962deb1847da96d3392bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->