### PR TITLE
feat(scheduled-messages): carry the "Reply in conversation" directive through scheduled sends

### DIFF
--- a/apps/backend/src/db/migrations/20260703100000_scheduled_messages_conversation_directive.sql
+++ b/apps/backend/src/db/migrations/20260703100000_scheduled_messages_conversation_directive.sql
@@ -1,0 +1,17 @@
+-- Carry a "Reply in conversation" directive through a scheduled send.
+--
+-- A scheduled message can be armed for a conversation the same way a live send
+-- is (message-input's "Reply in conversation" strip is available in the same
+-- composer as the schedule picker). We store the declared ConversationDirective
+-- here so the fire path forwards it to EventService.createMessage — the delivered
+-- message files into the conversation exactly as an immediate send would, instead
+-- of silently landing flat in the channel.
+--
+-- Nullable: an ordinary scheduled send (no arm) leaves it NULL and the async
+-- boundary-extractor infers the conversation at fire time, same as today. The
+-- value is an opaque directive object ({ intent, conversationId? }) validated at
+-- write time by the same wire schema the live-send path uses; the assigner
+-- re-validates access at fire time. Not a foreign key (INV-1), not indexed
+-- (read only as part of a row already fetched by id at fire time).
+
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS conversation_directive JSONB;

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -31,7 +31,7 @@ import { messageMetadataSchema } from "./metadata-schema"
 // Optional conversation directive: declare the message's conversation instead
 // of leaving the extractor to infer it. The id is a sibling of the discriminant,
 // so `existing` without a non-empty id is a validation error, distinct from `new`.
-const conversationDirectiveSchema = z.discriminatedUnion("intent", [
+export const conversationDirectiveSchema = z.discriminatedUnion("intent", [
   z.object({ intent: z.literal("new") }),
   z.object({ intent: z.literal("existing"), conversationId: z.string().min(1) }),
   z.object({ intent: z.literal("threadFromMessage"), sourceConversationId: z.string().min(1) }),

--- a/apps/backend/src/features/messaging/index.ts
+++ b/apps/backend/src/features/messaging/index.ts
@@ -48,6 +48,7 @@ export {
   addReactionSchema,
   moveMessagesToThreadSchema,
   validateMoveMessagesToThreadSchema,
+  conversationDirectiveSchema,
 } from "./handlers"
 
 export {

--- a/apps/backend/src/features/scheduled-messages/handlers.ts
+++ b/apps/backend/src/features/scheduled-messages/handlers.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import { HttpError } from "../../lib/errors"
-import { deriveContentMarkdown } from "../messaging"
+import { deriveContentMarkdown, conversationDirectiveSchema } from "../messaging"
 import type { ScheduledMessagesService } from "./service"
 
 const contentJsonSchema = z.object({
@@ -17,6 +17,7 @@ const scheduleSchema = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   scheduledFor: z.string().datetime(),
   clientMessageId: z.string().min(1).optional(),
+  conversation: conversationDirectiveSchema.optional(),
 })
 
 // PATCH allows any subset of editable fields plus a required
@@ -73,6 +74,7 @@ export function createScheduledMessagesHandlers({ scheduledMessagesService }: De
         metadata: data.metadata ?? null,
         scheduledFor: new Date(data.scheduledFor),
         clientMessageId: data.clientMessageId ?? null,
+        conversationDirective: data.conversation ?? null,
       })
 
       res.status(201).json({ scheduled })

--- a/apps/backend/src/features/scheduled-messages/repository.test.ts
+++ b/apps/backend/src/features/scheduled-messages/repository.test.ts
@@ -17,6 +17,7 @@ const SCHEDULED_ROW = {
   content_markdown: "hello",
   attachment_ids: [],
   metadata: null,
+  conversation_directive: null,
   scheduled_for: SCHEDULED_FOR,
   status: ScheduledMessageStatuses.PENDING,
   sent_message_id: null,
@@ -64,13 +65,37 @@ describe("ScheduledMessagesRepository.insert", () => {
       contentMarkdown: "hello",
       attachmentIds: [],
       metadata: null,
+      conversationDirective: null,
       scheduledFor: SCHEDULED_FOR,
       clientMessageId: "cli_1",
     })
 
     expect(captured.text).toContain("INSERT INTO scheduled_messages")
+    expect(captured.text).toContain("conversation_directive")
     expect(captured.text).toContain("RETURNING")
     expect(captured.values).toContain("cli_1")
+  })
+
+  it("serializes the conversation directive into the row when armed for 'Reply in conversation'", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured)
+
+    await ScheduledMessagesRepository.insert(db, {
+      id: "sched_02",
+      workspaceId: "ws_1",
+      userId: "usr_1",
+      streamId: "stream_1",
+      parentMessageId: null,
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "hello",
+      attachmentIds: [],
+      metadata: null,
+      conversationDirective: { intent: "existing", conversationId: "conv_7" },
+      scheduledFor: SCHEDULED_FOR,
+      clientMessageId: null,
+    })
+
+    expect(captured.values).toContain(JSON.stringify({ intent: "existing", conversationId: "conv_7" }))
   })
 })
 

--- a/apps/backend/src/features/scheduled-messages/repository.ts
+++ b/apps/backend/src/features/scheduled-messages/repository.ts
@@ -1,6 +1,11 @@
 import type { Querier } from "../../db"
 import { sql } from "../../db"
-import { ScheduledMessageStatuses, type ScheduledMessageStatus, type JSONContent } from "@threa/types"
+import {
+  ScheduledMessageStatuses,
+  type ScheduledMessageStatus,
+  type JSONContent,
+  type ConversationDirective,
+} from "@threa/types"
 
 interface ScheduledMessageRow {
   id: string
@@ -12,6 +17,7 @@ interface ScheduledMessageRow {
   content_markdown: string
   attachment_ids: string[]
   metadata: Record<string, string> | null
+  conversation_directive: ConversationDirective | null
   scheduled_for: Date
   status: string
   sent_message_id: string | null
@@ -36,6 +42,13 @@ export interface ScheduledMessage {
   contentMarkdown: string
   attachmentIds: string[]
   metadata: Record<string, string> | null
+  /**
+   * Declared conversation for the delivered message ("Reply in conversation"
+   * armed at schedule time), forwarded to `EventService.createMessage` at fire
+   * time. Null → the async extractor infers the conversation, same as a live
+   * send with no directive.
+   */
+  conversationDirective: ConversationDirective | null
   scheduledFor: Date
   status: ScheduledMessageStatus
   sentMessageId: string | null
@@ -74,6 +87,7 @@ export interface InsertScheduledMessageParams {
   contentMarkdown: string
   attachmentIds: string[]
   metadata: Record<string, string> | null
+  conversationDirective: ConversationDirective | null
   scheduledFor: Date
   clientMessageId: string | null
 }
@@ -86,7 +100,7 @@ export interface ListScheduledOpts {
 }
 
 const COLUMNS =
-  "id, workspace_id, user_id, stream_id, parent_message_id, content_json, content_markdown, attachment_ids, metadata, scheduled_for, status, sent_message_id, last_error, queue_message_id, edit_active_until, client_message_id, retry_count, version, created_at, updated_at, status_changed_at"
+  "id, workspace_id, user_id, stream_id, parent_message_id, content_json, content_markdown, attachment_ids, metadata, conversation_directive, scheduled_for, status, sent_message_id, last_error, queue_message_id, edit_active_until, client_message_id, retry_count, version, created_at, updated_at, status_changed_at"
 
 function mapRow(row: ScheduledMessageRow): ScheduledMessage {
   return {
@@ -99,6 +113,7 @@ function mapRow(row: ScheduledMessageRow): ScheduledMessage {
     contentMarkdown: row.content_markdown,
     attachmentIds: Array.isArray(row.attachment_ids) ? row.attachment_ids : [],
     metadata: row.metadata,
+    conversationDirective: row.conversation_directive,
     scheduledFor: row.scheduled_for,
     status: row.status as ScheduledMessageStatus,
     sentMessageId: row.sent_message_id,
@@ -127,7 +142,7 @@ export const ScheduledMessagesRepository = {
       INSERT INTO scheduled_messages (
         id, workspace_id, user_id, stream_id, parent_message_id,
         content_json, content_markdown, attachment_ids, metadata,
-        scheduled_for, status, client_message_id
+        conversation_directive, scheduled_for, status, client_message_id
       )
       VALUES (
         ${params.id},
@@ -139,6 +154,7 @@ export const ScheduledMessagesRepository = {
         ${params.contentMarkdown},
         ${JSON.stringify(params.attachmentIds)}::jsonb,
         ${params.metadata ? JSON.stringify(params.metadata) : null}::jsonb,
+        ${params.conversationDirective ? JSON.stringify(params.conversationDirective) : null}::jsonb,
         ${params.scheduledFor},
         ${ScheduledMessageStatuses.PENDING},
         ${params.clientMessageId}

--- a/apps/backend/src/features/scheduled-messages/service.test.ts
+++ b/apps/backend/src/features/scheduled-messages/service.test.ts
@@ -52,6 +52,7 @@ function fakeScheduled(overrides: Partial<ScheduledMessage> = {}): ScheduledMess
     contentMarkdown: "hello",
     attachmentIds: [],
     metadata: null,
+    conversationDirective: null,
     scheduledFor: FUTURE,
     status: ScheduledMessageStatuses.PENDING,
     sentMessageId: null,
@@ -112,6 +113,7 @@ describe("ScheduledMessagesService.schedule", () => {
         contentMarkdown: "x",
         attachmentIds: [],
         metadata: null,
+        conversationDirective: null,
         scheduledFor: FUTURE,
         clientMessageId: null,
       })
@@ -133,6 +135,7 @@ describe("ScheduledMessagesService.schedule", () => {
         contentMarkdown: "x",
         attachmentIds: [],
         metadata: null,
+        conversationDirective: null,
         scheduledFor: FUTURE,
         clientMessageId: null,
       })
@@ -155,6 +158,7 @@ describe("ScheduledMessagesService.schedule", () => {
         contentMarkdown: "x",
         attachmentIds: [],
         metadata: null,
+        conversationDirective: null,
         scheduledFor: FUTURE,
         clientMessageId: null,
       })
@@ -177,6 +181,7 @@ describe("ScheduledMessagesService.schedule", () => {
       contentMarkdown: "x",
       attachmentIds: [],
       metadata: null,
+      conversationDirective: null,
       scheduledFor: FUTURE,
       clientMessageId: "cli_1",
     })
@@ -205,6 +210,7 @@ describe("ScheduledMessagesService.schedule", () => {
       contentMarkdown: "hello",
       attachmentIds: [],
       metadata: null,
+      conversationDirective: null,
       scheduledFor: FUTURE,
       clientMessageId: null,
     })
@@ -548,5 +554,47 @@ describe("ScheduledMessagesService.fire (worker entry)", () => {
     const call = (createMessage as any).mock.calls[0][0]
     expect(call.clientMessageId).toBe(`scheduled:${SCHEDULED_ID}`)
     expect(outboxInsert).toHaveBeenCalledWith(expect.anything(), "scheduled_message:sent", expect.any(Object))
+  })
+
+  it("forwards a stored conversation directive to createMessage so a scheduled reply files into its conversation", async () => {
+    const createMessage = mock(async () => ({
+      id: "msg_42",
+      streamId: STREAM_ID,
+      sequence: 1n,
+      authorId: USER_ID,
+      authorType: "user" as const,
+      contentJson: { type: "doc", content: [] },
+      contentMarkdown: "hello",
+      replyCount: 0,
+      clientMessageId: null,
+      sentVia: null,
+      reactions: {},
+      metadata: {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt: NOW,
+    }))
+    const service = setupService({ createMessage } as unknown as EventService)
+    const due = new Date(Date.now() - 1_000)
+    const row = fakeScheduled({
+      scheduledFor: due,
+      conversationDirective: { intent: "existing", conversationId: "conv_99" },
+    })
+    spyOn(ScheduledMessagesRepository, "findByIdScoped").mockResolvedValue(row)
+    spyOn(ScheduledMessagesRepository, "tryStartSend").mockResolvedValue({
+      ...row,
+      status: ScheduledMessageStatuses.SENDING,
+    })
+    spyOn(ScheduledMessagesRepository, "markSent").mockResolvedValue({
+      ...row,
+      status: ScheduledMessageStatuses.SENT,
+      sentMessageId: "msg_42",
+    })
+    spyOn(OutboxRepository, "insert").mockResolvedValue({} as any)
+
+    await service.fire({ workspaceId: WORKSPACE_ID, scheduledMessageId: SCHEDULED_ID })
+
+    const call = (createMessage as any).mock.calls[0][0]
+    expect(call.conversation).toEqual({ intent: "existing", conversationId: "conv_99" })
   })
 })

--- a/apps/backend/src/features/scheduled-messages/service.ts
+++ b/apps/backend/src/features/scheduled-messages/service.ts
@@ -1,5 +1,11 @@
 import type { Pool, PoolClient } from "pg"
-import { AuthorTypes, ScheduledMessageStatuses, type ScheduledMessageView, type JSONContent } from "@threa/types"
+import {
+  AuthorTypes,
+  ScheduledMessageStatuses,
+  type ScheduledMessageView,
+  type JSONContent,
+  type ConversationDirective,
+} from "@threa/types"
 import { withTransaction } from "../../db"
 import { HttpError, isUniqueViolation } from "../../lib/errors"
 // Side-effect import: matches the load-order workaround used by other features
@@ -31,6 +37,7 @@ export interface ScheduleParams {
   contentMarkdown: string
   attachmentIds: string[]
   metadata: Record<string, string> | null
+  conversationDirective: ConversationDirective | null
   scheduledFor: Date
   clientMessageId: string | null
 }
@@ -146,6 +153,7 @@ export class ScheduledMessagesService {
           contentMarkdown: params.contentMarkdown,
           attachmentIds: params.attachmentIds,
           metadata: params.metadata,
+          conversationDirective: params.conversationDirective,
           scheduledFor: clamped,
           clientMessageId: params.clientMessageId,
         })
@@ -524,6 +532,14 @@ export class ScheduledMessagesService {
       contentMarkdown: row.contentMarkdown,
       attachmentIds: row.attachmentIds.length > 0 ? row.attachmentIds : undefined,
       metadata: row.metadata ?? undefined,
+      // Forward the armed "Reply in conversation" directive so the delivered
+      // message files into its conversation synchronously, exactly as a live
+      // send would. Null → let the async extractor infer (INV-62). The assigner
+      // re-validates access/root at fire time (cross-stream within one root is
+      // allowed); a since-deleted or cross-root conversation throws, and fire()'s
+      // catch marks the row `failed` and upserts it so the user sees it, rather
+      // than silently dropping into the wrong place.
+      conversation: row.conversationDirective ?? undefined,
       // Use the scheduled message id as the idempotency key. If the same
       // scheduled row gets re-fired after an interrupted finalize (process
       // restart between createMessage and markSent), the second attempt

--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -85,6 +85,10 @@ let registeredQuoteReplyHandler:
     }) => void)
   | null = null
 let registeredConversationReplyHandler: ((data: { conversationId: string }) => void) | null = null
+const mockScheduleMutateAsync = vi.fn()
+// Captured from the mocked ScheduledMessagesPicker so a test can drive the
+// schedule flow (which lands on `handleSchedule`) without the real picker UI.
+let capturedOnSchedule: ((when: Date) => void | Promise<void>) | null = null
 
 // Composer state that tests can modify
 let mockComposerState = {
@@ -110,6 +114,9 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockSendMessage.mockReset()
   mockSendMessage.mockResolvedValue({})
+  mockScheduleMutateAsync.mockReset()
+  mockScheduleMutateAsync.mockResolvedValue({})
+  capturedOnSchedule = null
   mockOpenPanel.mockReset()
   infoToastSpy = vi.spyOn(toast, "info").mockImplementation(() => "toast-id")
   resetConversationReplyOpenStoreCache()
@@ -261,10 +268,21 @@ beforeEach(() => {
   // ServicesProvider; tests run without that wrapper, so stub the hook to a
   // no-op mutation. The schedule path itself is exercised by the page tests.
   vi.spyOn(hooksModule, "useScheduleMessage").mockReturnValue({
-    mutateAsync: vi.fn().mockResolvedValue({}),
+    mutateAsync: mockScheduleMutateAsync,
     mutate: vi.fn(),
     isPending: false,
   } as unknown as ReturnType<typeof hooksModule.useScheduleMessage>)
+  // Capture the picker's onSchedule (bound to `handleSchedule`) so a test can
+  // drive the schedule path directly; the real picker's date UI is exercised by
+  // page tests.
+  vi.spyOn(composerModule, "ScheduledMessagesPicker").mockImplementation((({
+    onSchedule,
+  }: {
+    onSchedule: (when: Date) => void | Promise<void>
+  }) => {
+    capturedOnSchedule = onSchedule
+    return <div data-testid="scheduled-messages-picker" />
+  }) as unknown as typeof composerModule.ScheduledMessagesPicker)
   // Stash previews decrypt via the shared cache, which reads auth/session; these
   // tests render without an AuthProvider, so stub the batch hook to an empty map.
   vi.spyOn(hooksModule, "useDecryptedDraftPreviews").mockReturnValue(new Map())
@@ -283,6 +301,7 @@ beforeEach(() => {
     hasFailed,
     pendingAttachments,
     composerRef,
+    scheduledMessagesTrigger,
   }: {
     content: JSONContent
     onContentChange: (v: JSONContent) => void
@@ -292,6 +311,7 @@ beforeEach(() => {
     hasFailed: boolean
     pendingAttachments: Array<{ id: string; filename: string; sizeBytes: number; status: string }>
     composerRef?: { current: { focus: () => void; focusAfterQuoteReply: () => void } | null }
+    scheduledMessagesTrigger?: ReactNode
   }) => {
     if (composerRef) {
       composerRef.current = {
@@ -313,6 +333,7 @@ beforeEach(() => {
         <button onClick={() => onSubmit(mockSubmitContentOverride)} disabled={!canSubmit || hasFailed}>
           {isSubmitting ? "Sending..." : "Send"}
         </button>
+        {scheduledMessagesTrigger}
       </div>
     )
   }) as unknown as typeof composerModule.MessageComposer)
@@ -597,6 +618,39 @@ describe("MessageInput", () => {
         conversation: { intent: "existing", conversationId: "conv_1" },
       })
       expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    })
+
+    it("carries the armed directive onto a scheduled send and clears the strip", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("send this later, in the conversation")
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await act(async () => {
+        await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
+      })
+
+      expect(mockScheduleMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamId,
+          conversation: { intent: "existing", conversationId: "conv_1" },
+        })
+      )
+      expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+    })
+
+    it("schedules with no directive when the composer isn't armed", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("just a normal scheduled message")
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+
+      await act(async () => {
+        await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
+      })
+
+      expect(mockScheduleMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ conversation: undefined }))
     })
 
     it("keeps the filing armed when the send fails, so a retry still files", async () => {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -723,7 +723,17 @@ function MessageInputComponent({
           contentJson: normalizedContent,
           attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
           scheduledFor: when.toISOString(),
+          // Armed by "Reply in conversation": the directive rides the scheduled
+          // row and is forwarded to the send at fire time, so a scheduled reply
+          // files into its conversation exactly as an immediate send would.
+          // Unlike the live send there's no thread-follow routing — the fired
+          // message posts into this stream and the assigner attaches it to the
+          // conversation by id (cross-stream within one root is allowed).
+          conversation: conversationReply
+            ? { intent: "existing", conversationId: conversationReply.conversationId }
+            : undefined,
         })
+        setConversationReply(null)
         composer.resolveDraft()
         composer.clearAttachments()
       } catch (err) {
@@ -734,7 +744,7 @@ function MessageInputComponent({
         composer.setIsSending(false)
       }
     },
-    [composer, scheduleMessageMutation, streamId]
+    [composer, scheduleMessageMutation, streamId, conversationReply]
   )
 
   if (disabled && disabledReason) {

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -535,7 +535,10 @@ stops being load-bearing for the surfaces people actually drive.
 2. **Attached context: content node vs. envelope field.** Attachments/quote-reply are
    content nodes, and the backend already extracts content references, so consistency
    says `conversationReference` is a content node — counter-argument: filing-into-a-
-   topic is arguably a message property, not body. _Lean: content node._
+   topic is arguably a message property, not body. _Resolved (#1146): envelope field._
+   The counter-argument won — a `conversation` `ConversationDirective` rides the send
+   input (`CreateMessageInputJson.conversation`), assigned synchronously in the
+   message's transaction, never a node in `contentJson`.
 3. **Chip source** — render the provenance chip from the attached reference
    (authoritative, no flicker) rather than from async membership? _Lean: from the
    reference._

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1849,6 +1849,12 @@ export interface ScheduleMessageInput {
   scheduledFor: string
   /** Idempotency key for optimistic create retries (mirrors message create). */
   clientMessageId?: string
+  /**
+   * Declare the delivered message's conversation (see {@link ConversationDirective}),
+   * stored on the row and forwarded to the send at fire time. Set by the composer's
+   * "Reply in conversation" arm; omit to let the extractor infer at fire time.
+   */
+  conversation?: ConversationDirective
 }
 
 /**


### PR DESCRIPTION
## Problem

"Reply in conversation" (Mechanism C, #1146/#1161) arms the stream composer to file its next send into a conversation — the composer shows a "Replying in <topic>" strip and the send carries a `ConversationDirective`. But the schedule picker lives in that **same** composer (`ScheduledMessagesPicker`, `onSchedule={handleSchedule}`), and `handleSchedule` never forwarded the arm. Arming a reply and then scheduling it (instead of sending) silently dropped the directive: the scheduled message fired later as a flat channel send, contradicting the strip the user saw. There was also no column to carry the directive — the `scheduled_messages` row had nowhere to store it.

## Solution

Store the declared `ConversationDirective` on the scheduled row and forward it to `EventService.createMessage` at fire time, so a scheduled reply files into its conversation exactly as an immediate send does. The fire pipeline already routes every scheduled send through `createMessage` (which accepts `conversation?`), so this is a store-and-forward, not new send logic.

### How it works

1. **Wire + schema.** `ScheduleMessageInput.conversation?: ConversationDirective`. The schedule zod (`scheduled-messages/handlers.ts`) validates it with messaging's existing `conversationDirectiveSchema`, now exported from the `messaging` barrel (INV-52) instead of duplicated — that schema carries the type-lock guard keeping it in sync with `@threa/types`.
2. **Storage.** Migration `20260703100000_scheduled_messages_conversation_directive.sql` adds a nullable `conversation_directive JSONB` column. `ScheduledMessagesRepository` maps it through the row (`conversationDirective`) and serializes it on `insert`. It's read only as part of a row already fetched by id at fire time, so it's not indexed and not a foreign key (INV-1).
3. **Fire-time forward.** `ScheduledMessagesService.finalizeSendInTx` passes `conversation: row.conversationDirective ?? undefined` into `createMessage`. Null → the async boundary-extractor infers the conversation, same as a live send with no directive (INV-62). The shared `EventService` (with `conversationAssigner`) is the same instance the live path uses (`server.ts:249,485`), so the assigner is available at fire time.
4. **Frontend.** `message-input.tsx:handleSchedule` forwards the armed directive as `{ intent: "existing", conversationId }` and clears the strip on success — mirroring `handleSubmit`. It rides the existing offline operation-queue path unchanged (`enqueueOperation("schedule_message", { input })` spreads the whole input, and `operation-queue.ts` POSTs it verbatim).

### Key design decisions

**1. No thread-follow routing on the scheduled path.** The live send (#1161) redirects to the conversation side panel when the conversation has moved into a thread, routing recency-biased into the live thread. A scheduled send can't "follow" a live thread — the target stream at fire time is unknown at schedule time — so `handleSchedule` unconditionally attaches `{intent:"existing", conversationId}`. The fired message posts into the scheduled stream (the root the user was viewing) and the assigner attaches it to the conversation by id. `conversation-assigner.ts` allows cross-stream attach within one root and only rejects cross-*root* (`CONVERSATION_NOT_IN_ROOT`), so the reply still files into its conversation even if it drifted into a thread meanwhile — it just lands in the root timeline rather than the thread. That's the best achievable semantics for a deferred send, and conversation grouping is preserved.

**2. Fail loud at fire time, don't mis-file.** If the conversation was deleted or moved cross-root between schedule and fire, `createMessage` throws; `fire()`'s catch marks the row `failed` and upserts it so the user sees the failure (`service.ts:493-503`), rather than silently dropping the message flat. Same directive semantics as the live path — a stale `existing` id is a validation error, not a fallback.

**3. Directive stored on create, untouched by edits.** `update()` doesn't write `conversation_directive`, so editing a scheduled message (content/time/attachments) preserves the arm. Not surfaced on `ScheduledMessageView` — no UI renders the arm on scheduled rows, so keeping it off the wire view is the smaller change; it round-trips through the row, not the projection.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260703100000_scheduled_messages_conversation_directive.sql` | Nullable `conversation_directive JSONB` column on `scheduled_messages` |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts` | `ScheduleMessageInput.conversation?: ConversationDirective` |
| `apps/backend/src/features/messaging/handlers.ts` | Export `conversationDirectiveSchema` |
| `apps/backend/src/features/messaging/index.ts` | Re-export `conversationDirectiveSchema` from the barrel |
| `apps/backend/src/features/scheduled-messages/handlers.ts` | Reuse `conversationDirectiveSchema` in the schedule zod; pass `conversationDirective` to the service |
| `apps/backend/src/features/scheduled-messages/repository.ts` | Column plumbing: row shape, `ScheduledMessage`, insert params, `COLUMNS`, `mapRow`, `INSERT` |
| `apps/backend/src/features/scheduled-messages/service.ts` | `ScheduleParams.conversationDirective`; store on insert; forward in `finalizeSendInTx` |
| `apps/frontend/src/components/timeline/message-input.tsx` | `handleSchedule` forwards the armed directive + clears the strip on success |
| `docs/board-view-design.md` | Resolve open-decision #2 (envelope field, shipped in #1146) — was stale "lean: content node" |
| `apps/backend/src/features/scheduled-messages/service.test.ts` | `conversationDirective` in fixtures; fire-path forwarding test |
| `apps/backend/src/features/scheduled-messages/repository.test.ts` | `conversation_directive` in fixture; insert-serialization test |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | Capture `onSchedule`; armed→carried+cleared and unarmed→undefined tests |

## Out of scope (deliberate)

- **E2E "Reply in conversation" (handover follow-up 3) — dropped as moot, not deferred.** Boundary extraction is skipped for E2E streams (`boundary-extraction-outbox-handler.ts:40`), so E2E streams have no conversations at all: `messageConversationId` is never populated for E2E messages, the action never appears, and there's no conversation to point a directive at. The scheduled service already refuses E2E scheduling outright (`E2E_STREAM_SCHEDULING_UNSUPPORTED`). Extending the E2E wire schema would be plumbing for a feature that can't exist; the #1146 note to "un-hide the action for E2E" overlooked this.
- **Panel/board flat-timeline chip suppression (handover follow-up 1)** — a separate "ask before doing" decision, untouched here.
- **`ScheduledMessageView.conversation`** — not exposed; no surface renders it (see decision 3).

## Test plan

- [x] Backend `bun test src/features/scheduled-messages/` — 38 pass (adds fire-path forward + insert-serialization)
- [x] Frontend `vitest run src/components/timeline/message-input.test.tsx` — 29 pass (adds armed-schedule + unarmed-schedule)
- [x] `tsc --noEmit` clean across `@threa/types`, backend, frontend
- [x] Pre-commit hook (full-monorepo prettier + lint + tsc + astro + api-docs + tests) — passed (exit 0)
- [x] Self-review: verified schema reuse + type-lock, cross-stream/one-root assigner semantics (`conversation-assigner.ts:63`), fire-catch → `failed` (`service.ts:493-503`), shared `EventService`+assigner instance, operation-queue passthrough, no other `ScheduleParams`/insert callers (backend tsc gate). No findings.
- [ ] No live-DB harness — the column round-trip is covered via the stubbed-`Querier` repo test like its siblings, not integration-tested against Postgres.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJNrXBxKiikEuJ1ki4VjF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785695660&installation_id=129946197&pr_number=1168&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1168&signature=5bda198636c05c5d45988f2d4e2d3425d510982be475136e829d4d58fe78f3c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->