### PR TITLE
feat(mobile): OS back gesture closes drawers and the sidebar instead of navigating

### DIFF
--- a/apps/frontend/src/components/layout/app-shell.tsx
+++ b/apps/frontend/src/components/layout/app-shell.tsx
@@ -4,6 +4,7 @@ import { useSidebar, useCoordinatedLoading, type UrgencyBlock } from "@/contexts
 import { useResizeDrag, useVisualViewport, useSidebarSwipe, usePullToRefresh, useTouchCapable } from "@/hooks"
 import { useInputMode } from "@/hooks/use-input-mode"
 import { useSyncEngine } from "@/sync/sync-engine"
+import { HistoryBackClose } from "@/components/ui/history-back-close"
 import { TopbarLoadingIndicator } from "./topbar-loading-indicator"
 import { ConnectionStatus } from "./connection-status"
 import { cn } from "@/lib/utils"
@@ -227,6 +228,9 @@ export function AppShell({ sidebar, children }: AppShellProps) {
   // which blacked the screen out for hundreds of ms on mobile GPUs.
   return (
     <div className="flex w-screen flex-col overflow-hidden" style={{ height: "var(--viewport-height, 100dvh)" }}>
+      {/* On mobile the sidebar is an overlay, so the OS back gesture should
+           dismiss it instead of navigating to the previous stream */}
+      {isMobile && <HistoryBackClose open={isOpen} onClose={collapse} />}
       {/* Pull-to-refresh container — pulling anywhere (sidebar or main content)
            translates the entire area uniformly */}
       <div ref={pullRef} className="relative flex flex-1 flex-col overflow-hidden">

--- a/apps/frontend/src/components/ui/drawer.tsx
+++ b/apps/frontend/src/components/ui/drawer.tsx
@@ -3,19 +3,49 @@
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
+import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
+import { HistoryBackClose } from "./history-back-close"
 
 const Drawer = ({
   shouldScaleBackground = true,
   repositionInputs = false,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
-  // repositionInputs=false disables Vaul's built-in visualViewport keyboard
-  // handling which sets inline style.height on the drawer content. This conflicts
-  // with our dvh units that already account for the virtual keyboard, causing
-  // drawers to shrink to strange sizes after focus/blur cycles on mobile.
-  <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} repositionInputs={repositionInputs} {...props} />
-)
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => {
+  const isMobile = useIsMobile()
+  // Open state is lifted out of vaul (mirroring uncontrolled usage into local
+  // state) so HistoryBackClose can close trigger-driven drawers too.
+  const isControlled = open !== undefined
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen ?? false)
+  const resolvedOpen = isControlled ? open : uncontrolledOpen
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next)
+      onOpenChange?.(next)
+    },
+    [isControlled, onOpenChange]
+  )
+
+  return (
+    <>
+      {isMobile && <HistoryBackClose open={resolvedOpen} onClose={() => handleOpenChange(false)} />}
+      {/* repositionInputs=false disables Vaul's built-in visualViewport keyboard
+          handling which sets inline style.height on the drawer content. This conflicts
+          with our dvh units that already account for the virtual keyboard, causing
+          drawers to shrink to strange sizes after focus/blur cycles on mobile. */}
+      <DrawerPrimitive.Root
+        shouldScaleBackground={shouldScaleBackground}
+        repositionInputs={repositionInputs}
+        open={resolvedOpen}
+        onOpenChange={handleOpenChange}
+        {...props}
+      />
+    </>
+  )
+}
 Drawer.displayName = "Drawer"
 
 const DrawerTrigger = DrawerPrimitive.Trigger

--- a/apps/frontend/src/components/ui/history-back-close.test.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { useState } from "react"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import { createMemoryRouter, Link, RouterProvider } from "react-router-dom"
 import * as mobileModule from "@/hooks/use-mobile"
-import { __resetOverlayHistoryForTests } from "./history-back-close"
+import { __resetOverlayHistoryForTests, attachOverlayHistoryRouter, OverlayHistoryLayout } from "./history-back-close"
 import { Drawer, DrawerContent, DrawerTitle } from "./drawer"
 
 afterEach(() => {
@@ -18,6 +18,14 @@ function DrawerHarness() {
       <span>{open ? "drawer-open" : "drawer-closed"}</span>
       <button onClick={() => setOpen(true)}>open-drawer</button>
       <button onClick={() => setOpen(false)}>close-drawer</button>
+      {/* A sidebar-style stream link: closes the overlay and pushes, one tick */}
+      <Link to="/other" onClick={() => setOpen(false)}>
+        navigate-item
+      </Link>
+      {/* A settings-style item: closes the overlay and replace-navigates */}
+      <Link to={`${STREAM_PATH}?settings=profile`} replace onClick={() => setOpen(false)}>
+        settings-item
+      </Link>
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerContent>
           <DrawerTitle>Menu</DrawerTitle>
@@ -74,13 +82,22 @@ function StackedHarness() {
 const STREAM_PATH = "/w/ws1/s/stream1"
 
 function makeRouter(ui: React.ReactElement) {
-  return createMemoryRouter(
+  // Same shape as production: the coordinator's location feed is a pathless
+  // layout wrapping every route, and the router itself is attached.
+  const router = createMemoryRouter(
     [
-      { path: "/other", element: <div>other-page</div> },
-      { path: STREAM_PATH, element: ui },
+      {
+        element: <OverlayHistoryLayout />,
+        children: [
+          { path: "/other", element: <div>other-page</div> },
+          { path: STREAM_PATH, element: ui },
+        ],
+      },
     ],
     { initialEntries: ["/other", STREAM_PATH], initialIndex: 1 }
   )
+  attachOverlayHistoryRouter(router)
+  return router
 }
 
 async function openDrawer(router: ReturnType<typeof makeRouter>, name = "open-drawer") {
@@ -186,6 +203,32 @@ describe("HistoryBackClose via Drawer (mobile)", () => {
     expect(screen.getByText("b-closed")).toBeInTheDocument()
   })
 
+  it("a menu item that closes the drawer and pushes a route actually navigates", async () => {
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router)
+    fireEvent.click(screen.getByText("navigate-item"))
+
+    // The navigation must survive the sentinel cleanup — not get popped away
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+    await act(async () => {})
+    expect(router.state.location.pathname).toBe("/other")
+  })
+
+  it("a menu item that closes the drawer and replace-navigates keeps its target", async () => {
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router)
+    fireEvent.click(screen.getByText("settings-item"))
+
+    await waitFor(() => expect(router.state.location.search).toBe("?settings=profile"))
+    await act(async () => {})
+    expect(router.state.location.search).toBe("?settings=profile")
+    await waitFor(() => expect(screen.getByText("drawer-closed")).toBeInTheDocument())
+  })
+
   it("same-tick handoff (close A, open B) keeps back working for B", async () => {
     const router = makeRouter(<StackedHarness />)
     render(<RouterProvider router={router} />)
@@ -233,10 +276,27 @@ describe("HistoryBackClose via Drawer (desktop)", () => {
   })
 })
 
+// DrawerHarness calls useNavigate, so the no-router test needs a router-free twin.
+function RouterlessDrawerHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <span>{open ? "drawer-open" : "drawer-closed"}</span>
+      <button onClick={() => setOpen(true)}>open-drawer</button>
+      <button onClick={() => setOpen(false)}>close-drawer</button>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent>
+          <DrawerTitle>Menu</DrawerTitle>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
 describe("HistoryBackClose outside a router", () => {
   it("drawer works without a router context", async () => {
     vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
-    render(<DrawerHarness />)
+    render(<RouterlessDrawerHarness />)
 
     fireEvent.click(screen.getByText("open-drawer"))
     expect(await screen.findByText("drawer-open")).toBeInTheDocument()

--- a/apps/frontend/src/components/ui/history-back-close.test.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { useState } from "react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { createMemoryRouter, RouterProvider } from "react-router-dom"
+import * as mobileModule from "@/hooks/use-mobile"
+import { Drawer, DrawerContent, DrawerTitle } from "./drawer"
+
+afterEach(() => vi.restoreAllMocks())
+
+function DrawerHarness() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <span>{open ? "drawer-open" : "drawer-closed"}</span>
+      <button onClick={() => setOpen(true)}>open-drawer</button>
+      <button onClick={() => setOpen(false)}>close-drawer</button>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent>
+          <DrawerTitle>Menu</DrawerTitle>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+function StackedHarness() {
+  const [aOpen, setAOpen] = useState(false)
+  const [bOpen, setBOpen] = useState(false)
+  return (
+    <div>
+      <span>{aOpen ? "a-open" : "a-closed"}</span>
+      <span>{bOpen ? "b-open" : "b-closed"}</span>
+      <button onClick={() => setAOpen(true)}>open-a</button>
+      <button onClick={() => setBOpen(true)}>open-b</button>
+      <button
+        onClick={() => {
+          setAOpen(false)
+          setBOpen(false)
+        }}
+      >
+        close-both
+      </button>
+      <Drawer open={aOpen} onOpenChange={setAOpen}>
+        <DrawerContent>
+          <DrawerTitle>A</DrawerTitle>
+        </DrawerContent>
+      </Drawer>
+      <Drawer open={bOpen} onOpenChange={setBOpen}>
+        <DrawerContent>
+          <DrawerTitle>B</DrawerTitle>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+}
+
+const STREAM_PATH = "/w/ws1/s/stream1"
+
+function makeRouter(ui: React.ReactElement) {
+  return createMemoryRouter(
+    [
+      { path: "/other", element: <div>other-page</div> },
+      { path: STREAM_PATH, element: ui },
+    ],
+    { initialEntries: ["/other", STREAM_PATH], initialIndex: 1 }
+  )
+}
+
+async function openDrawer(router: ReturnType<typeof makeRouter>, name = "open-drawer") {
+  const keyBefore = router.state.location.key
+  fireEvent.click(screen.getByText(name))
+  // The sentinel entry lands asynchronously
+  await waitFor(() => expect(router.state.location.key).not.toBe(keyBefore))
+}
+
+describe("HistoryBackClose via Drawer (mobile)", () => {
+  beforeEach(() => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+  })
+
+  it("back gesture closes the drawer and stays on the page", async () => {
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router)
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+
+    await waitFor(() => expect(screen.getByText("drawer-closed")).toBeInTheDocument())
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+  })
+
+  it("closing via UI pops the sentinel entry so back leaves the page", async () => {
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    await openDrawer(router)
+    fireEvent.click(screen.getByText("close-drawer"))
+
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+  })
+
+  it("survives a forward navigation and closes on the back that pops its sentinel", async () => {
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router)
+
+    // A forward push (drawer stacking, in-page navigation) must not close it
+    await act(async () => {
+      await router.navigate(`${STREAM_PATH}?x=1`)
+    })
+    expect(screen.getByText("drawer-open")).toBeInTheDocument()
+
+    // Back onto the sentinel: still open — the sentinel is current again
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.search).toBe(""))
+    expect(screen.getByText("drawer-open")).toBeInTheDocument()
+
+    // Back past the sentinel closes the drawer without leaving the page
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(screen.getByText("drawer-closed")).toBeInTheDocument())
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+  })
+
+  it("back closes only the top drawer of a stack", async () => {
+    const router = makeRouter(<StackedHarness />)
+    render(<RouterProvider router={router} />)
+
+    await openDrawer(router, "open-a")
+    await openDrawer(router, "open-b")
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+
+    await waitFor(() => expect(screen.getByText("b-closed")).toBeInTheDocument())
+    expect(screen.getByText("a-open")).toBeInTheDocument()
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+  })
+
+  it("closing a stack in one tick unwinds both sentinel entries", async () => {
+    const router = makeRouter(<StackedHarness />)
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    await openDrawer(router, "open-a")
+    await openDrawer(router, "open-b")
+
+    fireEvent.click(screen.getByText("close-both"))
+
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+    expect(screen.getByText("a-closed")).toBeInTheDocument()
+    expect(screen.getByText("b-closed")).toBeInTheDocument()
+  })
+})
+
+describe("HistoryBackClose via Drawer (desktop)", () => {
+  it("opening pushes nothing; back navigates away", async () => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(false)
+    const router = makeRouter(<DrawerHarness />)
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    fireEvent.click(screen.getByText("open-drawer"))
+    expect(await screen.findByText("drawer-open")).toBeInTheDocument()
+    // Flush any pending navigation before asserting none happened
+    await act(async () => {})
+    expect(router.state.location.key).toBe(initialKey)
+
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
+  })
+})
+
+describe("HistoryBackClose outside a router", () => {
+  it("drawer works without a router context", async () => {
+    vi.spyOn(mobileModule, "useIsMobile").mockReturnValue(true)
+    render(<DrawerHarness />)
+
+    fireEvent.click(screen.getByText("open-drawer"))
+    expect(await screen.findByText("drawer-open")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("close-drawer"))
+    expect(await screen.findByText("drawer-closed")).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/ui/history-back-close.test.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.test.tsx
@@ -3,9 +3,13 @@ import { useState } from "react"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { createMemoryRouter, RouterProvider } from "react-router-dom"
 import * as mobileModule from "@/hooks/use-mobile"
+import { __resetOverlayHistoryForTests } from "./history-back-close"
 import { Drawer, DrawerContent, DrawerTitle } from "./drawer"
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  vi.restoreAllMocks()
+  __resetOverlayHistoryForTests()
+})
 
 function DrawerHarness() {
   const [open, setOpen] = useState(false)
@@ -23,6 +27,11 @@ function DrawerHarness() {
   )
 }
 
+/**
+ * Two drawers with a same-tick handoff, mirroring the sidebar footer's
+ * account-drawer → status-picker flow (`openStatus` closes the drawer and
+ * opens the dialog in one click handler).
+ */
 function StackedHarness() {
   const [aOpen, setAOpen] = useState(false)
   const [bOpen, setBOpen] = useState(false)
@@ -32,6 +41,14 @@ function StackedHarness() {
       <span>{bOpen ? "b-open" : "b-closed"}</span>
       <button onClick={() => setAOpen(true)}>open-a</button>
       <button onClick={() => setBOpen(true)}>open-b</button>
+      <button
+        onClick={() => {
+          setAOpen(false)
+          setBOpen(true)
+        }}
+      >
+        handoff-a-to-b
+      </button>
       <button
         onClick={() => {
           setAOpen(false)
@@ -109,26 +126,19 @@ describe("HistoryBackClose via Drawer (mobile)", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
   })
 
-  it("survives a forward navigation and closes on the back that pops its sentinel", async () => {
+  it("survives a forward navigation and closes on the next back, in place", async () => {
     const router = makeRouter(<DrawerHarness />)
     render(<RouterProvider router={router} />)
 
     await openDrawer(router)
 
-    // A forward push (drawer stacking, in-page navigation) must not close it
+    // A forward push must not close the drawer; the coordinator re-establishes
+    // the sentinel at the new location.
     await act(async () => {
       await router.navigate(`${STREAM_PATH}?x=1`)
     })
     expect(screen.getByText("drawer-open")).toBeInTheDocument()
 
-    // Back onto the sentinel: still open — the sentinel is current again
-    await act(async () => {
-      await router.navigate(-1)
-    })
-    await waitFor(() => expect(router.state.location.search).toBe(""))
-    expect(screen.getByText("drawer-open")).toBeInTheDocument()
-
-    // Back past the sentinel closes the drawer without leaving the page
     await act(async () => {
       await router.navigate(-1)
     })
@@ -141,7 +151,8 @@ describe("HistoryBackClose via Drawer (mobile)", () => {
     render(<RouterProvider router={router} />)
 
     await openDrawer(router, "open-a")
-    await openDrawer(router, "open-b")
+    fireEvent.click(screen.getByText("open-b"))
+    await waitFor(() => expect(screen.getByText("b-open")).toBeInTheDocument())
 
     await act(async () => {
       await router.navigate(-1)
@@ -150,21 +161,55 @@ describe("HistoryBackClose via Drawer (mobile)", () => {
     await waitFor(() => expect(screen.getByText("b-closed")).toBeInTheDocument())
     expect(screen.getByText("a-open")).toBeInTheDocument()
     expect(router.state.location.pathname).toBe(STREAM_PATH)
+
+    // Second back peels the remaining drawer, still without leaving the page
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(screen.getByText("a-closed")).toBeInTheDocument())
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
   })
 
-  it("closing a stack in one tick unwinds both sentinel entries", async () => {
+  it("closing a stack in one tick unwinds the sentinel", async () => {
     const router = makeRouter(<StackedHarness />)
     render(<RouterProvider router={router} />)
     const initialKey = router.state.location.key
 
     await openDrawer(router, "open-a")
-    await openDrawer(router, "open-b")
+    fireEvent.click(screen.getByText("open-b"))
+    await waitFor(() => expect(screen.getByText("b-open")).toBeInTheDocument())
 
     fireEvent.click(screen.getByText("close-both"))
 
     await waitFor(() => expect(router.state.location.key).toBe(initialKey))
     expect(screen.getByText("a-closed")).toBeInTheDocument()
     expect(screen.getByText("b-closed")).toBeInTheDocument()
+  })
+
+  it("same-tick handoff (close A, open B) keeps back working for B", async () => {
+    const router = makeRouter(<StackedHarness />)
+    render(<RouterProvider router={router} />)
+    const initialKey = router.state.location.key
+
+    await openDrawer(router, "open-a")
+    fireEvent.click(screen.getByText("handoff-a-to-b"))
+    await waitFor(() => expect(screen.getByText("b-open")).toBeInTheDocument())
+    expect(screen.getByText("a-closed")).toBeInTheDocument()
+
+    // Let any serialized pop/push settle, then back must close B in place
+    await act(async () => {})
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(screen.getByText("b-closed")).toBeInTheDocument())
+    expect(router.state.location.pathname).toBe(STREAM_PATH)
+
+    // History is balanced: the next back leaves the page
+    await waitFor(() => expect(router.state.location.key).toBe(initialKey))
+    await act(async () => {
+      await router.navigate(-1)
+    })
+    await waitFor(() => expect(router.state.location.pathname).toBe("/other"))
   })
 })
 

--- a/apps/frontend/src/components/ui/history-back-close.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.tsx
@@ -1,13 +1,9 @@
 import * as React from "react"
-import {
-  useInRouterContext,
-  useLocation,
-  useNavigate,
-  useNavigationType,
-  type Location,
-  type NavigateFunction,
-  type NavigationType,
-} from "react-router-dom"
+import { Outlet, useLocation, useNavigationType, type Location, type NavigationType } from "react-router-dom"
+import type { createMemoryRouter } from "react-router-dom"
+
+/** Any react-router data router (browser or memory) — same object shape. */
+type DataRouter = ReturnType<typeof createMemoryRouter>
 
 interface HistoryBackCloseProps {
   open: boolean
@@ -44,32 +40,52 @@ interface OverlayEntry {
  * ordering to get wrong. The back gesture pops the sentinel; the coordinator
  * closes the top overlay and re-pushes the sentinel if others remain, so a
  * stack of overlays peels one per back press, native-style.
+ *
+ * Ground truth is `router.state` (attached via {@link attachOverlayHistoryRouter}),
+ * NEVER a React-committed location. Router navigations run inside
+ * `startTransition` and lazy routes hold the location commit until their chunk
+ * loads, so a location observed through hooks can lag the real history by an
+ * unbounded window. Deciding a pop against that lag is how "tap a sidebar
+ * link → the coordinator pops the sentinel it still thinks is current → the
+ * pop lands after the navigation and reverts it" broke ALL mobile navigation.
+ * `router.state.location` updates in lockstep with history, and
+ * `router.state.navigation.state` exposes in-flight transitions so reconcile
+ * can wait them out instead of guessing.
  */
 class OverlayHistoryCoordinator {
   private stack: OverlayEntry[] = []
   private inFlight: "push" | "pop" | null = null
+  private reconcileScheduled = false
+  // True once a sentinel WE pushed this session has settled. reconcile() only
+  // pops marked entries we own — a marker restored from a reloaded session is
+  // inert data, and auto-popping it would navigate the user on page load.
+  private ownsSentinel = false
   private lastKey: string | null = null
-  private current: Location | null = null
-  navigate: NavigateFunction | null = null
+  private router: DataRouter | null = null
+
+  attachRouter(router: DataRouter): void {
+    this.router = router
+  }
 
   register(entry: OverlayEntry): void {
     this.stack.push(entry)
-    this.reconcile()
+    this.scheduleReconcile()
   }
 
   unregister(entry: OverlayEntry): void {
     const index = this.stack.indexOf(entry)
     if (index !== -1) this.stack.splice(index, 1)
-    this.reconcile()
+    this.scheduleReconcile()
   }
 
+  /** Fed committed locations by {@link OverlayHistoryLayout} (always mounted). */
   handleLocation(location: Location, navigationType: NavigationType): void {
-    // Every mounted bridge feeds every location change; dedupe by entry key.
     if (location.key === this.lastKey) return
     this.lastKey = location.key
-    this.current = location
     const settledOp = this.inFlight
     this.inFlight = null
+    if (settledOp === "push") this.ownsSentinel = true
+    if (settledOp === "pop") this.ownsSentinel = false
 
     // The back gesture consumed the sentinel (a POP we didn't issue): close the
     // top overlay in place. Removed from the stack synchronously so the
@@ -79,41 +95,88 @@ class OverlayHistoryCoordinator {
       top?.close()
     }
 
-    this.reconcile()
+    this.scheduleReconcile()
+  }
+
+  // Reconcile on a microtask, never synchronously: within a commit, effect
+  // cleanups (an overlay's unregister) run before effect creates, so acting
+  // immediately would interleave with the same commit's other work.
+  private scheduleReconcile(): void {
+    if (this.reconcileScheduled) return
+    this.reconcileScheduled = true
+    queueMicrotask(() => {
+      this.reconcileScheduled = false
+      this.reconcile()
+    })
   }
 
   private reconcile(): void {
-    if (this.inFlight || !this.current || !this.navigate) return
+    const router = this.router
+    if (!router || this.inFlight) return
+    // A navigation is mid-flight (e.g. a lazy route chunk loading): decide
+    // nothing against a moving target. Its completion commits a location,
+    // which re-feeds handleLocation and reschedules this reconcile.
+    if (router.state.navigation.state !== "idle") return
+    const location = router.state.location
     const want = this.stack.length > 0
-    const have = hasSentinel(this.current.state)
+    const have = hasSentinel(location.state)
     if (want && !have) {
       this.inFlight = "push"
-      this.navigate(
-        { pathname: this.current.pathname, search: this.current.search, hash: this.current.hash },
+      void router.navigate(
+        { pathname: location.pathname, search: location.search, hash: location.hash },
         {
-          state: { ...(this.current.state ?? {}), [HISTORY_OVERLAY_KEY]: true },
+          state: { ...(location.state ?? {}), [HISTORY_OVERLAY_KEY]: true },
           preventScrollReset: true,
         }
       )
-    } else if (!want && have) {
+    } else if (!want && have && this.ownsSentinel) {
       this.inFlight = "pop"
-      this.navigate(-1)
+      void router.navigate(-1)
     }
   }
 
   resetForTests(): void {
     this.stack = []
     this.inFlight = null
+    this.ownsSentinel = false
     this.lastKey = null
-    this.current = null
-    this.navigate = null
+    this.router = null
+    // A microtask scheduled before the reset may still fire; reconcile() is a
+    // no-op with the router cleared.
   }
 }
 
 const coordinator = new OverlayHistoryCoordinator()
 
+/**
+ * Hand the coordinator its data router. Called once at router creation
+ * (`routes/index.tsx`); tests attach their memory router the same way.
+ * Without an attached router the coordinator is inert, so drawers mounted in
+ * router-less unit tests keep working untouched.
+ */
+export function attachOverlayHistoryRouter(router: DataRouter): void {
+  coordinator.attachRouter(router)
+}
+
 export function __resetOverlayHistoryForTests(): void {
   coordinator.resetForTests()
+}
+
+/**
+ * The coordinator's feed of committed locations (for back-gesture detection
+ * and op settlement). Mounted once as a pathless layout route wrapping the
+ * ENTIRE route tree (see `routes/index.tsx`), so it stays mounted across every
+ * navigation — including ones that unmount the page an overlay lives in.
+ */
+export function OverlayHistoryLayout() {
+  const location = useLocation()
+  const navigationType = useNavigationType()
+
+  React.useEffect(() => {
+    coordinator.handleLocation(location, navigationType)
+  }, [location, navigationType])
+
+  return <Outlet />
 }
 
 /**
@@ -123,30 +186,12 @@ export function __resetOverlayHistoryForTests(): void {
  * dismissed overlay.
  *
  * Mount only for overlays that should behave this way (callers gate on
- * mobile). Renders nothing, and is inert outside a router (tests mount drawers
- * without one). All instances share {@link OverlayHistoryCoordinator}, so
- * stacked and handed-off overlays coordinate instead of fighting over history.
+ * mobile). Renders nothing; registration is its only job — history is handled
+ * by the shared {@link OverlayHistoryCoordinator}.
  */
-export function HistoryBackClose(props: HistoryBackCloseProps) {
-  const inRouter = useInRouterContext()
-  if (!inRouter) return null
-  return <HistoryBackCloseBridge {...props} />
-}
-
-function HistoryBackCloseBridge({ open, onClose }: HistoryBackCloseProps) {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const navigationType = useNavigationType()
-
+export function HistoryBackClose({ open, onClose }: HistoryBackCloseProps) {
   const onCloseRef = React.useRef(onClose)
   onCloseRef.current = onClose
-
-  // Feed the coordinator before any register/unregister effect runs this
-  // commit, and keep its navigate binding fresh.
-  React.useEffect(() => {
-    coordinator.navigate = navigate
-    coordinator.handleLocation(location, navigationType)
-  }, [location, navigate, navigationType])
 
   React.useEffect(() => {
     if (!open) return

--- a/apps/frontend/src/components/ui/history-back-close.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.tsx
@@ -1,0 +1,121 @@
+import * as React from "react"
+import { useInRouterContext, useLocation, useNavigate, useNavigationType } from "react-router-dom"
+
+interface HistoryBackCloseProps {
+  open: boolean
+  onClose: () => void
+}
+
+// Marker stored in `location.state` on the sentinel entry an overlay pushes.
+// Spread alongside any existing state so entries that carry app state (e.g.
+// share-picker's `shareMeta`) keep it on the duplicated entry.
+const HISTORY_OVERLAY_KEY = "__overlayBack"
+
+function readMarker(state: unknown): string | null {
+  if (state && typeof state === "object" && HISTORY_OVERLAY_KEY in state) {
+    const value = (state as Record<string, unknown>)[HISTORY_OVERLAY_KEY]
+    return typeof value === "string" ? value : null
+  }
+  return null
+}
+
+/**
+ * Makes the OS back gesture close an overlay (mobile drawer, sheet) instead of
+ * navigating away, matching native app behavior.
+ *
+ * Opening pushes a same-URL history entry tagged with this instance's id in
+ * `location.state`; the back gesture pops that entry, we see our marker vanish
+ * and call `onClose`. Closing through the UI (swipe-down, backdrop, action)
+ * pops the sentinel entry so a later back press doesn't resurface a location
+ * the user already dismissed.
+ *
+ * Mount only for overlays that should behave this way (the caller gates on
+ * mobile). Renders nothing, and is inert outside a router (tests mount drawers
+ * without one).
+ */
+export function HistoryBackClose(props: HistoryBackCloseProps) {
+  const inRouter = useInRouterContext()
+  if (!inRouter) return null
+  return <HistoryBackCloseBridge {...props} />
+}
+
+function HistoryBackCloseBridge({ open, onClose }: HistoryBackCloseProps) {
+  const id = React.useId()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const navigationType = useNavigationType()
+
+  // Sentinel entry lifecycle: "pushing" between navigate() and the location
+  // update landing, "landed" once our marker is current, "popPending" when the
+  // overlay closed while our sentinel isn't current yet (closed before the
+  // push landed, or a stacked overlay's pop is still in flight) — pop it the
+  // moment it becomes current. A ref, not state — transitions must be visible
+  // synchronously across the two effects below and must survive StrictMode's
+  // double effect invocation.
+  const phaseRef = React.useRef<"idle" | "pushing" | "landed" | "popPending">("idle")
+  const locationRef = React.useRef(location)
+  locationRef.current = location
+  const onCloseRef = React.useRef(onClose)
+  onCloseRef.current = onClose
+  const navigateRef = React.useRef(navigate)
+  navigateRef.current = navigate
+
+  React.useEffect(() => {
+    const current = locationRef.current
+    if (open && (phaseRef.current === "idle" || phaseRef.current === "popPending")) {
+      // A popPending sentinel that never resurfaced (e.g. it was clobbered by a
+      // replace navigation) must not block a fresh open — push a new one.
+      phaseRef.current = "pushing"
+      navigateRef.current(
+        { pathname: current.pathname, search: current.search, hash: current.hash },
+        { state: { ...(current.state ?? {}), [HISTORY_OVERLAY_KEY]: id }, preventScrollReset: true }
+      )
+    } else if (!open && phaseRef.current === "pushing") {
+      phaseRef.current = "popPending"
+    } else if (!open && phaseRef.current === "landed") {
+      if (readMarker(current.state) === id) {
+        phaseRef.current = "idle"
+        navigateRef.current(-1)
+      } else {
+        // A stacked overlay above us is mid-pop (both closed in one tick);
+        // our sentinel surfaces once that pop lands, and we pop it then.
+        phaseRef.current = "popPending"
+      }
+    }
+  }, [open, id])
+
+  React.useEffect(() => {
+    const marker = readMarker(location.state)
+    if (marker === id) {
+      if (phaseRef.current === "pushing") {
+        phaseRef.current = "landed"
+      } else if (phaseRef.current === "popPending") {
+        phaseRef.current = "idle"
+        navigateRef.current(-1)
+      }
+      return
+    }
+    // Our marker vanished on a back/forward traversal: the back gesture popped
+    // the sentinel — close the overlay. Only POP counts: a forward push with a
+    // different marker (a drawer stacking on top of us, an in-page navigation)
+    // leaves our sentinel in place behind it and must not close us.
+    if (phaseRef.current === "landed" && navigationType === "POP") {
+      phaseRef.current = "idle"
+      onCloseRef.current()
+    }
+  }, [location, navigationType, id])
+
+  // Unmounting while our sentinel is current would leave a stale duplicate
+  // entry, making the next back press a visual no-op; pop it.
+  React.useEffect(
+    () => () => {
+      if (phaseRef.current === "landed" && readMarker(locationRef.current.state) === id) {
+        phaseRef.current = "idle"
+        navigateRef.current(-1)
+      }
+    },
+    [id]
+  )
+
+  return null
+}

--- a/apps/frontend/src/components/ui/history-back-close.tsx
+++ b/apps/frontend/src/components/ui/history-back-close.tsx
@@ -1,37 +1,131 @@
 import * as React from "react"
-import { useInRouterContext, useLocation, useNavigate, useNavigationType } from "react-router-dom"
+import {
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+  type Location,
+  type NavigateFunction,
+  type NavigationType,
+} from "react-router-dom"
 
 interface HistoryBackCloseProps {
   open: boolean
   onClose: () => void
 }
 
-// Marker stored in `location.state` on the sentinel entry an overlay pushes.
-// Spread alongside any existing state so entries that carry app state (e.g.
-// share-picker's `shareMeta`) keep it on the duplicated entry.
+// Marker stored in `location.state` on the sentinel entry. Spread alongside any
+// existing state so entries that carry app state (e.g. share-picker's
+// `shareMeta`) keep it on the duplicated entry.
 const HISTORY_OVERLAY_KEY = "__overlayBack"
 
-function readMarker(state: unknown): string | null {
-  if (state && typeof state === "object" && HISTORY_OVERLAY_KEY in state) {
-    const value = (state as Record<string, unknown>)[HISTORY_OVERLAY_KEY]
-    return typeof value === "string" ? value : null
-  }
-  return null
+function hasSentinel(state: unknown): boolean {
+  return state !== null && typeof state === "object" && (state as Record<string, unknown>)[HISTORY_OVERLAY_KEY] === true
+}
+
+interface OverlayEntry {
+  close: () => void
 }
 
 /**
- * Makes the OS back gesture close an overlay (mobile drawer, sheet) instead of
- * navigating away, matching native app behavior.
+ * Coordinates every open overlay against ONE sentinel history entry.
  *
- * Opening pushes a same-URL history entry tagged with this instance's id in
- * `location.state`; the back gesture pops that entry, we see our marker vanish
- * and call `onClose`. Closing through the UI (swipe-down, backdrop, action)
- * pops the sentinel entry so a later back press doesn't resurface a location
- * the user already dismissed.
+ * Invariant: the sentinel entry exists iff at least one overlay is registered.
+ * Overlays never touch history themselves — they register on open and
+ * unregister on close/unmount, and `reconcile()` converges history toward the
+ * invariant, one navigation at a time (`inFlight` serializes ops, because a
+ * browser `history.go(-1)` settles asynchronously and a concurrent push would
+ * interleave with it).
  *
- * Mount only for overlays that should behave this way (the caller gates on
+ * Why one sentinel instead of one entry per overlay: overlay *handoffs* — a
+ * menu drawer closing while the dialog it launched opens in the same tick
+ * (sidebar footer → account drawer → status picker) — then net out to "stack
+ * still non-empty", i.e. zero history operations, so there is no cross-instance
+ * ordering to get wrong. The back gesture pops the sentinel; the coordinator
+ * closes the top overlay and re-pushes the sentinel if others remain, so a
+ * stack of overlays peels one per back press, native-style.
+ */
+class OverlayHistoryCoordinator {
+  private stack: OverlayEntry[] = []
+  private inFlight: "push" | "pop" | null = null
+  private lastKey: string | null = null
+  private current: Location | null = null
+  navigate: NavigateFunction | null = null
+
+  register(entry: OverlayEntry): void {
+    this.stack.push(entry)
+    this.reconcile()
+  }
+
+  unregister(entry: OverlayEntry): void {
+    const index = this.stack.indexOf(entry)
+    if (index !== -1) this.stack.splice(index, 1)
+    this.reconcile()
+  }
+
+  handleLocation(location: Location, navigationType: NavigationType): void {
+    // Every mounted bridge feeds every location change; dedupe by entry key.
+    if (location.key === this.lastKey) return
+    this.lastKey = location.key
+    this.current = location
+    const settledOp = this.inFlight
+    this.inFlight = null
+
+    // The back gesture consumed the sentinel (a POP we didn't issue): close the
+    // top overlay in place. Removed from the stack synchronously so the
+    // reconcile below re-pushes only when other overlays remain underneath.
+    if (navigationType === "POP" && settledOp !== "pop" && !hasSentinel(location.state) && this.stack.length > 0) {
+      const top = this.stack.pop()
+      top?.close()
+    }
+
+    this.reconcile()
+  }
+
+  private reconcile(): void {
+    if (this.inFlight || !this.current || !this.navigate) return
+    const want = this.stack.length > 0
+    const have = hasSentinel(this.current.state)
+    if (want && !have) {
+      this.inFlight = "push"
+      this.navigate(
+        { pathname: this.current.pathname, search: this.current.search, hash: this.current.hash },
+        {
+          state: { ...(this.current.state ?? {}), [HISTORY_OVERLAY_KEY]: true },
+          preventScrollReset: true,
+        }
+      )
+    } else if (!want && have) {
+      this.inFlight = "pop"
+      this.navigate(-1)
+    }
+  }
+
+  resetForTests(): void {
+    this.stack = []
+    this.inFlight = null
+    this.lastKey = null
+    this.current = null
+    this.navigate = null
+  }
+}
+
+const coordinator = new OverlayHistoryCoordinator()
+
+export function __resetOverlayHistoryForTests(): void {
+  coordinator.resetForTests()
+}
+
+/**
+ * Makes the OS back gesture close an overlay (mobile drawer, sidebar sheet)
+ * instead of navigating away, matching native app behavior. UI dismissal pops
+ * the sentinel entry back out, so a later back press never resurfaces a
+ * dismissed overlay.
+ *
+ * Mount only for overlays that should behave this way (callers gate on
  * mobile). Renders nothing, and is inert outside a router (tests mount drawers
- * without one).
+ * without one). All instances share {@link OverlayHistoryCoordinator}, so
+ * stacked and handed-off overlays coordinate instead of fighting over history.
  */
 export function HistoryBackClose(props: HistoryBackCloseProps) {
   const inRouter = useInRouterContext()
@@ -40,82 +134,26 @@ export function HistoryBackClose(props: HistoryBackCloseProps) {
 }
 
 function HistoryBackCloseBridge({ open, onClose }: HistoryBackCloseProps) {
-  const id = React.useId()
   const location = useLocation()
   const navigate = useNavigate()
   const navigationType = useNavigationType()
 
-  // Sentinel entry lifecycle: "pushing" between navigate() and the location
-  // update landing, "landed" once our marker is current, "popPending" when the
-  // overlay closed while our sentinel isn't current yet (closed before the
-  // push landed, or a stacked overlay's pop is still in flight) — pop it the
-  // moment it becomes current. A ref, not state — transitions must be visible
-  // synchronously across the two effects below and must survive StrictMode's
-  // double effect invocation.
-  const phaseRef = React.useRef<"idle" | "pushing" | "landed" | "popPending">("idle")
-  const locationRef = React.useRef(location)
-  locationRef.current = location
   const onCloseRef = React.useRef(onClose)
   onCloseRef.current = onClose
-  const navigateRef = React.useRef(navigate)
-  navigateRef.current = navigate
+
+  // Feed the coordinator before any register/unregister effect runs this
+  // commit, and keep its navigate binding fresh.
+  React.useEffect(() => {
+    coordinator.navigate = navigate
+    coordinator.handleLocation(location, navigationType)
+  }, [location, navigate, navigationType])
 
   React.useEffect(() => {
-    const current = locationRef.current
-    if (open && (phaseRef.current === "idle" || phaseRef.current === "popPending")) {
-      // A popPending sentinel that never resurfaced (e.g. it was clobbered by a
-      // replace navigation) must not block a fresh open — push a new one.
-      phaseRef.current = "pushing"
-      navigateRef.current(
-        { pathname: current.pathname, search: current.search, hash: current.hash },
-        { state: { ...(current.state ?? {}), [HISTORY_OVERLAY_KEY]: id }, preventScrollReset: true }
-      )
-    } else if (!open && phaseRef.current === "pushing") {
-      phaseRef.current = "popPending"
-    } else if (!open && phaseRef.current === "landed") {
-      if (readMarker(current.state) === id) {
-        phaseRef.current = "idle"
-        navigateRef.current(-1)
-      } else {
-        // A stacked overlay above us is mid-pop (both closed in one tick);
-        // our sentinel surfaces once that pop lands, and we pop it then.
-        phaseRef.current = "popPending"
-      }
-    }
-  }, [open, id])
-
-  React.useEffect(() => {
-    const marker = readMarker(location.state)
-    if (marker === id) {
-      if (phaseRef.current === "pushing") {
-        phaseRef.current = "landed"
-      } else if (phaseRef.current === "popPending") {
-        phaseRef.current = "idle"
-        navigateRef.current(-1)
-      }
-      return
-    }
-    // Our marker vanished on a back/forward traversal: the back gesture popped
-    // the sentinel — close the overlay. Only POP counts: a forward push with a
-    // different marker (a drawer stacking on top of us, an in-page navigation)
-    // leaves our sentinel in place behind it and must not close us.
-    if (phaseRef.current === "landed" && navigationType === "POP") {
-      phaseRef.current = "idle"
-      onCloseRef.current()
-    }
-  }, [location, navigationType, id])
-
-  // Unmounting while our sentinel is current would leave a stale duplicate
-  // entry, making the next back press a visual no-op; pop it.
-  React.useEffect(
-    () => () => {
-      if (phaseRef.current === "landed" && readMarker(locationRef.current.state) === id) {
-        phaseRef.current = "idle"
-        navigateRef.current(-1)
-      }
-    },
-    [id]
-  )
+    if (!open) return
+    const entry: OverlayEntry = { close: () => onCloseRef.current() }
+    coordinator.register(entry)
+    return () => coordinator.unregister(entry)
+  }, [open])
 
   return null
 }

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { FallbackLoader } from "@/components/fallback-loader"
+import { attachOverlayHistoryRouter, OverlayHistoryLayout } from "@/components/ui/history-back-close"
 import { useSidebar } from "@/contexts"
 import { useLastStream } from "@/hooks"
 import { getLastWorkspaceId } from "@/lib/last-workspace"
@@ -11,136 +12,148 @@ import { getLastWorkspaceId } from "@/lib/last-workspace"
 // with the pages that actually use them instead of bloating the main bundle.
 export const router = createBrowserRouter([
   {
-    path: "/",
-    element: <RootRedirect />,
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    path: "/login",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/login")).LoginPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    path: "/workspaces",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/workspace-select")).WorkspaceSelectPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    // Custom add-account picker. Sits in front of `/api/auth/login?intent=add`
-    // because AuthKit's hosted UI silent-refreshes and can't reliably show an
-    // account picker. Buttons hit provider-direct social URLs or the magic
-    // auth endpoints — see apps/control-plane/src/features/auth/handlers.ts.
-    path: "/add-account",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/add-account")).AddAccountPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    path: "/share",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/share-target")).ShareTargetPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    // Public, unauthenticated. The recipient enters their email to claim the
-    // invitation — no workspace bootstrap needed, lives outside WorkspaceLayout.
-    path: "/join/:token",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/join")).JoinPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    // Setup page lives outside WorkspaceLayout — it's a lightweight form that
-    // doesn't need the full workspace bootstrap (socket, sidebar, etc.)
-    path: "/w/:workspaceId/setup",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/user-setup")).UserSetupPage }),
-    errorElement: <ErrorBoundary />,
-  },
-  {
-    path: "/w/:workspaceId",
-    HydrateFallback: FallbackLoader,
-    lazy: async () => ({ Component: (await import("@/pages/workspace-layout")).WorkspaceLayout }),
+    // Pathless layout so the overlay-history coordinator's location feed stays
+    // mounted across EVERY navigation (see history-back-close.tsx).
+    element: <OverlayHistoryLayout />,
     errorElement: <ErrorBoundary />,
     children: [
       {
-        index: true,
-        element: <WorkspaceHome />,
+        path: "/",
+        element: <RootRedirect />,
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "drafts",
+        path: "/login",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/drafts")).DraftsPage }),
+        lazy: async () => ({ Component: (await import("@/pages/login")).LoginPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "saved/:tab?",
+        path: "/workspaces",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/saved")).SavedPage }),
+        lazy: async () => ({ Component: (await import("@/pages/workspace-select")).WorkspaceSelectPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "scheduled/:tab?",
+        // Custom add-account picker. Sits in front of `/api/auth/login?intent=add`
+        // because AuthKit's hosted UI silent-refreshes and can't reliably show an
+        // account picker. Buttons hit provider-direct social URLs or the magic
+        // auth endpoints — see apps/control-plane/src/features/auth/handlers.ts.
+        path: "/add-account",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/scheduled")).ScheduledPage }),
+        lazy: async () => ({ Component: (await import("@/pages/add-account")).AddAccountPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "board",
+        path: "/share",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/board")).BoardPage }),
+        lazy: async () => ({ Component: (await import("@/pages/share-target")).ShareTargetPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "activity/:filter?",
+        // Public, unauthenticated. The recipient enters their email to claim the
+        // invitation — no workspace bootstrap needed, lives outside WorkspaceLayout.
+        path: "/join/:token",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/activity")).ActivityPage }),
+        lazy: async () => ({ Component: (await import("@/pages/join")).JoinPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "search",
+        // Setup page lives outside WorkspaceLayout — it's a lightweight form that
+        // doesn't need the full workspace bootstrap (socket, sidebar, etc.)
+        path: "/w/:workspaceId/setup",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/search")).SearchPage }),
+        lazy: async () => ({ Component: (await import("@/pages/user-setup")).UserSetupPage }),
+        errorElement: <ErrorBoundary />,
       },
       {
-        path: "memory",
+        path: "/w/:workspaceId",
         HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/memory")).MemoryPage }),
-      },
-      {
-        path: "labels",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/labels")).LabelsPage }),
-      },
-      {
-        path: "labels/:labelId",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/label-detail")).LabelDetailPage }),
-      },
-      {
-        path: "files",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/files")).FilesPage }),
-      },
-      {
-        path: "memos/:memoId",
-        element: <LegacyMemoRedirect />,
-      },
-      {
-        path: "s/:streamId",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/stream")).StreamPage }),
-      },
-      {
-        path: "share",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/share-picker")).SharePickerPage }),
-      },
-      {
-        path: "admin/ai-usage",
-        HydrateFallback: FallbackLoader,
-        lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
+        lazy: async () => ({ Component: (await import("@/pages/workspace-layout")).WorkspaceLayout }),
+        errorElement: <ErrorBoundary />,
+        children: [
+          {
+            index: true,
+            element: <WorkspaceHome />,
+          },
+          {
+            path: "drafts",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/drafts")).DraftsPage }),
+          },
+          {
+            path: "saved/:tab?",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/saved")).SavedPage }),
+          },
+          {
+            path: "scheduled/:tab?",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/scheduled")).ScheduledPage }),
+          },
+          {
+            path: "board",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/board")).BoardPage }),
+          },
+          {
+            path: "activity/:filter?",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/activity")).ActivityPage }),
+          },
+          {
+            path: "search",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/search")).SearchPage }),
+          },
+          {
+            path: "memory",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/memory")).MemoryPage }),
+          },
+          {
+            path: "labels",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/labels")).LabelsPage }),
+          },
+          {
+            path: "labels/:labelId",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/label-detail")).LabelDetailPage }),
+          },
+          {
+            path: "files",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/files")).FilesPage }),
+          },
+          {
+            path: "memos/:memoId",
+            element: <LegacyMemoRedirect />,
+          },
+          {
+            path: "s/:streamId",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/stream")).StreamPage }),
+          },
+          {
+            path: "share",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/share-picker")).SharePickerPage }),
+          },
+          {
+            path: "admin/ai-usage",
+            HydrateFallback: FallbackLoader,
+            lazy: async () => ({ Component: (await import("@/pages/ai-usage-admin")).AIUsageAdminPage }),
+          },
+        ],
       },
     ],
   },
 ])
+
+// The overlay-history coordinator reads router.state directly (never a
+// React-committed location — see history-back-close.tsx).
+attachOverlayHistoryRouter(router)
 
 // PWA `start_url` is `/`. A returning user almost always wants the workspace
 // they last had open, which renders instantly from IndexedDB — so jump


### PR DESCRIPTION
## Problem

On mobile, the hardware back button / edge back-swipe performs a router navigation, so dismissing an open overlay the way every native app allows — long-press action drawer, reaction details, a responsive dialog, the sidebar — instead transitions to the previous stream with the overlay still conceptually "open". Kris's report: closing drawers via back "transitions me to another stream instead of strictly closing the menu."

Three constraints make this non-trivial (each one broke an earlier version of this PR):

1. After closing a drawer through the UI, pressing back must **not** resurface it — history has to stay balanced.
2. Overlays hand off to each other in a single tick. The sidebar footer's `openStatus` (`sidebar-footer.tsx`) does `collapseOnMobile()` + `setDrawerOpen(false)` + `setStatusOpen(true)` in one click handler. Per-overlay history entries issue concurrent pushes and async pops (`history.go(-1)` settles asynchronously) that interleave and corrupt the stack.
3. On mobile, **every navigation starts inside an overlay** — the sidebar is the nav surface, and tapping a link both navigates and closes it in the same tick. Any history bookkeeping decided against stale location knowledge reverts the user's navigation.

## Solution

One null-rendering bridge, `HistoryBackClose`, that overlays mount when they should have native back semantics — wired centrally in the vaul `Drawer` wrapper (every mobile drawer inherits it, call sites unchanged) and in `AppShell` for the custom mobile sidebar overlay. All instances register with a module-level `OverlayHistoryCoordinator` that owns a **single** sentinel history entry under one invariant: *the sentinel exists iff at least one overlay is open*. Desktop is untouched (both mounts gate on mobile).

This follows the repo's existing precedent — `media-gallery-context.tsx` already does push-on-open / `navigate(-1)`-on-close for the image gallery — but uses `location.state` instead of a search param because drawers are ephemeral and must not be deep-linkable.

### How it works

1. **Ground truth is `router.state`, never a React-committed location.** `attachOverlayHistoryRouter(router)` (called once in `routes/index.tsx`) hands the coordinator the data router. `router.state.location` updates in lockstep with history, and `router.state.navigation.state` exposes in-flight transitions — reconcile defers while a navigation (e.g. a lazy route chunk load) is mid-flight instead of guessing.
2. **Open** — the bridge registers an entry. Stack 0→1 makes `reconcile()` push a same-URL entry with `state: { ...state, __overlayBack: true }`. Stack 1→2 (drawer on drawer) pushes nothing — one sentinel serves the whole stack.
3. **Back gesture** — a POP the coordinator didn't issue consumes the sentinel: `OverlayHistoryLayout` (a pathless layout route wrapping the entire route tree, so it survives every navigation) feeds committed locations; the coordinator closes the **top** overlay in place and re-pushes the sentinel if overlays remain. A stack peels one per back press, native-style.
4. **UI dismissal** — the overlay unregisters; when the stack empties, `reconcile()` pops the sentinel, so a later back press performs a real navigation and can never resurrect the drawer. Pops only fire on sentinels pushed this session (`ownsSentinel`), so a reload-restored marker is never auto-popped on page load.
5. **Handoffs and nav-with-close** — close-A-open-B nets out to "stack still non-empty": zero history operations. A tap that navigates AND closes overlays reconciles to "no overlay, no sentinel at the new location": also zero operations. Reconcile runs on a microtask (same-commit cleanups settle first) and ops are serialized through an `inFlight` guard.
6. **Inert where it must be** — without an attached router the coordinator does nothing, so router-less unit tests that mount drawers are unaffected; only mobile mounts the bridge, so desktop never pushes an entry.

### Key design decisions

**1. One shared sentinel + coordinator, not per-overlay entries** — v1 gave each overlay its own sentinel with a per-instance phase machine. It survived unit tests (memory-router pops are synchronous) but broke on staging: the account-drawer → status-picker handoff issued a pop and a push concurrently and the status picker's back stopped working. The single-sentinel model makes handoffs zero-op — the race is eliminated structurally. Kris's ruling: "have a shared drawer component… with a state key… so this works for all types of drawers wherever they are used."

**2. Decide against `router.state`, defer while navigating** — v2 fed the coordinator locations through the mounted components' hooks. Two fatal lags: an unregister (effect cleanup) runs before the same commit's location effect, and — worse — React Router wraps navigations in `startTransition`, so with lazy routes the committed location lags real history by an unbounded window (a network fetch). The coordinator popped its sentinel against that stale location and the pop **reverted the user's navigation** — on staging this broke all mobile navigation, since every mobile nav starts in the sidebar overlay. v3 reads `router.state.location` (synchronous with history) and skips reconciliation while `router.state.navigation.state !== "idle"`. Regression-tested for both push (sidebar link) and replace (`?settings=` via `setSearchParams`) navigation out of an open drawer.

**3. Close only the top overlay on a back-POP** — the popped entry's marker vanishing tells the coordinator the user went back; it closes `stack[top]` only, removed synchronously so the immediate re-push happens exactly when other overlays remain.

**4. `location.state` sentinel, not a search param** — a context menu must not be deep-linkable; a `?drawer=` param would leak into copied URLs. Stale markers in restored entries are inert (`ownsSentinel` guard) — no INV-59 violation because drawers are deliberately *not* URL-derived views.

**5. Wire once in the `Drawer` wrapper, not per call site** — every mobile drawer (message actions, sidebar item long-press, reaction details, moved-messages, scheduled actions, `ResponsiveDialog`/`ResponsiveAlertDialog` on mobile — including the status picker) renders through `components/ui/drawer.tsx`. This required lifting vaul's open state: uncontrolled (trigger-driven) usage is mirrored into local state so the coordinator can force-close it; vaul's `useControllableState` accepts always-controlled props.

**6. Sidebar wired in `AppShell`, not `ui/sidebar.tsx`** — the shadcn `components/ui/sidebar.tsx` is dead scaffolding (zero importers); the real mobile sidebar is the custom overlay in `app-shell.tsx` driven by `sidebar-context`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/ui/history-back-close.tsx` | `OverlayHistoryCoordinator` (single-sentinel reconciler against `router.state`), `OverlayHistoryLayout` (root location feed), `attachOverlayHistoryRouter`, and the `HistoryBackClose` bridge |
| `apps/frontend/src/components/ui/history-back-close.test.tsx` | 10 tests: back-closes-in-place, UI-close balances history, forward-nav survival, stack peeling, same-tick stack unwind, same-tick handoff (status-picker case), **push-nav out of a drawer survives**, **replace-nav out of a drawer survives**, desktop no-op, no-router inertness |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/ui/drawer.tsx` | `Drawer` lifts open state (controlled-or-mirrored) and mounts `HistoryBackClose` when `useIsMobile()` |
| `apps/frontend/src/components/layout/app-shell.tsx` | Mounts `HistoryBackClose` for the mobile sidebar overlay (`open={isOpen}`, `onClose={collapse}`) |
| `apps/frontend/src/routes/index.tsx` | Wraps the route tree in the `OverlayHistoryLayout` pathless layout; attaches the router to the coordinator |

## Out of scope (deliberate)

- **`components/ui/sidebar.tsx` is dead code** (nothing imports it) — deleting it (INV-38) is a separate mechanical PR.
- **Radix `Dialog`/`Sheet` surfaces that render as-is on mobile** are not wired; any future mobile overlay can mount the bridge directly, as `AppShell` does.

## Test plan

- [x] `history-back-close.test.tsx` — 10 pass (memory-router harness driving real vaul `Drawer`s; includes the handoff regression and both navigate-out-of-drawer regressions)
- [x] Full frontend unit suite — 3522 pass, 0 fail
- [x] `tsc -b apps/frontend` clean; pre-commit hook re-ran monorepo lint + typecheck green
- [x] Live end-to-end drives (full local stack, Playwright, Pixel-7 touch viewport, temp scripts deleted after): (a) **sidebar link → another stream: navigation sticks** (isolated against pre-change code to prove the harness itself passes there); (b) Activity quick link; (c) account drawer → Settings (`?settings=` replace nav) opens; (d) sidebar → account drawer → "Set a status" handoff → back closes the picker in place, next back leaves the stream; (e) message action drawer back-close + Escape-close history balance
- [x] Design evolution: v1 per-overlay sentinels → broken handoffs; v2 single sentinel fed by component hooks → stale-location pops reverted all mobile navigation on staging; v3 reads `router.state` and defers while navigating
- [ ] Not exercised on a physical iOS edge-swipe — Chromium `goBack()` is the verified path; iOS Safari's swipe triggers the same `popstate`

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Mobile back button / back swipe closes open overlays (context-menu drawers, responsive dialogs, sidebar) in place instead of navigating; UI dismissal keeps history balanced; overlay handoffs and navigate-out-of-overlay taps must be unaffected. Desktop unchanged.

**What was built:**
- `OverlayHistoryCoordinator`: registry of open overlays against ONE sentinel history entry (`location.state.__overlayBack`). `reconcile()` (microtask-scheduled, `inFlight`-serialized) converges history toward "sentinel iff stack non-empty", reading `router.state.location` as ground truth and deferring while `router.state.navigation` isn't idle. A back-POP closes the top overlay and re-pushes when others remain. `ownsSentinel` prevents popping reload-restored markers.
- `OverlayHistoryLayout`: pathless layout route wrapping the whole tree; feeds committed locations for back-gesture detection.
- `HistoryBackClose` bridge: register/unregister only. Mounted centrally in the vaul `Drawer` wrapper (with open-state lifting) and `AppShell` (mobile sidebar).

**Design evolution:**
- v1: per-overlay sentinel entries — concurrent pop/push on same-tick handoffs corrupted history (status picker broke on staging).
- v2: single sentinel, location fed by component hooks — stale-location pops reverted navigations; since all mobile navigation starts in the sidebar overlay, **all mobile navigation broke** on staging. React Router's `startTransition` + lazy route chunks make the committed-location lag unbounded, so no timing fix suffices.
- v3: coordinator reads `router.state` directly (attached at router creation) and defers while a navigation is in flight. Verified e2e against the exact staging repros.

**What's NOT included:** deletion of the unused shadcn `ui/sidebar.tsx`; wiring for non-vaul overlays.

**Status:** Complete — 10 unit tests, full suite green, five e2e drives on a mobile viewport against the full local stack, including an isolation run against pre-change code to validate the harness.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_