### PR TITLE
feat(agents): anchor agent replies to the trigger's conversation (roadmap 3.3)

### DIFF
--- a/apps/backend/src/features/agents/companion/conversation-highlight.test.ts
+++ b/apps/backend/src/features/agents/companion/conversation-highlight.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, spyOn, afterEach, mock } from "bun:test"
+import { ConversationStatuses } from "@threa/types"
+import { ConversationRepository, type Conversation } from "../../conversations"
+import { resolveEligibleConversation, loadConversationHighlight } from "./conversation-highlight"
+
+// The resolver only threads `db` into the (spied) repository, so a dummy stands
+// in for a real Querier — same fake-Querier convention as the assigner and the
+// per-stream-concurrency tests.
+const DB = {} as never
+const WORKSPACE_ID = "ws_1"
+
+function conversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_x",
+    workspaceId: WORKSPACE_ID,
+    streamId: "chan_1",
+    status: ConversationStatuses.ACTIVE,
+    topicSummary: "a topic",
+    ...overrides,
+  } as unknown as Conversation
+}
+
+afterEach(() => mock.restore())
+
+describe("resolveEligibleConversation — reply anchoring (roadmap 3.3)", () => {
+  test("prefers the trigger's own conversation over the most-recently-active one", async () => {
+    // The interleaved-topics case: the trigger was classified into the OLDER
+    // topic `conv_trigger`; `conv_recent` is what was touched last. The reply
+    // must anchor to the trigger's conversation, not the last-active one.
+    const findPrimary = spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(
+      conversation({ id: "conv_trigger" })
+    )
+    const findByMessageIds = spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([
+      conversation({ id: "conv_recent" }),
+    ])
+
+    const result = await resolveEligibleConversation(DB, {
+      workspaceId: WORKSPACE_ID,
+      preferMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a", "msg_b"],
+      isEligible: () => true,
+    })
+
+    expect(result?.id).toBe("conv_trigger")
+    expect(findPrimary).toHaveBeenCalledWith(DB, WORKSPACE_ID, "msg_trigger")
+    // Preferred won outright — no need to scan the window.
+    expect(findByMessageIds).not.toHaveBeenCalled()
+  })
+
+  test("falls back to the most-recently-active conversation when the trigger isn't classified yet", async () => {
+    // Extraction lags, so the trigger has no primary conversation on this turn.
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(null)
+    // findByMessageIds orders by last_activity_at DESC, so the first is the live topic.
+    spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([
+      conversation({ id: "conv_recent" }),
+      conversation({ id: "conv_older" }),
+    ])
+
+    const result = await resolveEligibleConversation(DB, {
+      workspaceId: WORKSPACE_ID,
+      preferMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a", "msg_b"],
+      isEligible: () => true,
+    })
+
+    expect(result?.id).toBe("conv_recent")
+  })
+
+  test("skips an ineligible preferred conversation and takes the first eligible in the window", async () => {
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(conversation({ id: "conv_trigger" }))
+    spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([
+      conversation({ id: "conv_recent" }),
+      conversation({ id: "conv_eligible" }),
+    ])
+
+    const result = await resolveEligibleConversation(DB, {
+      workspaceId: WORKSPACE_ID,
+      preferMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a"],
+      isEligible: (c) => c.id === "conv_eligible",
+    })
+
+    expect(result?.id).toBe("conv_eligible")
+  })
+
+  test("resolves to null when nothing in the window is eligible", async () => {
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(null)
+    spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([conversation({ id: "conv_recent" })])
+
+    const result = await resolveEligibleConversation(DB, {
+      workspaceId: WORKSPACE_ID,
+      preferMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a"],
+      isEligible: () => false,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test("resolves to null with an empty window and no preferred match", async () => {
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(null)
+    const findByMessageIds = spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([])
+
+    const result = await resolveEligibleConversation(DB, {
+      workspaceId: WORKSPACE_ID,
+      preferMessageId: "msg_trigger",
+      windowMessageIds: [],
+      isEligible: () => true,
+    })
+
+    expect(result).toBeNull()
+    // Empty window short-circuits before any DB scan.
+    expect(findByMessageIds).not.toHaveBeenCalled()
+  })
+})
+
+describe("loadConversationHighlight — topic eligibility", () => {
+  test("returns the trigger topic, ignoring a resolved or topic-less preferred conversation", async () => {
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(
+      conversation({ id: "conv_trigger", topicSummary: "  Deploy cadence  " })
+    )
+
+    const topic = await loadConversationHighlight(DB, {
+      workspaceId: WORKSPACE_ID,
+      triggerMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a"],
+    })
+
+    expect(topic).toBe("Deploy cadence")
+  })
+
+  test("skips a resolved preferred conversation and falls to an active topic in the window", async () => {
+    spyOn(ConversationRepository, "findPrimaryByMessageId").mockResolvedValue(
+      conversation({ id: "conv_trigger", status: ConversationStatuses.RESOLVED, topicSummary: "old" })
+    )
+    spyOn(ConversationRepository, "findByMessageIds").mockResolvedValue([
+      conversation({ id: "conv_live", topicSummary: "live topic" }),
+    ])
+
+    const topic = await loadConversationHighlight(DB, {
+      workspaceId: WORKSPACE_ID,
+      triggerMessageId: "msg_trigger",
+      windowMessageIds: ["msg_a"],
+    })
+
+    expect(topic).toBe("live topic")
+  })
+})

--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -5,9 +5,11 @@ import {
   AgentStepTypes,
   AgentToolNames,
   AuthorTypes,
+  ConversationIntents,
   StreamTypes,
   type AgentSessionRerunContext,
   type AuthorType,
+  type ConversationDirective,
   type SourceItem,
 } from "@threa/types"
 import type { UserPreferencesService } from "../user-preferences"
@@ -98,6 +100,13 @@ export interface PersonaAgentDeps {
      * a privilege escalation.
      */
     accessibleStreamIds?: string[]
+    /**
+     * Declared conversation for this reply (roadmap 3.3): an agent reply joins
+     * the conversation it's participating in, resolved from the trigger's own
+     * topic. Omit to let boundary extraction infer (today's most-recently-active
+     * fallback). Only `existing` is used here — the anchor is an extant topic.
+     */
+    conversation?: ConversationDirective
   }) => Promise<{ id: string }>
   editMessage: (params: {
     workspaceId: string
@@ -503,6 +512,33 @@ export class PersonaAgent {
         else if (purpose.kind === "follow_up" && !isFollowUp) effectivePurpose = { kind: "catch_up" }
         const turnFlags = deriveTurnFlags(effectivePurpose)
 
+        // The turn's conversation anchor (roadmap 3.3): the trigger message's own
+        // topic, resolved via the canonical resolver (INV-35) — prefer the
+        // trigger's PRIMARY conversation, else the most recently active one
+        // overlapping the context window (the fallback carries the common case,
+        // since the trigger is usually not classified on the turn it fires —
+        // extraction lags). Best-effort per §2.8 Q8; null when nothing overlaps
+        // (e.g. E2E streams the segmenter skips, or a follow-up turn with no
+        // trigger message). Memoized so every write this turn — the reply's
+        // declared conversation AND a scheduled follow-up's source anchor — lands
+        // on the same topic, and so it resolves at most once.
+        let triggerConversationResolved = false
+        let triggerConversationId: string | null = null
+        const resolveTriggerConversationId = async (): Promise<string | null> => {
+          if (triggerConversationResolved) return triggerConversationId
+          triggerConversationResolved = true
+          if (agentContext.triggerMessage) {
+            const anchor = await resolveEligibleConversation(db, {
+              workspaceId,
+              preferMessageId: agentContext.triggerMessage.id,
+              windowMessageIds: contextMessageIds,
+              isEligible: () => true,
+            })
+            triggerConversationId = anchor?.id ?? null
+          }
+          return triggerConversationId
+        }
+
         // `sources` is required on the commit payload (empty array = none) so a
         // caller can't silently drop citations — see TurnCommit.
         const doSendMessage = async (msgInput: { content: string; sources: SourceItem[] }) => {
@@ -542,6 +578,17 @@ export class PersonaAgent {
             }
           }
 
+          // Declare the reply's conversation (roadmap 3.3) so it's assigned
+          // synchronously to the trigger's topic in the send txn and boundary
+          // extraction skips its most-recently-active fallback — this is the fix
+          // for busy channels where the last-touched topic isn't the one being
+          // replied to. The anchor is the trigger's own conversation, which
+          // always shares the reply's access root (trigger + reply sit in the
+          // same stream, or a channel and a thread beneath it), so the assigner's
+          // cross-root guard never rejects it. Null anchor → omit → today's
+          // behavior. Not on the supersede EDIT path above: an edit keeps the
+          // conversation the original send already declared.
+          const declaredConversationId = await resolveTriggerConversationId()
           const message = await createMessage({
             workspaceId,
             streamId: targetStreamId,
@@ -550,6 +597,9 @@ export class PersonaAgent {
             content: msgInput.content,
             sources: msgInput.sources,
             sessionId: session.id,
+            ...(declaredConversationId && {
+              conversation: { intent: ConversationIntents.EXISTING, conversationId: declaredConversationId },
+            }),
             // Personas have no `stream_members` rows; pass the agent's
             // scope-restricted `AgentAccessSpec` reach so inline-attachment
             // and share gates run against the same set the workspace tools
@@ -602,37 +652,22 @@ export class PersonaAgent {
         }
 
         // Follow-up scheduling for the schedule_follow_up tool, bound to this
-        // persona/session/stream. The source-conversation anchor reuses the
-        // canonical resolver (INV-35): prefer the trigger's own conversation,
-        // else the most recently active one overlapping the context window —
-        // the fallback matters because the trigger is usually not classified on
-        // the turn it fires (extraction lags), so prefer-only would resolve to
-        // null in the common case. Best-effort per §2.8 Q8; null when nothing
-        // overlaps (e.g. E2E streams the segmenter skips).
+        // persona/session/stream. The source-conversation anchor shares the
+        // reply's anchor (`resolveTriggerConversationId`, INV-35) so a follow-up
+        // and the reply that scheduled it point at the same topic.
         const followUpDeps: import("./tools/tool-deps").FollowUpToolDeps | undefined =
           scheduleFollowUp && listFollowUps && cancelFollowUp && updateFollowUp
             ? {
-                scheduleFollowUp: async ({ note, scheduledFor }) => {
-                  let sourceConversationId: string | null = null
-                  if (agentContext.triggerMessage) {
-                    const anchor = await resolveEligibleConversation(db, {
-                      workspaceId,
-                      preferMessageId: agentContext.triggerMessage.id,
-                      windowMessageIds: contextMessageIds,
-                      isEligible: () => true,
-                    })
-                    sourceConversationId = anchor?.id ?? null
-                  }
-                  return scheduleFollowUp({
+                scheduleFollowUp: async ({ note, scheduledFor }) =>
+                  scheduleFollowUp({
                     workspaceId,
                     streamId: session.streamId,
                     personaId: persona.id,
                     sessionId: session.id,
-                    sourceConversationId,
+                    sourceConversationId: await resolveTriggerConversationId(),
                     note,
                     scheduledFor,
-                  })
-                },
+                  }),
                 listFollowUps: () => listFollowUps({ workspaceId, streamId: session.streamId }),
                 cancelFollowUp: ({ followUpId }) =>
                   cancelFollowUp({ workspaceId, streamId: session.streamId, followUpId }),

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -184,7 +184,7 @@ import { AttachmentRepository } from "./features/attachments"
 import { ulid } from "ulid"
 import { loadConfig } from "./lib/env"
 import { createCorsOriginChecker } from "./lib/cors"
-import type { AuthorType } from "@threa/types"
+import type { AuthorType, ConversationDirective } from "@threa/types"
 import { collectAttachmentReferenceIds, parseMarkdown } from "@threa/prosemirror"
 import { normalizeMessage, toEmoji } from "./features/emoji"
 import { logger } from "./lib/logger"
@@ -353,6 +353,8 @@ export async function startServer(): Promise<ServerInstance> {
      * user's full access here would be a privilege escalation.
      */
     accessibleStreamIds?: string[]
+    /** Declared conversation for an agent reply (roadmap 3.3); forwarded to event-service's synchronous assigner. */
+    conversation?: ConversationDirective
   }) => {
     const initialMarkdown = normalizeMessage(params.content)
     const initialJson = parseMarkdown(initialMarkdown, undefined, toEmoji)
@@ -393,6 +395,7 @@ export async function startServer(): Promise<ServerInstance> {
       sessionId: params.sessionId,
       clientMessageId: params.clientMessageId,
       accessibleStreamIds: params.accessibleStreamIds,
+      conversation: params.conversation,
     })
   }
   const editMessage = async (params: {

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -45,7 +45,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |
 | 3.1  | Persisted episode summaries                          | ☑      | #1162 |
 | 3.2  | Per-thread session concurrency                       | ☑      | #1167 |
-| 3.3  | Conversation-anchored agent replies                  | ☑      | #TBD  |
+| 3.3  | Conversation-anchored agent replies                  | ☑      | #1170 |
 | 4.1  | `stream_briefs` storage + endpoints + injection      | ☐      |       |
 | 4.2  | `update_stream_brief` tool + timeline event          | ☐      |       |
 | 4.3  | Brief UI: settings editor + timeline event           | ☐      |       |

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -45,7 +45,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 2.3  | Per-turn model resolution + first escalation rule    | ☐      |       |
 | 3.1  | Persisted episode summaries                          | ☑      | #1162 |
 | 3.2  | Per-thread session concurrency                       | ☑      | #1167 |
-| 3.3  | Conversation-anchored agent replies                  | ☐      |       |
+| 3.3  | Conversation-anchored agent replies                  | ☑      | #TBD  |
 | 4.1  | `stream_briefs` storage + endpoints + injection      | ☐      |       |
 | 4.2  | `update_stream_brief` tool + timeline event          | ☐      |       |
 | 4.3  | Brief UI: settings editor + timeline event           | ☐      |       |
@@ -290,6 +290,14 @@ So a channel/scratchpad and a thread beneath it already run concurrently, and tw
 **Tests:** the interleaved-topics case — two active conversations in one channel, trigger in the older one, reply lands in the trigger's conversation; fallback when no primary resolves; board card shows the reply under the right post.
 
 **Done when:** in a channel with two live topics, Ariadne's reply is assigned to the trigger's conversation, synchronously, without the extractor.
+
+**Deviations (shipped):**
+
+- **Wire shape: the existing `conversation` directive, not a new param (INV-35).** `doSendMessage` (`persona-agent.ts`) passes `conversation: { intent: 'existing', conversationId }` into `createMessage` → `EventService.createMessage`, whose injected `conversationAssigner` attaches the reply in the send transaction and stamps `conversation_intent` on the row. Boundary extraction then short-circuits on `message.conversationIntent !== null` (`declaredSkip`, `boundary-extraction-service.ts:74`) — it never reaches `assignAgentReply`'s most-recently-active fallback. No anchor resolves → the directive is omitted → today's `assignAgentReply` behavior. No new send path, no direct conversation-id param.
+- **Anchor reuses `resolveEligibleConversation` (INV-35).** The reply's declared conversation is the trigger's own topic via a memoized `resolveTriggerConversationId` in the turn: prefer the trigger's PRIMARY conversation, else the most recently active over the context window. The follow-up `source_conversation_id` resolution (§1.1) now shares this exact memoized closure — a reply and any follow-up it schedules anchor to the same topic, and the resolver runs at most once per turn.
+- **Cross-root safety is structural, not a catch.** The anchor is always the trigger's own conversation, which shares the reply's access root by construction (trigger + reply sit in the same stream, or a channel and a thread beneath it), so the assigner's `CONVERSATION_NOT_IN_ROOT` guard never fires on this path — no send-failing 400 to defend against.
+- **Not on the supersede EDIT path.** A supersede rerun edits an existing message; an edit keeps the conversation the original send already declared, so the directive is only set on the `createMessage` (new-message) branch.
+- **Test coverage: the anchor resolver, previously untested.** `resolveEligibleConversation` embodies the whole 3.3 contract (prefer the trigger's conversation over most-recently-active) and had no test; `companion/conversation-highlight.test.ts` now covers the interleaved-topics case (trigger classified into the older topic → resolver returns it, not the last-active one), the extraction-lag fallback, eligibility skipping, and the null cases. Fake-`Querier` + scoped `spyOn` (INV-48), consistent with the assigner and per-stream-concurrency tests. The declared→attach path itself is already covered by `conversation-assigner.test.ts` (existing same-root guard).
 
 ---
 


### PR DESCRIPTION
**Roadmap:** [`docs/plans/ariadne-collaborator-roadmap.md`](../blob/main/docs/plans/ariadne-collaborator-roadmap.md) §3.3 — Conversation-anchored agent replies.

## Problem

Agent replies skip the LLM boundary extractor (correct — a reply continues the conversation it's posted in), but they were assigned deterministically to the stream's **most-recently-active** conversation: `assignAgentReply` → `ConversationRepository.findActiveByStream(...)[0]` in `boundary-extraction-service.ts`. In a busy channel with interleaved topics, a reply triggered by a message in topic X gets filed under whichever topic Y was touched last. On the board that surfaces the reply under the wrong post.

## Solution

Declare the reply's conversation at send time instead of inferring it after the fact — the same mechanism the board composer already uses for human sends. `doSendMessage` resolves the trigger message's own topic and passes it as a `conversation: { intent: 'existing', conversationId }` directive into `createMessage`; the injected `conversationAssigner` attaches the message synchronously in the send transaction and stamps `conversation_intent` on the row, so the async extractor short-circuits its most-recently-active fallback.

### How it works

1. **Anchor resolution.** A memoized `resolveTriggerConversationId` in the turn calls the canonical `resolveEligibleConversation` (`companion/conversation-highlight.ts`): prefer the trigger's PRIMARY conversation (`findPrimaryByMessageId`), else the most recently active one overlapping the context window (`findByMessageIds`, ordered `last_activity_at DESC`). The fallback carries the common case — the trigger is usually not classified on the turn it fires (segmenter lag), so prefer-only would resolve to null. Null when nothing overlaps (E2E streams the segmenter skips, or a follow-up turn with no trigger message).
2. **Declared send.** `doSendMessage` spreads `conversation: { intent: ConversationIntents.EXISTING, conversationId }` into `createMessage` only when an anchor resolves. `server.ts` forwards the directive to `EventService.createMessage`, which runs `conversationAssigner.assignInTransaction` in the send txn (attach + activity bump + `emitAssignmentEvents`, INV-4/7) and writes `conversation_intent` on the message row.
3. **Extractor short-circuit.** `BoundaryExtractionService.processMessage` returns early on `message.conversationIntent !== null` (`declaredSkip`, `boundary-extraction-service.ts:74`) — it never reaches the `assignAgentReply` most-recently-active path. No anchor → directive omitted → today's `assignAgentReply` behavior, unchanged.

### Key design decisions

**1. The existing `conversation` directive, not a new param (INV-35).** `createMessage` → `EventService.createMessage` already accepts `conversation?: ConversationDirective` and owns a synchronous assigner with a row-locked, cross-root-guarded `existing` path (`conversation-assigner.ts`, tested). Reusing it means no parallel send path and no second place that assigns agent conversations. A direct conversation-id param on the persona write was the rejected alternative — it would have duplicated the assigner's validation.

**2. Cross-root safety is structural, not a catch.** The assigner throws `CONVERSATION_NOT_IN_ROOT` for a cross-root `existing` attach, which would fail the whole send. That can't fire here: the anchor is the trigger's own conversation, and the trigger and the reply always share an access root by construction — same stream, or a channel and a thread beneath it (thread root = channel). So no defensive try/catch is needed, only the invariant documented at the call site.

**3. Shared, memoized anchor.** The follow-up `source_conversation_id` resolution (§1.1) previously inlined the same `resolveEligibleConversation` call. Both now share one memoized closure: a reply and any follow-up it schedules anchor to the same topic, and the resolver runs at most once per turn (INV-35).

**4. New-message branch only.** A supersede rerun edits an existing message via `editMessage` and returns before `createMessage`; an edit keeps the conversation the original send declared, so the directive is set only on the create branch.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/agents/persona-agent.ts` | Memoized `resolveTriggerConversationId`; `doSendMessage` declares the reply's conversation on the create branch; follow-up deps reuse the shared resolver; import `ConversationIntents` + `ConversationDirective` type. |
| `apps/backend/src/server.ts` | Thread `conversation?: ConversationDirective` through the persona `createMessage` binding into `eventService.createMessage`. |
| `docs/plans/ariadne-collaborator-roadmap.md` | Check the 3.3 box (`#TBD`); record shipped deviations. |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/agents/companion/conversation-highlight.test.ts` | Covers `resolveEligibleConversation` — the anchor the step turns on, previously untested. |

## Out of scope (deliberate)

- **The board-card assertion** ("reply lands under the right post") is a UI outcome of the declared assignment; it's exercised on staging, not in the unit suite — there's no board render harness here.
- **Bot-invocation replies** (`public-api`) and the enclave send path are unchanged — this targets the companion/persona-agent reply path named in §3.3.

## Test plan

- [x] `bun test apps/backend/src/features/agents/companion/conversation-highlight.test.ts` — 7 pass (interleaved-topics prefers the trigger's conversation over last-active; extraction-lag fallback; eligibility skip; null cases; highlight topic eligibility)
- [x] `bun test` over `agents/` + `conversations/` + `messaging/` — 556 pass, 0 fail
- [x] `bun run --cwd apps/backend typecheck` (prod + `tsconfig.tests.json`) clean
- [x] Full pre-commit gate green — monorepo typecheck (all workspaces), `astro check`, `generate-api-docs --check` (spec up to date), prettier
- [ ] No live-DB harness in the unit suite — the declared→attach path is covered structurally by the existing `conversation-assigner.test.ts` (same-root guard) and the resolver test above; the end-to-end fired reply is a staging check, consistent with §3.1/§3.2

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LdqfsDCncN9ZPYZCBwVHd)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785697579&installation_id=129946197&pr_number=1170&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1170&signature=e3ec42f250ccb937036b2c335325243614f702907ab029a181a3d1d150b21433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->