### PR TITLE
fix(timeline): signal when a scheduled reply files into a drifted conversation

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -640,6 +640,69 @@ describe("MessageInput", () => {
       expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
     })
 
+    it("stays silent when scheduling a reply whose conversation is live in this same stream", async () => {
+      // Default mock: last-active stream === rendered stream, so the strip is
+      // shown inline and a scheduled send behaves like the obvious happy path —
+      // no toast (INV-63: the strip already shows what will happen).
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("later, same channel")
+
+      render$(<MessageInput workspaceId={workspaceId} streamId={streamId} />)
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      await act(async () => {
+        await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
+      })
+
+      expect(mockScheduleMutateAsync).toHaveBeenCalled()
+      expect(infoToastSpy).not.toHaveBeenCalled()
+    })
+
+    it("signals that a scheduled reply will still file into a drifted (thread-live) conversation", async () => {
+      // Arm same-stream (route latches inline, strip stays), then a background
+      // update moves the conversation into a thread — the latch keeps the arm put
+      // rather than evicting to the panel. A live send would hand off; a scheduled
+      // send can't, so it files by id at fire time. Surface that so the deferred
+      // reply doesn't read as a flat channel send (INV-63).
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("later, into the thread's conversation")
+
+      const { rerender } = render(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+      expect(mockOpenPanel).not.toHaveBeenCalled()
+
+      vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({
+        post: {
+          conversation: { id: "conv_1", streamId, topicSummary: "Pizza plans" },
+          recentMessages: [{ streamId: "thread_789" }],
+        },
+        isLoading: false,
+        notFound: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>)
+      rerender(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+      expect(mockOpenPanel).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
+      })
+
+      expect(mockScheduleMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversation: { intent: "existing", conversationId: "conv_1" },
+        })
+      )
+      expect(infoToastSpy).toHaveBeenCalled()
+    })
+
     it("schedules with no directive when the composer isn't armed", async () => {
       mockComposerState.canSend = true
       mockComposerState.content = makeDoc("just a normal scheduled message")

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -715,6 +715,15 @@ function MessageInputComponent({
       const attachments = extractUploadedAttachments(normalizedContent)
       const attachmentIds = attachments.map((a) => a.id)
 
+      // A live send whose conversation has drifted into a thread hands off to the
+      // panel (handleSubmit above). A scheduled send can't — there's no live thread
+      // at fire time and the picker has no panel affordance — so it always files by
+      // id. Surface that divergence when armed-and-drifted so the deferred reply
+      // doesn't read as a flat channel send (INV-63: deferred action, no other
+      // on-screen signal). Same-stream stays silent (the strip already shows it).
+      const filesIntoDriftedConversation =
+        conversationReply !== null && conversationReplyLastActiveStreamId !== streamId
+
       try {
         composer.setContent(EMPTY_DOC)
         setExpanded(false)
@@ -736,6 +745,9 @@ function MessageInputComponent({
         setConversationReply(null)
         composer.resolveDraft()
         composer.clearAttachments()
+        if (filesIntoDriftedConversation) {
+          toast.info("Scheduled — this reply will file into the conversation when it sends.")
+        }
       } catch (err) {
         composer.setContent(liveContent)
         const message = err instanceof Error ? err.message : "Could not schedule message"
@@ -744,7 +756,7 @@ function MessageInputComponent({
         composer.setIsSending(false)
       }
     },
-    [composer, scheduleMessageMutation, streamId, conversationReply]
+    [composer, scheduleMessageMutation, streamId, conversationReply, conversationReplyLastActiveStreamId]
   )
 
   if (disabled && disabledReason) {


### PR DESCRIPTION
## Problem

Arming a timeline message for "Reply in conversation" and then **scheduling** it (rather than sending) files the deferred message into the conversation correctly — #1168 carries the `ConversationDirective` through the scheduled row to the fire-time `createMessage`. But the composer gave no signal that it would, and its behavior silently diverged from an immediate send:

- An **immediate** send whose conversation has drifted into a thread (`conversationReplyLastActiveStreamId !== streamId`) does not file flat — `handleSubmit` hands off to the conversation panel and toasts (`message-input.tsx:635`), because a flat send would re-interleave the channel.
- A **scheduled** send can't do that handoff: there's no live thread at fire time and the schedule picker has no panel affordance. It always files by id (the assigner attaches cross-stream within one root). Correct, but with zero on-screen signal the deferred reply reads as a flat channel send.

## Solution

Signal-only, no routing change. `handleSchedule` emits a `toast.info` on successful schedule **only** when armed AND the conversation's last-active stream differs from the current stream — the same drift boundary `handleSubmit` uses. Same-stream stays silent (the inline reply strip already shows what will happen, INV-63).

### How it works

- `message-input.tsx:handleSchedule` computes `filesIntoDriftedConversation = conversationReply !== null && conversationReplyLastActiveStreamId !== streamId` before mutating.
- On a successful `scheduleMessageMutation.mutateAsync`, if that flag is set it fires `toast.info("Scheduled — this reply will file into the conversation when it sends.")`.
- `conversationReplyLastActiveStreamId` added to the callback deps.

### Key design decisions

**1. Signal, don't re-route.** The `/code-review` finding wanted the send/schedule divergence *surfaced*, not eliminated. A scheduled reply genuinely can't thread-follow, so the fix adds a word rather than changing where the message lands.

**2. `toast.info`, not `toast.success`.** INV-63's deferred-action carve-out: a scheduled send is deferred and, on the drift path, has no other on-screen signal (the strip clears on schedule). Same-stream keeps no toast — the strip already showed the arm, so a happy-path toast there would be noise (and `no-happy-path-success-toast.test.ts` forbids it).

**3. Drift is only reachable via the latch.** Arming a conversation that's *already* thread-live redirects to the panel on arm (the routing effect at `message-input.tsx:364`) and clears the arm — so it never reaches `handleSchedule`. The reachable drift is: arm same-stream (route latches inline via `routedArmIdRef`), a background board-post update then moves the conversation into a thread, the latch keeps the arm put. The toast-on-drift test reproduces exactly this sequence; a naive "arm thread-live directly" test would assert against an arm that no longer exists (caught while writing the tests).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-input.tsx` | `handleSchedule` toasts on the armed-and-drifted path; `conversationReplyLastActiveStreamId` added to deps |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | +2 tests: no-toast same-stream, toast-on-drift (arm → background-move to thread → schedule) |

## Out of scope (deliberate)

- **Routing** — scheduled sends still always file by id; not touched.
- **E2E streams** — scheduling already refuses them (`E2E_STREAM_SCHEDULING_UNSUPPORTED`) and E2E streams have no conversations to arm against, so there's nothing to signal.
- **Panel/board flat-timeline chip suppression** — a separate inherited follow-up.

## Test plan

- [x] `vitest run src/components/timeline/message-input.test.tsx` — 31 pass (29 prior + 2 new)
- [x] `tsc --noEmit -p tsconfig.json` (frontend) clean
- [x] Full pre-commit suite (prettier + monorepo lint/tsc/tests) green on commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_