### PR TITLE
fix(scheduled-messages): signal a scheduled reply whose conversation drifted into a thread

### DIFF
--- a/apps/frontend/src/components/timeline/message-input.test.tsx
+++ b/apps/frontend/src/components/timeline/message-input.test.tsx
@@ -638,6 +638,51 @@ describe("MessageInput", () => {
         })
       )
       expect(screen.queryByTestId("conversation-reply-strip")).not.toBeInTheDocument()
+      // Same-stream (default mock): the scheduled reply files where the strip
+      // promised, so no divergence signal — success stays silent (INV-63).
+      expect(infoToastSpy).not.toHaveBeenCalled()
+    })
+
+    it("signals the deferred outcome when scheduling an armed reply whose conversation drifted into a thread", async () => {
+      mockComposerState.canSend = true
+      mockComposerState.content = makeDoc("schedule this drifted reply")
+
+      const { rerender } = render(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+      // Arm same-stream: inline strip, route latched, no redirect.
+      act(() => registeredConversationReplyHandler?.({ conversationId: "conv_1" }))
+
+      // A background update moves the conversation into a thread. The latch keeps
+      // the strip inline (no eviction), but the last-active stream is now the thread.
+      vi.spyOn(useConversationsModule, "useConversationBoardPost").mockReturnValue({
+        post: {
+          conversation: { id: "conv_1", streamId, topicSummary: "Pizza plans" },
+          recentMessages: [{ streamId: "thread_789" }],
+        },
+        isLoading: false,
+        notFound: false,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useConversationsModule.useConversationBoardPost>)
+      rerender(
+        <Wrapper>
+          <MessageInput workspaceId={workspaceId} streamId={streamId} />
+        </Wrapper>
+      )
+
+      await act(async () => {
+        await capturedOnSchedule?.(new Date("2099-01-01T00:00:00.000Z"))
+      })
+
+      // Directive still forwarded (files into the conversation by id)...
+      expect(mockScheduleMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ conversation: { intent: "existing", conversationId: "conv_1" } })
+      )
+      // ...but the divergence from the live send (which redirects to the panel) is
+      // signalled — the scheduled reply lands flat here, not in the live thread.
+      expect(infoToastSpy).toHaveBeenCalled()
     })
 
     it("schedules with no directive when the composer isn't armed", async () => {

--- a/apps/frontend/src/components/timeline/message-input.tsx
+++ b/apps/frontend/src/components/timeline/message-input.tsx
@@ -715,6 +715,16 @@ function MessageInputComponent({
       const attachments = extractUploadedAttachments(normalizedContent)
       const attachmentIds = attachments.map((a) => a.id)
 
+      // A scheduled reply whose conversation isn't confirmed live in THIS stream
+      // (thread-live, or the projection hasn't resolved) behaves differently from
+      // the same arm on the live send: `handleSubmit` redirects that case into the
+      // conversation panel (thread-follow), but a deferred send can't follow a live
+      // thread, so it always attaches by id and lands flat in this stream. Same
+      // guard boundary as handleSubmit (line ~635); used only to signal the
+      // divergence below so the strip's "Replying in <topic>" doesn't silently mean
+      // something different once scheduled.
+      const filesFlatIntoConversation = conversationReply !== null && conversationReplyLastActiveStreamId !== streamId
+
       try {
         composer.setContent(EMPTY_DOC)
         setExpanded(false)
@@ -736,6 +746,14 @@ function MessageInputComponent({
         setConversationReply(null)
         composer.resolveDraft()
         composer.clearAttachments()
+        // Signal the deferred, non-obvious outcome: the reply is filed into its
+        // conversation but lands in this stream rather than following the live
+        // thread (INV-63 deferred-action carve-out — not a happy-path success
+        // toast; the same-stream case stays silent, the Scheduled page is the
+        // visible result there).
+        if (filesFlatIntoConversation) {
+          toast.info("Scheduled — this reply will file into the conversation when it sends.")
+        }
       } catch (err) {
         composer.setContent(liveContent)
         const message = err instanceof Error ? err.message : "Could not schedule message"
@@ -744,7 +762,7 @@ function MessageInputComponent({
         composer.setIsSending(false)
       }
     },
-    [composer, scheduleMessageMutation, streamId, conversationReply]
+    [composer, scheduleMessageMutation, streamId, conversationReply, conversationReplyLastActiveStreamId]
   )
 
   if (disabled && disabledReason) {


### PR DESCRIPTION
Follow-up to #1168 (merged), from the `/code-review` pass on that change — the one surviving finding, split out because #1168 merged before this commit landed.

## Problem

#1168 made a scheduled send carry an armed "Reply in conversation" directive. But arming and *scheduling* now diverges silently from arming and *sending*. The composer's "Replying in <topic>" strip sits above both the Send button and the schedule picker. When the armed conversation has drifted **thread-live** (a background reply moved it into a thread after the same-stream arm latched — `routedArmIdRef` in `message-input.tsx` keeps the strip inline rather than evicting the user), the two paths behave differently:

- **Send** (`handleSubmit`, guard at `message-input.tsx:635`): redirects into the conversation panel (thread-follow) + `toast.info`, keeping the draft.
- **Schedule** (`handleSchedule`): can't follow a live thread — a deferred send has no live thread at fire time, and the panel has no schedule affordance — so it correctly attaches by conversation id and lands flat in the composer's stream. But it did so with **no signal**: same strip, materially different outcome.

## Solution

Signal the divergence; don't change the routing. `handleSchedule` now emits a `toast.info` on the **same guard boundary** `handleSubmit` uses — armed AND the conversation not confirmed same-stream (`conversationReply !== null && conversationReplyLastActiveStreamId !== streamId`, covering both thread-live and not-yet-resolved). The same-stream case stays silent (the Scheduled page is the visible result there). The directive is still forwarded either way; the assigner attaches it cross-stream within one root at fire time.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/message-input.tsx` | `handleSchedule`: derive `filesFlatIntoConversation` (same boundary as `handleSubmit`); `toast.info(...)` after a successful schedule when true; add `conversationReplyLastActiveStreamId` to the deps |
| `apps/frontend/src/components/timeline/message-input.test.tsx` | same-stream schedule asserts **no** toast; new drift test (arm same-stream → `rerender` with a thread-live `useConversationBoardPost` → schedule) asserts the directive is still forwarded **and** the toast fires |

## Key design decision

**Signal, not reroute.** Mirroring `handleSubmit`'s panel redirect isn't available — a scheduled send fires later (no live thread to follow, and the conversation panel exposes no schedule affordance), so attaching by id + landing in the origin stream is the only sensible deferred semantics (conversation grouping is preserved via the directive; the assigner allows cross-stream-within-one-root). The gap was purely the missing cue, so the fix is purely the cue. `toast.info` is the INV-63 deferred-action carve-out (not a happy-path `toast.success` — success stays silent), so the guard test `no-happy-path-success-toast.test.ts` still passes.

## Test plan

- [x] Frontend `vitest run src/components/timeline/message-input.test.tsx` — 30 pass (adds no-toast-same-stream + toast-on-drift)
- [x] Frontend `vitest run src/lib/no-happy-path-success-toast.test.ts` — 1 pass (the `toast.info` is not a happy-path success toast)
- [x] `tsc --noEmit -p apps/frontend/tsconfig.json` clean
- [x] `/code-review` (3 Sonnet agents) on the parent diff scored 7/7 after this fix; this commit *is* that fix (UX lens finding, 85). Correctness & Data-Flow and Spec & Design lenses were clean.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGJNrXBxKiikEuJ1ki4VjF)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785700742&installation_id=129946197&pr_number=1172&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1172&signature=a0ede5f51eb50a157b2c5d784af61a3e69c86e49941ed6c56248d7fee7df40b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->