### PR TITLE
docs(board): v4 shipped-state pass — agents on the board, hide & mute, resolved decisions, re-sequenced plan

### DIFF
--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -772,6 +772,22 @@ thread open. Add the human correction for when it lands wrong: **"split this
 thread into its own topic"** (cheap: reassign the thread's members to a minted
 conversation; the stub falls out of the branch relationship).
 
+**The branch gesture must live on the board/panel (Kris, 2026-07-04).** The
+board and conversation panel are where conversations turn from implicit to
+explicit, so the explicit branch originates there, not only in the timeline:
+on any member message row, a **"new sub-topic"** action opens a real thread
+under that message _and_ mints the child conversation in the same declared,
+determinable path (sync assign + bump, no LLM). That completes the symmetry of
+declared gestures from the board: **reply = declared continue**
+(recency-routed into the conversation's live stream); **new sub-topic =
+declared branch** (thread under the chosen message + minted conversation).
+Both are clean labels; neither touches the source stream's order — a thread
+under a message is additive. The branch relationship needs **no new column**:
+the child conversation's anchor thread hangs off a `parentMessageId` that is a
+member of the parent conversation, so the parent card's stub and the child's
+"branched from" provenance both derive from the graph — structure decides
+rendering, here too.
+
 **What stays correct as-is:** the sync determinable path files thread replies
 into the parent message's conversation — right even when a later pass splits
 (the split is refinement, not correction; same blessing as the realtime
@@ -830,8 +846,9 @@ Next, in order (re-sequenced 2026-07-03):
    read-state shipped at message grain.
 5. **Nested threads on the card** (section above) — branch stubs + "branched
    from" provenance, the soft-thread seam, bounded spanning-tree rendering;
-   the declared thread-open directive and "split this thread into its own
-   topic" ride along.
+   the declared thread-open directive — with the "new sub-topic" action on
+   board-card and panel message rows as its primary home — and "split this
+   thread into its own topic" ride along.
 6. **Mine lens** (Saved later, per the 2026-06-22 decisions).
 7. **Retitle + mark-resolved** on cards. Merge/split UI drops to backlog —
    declared filing has replaced corrections as the primary eval fuel, and

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -1,10 +1,10 @@
 # Exploration: The Board — a second way to interact with a stream
 
-Status: exploration / design, v3. Sibling to
+Status: design of record, v4 — the board is largely **shipped** (flag-gated
+`board-view`); this doc tracks the settled model, resolved decisions, and the
+active plan. Sibling to
 [`nonlinear-stream-views-exploration.md`](./nonlinear-stream-views-exploration.md),
-which argues a stream is a container and the timeline is one projection. This
-doc designs the **board** as a co-equal interaction mode and as the home for
-"find what matters." No code yet.
+which argues a stream is a container and the timeline is one projection.
 
 > **v3 (after Kris's "turn it on its head"):** the board's "post" is a
 > **conversation**, but conversations are now seeded **two ways** — _authored_
@@ -13,6 +13,13 @@ doc designs the **board** as a co-equal interaction mode and as the home for
 > retires the maturity caveats. Headline surface stays a **workspace-wide board
 > as your entrypoint**, per-stream a scoped filter. v1's thread-as-post framing
 > is the de-risking appendix.
+
+> **v4 (2026-07-03, shipped-state pass):** the original Phasing is replaced by
+> "Where we are + what's next"; the soft-thread open decisions are resolved by
+> #1146 (filing is a hidden message field, **not** a content node — reversing
+> the earlier lean); new sections: **Agents on the board** (traces visible in
+> conversation surfaces, never bumping) and **Hide & mute** (per-viewer
+> exclusions, two grains).
 
 ## The thesis
 
@@ -202,8 +209,9 @@ Q3, it mostly resolves:
   components already exist; the board is a new page that reuses them in a
   cross-stream layout. **Liveness and optimism ride the sync engine (IDB +
   `SocketEventGate`), NOT React-Query — see "Realtime / sync model" below.**
-  Slice 1's React-Query `use-conversations` board hook is a deliberate stopgap
-  (it refetch-on-opens and feels junky), scheduled for migration onto the rails.
+  (Done since the realtime slice, #1100: board reads are IDB-reactive; TanStack
+  Query remains the bootstrap/pagination fetcher that seeds the store — what
+  changed is that the query result is no longer treated as the live store.)
 - **INV-61 untouched:** the board is a separate projection; the contiguous
   timeline keeps its `sequence`/`broadcastSequence` order. Resurfacing is
   forbidden in the timeline and free in the board precisely because they're
@@ -528,25 +536,32 @@ forcing-function loop), **the classifier only has to be good for the genuinely
 ambient case** — free-form messages nobody filed. #1 stays "simple but hard," but
 stops being load-bearing for the surfaces people actually drive.
 
-### Open decisions
+### Open decisions — all resolved (2026-07-03)
 
-1. **Indicator trigger** — loud `↪ continues X` only on revivals (old/non-adjacent
-   prior message), subtle tick at most on ordinary switches? _Lean: yes._
-2. **Attached context: content node vs. envelope field.** Attachments/quote-reply are
-   content nodes, and the backend already extracts content references, so consistency
-   says `conversationReference` is a content node — counter-argument: filing-into-a-
-   topic is arguably a message property, not body. _Resolved (#1146): envelope field._
-   The counter-argument won — a `conversation` `ConversationDirective` rides the send
-   input (`CreateMessageInputJson.conversation`), assigned synchronously in the
-   message's transaction, never a node in `contentJson`.
-3. **Chip source** — render the provenance chip from the attached reference
-   (authoritative, no flicker) rather than from async membership? _Lean: from the
-   reference._
-4. **Panel routing** — conversations as a peer panel kind `?panel=conv:<id>` rendering
-   a projection, alongside `?panel=streamId` for threads? _Lean: yes._
-5. **Filing tag vs. context anchor** — is an attached conversation a compact pill, or
-   an expandable "re: Pizza, this morning" card that makes a revived reply self-
-   contained for someone (or GAM) who wasn't there? _Same node, more rendering._
+1. **Indicator trigger** — loud `↪ continues X` only on revivals. **Shipped that
+   way (#1140).**
+2. **Attached context: content node vs. envelope field.** **Resolved the
+   _opposite_ of the earlier lean (#1146): a hidden field, not a
+   `conversationReference` content node.** The counter-argument won — a
+   `conversation` `ConversationDirective` rides the send input
+   (`CreateMessageInputJson.conversation`), assigned synchronously in the
+   message's transaction, and the payload carries `declaredConversationId`;
+   never a node in `contentJson`. The content-node cut was built first and
+   rejected: it duplicated the footer provenance chip with an in-body chip, and
+   it baked a routing pointer into user-authored body content (plus a markdown
+   round-trip) when filing is message _metadata_, not content. Nothing renders
+   in the body.
+3. **Chip source** — **resolved (#1146): declared id first, async membership map
+   as fallback.** One follow-up rule so the two sources can't drift: when a
+   declared id no longer resolves (the conversation was merged/retired by a
+   later extraction pass), fall back to the async map instead of pointing at a
+   dead shell.
+4. **Panel routing** — **shipped (#1119)** as `?panel=conv:<id>` rendering a
+   projection, peer to `?panel=streamId` for threads.
+5. **Filing tag vs. context anchor** — **moot under the field resolution**:
+   nothing renders in the body, the footer chip is the only surface. Revisit
+   only if a self-contained "re: Pizza, this morning" anchor card is wanted
+   later.
 
 ## Conversations span streams within one root — the model, made precise (2026-06-30)
 
@@ -630,7 +645,127 @@ synchronous `existing` guard from same-**stream** to same-**root**, and reject c
    (board list, expand, rails). Do **not** add per-message-stream gating — it's redundant
    under the invariant and only invites drift.
 
-## Phasing
+## Agents on the board — traces visible, never bumping (2026-07-03)
+
+How agent activity meets conversations today:
+
+- **Agent replies are already conversation members.** Every persona/bot reply is
+  assigned deterministically — no LLM — to the conversation it replies within,
+  minting one if needed (`agent_reply`, stream-locked against double-mint;
+  `boundary-extraction-service.ts:587`), and #1170 anchors them to the
+  _trigger's_ conversation. Agent conversations are ordinary board cards. (This
+  is also why the scope filter is load-bearing: the floor data's 454-of-485 DM
+  concentration is one AI-persona DM.)
+- **Traces are not conversations, by construction — and stay that way.** Trace
+  steps live in `agent_session_steps`, stream to the session room, and render
+  via `components/trace/`; the timeline's working indicator is the
+  `agent_session:started/completed/failed` stream events rendered by
+  `AgentSessionEvent` (`timeline/agent-session-event.tsx`) with live step counts
+  from the session socket. None of this passes through `message:created`, so
+  none of it feeds extraction or bumps `last_activity_at` — only the agent's
+  final reply message does. **Invariant to keep: session/step events never bump
+  a conversation.**
+
+**The gap (Kris, dogfooding): trigger an agent from the board and it looks
+dead.** The board card and the conversation panel render member _messages_ only
+(`MessageItem` rows in `board-card.tsx` / `conversation-panel.tsx`), so
+`agent_session:*` events never draw there — between the invoking message and
+the final reply there is no sign the agent is working. The timeline shows the
+running card; the board shows nothing.
+
+**Fix shape (build item):** conversation surfaces interleave the
+`agent_session:*` events of sessions **whose invoking message is a conversation
+member**, at their chronological slot, reusing `AgentSessionEvent` + the
+live-activity hook as-is. The events already ride the stream rails the card
+subscribes to (they're ordinary stream events in IDB), so this is a
+projection/filter change — include them alongside member messages — not new
+delivery. Rendering only: no assignment, no bump, no read-state effect.
+
+**Scratchpad-linked agents:** an agent working a linked scratchpad writes real
+messages, and scratchpad = one conversation — so a long-running agent is one
+board card that bumps on every message it sends. Coherent ("what is my agent up
+to?"), but ambient churn on the Active lens. The mitigation is the per-viewer
+stream mute below — not special-casing agent messages out of the bump.
+
+## Hide & mute — per-viewer exclusions (2026-07-03)
+
+Nothing exists yet. Two grains, deliberately separate:
+
+- **Mute a stream on the board** — "never board-surface my Ariadne DM / that
+  agent scratchpad." A per-viewer scope exclusion; ships as part of the scope
+  filter (next-up item 2 below). The higher-value grain, given the floor data's
+  one-DM concentration and agent-scratchpad churn.
+- **Hide a card** — per-conversation. Read-state shipped as a _message_-granular
+  sparse overlay (#1165, `stream_member_message_reads` — read iff below the
+  watermark or in the overlay), so there is no per-(user, conversation) row for
+  hide to piggyback: it gets its own small table (`hidden_at` /
+  `snoozed_until`), one extra left-join on the board query. Decide hide-forever
+  vs snooze-until-activity at build time (lean: snooze — a hidden topic that
+  genuinely revives is exactly what the board exists to resurface).
+
+Dismissals are signal (quiet-collector precedent): hiding a derived card is a
+soft "this topic wasn't worth surfacing" label for the eval loop.
+
+## Where we are + what's next (2026-07-03; replaces the original Phasing)
+
+Shipped, all flag-gated behind `board-view`:
+
+- **The board** — workspace-wide feed at `/w/:ws/board`, message-led cards
+  grouped by recency, authored posts via the board composer.
+- **Sync data plane** — conversations in IDB, `conversation:*` through
+  `SocketEventGate`, synchronous determinable assign + bump
+  (#1100/#1106/#1109/#1111).
+- **Stable view v1** — committed snapshot + "N new" pill + top scroll-anchor
+  (2026-06-28, section above).
+- **One-root cross-stream model** — the assigner enforces same-root attach
+  (section above).
+- **Soft threads** — conversation panel `?panel=conv:<id>` (#1119); provenance
+  chip on revivals (#1140); declared filing via hidden field + "Reply in
+  conversation" (#1146), with thread-follow routing for the directive (#1161),
+  carried through scheduled sends (#1168) with a drift signal when a scheduled
+  reply files into a conversation that moved (#1171), and agent replies
+  anchored to the trigger's conversation (#1170).
+- **Read-state (#1165)** — sparse read overlay: `stream_member_message_reads`
+  holds individually-read messages above the member's watermark (read iff below
+  watermark or in overlay); conversation-aware read state on board/panel +
+  phantom-unread fixes. The "rising baseline + exceptions" shape, shipped at
+  message grain.
+- **Board row actions** — reply, quote-reply, quote-selection, react,
+  copy-link, edit, delete (#1124–#1136); conversation-aware save (#1141) and
+  share back-link (#1143).
+- **Extraction quality** — time-grounded boundaries + memo dedup (#1131); the
+  topic-title prompt tightening the floor measurement asked for is in
+  (`boundary-extraction/config.ts` now enforces ≤5 words, no framing).
+
+Next, in order (re-sequenced 2026-07-03):
+
+1. **Scope filter + structural lenses** (+ stream-level board mute, above).
+   _This — not AI quality — is the promotion blocker:_ the floor data's worst
+   defect is flooding, and flooding is a WHERE clause. Active /
+   Needs-resolution / Decisions lenses are all existing signals; INV-59 route
+   segments.
+2. **Agent sessions visible in conversation surfaces** (section above) — small
+   projection change, big perceived-liveness win when driving agents from the
+   board.
+3. **Declared-id fallback rule** (resolved decision 3 above) — small; keeps the
+   chip honest when a declared conversation is later merged/retired.
+4. **Per-card hide** (above) — its own per-(user, conversation) table now that
+   read-state shipped at message grain.
+5. **Mine lens** (Saved later, per the 2026-06-22 decisions).
+6. **Retitle + mark-resolved** on cards. Merge/split UI drops to backlog —
+   declared filing has replaced corrections as the primary eval fuel, and
+   merge/split is the expensive end of the correction set.
+7. **Promotion gate, with numbers** — re-run the floor query post-scope-filter;
+   watch declared share of new assignments (up) and correction rate per active
+   conversation (down); one dogfood week with the scoped Active lens as the
+   actual landing page. Land Q4 as a **per-user default-landing setting**, not
+   a global flip — reversible, and solo-first anyway.
+
+Deferred, unchanged: `virtua` for the board and the backend stable-paging key
+(revisit at ~2–3× the current ~430-card floor), intersection-observer "seen",
+the per-card "updated" dot.
+
+## Phasing (superseded 2026-07-03 — kept for the record)
 
 The inversion changes the order. Two candidate entry points:
 
@@ -685,6 +820,11 @@ The feedback loop is already half-built:
   evals call production entry points). Like the quiet collector learning from
   dismissals, conversations improve the more the board is used.
 
+_Update (2026-07-03):_ declared filing (#1146, plus the reply-in-conversation
+follow-up) now yields a clean label on every filed reply, so corrections are no
+longer the primary eval fuel. Retitle and mark-resolved stay on the plan (user
+value in themselves); merge/split UI drops to backlog.
+
 ### Sequencing to de-risk (the one caution)
 
 The inversion above softens this a lot: an **authored**-first board is clean
@@ -714,8 +854,9 @@ distribution, so "is it mature enough?" gets a number instead of a guess.
 4. **Mutability UX** → **skip** surfacing "merged/retitled" notices for now
    (such notes get ignored anyway).
 
-With these, the design is settled. Step **(0)** — measure the floor — is now
-done (below); what remains is **(1b)** build the authored board.
+With these, the design is settled. Step **(0)** — measure the floor — is done
+(below), and **(1b)** — the authored board — has shipped; the live plan is
+"Where we are + what's next" above.
 
 ## Floor measurement — real prod data (2026-06-22)
 

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -622,7 +622,9 @@ extractor's continuation need this; lone-post→thread stays the one special cas
 across the root + its threads, live** — it subscribes to the rails of the streams its
 members span (a bounded set under one root) and merges by time. A thread-anchored
 conversation (legacy, below) still shows its thread parent as the opener; a root-anchored
-multi-stream conversation's opener is just its earliest member.
+multi-stream conversation's opener is just its earliest member. _The flatten is a v1
+rendering choice, not a model constraint — see "Nested threads × conversations" below
+for the structured rendering that replaces it._
 
 **Boundary extraction needs no tightening.** Same-root thread conversations appearing as
 assignment candidates (`findByMessageIds` over thread-context messages,
@@ -706,6 +708,81 @@ Nothing exists yet. Two grains, deliberately separate:
 Dismissals are signal (quiet-collector precedent): hiding a derived card is a
 soft "this topic wasn't worth surfacing" label for the eval loop.
 
+## Nested threads × conversations — soft vs true threads (2026-07-04)
+
+The worry (Kris): the board either hides or flattens nested threads depending on
+how they wound up being used — and thread nesting in the timeline is one of the
+genuinely useful things recently added; it must not be lost because the
+conversation system struggles with it.
+
+**Fact of the model first: a sub-thread is neither forced into the parent
+conversation nor forced to branch — it's classified.** For a message in any
+thread (any depth), the extractor fetches the conversation of the thread's
+_parent message_ and hands it to the LLM as an explicit candidate
+(`parentMessageConversations`, `boundary-extraction-service.ts:148-155`, in the
+prompt and `validUpdateTargets`). Both outcomes occur today: a thread that
+continues the discussion joins the parent's conversation as a cross-stream
+member (one root); a thread that changes subject gets a fresh conversation.
+
+**And nesting cannot be lost at the data layer.** Thread structure lives in the
+stream graph (`parentStreamId`/`parentMessageId`), not in conversation
+membership — conversations are flat sets of message ids, and every member still
+knows which thread it sits in. The v1 card _chose_ to flatten (see "Board
+rendering" above); the structure was never discarded. The only place nesting
+can be lost is the renderer, so the renderer is the fix.
+
+**The rule: topic decides membership; structure decides rendering.** Two named
+cases (Kris's vocabulary — and behavior the classifier already exhibits, just
+invisible and unnamed today):
+
+- **Soft thread** — the thread is _transport_, not a new subject: the
+  migrate-to-thread continuation, quote-reply spillover, convert-to-thread.
+  Same conversation, same card. Renders as continuation — at most a subtle
+  "moved to thread" seam, **no indent**, because topically nothing branched.
+- **True thread** — the thread is a _sub-topic_. Own conversation, own card,
+  linked both ways: a **branch stub** at the fork point on the parent card
+  ("↳ _GPU budget_") and "branched from _Hardware refresh_" provenance on the
+  child. Nesting survives **between** cards instead of inside one — the
+  conversation-grain mirror of the message-grain provenance chip.
+- **Spanning case** (one conversation genuinely across nested threads with
+  back-and-forth in several) — Reddit-style but bounded: indent per **thread
+  boundary** only (never per reply; Threa's tree is structural, not
+  reply-chain-deep), visible depth capped ~2, deeper collapsed behind a
+  "continue this thread →" link into the conversation panel / thread. Slack's
+  strictness stays right for the _timeline_ (the room); the card is the
+  overview surface, and an overview that can't show shape is why the flatten
+  feels unnatural. Likely the rarest of the three.
+
+**No depth special-case.** The rejected alternative was "the conversation chip
+covers top-level + first-level threading; nest everything deeper." That
+hard-codes a depth rule where soft/true does the work uniformly at every depth:
+a first-level thread can be a true sub-topic, a third-level thread can be a
+soft continuation. Depth is the wrong signal; topic trajectory is the signal —
+and topic trajectory is exactly what's being classified.
+
+**The decider shouldn't only be the LLM.** The channel case — a top-level
+message in an otherwise flat channel conversation branches off into a thread —
+is where the classifier is weakest, and it fights the "conversation starts in
+channel, migrates to thread" flow only apparently: recency-biased continuation
+answers _where new messages go_, not what renders where. Extend the #1146
+declared-beats-inferred rule to the **thread-opening moment**: the open carries
+a directive — _continue this conversation_ vs _new sub-topic_ — defaulting to
+continue for quote-reply/convert-to-thread, classifier-decides for a bare
+thread open. Add the human correction for when it lands wrong: **"split this
+thread into its own topic"** (cheap: reassign the thread's members to a minted
+conversation; the stub falls out of the branch relationship).
+
+**What stays correct as-is:** the sync determinable path files thread replies
+into the parent message's conversation — right even when a later pass splits
+(the split is refinement, not correction; same blessing as the realtime
+section). Read-state is message-grain (#1165), so it follows messages wherever
+they nest.
+
+**Build notes:** the card's contiguous-run logic (`board-card.tsx:109`) and
+`isContinuation` grouping assume a flat run — per-branch grouping replaces
+them; the stable-view rule extends naturally (a branch growing while committed
+updates in place, it never re-sorts siblings).
+
 ## Where we are + what's next (2026-07-03; replaces the original Phasing)
 
 Shipped, all flag-gated behind `board-view`:
@@ -751,11 +828,18 @@ Next, in order (re-sequenced 2026-07-03):
    chip honest when a declared conversation is later merged/retired.
 4. **Per-card hide** (above) — its own per-(user, conversation) table now that
    read-state shipped at message grain.
-5. **Mine lens** (Saved later, per the 2026-06-22 decisions).
-6. **Retitle + mark-resolved** on cards. Merge/split UI drops to backlog —
+5. **Nested threads on the card** (section above) — branch stubs + "branched
+   from" provenance, the soft-thread seam, bounded spanning-tree rendering;
+   the declared thread-open directive and "split this thread into its own
+   topic" ride along.
+6. **Mine lens** (Saved later, per the 2026-06-22 decisions).
+7. **Retitle + mark-resolved** on cards. Merge/split UI drops to backlog —
    declared filing has replaced corrections as the primary eval fuel, and
-   merge/split is the expensive end of the correction set.
-7. **Promotion gate, with numbers** — re-run the floor query post-scope-filter;
+   merge/split is the expensive end of the correction set. (The nested-threads
+   "split this thread into its own topic" is the exception that stays — it's a
+   structural split along an existing thread boundary, not the free-form
+   message-picker split that made the UI expensive.)
+8. **Promotion gate, with numbers** — re-run the floor query post-scope-filter;
    watch declared share of new assignments (up) and correction rate per active
    conversation (down); one dogfood week with the scoped Active lens as the
    actual landing page. Land Q4 as a **per-user default-landing setting**, not


### PR DESCRIPTION
## Problem

`docs/board-view-design.md` is the anchor doc every board session (remote and local) plans from, and it had drifted badly behind the code:

- Header still said "exploration … No code yet" while the board, sync data plane, stable view, soft threads (#1119/#1140/#1146), and board row actions have all shipped.
- The soft-threads "Open decisions" still **leaned the opposite way of what shipped**: #1146 resolved attached-context as a hidden `declaredConversationId` field after building and rejecting the `conversationReference` content-node cut — a next session reading the stale lean could faithfully rebuild the rejected design.
- The Phasing section predated the authored board shipping; the Architecture sketch still described the React-Query board hook as a live stopgap (gone since #1100).
- Two decisions from this session's design discussion existed only in chat: agent traces in conversation surfaces, and per-viewer hide/mute.

## Solution

A v4 shipped-state pass on the doc: mark it the design of record, close out resolved decisions with the actual (reversed) resolutions, supersede Phasing with a shipped log + re-sequenced plan, and add the two new design sections.

**New section: Agents on the board — traces visible, never bumping.** Records what's true today — agent replies are already deterministic conversation members (`agent_reply` assignment, `boundary-extraction-service.ts:587`), and trace/session data (`agent_session_steps`, `agent_session:*` stream events) never passes through `message:created`, so it structurally cannot bump `last_activity_at`. States Kris's requirement as an invariant (session/step events never bump a conversation) plus the build item: board card and conversation panel render member messages only (`MessageItem` rows), so a board-triggered agent looks dead until its final reply — fix is to interleave `agent_session:*` events of sessions whose invoking message is a member, at their chronological slot, reusing `AgentSessionEvent` + the live-activity hook. The events already ride the stream rails in IDB, so it's a projection/filter change, not new delivery.

**New section: Hide & mute — per-viewer exclusions.** Two grains kept deliberately separate: stream-level board mute (ships with the scope filter; counters the floor data's 454-of-485 one-DM concentration and agent-scratchpad churn) and per-card hide (ships with read-state; `hidden_at` shares the per-(user, conversation) row with `seen_at`, one left-join). Lean recorded: snooze-until-activity over hide-forever; dismissals feed the eval loop.

**Decisions closed out.** #1140 (revival-only chip), #1119 (`?panel=conv:<id>`), #1146 (field, not content node — with the rejection rationale preserved), plus a new drift rule: when a declared conversation id no longer resolves (merged/retired by a later pass), the chip falls back to the async membership map instead of pointing at a dead shell.

**Plan re-sequenced** ("Where we are + what's next"): merge #1146 → scope filter + structural lenses + stream mute (named the promotion blocker — flooding is a WHERE clause, not an AI-quality problem) → agent sessions in conversation surfaces → reply-in-conversation action → read-state + card hide → Mine lens → retitle/mark-resolved (merge/split UI to backlog, since declared filing replaced corrections as primary eval fuel) → numeric promotion gate with Q4 landing as a per-user setting. Original Phasing kept under a "superseded" heading for the record.

## Files changed

| File | Change |
| ---- | ------ |
| `docs/board-view-design.md` | v4 pass: status header + v4 changelog note; React-Query stopgap note closed out; soft-thread open decisions resolved; two new sections (Agents on the board, Hide & mute); "Where we are + what's next" supersedes Phasing; forcing-function eval-fuel update; stale "(1b) remains" line fixed |

## Test plan

Docs-only change — no runtime surface.

- [x] Claims verified against code: `boundary-extraction-service.ts:587` (deterministic `agent_reply` assignment), `trace-steps.ts`/`agent_session_steps` (session room, not `message:created`), `timeline/agent-session-event.tsx` (timeline-only rendering), `board-card.tsx` / `conversation-panel.tsx` (both import `MessageItem`, no session events), `boundary-extraction/config.ts:82,116` (title prompt tightened), #1146 body (field-not-node rationale)
- [x] Pre-commit hook (prettier + full-monorepo lint & `tsc --noEmit`) — passed on commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01TpkNvS7g1hzUPGVB7y4Xa6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpkNvS7g1hzUPGVB7y4Xa6)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785701976&installation_id=129946197&pr_number=1173&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1173&signature=897f435becc35d92f6693a277c8eeb201934079b7bd045f6b056e868f79d88b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->