### PR TITLE
feat(reads): viewport auto-read on conversation surfaces — reading is marking

### DIFF
--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, act } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { BoardPostMessage } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+
+const WS = "ws_1"
+const STREAM = "stream_1"
+
+function openingMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMessage {
+  return {
+    id: "m_open",
+    streamId: STREAM,
+    authorId: "usr_other",
+    authorType: "user",
+    contentMarkdown: "Opening body.",
+    reactions: {},
+    attachments: [],
+    linkPreviews: [],
+    createdAt: "2026-06-22T12:00:00.000Z",
+    editedAt: null,
+    ...overrides,
+  }
+}
+
+function makePost(): BoardViewPost {
+  const opening = openingMessage()
+  return {
+    id: "conv_1",
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: [STREAM],
+    conversation: {
+      id: "conv_1",
+      streamId: STREAM,
+      messageIds: ["m_open"],
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+    },
+    openingMessage: opening,
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as BoardViewPost
+}
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = []
+  observed = new Set<Element>()
+  constructor(private callback: IntersectionObserverCallback) {
+    FakeIntersectionObserver.instances.push(this)
+  }
+  observe(el: Element) {
+    this.observed.add(el)
+  }
+  unobserve(el: Element) {
+    this.observed.delete(el)
+  }
+  disconnect() {
+    this.observed.clear()
+  }
+  fire(entries: Array<{ target: Element; isIntersecting: boolean }>) {
+    this.callback(entries as unknown as IntersectionObserverEntry[], this as unknown as IntersectionObserver)
+  }
+}
+
+const markRead = vi.fn().mockResolvedValue({ streams: [] })
+const markUnread = vi.fn().mockResolvedValue({ streams: [] })
+
+function mountCard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: { markRead, markUnread } as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <PanelProvider>
+              <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
+            </PanelProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+  FakeIntersectionObserver.instances = []
+  markRead.mockClear()
+  markUnread.mockClear()
+  __clearBoardRailRegistry()
+  // Focused, visible desktop page.
+  vi.spyOn(document, "hasFocus").mockReturnValue(true)
+
+  // REAL controller derivation: the stream has unread (count 2), the viewer's
+  // watermark timestamp predates the opening message, no overlay.
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUnreadState").mockReturnValue({
+    workspaceId: WS,
+    unreadCounts: { [STREAM]: 2 },
+    mentionCounts: {},
+    messageCounts: { [STREAM]: 5 },
+    readMessageIds: {},
+  } as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreamMemberships").mockReturnValue([
+    {
+      id: `${WS}:${STREAM}`,
+      workspaceId: WS,
+      streamId: STREAM,
+      lastReadSequence: "1",
+      lastReadAt: "2026-06-20T00:00:00.000Z",
+      lastReadEventId: "evt_old",
+    },
+  ] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+})
+
+afterEach(() => {
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("BoardCard viewport auto-read (full wiring: real card, real controller, real hook)", () => {
+  it("marks the conversation read after the opening row dwells in the viewport", async () => {
+    mountCard()
+    await act(async () => {})
+    expect(screen.getByText("Opening body.")).toBeTruthy()
+
+    const io = FakeIntersectionObserver.instances.at(-1)
+    expect(io, "an IntersectionObserver should have been constructed").toBeTruthy()
+    const rowEl = document.querySelector('[data-message-row][data-message-id="m_open"]')
+    expect(rowEl, "the opening row should carry data-message-row").toBeTruthy()
+    expect(io!.observed.has(rowEl!), "the opening row should be observed").toBe(true)
+
+    act(() => {
+      io!.fire([{ target: rowEl!, isIntersecting: true }])
+    })
+    act(() => {
+      vi.advanceTimersByTime(1_100) // dwell
+    })
+    act(() => {
+      vi.advanceTimersByTime(2_100) // debounce
+    })
+
+    expect(markRead).toHaveBeenCalledWith(WS, "conv_1", "m_open")
+  })
+})

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -106,6 +106,7 @@ describe("BoardCard unread dot", () => {
       value: readValue,
       hasUnread: () => true,
       markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
     })
     mountCard()
     expect(await screen.findByLabelText("Unread")).toBeTruthy()
@@ -116,6 +117,7 @@ describe("BoardCard unread dot", () => {
       value: readValue,
       hasUnread: () => false,
       markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
     })
     mountCard()
     await screen.findByText("Opening body.")

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -105,6 +105,7 @@ describe("BoardCard unread dot", () => {
     vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
       value: readValue,
       hasUnread: () => true,
+      markReadSilently: () => Promise.resolve(),
     })
     mountCard()
     expect(await screen.findByLabelText("Unread")).toBeTruthy()
@@ -114,6 +115,7 @@ describe("BoardCard unread dot", () => {
     vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
       value: readValue,
       hasUnread: () => false,
+      markReadSilently: () => Promise.resolve(),
     })
     mountCard()
     await screen.findByText("Opening body.")

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -107,6 +107,7 @@ describe("BoardCard unread dot", () => {
       hasUnread: () => true,
       markReadSilently: () => Promise.resolve(),
       setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
     })
     mountCard()
     expect(await screen.findByLabelText("Unread")).toBeTruthy()
@@ -118,6 +119,7 @@ describe("BoardCard unread dot", () => {
       hasUnread: () => false,
       markReadSilently: () => Promise.resolve(),
       setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
     })
     mountCard()
     await screen.findByText("Opening body.")

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -78,6 +78,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     hasUnread,
     markReadSilently,
     setExplicitUnreadListener,
+    getReadTruth,
   } = useConversationReadController(workspaceId, conversation.id, streamId, currentUserId)
   // Over the card's known local messages (opening + the full local reply rail);
   // own-authored rows are excluded inside `hasUnread`.
@@ -143,6 +144,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     rowState: conversationReadValue.state,
     markRead: markReadSilently,
     registerExplicitUnread: setExplicitUnreadListener,
+    getReadTruth,
   })
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => (

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
+import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
@@ -72,12 +73,11 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // the card's effectively-unread signal for the header dot. Both derive live
   // from the overlay + per-stream watermarks, so the dot clears the moment a
   // read lands (docs/sparse-read-overlay-design.md).
-  const { value: conversationReadValue, hasUnread } = useConversationReadController(
-    workspaceId,
-    conversation.id,
-    streamId,
-    currentUserId
-  )
+  const {
+    value: conversationReadValue,
+    hasUnread,
+    markReadSilently,
+  } = useConversationReadController(workspaceId, conversation.id, streamId, currentUserId)
   // Over the card's known local messages (opening + the full local reply rail);
   // own-authored rows are excluded inside `hasUnread`.
   const knownMessages = useMemo(
@@ -126,6 +126,22 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // No middle is hidden, so opening + replies form one uninterrupted run that
   // groups across the boundary. Otherwise a gap row sits between them.
   const contiguous = (expanded && (!incompleteLocally || !!allMessages)) || (!expanded && hiddenCount === 0)
+
+  // Viewport auto-read: rows that dwell on screen mark themselves read (the menu
+  // actions are the override). Eligibility is the contiguous-from-the-start run
+  // only — with an "N more" gap the cutoff could otherwise read the hidden middle
+  // the viewer never saw, so a collapsed card auto-reads no further than its
+  // opening and the trailing preview stays unread until expanded.
+  let autoReadRows: RenderableMessage[]
+  if (contiguous) autoReadRows = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
+  else autoReadRows = openingMessage ? [openingMessage] : []
+  useConversationAutoRead({
+    containerRef: cardRef,
+    messages: autoReadRows,
+    rootStreamId: streamId,
+    rowState: conversationReadValue.state,
+    markRead: markReadSilently,
+  })
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => (
     <MessageItem

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -129,13 +129,13 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const contiguous = (expanded && (!incompleteLocally || !!allMessages)) || (!expanded && hiddenCount === 0)
 
   // Viewport auto-read: rows that dwell on screen mark themselves read (the menu
-  // actions are the override). Eligibility is the contiguous-from-the-start run
-  // only — with an "N more" gap the cutoff could otherwise read the hidden middle
-  // the viewer never saw, so a collapsed card auto-reads no further than its
-  // opening and the trailing preview stays unread until expanded.
-  let autoReadRows: RenderableMessage[]
-  if (contiguous) autoReadRows = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
-  else autoReadRows = openingMessage ? [openingMessage] : []
+  // actions are the override). Every rendered row is eligible — on a collapsed
+  // card the cutoff through a trailing-preview row also covers the hidden "N
+  // more" middle, deliberately: the card IS the conversation surface, so reading
+  // its visible tail reads the conversation up to there, exactly like invoking
+  // "Mark as read up to here" on that row (Kris's dogfood ruling on PR #1174 —
+  // having the conversation open is enough to mark it).
+  const autoReadRows = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
   useConversationAutoRead({
     containerRef: cardRef,
     messages: autoReadRows,

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -77,6 +77,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     value: conversationReadValue,
     hasUnread,
     markReadSilently,
+    setExplicitUnreadListener,
   } = useConversationReadController(workspaceId, conversation.id, streamId, currentUserId)
   // Over the card's known local messages (opening + the full local reply rail);
   // own-authored rows are excluded inside `hasUnread`.
@@ -141,6 +142,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     rootStreamId: streamId,
     rowState: conversationReadValue.state,
     markRead: markReadSilently,
+    registerExplicitUnread: setExplicitUnreadListener,
   })
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => (

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -245,12 +245,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // Per-row read state + the mark-read/unread actions for this conversation's
   // rows (docs/sparse-read-overlay-design.md). The panel has no unread dot, so
   // only the provider value is used.
-  const { value: conversationReadValue, markReadSilently } = useConversationReadController(
-    workspaceId,
-    conversation.id,
-    conversation.streamId,
-    currentUserId
-  )
+  const {
+    value: conversationReadValue,
+    markReadSilently,
+    setExplicitUnreadListener,
+  } = useConversationReadController(workspaceId, conversation.id, conversation.streamId, currentUserId)
   // Deep-link target from `?m=` — the row to scroll to + flash. Shared with the
   // host page's `m` param, but only the conversation panel reads it here (the
   // board page, the panel's host for a conversation link, ignores it), so a
@@ -322,6 +321,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     rootStreamId: conversation.streamId,
     rowState: conversationReadValue.state,
     markRead: markReadSilently,
+    registerExplicitUnread: setExplicitUnreadListener,
   })
 
   return (

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -16,6 +16,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
+import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
@@ -244,7 +245,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // Per-row read state + the mark-read/unread actions for this conversation's
   // rows (docs/sparse-read-overlay-design.md). The panel has no unread dot, so
   // only the provider value is used.
-  const { value: conversationReadValue } = useConversationReadController(
+  const { value: conversationReadValue, markReadSilently } = useConversationReadController(
     workspaceId,
     conversation.id,
     conversation.streamId,
@@ -305,6 +306,23 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
 
   // Scopes text-selection quoting to this panel's message list.
   const listRef = useRef<HTMLDivElement>(null)
+
+  // Viewport auto-read: the panel always renders the full conversation, so once
+  // the rail/backfill is complete every row is eligible. While older replies are
+  // still loading the rendered run has a hidden gap after the opening, so only
+  // the opening can mark (a cutoff through a later row would read the unseen
+  // middle) — mirrors the board card's collapsed-gap rule.
+  const complete = !incompleteLocally || !!allMessages
+  let autoReadRows: RenderableMessage[]
+  if (complete) autoReadRows = all
+  else autoReadRows = openingMessage ? [openingMessage] : []
+  useConversationAutoRead({
+    containerRef: listRef,
+    messages: autoReadRows,
+    rootStreamId: conversation.streamId,
+    rowState: conversationReadValue.state,
+    markRead: markReadSilently,
+  })
 
   return (
     // Quote reply from a row routes into this conversation's reply composer.

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -249,6 +249,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     value: conversationReadValue,
     markReadSilently,
     setExplicitUnreadListener,
+    getReadTruth,
   } = useConversationReadController(workspaceId, conversation.id, conversation.streamId, currentUserId)
   // Deep-link target from `?m=` — the row to scroll to + flash. Shared with the
   // host page's `m` param, but only the conversation panel reads it here (the
@@ -318,6 +319,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     rowState: conversationReadValue.state,
     markRead: markReadSilently,
     registerExplicitUnread: setExplicitUnreadListener,
+    getReadTruth,
   })
 
   return (

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -306,15 +306,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // Scopes text-selection quoting to this panel's message list.
   const listRef = useRef<HTMLDivElement>(null)
 
-  // Viewport auto-read: the panel always renders the full conversation, so once
-  // the rail/backfill is complete every row is eligible. While older replies are
-  // still loading the rendered run has a hidden gap after the opening, so only
-  // the opening can mark (a cutoff through a later row would read the unseen
-  // middle) — mirrors the board card's collapsed-gap rule.
-  const complete = !incompleteLocally || !!allMessages
-  let autoReadRows: RenderableMessage[]
-  if (complete) autoReadRows = all
-  else autoReadRows = openingMessage ? [openingMessage] : []
+  // Viewport auto-read: every rendered row is eligible. While older replies are
+  // still backfilling, the cutoff through a rendered row also covers the not-
+  // yet-fetched middle — deliberate, same as the board card: reading the
+  // conversation's visible tail reads it up to there.
+  const autoReadRows = all
   useConversationAutoRead({
     containerRef: listRef,
     messages: autoReadRows,

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -96,7 +96,14 @@ export function useConversationReadController(
   conversationId: string,
   rootStreamId: string,
   currentUserId: string | null
-): { value: ConversationRowRead; hasUnread: (messages: RenderableMessage[]) => boolean } {
+): {
+  value: ConversationRowRead
+  hasUnread: (messages: RenderableMessage[]) => boolean
+  /** The mark-read mutation without the failure toast — for viewport auto-read,
+   * where a background action failing must stay silent (the next dwell retries);
+   * the toast is reserved for the user-initiated menu action. */
+  markReadSilently: (messageId: string) => Promise<void>
+} {
   const conversationService = useConversationService()
   const unreadState = useWorkspaceUnreadState(workspaceId)
   const overlay = unreadState?.readMessageIds
@@ -117,14 +124,19 @@ export function useConversationReadController(
     [overlay, unreadCounts, frontierByStream, rootStreamId]
   )
 
-  const markReadUpToHere = useCallback(
-    (messageId: string) => {
+  const markReadSilently = useCallback(
+    (messageId: string) =>
       conversationService
         .markRead(workspaceId, conversationId, messageId)
-        .then((res) => applyReadStateSnapshots(workspaceId, res.streams))
-        .catch(() => toast.error("Couldn't mark as read"))
-    },
+        .then((res) => applyReadStateSnapshots(workspaceId, res.streams)),
     [conversationService, workspaceId, conversationId]
+  )
+
+  const markReadUpToHere = useCallback(
+    (messageId: string) => {
+      markReadSilently(messageId).catch(() => toast.error("Couldn't mark as read"))
+    },
+    [markReadSilently]
   )
 
   const markUnread = useCallback(
@@ -151,5 +163,5 @@ export function useConversationReadController(
     [state, currentUserId, rootStreamId]
   )
 
-  return { value, hasUnread }
+  return { value, hasUnread, markReadSilently }
 }

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -23,6 +23,8 @@ export interface ConversationRowRead {
 
 const ConversationReadContext = createContext<ConversationRowRead | null>(null)
 
+const EMPTY_OVERLAY: readonly string[] = []
+
 export function useConversationRowRead(): ConversationRowRead | null {
   return useContext(ConversationReadContext)
 }
@@ -107,6 +109,12 @@ export function useConversationReadController(
    * request departs — a dwell-scheduled auto mark-read firing mid-flight would
    * otherwise race the explicit unread, with server arrival order deciding. */
   setExplicitUnreadListener: (listener: (() => void) | null) => void
+  /** One stream's RAW read truth (watermark sequence + overlay ids) — what the
+   * auto-read hook diffs to detect a cross-device mark-unread. Raw primitives,
+   * not derived row state: derivation flaps (the `unreadCounts === 0`
+   * short-circuit, a stale `lastReadAt` fallback) must never read as a
+   * regression, or auto-read false-pins and wedges on a static board card. */
+  getReadTruth: (streamId: string) => { lastReadSequence: string | null; readMessageIds: readonly string[] }
 } {
   const conversationService = useConversationService()
   const unreadState = useWorkspaceUnreadState(workspaceId)
@@ -143,6 +151,14 @@ export function useConversationReadController(
     [markReadSilently]
   )
 
+  const getReadTruth = useCallback(
+    (streamId: string) => ({
+      lastReadSequence: frontierByStream.get(streamId)?.lastReadSequence ?? null,
+      readMessageIds: overlay?.[streamId] ?? EMPTY_OVERLAY,
+    }),
+    [frontierByStream, overlay]
+  )
+
   const explicitUnreadListenerRef = useRef<(() => void) | null>(null)
   const setExplicitUnreadListener = useCallback((listener: (() => void) | null) => {
     explicitUnreadListenerRef.current = listener
@@ -173,5 +189,5 @@ export function useConversationReadController(
     [state, currentUserId, rootStreamId]
   )
 
-  return { value, hasUnread, markReadSilently, setExplicitUnreadListener }
+  return { value, hasUnread, markReadSilently, setExplicitUnreadListener, getReadTruth }
 }

--- a/apps/frontend/src/components/message/conversation-read-context.tsx
+++ b/apps/frontend/src/components/message/conversation-read-context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo } from "react"
+import { createContext, useCallback, useContext, useMemo, useRef } from "react"
 import { toast } from "sonner"
 import { useConversationService } from "@/contexts"
 import { useWorkspaceStreamMemberships, useWorkspaceUnreadState } from "@/stores/workspace-store"
@@ -103,6 +103,10 @@ export function useConversationReadController(
    * where a background action failing must stay silent (the next dwell retries);
    * the toast is reserved for the user-initiated menu action. */
   markReadSilently: (messageId: string) => Promise<void>
+  /** Registers the auto-read pin `markUnread` invokes synchronously BEFORE its
+   * request departs — a dwell-scheduled auto mark-read firing mid-flight would
+   * otherwise race the explicit unread, with server arrival order deciding. */
+  setExplicitUnreadListener: (listener: (() => void) | null) => void
 } {
   const conversationService = useConversationService()
   const unreadState = useWorkspaceUnreadState(workspaceId)
@@ -139,8 +143,14 @@ export function useConversationReadController(
     [markReadSilently]
   )
 
+  const explicitUnreadListenerRef = useRef<(() => void) | null>(null)
+  const setExplicitUnreadListener = useCallback((listener: (() => void) | null) => {
+    explicitUnreadListenerRef.current = listener
+  }, [])
+
   const markUnread = useCallback(
     (messageId: string) => {
+      explicitUnreadListenerRef.current?.()
       conversationService
         .markUnread(workspaceId, conversationId, messageId)
         .then((res) => applyReadStateSnapshots(workspaceId, res.streams))
@@ -163,5 +173,5 @@ export function useConversationReadController(
     [state, currentUserId, rootStreamId]
   )
 
-  return { value, hasUnread, markReadSilently }
+  return { value, hasUnread, markReadSilently, setExplicitUnreadListener }
 }

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -599,6 +599,7 @@ export function MessageItem({
       <div
         ref={containerRef}
         tabIndex={-1}
+        data-message-row=""
         data-message-id={message.id}
         data-stream-id={streamId}
         data-author-name={authorName}
@@ -646,6 +647,7 @@ export function MessageItem({
     <div
       ref={containerRef}
       tabIndex={-1}
+      data-message-row=""
       data-message-id={message.id}
       data-stream-id={streamId}
       data-author-name={authorName}

--- a/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useConversationAutoRead } from "./use-conversation-auto-read"
+import * as autoMarkModule from "@/hooks/use-auto-mark-as-read"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+const ROOT = "stream_root"
+
+function msg(id: string, minute: number): RenderableMessage {
+  return {
+    id,
+    streamId: ROOT,
+    authorId: "usr_other",
+    authorType: "user",
+    contentMarkdown: `body ${id}`,
+    reactions: {},
+    createdAt: `2026-07-01T12:${String(minute).padStart(2, "0")}:00.000Z`,
+  }
+}
+
+/** A fresh function per call — the hook's pin effect keys on `rowState` identity,
+ * exactly as the production controller hands out a new callback when the
+ * overlay/watermark caches change. */
+function makeRowState(states: Record<string, RowReadState>) {
+  return (_streamId: string, messageId: string): RowReadState => states[messageId] ?? "ungated"
+}
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = []
+  observed = new Set<Element>()
+  constructor(private callback: IntersectionObserverCallback) {
+    FakeIntersectionObserver.instances.push(this)
+  }
+  observe(el: Element) {
+    this.observed.add(el)
+  }
+  unobserve(el: Element) {
+    this.observed.delete(el)
+  }
+  disconnect() {
+    this.observed.clear()
+  }
+  fire(entries: Array<{ target: Element; isIntersecting: boolean }>) {
+    this.callback(entries as unknown as IntersectionObserverEntry[], this as unknown as IntersectionObserver)
+  }
+}
+
+let container: HTMLDivElement
+const rowEls = new Map<string, HTMLElement>()
+let attention = true
+
+function addRow(id: string) {
+  const el = document.createElement("div")
+  el.dataset.messageId = id
+  container.appendChild(el)
+  rowEls.set(id, el)
+}
+
+function io(): FakeIntersectionObserver {
+  const instance = FakeIntersectionObserver.instances.at(-1)
+  if (!instance) throw new Error("no IntersectionObserver constructed")
+  return instance
+}
+
+function enter(...ids: string[]) {
+  act(() => {
+    io().fire(ids.map((id) => ({ target: rowEls.get(id)!, isIntersecting: true })))
+  })
+}
+
+function leave(...ids: string[]) {
+  act(() => {
+    io().fire(ids.map((id) => ({ target: rowEls.get(id)!, isIntersecting: false })))
+  })
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+/** Dwell (1s) + trailing debounce (2s), with margin. */
+function settle() {
+  advance(1_100)
+  advance(2_100)
+}
+
+const markRead = vi.fn<(messageId: string) => Promise<void>>()
+
+function mount(messages: RenderableMessage[], states: Record<string, RowReadState>) {
+  const containerRef = { current: container }
+  return renderHook(
+    (props: { messages: RenderableMessage[]; rowState: ReturnType<typeof makeRowState> }) =>
+      useConversationAutoRead({
+        containerRef,
+        messages: props.messages,
+        rootStreamId: ROOT,
+        rowState: props.rowState,
+        markRead,
+      }),
+    { initialProps: { messages, rowState: makeRowState(states) } }
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver)
+  FakeIntersectionObserver.instances = []
+  rowEls.clear()
+  attention = true
+  markRead.mockReset()
+  markRead.mockResolvedValue(undefined)
+  vi.spyOn(autoMarkModule, "useAutoReadAttention").mockImplementation(() => attention)
+  container = document.createElement("div")
+  document.body.appendChild(container)
+})
+
+afterEach(() => {
+  container.remove()
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("useConversationAutoRead", () => {
+  it("marks through the newest seen row after dwell + debounce", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1), msg("m_c", 2)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "unread", m_b: "unread", m_c: "unread" })
+
+    enter("m_a", "m_b", "m_c")
+    settle()
+
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_c")
+  })
+
+  it("marks only through the furthest row that actually dwelled", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "unread", m_b: "unread" })
+
+    enter("m_a")
+    settle()
+
+    expect(markRead).toHaveBeenCalledWith("m_a")
+  })
+
+  it("a scroll-past that leaves before the dwell completes does not mark", () => {
+    const messages = [msg("m_a", 0)]
+    addRow("m_a")
+    mount(messages, { m_a: "unread" })
+
+    enter("m_a")
+    advance(500)
+    leave("m_a")
+    advance(10_000)
+
+    expect(markRead).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when everything at/below the target is already read", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "read", m_b: "read" })
+
+    enter("m_a", "m_b")
+    settle()
+
+    expect(markRead).not.toHaveBeenCalled()
+  })
+
+  it("never targets an optimistic temp_ row and ignores rendered rows outside the eligible run", () => {
+    // temp_ is filtered from eligibility; m_x is in the DOM (e.g. a trailing
+    // preview past a collapsed gap) but not in `messages`, so it is not observed.
+    const messages = [msg("m_a", 0), msg("temp_b", 1)]
+    addRow("m_a")
+    addRow("temp_b")
+    addRow("m_x")
+    mount(messages, { m_a: "unread", temp_b: "unread", m_x: "unread" })
+
+    expect(io().observed.has(rowEls.get("temp_b")!)).toBe(false)
+    expect(io().observed.has(rowEls.get("m_x")!)).toBe(false)
+
+    enter("m_a")
+    settle()
+
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_a")
+  })
+
+  it("pins after a read → unread regression: no re-mark while the rows stay on screen, resumes after leave + re-enter", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1), msg("m_c", 2)]
+    messages.forEach((m) => addRow(m.id))
+    const { rerender } = mount(messages, { m_a: "unread", m_b: "unread", m_c: "unread" })
+
+    enter("m_a", "m_b", "m_c")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+
+    // The optimistic apply lands: everything read.
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read", m_c: "read" }) })
+    // The viewer marks unread from m_b (cutoff regresses m_b and m_c).
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "unread", m_c: "unread" }) })
+
+    // Rows are still on screen — pinned, nothing re-marks.
+    advance(10_000)
+    expect(markRead).toHaveBeenCalledTimes(1)
+
+    // A new unread reply dwelling while pinned must NOT cutoff-mark over the
+    // explicit unread.
+    const withNew = [...messages, msg("m_d", 3)]
+    addRow("m_d")
+    rerender({
+      messages: withNew,
+      rowState: makeRowState({ m_a: "read", m_b: "unread", m_c: "unread", m_d: "unread" }),
+    })
+    enter("m_d")
+    advance(10_000)
+    expect(markRead).toHaveBeenCalledTimes(1)
+
+    // Leaving releases the pin row-by-row; coming back re-reads deliberately.
+    leave("m_a", "m_b", "m_c", "m_d")
+    enter("m_a", "m_b", "m_c", "m_d")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(2)
+    expect(markRead).toHaveBeenLastCalledWith("m_d")
+  })
+
+  it("does not observe at all while the viewer's attention is off the page", () => {
+    attention = false
+    const messages = [msg("m_a", 0)]
+    addRow("m_a")
+    const { rerender } = mount(messages, { m_a: "unread" })
+
+    expect(FakeIntersectionObserver.instances).toHaveLength(0)
+
+    // Attention returns → the observer arms and dwell proceeds normally.
+    attention = true
+    rerender({ messages, rowState: makeRowState({ m_a: "unread" }) })
+    enter("m_a")
+    settle()
+    expect(markRead).toHaveBeenCalledWith("m_a")
+  })
+
+  it("flushes a pending debounce on unmount so a seen row is not lost", () => {
+    const messages = [msg("m_a", 0)]
+    addRow("m_a")
+    const { unmount } = mount(messages, { m_a: "unread" })
+
+    enter("m_a")
+    advance(1_100) // dwell done, debounce still pending
+    expect(markRead).not.toHaveBeenCalled()
+
+    act(() => unmount())
+    expect(markRead).toHaveBeenCalledWith("m_a")
+  })
+
+  it("releases the dedup after a failed mark so a later evaluation retries", async () => {
+    markRead.mockRejectedValueOnce(new Error("offline"))
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "unread", m_b: "unread" })
+
+    enter("m_a")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    await act(async () => {}) // let the rejection settle and clear the dedup
+
+    enter("m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(2)
+    expect(markRead).toHaveBeenLastCalledWith("m_b")
+  })
+})

--- a/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
@@ -7,10 +7,11 @@ import type { RenderableMessage } from "@/components/message/message-item"
 
 const ROOT = "stream_root"
 
-function msg(id: string, minute: number): RenderableMessage {
+function msg(id: string, minute: number, sequence?: string): RenderableMessage {
   return {
     id,
     streamId: ROOT,
+    sequence,
     authorId: "usr_other",
     authorType: "user",
     contentMarkdown: `body ${id}`,
@@ -97,6 +98,12 @@ const registerExplicitUnread = (listener: (() => void) | null) => {
   explicitUnreadPin = listener
 }
 
+/** Mutable raw read truth per stream, standing in for the controller's
+ * `getReadTruth`; the hook's cross-device pin arm diffs this — never derived
+ * row state. Tests mutate it then rerender to deliver the change. */
+let readTruth: Record<string, { lastReadSequence: string | null; readMessageIds: string[] }> = {}
+const getReadTruth = (streamId: string) => readTruth[streamId] ?? { lastReadSequence: null, readMessageIds: [] }
+
 function mount(messages: RenderableMessage[], states: Record<string, RowReadState>) {
   const containerRef = { current: container }
   return renderHook(
@@ -108,6 +115,7 @@ function mount(messages: RenderableMessage[], states: Record<string, RowReadStat
         rowState: props.rowState,
         markRead,
         registerExplicitUnread,
+        getReadTruth,
       }),
     { initialProps: { messages, rowState: makeRowState(states) } }
   )
@@ -120,6 +128,7 @@ beforeEach(() => {
   rowEls.clear()
   attention = true
   explicitUnreadPin = null
+  readTruth = {}
   markRead.mockReset()
   markRead.mockResolvedValue(undefined)
   vi.spyOn(autoMarkModule, "useAutoReadAttention").mockImplementation(() => attention)
@@ -217,18 +226,22 @@ describe("useConversationAutoRead", () => {
     expect(io().observed.has(quoteNode)).toBe(false)
   })
 
-  it("pins after a read → unread regression: no re-mark while the rows stay on screen, resumes after leave + re-enter", () => {
-    const messages = [msg("m_a", 0), msg("m_b", 1), msg("m_c", 2)]
+  it("pins on a raw watermark regression (cross-device mark-unread): no re-mark on screen, resumes after leave + re-enter", () => {
+    const messages = [msg("m_a", 0, "1"), msg("m_b", 1, "2"), msg("m_c", 2, "3")]
     messages.forEach((m) => addRow(m.id))
+    readTruth[ROOT] = { lastReadSequence: "0", readMessageIds: [] }
     const { rerender } = mount(messages, { m_a: "unread", m_b: "unread", m_c: "unread" })
 
     enter("m_a", "m_b", "m_c")
     settle()
     expect(markRead).toHaveBeenCalledTimes(1)
 
-    // The optimistic apply lands: everything read.
+    // The mark lands and compacts: watermark at m_c, everything read.
+    readTruth[ROOT] = { lastReadSequence: "3", readMessageIds: [] }
     rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read", m_c: "read" }) })
-    // The viewer marks unread from m_b (cutoff regresses m_b and m_c).
+    // Another device marks unread from m_b: the watermark REGRESSES to just
+    // before it, and the exposed rows derive unread.
+    readTruth[ROOT] = { lastReadSequence: "1", readMessageIds: [] }
     rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "unread", m_c: "unread" }) })
 
     // Rows are still on screen — pinned, nothing re-marks.
@@ -237,7 +250,7 @@ describe("useConversationAutoRead", () => {
 
     // A new unread reply dwelling while pinned must NOT cutoff-mark over the
     // explicit unread.
-    const withNew = [...messages, msg("m_d", 3)]
+    const withNew = [...messages, msg("m_d", 3, "4")]
     addRow("m_d")
     rerender({
       messages: withNew,
@@ -253,6 +266,56 @@ describe("useConversationAutoRead", () => {
     settle()
     expect(markRead).toHaveBeenCalledTimes(2)
     expect(markRead).toHaveBeenLastCalledWith("m_d")
+  })
+
+  it("pins on an overlay drop without watermark advance (mark-unread above the watermark)", () => {
+    const messages = [msg("m_a", 0, "5"), msg("m_b", 1, "6")]
+    messages.forEach((m) => addRow(m.id))
+    // Both rows read via the sparse overlay, watermark below them.
+    readTruth[ROOT] = { lastReadSequence: "4", readMessageIds: ["m_a", "m_b"] }
+    const { rerender } = mount(messages, { m_a: "read", m_b: "read" })
+
+    // Another device marks m_b unread: its id drops from the overlay, the
+    // watermark does not move.
+    readTruth[ROOT] = { lastReadSequence: "4", readMessageIds: ["m_a"] }
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "unread" }) })
+
+    enter("m_a", "m_b")
+    advance(10_000)
+    expect(markRead).not.toHaveBeenCalled()
+  })
+
+  it("does not pin on derived-state flapping while raw read truth is unchanged (staging board-wedge regression)", () => {
+    // The dogfood failure: a count leaving zero (own send) re-derives rows
+    // from a stale frontier — read → unread with NO change to the watermark
+    // or overlay. Auto-read must keep working, not wedge.
+    const messages = [msg("m_a", 0, "1"), msg("m_b", 1, "2")]
+    messages.forEach((m) => addRow(m.id))
+    readTruth[ROOT] = { lastReadSequence: "0", readMessageIds: [] }
+    const { rerender } = mount(messages, { m_a: "read", m_b: "read" })
+
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_b")
+  })
+
+  it("does not pin when compaction drops overlay ids while advancing the watermark", () => {
+    const messages = [msg("m_a", 0, "5"), msg("m_b", 1, "6")]
+    messages.forEach((m) => addRow(m.id))
+    readTruth[ROOT] = { lastReadSequence: "4", readMessageIds: ["m_a"] }
+    const { rerender } = mount(messages, { m_a: "read", m_b: "unread" })
+
+    // Compaction: the overlay id is absorbed, the watermark advances past it.
+    readTruth[ROOT] = { lastReadSequence: "5", readMessageIds: [] }
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "unread" }) })
+
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("m_b")
   })
 
   it("pins synchronously when the menu mark-unread fires, cancelling a pending debounce", () => {
@@ -276,18 +339,22 @@ describe("useConversationAutoRead", () => {
   })
 
   it("pins on a regression that lands while attention is off, so refocus does not undo it", () => {
-    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    const messages = [msg("m_a", 0, "1"), msg("m_b", 1, "2")]
     messages.forEach((m) => addRow(m.id))
+    readTruth[ROOT] = { lastReadSequence: "0", readMessageIds: [] }
     const { rerender } = mount(messages, { m_a: "unread", m_b: "unread" })
 
     enter("m_a", "m_b")
     settle()
     expect(markRead).toHaveBeenCalledTimes(1)
+    readTruth[ROOT] = { lastReadSequence: "2", readMessageIds: [] }
     rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read" }) })
 
-    // Attention drops (observer torn down), then another device marks unread.
+    // Attention drops (observer torn down), then another device marks unread
+    // from m_a — the watermark regresses.
     attention = false
     rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read" }) })
+    readTruth[ROOT] = { lastReadSequence: "0", readMessageIds: [] }
     rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
 
     // Refocus: the rebuilt observer's initial entries report the rows still on

--- a/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.test.tsx
@@ -52,6 +52,7 @@ let attention = true
 
 function addRow(id: string) {
   const el = document.createElement("div")
+  el.dataset.messageRow = ""
   el.dataset.messageId = id
   container.appendChild(el)
   rowEls.set(id, el)
@@ -89,6 +90,13 @@ function settle() {
 
 const markRead = vi.fn<(messageId: string) => Promise<void>>()
 
+/** Captures the pin the hook registers, standing in for the controller's
+ * `setExplicitUnreadListener`; tests invoke it to simulate the menu action. */
+let explicitUnreadPin: (() => void) | null = null
+const registerExplicitUnread = (listener: (() => void) | null) => {
+  explicitUnreadPin = listener
+}
+
 function mount(messages: RenderableMessage[], states: Record<string, RowReadState>) {
   const containerRef = { current: container }
   return renderHook(
@@ -99,6 +107,7 @@ function mount(messages: RenderableMessage[], states: Record<string, RowReadStat
         rootStreamId: ROOT,
         rowState: props.rowState,
         markRead,
+        registerExplicitUnread,
       }),
     { initialProps: { messages, rowState: makeRowState(states) } }
   )
@@ -110,6 +119,7 @@ beforeEach(() => {
   FakeIntersectionObserver.instances = []
   rowEls.clear()
   attention = true
+  explicitUnreadPin = null
   markRead.mockReset()
   markRead.mockResolvedValue(undefined)
   vi.spyOn(autoMarkModule, "useAutoReadAttention").mockImplementation(() => attention)
@@ -192,6 +202,21 @@ describe("useConversationAutoRead", () => {
     expect(markRead).toHaveBeenCalledWith("m_a")
   })
 
+  it("only observes message rows — an editor node carrying an eligible data-message-id is not observed", () => {
+    // A quote-reply/in-app-link node in the card's composer renders
+    // data-message-id for an eligible row; without the data-message-row scope it
+    // would dwell beside the cursor and mark rows never on screen.
+    const messages = [msg("m_a", 0)]
+    addRow("m_a")
+    const quoteNode = document.createElement("span")
+    quoteNode.dataset.messageId = "m_a"
+    container.appendChild(quoteNode)
+    mount(messages, { m_a: "unread" })
+
+    expect(io().observed.has(rowEls.get("m_a")!)).toBe(true)
+    expect(io().observed.has(quoteNode)).toBe(false)
+  })
+
   it("pins after a read → unread regression: no re-mark while the rows stay on screen, resumes after leave + re-enter", () => {
     const messages = [msg("m_a", 0), msg("m_b", 1), msg("m_c", 2)]
     messages.forEach((m) => addRow(m.id))
@@ -228,6 +253,56 @@ describe("useConversationAutoRead", () => {
     settle()
     expect(markRead).toHaveBeenCalledTimes(2)
     expect(markRead).toHaveBeenLastCalledWith("m_d")
+  })
+
+  it("pins synchronously when the menu mark-unread fires, cancelling a pending debounce", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    mount(messages, { m_a: "read", m_b: "unread" })
+
+    enter("m_a", "m_b")
+    advance(1_100) // dwell done, debounce pending
+    // The user marks m_a unread; the controller invokes the registered pin
+    // before its request departs — the pending debounce must not fire.
+    act(() => explicitUnreadPin!())
+    advance(10_000)
+    expect(markRead).not.toHaveBeenCalled()
+
+    // Leave-and-return releases the pin and re-reads deliberately.
+    leave("m_a", "m_b")
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledWith("m_b")
+  })
+
+  it("pins on a regression that lands while attention is off, so refocus does not undo it", () => {
+    const messages = [msg("m_a", 0), msg("m_b", 1)]
+    messages.forEach((m) => addRow(m.id))
+    const { rerender } = mount(messages, { m_a: "unread", m_b: "unread" })
+
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(1)
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read" }) })
+
+    // Attention drops (observer torn down), then another device marks unread.
+    attention = false
+    rerender({ messages, rowState: makeRowState({ m_a: "read", m_b: "read" }) })
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+
+    // Refocus: the rebuilt observer's initial entries report the rows still on
+    // screen — they must stay pinned, not dwell into a re-mark.
+    attention = true
+    rerender({ messages, rowState: makeRowState({ m_a: "unread", m_b: "unread" }) })
+    enter("m_a", "m_b")
+    advance(10_000)
+    expect(markRead).toHaveBeenCalledTimes(1)
+
+    leave("m_a", "m_b")
+    enter("m_a", "m_b")
+    settle()
+    expect(markRead).toHaveBeenCalledTimes(2)
+    expect(markRead).toHaveBeenLastCalledWith("m_b")
   })
 
   it("does not observe at all while the viewer's attention is off the page", () => {

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -4,6 +4,18 @@ import type { RowReadState } from "@/components/timeline/read-frontier-context"
 import type { ConversationRowRead } from "@/components/message/conversation-read-context"
 import type { RenderableMessage } from "@/components/message/message-item"
 
+/**
+ * Flag-gated tracer (`window.__threaAutoReadDebug = true`, then reload) — the
+ * whole pipeline is invisible timers and observer callbacks, so a staging "it
+ * didn't mark" report is undiagnosable without seeing which stage stopped
+ * (armed → seen → evaluate → fire). Mirrors `deepLinkDebug` in stream-content.
+ */
+function autoReadDebug(...args: unknown[]) {
+  if (typeof window !== "undefined" && (window as { __threaAutoReadDebug?: boolean }).__threaAutoReadDebug) {
+    console.debug("[auto-read]", ...args)
+  }
+}
+
 /** A row is "seen" once any part of it has stayed in the viewport this long
  * while the viewer's attention is on the page. */
 const DWELL_MS = 1_000
@@ -114,13 +126,19 @@ export function useConversationAutoRead({
     debounceRef.current = null
     // An active pin blocks firing entirely (not just for the pinned rows): the
     // cutoff means marking through ANY newer row would undo the explicit unread.
-    if (suppressedRef.current.size > 0) return
+    if (suppressedRef.current.size > 0) {
+      autoReadDebug("evaluate: pinned", { suppressed: [...suppressedRef.current] })
+      return
+    }
     const rows = eligibleRef.current
     let targetIdx = -1
     for (let i = 0; i < rows.length; i++) {
       if (seenRef.current.has(rows[i].id)) targetIdx = i
     }
-    if (targetIdx < 0) return
+    if (targetIdx < 0) {
+      autoReadDebug("evaluate: nothing seen", { eligible: rows.map((m) => m.id) })
+      return
+    }
     const target = rows[targetIdx]
     if (lastMarkedRef.current === target.id) return
     // Fire only when the cutoff would actually read something: any row at/below
@@ -130,9 +148,17 @@ export function useConversationAutoRead({
     for (let i = 0; i <= targetIdx && !anyUnread; i++) {
       if (stateOf(rows[i]) === "unread") anyUnread = true
     }
-    if (!anyUnread) return
+    if (!anyUnread) {
+      autoReadDebug("evaluate: nothing unread at/below target", {
+        target: target.id,
+        states: rows.slice(0, targetIdx + 1).map((m) => `${m.id}=${stateOf(m)}`),
+      })
+      return
+    }
+    autoReadDebug("evaluate: firing markRead", { target: target.id })
     lastMarkedRef.current = target.id
-    markReadRef.current(target.id).catch(() => {
+    markReadRef.current(target.id).catch((err) => {
+      autoReadDebug("markRead failed", err)
       // Background action: fail silently; releasing the dedup lets the next
       // evaluation retry.
       if (lastMarkedRef.current === target.id) lastMarkedRef.current = null
@@ -148,6 +174,7 @@ export function useConversationAutoRead({
    * the dedup (after the pin lifts, re-reading may legitimately re-target the
    * same newest row), and suppress every eligible row. */
   const pin = useCallback(() => {
+    autoReadDebug("pin engaged")
     seenRef.current.clear()
     for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
     dwellTimersRef.current.clear()
@@ -180,7 +207,10 @@ export function useConversationAutoRead({
   // the rebuild's initial entries restart dwells for rows still on screen.
   // Already-seen rows stay seen across rebuilds — they were legitimately read.
   useEffect(() => {
-    if (!canAutoRead || eligibleIdsKey === "") return
+    if (!canAutoRead || eligibleIdsKey === "") {
+      autoReadDebug("observer: off", { canAutoRead, eligible: eligibleIdsKey })
+      return
+    }
     // jsdom (and any environment without IO) — auto-read simply stays off, the
     // same soft degradation as useLastSeenEvent's ResizeObserver guard.
     if (typeof IntersectionObserver === "undefined") return
@@ -199,6 +229,7 @@ export function useConversationAutoRead({
             setTimeout(() => {
               dwellTimersRef.current.delete(id)
               seenRef.current.add(id)
+              autoReadDebug("seen", { id })
               scheduleEvaluate()
             }, DWELL_MS)
           )
@@ -211,10 +242,15 @@ export function useConversationAutoRead({
         }
       }
     })
+    let observed = 0
     for (const el of container.querySelectorAll<HTMLElement>("[data-message-row]")) {
       const id = el.dataset.messageId
-      if (id && eligibleIds.has(id)) io.observe(el)
+      if (id && eligibleIds.has(id)) {
+        io.observe(el)
+        observed++
+      }
     }
+    autoReadDebug("observer: armed", { eligible: [...eligibleIds], observed })
     return () => {
       io.disconnect()
       for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -14,7 +14,10 @@ const DEBOUNCE_MS = 2_000
 
 interface UseConversationAutoReadOptions {
   /** Wraps this surface's rendered `MessageItem` rows (the board card's root, the
-   * panel's scroller) — rows are found by their `data-message-id` attribute. */
+   * panel's scroller). Rows are matched by `data-message-row` — NOT bare
+   * `data-message-id`, which editor nodes (quote reply, in-app links) also render
+   * inside a composer that may live in this container; observing those would let
+   * a quoted message "dwell" beside the cursor and mark rows never on screen. */
   containerRef: React.RefObject<HTMLElement | null>
   /**
    * The rows eligible for auto-read, chronological: the contiguous-from-the-start
@@ -25,7 +28,8 @@ interface UseConversationAutoReadOptions {
    * not be referentially stable; effects key on the id set.
    */
   messages: RenderableMessage[]
-  /** Fallback stream for rows without their own `streamId`, as row rendering. */
+  /** Fallback stream for rows without their own `streamId` — the same fallback
+   * the hosts pass when rendering the row. */
   rootStreamId: string
   /** The controller's per-row derivation — auto-read fires only when something
    * at/below the target is effectively unread, so it is idempotent against the
@@ -33,7 +37,11 @@ interface UseConversationAutoReadOptions {
   rowState: ConversationRowRead["state"]
   /** The silent mark-read mutation (`markReadSilently` off the controller). */
   markRead: (messageId: string) => Promise<void>
-  enabled?: boolean
+  /** The controller's `setExplicitUnreadListener`: lets the menu "Mark as
+   * unread" pin this hook synchronously BEFORE its request departs — a pending
+   * dwell-scheduled mark-read firing mid-flight would otherwise cutoff right
+   * back over the explicit unread, with server arrival order deciding. */
+  registerExplicitUnread: (listener: (() => void) | null) => void
 }
 
 /**
@@ -52,13 +60,20 @@ interface UseConversationAutoReadOptions {
  *   their dwell are covered by the cutoff — the viewer scrolled past them
  *   inside a run they were reading, the same acceptance as the timeline's
  *   partial reads.
- * - Mark-as-unread pins: when any eligible row regresses read → unread (the
- *   viewer's explicit action, here or on another device), everything unseen-s
- *   and the rows still on screen are suppressed — auto-read holds entirely
- *   until every suppressed row has left the viewport (the timeline's
- *   `pinnedRef`, with leave-and-return as the resume gesture instead of a
- *   scroll, which a small card doesn't have). Without the full hold, a newer
- *   row dwelling would cutoff-mark right back over the explicit unread.
+ * - Mark-as-unread pins (the timeline's `pinnedRef`, with leave-and-return as
+ *   the resume gesture instead of a scroll, which a small card doesn't have):
+ *   an explicit unread — the controller's synchronous signal, or a
+ *   read → unread regression from another device — unsees everything and
+ *   suppresses EVERY eligible row, holding auto-read entirely until the
+ *   suppressions release. All of them, not just the currently-visible set:
+ *   visibility is unknowable across observer teardowns (attention loss, id-set
+ *   changes), and under-suppressing would let a still-on-screen row dwell and
+ *   cutoff-mark right back over the explicit unread. Each row's suppression
+ *   releases when the observer reports it off-screen — immediately for rows
+ *   that weren't visible, on leave for the ones that were.
+ * - A pending debounce fires on unmount, and without re-checking attention:
+ *   the dwell already happened while the viewer was attending, so the read is
+ *   real — only the batching timer is late.
  * - Optimistic `temp_` rows are never targets (the id doesn't exist
  *   server-side yet); their confirmed swap re-enters normally.
  */
@@ -68,7 +83,7 @@ export function useConversationAutoRead({
   rootStreamId,
   rowState,
   markRead,
-  enabled = true,
+  registerExplicitUnread,
 }: UseConversationAutoReadOptions): void {
   const canAutoRead = useAutoReadAttention()
 
@@ -82,12 +97,9 @@ export function useConversationAutoRead({
   rootStreamIdRef.current = rootStreamId
   const markReadRef = useRef(markRead)
   markReadRef.current = markRead
-  const enabledRef = useRef(enabled)
-  enabledRef.current = enabled
 
   const seenRef = useRef(new Set<string>())
   const suppressedRef = useRef(new Set<string>())
-  const visibleRef = useRef(new Set<string>())
   const dwellTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>())
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
@@ -100,7 +112,6 @@ export function useConversationAutoRead({
 
   const evaluate = useCallback(() => {
     debounceRef.current = null
-    if (!enabledRef.current) return
     // An active pin blocks firing entirely (not just for the pinned rows): the
     // cutoff means marking through ANY newer row would undo the explicit unread.
     if (suppressedRef.current.size > 0) return
@@ -133,6 +144,29 @@ export function useConversationAutoRead({
     debounceRef.current = setTimeout(evaluate, DEBOUNCE_MS)
   }, [evaluate])
 
+  /** Engage the mark-unread pin: unsee everything, cancel pending work, release
+   * the dedup (after the pin lifts, re-reading may legitimately re-target the
+   * same newest row), and suppress every eligible row. */
+  const pin = useCallback(() => {
+    seenRef.current.clear()
+    for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
+    dwellTimersRef.current.clear()
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    lastMarkedRef.current = null
+    for (const m of eligibleRef.current) suppressedRef.current.add(m.id)
+  }, [])
+
+  // The controller invokes this synchronously at the top of the menu "Mark as
+  // unread", before the request departs — closing the window where a pending
+  // debounce could race the in-flight unread.
+  useEffect(() => {
+    registerExplicitUnread(pin)
+    return () => registerExplicitUnread(null)
+  }, [registerExplicitUnread, pin])
+
   const cancelDwell = (id: string) => {
     const timer = dwellTimersRef.current.get(id)
     if (timer) {
@@ -146,7 +180,7 @@ export function useConversationAutoRead({
   // the rebuild's initial entries restart dwells for rows still on screen.
   // Already-seen rows stay seen across rebuilds — they were legitimately read.
   useEffect(() => {
-    if (!enabled || !canAutoRead || eligibleIdsKey === "") return
+    if (!canAutoRead || eligibleIdsKey === "") return
     // jsdom (and any environment without IO) — auto-read simply stays off, the
     // same soft degradation as useLastSeenEvent's ResizeObserver guard.
     if (typeof IntersectionObserver === "undefined") return
@@ -158,7 +192,6 @@ export function useConversationAutoRead({
         const id = (entry.target as HTMLElement).dataset.messageId
         if (!id) continue
         if (entry.isIntersecting) {
-          visibleRef.current.add(id)
           if (seenRef.current.has(id) || suppressedRef.current.has(id)) continue
           if (dwellTimersRef.current.has(id)) continue
           dwellTimersRef.current.set(
@@ -170,14 +203,15 @@ export function useConversationAutoRead({
             }, DWELL_MS)
           )
         } else {
-          visibleRef.current.delete(id)
-          // Leaving the viewport is the pin's release gesture for this row.
+          // Off-screen is the pin's release gesture for this row — a genuine
+          // leave, or a rebuild's initial entries reporting it was never
+          // visible at all.
           suppressedRef.current.delete(id)
           cancelDwell(id)
         }
       }
     })
-    for (const el of container.querySelectorAll<HTMLElement>("[data-message-id]")) {
+    for (const el of container.querySelectorAll<HTMLElement>("[data-message-row]")) {
       const id = el.dataset.messageId
       if (id && eligibleIds.has(id)) io.observe(el)
     }
@@ -185,16 +219,13 @@ export function useConversationAutoRead({
       io.disconnect()
       for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
       dwellTimersRef.current.clear()
-      // Visibility is unknowable while unobserved; the rebuild's initial
-      // entries repopulate it (and release pins for rows that left meanwhile).
-      visibleRef.current.clear()
     }
-  }, [enabled, canAutoRead, eligibleIdsKey, containerRef, scheduleEvaluate])
+  }, [canAutoRead, eligibleIdsKey, containerRef, scheduleEvaluate])
 
-  // The mark-unread pin. Watches per-row state for a read → unread regression —
-  // the viewer's explicit action (menu here, or another device) — and freezes
-  // auto-read: everything unseen-s, pending work cancels, and every row still on
-  // screen is suppressed until it leaves the viewport. First run only baselines.
+  // The cross-device arm of the pin: watches per-row state for a read → unread
+  // regression (a mark-unread applied elsewhere — the local menu action pins
+  // synchronously via registerExplicitUnread above, without waiting for its
+  // snapshot to land). First run only baselines.
   const prevStatesRef = useRef<Map<string, RowReadState> | null>(null)
   useEffect(() => {
     const next = new Map<string, RowReadState>()
@@ -206,26 +237,13 @@ export function useConversationAutoRead({
     for (const id of suppressedRef.current) if (!next.has(id)) suppressedRef.current.delete(id)
     for (const id of seenRef.current) if (!next.has(id)) seenRef.current.delete(id)
     if (!prev) return
-    let regressed = false
     for (const [id, state] of next) {
       if (state === "unread" && prev.get(id) === "read") {
-        regressed = true
-        break
+        pin()
+        return
       }
     }
-    if (!regressed) return
-    seenRef.current.clear()
-    for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
-    dwellTimersRef.current.clear()
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current)
-      debounceRef.current = null
-    }
-    // Release the dedup too: after the pin lifts, re-reading may legitimately
-    // re-target the same newest row.
-    lastMarkedRef.current = null
-    for (const id of visibleRef.current) suppressedRef.current.add(id)
-  }, [rowState, eligibleIdsKey, rootStreamId, stateOf])
+  }, [rowState, eligibleIdsKey, rootStreamId, stateOf, pin])
 
   // Flush a pending debounce on unmount (panel closed, card scrolled out of the
   // board's window mid-read) — the rows were seen; losing the mark to the

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useRef } from "react"
+import { useAutoReadAttention } from "@/hooks/use-auto-mark-as-read"
+import type { RowReadState } from "@/components/timeline/read-frontier-context"
+import type { ConversationRowRead } from "@/components/message/conversation-read-context"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/** A row is "seen" once any part of it has stayed in the viewport this long
+ * while the viewer's attention is on the page. */
+const DWELL_MS = 1_000
+
+/** Seen rows batch into one mark-read call per conversation — a trailing
+ * debounce, so reading down a card coalesces instead of firing per row. */
+const DEBOUNCE_MS = 2_000
+
+interface UseConversationAutoReadOptions {
+  /** Wraps this surface's rendered `MessageItem` rows (the board card's root, the
+   * panel's scroller) — rows are found by their `data-message-id` attribute. */
+  containerRef: React.RefObject<HTMLElement | null>
+  /**
+   * The rows eligible for auto-read, chronological: the contiguous-from-the-start
+   * run of the conversation the surface is actually showing. A collapsed board
+   * card with an "N more" gap passes only the opening — marking is a `createdAt`
+   * cutoff (ConversationService.markRead), so marking through a row past the gap
+   * would silently read the hidden middle the viewer never saw. The array need
+   * not be referentially stable; effects key on the id set.
+   */
+  messages: RenderableMessage[]
+  /** Fallback stream for rows without their own `streamId`, as row rendering. */
+  rootStreamId: string
+  /** The controller's per-row derivation — auto-read fires only when something
+   * at/below the target is effectively unread, so it is idempotent against the
+   * overlay/watermark state and never loops. */
+  rowState: ConversationRowRead["state"]
+  /** The silent mark-read mutation (`markReadSilently` off the controller). */
+  markRead: (messageId: string) => Promise<void>
+  enabled?: boolean
+}
+
+/**
+ * Viewport auto-read for a conversation surface (board card, conversation
+ * panel): reading IS marking. A row that dwells in the viewport for a beat
+ * while the tab has the viewer's attention becomes "seen"; seen rows debounce
+ * into one conversation mark-read through the newest seen row (the same
+ * cutoff API as the menu action). The explicit menu actions remain as the
+ * override.
+ *
+ * Semantics, mirroring the stream timeline's auto-read where they map:
+ * - A row counts as visible when ANY part of it intersects the viewport (a row
+ *   taller than the viewport still counts) — `pickVisibleRange` semantics; the
+ *   dwell requirement is what keeps a scroll-past from marking.
+ * - Marking runs through the FURTHEST seen row. Rows above it that never got
+ *   their dwell are covered by the cutoff — the viewer scrolled past them
+ *   inside a run they were reading, the same acceptance as the timeline's
+ *   partial reads.
+ * - Mark-as-unread pins: when any eligible row regresses read → unread (the
+ *   viewer's explicit action, here or on another device), everything unseen-s
+ *   and the rows still on screen are suppressed — auto-read holds entirely
+ *   until every suppressed row has left the viewport (the timeline's
+ *   `pinnedRef`, with leave-and-return as the resume gesture instead of a
+ *   scroll, which a small card doesn't have). Without the full hold, a newer
+ *   row dwelling would cutoff-mark right back over the explicit unread.
+ * - Optimistic `temp_` rows are never targets (the id doesn't exist
+ *   server-side yet); their confirmed swap re-enters normally.
+ */
+export function useConversationAutoRead({
+  containerRef,
+  messages,
+  rootStreamId,
+  rowState,
+  markRead,
+  enabled = true,
+}: UseConversationAutoReadOptions): void {
+  const canAutoRead = useAutoReadAttention()
+
+  const eligible = messages.filter((m) => !m.id.startsWith("temp_"))
+  const eligibleIdsKey = eligible.map((m) => m.id).join(",")
+  const eligibleRef = useRef(eligible)
+  eligibleRef.current = eligible
+  const rowStateRef = useRef(rowState)
+  rowStateRef.current = rowState
+  const rootStreamIdRef = useRef(rootStreamId)
+  rootStreamIdRef.current = rootStreamId
+  const markReadRef = useRef(markRead)
+  markReadRef.current = markRead
+  const enabledRef = useRef(enabled)
+  enabledRef.current = enabled
+
+  const seenRef = useRef(new Set<string>())
+  const suppressedRef = useRef(new Set<string>())
+  const visibleRef = useRef(new Set<string>())
+  const dwellTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>())
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastMarkedRef = useRef<string | null>(null)
+
+  const stateOf = useCallback(
+    (m: RenderableMessage): RowReadState =>
+      rowStateRef.current(m.streamId ?? rootStreamIdRef.current, m.id, m.sequence, m.createdAt),
+    []
+  )
+
+  const evaluate = useCallback(() => {
+    debounceRef.current = null
+    if (!enabledRef.current) return
+    // An active pin blocks firing entirely (not just for the pinned rows): the
+    // cutoff means marking through ANY newer row would undo the explicit unread.
+    if (suppressedRef.current.size > 0) return
+    const rows = eligibleRef.current
+    let targetIdx = -1
+    for (let i = 0; i < rows.length; i++) {
+      if (seenRef.current.has(rows[i].id)) targetIdx = i
+    }
+    if (targetIdx < 0) return
+    const target = rows[targetIdx]
+    if (lastMarkedRef.current === target.id) return
+    // Fire only when the cutoff would actually read something: any row at/below
+    // the target effectively unread. All-read (another device, a prior mark) and
+    // all-ungated (no resolvable frontier) both no-op.
+    let anyUnread = false
+    for (let i = 0; i <= targetIdx && !anyUnread; i++) {
+      if (stateOf(rows[i]) === "unread") anyUnread = true
+    }
+    if (!anyUnread) return
+    lastMarkedRef.current = target.id
+    markReadRef.current(target.id).catch(() => {
+      // Background action: fail silently; releasing the dedup lets the next
+      // evaluation retry.
+      if (lastMarkedRef.current === target.id) lastMarkedRef.current = null
+    })
+  }, [stateOf])
+
+  const scheduleEvaluate = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(evaluate, DEBOUNCE_MS)
+  }, [evaluate])
+
+  const cancelDwell = (id: string) => {
+    const timer = dwellTimersRef.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      dwellTimersRef.current.delete(id)
+    }
+  }
+
+  // The observer: dwell timers start on enter, cancel on leave. Torn down (with
+  // all pending dwells) whenever attention drops or the eligible set changes;
+  // the rebuild's initial entries restart dwells for rows still on screen.
+  // Already-seen rows stay seen across rebuilds — they were legitimately read.
+  useEffect(() => {
+    if (!enabled || !canAutoRead || eligibleIdsKey === "") return
+    // jsdom (and any environment without IO) — auto-read simply stays off, the
+    // same soft degradation as useLastSeenEvent's ResizeObserver guard.
+    if (typeof IntersectionObserver === "undefined") return
+    const container = containerRef.current
+    if (!container) return
+    const eligibleIds = new Set(eligibleRef.current.map((m) => m.id))
+    const io = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const id = (entry.target as HTMLElement).dataset.messageId
+        if (!id) continue
+        if (entry.isIntersecting) {
+          visibleRef.current.add(id)
+          if (seenRef.current.has(id) || suppressedRef.current.has(id)) continue
+          if (dwellTimersRef.current.has(id)) continue
+          dwellTimersRef.current.set(
+            id,
+            setTimeout(() => {
+              dwellTimersRef.current.delete(id)
+              seenRef.current.add(id)
+              scheduleEvaluate()
+            }, DWELL_MS)
+          )
+        } else {
+          visibleRef.current.delete(id)
+          // Leaving the viewport is the pin's release gesture for this row.
+          suppressedRef.current.delete(id)
+          cancelDwell(id)
+        }
+      }
+    })
+    for (const el of container.querySelectorAll<HTMLElement>("[data-message-id]")) {
+      const id = el.dataset.messageId
+      if (id && eligibleIds.has(id)) io.observe(el)
+    }
+    return () => {
+      io.disconnect()
+      for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
+      dwellTimersRef.current.clear()
+      // Visibility is unknowable while unobserved; the rebuild's initial
+      // entries repopulate it (and release pins for rows that left meanwhile).
+      visibleRef.current.clear()
+    }
+  }, [enabled, canAutoRead, eligibleIdsKey, containerRef, scheduleEvaluate])
+
+  // The mark-unread pin. Watches per-row state for a read → unread regression —
+  // the viewer's explicit action (menu here, or another device) — and freezes
+  // auto-read: everything unseen-s, pending work cancels, and every row still on
+  // screen is suppressed until it leaves the viewport. First run only baselines.
+  const prevStatesRef = useRef<Map<string, RowReadState> | null>(null)
+  useEffect(() => {
+    const next = new Map<string, RowReadState>()
+    for (const m of eligibleRef.current) next.set(m.id, stateOf(m))
+    const prev = prevStatesRef.current
+    prevStatesRef.current = next
+    // Rows that left the conversation (deleted, re-clustered) can't hold a pin
+    // or a seen slot forever.
+    for (const id of suppressedRef.current) if (!next.has(id)) suppressedRef.current.delete(id)
+    for (const id of seenRef.current) if (!next.has(id)) seenRef.current.delete(id)
+    if (!prev) return
+    let regressed = false
+    for (const [id, state] of next) {
+      if (state === "unread" && prev.get(id) === "read") {
+        regressed = true
+        break
+      }
+    }
+    if (!regressed) return
+    seenRef.current.clear()
+    for (const timer of dwellTimersRef.current.values()) clearTimeout(timer)
+    dwellTimersRef.current.clear()
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    // Release the dedup too: after the pin lifts, re-reading may legitimately
+    // re-target the same newest row.
+    lastMarkedRef.current = null
+    for (const id of visibleRef.current) suppressedRef.current.add(id)
+  }, [rowState, eligibleIdsKey, rootStreamId, stateOf])
+
+  // Flush a pending debounce on unmount (panel closed, card scrolled out of the
+  // board's window mid-read) — the rows were seen; losing the mark to the
+  // trailing debounce would resurface them unread on the next visit.
+  useEffect(
+    () => () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current)
+        evaluate()
+      }
+    },
+    [evaluate]
+  )
+}

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -55,6 +55,10 @@ interface UseConversationAutoReadOptions {
    * dwell-scheduled mark-read firing mid-flight would otherwise cutoff right
    * back over the explicit unread, with server arrival order deciding. */
   registerExplicitUnread: (listener: (() => void) | null) => void
+  /** The controller's `getReadTruth`: raw per-stream watermark sequence +
+   * overlay ids, diffed to catch a cross-device mark-unread. See the pin notes
+   * on the hook doc for why this is raw truth and not derived row state. */
+  getReadTruth: (streamId: string) => { lastReadSequence: string | null; readMessageIds: readonly string[] }
 }
 
 /**
@@ -75,12 +79,20 @@ interface UseConversationAutoReadOptions {
  *   partial reads.
  * - Mark-as-unread pins (the timeline's `pinnedRef`, with leave-and-return as
  *   the resume gesture instead of a scroll, which a small card doesn't have):
- *   an explicit unread — the controller's synchronous signal, or a
- *   read → unread regression from another device — unsees everything and
- *   suppresses EVERY eligible row, holding auto-read entirely until the
- *   suppressions release. All of them, not just the currently-visible set:
- *   visibility is unknowable across observer teardowns (attention loss, id-set
- *   changes), and under-suppressing would let a still-on-screen row dwell and
+ *   an explicit unread — the controller's synchronous signal, or a RAW
+ *   read-truth regression from another device (watermark sequence decreasing,
+ *   or overlay ids removed without a compensating watermark advance, on a row
+ *   this surface shows) — unsees everything and suppresses EVERY eligible
+ *   row, holding auto-read entirely until the suppressions release. The
+ *   cross-device arm deliberately watches raw primitives, never derived row
+ *   state: derivation flaps (the `unreadCounts === 0` short-circuit falling
+ *   back to a stale frontier when a count leaves zero, a stale `lastReadAt`
+ *   time fallback after compaction) would read as mass regressions and
+ *   false-pin — and a pinned card on a static board never releases, wedging
+ *   auto-read (first dogfood's board failure). Suppression covers all
+ *   eligible rows, not just the currently-visible set: visibility is
+ *   unknowable across observer teardowns (attention loss, id-set changes),
+ *   and under-suppressing would let a still-on-screen row dwell and
  *   cutoff-mark right back over the explicit unread. Each row's suppression
  *   releases when the observer reports it off-screen — immediately for rows
  *   that weren't visible, on leave for the ones that were.
@@ -97,6 +109,7 @@ export function useConversationAutoRead({
   rowState,
   markRead,
   registerExplicitUnread,
+  getReadTruth,
 }: UseConversationAutoReadOptions): void {
   const canAutoRead = useAutoReadAttention()
 
@@ -259,28 +272,66 @@ export function useConversationAutoRead({
     }
   }, [canAutoRead, eligibleIdsKey, containerRef, scheduleEvaluate])
 
-  // The cross-device arm of the pin: watches per-row state for a read → unread
-  // regression (a mark-unread applied elsewhere — the local menu action pins
-  // synchronously via registerExplicitUnread above, without waiting for its
-  // snapshot to land). First run only baselines.
-  const prevStatesRef = useRef<Map<string, RowReadState> | null>(null)
+  // The cross-device arm of the pin: diff RAW per-stream read truth (the local
+  // menu action pins synchronously via registerExplicitUnread above, without
+  // waiting for its snapshot to land). A stream regresses when its watermark
+  // sequence decreases, or when overlay ids vanish without the watermark
+  // advancing (compaction drops ids but always advances; a message move drops
+  // ids but the row leaves the stream too). Pin only when the regression
+  // exposes a row THIS surface shows: previously covered by the old truth
+  // (id in the old overlay, or sequence at/below the old watermark) and now
+  // deriving unread — that is an actual mark-unread of on-surface content, not
+  // a move artifact. First run only baselines. Derived row state is NEVER the
+  // trigger — see the pin notes above.
+  const prevTruthRef = useRef<Map<string, { seq: bigint | null; overlay: Set<string> }> | null>(null)
   useEffect(() => {
-    const next = new Map<string, RowReadState>()
-    for (const m of eligibleRef.current) next.set(m.id, stateOf(m))
-    const prev = prevStatesRef.current
-    prevStatesRef.current = next
+    const eligibleIds = new Set(eligibleRef.current.map((m) => m.id))
     // Rows that left the conversation (deleted, re-clustered) can't hold a pin
     // or a seen slot forever.
-    for (const id of suppressedRef.current) if (!next.has(id)) suppressedRef.current.delete(id)
-    for (const id of seenRef.current) if (!next.has(id)) seenRef.current.delete(id)
+    for (const id of suppressedRef.current) if (!eligibleIds.has(id)) suppressedRef.current.delete(id)
+    for (const id of seenRef.current) if (!eligibleIds.has(id)) seenRef.current.delete(id)
+
+    const streamIds = new Set<string>([rootStreamIdRef.current])
+    for (const m of eligibleRef.current) if (m.streamId) streamIds.add(m.streamId)
+    const next = new Map<string, { seq: bigint | null; overlay: Set<string> }>()
+    for (const streamId of streamIds) {
+      const truth = getReadTruth(streamId)
+      next.set(streamId, {
+        seq: truth.lastReadSequence != null ? BigInt(truth.lastReadSequence) : null,
+        overlay: new Set(truth.readMessageIds),
+      })
+    }
+    const prev = prevTruthRef.current
+    prevTruthRef.current = next
     if (!prev) return
-    for (const [id, state] of next) {
-      if (state === "unread" && prev.get(id) === "read") {
-        pin()
-        return
+
+    for (const [streamId, truth] of next) {
+      const before = prev.get(streamId)
+      if (!before) continue
+      const seqRegressed = truth.seq != null && before.seq != null && truth.seq < before.seq
+      const advanced = truth.seq != null && before.seq != null && truth.seq > before.seq
+      let overlayDropped = false
+      if (!advanced) {
+        for (const id of before.overlay) {
+          if (!truth.overlay.has(id)) {
+            overlayDropped = true
+            break
+          }
+        }
+      }
+      if (!seqRegressed && !overlayDropped) continue
+      for (const m of eligibleRef.current) {
+        if ((m.streamId ?? rootStreamIdRef.current) !== streamId) continue
+        const wasCovered =
+          before.overlay.has(m.id) || (m.sequence != null && before.seq != null && BigInt(m.sequence) <= before.seq)
+        if (wasCovered && stateOf(m) === "unread") {
+          autoReadDebug("pin: read-truth regression", { streamId, row: m.id })
+          pin()
+          return
+        }
       }
     }
-  }, [rowState, eligibleIdsKey, rootStreamId, stateOf, pin])
+  }, [rowState, eligibleIdsKey, rootStreamId, getReadTruth, stateOf, pin])
 
   // Flush a pending debounce on unmount (panel closed, card scrolled out of the
   // board's window mid-read) — the rows were seen; losing the mark to the

--- a/apps/frontend/src/components/message/use-conversation-auto-read.ts
+++ b/apps/frontend/src/components/message/use-conversation-auto-read.ts
@@ -32,12 +32,13 @@ interface UseConversationAutoReadOptions {
    * a quoted message "dwell" beside the cursor and mark rows never on screen. */
   containerRef: React.RefObject<HTMLElement | null>
   /**
-   * The rows eligible for auto-read, chronological: the contiguous-from-the-start
-   * run of the conversation the surface is actually showing. A collapsed board
-   * card with an "N more" gap passes only the opening — marking is a `createdAt`
-   * cutoff (ConversationService.markRead), so marking through a row past the gap
-   * would silently read the hidden middle the viewer never saw. The array need
-   * not be referentially stable; effects key on the id set.
+   * The rows eligible for auto-read: the surface's rendered rows, chronological.
+   * Marking is a `createdAt` cutoff (ConversationService.markRead), so a mark
+   * through a rendered row also covers older rows the surface is hiding (a
+   * collapsed card's "N more" middle, a panel's still-backfilling older
+   * replies) — deliberate: reading a conversation's visible tail reads it up to
+   * there, the same contract as the menu's "Mark as read up to here" on that
+   * row. The array need not be referentially stable; effects key on the id set.
    */
   messages: RenderableMessage[]
   /** Fallback stream for rows without their own `streamId` — the same fallback

--- a/apps/frontend/src/hooks/use-auto-mark-as-read.ts
+++ b/apps/frontend/src/hooks/use-auto-mark-as-read.ts
@@ -18,6 +18,28 @@ interface UseAutoMarkAsReadOptions {
 }
 
 /**
+ * Whether the viewer's attention is plausibly on this page — the shared gate for
+ * every auto-read surface (stream timeline here, conversation surfaces via
+ * `useConversationAutoRead`). Focus tells you which of several overlapping
+ * windows the user is working in — a fine-pointer, multi-window (desktop)
+ * signal. On a phone-like device (coarse pointer AND a phone-width viewport)
+ * `document.hasFocus()` is an unreliable proxy for attention: mobile browsers
+ * and installed PWAs routinely report no focus while the page is the
+ * foreground, and the resume `focus` event often never fires — so there a
+ * visible page is "active". A coarse-but-wide device (tablet, iPad split view)
+ * keeps the focus gate, so working in the adjacent pane does not auto-read this
+ * one. This relaxation is deliberately local to auto-read;
+ * `usePageActivity().isActive` stays the strict visible-and-focused signal its
+ * other consumers (socket, connection status, app-update) rely on.
+ */
+export function useAutoReadAttention(): boolean {
+  const { isVisible, isFocused } = usePageActivity()
+  const isMobile = useIsMobile()
+  const isCoarsePointer = useIsCoarsePointer()
+  return isVisible && (isFocused || (isMobile && isCoarsePointer))
+}
+
+/**
  * Hook that automatically marks a stream as read when viewing it.
  * Debounces the mark-as-read call to avoid excessive API calls when rapidly switching streams.
  *
@@ -38,20 +60,7 @@ export function useAutoMarkAsRead(
   const { enabled = true, debounceMs = 500, partial = false } = options
   const { markAsRead, getUnreadCount } = useUnreadCounts(workspaceId)
   const { getActivityCount } = useActivityCounts(workspaceId)
-  const { isVisible, isFocused } = usePageActivity()
-  const isMobile = useIsMobile()
-  const isCoarsePointer = useIsCoarsePointer()
-  // Focus tells you which of several overlapping windows the user is working in —
-  // a fine-pointer, multi-window (desktop) signal. On a phone-like device (coarse
-  // pointer AND a phone-width viewport) `document.hasFocus()` is an unreliable
-  // proxy for attention: mobile browsers and installed PWAs routinely report no
-  // focus while the page is the foreground, and the resume `focus` event often
-  // never fires — so there a visible page is "active". A coarse-but-wide device
-  // (tablet, iPad split view) keeps the focus gate, so working in the adjacent
-  // pane does not auto-read this one. This relaxation is deliberately local to
-  // auto-read; `usePageActivity().isActive` stays the strict visible-and-focused
-  // signal its other consumers (socket, connection status, app-update) rely on.
-  const canAutoRead = isVisible && (isFocused || (isMobile && isCoarsePointer))
+  const canAutoRead = useAutoReadAttention()
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastMarkedRef = useRef<string | null>(null)
   // Track the partial-ness of the last mark so a partial→full transition at the

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -295,16 +295,23 @@ newestSeenRow)` per conversation; the gate re-checks effective unread at
   inert on any active conversation — Kris's ruling: having the conversation
   open is enough to mark it.)
 - Mark-as-unread **pins**: the menu action signals the hook synchronously
-  BEFORE its request departs (the controller's `setExplicitUnreadListener`),
-  and a read → unread regression on any eligible row catches the cross-device
-  case. Pinning unsees everything and suppresses **every eligible row** — not
-  just the currently-visible set, because visibility is unknowable across
-  observer teardowns (attention loss, id-set changes) and under-suppressing
-  would let a still-on-screen row dwell and cutoff-mark right back over the
-  explicit unread. Auto-read holds entirely while any suppression is active;
-  each row's suppression releases when the observer reports it off-screen —
-  the stream timeline's `pinnedRef`, with leave-and-return as the resume
-  gesture (a small card has no scroll to watch).
+  BEFORE its request departs (the controller's `setExplicitUnreadListener`);
+  the cross-device case is caught by diffing **raw read truth** per spanned
+  stream (the controller's `getReadTruth`) — a watermark sequence decrease,
+  or overlay ids removed without a compensating watermark advance, exposing
+  a row the surface shows. Never derived row state: derivation flaps (the
+  `unreadCounts === 0` short-circuit falling back to a stale frontier when a
+  count leaves zero, the stale-`lastReadAt` time fallback) read as mass
+  read → unread regressions, and a false pin on a static board card never
+  releases — that wedge was the first dogfood failure. Pinning unsees
+  everything and suppresses **every eligible row** — not just the
+  currently-visible set, because visibility is unknowable across observer
+  teardowns (attention loss, id-set changes) and under-suppressing would let
+  a still-on-screen row dwell and cutoff-mark right back over the explicit
+  unread. Auto-read holds entirely while any suppression is active; each
+  row's suppression releases when the observer reports it off-screen — the
+  stream timeline's `pinnedRef`, with leave-and-return as the resume gesture
+  (a small card has no scroll to watch).
 - Rows are matched by `data-message-row` on the `MessageItem` container, not
   bare `data-message-id` — editor nodes (quote reply, in-app links) render
   `data-message-id` inside the card's composer, and observing those would let

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -292,12 +292,21 @@ newestSeenRow)` per conversation; the gate re-checks effective unread at
   cutoff would otherwise silently read the hidden middle. The collapsed
   trailing preview therefore stays unread until expanded — the card dot is
   honest about the unseen middle.
-- Mark-as-unread **pins**: a read → unread regression on any eligible row
-  (menu here, or another device) clears the seen set and holds auto-read
-  entirely until every still-on-screen row has left the viewport — the
-  stream timeline's `pinnedRef`, with leave-and-return as the resume gesture
-  (a small card has no scroll to watch). Without the full hold, any newer
-  row dwelling would cutoff-mark right back over the explicit unread.
+- Mark-as-unread **pins**: the menu action signals the hook synchronously
+  BEFORE its request departs (the controller's `setExplicitUnreadListener`),
+  and a read → unread regression on any eligible row catches the cross-device
+  case. Pinning unsees everything and suppresses **every eligible row** — not
+  just the currently-visible set, because visibility is unknowable across
+  observer teardowns (attention loss, id-set changes) and under-suppressing
+  would let a still-on-screen row dwell and cutoff-mark right back over the
+  explicit unread. Auto-read holds entirely while any suppression is active;
+  each row's suppression releases when the observer reports it off-screen —
+  the stream timeline's `pinnedRef`, with leave-and-return as the resume
+  gesture (a small card has no scroll to watch).
+- Rows are matched by `data-message-row` on the `MessageItem` container, not
+  bare `data-message-id` — editor nodes (quote reply, in-app links) render
+  `data-message-id` inside the card's composer, and observing those would let
+  a quoted message "dwell" beside the cursor.
 - Optimistic `temp_` rows are never targets (the id doesn't exist
   server-side yet).
 

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -286,12 +286,14 @@ same conversation mark-read cutoff API:
 newestSeenRow)` per conversation; the gate re-checks effective unread at
   fire time, so it is idempotent against the overlay and never fires on a
   read conversation.
-- Eligibility is the **contiguous-from-the-start rendered run** only: a
-  collapsed card with an "N more" gap (or a panel still backfilling older
-  replies) auto-reads no further than its opening, because the `createdAt`
-  cutoff would otherwise silently read the hidden middle. The collapsed
-  trailing preview therefore stays unread until expanded — the card dot is
-  honest about the unseen middle.
+- Every **rendered row** is eligible. On a collapsed card the cutoff through
+  a trailing-preview row also covers the hidden "N more" middle —
+  deliberate: the card IS the conversation surface, so reading its visible
+  tail reads the conversation up to there, exactly like invoking "Mark as
+  read up to here" on that row. (v1 protected the hidden middle by making
+  gapped cards opening-only; dogfooding showed that renders the feature
+  inert on any active conversation — Kris's ruling: having the conversation
+  open is enough to mark it.)
 - Mark-as-unread **pins**: the menu action signals the hook synchronously
   BEFORE its request departs (the controller's `setExplicitUnreadListener`),
   and a read → unread regression on any eligible row catches the cross-device

--- a/docs/sparse-read-overlay-design.md
+++ b/docs/sparse-read-overlay-design.md
@@ -43,7 +43,7 @@ Two layers of truth, one derivation:
    owning it.
 
 2. **A sparse overlay above the watermark.** Table
-   `stream_member_message_reads`: individually-read messages *above* the
+   `stream_member_message_reads`: individually-read messages _above_ the
    watermark. A message is **effectively read** iff
    `sequence ≤ watermark OR id ∈ overlay`.
 
@@ -58,7 +58,7 @@ Two layers of truth, one derivation:
    immediately above the watermark, advance the watermark over that run and
    delete the absorbed rows (set-based, under the locked membership row).
    Reading the frontier on the board just moves the watermark; the overlay
-   only holds *holes*, and most reading happens in the timeline (wholesale
+   only holds _holes_, and most reading happens in the timeline (wholesale
    watermark advance), so the overlay stays small and self-erasing.
 
 **Overlay invariant: every overlay row sits strictly above its member's
@@ -98,9 +98,9 @@ that is load-bearing for threads (see below).
   `unreadCounts[s] = max(0, latestOrdinals[s] − readOrdinal(s) − |overlay(s)|)`
   with the read position reconstructed as `latest − unread − |overlay|`.
 - **Card unread** = "does this conversation contain any effectively-unread
-  message", computed at read time against *current* membership.
+  message", computed at read time against _current_ membership.
 - **Timeline**: row read state, the "new messages" divider, and the
-  new-message flash all mean "first/any *effectively* unread" — watermark
+  new-message flash all mean "first/any _effectively_ unread" — watermark
   comparison plus an overlay-set membership check.
 
 ### Mark-unread (the asymmetric inverse)
@@ -109,7 +109,7 @@ that is load-bearing for threads (see below).
 - **Below the watermark**: regress the watermark to just before the
   conversation's earliest member in that stream (existing `stream:read_set`
   semantics), accepting collateral un-reading of interleaved messages — the
-  same contract the timeline's "mark as unread" already has. A *negative*
+  same contract the timeline's "mark as unread" already has. A _negative_
   overlay (sparse unread exceptions below the watermark) is explicitly
   rejected: two overlays with opposite signs is unmaintainable.
 
@@ -136,8 +136,8 @@ house split (backend `lib/outbox/repository.ts`, frontend inline in
 - **NEW `stream:read_messages`** — the absolute post-write read-state snapshot
   for one stream:
   `{ workspaceId, authorId, streamId, readMessageIds: string[],
-  lastReadEventId: string | null, lastReadSequence: string,
-  lastReadOrdinal: number }`.
+lastReadEventId: string | null, lastReadSequence: string,
+lastReadOrdinal: number }`.
   `readMessageIds` is the **entire** overlay for that (stream, member) after
   the write (post-compaction) — absolute state, not a delta, so application is
   idempotent and order-convergent under the sync log's per-workspace total
@@ -156,7 +156,7 @@ house split (backend `lib/outbox/repository.ts`, frontend inline in
   surviving prior source event (set-based) — fix A3 below.
 - **Message delete**: the delete transaction marks the message's
   `user_activity` rows read (`read_at = NOW() WHERE message_id = … AND
-  read_at IS NULL`). No new socket event: clients already receive the
+read_at IS NULL`). No new socket event: clients already receive the
   `message_deleted` stream event and drop held activity rows for that
   message id there (mirror `dropReactionActivity`) — fix A2 below.
 
@@ -175,7 +175,7 @@ read(s) is implicit: latest − unread − |overlay|
 - Watermark ordinals keep their existing merge rules (`stream:read`
   max-merges, `read_set` SETs).
 - `messages:moved` applier **SETs** `latestOrdinals[source] =
-  sourceMessageOrdinal` and recomputes unread — the one sanctioned
+sourceMessageOrdinal` and recomputes unread — the one sanctioned
   non-monotonic latest write (precedent: `applyStreamReadSet`). Fix A1 below.
 - Bootstrap (`toCounterState`/`withCounterState`) carries the overlay;
   `mergeReconnectWorkspaceBootstrap` must keep the
@@ -183,7 +183,7 @@ read(s) is implicit: latest − unread − |overlay|
   stream (today it pairs the first two).
 
 `WorkspaceBootstrap` gains `readMessageIds?: Record<string, string[]>`
-(this one *is* a shared API type in `@threa/types`).
+(this one _is_ a shared API type in `@threa/types`).
 
 ## Conversation read API (pinned)
 
@@ -243,8 +243,8 @@ Investigated and adversarially re-verified; three real defects:
    sticks for the whole session (heals only on a full network bootstrap;
    cache-first bootstrap re-serves the drift). **Fix:** the
    `sourceMessageOrdinal` payload + SET applier above.
-   *(The originally-suspected delete trigger is refuted: deletion soft-deletes
-   and keeps the `message_created` row, so ordinals are delete-stable.)*
+   _(The originally-suspected delete trigger is refuted: deletion soft-deletes
+   and keeps the `message_created` row, so ordinals are delete-stable.)_
 2. **A2 (CONFIRMED, reload-surviving)** — message deletion never touches
    `user_activity` (`event-service.ts:916-957`): an unread activity row for a
    deleted message survives server-side forever unless the user opens that
@@ -253,7 +253,7 @@ Investigated and adversarially re-verified; three real defects:
 3. **A4 (CONFIRMED, reload-surviving)** — on move, the activity row is
    rehomed to the destination thread on both sides
    (`messaging/repository.ts:513-519`, `rehomeActivities`); opening the
-   *root* clears nothing under the thread, so the badge persists on a stream
+   _root_ clears nothing under the thread, so the badge persists on a stream
    the user never visits. Rehoming itself is correct (the row must deep-link
    to where the message lives). **Fix (backstop):** opening the activity feed
    reconciles the held set against the server's `unreadOnly` feed — replacing
@@ -266,15 +266,43 @@ Investigated and adversarially re-verified; three real defects:
    (`event-repository.ts:707`) — survives reload. **Fix:** the watermark
    repoint in the move transaction. Ship with a regression test either way.
 
-*(The activity half's originally-hypothesized D2-guard blockage was refuted
+_(The activity half's originally-hypothesized D2-guard blockage was refuted
 in verification: `prevRead` collapses to 0 in the canonical scenario and the
 `markAsReadMutation` clears held rows unconditionally on stream open. The D2
-coupling is untouched by this work.)*
+coupling is untouched by this work.)_
+
+## Viewport auto-read (shipped as a follow-up)
+
+Reading IS marking — the menu actions are the override, not the primary UX.
+`useConversationAutoRead` (`apps/frontend/src/components/message/use-conversation-auto-read.ts`)
+runs on both conversation surfaces (board card, panel), frontend-only over the
+same conversation mark-read cutoff API:
+
+- A row is **seen** after ~1s of any-part-in-viewport dwell
+  (IntersectionObserver) while the viewer's attention is on the page — the
+  same visible/focused gate as the stream's auto-read, shared via
+  `useAutoReadAttention` (phone-like devices relax the focus check).
+- Seen rows debounce (~2s) into **one** `markRead(conversationId,
+newestSeenRow)` per conversation; the gate re-checks effective unread at
+  fire time, so it is idempotent against the overlay and never fires on a
+  read conversation.
+- Eligibility is the **contiguous-from-the-start rendered run** only: a
+  collapsed card with an "N more" gap (or a panel still backfilling older
+  replies) auto-reads no further than its opening, because the `createdAt`
+  cutoff would otherwise silently read the hidden middle. The collapsed
+  trailing preview therefore stays unread until expanded — the card dot is
+  honest about the unseen middle.
+- Mark-as-unread **pins**: a read → unread regression on any eligible row
+  (menu here, or another device) clears the seen set and holds auto-read
+  entirely until every still-on-screen row has left the viewport — the
+  stream timeline's `pinnedRef`, with leave-and-return as the resume gesture
+  (a small card has no scroll to watch). Without the full hold, any newer
+  row dwelling would cutoff-mark right back over the explicit unread.
+- Optimistic `temp_` rows are never targets (the id doesn't exist
+  server-side yet).
 
 ## Out of scope for v1
 
-- Viewport-driven auto-read on the board (the "seen" question —
-  board-view-design edge 6 territory).
 - Restoring activity badges on mark-unread (accepted gap, matches the
   stream path).
 - Offline queueing for read actions (existing read mutations are not queued;


### PR DESCRIPTION
## Problem

#1165 shipped conversation-aware read state with **explicit menu actions only** ("Mark as read up to here" / "Mark as unread" on `MessageItem`). Kris's ruling on that PR: menu-driven marking is not how you use an app like this — **reading is marking**; the menu is the override. Until now a board card you actually read kept its unread dot (and the stream badge) until you invoked a menu item, which nobody does per-card.

## Solution

Viewport auto-read on both conversation surfaces (board card, conversation panel), frontend-only over the merged conversation mark-read API: a row that dwells ~1s in the viewport while the tab has the viewer's attention becomes *seen*; seen rows debounce ~2s into **one** `markRead(conversationId, newestSeenRow)` per conversation. The sparse-read overlay/watermark plumbing from #1165 is untouched — this PR is a client of it.

### How it works

1. **`useConversationAutoRead`** (`apps/frontend/src/components/message/use-conversation-auto-read.ts`) — one IntersectionObserver per surface over the host's rows, matched by a new `data-message-row` marker on the `MessageItem` container. Any-part-visible counts (the `pickVisibleRange` semantics the stream timeline uses); the 1s dwell (`DWELL_MS`) is what keeps a scroll-past from marking. Dwell timers start on enter, cancel on leave, and tear down whenever attention drops.
2. **One call per conversation** — dwell completions reset a 2s trailing debounce (`DEBOUNCE_MS`); at fire time the hook picks the newest seen eligible row and re-checks the gate: it fires only if some row at/below the target derives `"unread"` via the controller's `state()`. That fire-time gate makes it idempotent against the overlay/watermark caches — a read conversation never fires, cross-device reads are respected, and there is no polling loop.
3. **Attention gate shared with the stream** — `useAutoReadAttention()` extracted from `useAutoMarkAsRead` (`apps/frontend/src/hooks/use-auto-mark-as-read.ts`): visible AND (focused OR phone-like device), including the mobile `document.hasFocus()` relaxation and its rationale comment. Verified behavior-identical against main; `useAutoMarkAsRead` unchanged.
4. **Silent mutation path** — `useConversationReadController` now also returns `markReadSilently` (the same `conversationService.markRead` → `applyReadStateSnapshots` pipeline as the menu action, minus the failure toast). A background action failing must stay silent (INV-63) — a failed mark releases the dedup so the next evaluation retries; the toast remains on the user-initiated menu action only.
5. **Flush on unmount** — a pending debounce fires immediately when the surface unmounts (panel closed mid-read), so seen rows aren't lost to the trailing timer. It also fires without re-checking attention: the dwell already happened while the viewer was attending; only the batching timer is late.
6. **Flag-gated tracer** — `window.__threaAutoReadDebug = true` logs the pipeline (`observer: armed` → `seen` → `evaluate` decision → fire/fail/pin), mirroring the `deepLinkDebug` precedent, so a staging "it didn't mark" report is diagnosable.

### Key design decisions

**1. Every rendered row is eligible; the cutoff covering hidden older rows is deliberate.** `ConversationService.markRead` is a `createdAt` cutoff over the conversation's member messages, so marking through a collapsed card's trailing-preview row also reads the hidden "N more" middle (and a still-backfilling panel's unfetched older replies). That is the intended contract: the card IS the conversation surface — reading its visible tail reads the conversation up to there, exactly like invoking "Mark as read up to here" on that row. *(Dogfood evolution: v1 protected the hidden middle by making gapped cards opening-only. On real data that rendered the board inert — most active conversations collapse with "N more" and a long-read opening, so nothing ever fired. Kris's ruling: having the conversation open is enough to mark it.)*

**2. Furthest-seen, not strict contiguity of seen rows.** Within the eligible run, marking goes through the furthest row that dwelled; rows above it the viewer scrolled past inside the run are covered by the cutoff. Same acceptance as the timeline's partial reads (`useLastSeenEvent` advances to the bottom of the visible run) — a card is small enough that per-row contiguity tracking buys nothing.

**3. Mark-as-unread pins auto-read entirely; released per-row by the observer reporting the row off-screen.** The stream timeline solves "auto-read instantly undoes an explicit mark-unread" with `pinnedRef`, released by a user scroll; a card has no scroll to watch, and the cutoff makes the hazard worse — *any* newer row dwelling would cutoff-mark right back over the explicit unread. Two arms:
   - **Local menu action**: the controller's `setExplicitUnreadListener` lets `markUnread` pin the hook **synchronously before the request departs**, closing the window where a pending 2s debounce could race the in-flight unread (server arrival order would decide).
   - **Cross-device**: a **raw read-truth regression** per spanned stream, diffed via the controller's new `getReadTruth` — the watermark `lastReadSequence` decreasing, or overlay ids removed without a compensating watermark advance, exposing a row the surface shows (previously covered by the old truth, now deriving unread). Compaction (ids dropped WITH a watermark advance) and message moves (the row leaves the stream) do not pin. **Never derived row state** — see dogfood round 2 below.

   Pinning suppresses **every eligible row**, not the currently-visible set — visibility is unknowable across observer teardowns (attention loss, id-set changes), and under-suppressing would re-mark rows that never left the screen. Each suppression releases when the observer reports the row off-screen; evaluate holds while any suppression is active. A new reply arriving while pinned dwells but cannot fire (covered by a test).

**4. Rows are matched by `data-message-row`, not bare `data-message-id`.** Quote-reply/in-app-link editor nodes render `data-message-id` into the composer DOM, and the board card's composer lives inside `cardRef` — observing those would let a quoted message "dwell" beside the cursor and mark rows never on screen (and alias the pin bookkeeping). The marker scopes observation to actual `MessageItem` row containers.

**5. Optimistic `temp_` rows are never targets.** A board reply's optimistic row carries a `temp_` message id until the echo swap (`generateClientId`); sending it would 404. Filtered from eligibility; the confirmed swap re-enters normally. Mirrors `useLastSeenEvent`'s refusal to persist `temp_` ids.

**6. Own-authored rows count toward the fire gate (unlike the dot).** `hasUnread` excludes own rows (your reply doesn't make the conversation unread *to you*), but auto-read deliberately fires when your own just-sent reply is the only unread — advancing the watermark past your own message is what the stream's auto-mark does, and it prevents self-inflicted badge residue.

### Design evolution (self-review + dogfood)

Two reviewer agents over the diff found three real defects in the first version, fixed in `eee24e5`:

1. **Pin loss while attention is off** — suppression was sourced from a `visibleRef` that the observer teardown clears, so a cross-device mark-unread landing while the tab was blurred suppressed nothing and was auto-undone ~3s after refocus (the same mechanism raced an `eligibleIdsKey` change in the same commit). Fixed by suppressing all eligible rows and letting the observer release off-screen ones; regression tests added for both the attention-off and menu paths.
2. **Debounce vs menu mark-unread race** — the pin previously engaged only when the markUnread *response* changed derived state; a pending debounce could fire mid-flight. Fixed with the synchronous `setExplicitUnreadListener` signal.
3. **Composer id aliasing** — the `data-message-row` scoping above.

**Dogfood round 1** (Kris, staging): the board was inert on real data — the v1 contiguous-run eligibility made gapped cards opening-only (decision 1's evolution note). Flipped in `7ce4e38`; tracer + full-wiring test in `036d058`.

**Dogfood round 2** (Kris, staging): a card wedged — an agent reply's dot stayed until the panel (a fresh hook) cleared it. Root cause: the cross-device pin diffed **derived** row state, and derivation flaps (the `unreadCounts === 0` short-circuit re-deriving rows against a stale frontier when a count leaves zero — e.g. on an own send; the stale-`lastReadAt` fallback after compaction) read as mass read→unread regressions. A false pin on a static board card never releases (rows never leave the viewport) — the exact class both reviewer agents had flagged as RISK. Fixed in `717870c`: the cross-device arm now diffs raw truth only, with pin/no-pin tests for watermark regression, overlay drop, compaction, and the derived-flap wedge itself.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/message/use-conversation-auto-read.ts` | The viewport auto-read hook: IO dwell → debounce → cutoff markRead, mark-unread pin (both arms), temp_ exclusion, unmount flush, flag-gated tracer |
| `apps/frontend/src/components/message/use-conversation-auto-read.test.tsx` | 15 tests: dwell/debounce marking, furthest-seen, scroll-past, already-read no-op, temp_/non-eligible/editor-node exclusion, menu pin, watermark-regression pin, overlay-drop pin, compaction no-pin, derived-flap no-pin (the staging wedge), attention-off regression, attention gate, unmount flush, failed-mark retry |
| `apps/frontend/src/components/board/board-card-auto-read.test.tsx` | Full-wiring test: real `BoardCard` + real `useConversationReadController` + real hook (only IO faked) — the dwell→debounce→markRead chain over the projection row shape |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-auto-mark-as-read.ts` | Extracted `useAutoReadAttention()` (shared gate incl. the phone-like focus relaxation); `useAutoMarkAsRead` consumes it — behavior unchanged |
| `apps/frontend/src/components/message/conversation-read-context.tsx` | Controller additionally returns `markReadSilently` (one mutation path; menu action wraps it with the toast), `setExplicitUnreadListener` (the synchronous pin signal), and `getReadTruth` (raw per-stream watermark + overlay for the pin's cross-device arm) |
| `apps/frontend/src/components/message/message-item.tsx` | Row containers gain `data-message-row` (both branches) — the auto-read observation scope |
| `apps/frontend/src/components/board/board-card.tsx` | Wires the hook over `cardRef`; every rendered row eligible |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Wires the hook over the panel scroller (`listRef`); every rendered row eligible |
| `apps/frontend/src/components/board/board-card.test.tsx` | Controller mocks gain the three new fields |
| `docs/sparse-read-overlay-design.md` | New "Viewport auto-read (shipped as a follow-up)" section; removed from "Out of scope for v1" (plus prettier reflow from the pre-commit hook) |

## Known accepted behaviors (deliberate, from review)

- **Busy conversation defers marking**: every eligible-id-set change restarts in-flight dwells, so replies landing <1s apart mark only once traffic pauses. Degrades gracefully; not worth delta-observation complexity now.
- **Sequenceless rows (projection/backfill) can leave the gate open after compaction empties the overlay** — the snapshot never updates `lastReadAt`, so such a row can re-derive "unread" against a stale time fallback. Extra traffic is capped at one idempotent call per newer-row dwell (the dedup blocks same-target refires); no loop. Pre-existing derivation gap shared with the menu action.
- **Auto-read seeds `unreadCounts[threadId] = 0` for non-member thread legs** via the shared snapshot apply; a later reply in that thread then derives "read" through the `=== 0` short-circuit until bootstrap replaces the counts. Pre-existing on main via the menu action; auto-read makes it the default path — flagged as a follow-up (skip count seeding for membership-less snapshots).
- **A cross-device mark-unread of a message the surface isn't rendering** (a collapsed card's hidden middle) doesn't pin — the truth diff guards on rows the surface shows — so a later dwell of the visible tail re-marks it. The local menu path pins synchronously regardless.
- **A3-style watermark repoints on message moves** decrease `lastReadSequence` without a mark-unread; the pin additionally requires an exposed on-surface row now deriving unread, which a move doesn't produce (the row leaves the stream), so moves don't false-pin.

## Out of scope (deliberate)

- **Offline queueing for read actions** — no read mutation (stream or conversation) is offline-queued today; a failed auto-read stays silent and retries on the next evaluation. Parity with #1165's accepted gap.
- **The label page** — no `ConversationReadProvider`, no auto-read; verified unchanged (`useConversationRowRead()` still returns `null` there, and the new controller fields aren't on the context value).
- **Principled non-member-thread frontier** — auto-read derives row state through the same `deriveRowState` (overlay first, then watermark/time fallback) as the dot; the v1 root-`lastReadAt` approximation is untouched.

## Test plan

- [x] Hook suite `use-conversation-auto-read.test.tsx` — 15 pass
- [x] Full-wiring `board-card-auto-read.test.tsx` (real card + controller + hook) — 1 pass
- [x] Adjacent suites (`use-auto-mark-as-read`, `conversation-read-context`, `board-card`) — pass
- [x] Component sweep `src/components/{message,board,timeline,conversations}` — pass (425+ on the widest run)
- [x] `bun run typecheck` — whole monorepo clean (re-run by the pre-commit hook on every commit)
- [x] Pre-PR review (2 reviewer agents over the diff): 3 confirmed defects fixed pre-PR; the two flagged RISKs (derived-state false pin) materialized in dogfood round 2 and are now fixed + regression-tested
- [x] Staging dogfood round 1 (Kris): board inert → eligibility flipped (`7ce4e38`)
- [x] Staging dogfood round 2 (Kris): card wedged by false pin → raw-truth pin (`717870c`)
- [ ] Staging dogfood round 3 pending — verify cards mark on view through sends/agent replies, sidebar badge + activity clear

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_