### PR TITLE
feat(board): render agent traces, reminders & memo captures via a shared stream-row spec

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -5,9 +5,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPostMessage } from "@threa/types"
 import { BoardCard } from "./board-card"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
-import { ServicesProvider, PanelProvider } from "@/contexts"
+import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
+import { db, type CachedEvent } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
 import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as useWorkspacesModule from "@/hooks/use-workspaces"
@@ -62,9 +64,11 @@ function mountCard() {
       <TooltipProvider>
         <ServicesProvider services={{ conversations: {} as never }}>
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
-            <PanelProvider>
-              <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
-            </PanelProvider>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
+              </PanelProvider>
+            </TraceProvider>
           </MemoryRouter>
         </ServicesProvider>
       </TooltipProvider>
@@ -72,10 +76,33 @@ function mountCard() {
   )
 }
 
+/** A minimal cached agent-session event on the card's stream, seeded into IDB so
+ *  the card's rail picks it up like the timeline does. */
+function sessionEvent(
+  eventType: "agent_session:started" | "agent_session:completed",
+  seconds: number,
+  payload: Record<string, unknown>
+): CachedEvent {
+  return {
+    id: `${eventType}_${seconds}`,
+    workspaceId: WS,
+    streamId: STREAM,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType,
+    payload,
+    actorId: "persona_1",
+    actorType: "persona",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
 const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
 
-beforeEach(() => {
+beforeEach(async () => {
   __clearBoardRailRegistry()
+  await db.events.clear()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
@@ -124,5 +151,57 @@ describe("BoardCard unread dot", () => {
     mountCard()
     await screen.findByText("Opening body.")
     expect(screen.queryByLabelText("Unread")).toBeNull()
+  })
+})
+
+describe("BoardCard agent activity", () => {
+  beforeEach(() => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => false,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+  })
+
+  it("renders an agent session whose invoking message is a conversation member", async () => {
+    // A session triggered by the card's opening message (m_open ∈ messageIds) —
+    // the "agent triggered from a card looks dead" gap this closes. The events ride
+    // the same rail the card reads; the card interleaves them via STREAM_ROW_SPEC.
+    await db.events.bulkPut([
+      sessionEvent("agent_session:started", 30, {
+        sessionId: "sess_A",
+        triggerMessageId: "m_open",
+        personaName: "Ariadne",
+      }),
+      sessionEvent("agent_session:completed", 40, {
+        sessionId: "sess_A",
+        stepCount: 3,
+        duration: 1200,
+        messageCount: 1,
+      }),
+    ])
+    mountCard()
+    expect(await screen.findByText("Session complete")).toBeTruthy()
+  })
+
+  it("does NOT render a session whose invoking message is not a conversation member", async () => {
+    await db.events.bulkPut([
+      sessionEvent("agent_session:started", 30, {
+        sessionId: "sess_B",
+        triggerMessageId: "m_outsider",
+        personaName: "Ariadne",
+      }),
+      sessionEvent("agent_session:completed", 40, {
+        sessionId: "sess_B",
+        stepCount: 3,
+        duration: 1200,
+        messageCount: 1,
+      }),
+    ])
+    mountCard()
+    await screen.findByText("Opening body.")
+    expect(screen.queryByText("Session complete")).toBeNull()
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -5,7 +5,9 @@ import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type 
 import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
+import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
@@ -63,6 +65,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     totalReplies,
     pendingReplies,
     source,
+    events: railEvents,
   } = useBoardCardMessages(post, streamType)
 
   const streamId = conversation.streamId
@@ -86,6 +89,21 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     [openingMessage, railReplies]
   )
   const cardHasUnread = hasUnread(knownMessages)
+
+  // Agent traces / memo captures / follow-ups on this conversation, interleaved
+  // into the message rows below. Render-only (STREAM_ROW_SPEC `bumps: false`), so
+  // they stay OUT of the read-state arrays above — they are not members and carry
+  // no read state. A session shows iff its invoking message is a conversation
+  // member; the member set is the card's known messages plus the server ids.
+  const memberMessageIds = useMemo(() => {
+    const set = new Set<string>(conversation.messageIds)
+    for (const message of knownMessages) set.add(message.id)
+    return set
+  }, [conversation.messageIds, knownMessages])
+  const eventRows = useMemo(
+    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
+    [railEvents, conversation.id, memberMessageIds]
+  )
 
   // The rail carries every locally-synced reply; older ones (or a wholly unsynced
   // stream — `source === "projection"`) may be missing, so on expand we backfill
@@ -236,8 +254,13 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
 
           <div className="mt-3 [&>*:first-child]:mt-0">
             {contiguous ? (
-              (openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies).map((message, i, all) =>
-                renderMessage(message, i > 0 && isContinuation(all[i - 1], message))
+              buildBoardRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies, eventRows).map(
+                (row) =>
+                  row.kind === "message" ? (
+                    renderMessage(row.message, row.continuation)
+                  ) : (
+                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+                  )
               )
             ) : (
               <>
@@ -267,8 +290,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                     Couldn't load older messages. Retry.
                   </button>
                 )}
-                {displayedReplies.map((message, i) =>
-                  renderMessage(message, i > 0 && isContinuation(displayedReplies[i - 1], message))
+                {buildBoardRows(displayedReplies, eventRows).map((row) =>
+                  row.kind === "message" ? (
+                    renderMessage(row.message, row.continuation)
+                  ) : (
+                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+                  )
                 )}
               </>
             )}

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import type { RenderableMessage } from "@/components/message/message-item"
+import type { BoardEventRow } from "@/lib/board/board-event-rows"
+import { buildBoardRows } from "./board-row-item"
+
+function msg(id: string, authorId: string, minute: number): RenderableMessage {
+  return {
+    id,
+    authorId,
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    createdAt: `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`,
+  }
+}
+
+// buildBoardRows only reads `kind` / `key` / `sortMs`, so the `event` field is a
+// stub — kept off `@/db` to leave this a pure-logic test (no persistence import).
+function memoEventRow(key: string, minute: number): BoardEventRow {
+  const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
+  return { kind: "memo", key, sortMs: new Date(createdAt).getTime(), event: { id: key, createdAt } } as BoardEventRow
+}
+
+describe("buildBoardRows", () => {
+  it("groups consecutive same-author messages as continuations", () => {
+    const rows = buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 1), msg("c", "u2", 2)], [])
+    expect(rows.map((r) => (r.kind === "message" ? r.continuation : "event"))).toEqual([false, true, false])
+  })
+
+  it("an interleaved event row breaks a same-author continuation run", () => {
+    // Two same-author messages that WOULD group, with an event between them by time.
+    const rows = buildBoardRows([msg("a", "u1", 0), msg("b", "u1", 2)], [memoEventRow("evt", 1)])
+    expect(rows.map((r) => r.kind)).toEqual(["message", "event", "message"])
+    // The second message follows an event row, so it is not a continuation.
+    const secondMessage = rows[2]
+    expect(secondMessage.kind === "message" && secondMessage.continuation).toBe(false)
+  })
+
+  it("drops an event that sorts before the first message (hidden middle)", () => {
+    const rows = buildBoardRows([msg("a", "u1", 5)], [memoEventRow("evt", 1)])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].kind).toBe("message")
+  })
+
+  it("appends an event after the last message at the tail (the 'agent just triggered' case)", () => {
+    const rows = buildBoardRows([msg("a", "u1", 0)], [memoEventRow("evt", 5)])
+    expect(rows.map((r) => r.kind)).toEqual(["message", "event"])
+  })
+
+  it("places a message before an event that shares its exact timestamp", () => {
+    const rows = buildBoardRows([msg("a", "u1", 3)], [memoEventRow("evt", 3)])
+    expect(rows.map((r) => r.kind)).toEqual(["message", "event"])
+  })
+})

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,0 +1,93 @@
+import type { StreamEvent } from "@threa/types"
+import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
+import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
+import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
+import type { BoardEventRow } from "@/lib/board/board-event-rows"
+
+/**
+ * One row in a board card / conversation panel: either a member message (with its
+ * same-author continuation flag) or an interleaved agent/memo/follow-up event row.
+ * The board renders both through {@link buildBoardRows} so a conversation surface
+ * is a second *view* of the stream's events, not a message-only parallel renderer.
+ */
+export type BoardRow =
+  | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean }
+  | { kind: "event"; key: string; row: BoardEventRow }
+
+/**
+ * Interleave a chronological message list with the conversation's event rows by
+ * time. Continuation grouping is preserved for messages and **broken by any
+ * interleaved event row** (a session/memo/follow-up between two same-author
+ * messages ends the run) — the board's analog of the timeline's
+ * `annotateAuthorGroups` reset on a non-message item.
+ *
+ * `messages` is assumed already ordered as it should render (the caller's
+ * opening + displayed replies). Event rows that sort *before* the first message
+ * are dropped: on a collapsed card they belong to the hidden middle, and
+ * expanding re-includes them once the opening leads the list. A running session
+ * after the last message therefore lands at the tail — exactly where "the agent I
+ * just triggered" should appear.
+ */
+export function buildBoardRows(messages: RenderableMessage[], eventRows: BoardEventRow[]): BoardRow[] {
+  if (eventRows.length === 0) {
+    let prev: RenderableMessage | null = null
+    return messages.map((message) => {
+      const continuation = prev != null && isContinuation(prev, message)
+      prev = message
+      return { kind: "message", key: message.id, message, continuation }
+    })
+  }
+
+  const firstMs = messages.length > 0 ? new Date(messages[0].createdAt).getTime() : Number.NEGATIVE_INFINITY
+
+  type Entry = { t: number; slot: number; message?: RenderableMessage; event?: BoardEventRow }
+  const entries: Entry[] = []
+  for (const message of messages) entries.push({ t: new Date(message.createdAt).getTime(), slot: 0, message })
+  for (const event of eventRows) if (event.sortMs >= firstMs) entries.push({ t: event.sortMs, slot: 1, event })
+  // Stable sort keeps input order within an equal (t, slot); `slot` places a
+  // message before an event sharing its exact timestamp.
+  entries.sort((a, b) => (a.t !== b.t ? a.t - b.t : a.slot - b.slot))
+
+  const rows: BoardRow[] = []
+  let prev: RenderableMessage | null = null
+  for (const entry of entries) {
+    if (entry.message) {
+      const continuation = prev != null && isContinuation(prev, entry.message)
+      rows.push({ kind: "message", key: entry.message.id, message: entry.message, continuation })
+      prev = entry.message
+    } else if (entry.event) {
+      rows.push({ kind: "event", key: entry.event.key, row: entry.event })
+      prev = null
+    }
+  }
+  return rows
+}
+
+/**
+ * Renders a non-message board row, reusing the timeline's own row components so a
+ * board trace/memo/follow-up is identical to its timeline counterpart. Message
+ * rows stay with the surface's own renderer (they carry card-specific read-state
+ * and action wiring), so this only handles the event kinds. A `CachedEvent` is a
+ * structural superset of `StreamEvent`, so the rail rows pass straight through.
+ */
+export function BoardEventRowItem({ row, workspaceId }: { row: BoardEventRow; workspaceId: string }) {
+  switch (row.kind) {
+    case "session":
+      return (
+        <div className="px-3 sm:px-4">
+          <AgentSessionEvent events={row.events as StreamEvent[]} />
+        </div>
+      )
+    case "memo":
+      return <MemoCapturedEvent event={row.event as StreamEvent} workspaceId={workspaceId} />
+    case "followUp":
+      return (
+        <FollowUpScheduledEvent
+          event={row.event as StreamEvent}
+          workspaceId={workspaceId}
+          cancelledByEvent={row.cancelled}
+        />
+      )
+  }
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -14,7 +14,9 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
-import { MessageItem, isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
+import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
@@ -268,6 +270,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     totalReplies,
     pendingReplies,
     source,
+    events: railEvents,
   } = useBoardCardMessages(post, hostStreamType)
 
   // Backfill the full window when the local rail is missing older replies (or the
@@ -300,6 +303,21 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const loadingMore = incompleteLocally && !allMessages && !backfillFailed
 
   const all = openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies
+
+  // Agent traces / memo captures / follow-ups on this conversation, interleaved
+  // into the message rows. Render-only (STREAM_ROW_SPEC `bumps: false`) — kept out
+  // of the read-state arrays (they are not members). A session shows iff its
+  // invoking message is a conversation member.
+  const memberMessageIds = useMemo(() => {
+    const set = new Set<string>(conversation.messageIds)
+    for (const message of all) set.add(message.id)
+    return set
+  }, [conversation.messageIds, all])
+  const eventRows = useMemo(
+    () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
+    [railEvents, conversation.id, memberMessageIds]
+  )
+  const rows = buildBoardRows(all, eventRows)
   // The conversation's most-recently-active stream — the latest reply's own stream
   // (a thread under the root), so a continuation follows the conversation there
   // instead of re-interleaving the channel (board-view-design.md). Falls back to
@@ -332,24 +350,28 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
         <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
-          {all.map((message, i) => (
-            <MessageItem
-              key={message.id}
-              workspaceId={workspaceId}
-              // Each row renders against its own stream so reactions and the
-              // permalink target where the message actually lives (one root, many
-              // streams); fall back to the anchor.
-              streamId={message.streamId ?? conversation.streamId}
-              message={message}
-              authorName={getActorName(message.authorId, message.authorType)}
-              currentUserId={currentUserId}
-              continuation={i > 0 && isContinuation(all[i - 1], message)}
-              conversationId={conversation.id}
-              conversationRootStreamId={conversation.streamId}
-              isHighlighted={message.id === highlightMessageId}
-              surfaceClassName="bg-background"
-            />
-          ))}
+          {rows.map((row) =>
+            row.kind === "message" ? (
+              <MessageItem
+                key={row.message.id}
+                workspaceId={workspaceId}
+                // Each row renders against its own stream so reactions and the
+                // permalink target where the message actually lives (one root, many
+                // streams); fall back to the anchor.
+                streamId={row.message.streamId ?? conversation.streamId}
+                message={row.message}
+                authorName={getActorName(row.message.authorId, row.message.authorType)}
+                currentUserId={currentUserId}
+                continuation={row.continuation}
+                conversationId={conversation.id}
+                conversationRootStreamId={conversation.streamId}
+                isHighlighted={row.message.id === highlightMessageId}
+                surfaceClassName="bg-background"
+              />
+            ) : (
+              <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+            )
+          )}
           {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
           {backfillFailed && (
             <button

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,15 +1,13 @@
 import { memo, useMemo } from "react"
 import {
   COMMAND_EVENT_TYPES,
-  AGENT_SESSION_EVENT_TYPES,
   type CommandEventType,
-  type AgentSessionEventType,
-  type AgentSessionStartedPayload,
   type StreamEvent,
   type CommandDispatchedPayload,
   type CommandCompletedPayload,
   type CommandFailedPayload,
 } from "@threa/types"
+import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "./session-grouping"
 import type { MessageAgentActivity } from "@/hooks"
 import { useSocket, useCoordinatedLoading } from "@/contexts"
 import { useAbortResearch } from "@/hooks"
@@ -74,24 +72,6 @@ function getCommandId(event: StreamEvent): string | null {
   if (!isCommandEvent(event)) return null
   const payload = event.payload as CommandDispatchedPayload | CommandCompletedPayload | CommandFailedPayload
   return payload.commandId
-}
-
-function isAgentSessionEvent(event: StreamEvent): boolean {
-  return AGENT_SESSION_EVENT_TYPES.includes(event.eventType as AgentSessionEventType)
-}
-
-function getSessionId(event: StreamEvent): string | null {
-  if (!isAgentSessionEvent(event)) return null
-  return (event.payload as { sessionId?: string })?.sessionId ?? null
-}
-
-function getTriggerMessageId(event: StreamEvent): string | null {
-  if (event.eventType !== "agent_session:started") return null
-  return (event.payload as AgentSessionStartedPayload).triggerMessageId ?? null
-}
-
-function getSessionSlotKey(sessionId: string, triggerMessageId: string | null): string {
-  return triggerMessageId ? `trigger:${triggerMessageId}` : `session:${sessionId}`
 }
 
 /**

--- a/apps/frontend/src/components/timeline/session-grouping.ts
+++ b/apps/frontend/src/components/timeline/session-grouping.ts
@@ -1,0 +1,34 @@
+import { AGENT_SESSION_EVENT_TYPES, type AgentSessionEventType, type AgentSessionStartedPayload } from "@threa/types"
+import type { StreamEvent } from "@threa/types"
+
+/**
+ * Agent-session grouping primitives, shared by the timeline (`event-list.tsx`) and
+ * the board/conversation projection (`lib/board/board-event-rows.ts`). One
+ * definition so the two views group a session the same way — the drift these live
+ * in a shared module to avoid. Works on any {@link StreamEvent}-shaped row (the
+ * board passes IDB `CachedEvent`s, a structural superset).
+ */
+
+export function isAgentSessionEvent(event: Pick<StreamEvent, "eventType">): boolean {
+  return AGENT_SESSION_EVENT_TYPES.includes(event.eventType as AgentSessionEventType)
+}
+
+export function getSessionId(event: Pick<StreamEvent, "eventType" | "payload">): string | null {
+  if (!isAgentSessionEvent(event)) return null
+  return (event.payload as { sessionId?: string })?.sessionId ?? null
+}
+
+/** Only `agent_session:started` carries the invoking message id. */
+export function getTriggerMessageId(event: Pick<StreamEvent, "eventType" | "payload">): string | null {
+  if (event.eventType !== "agent_session:started") return null
+  return (event.payload as AgentSessionStartedPayload).triggerMessageId ?? null
+}
+
+/**
+ * A stable key for the row-slot a session occupies. Keyed on the trigger message
+ * when known (so a re-run against the same invoking message reuses the slot),
+ * else the session id.
+ */
+export function getSessionSlotKey(sessionId: string, triggerMessageId: string | null): string {
+  return triggerMessageId ? `trigger:${triggerMessageId}` : `session:${sessionId}`
+}

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -4,8 +4,17 @@ import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
 import { RECENT_PREVIEW_CAP } from "@/stores/board-store"
 import type { RenderableMessage } from "@/components/message/message-item"
-import { StreamTypes, type AuthorType } from "@threa/types"
+import { StreamTypes, BOARD_EVENT_ROW_TYPES, type AuthorType, type EventType } from "@threa/types"
 import type { BoardViewPost } from "./use-stable-board-view"
+
+/**
+ * Event types the board rail reads alongside `message_created`: the non-message
+ * rows the board draws (agent sessions, memo captures, follow-ups — derived from
+ * the shared STREAM_ROW_SPEC) plus the follow-up *cancel* patch, which carries no
+ * row of its own but flips a scheduled card to "Cancelled". Registering a new
+ * conversation-scoped row kind in the spec adds it here automatically.
+ */
+const BOARD_RAIL_EVENT_TYPES: EventType[] = [...BOARD_EVENT_ROW_TYPES, "agent:follow_up_cancelled", "message_created"]
 
 interface MessageCreatedPayloadShape {
   messageId?: string
@@ -57,6 +66,10 @@ interface StreamRail {
    *  hand-off); once it's in `messageIds` the card dedups it. Only board replies
    *  carry the tag, so this stays proportional to the stream's reply count. */
   taggedByConversation: Map<string, RenderableMessage[]>
+  /** Spec-eligible non-message rows on this stream (agent sessions, memo captures,
+   *  follow-up scheduled/cancelled), in read order — resolved to conversation rows
+   *  by `resolveBoardEventRows`. Render-only: none is a member or bumps activity. */
+  events: CachedEvent[]
   /** False until the first IDB read resolves — distinguishes loading from empty. */
   resolved: boolean
 }
@@ -65,6 +78,7 @@ const LOADING_RAIL: StreamRail = {
   messages: new Map(),
   seen: new Set(),
   taggedByConversation: new Map(),
+  events: [],
   resolved: false,
 }
 
@@ -72,7 +86,14 @@ function buildRail(events: CachedEvent[]): StreamRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
+  const eventRows: CachedEvent[] = []
   for (const event of events) {
+    // The rail reads message_created + the board's non-message row types; anything
+    // that isn't a message is a spec event row (a trace/memo/follow-up).
+    if (event.eventType !== "message_created") {
+      eventRows.push(event)
+      continue
+    }
     const payload = (event.payload ?? {}) as MessageCreatedPayloadShape
     if (payload.messageId) seen.add(payload.messageId)
     const message = eventToRenderable(event)
@@ -91,7 +112,7 @@ function buildRail(events: CachedEvent[]): StreamRail {
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, taggedByConversation, resolved: true }
+  return { messages, seen, taggedByConversation, events: eventRows, resolved: true }
 }
 
 interface StreamRailEntry {
@@ -141,7 +162,10 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
     // entry so a late emission after teardown is a no-op.
     railRegistry.set(streamId, created)
     created.subscription = liveQuery(() =>
-      db.events.where("[streamId+eventType]").equals([streamId, "message_created"]).toArray()
+      db.events
+        .where("[streamId+eventType]")
+        .anyOf(BOARD_RAIL_EVENT_TYPES.map((eventType) => [streamId, eventType]))
+        .toArray()
     ).subscribe((events) => {
       const live = railRegistry.get(streamId)
       if (!live) return
@@ -192,6 +216,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
+  const eventsById = new Map<string, CachedEvent>()
   // Resolved once every GATING rail has read — a still-loading discovered thread
   // doesn't count, so the card keeps its live view instead of dropping to the
   // projection the instant a thread appears.
@@ -204,6 +229,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
     }
     for (const [id, message] of rail.messages) messages.set(id, message)
     for (const id of rail.seen) seen.add(id)
+    for (const event of rail.events) eventsById.set(event.id, event)
     for (const [conversationId, list] of rail.taggedByConversation) {
       const existing = taggedByConversation.get(conversationId)
       if (existing) existing.push(...list)
@@ -213,7 +239,10 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, taggedByConversation, resolved, allResolved }
+  const events = [...eventsById.values()].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  )
+  return { messages, seen, taggedByConversation, events, resolved, allResolved }
 }
 
 /**
@@ -384,6 +413,11 @@ export interface BoardCardMessages {
   /** Where the bodies came from: the live `db.events` rail, or the cached server
    *  projection (a stream not yet synced into IDB — a cold/offline first open). */
   source: "events" | "projection"
+  /** Spec-eligible non-message rows across the conversation's streams (agent
+   *  sessions, memo captures, follow-ups), unresolved — the card runs
+   *  `resolveBoardEventRows` to filter+group them to this conversation. Always the
+   *  live rail's rows (empty on a cold projection open, filled once synced). */
+  events: CachedEvent[]
 }
 
 const NO_PENDING: RenderableMessage[] = []
@@ -535,6 +569,7 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
         totalReplies: serverTotal,
         pendingReplies,
         source: "projection" as const,
+        events: rail.events,
         nextRetained,
       }
     }
@@ -589,7 +624,15 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     else if (bridgeCount > 0) nextRetained = retained
     else nextRetained = NO_PENDING
 
-    return { openingMessage, replies, totalReplies, pendingReplies, source: "events" as const, nextRetained }
+    return {
+      openingMessage,
+      replies,
+      totalReplies,
+      pendingReplies,
+      source: "events" as const,
+      events: rail.events,
+      nextRetained,
+    }
   }, [rail, replyIds, openingId, messageIds, post, conversationId])
 
   // Commit the bridge bookkeeping after render, never during it.

--- a/apps/frontend/src/lib/board/board-event-rows.test.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest"
+import type { CachedEvent } from "@/db"
+import { resolveBoardEventRows } from "./board-event-rows"
+
+let seq = 0
+function cachedEvent(
+  partial: Partial<CachedEvent> & { eventType: CachedEvent["eventType"]; createdAt: string }
+): CachedEvent {
+  seq += 1
+  return {
+    id: partial.id ?? `evt_${seq}`,
+    workspaceId: "ws_1",
+    streamId: partial.streamId ?? "stream_1",
+    sequence: String(seq),
+    _sequenceNum: seq,
+    eventType: partial.eventType,
+    payload: partial.payload ?? {},
+    actorId: partial.actorId ?? null,
+    actorType: partial.actorType ?? null,
+    createdAt: partial.createdAt,
+    _cachedAt: seq,
+  }
+}
+
+const CONV = "conv_1"
+
+describe("resolveBoardEventRows", () => {
+  it("keeps a memo capture whose payload names this conversation, drops others", () => {
+    const events = [
+      cachedEvent({
+        id: "m_here",
+        eventType: "memos:captured",
+        createdAt: "2026-07-04T10:00:00Z",
+        payload: { conversationId: CONV },
+      }),
+      cachedEvent({
+        id: "m_other",
+        eventType: "memos:captured",
+        createdAt: "2026-07-04T10:01:00Z",
+        payload: { conversationId: "conv_other" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set() })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ kind: "memo", key: "m_here" })
+  })
+
+  it("marks a scheduled follow-up cancelled when a matching cancel event is present", () => {
+    const events = [
+      cachedEvent({
+        id: "f1",
+        eventType: "agent:follow_up_scheduled",
+        createdAt: "2026-07-04T10:00:00Z",
+        payload: { followUpId: "fup_1", sourceConversationId: CONV },
+      }),
+      cachedEvent({
+        id: "f2",
+        eventType: "agent:follow_up_scheduled",
+        createdAt: "2026-07-04T10:01:00Z",
+        payload: { followUpId: "fup_2", sourceConversationId: CONV },
+      }),
+      cachedEvent({
+        eventType: "agent:follow_up_cancelled",
+        createdAt: "2026-07-04T10:02:00Z",
+        payload: { followUpId: "fup_1" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set() })
+    const followUps = rows.filter((r) => r.kind === "followUp")
+    expect(followUps).toHaveLength(2)
+    expect(followUps.find((r) => r.key === "f1")).toMatchObject({ cancelled: true })
+    expect(followUps.find((r) => r.key === "f2")).toMatchObject({ cancelled: false })
+  })
+
+  it("groups a session's lifecycle events into one row iff its trigger is a member", () => {
+    const events = [
+      cachedEvent({
+        eventType: "agent_session:started",
+        createdAt: "2026-07-04T10:00:00Z",
+        payload: { sessionId: "sess_A", triggerMessageId: "msg_member" },
+      }),
+      cachedEvent({
+        eventType: "agent_session:completed",
+        createdAt: "2026-07-04T10:00:30Z",
+        payload: { sessionId: "sess_A" },
+      }),
+      // A second session whose trigger is NOT a conversation member — excluded.
+      cachedEvent({
+        eventType: "agent_session:started",
+        createdAt: "2026-07-04T10:05:00Z",
+        payload: { sessionId: "sess_B", triggerMessageId: "msg_outsider" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, {
+      conversationId: CONV,
+      memberMessageIds: new Set(["msg_member"]),
+    })
+    const sessions = rows.filter((r) => r.kind === "session")
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({ kind: "session", key: "session:sess_A" })
+    if (sessions[0].kind === "session") expect(sessions[0].events).toHaveLength(2)
+  })
+
+  it("returns rows ordered by time across kinds", () => {
+    const events = [
+      cachedEvent({
+        id: "late_memo",
+        eventType: "memos:captured",
+        createdAt: "2026-07-04T12:00:00Z",
+        payload: { conversationId: CONV },
+      }),
+      cachedEvent({
+        eventType: "agent_session:started",
+        createdAt: "2026-07-04T09:00:00Z",
+        payload: { sessionId: "sess_A", triggerMessageId: "msg_member" },
+      }),
+    ]
+    const rows = resolveBoardEventRows(events, { conversationId: CONV, memberMessageIds: new Set(["msg_member"]) })
+    expect(rows.map((r) => r.kind)).toEqual(["session", "memo"])
+  })
+})

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -1,0 +1,97 @@
+import { STREAM_ROW_SPEC } from "@threa/types"
+import type { CachedEvent } from "@/db"
+import { getSessionId, getTriggerMessageId } from "@/components/timeline/session-grouping"
+
+/**
+ * A non-message stream event, resolved to the conversation it should draw on for
+ * the board card / conversation panel. Agent-session lifecycle events are grouped
+ * into one `session` row (start + complete/failed/deleted), matching the timeline;
+ * memo captures and scheduled follow-ups are single rows. Every kind is
+ * render-only — none is a conversation member and none bumps activity (INV: the
+ * `bumps: false` contract in STREAM_ROW_SPEC).
+ */
+export type BoardEventRow =
+  | { kind: "session"; key: string; sortMs: number; events: CachedEvent[] }
+  | { kind: "memo"; key: string; sortMs: number; event: CachedEvent }
+  | { kind: "followUp"; key: string; sortMs: number; event: CachedEvent; cancelled: boolean }
+
+export interface ResolveBoardEventRowsCtx {
+  /** The conversation the card renders. */
+  conversationId: string
+  /**
+   * The conversation's member message ids (opening + replies + server
+   * `messageIds`). An agent session belongs here iff its invoking message is one
+   * of these — the same "trigger message is a conversation member" rule the board
+   * design specifies for showing traces without new delivery.
+   */
+  memberMessageIds: Set<string>
+}
+
+function timeMs(event: CachedEvent): number {
+  return new Date(event.createdAt).getTime()
+}
+
+/**
+ * Resolve the spec-eligible non-message events on a card's stream rail into the
+ * ordered, conversation-scoped rows the board draws. Pure over its inputs so the
+ * placement rules are unit-testable in isolation.
+ *
+ * - `source-conversation` rows (memos:captured, follow-ups) match on the
+ *   conversation id their payload names.
+ * - `trigger-message` rows (agent sessions) are grouped by session id; the group
+ *   shows iff the session's `started` event names a trigger that is a member.
+ * - `agent:follow_up_cancelled` is a patch, not a row: it flips the matching
+ *   scheduled card's `cancelled` flag (mirrors the timeline's cancel handling).
+ */
+export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEventRowsCtx): BoardEventRow[] {
+  const cancelledFollowUpIds = new Set<string>()
+  for (const event of events) {
+    if (event.eventType !== "agent:follow_up_cancelled") continue
+    const followUpId = (event.payload as { followUpId?: string })?.followUpId
+    if (followUpId) cancelledFollowUpIds.add(followUpId)
+  }
+
+  const sessions = new Map<string, { events: CachedEvent[]; trigger: string | null }>()
+  const rows: BoardEventRow[] = []
+
+  for (const event of events) {
+    const ref = STREAM_ROW_SPEC[event.eventType].conversationRef
+    if (ref === "trigger-message") {
+      const sessionId = getSessionId(event)
+      if (!sessionId) continue
+      let session = sessions.get(sessionId)
+      if (!session) {
+        session = { events: [], trigger: null }
+        sessions.set(sessionId, session)
+      }
+      session.events.push(event)
+      const trigger = getTriggerMessageId(event)
+      if (trigger) session.trigger = trigger
+    } else if (ref === "source-conversation") {
+      const payload = event.payload as { conversationId?: string; sourceConversationId?: string }
+      const target = payload?.conversationId ?? payload?.sourceConversationId ?? null
+      if (target !== ctx.conversationId) continue
+      if (event.eventType === "memos:captured") {
+        rows.push({ kind: "memo", key: event.id, sortMs: timeMs(event), event })
+      } else if (event.eventType === "agent:follow_up_scheduled") {
+        const followUpId = (event.payload as { followUpId?: string })?.followUpId
+        rows.push({
+          kind: "followUp",
+          key: event.id,
+          sortMs: timeMs(event),
+          event,
+          cancelled: followUpId ? cancelledFollowUpIds.has(followUpId) : false,
+        })
+      }
+    }
+  }
+
+  for (const [sessionId, session] of sessions) {
+    if (!session.trigger || !ctx.memberMessageIds.has(session.trigger)) continue
+    const ordered = [...session.events].sort((a, b) => timeMs(a) - timeMs(b))
+    rows.push({ kind: "session", key: `session:${sessionId}`, sortMs: timeMs(ordered[0]), events: ordered })
+  }
+
+  rows.sort((a, b) => a.sortMs - b.sortMs)
+  return rows
+}

--- a/docs/board-timeline-drift-audit.md
+++ b/docs/board-timeline-drift-audit.md
@@ -1,0 +1,385 @@
+# Board × Timeline event-rendering drift — audit + recommendation
+
+Status: audit memo (2026-07-04). Sibling to
+[`board-view-design.md`](./board-view-design.md); this is the "why do we have to
+wire events into two views" question, answered with code.
+
+Produced by a Sonnet-map / Opus-design / Opus-judge workflow, then the
+load-bearing claims were re-verified by hand against the code (see
+"Verification" at the end).
+
+## Executive summary
+
+- **The drift is real and structural, not cosmetic.** The timeline dispatches
+  ~11 visible row kinds through one switch (`event-item.tsx:68`); the board
+  renders exactly one (`MessageItem`) because its data source is a single hard
+  Dexie filter — `db.events.where("[streamId+eventType]").equals([streamId,
+"message_created"])` (`use-board-card-messages.ts:127`). Every non-message
+  event is excluded **before any component runs**. Board components contain **0**
+  `eventType` references (grep-confirmed).
+- **User-visible consequence:** agent traces (`agent_session:*`), scheduled
+  reminders (`agent:follow_up_scheduled`), and memory captures (`memos:captured`)
+  render in the timeline but are invisible on the board/panel for the _exact same
+  conversation_. Agent-triggered-from-a-card looks dead until the final reply
+  lands.
+- **Root cause:** there is no shared "renderable stream row" model. The timeline
+  has an _implicit_ registry (a switch plus ~8 scattered type-sets); the board has
+  _no_ registry at all. Adding one row kind = editing 4–8 places in the timeline
+  and 7 more in the board — with no compiler forcing the second view.
+- **Proof it's live drift, not theory:** commit `caae3643` (scheduled
+  follow-ups, roadmap 1.3, 3 days ago) touched only timeline files — zero
+  board/panel edits — and silently doesn't work on the board. Landing a timeline
+  feature required _zero awareness_ the board exists.
+- **Recommendation: synthesize.** Take the structural proposal's SSOT device (an
+  **exhaustive `Record<EventType, RowSpec>` in `packages/types`** — a compile
+  error is the only thing that stops the _next_ drift) with the minimal proposal's
+  staging discipline (ship agent-on-board fast; do **not** big-bang the timeline
+  switch). Reject a frontend-only `Partial<Record>` as the SSOT — it silently
+  omits, which is the failure mode we're fixing.
+- **The three agent surfaces fall out for free:** once the spec's
+  `conversationRef` axis exists, `memos:captured`→`payload.conversationId`,
+  `follow_up_scheduled`→`sourceConversationId`, `agent_session:*`→`triggerMessageId`
+  each resolve to a conversation with render-only semantics (`bumps:false`),
+  reusing the existing row components unchanged.
+- **Scope guard:** do NOT merge `MessageItem`/`MessageEvent`, do NOT touch backend
+  membership/bump/delivery-groups, do NOT port live step-tickers in step 1. The
+  one real risk: the new "reset author-run on an interleaved row" logic (the board
+  has never needed it) must be tested.
+
+## 1. Drift audit (cited)
+
+**The mechanism.** Two pipelines read the same `db.events` table with different
+scope:
+
+- Timeline: `useStreamEvents` loads the _full_ per-stream window
+  (`stream-store.ts:86`, index `[streamId+_sequenceNum]`), then `EventItem`
+  dispatches per type (`event-item.tsx:68`, ~15 arms).
+- Board: `useBoardCardMessages` loads a _type-filtered_ window —
+  `message_created` only (`use-board-card-messages.ts:127`) — projects via
+  `eventToRenderable` (message-only, `:26`), renders `<MessageItem>` inline with
+  no dispatch (`board-card.tsx:214-250`, `conversation-panel.tsx:332-349`).
+
+This is not a render gate the board could relax; the rows **never enter the data
+structure**. Confirmed: 0 `eventType` refs anywhere under `components/board/` or
+in `conversation-panel.tsx`.
+
+**Concrete user symptoms:**
+
+1. _Agent working, board looks dead._ Trigger an agent from a card — nothing
+   shows until the final reply (`message_created`) lands. The running session card
+   is right there in the timeline. (`agent_session:*` never enters the rail.)
+2. _A just-scheduled reminder is invisible off the timeline._ The `caae3643`
+   Cancel-able scheduled-follow-up card exists only in
+   `event-item.tsx`/`event-list.tsx`. Zero board wiring.
+3. _Memory capture is invisible on the surface built to close the loop._ GAM
+   captures a memo from a conversation's source stream; timeline shows the
+   "captured" row (INV-62 "visible in situ"), the board card for that same
+   conversation shows nothing — even though the doc's own "Decisions/Knowledge"
+   lens is _defined_ as "conversations with a captured memo"
+   (`board-view-design.md:168-169`).
+
+**Compact drift matrix** (24 `EVENT_TYPES` at `constants.ts:91-116`):
+
+| Event type                                       | Timeline row                    | Board / panel         | Conv. member        | Bumps activity | Bcast slot |
+| ------------------------------------------------ | ------------------------------- | --------------------- | ------------------- | -------------- | ---------- |
+| `message_created`                                | ✓ MessageEvent                  | ✓ (only type carried) | ✓                   | ✓              | ✓          |
+| `agent_session:started/completed/failed/deleted` | ✓ grouped (`AgentSessionEvent`) | **✗**                 | ✗                   | ✗              | ✓          |
+| `memos:captured`                                 | ✓ `MemoCapturedEvent`           | **✗**                 | ✗ (provenance only) | ✗              | ✓          |
+| `agent:follow_up_scheduled`                      | ✓ `FollowUpScheduledEvent`      | **✗**                 | ✗                   | ✗              | ✓          |
+| `agent:follow_up_cancelled`                      | patch (null)                    | ✗                     | ✗                   | ✗              | ✗          |
+| `member_joined/added/left`                       | ✓ `MembershipEvent`             | ✗ (correct)           | ✗                   | ✗              | ✓          |
+| `description_set`                                | ✓                               | ✗ (correct)           | ✗                   | ✗              | ✓          |
+| `stream_archived/unarchived`                     | ✓ `SystemEvent`                 | ✗ (correct)           | ✗                   | ✗              | ✓          |
+| `messages:moved`                                 | ✓ source-side                   | ✗                     | stale-risk          | ✗              | ✓          |
+| `command_*`                                      | ✓ grouped, author-scoped        | ✗ (correct)           | ✗                   | ✗              | ✗          |
+| `message_edited/deleted`, `reaction_*`           | patch                           | patch                 | n/a                 | ✗              | ✗          |
+
+Rows 2–4 (bold ✗) are the wrong-absence — conversation-scoped agent activity that
+_belongs_ on the board. Rows 6–12 are correct-absence (channel chrome, not topic
+content) — but the board has no way to express even that as a decision; it's an
+accident of the Dexie filter.
+
+## 2. Root cause (named precisely)
+
+**There is no shared "renderable stream row" model.**
+
+- The timeline's renderability knowledge is an _implicit registry_ smeared across
+  ≥8 sites, each with a distinct failure mode if you miss it: `EVENT_TYPES`
+  (`constants.ts:91`), `TIMELINE_BROADCAST_EVENT_TYPES` (`constants.ts:141`),
+  `COMMAND_EVENT_TYPES`/`AGENT_SESSION_EVENT_TYPES` (`constants.ts:120,485`), the
+  `EventItem` switch (`event-item.tsx:68`), `MESSAGE_EVENT_TYPES`
+  (`event-list.tsx:163`), `ZERO_HEIGHT_EVENT_TYPES` (`event-list.tsx:304`),
+  `groupTimelineItems` slot logic (`event-list.tsx:533`),
+  `THREAD_HIDDEN_EVENT_TYPES` (`stream-content.tsx:106`), plus backend
+  `enrichBootstrapEvents` filtering (`event-service.ts:1730`).
+- The board has **no registry** — it hard-filters to messages at the Dexie layer,
+  so it can't even drift _toward_ the timeline. It's blind to 23 of 24 types
+  before rendering logic exists.
+
+Net: adding a conversation-scoped row kind touches **4–8 timeline sites and 7
+board sites**, none enforced by the type system. Nothing makes "wire it into both
+views" a requirement. That's the drift generator.
+
+## 3. Recommendation — synthesize the SSOT device with staged rollout
+
+**Pick the structural proposal's location and exhaustiveness for the SSOT; pick
+the minimal proposal's discipline for the rollout.**
+
+Why not a partial frontend table: a `Partial<Record<EventType,
+BoardEventRowSpec>>` in `components/board/` _silently omits_ — a future
+`EVENT_TYPE` that forgets an entry just doesn't render, which is **exactly today's
+failure mode**. It fixes the three known cases but doesn't make the _next_ drift
+impossible.
+
+Why not big-bang the whole timeline first: ripping the `EventItem` switch out and
+re-routing the whole timeline through a renderer registry in the same arc is the
+correct endgame, but it's a large, higher-risk change that is **not required** to
+put agent activity on the board. The drift for the three agent cases dies without
+touching the timeline switch.
+
+### The SSOT shape
+
+**File:** `packages/types/src/stream-rows.ts` (new), exported via the
+`packages/types` barrel (INV-52).
+
+**Type:** one exhaustive record — the exhaustiveness is the load-bearing
+anti-drift device:
+
+```ts
+export interface RowSpec {
+  rendersAsOwnRow: boolean
+  grouping?: "command" | "session"
+  authorGroupable: boolean // replaces MESSAGE_EVENT_TYPES
+  patchesRow: boolean // → derives ZERO_HEIGHT_EVENT_TYPES
+  broadcastSlot: boolean // → derives TIMELINE_BROADCAST_EVENT_TYPES (INV-61)
+  hiddenInThread: boolean // replaces THREAD_HIDDEN_EVENT_TYPES
+  conversationRef: "self-message" | "trigger-message" | "source-conversation" | "none"
+  bumps: boolean // contract: only message_created is true
+}
+export const STREAM_ROW_SPEC: Record<EventType, RowSpec> = {
+  /* one entry per EVENT_TYPE */
+}
+```
+
+`Record<EventType, RowSpec>` means **adding a member to `EVENT_TYPES` is a compile
+error until it declares how both views treat it.** That is the single change that
+converts "drift by omission" into "won't build."
+
+**Three orthogonal axes, promoted from prose to typed data** (this is the doc's
+"rendering only: no assignment, no bump" at `board-view-design.md:684`, made
+structural):
+
+- _renders here_ = `rendersAsOwnRow || grouping != null` + `conversationRef != "none"`.
+- _is a member_ = backend fact, single-sourced already (`conversation-assigner.ts`,
+  `boundary-extraction-service.ts:595` — messages only). The spec does **not** own
+  this; `conversationRef` is _render-side placement_, deliberately distinct from
+  `conversations.message_ids`.
+- _bumps_ = `bumps` field; enforced-false for every agent/memo/follow-up type.
+  This is also the stable-view guard (§7).
+
+### How both views consume it
+
+- **Board** (the step-1 payoff): the rail reads spec-eligible types and filters
+  with one predicate, `conversationKeyOf(row) === conversationId`, driven by
+  `conversationRef`: `self-message`→`messageId`,
+  `trigger-message`→`payload.triggerMessageId` (`agent-trace.ts:137`;
+  `completed/failed/deleted` key off the session→trigger map the grouping already
+  builds), `source-conversation`→`payload.conversationId`/`sourceConversationId`
+  (`api.ts:1161,1178`), `none`→dropped. "X joined the channel" correctly never
+  shows — as a _decision in the table_, not an accident.
+- **Timeline** (later): `EventItem`'s switch and the scattered type-sets become
+  spec lookups. Deferred to a separate PR.
+
+### Exact current touch points eliminated
+
+| Today (scattered)                                                                     | Becomes                                         |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `MESSAGE_EVENT_TYPES` (`event-list.tsx:163`)                                          | derived `authorGroupable`                       |
+| `ZERO_HEIGHT_EVENT_TYPES` (`event-list.tsx:304`)                                      | derived `patchesRow \|\| grouping`              |
+| `THREAD_HIDDEN_EVENT_TYPES` (`stream-content.tsx:106`)                                | derived `hiddenInThread`                        |
+| `TIMELINE_BROADCAST/COMMAND/AGENT_SESSION_EVENT_TYPES` (`constants.ts:120,141,485`)   | derived from spec (INV-31)                      |
+| Board Dexie `message_created` filter (`use-board-card-messages.ts:127`)               | spec-eligible read + `conversationKeyOf` filter |
+| `eventToRenderable` message-only projection (`:26`)                                   | shared `buildBoardRows`                         |
+| `isContinuation` inline maps (`board-card.tsx:216,247`, `conversation-panel.tsx:343`) | one shared continuation pass                    |
+| `EventItem` switch (`event-item.tsx:68`)                                              | `ROW_RENDERERS` lookup (deferred PR)            |
+
+## 4. How the agent surfaces fall out (once the SSOT exists)
+
+Each is a spec entry plus reuse of the existing row component — no new rendering,
+no membership write, no bump:
+
+- **Memory captures** — `{ rendersAsOwnRow:true, conversationRef:"source-conversation",
+bumps:false }`. `payload.conversationId` (`api.ts:1161`) names the source
+  conversation; the card renders the existing `MemoCapturedEvent`. Satisfies
+  INV-62 on the surface people actually look at.
+- **Reminders** — `{ rendersAsOwnRow:true, conversationRef:"source-conversation",
+bumps:false }`. `sourceConversationId` (`api.ts:1178`) resolves it; reuse
+  `FollowUpScheduledEvent` + the already-`export`ed `collectCancelledFollowUpIds`
+  (`event-list.tsx:359`) so the Cancelled state is authoritative for every viewer.
+  Closes the `caae3643` drift.
+- **Agent traces** — `{ grouping:"session", conversationRef:"trigger-message",
+bumps:false }`. Session grouping via the reused `getSessionSlotKey`
+  (`event-list.tsx:93`); filtered to sessions whose _trigger message is a
+  conversation member_. This **is** `board-view-design.md:678-684` verbatim — same
+  "invoking message is a member," same `AgentSessionEvent`, "rendering only."
+
+`bumps:false` on all three is what makes them render-only: they cannot move
+`conversations.last_activity_at`, cannot perturb the stable view, cannot become
+fake members. The doc's invariant is now enforced by a type field, not by
+remembering.
+
+The board's cross-stream reach already exists: `useMergedStreamRail` unions root +
+child-thread streams (`use-board-card-messages.ts:192`, `useChildThreadStreamIds:283`),
+so a session/memo/follow-up fired in a thread resolves to the root conversation
+through the _same_ `conversationKeyOf`. No extra code for the nested case.
+
+## 5. Sequenced PR plan (minimal-patch first, each shippable)
+
+**PR 1 — Extract session-grouping helpers (pure refactor, tiny).**
+New `apps/frontend/src/components/timeline/session-grouping.ts` exporting
+`getSessionId`/`getTriggerMessageId`/`getSessionSlotKey` moved verbatim from
+`event-list.tsx:83-95`; local copies **deleted** (INV-38/35). No behavior change.
+Enables board reuse without duplicating trigger-slot logic. Trivially revertible.
+
+**PR 2 — SSOT seam + agent activity on the board (the "step 1" that does both).**
+
+- New `packages/types/src/stream-rows.ts`: exhaustive `STREAM_ROW_SPEC`.
+  **Additive** — do not delete the literal arrays yet. Guard test: spec-derived
+  sets `deepEqual` today's `TIMELINE_BROADCAST/COMMAND/AGENT_SESSION_EVENT_TYPES`
+  (freezes behavior, proves the spec matches reality). Respects INV-31, INV-61
+  (spec only _describes_ broadcast slots; write-side gating unchanged).
+- New `apps/frontend/src/hooks/use-board-event-rows.ts`: ref-counted per-stream
+  rail (mirrors the proven `subscribeStreamRail` pattern,
+  `use-board-card-messages.ts:113-148`) over spec-eligible types via
+  `[streamId+eventType].anyOf(...)`; unions the same stream set as the message
+  rail. Separate file so the message rail is untouched and the feature is a clean
+  revert.
+- New `apps/frontend/src/components/board/conversation-event-rows.tsx`:
+  `buildBoardRows` (interleave message + event rows by time, **reset the
+  author-run on any interleaved non-message row** — the board analog of
+  `annotateAuthorGroups`, `event-list.tsx:186`) + `<BoardRowItem>` dispatcher
+  reusing `MessageItem`/`AgentSessionEvent`/`MemoCapturedEvent`/`FollowUpScheduledEvent`.
+- Changed `board-card.tsx` + `conversation-panel.tsx`: feed `buildBoardRows(...)`
+  → `<BoardRowItem>`; **delete** the two inline `isContinuation` maps.
+- Tests (INV-39 real mount, INV-23 presence-not-counts): a card whose member
+  message triggered a session / captured a memo / scheduled a follow-up renders
+  that row; a session row resets a same-author run.
+- Closes drift symptoms 1–3. Board route already sits under `TraceProvider`
+  (`workspace-layout.tsx:463`), so `AgentSessionEvent`'s `useTrace()` resolves
+  with no wiring. INV-51/52/29/43 respected (variant config in the spec table; one
+  shared render path).
+
+**PR 3 — Collapse the scattered arrays into the spec (derive + delete, no behavior
+change).**
+Re-derive `TIMELINE_BROADCAST/COMMAND/AGENT_SESSION_EVENT_TYPES` (`constants.ts`),
+`MESSAGE_/ZERO_HEIGHT_/THREAD_HIDDEN_EVENT_TYPES` (`event-list.tsx`,
+`stream-content.tsx`) from `STREAM_ROW_SPEC`; **delete** the literals (INV-38).
+PR 2's guard test guarantees identical values. Backend broadcast gating reads the
+derived set. This is where the timeline's _implicit_ registry becomes explicit.
+
+**PR 4 — Migrate the timeline switch onto the registry (deferred).**
+New `components/timeline/stream-rows/registry.tsx` (`ROW_RENDERERS` keyed by
+row-kind); `EventItem` switch → lookup. Now a new event type = one spec entry +
+one renderer entry, _both views by construction_. Larger, independently
+revertible, not required for the agent fix.
+
+**PR 5 — Live session step-counts on the board.**
+Mount `useAgentActivity` (`use-agent-activity.ts:65`) for the card's
+already-subscribed streams so the session card shows live counts, not just
+persisted lifecycle. Closes the "0 steps until complete" degradation PR 2 ships
+with.
+
+**Not bundled — separate backend correctness follow-ups** (§7): move-message
+one-root membership strip; delivery-groups workspace promotion for agent events;
+`conversation-item.tsx` INV-60 strip.
+
+## 6. Relationship to the doc (and divergences the maps found)
+
+- **"Agents on the board" (next-up #2, `board-view-design.md:840-842`):** PR 2
+  _is_ this item, delivered as a spec entry rather than bespoke board plumbing.
+  The doc frames it as a small addition; the code shows **zero board-side
+  scaffolding** (`useBoardCardMessages` is type-keyed to `message_created`), so
+  the honest cost is a rail + a shared dispatcher — which the SSOT amortizes across
+  all future types instead of paying per-feature.
+- **"Nested threads × conversations":** the SSOT makes this _cheaper_.
+  `conversationRef` + the existing root+thread rail union (`useMergedStreamRail`)
+  means a thread-fired event resolves to the root conversation through one
+  predicate — no per-type cross-stream logic.
+- **Doc/code divergences to log (not fix here):**
+  1. `useStreamRail` (`board-view-design.md:579`) **does not exist**; the real
+     construct is `subscribeStreamRail`/`useMergedStreamRail` in
+     `use-board-card-messages.ts` — and it's `message_created`-only, structurally
+     the root of the drift.
+  2. Move-message one-root membership strip (`:644-645`) guards an operation that
+     **doesn't exist yet** — `moveMessagesToThread` (`event-service.ts:1068`) is
+     same-root by construction and never touches `conversations`. Aspirational,
+     not a live bug; becomes live only if a real cross-root move ships.
+  3. Delivery-groups asymmetry: `conversation:created/updated` get a
+     `WORKSPACE_GROUP` promotion (`delivery-groups.ts:198-214`);
+     `agent_session:*`/`memos:captured`/follow-up events do **not**. On-screen
+     cards are covered by `useBoardStreamSubscriptions` joining rooms; the residual
+     exposure is a never-opened public channel lagging agent activity until next
+     catch-up. Undocumented in the doc's "Agents on the board" section.
+  4. Superseded "Architecture sketch" reuse claim (`:208`): the shipped board
+     (`BoardCard`/`useBoardCardMessages`) does **not** reuse
+     `conversation-item.tsx`/`conversation-list.tsx`; those are leftover,
+     still-mounted, and `MessagePreview` (`conversation-item.tsx:189`) renders raw
+     `contentMarkdown.slice(0,200)` in a plain `<p>` — an **INV-60 violation**
+     (unstripped markdown). Flag for separate cleanup.
+
+## 7. Scope guard & risks
+
+**Do NOT (INV-36 / scope):**
+
+- **Merge `MessageItem` and `MessageEvent`.** They're two independent components
+  with hand-rolled action contexts and real drift (`MessageEvent` has
+  `ACTOR_ROW_THEME` persona/bot theming, `MessageItem` has none). The SSOT lets
+  `ROW_RENDERERS.message` resolve per-surface later; forcing the merge now is a
+  large unrelated change. Honest cost: a persona's gold stripe still won't show on
+  a board reply until that separate PR.
+- **Touch backend membership/bump/delivery-groups in the render PRs.** All three
+  follow-ups above are orthogonal correctness issues; on-screen cards already get
+  live agent events via room joins.
+- **Port live step-tickers in PR 2.** `AgentSessionEvent` degrades gracefully to
+  "working…/complete • N steps" without `useAgentActivity`
+  (`agent-session-event.tsx:184`). Ship that; add live counts in PR 5.
+- **Big-bang the timeline switch (PR 4) before PR 2 ships value.** The agent drift
+  dies without it.
+
+**INV-61 / stable-view risks:**
+
+- The board is a _resurfacing projection_ sorted by `sortMs`, **not** by
+  `broadcastSequence`. It must never inject gaps or read the contiguity path.
+  Guard: `buildBoardRows` emits no `gap`/`skeleton` rows; a test asserts it.
+  INV-61 stays strictly timeline-side.
+- Stable view (`use-stable-board-view.ts:72-107`) freezes _card set and order_;
+  the row model lives strictly _below_ the card boundary and changes only card
+  _content_ — which the model already treats as live. `bumps:false` on every
+  agent/memo/follow-up type means `last_activity_at` can't move, so the frozen
+  grouping key can't be perturbed. The type field that enforces INV-62 also
+  protects the stable view.
+
+**The one thing most likely to go wrong:** the _continuation reset on an
+interleaved row_. The board's `isContinuation` (`message-item.tsx:92`) has never
+had to break a same-author run on a non-message row because its array was
+homogeneous by construction. Get this wrong and a reply after a session card
+silently mis-groups (loses/gains a header). It's the single piece of genuinely new
+logic — it must have a dedicated mount test in PR 2. Everything else is reuse.
+
+**Where to start:** PR 1 is a 3-symbol mechanical extraction — open it now. PR 2
+builds the spec against confirmed payload fields (`agent-trace.ts:137`,
+`api.ts:1161`, `api.ts:1178`) and the existing components.
+
+## Verification
+
+Load-bearing claims re-checked by hand against the working tree (2026-07-04):
+
+- Board rail Dexie filter is `message_created`-only —
+  `use-board-card-messages.ts:127` ✓
+- Zero non-test `eventType` references under `components/board/` and in
+  `conversation-panel.tsx` ✓
+- `MemosCapturedEventPayload.conversationId` (`api.ts:1161`), follow-up
+  `sourceConversationId` (`api.ts:1178`, `domain.ts:737`), agent-trace
+  `triggerMessageId` (`agent-trace.ts:137`) all exist — the "falls out for free"
+  resolution is grounded ✓
+- `caae3643` `--stat` touched only timeline files, no board/panel/use-board edits ✓

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -271,6 +271,11 @@ export {
   LabelActorTypes,
 } from "./constants"
 
+// Single source of truth for how each stream event renders across the timeline
+// and the board/conversation projection (anti-drift spec — see stream-rows.ts).
+export { STREAM_ROW_SPEC, BOARD_EVENT_ROW_TYPES } from "./stream-rows"
+export type { StreamRowSpec, ConversationRef } from "./stream-rows"
+
 // Markdown → plain-text stripping for preview surfaces (shared FE/BE, INV-60)
 export { stripMarkdown, stripMarkdownToInline } from "./markdown-strip"
 

--- a/packages/types/src/stream-rows.test.ts
+++ b/packages/types/src/stream-rows.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "bun:test"
+import {
+  EVENT_TYPES,
+  TIMELINE_BROADCAST_EVENT_TYPES,
+  COMMAND_EVENT_TYPES,
+  AGENT_SESSION_EVENT_TYPES,
+  type EventType,
+} from "./constants"
+import { STREAM_ROW_SPEC, BOARD_EVENT_ROW_TYPES } from "./stream-rows"
+
+function typesWhere(predicate: (type: EventType) => boolean): Set<EventType> {
+  return new Set(EVENT_TYPES.filter(predicate))
+}
+
+/**
+ * These assertions freeze the spec against the scattered constant sets it will
+ * eventually replace. If a future event type declares a treatment that disagrees
+ * with the live wiring, one of these fails — the spec cannot silently drift from
+ * reality, and the follow-up that derives-and-deletes the literals stays safe.
+ */
+describe("STREAM_ROW_SPEC", () => {
+  test("has exactly one entry per EVENT_TYPE", () => {
+    expect(new Set(Object.keys(STREAM_ROW_SPEC))).toEqual(new Set(EVENT_TYPES))
+  })
+
+  test("broadcastSlot mirrors TIMELINE_BROADCAST_EVENT_TYPES (INV-61)", () => {
+    expect(typesWhere((t) => STREAM_ROW_SPEC[t].broadcastSlot)).toEqual(new Set(TIMELINE_BROADCAST_EVENT_TYPES))
+  })
+
+  test("grouping:'command' mirrors COMMAND_EVENT_TYPES", () => {
+    expect(typesWhere((t) => STREAM_ROW_SPEC[t].grouping === "command")).toEqual(new Set(COMMAND_EVENT_TYPES))
+  })
+
+  test("grouping:'session' mirrors AGENT_SESSION_EVENT_TYPES", () => {
+    expect(typesWhere((t) => STREAM_ROW_SPEC[t].grouping === "session")).toEqual(new Set(AGENT_SESSION_EVENT_TYPES))
+  })
+
+  test("authorGroupable mirrors the message body types", () => {
+    expect(typesWhere((t) => STREAM_ROW_SPEC[t].authorGroupable)).toEqual(
+      new Set<EventType>(["message_created", "companion_response"])
+    )
+  })
+
+  test("only member messages bump conversation activity", () => {
+    // Render-only rows (agent sessions, memo captures, follow-ups) must never move
+    // a card in the board's activity order or perturb its frozen stable view.
+    expect(typesWhere((t) => STREAM_ROW_SPEC[t].bumps)).toEqual(new Set<EventType>(["message_created"]))
+  })
+
+  test("a grouped or patched row is never also its own standalone row", () => {
+    for (const type of EVENT_TYPES) {
+      const spec = STREAM_ROW_SPEC[type]
+      if (spec.grouping !== null || spec.patchesRow) expect(spec.rendersAsOwnRow).toBe(false)
+    }
+  })
+
+  test("BOARD_EVENT_ROW_TYPES are exactly the conversation-referring non-message rows", () => {
+    expect(new Set(BOARD_EVENT_ROW_TYPES)).toEqual(
+      new Set<EventType>([
+        "agent_session:started",
+        "agent_session:completed",
+        "agent_session:failed",
+        "agent_session:deleted",
+        "memos:captured",
+        "agent:follow_up_scheduled",
+      ])
+    )
+    // None of them are message bodies (those are `self-message`, handled directly).
+    for (const type of BOARD_EVENT_ROW_TYPES) expect(STREAM_ROW_SPEC[type].authorGroupable).toBe(false)
+  })
+})

--- a/packages/types/src/stream-rows.ts
+++ b/packages/types/src/stream-rows.ts
@@ -1,0 +1,219 @@
+import { EVENT_TYPES, type EventType } from "./constants"
+
+/**
+ * How a stream event resolves to a conversation on the board / conversation-panel
+ * projection (the "second view" of a stream's content). This is *render-side
+ * placement* — deliberately distinct from `conversations.message_ids`, which is
+ * the backend membership truth. It answers "which card does this row draw on,"
+ * not "is this a member of the conversation."
+ *
+ * - `self-message`     — the row IS a member message; keyed by its own messageId.
+ * - `trigger-message`  — keyed by the invoking message id (agent sessions: the
+ *                        session shows on the conversation its trigger belongs to).
+ * - `source-conversation` — the payload names the conversation directly
+ *                        (memos:captured → `conversationId`,
+ *                        agent:follow_up_scheduled → `sourceConversationId`).
+ * - `none`             — never drawn on conversation surfaces (channel chrome like
+ *                        member/description events, author-scoped command events,
+ *                        and patch-style rows).
+ */
+export type ConversationRef = "self-message" | "trigger-message" | "source-conversation" | "none"
+
+/**
+ * The single description of how a stream event participates in the two views over
+ * a stream's content — the chronological timeline (the room) and the board /
+ * conversation projection (topic cards + side panel).
+ *
+ * There is exactly one entry per {@link EventType} in {@link STREAM_ROW_SPEC}, and
+ * the record is `Record<EventType, StreamRowSpec>` (not `Partial`) on purpose:
+ * adding a member to `EVENT_TYPES` is a compile error until it declares how BOTH
+ * views treat it. That is the anti-drift device — before this, the timeline knew
+ * ~8 scattered constant sets and the board knew none, so a new row kind could ship
+ * to one view and be silently invisible in the other (INV-61 contiguity for the
+ * timeline; a hard `message_created` Dexie filter for the board).
+ *
+ * The existing scattered sets remain the live wiring for now; the guard test
+ * (`stream-rows.test.ts`) proves this spec's derived sets match them exactly, so
+ * they can be re-derived and deleted in a follow-up without behavior change.
+ */
+export interface StreamRowSpec {
+  /**
+   * Renders as its own standalone row (a message body, a system notice, a memo
+   * capture, a scheduled follow-up). False for rows that are grouped before
+   * rendering (`grouping != null`) or delivered as patches (`patchesRow`).
+   */
+  rendersAsOwnRow: boolean
+  /**
+   * Grouped with adjacent same-group events into one rendered card before it
+   * draws: command lifecycle (dispatched/completed/failed) and agent-session
+   * lifecycle (started/completed/failed/deleted). `null` for ungrouped rows.
+   */
+  grouping: "command" | "session" | null
+  /**
+   * Participates in same-author continuation grouping (consecutive messages by
+   * one actor within a short window collapse their repeated header). True only
+   * for message bodies. Mirror of the timeline's `MESSAGE_EVENT_TYPES`.
+   */
+  authorGroupable: boolean
+  /**
+   * Delivered live as a payload *patch* onto an existing row rather than an
+   * appended row (edits, reactions, deletes, follow-up cancels). Patches never
+   * take a broadcast slot. Mirror of the timeline's `ZERO_HEIGHT_EVENT_TYPES`
+   * minus the grouped types.
+   */
+  patchesRow: boolean
+  /**
+   * Consumes a dense per-stream `broadcastSequence` slot — every member receives
+   * it as an appended timeline row, so a missing number is always a real gap
+   * (INV-61). Exact mirror of `TIMELINE_BROADCAST_EVENT_TYPES`.
+   */
+  broadcastSlot: boolean
+  /** {@link ConversationRef}: how the board/panel projection places this row. */
+  conversationRef: ConversationRef
+  /**
+   * Whether appending this event bumps `conversations.last_activity_at` (moves the
+   * card in the board's activity order). Contract: only a member message bumps —
+   * every render-only agent/memo/follow-up row is `false`, so it can appear on a
+   * card without perturbing the board's activity sort or its frozen stable view
+   * ("Agents on the board — traces visible, never bumping", board-view-design.md).
+   */
+  bumps: boolean
+}
+
+const MESSAGE: StreamRowSpec = {
+  rendersAsOwnRow: true,
+  grouping: null,
+  authorGroupable: true,
+  patchesRow: false,
+  broadcastSlot: true,
+  conversationRef: "self-message",
+  bumps: true,
+}
+
+/** A live patch onto an existing row (edit / reaction / delete / cancel). */
+const PATCH: StreamRowSpec = {
+  rendersAsOwnRow: false,
+  grouping: null,
+  authorGroupable: false,
+  patchesRow: true,
+  broadcastSlot: false,
+  conversationRef: "none",
+  bumps: false,
+}
+
+/** Channel chrome: a broadcast row in the timeline, never a board/topic row. */
+const CHROME_BROADCAST: StreamRowSpec = {
+  rendersAsOwnRow: true,
+  grouping: null,
+  authorGroupable: false,
+  patchesRow: false,
+  broadcastSlot: true,
+  conversationRef: "none",
+  bumps: false,
+}
+
+const AGENT_SESSION: StreamRowSpec = {
+  rendersAsOwnRow: false,
+  grouping: "session",
+  authorGroupable: false,
+  patchesRow: false,
+  broadcastSlot: true,
+  conversationRef: "trigger-message",
+  bumps: false,
+}
+
+const COMMAND: StreamRowSpec = {
+  rendersAsOwnRow: false,
+  grouping: "command",
+  authorGroupable: false,
+  patchesRow: false,
+  broadcastSlot: false,
+  conversationRef: "none",
+  bumps: false,
+}
+
+export const STREAM_ROW_SPEC: Record<EventType, StreamRowSpec> = {
+  message_created: MESSAGE,
+  // Legacy/no-longer-emitted, but still renders as a message body where present
+  // (author-groupable like `message_created`); it rides along without a broadcast
+  // slot, so it is not a board topic row.
+  companion_response: {
+    rendersAsOwnRow: true,
+    grouping: null,
+    authorGroupable: true,
+    patchesRow: false,
+    broadcastSlot: false,
+    conversationRef: "none",
+    bumps: false,
+  },
+  message_edited: PATCH,
+  reaction_added: PATCH,
+  reaction_removed: PATCH,
+  // A soft-delete: the board rail folds it into the `message_created` row's
+  // `deletedAt`, so it is a patch there; the timeline draws a small tombstone.
+  message_deleted: PATCH,
+
+  member_joined: CHROME_BROADCAST,
+  member_added: CHROME_BROADCAST,
+  member_left: CHROME_BROADCAST,
+  description_set: CHROME_BROADCAST,
+  stream_archived: CHROME_BROADCAST,
+  stream_unarchived: CHROME_BROADCAST,
+  // Source-side tombstone for a move; the board does not surface move notices.
+  "messages:moved": CHROME_BROADCAST,
+  // Legacy/no-longer-emitted; rendered as a plain system notice, no slot.
+  thread_created: {
+    rendersAsOwnRow: true,
+    grouping: null,
+    authorGroupable: false,
+    patchesRow: false,
+    broadcastSlot: false,
+    conversationRef: "none",
+    bumps: false,
+  },
+
+  command_dispatched: COMMAND,
+  command_completed: COMMAND,
+  command_failed: COMMAND,
+
+  "agent_session:started": AGENT_SESSION,
+  "agent_session:completed": AGENT_SESSION,
+  "agent_session:failed": AGENT_SESSION,
+  "agent_session:deleted": AGENT_SESSION,
+
+  // GAM memory capture — provenance carries the source `conversationId`.
+  "memos:captured": {
+    rendersAsOwnRow: true,
+    grouping: null,
+    authorGroupable: false,
+    patchesRow: false,
+    broadcastSlot: true,
+    conversationRef: "source-conversation",
+    bumps: false,
+  },
+  // Scheduled agent follow-up — payload carries `sourceConversationId`.
+  "agent:follow_up_scheduled": {
+    rendersAsOwnRow: true,
+    grouping: null,
+    authorGroupable: false,
+    patchesRow: false,
+    broadcastSlot: true,
+    conversationRef: "source-conversation",
+    bumps: false,
+  },
+  // A patch that flips the matching scheduled card to "Cancelled" — not its own row.
+  "agent:follow_up_cancelled": PATCH,
+}
+
+/**
+ * Event types the board / conversation-panel projection draws as their own
+ * (non-message) rows, resolved to a conversation via `conversationRef`. Derived
+ * from {@link STREAM_ROW_SPEC} so a newly-registered conversation-scoped row kind
+ * joins the board automatically instead of requiring a second, separate wiring —
+ * this is the drift the spec exists to prevent.
+ */
+export const BOARD_EVENT_ROW_TYPES: EventType[] = EVENT_TYPES.filter(
+  (type) =>
+    STREAM_ROW_SPEC[type].conversationRef === "trigger-message" ||
+    STREAM_ROW_SPEC[type].conversationRef === "source-conversation"
+)


### PR DESCRIPTION
## Summary

The board card and conversation panel are supposed to be a **second view** of a stream's content, but they were a message-only parallel renderer: `useBoardCardMessages` reads `db.events` through a hard `message_created` Dexie filter, so agent traces (`agent_session:*`), scheduled reminders (`agent:follow_up_scheduled`), and memo captures (`memos:captured`) — all visible in the timeline — never entered the board's data structure. Trigger an agent from a card and it looks dead until the final reply lands.

Root cause: there's **no shared "renderable stream row" model**. The timeline has an implicit registry (a `switch` in `event-item.tsx` + ~8 scattered type-sets); the board has none. Adding a row kind meant editing both views with nothing forcing the second. Full write-up: `docs/board-timeline-drift-audit.md`.

This PR lands the anti-drift device **and** the visible payoff (agent activity on the board), reusing the timeline's own row components.

> Draft: this is the first, self-contained slice. Follow-ups (derive+delete the scattered constant sets from the spec; migrate the timeline `EventItem` switch onto the spec; live session step-counts) are listed at the bottom, not in this PR.

## The SSOT — `packages/types/src/stream-rows.ts`

One exhaustive `STREAM_ROW_SPEC: Record<EventType, StreamRowSpec>` describing how each event renders across both views:

```
rendersAsOwnRow · grouping · authorGroupable · patchesRow · broadcastSlot · conversationRef · bumps
```

`Record` (not `Partial`) is the point: **adding an `EVENT_TYPE` is a compile error until it declares how both views treat it.** A guard test (`stream-rows.test.ts`) freezes the spec's derived sets against today's scattered arrays (`TIMELINE_BROADCAST_EVENT_TYPES`, `COMMAND_EVENT_TYPES`, `AGENT_SESSION_EVENT_TYPES`, the message-body set) so a later PR can derive-and-delete the literals with no behavior change.

Three axes it makes explicit: *renders here* (spec) vs *is a conversation member* (backend `message_ids`, untouched) vs *bumps activity* (`bumps: false` for every agent/memo/follow-up type — so they can't move a card in the board's activity order or perturb the frozen stable view).

## How the board consumes it

- **`use-board-card-messages`** reads the spec-eligible event types alongside `message_created` (one `anyOf` query; the ref-counted rail is otherwise unchanged) and returns them as `events`.
- **`resolveBoardEventRows`** (pure) keys each event to its conversation via `conversationRef` — memos→`conversationId`, follow-ups→`sourceConversationId`, sessions→trigger message must be a member — and groups a session's lifecycle events into one row. `agent:follow_up_cancelled` is a patch that flips the matching card to Cancelled.
- **`buildBoardRows`** (pure) interleaves event rows into the message list by time and **breaks same-author continuation on any event row** (the board's analog of the timeline's `annotateAuthorGroups` reset). `BoardEventRowItem` reuses `AgentSessionEvent` / `MemoCapturedEvent` / `FollowUpScheduledEvent` as-is.
- **`board-card` and `conversation-panel`** render the merged rows. Read-state and auto-read arrays stay message-only — events are render-only, never members.

`getSessionId` / `getTriggerMessageId` / `getSessionSlotKey` are extracted to `session-grouping.ts`, shared by the timeline and the board (INV-35).

## Design decisions

- **Spec in `@threa/types`, exhaustive `Record`.** A frontend-only `Partial` would silently omit a new type — the exact failure being fixed. Putting it in the types package and keying on `EventType` makes omission a build error.
- **Additive, not a rewrite.** The scattered arrays remain the live wiring; the guard test proves the spec matches them. The timeline `switch` is untouched in this PR (staged, lower-risk).
- **Events are render-only (`bumps:false`), kept out of read-state.** They aren't members and carry no read state; this is what protects the board's activity sort and stable-view freeze ("Agents on the board — traces visible, never bumping", `board-view-design.md`).
- **Continuation reset on an interleaved row** is the one genuinely-new bit of logic (the board's list was homogeneous before) — covered by a dedicated unit test.
- **Events before the first displayed message are dropped** (they belong to a collapsed card's hidden middle); a running session after the last message lands at the tail — exactly the "agent I just triggered" case.

## Tests

- SSOT guard — spec derives today's constant sets exactly (8).
- `resolveBoardEventRows` — conversation keying, session member-gating + grouping, follow-up cancel, ordering (4).
- `buildBoardRows` — continuation grouping, reset on interleaved event, drop-before-first, tail append, timestamp tie-break (5).
- `board-card` mount — a member-triggered session renders "Session complete"; a non-member one doesn't (2, INV-39 real mount).
- No regressions across board / conversation-panel / use-board-card-messages / event-list / agent-session (95 existing). Frontend + `@threa/types` typecheck clean.

## Not in this PR (follow-ups, in the audit doc)

1. Derive `TIMELINE_BROADCAST/COMMAND/AGENT_SESSION_EVENT_TYPES` + `MESSAGE_/ZERO_HEIGHT_/THREAD_HIDDEN_EVENT_TYPES` from the spec, delete the literals.
2. Migrate the timeline `EventItem` switch onto a spec-keyed renderer registry (then a new event type = one spec entry, both views by construction).
3. Live session step-counts on the board (`useAgentActivity`) — the card degrades gracefully to persisted lifecycle without it.
4. Orthogonal backend items the audit flags (delivery-groups workspace promotion for agent events; `conversation-item.tsx` INV-60 raw-markdown strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785793411&installation_id=129946197&pr_number=1179&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1179&signature=02d25d608758f278e8ababc7409c600fc2ea7179a0841962e06adfd8a871f8a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->