### PR TITLE
fix(push): suppress accurately on panel/thread views and detect dead subscriptions

### DIFF
--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -158,11 +158,12 @@ describe("BoardCard viewport auto-read (full wiring: real card, real controller,
     await act(async () => {})
     expect(screen.getByText("Opening body.")).toBeTruthy()
 
-    const io = FakeIntersectionObserver.instances.at(-1)
-    expect(io, "an IntersectionObserver should have been constructed").toBeTruthy()
     const rowEl = document.querySelector('[data-message-row][data-message-id="m_open"]')
     expect(rowEl, "the opening row should carry data-message-row").toBeTruthy()
-    expect(io!.observed.has(rowEl!), "the opening row should be observed").toBe(true)
+    // The card constructs several observers (auto-read rows, visible-streams
+    // viewport gate) — pick the one actually watching the opening row.
+    const io = FakeIntersectionObserver.instances.find((instance) => instance.observed.has(rowEl!))
+    expect(io, "an IntersectionObserver should be observing the opening row").toBeTruthy()
 
     act(() => {
       io!.fire([{ target: rowEl!, isIntersecting: true }])

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type LucideIcon } from "lucide-react"
@@ -11,7 +11,7 @@ import { useConversationAutoRead } from "@/components/message/use-conversation-a
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
-import { useActors } from "@/hooks"
+import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
@@ -146,6 +146,26 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     registerExplicitUnread: setExplicitUnreadListener,
     getReadTruth,
   })
+
+  // The card is a first-class reading surface (live message bodies, viewport
+  // auto-read above), so while any part of it is on screen its streams count
+  // as visible for push suppression — otherwise a push banners the exact
+  // message the user is reading on the board. Viewport-gated (not mount-gated)
+  // so off-screen cards on a long board don't suppress streams the user can't
+  // see.
+  const [cardInViewport, setCardInViewport] = useState(false)
+  useEffect(() => {
+    const el = cardRef.current
+    if (!el || typeof IntersectionObserver === "undefined") return
+    const observer = new IntersectionObserver(([entry]) => setCardInViewport(entry.isIntersecting))
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+  const cardVisibleStreamIds = useMemo(
+    () => (cardInViewport ? [...new Set([streamId, ...(post.streamIds ?? [])])] : []),
+    [cardInViewport, streamId, post.streamIds]
+  )
+  useVisibleStreams(cardVisibleStreamIds)
 
   const renderMessage = (message: RenderableMessage, continuation: boolean) => (
     <MessageItem

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -22,7 +22,7 @@ import { BoardReplyComposer } from "@/components/board/board-reply-composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
-import { useActors } from "@/hooks"
+import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useStreamName } from "@/hooks/use-stream-name"
 import { useConversationService, usePanel, parseConversationPanel, useSidebar } from "@/contexts"
@@ -84,6 +84,9 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
     [post]
   )
   usePanelStreamSubscriptions(panelStreamIds)
+  // The panel's streams aren't in the URL (`?panel=conv:…`), so the SW's push
+  // suppression can only know they're on screen if we register them here.
+  useVisibleStreams(panelStreamIds)
 
   // Escape closes the panel, matching StreamPanel — the two are peers in the same
   // slot, so the keyboard affordance should be consistent. Skip when the event was

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -186,6 +186,8 @@ export { useUnreadTabIndicator } from "./use-unread-tab-indicator"
 
 export { useNotificationSweep } from "./use-notification-sweep"
 
+export { useVisibleStreams } from "./use-visible-streams"
+
 export {
   useSavedList,
   useSavedForMessage,

--- a/apps/frontend/src/hooks/use-page-interaction.ts
+++ b/apps/frontend/src/hooks/use-page-interaction.ts
@@ -8,8 +8,8 @@ export interface PageInteractionTracker {
 }
 
 /**
- * Tracks pointer/key/touch interactions on the document. State is stored in
- * refs so mouse movement doesn't re-render consumers — callers read the
+ * Tracks pointer/key/touch/wheel interactions on the document. State is stored
+ * in refs so mouse movement doesn't re-render consumers — callers read the
  * timestamp at heartbeat time and may subscribe to the event stream to drive
  * their own throttled "user resumed activity" signal.
  */
@@ -34,15 +34,24 @@ export function usePageInteraction(): PageInteractionTracker {
       for (const cb of listenersRef.current) cb()
     }
 
+    // `wheel` counts reading: desktop scrolling fires no pointerdown/keydown,
+    // so without it a user reading a long stream "ages out" of presence after
+    // 2 minutes and gets pushed for the very stream they're looking at. It is
+    // deliberately `wheel` (hardware input) and NOT `scroll` — programmatic
+    // scrolls (auto-follow on new messages, virtualizer adjustments) fire
+    // `scroll` on an abandoned-but-focused tab and would fake presence,
+    // which is exactly what this interaction gate exists to prevent.
     const opts: AddEventListenerOptions = { passive: true, capture: true }
     window.addEventListener("pointerdown", handle, opts)
     window.addEventListener("keydown", handle, opts)
     window.addEventListener("touchstart", handle, opts)
+    window.addEventListener("wheel", handle, opts)
 
     return () => {
       window.removeEventListener("pointerdown", handle, opts)
       window.removeEventListener("keydown", handle, opts)
       window.removeEventListener("touchstart", handle, opts)
+      window.removeEventListener("wheel", handle, opts)
     }
   }, [])
 

--- a/apps/frontend/src/hooks/use-push-notifications.ts
+++ b/apps/frontend/src/hooks/use-push-notifications.ts
@@ -53,6 +53,17 @@ const SUBSCRIBE_TIMEOUT_MS = 15_000
  */
 const RESUBSCRIBE_THROTTLE_MS = 5 * 60_000
 
+/**
+ * How often to re-verify that the browser still holds a push subscription.
+ * Firefox revokes a subscription when its silent-push quota is exhausted and
+ * defers the `pushsubscriptionchange` event for up to ~a day (idle timer /
+ * browser restart) — a long-lived focused tab fires none of the
+ * foreground/online triggers in that window, so without this check the UI
+ * says "Enabled" while delivery is dead. `getSubscription()` is a local call;
+ * a missing subscription triggers the full idempotent re-subscribe.
+ */
+const LIVENESS_CHECK_INTERVAL_MS = 5 * 60_000
+
 class SubscribeTimeoutError extends Error {
   constructor() {
     super("Timed out while subscribing to push notifications")
@@ -359,10 +370,27 @@ export function usePushNotifications(workspaceId: string | undefined): UsePushNo
       if (document.visibilityState !== "visible") return
       resubscribeThrottled()
     }
+    // Liveness re-verify (see LIVENESS_CHECK_INTERVAL_MS): a browser-side
+    // revocation with no visibility/online event otherwise goes unnoticed
+    // until the next app open. Bypasses the resubscribe throttle on purpose —
+    // it only acts when the subscription is genuinely gone.
+    const livenessTimer = setInterval(() => {
+      void (async () => {
+        try {
+          const registration = await navigator.serviceWorker?.ready
+          const existing = await registration?.pushManager.getSubscription()
+          if (!existing) void subscribe()
+        } catch {
+          // next tick retries
+        }
+      })()
+    }, LIVENESS_CHECK_INTERVAL_MS)
+
     window.addEventListener("pushsubscriptionchanged", handleSubscriptionChange)
     document.addEventListener("visibilitychange", handleVisible)
     window.addEventListener("online", resubscribeThrottled)
     return () => {
+      clearInterval(livenessTimer)
       window.removeEventListener("pushsubscriptionchanged", handleSubscriptionChange)
       document.removeEventListener("visibilitychange", handleVisible)
       window.removeEventListener("online", resubscribeThrottled)

--- a/apps/frontend/src/hooks/use-visible-streams.ts
+++ b/apps/frontend/src/hooks/use-visible-streams.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react"
+import { createVisibleStreamRegistry, publishVisibleStreams, type VisibleStreamRegistry } from "@/lib/visible-streams"
+
+/**
+ * One registry per tab, publishing to the shared presence cache. The focus
+ * listener re-asserts this tab's set when it becomes the focused one — the
+ * cache entry is last-writer-wins across tabs, and the service worker only
+ * suppresses for the focused client's streams.
+ */
+let sharedRegistry: VisibleStreamRegistry | null = null
+function getRegistry(): VisibleStreamRegistry {
+  if (!sharedRegistry) {
+    sharedRegistry = createVisibleStreamRegistry((ids) => void publishVisibleStreams(ids))
+    window.addEventListener("focus", () => sharedRegistry?.republish())
+  }
+  return sharedRegistry
+}
+
+/**
+ * Marks the given streams as on-screen for push suppression while the calling
+ * component is mounted (see lib/visible-streams.ts). Register from surfaces
+ * that actually render a stream's messages: the workspace layout (URL stream +
+ * bare-stream panels) and the conversation panel (its resolved stream ids).
+ */
+export function useVisibleStreams(streamIds: readonly string[]): void {
+  // Key on content, not array identity — callers rebuild the array per render.
+  const key = [...streamIds].sort().join(" ")
+  useEffect(() => {
+    if (typeof window === "undefined" || !("caches" in window)) return
+    const ids = key ? key.split(" ") : []
+    if (ids.length === 0) return
+    return getRegistry().register(ids)
+  }, [key])
+}

--- a/apps/frontend/src/hooks/use-visible-streams.ts
+++ b/apps/frontend/src/hooks/use-visible-streams.ts
@@ -2,15 +2,24 @@ import { useEffect } from "react"
 import { createVisibleStreamRegistry, publishVisibleStreams, type VisibleStreamRegistry } from "@/lib/visible-streams"
 
 /**
- * One registry per tab, publishing to the shared presence cache. The focus
- * listener re-asserts this tab's set when it becomes the focused one — the
- * cache entry is last-writer-wins across tabs, and the service worker only
- * suppresses for the focused client's streams.
+ * One registry per tab, publishing to the shared presence cache. Ownership
+ * rule: ONLY the focused tab writes the entry. The cache is last-writer-wins
+ * across tabs and the SW reads it as "what the focused client is viewing" —
+ * an unfocused tab publishing its own set (a stream opened in a background
+ * tab, a conversation panel whose data resolves after a tab switch) would
+ * clobber the focused tab's set and silently suppress pushes the user cannot
+ * see. A tab that registers while backgrounded publishes on its next focus
+ * via the listener below, which also heals the entry after a tab closes
+ * without cleanup: whichever Threa tab the user focuses next overwrites it,
+ * and until one is focused the SW's focused-client gate keeps it inert.
  */
 let sharedRegistry: VisibleStreamRegistry | null = null
 function getRegistry(): VisibleStreamRegistry {
   if (!sharedRegistry) {
-    sharedRegistry = createVisibleStreamRegistry((ids) => void publishVisibleStreams(ids))
+    sharedRegistry = createVisibleStreamRegistry((ids) => {
+      if (!document.hasFocus()) return
+      void publishVisibleStreams(ids)
+    })
     window.addEventListener("focus", () => sharedRegistry?.republish())
   }
   return sharedRegistry
@@ -20,7 +29,8 @@ function getRegistry(): VisibleStreamRegistry {
  * Marks the given streams as on-screen for push suppression while the calling
  * component is mounted (see lib/visible-streams.ts). Register from surfaces
  * that actually render a stream's messages: the workspace layout (URL stream +
- * bare-stream panels) and the conversation panel (its resolved stream ids).
+ * bare-stream panels), the conversation panel (its resolved stream ids), and
+ * viewport-visible board cards.
  */
 export function useVisibleStreams(streamIds: readonly string[]): void {
   // Key on content, not array identity — callers rebuild the array per render.

--- a/apps/frontend/src/lib/visible-streams.test.ts
+++ b/apps/frontend/src/lib/visible-streams.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, expect, it } from "vitest"
 import { createVisibleStreamRegistry } from "./visible-streams"
 
 const flushMicrotasks = () => Promise.resolve()

--- a/apps/frontend/src/lib/visible-streams.test.ts
+++ b/apps/frontend/src/lib/visible-streams.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "bun:test"
+import { createVisibleStreamRegistry } from "./visible-streams"
+
+const flushMicrotasks = () => Promise.resolve()
+
+describe("createVisibleStreamRegistry", () => {
+  it("publishes the deduped, sorted union of registered ids", async () => {
+    const published: string[][] = []
+    const registry = createVisibleStreamRegistry((ids) => published.push(ids))
+
+    registry.register(["stream_b", "stream_a"])
+    registry.register(["stream_a"])
+    await flushMicrotasks()
+
+    expect(published).toEqual([["stream_a", "stream_b"]])
+    expect(registry.snapshot()).toEqual(["stream_a", "stream_b"])
+  })
+
+  it("keeps an id visible until every registration for it is released", async () => {
+    const published: string[][] = []
+    const registry = createVisibleStreamRegistry((ids) => published.push(ids))
+
+    const releaseFirst = registry.register(["stream_a"])
+    const releaseSecond = registry.register(["stream_a", "stream_b"])
+    await flushMicrotasks()
+
+    releaseFirst()
+    await flushMicrotasks()
+    expect(registry.snapshot()).toEqual(["stream_a", "stream_b"])
+
+    releaseSecond()
+    await flushMicrotasks()
+    expect(registry.snapshot()).toEqual([])
+    expect(published.at(-1)).toEqual([])
+  })
+
+  it("coalesces a same-tick swap into one publish and ignores double release", async () => {
+    const published: string[][] = []
+    const registry = createVisibleStreamRegistry((ids) => published.push(ids))
+
+    const release = registry.register(["stream_a"])
+    await flushMicrotasks()
+    published.length = 0
+
+    // Panel swap: unregister + register within one render pass.
+    release()
+    release() // double release must not underflow another registration's count
+    registry.register(["stream_b"])
+    await flushMicrotasks()
+
+    expect(published).toEqual([["stream_b"]])
+  })
+})

--- a/apps/frontend/src/lib/visible-streams.ts
+++ b/apps/frontend/src/lib/visible-streams.ts
@@ -11,12 +11,15 @@ import { PRESENCE_CACHE } from "./sw-presence"
  * render a stream register their ids here, and the SW checks membership when
  * deciding whether a push is for something the user can already see.
  *
- * The cache entry is last-writer-wins across tabs; the registering hook
- * re-publishes on window focus so the focused tab's set is authoritative. No
- * TTL: the entry only changes when the visible set changes, and the SW
- * additionally requires a currently-focused client plus recent interaction
- * (isDevicePresent) before it suppresses, so a stale entry from a closed tab
- * can't eat notifications on its own.
+ * The cache entry is last-writer-wins across tabs, so it carries a strict
+ * ownership rule (enforced in use-visible-streams.ts): only the focused tab
+ * ever writes it, and every focus gain re-publishes. That makes the entry
+ * "what the focused Threa tab is viewing" by construction — a background tab
+ * can't clobber it, and after a tab closes without cleanup the entry is
+ * rewritten the moment any Threa tab gains focus. No TTL: while no Threa tab
+ * is focused, the SW's focused-client gate (plus the isDevicePresent
+ * interaction window) keeps a stale entry inert; while one is focused, the
+ * entry is that tab's own set.
  */
 
 // Synthetic request key — never hits the network; a stable Cache lookup key.

--- a/apps/frontend/src/lib/visible-streams.ts
+++ b/apps/frontend/src/lib/visible-streams.ts
@@ -1,0 +1,95 @@
+import { PRESENCE_CACHE } from "./sw-presence"
+
+/**
+ * Which streams are actually on screen right now — the page-side half of push
+ * suppression, shared with the service worker via Cache Storage (same
+ * mechanism and cache as the interaction-presence signal in sw-presence.ts).
+ *
+ * The SW can't derive this from window URLs alone: threads and conversations
+ * open as `?panel=` params on whatever route is current, and a conversation
+ * panel's underlying stream ids aren't in the URL at all. So the surfaces that
+ * render a stream register their ids here, and the SW checks membership when
+ * deciding whether a push is for something the user can already see.
+ *
+ * The cache entry is last-writer-wins across tabs; the registering hook
+ * re-publishes on window focus so the focused tab's set is authoritative. No
+ * TTL: the entry only changes when the visible set changes, and the SW
+ * additionally requires a currently-focused client plus recent interaction
+ * (isDevicePresent) before it suppresses, so a stale entry from a closed tab
+ * can't eat notifications on its own.
+ */
+
+// Synthetic request key — never hits the network; a stable Cache lookup key.
+const VISIBLE_STREAMS_KEY = "https://threa.local/__presence__/visible-streams"
+
+export interface VisibleStreamRegistry {
+  /** Register stream ids as visible; returns an unregister function. Refcounted. */
+  register(streamIds: readonly string[]): () => void
+  /** Re-publish the current set (e.g. when this tab regains focus). */
+  republish(): void
+  snapshot(): string[]
+}
+
+/**
+ * Refcounted registry of on-screen stream ids. Publishes the deduped set via
+ * `publish` on every change, coalesced to one call per microtask so a panel
+ * swap (unregister + register in one render) publishes once.
+ */
+export function createVisibleStreamRegistry(publish: (streamIds: string[]) => void): VisibleStreamRegistry {
+  const counts = new Map<string, number>()
+  let queued = false
+
+  const flush = () => {
+    queued = false
+    publish([...counts.keys()].sort())
+  }
+  const schedule = () => {
+    if (queued) return
+    queued = true
+    queueMicrotask(flush)
+  }
+
+  return {
+    register(streamIds: readonly string[]): () => void {
+      for (const id of streamIds) counts.set(id, (counts.get(id) ?? 0) + 1)
+      schedule()
+      let released = false
+      return () => {
+        if (released) return
+        released = true
+        for (const id of streamIds) {
+          const next = (counts.get(id) ?? 1) - 1
+          if (next <= 0) counts.delete(id)
+          else counts.set(id, next)
+        }
+        schedule()
+      }
+    },
+    republish: schedule,
+    snapshot: () => [...counts.keys()].sort(),
+  }
+}
+
+/** Best-effort write; a failure just means the SW falls back to URL matching. */
+export async function publishVisibleStreams(streamIds: string[]): Promise<void> {
+  try {
+    const cache = await caches.open(PRESENCE_CACHE)
+    await cache.put(VISIBLE_STREAMS_KEY, new Response(JSON.stringify(streamIds)))
+  } catch {
+    // ignore — fails open to showing notifications
+  }
+}
+
+/** Read by the service worker. Empty set on missing/malformed/unreadable entry. */
+export async function readVisibleStreams(): Promise<ReadonlySet<string>> {
+  try {
+    const cache = await caches.open(PRESENCE_CACHE)
+    const res = await cache.match(VISIBLE_STREAMS_KEY)
+    if (!res) return new Set()
+    const parsed = (await res.json()) as unknown
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((value): value is string => typeof value === "string"))
+  } catch {
+    return new Set()
+  }
+}

--- a/apps/frontend/src/pages/workspace-layout.tsx
+++ b/apps/frontend/src/pages/workspace-layout.tsx
@@ -53,6 +53,7 @@ import {
   useMessageQueue,
   useUnreadTabIndicator,
   useNotificationSweep,
+  useVisibleStreams,
   useBackgroundBootstrapSync,
 } from "@/hooks"
 import { useDecryptStreamNames } from "@/hooks/use-decrypt-stream-names"
@@ -344,6 +345,16 @@ function NotificationSweeper({ workspaceId }: { workspaceId: string }) {
   return null
 }
 
+/**
+ * Publishes the URL-derived visible streams (main stream + bare-stream panels)
+ * for push suppression. `conv:` panels resolve their stream ids only after
+ * their post loads, so the conversation panel registers those itself.
+ */
+function VisibleStreamPresence({ streamIds }: { streamIds: string[] }) {
+  useVisibleStreams(streamIds.filter((id) => id.startsWith("stream_")))
+  return null
+}
+
 function AppUpdateChecker() {
   useAppUpdate()
   return null
@@ -448,6 +459,7 @@ export function WorkspaceLayout() {
         <WorkspaceSyncHandler workspaceId={workspaceId} visibleStreamIds={streamIds}>
           <UnreadTabIndicator workspaceId={workspaceId} />
           <NotificationSweeper workspaceId={workspaceId} />
+          <VisibleStreamPresence streamIds={streamIds} />
           <AppUpdateChecker />
           <FreshnessWatchers />
           <MessageQueueHandler />

--- a/apps/frontend/src/sw.ts
+++ b/apps/frontend/src/sw.ts
@@ -2,6 +2,7 @@
 import { cleanupOutdatedCaches, matchPrecache, precacheAndRoute } from "workbox-precaching"
 import { resolveTag } from "./lib/sw-notification-format"
 import { isDevicePresent, PRESENCE_CACHE } from "./lib/sw-presence"
+import { readVisibleStreams } from "./lib/visible-streams"
 import {
   BOOTSTRAP_SYNC_TAG,
   PENDING_SYNC_CACHE,
@@ -462,15 +463,20 @@ self.addEventListener("push", (event) => {
   // rule. Backend always sends the push; the SW decides whether to display it.
   // Skipping only the on-screen stream also keeps us off the userVisibleOnly
   // silent-push budget that browsers penalize on mobile.
+  //
+  // "Viewing" is two signals, either suffices: the window URL matches the
+  // stream route (/w/:ws/s/:id), or the page registered the stream as
+  // on-screen in the visible-streams presence entry — threads and
+  // conversations render as `?panel=` params (on any route, including /board),
+  // so their stream ids never appear in the URL path and only the registry
+  // knows they're being read.
   event.waitUntil(
-    Promise.all([fmt, self.clients.matchAll({ type: "window", includeUncontrolled: true })]).then(
-      async ([{ appendMessage, formatTitle, formatBody, isViewingStream }, clients]) => {
-        const viewingThisStream = clients.some(
-          (c) =>
-            c.focused &&
-            new URL(c.url).origin === self.location.origin &&
-            isViewingStream(c.url, data.workspaceId, data.streamId)
-        )
+    Promise.all([fmt, self.clients.matchAll({ type: "window", includeUncontrolled: true }), readVisibleStreams()]).then(
+      async ([{ appendMessage, formatTitle, formatBody, isViewingStream }, clients, visibleStreams]) => {
+        const focusedClients = clients.filter((c) => c.focused && new URL(c.url).origin === self.location.origin)
+        const viewingThisStream =
+          focusedClients.some((c) => isViewingStream(c.url, data.workspaceId, data.streamId)) ||
+          (focusedClients.length > 0 && !!data.streamId && visibleStreams.has(data.streamId))
         if (viewingThisStream && (await isDevicePresent())) return
 
         // Accumulate a rolling list of recent messages from the existing notification
@@ -628,9 +634,11 @@ self.addEventListener("pushsubscriptionchange", (event) => {
         const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true })
 
         if (clients.length === 0) {
-          // No open windows — persist to IndexedDB so the app can sync on next load.
-          // The usePushNotifications hook re-subscribes on mount anyway (idempotent upsert),
-          // so a lost change event is recovered naturally when the user reopens the app.
+          // No open windows — the SW can't register with the backend itself
+          // (no workspace context or auth). The re-subscribe above keeps the
+          // browser side warm; usePushNotifications re-registers it on next
+          // app open (mount) or within LIVENESS_CHECK_INTERVAL_MS on an
+          // already-open tab, as a plain idempotent upsert.
           return
         }
 


### PR DESCRIPTION
> Stacked on #1180 (`fix/push-quota-hardening`) — merge that first.

## Problem

Two audit-confirmed defects in how the client decides "the user can already see this":

1. **Over-delivery for the stream you're reading** (the reported "banner pops for the stream I'm viewing, then instantly resolves"). Two independent causes:
   - The SW's suppression derives the viewed stream from the URL path (`isViewingStream`, `/^\/w\/([^/]+)\/s\/([^/]+)/` in `sw-notification-format.ts`). But threads and conversations open as `?panel=<streamId|conv:id>` on whatever route is current (`panel-context.tsx`), and board/activity/search conversations live on non-`/s/` routes entirely. A thread reply's push carries the *thread's* stream id while the path names the root (or `/board`) → no match → the push displays over the very messages the user is reading, and the read-advance clear then dismisses it.
   - "Presence" counts only `pointerdown`/`keydown`/`touchstart` (`use-page-interaction.ts`). Desktop wheel-scrolling fires none, so a user reading for >2 min without clicking ages out of `PRESENCE_INTERACTION_WINDOW_MS` — the SW stops suppressing (and the backend's attended-device gate stops routing) for someone actively looking at the app.
2. **Dead subscriptions go unnoticed for up to ~a day.** Firefox revokes a subscription when its silent-push quota exhausts and defers `pushsubscriptionchange` to an idle timer / browser restart. `usePushNotifications` only re-verifies on mount, `visibilitychange`, and `online` — a long-lived focused tab fires none of those, so the settings UI shows "Enabled" while delivery is dead. (#1180 removes the quota burn that *causes* most revocations; this closes the recovery blind window for the ones that still happen.)

## Solution

Let the pages that render a stream say so explicitly, and let the push hook notice when the browser quietly dropped the subscription.

### How it works

1. **Visible-streams registry** (`lib/visible-streams.ts`): a refcounted set of on-screen stream ids, published (coalesced per microtask) into the existing `threa-presence` Cache Storage bucket — the same page↔SW channel `sw-presence.ts` already uses. Two registration points:
   - `VisibleStreamPresence` in `workspace-layout.tsx` registers the URL-derived streams (main stream + `?panel=` values that are bare `stream_…` ids).
   - `ConversationPanel` registers `panelStreamIds` — `[post.conversation.streamId, ...post.streamIds]`, the exact set it already computes for `usePanelStreamSubscriptions` — which the URL cannot express (`?panel=conv:…`).
2. **SW suppression** (`sw.ts` push handler) now suppresses when a focused same-origin client exists AND (the URL matches the pushed stream — unchanged fallback — OR the pushed `streamId` is in the visible set), still gated on `isDevicePresent()`. Multi-tab: the cache entry is last-writer-wins and the registering hook re-publishes on window `focus`, so the focused tab's set is authoritative; a stale entry alone can't suppress because the focused-client and presence gates still apply.
3. **`wheel` counts as interaction** (`use-page-interaction.ts`), feeding both the SW presence timestamp and the backend attended-device heartbeat through the one shared tracker. Deliberately `wheel` (hardware input), not `scroll`: auto-follow and virtualizer adjustments fire `scroll` on an abandoned-but-focused tab, which would fake exactly the presence this gate exists to age out. Mobile touch-scroll is already covered by `touchstart`; keyboard scroll by `keydown`.
4. **Liveness re-verify** (`use-push-notifications.ts`): every 5 minutes (`LIVENESS_CHECK_INTERVAL_MS`), `pushManager.getSubscription()` — a local call — and if the browser holds no subscription while the hook is active, re-run the idempotent `subscribe()`. Bypasses `RESUBSCRIBE_THROTTLE_MS` on purpose: it only acts when the subscription is genuinely gone. Recovery window for a Firefox quota revocation on a long-lived tab drops from up-to-a-day to ≤5 min.
5. **Honest comment** in `sw.ts` `pushsubscriptionchange`: the no-window branch claimed "persist to IndexedDB so the app can sync on next load" — no IDB write ever existed. The comment now states the real recovery path (mount re-subscribe / liveness interval).

### Key design decisions

**1. Registration over URL parsing.** Alternative rejected: teaching the SW to parse `?panel=` and resolve `conv:` ids — the SW has no access to the conversation→stream mapping (it lives in the page's query cache), and every new surface shape would need new URL grammar in the SW. Registration inverts it: the component that renders messages declares its streams; the SW only does set membership. The URL fallback stays so a registration gap degrades to today's behavior, never worse.

**2. Residual over-delivery accepted:** reading without any wheel/key/pointer event for >2 min (e.g. a short stream that needs no scrolling) still ages out of presence and shows the banner. Counting focus alone as presence would revert the deliberate "focused tab left behind keeps eating notifications" fix that the interaction gate exists for.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/visible-streams.ts` | Refcounted registry + Cache Storage publish/read (page + SW shared) |
| `apps/frontend/src/lib/visible-streams.test.ts` | Registry: dedup/sort, refcount release, same-tick swap coalescing, double-release safety |
| `apps/frontend/src/hooks/use-visible-streams.ts` | Per-tab singleton registry wiring + focus re-publish; content-keyed effect |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/sw.ts` | Suppression reads the visible set (URL match kept as fallback); `pushsubscriptionchange` comment corrected |
| `apps/frontend/src/pages/workspace-layout.tsx` | `VisibleStreamPresence` null-host registers URL-derived streams |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Registers `panelStreamIds` while mounted |
| `apps/frontend/src/hooks/use-page-interaction.ts` | `wheel` listener added (with the wheel-not-scroll rationale) |
| `apps/frontend/src/hooks/use-push-notifications.ts` | 5-min `getSubscription()` liveness interval → re-subscribe on loss |
| `apps/frontend/src/hooks/index.ts` | Barrel export |

## Out of scope (deliberate)

- Draft panels and any future panel kinds register nothing — they don't render a stream's messages, so there's nothing to suppress.
- Backend attended-device routing changes (escalation/re-fanout) — audit verified the "sole copy surfaces nowhere" claim REFUTED; the narrow OS-DND edge isn't worth routing complexity now.
- Random per-installation device key — separate hygiene follow-up.

## Test plan

- [x] `bun test src/lib/visible-streams.test.ts src/lib/notification-sweep.test.ts` — 6 pass
- [x] Frontend + monorepo typecheck clean; pre-commit lint green
- [x] Frontend suite failure set diffed against clean `origin/main` — byte-identical (the 157 pre-existing environmental `localStorage` failures on this dev machine; CI runs these green)
- [ ] `use-push-notifications` liveness interval has no unit test — that file's tests can't run on this machine (the pre-existing environmental failure above), and shipping an unexecuted test is worse than an honest gap; the logic is a 6-line interval around the existing `subscribe()`
- [ ] Live two-device suppression check (thread/conversation open in a panel while a reply arrives) — needs a deployed env; verify on staging (`staging` label) or post-deploy

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785825130&installation_id=129946197&pr_number=1181&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1181&signature=4e7385229824825cf5239226fc17bb029348c21edd2ca09d15cdb7434ecd62bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->