### PR TITLE
fix(timeline): re-pin thread scroll when the composer resizes

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -2298,7 +2298,7 @@ export function StreamContent({
                       disabled={isArchived || isSystem}
                       disabledReason={disabledReason}
                       autoFocus={autoFocus}
-                      onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
+                      onComposerHeightChange={handleComposerHeightChange}
                     />
                   )}
                 </div>

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -535,3 +535,52 @@ describe("useTimelineScroll — deferred re-check after a resize skipped for an 
     }
   })
 })
+
+describe("useTimelineScroll — cold-load settle across a stream switch", () => {
+  it("does not prematurely reveal when superseding a settle still in flight from the stream navigated away from", () => {
+    // Regression: settleToBottom's own supersede-cancel used to call the
+    // PREVIOUS settle's cleanup unconditionally, which always reveals
+    // (setIsInitialSettling(false)) — so navigating to a new stream before the
+    // old one's cold-load settle converged stripped the new stream's mask
+    // before it ran even one frame of its own convergence, exposing whatever
+    // unsettled position virtua was still mid-measurement at (the last row
+    // parked behind the composer until something else happened to re-pin it).
+    const rafCallbacks: FrameRequestCallback[] = []
+    const raf = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+    const caf = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+    const runFrame = () => act(() => rafCallbacks.shift()?.(performance.now()))
+    try {
+      const harness = renderScrollHook(opts({ itemCount: 0, getFirstKey: () => null, resetKey: "stream_a" }))
+      const content = document.createElement("div")
+      harness.current.contentRef.current = content
+      let height = 1000
+      const el = makeScrollerDiv({ scrollHeight: 0, clientHeight: 800 })
+      Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => height })
+      act(() => harness.current.registerScroller(el))
+
+      // Stream A's first window lands — the cold-load settle starts, masked.
+      harness.rerender(opts({ itemCount: 10, getFirstKey: () => "a1", resetKey: "stream_a" }))
+      expect(harness.current.isInitialSettling).toBe(true)
+
+      // One frame in: height is still moving (virtua still measuring) — not
+      // converged, so the settle re-schedules itself for another frame.
+      height = 1200
+      runFrame()
+      expect(harness.current.isInitialSettling).toBe(true)
+      expect(rafCallbacks).toHaveLength(1)
+
+      // Navigate away to stream B before stream A's settle ever converged.
+      harness.rerender(opts({ itemCount: 5, getFirstKey: () => "b1", resetKey: "stream_b" }))
+
+      // Stream B's own settle just started, superseding A's stale one — still
+      // masked, since it hasn't run a single frame of its own convergence yet.
+      expect(harness.current.isInitialSettling).toBe(true)
+    } finally {
+      raf.mockRestore()
+      caf.mockRestore()
+    }
+  })
+})

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -432,3 +432,106 @@ describe("useTimelineScroll — gesture stamp attaches when the scroller mounts 
     expect(userInteractedAtRef.current).toBeGreaterThan(0)
   })
 })
+
+describe("useTimelineScroll — deferred re-check after a resize skipped for an active scroll", () => {
+  it("catches up once the grace window elapses if a resize was skipped for a just-landed scroller gesture", () => {
+    // Regression: a content resize (new message, session card, composer growth)
+    // that lands within USER_SCROLL_GRACE_MS (300ms) of a genuine scroller
+    // gesture is deliberately skipped, so it doesn't fight an active scroll.
+    // But if that's the only resize this content change ever fires, skipping it
+    // with no follow-up misses it forever — the tail never re-pins and the
+    // last row stays stranded behind the composer. There must be a guaranteed
+    // recheck once the grace window actually elapses.
+    class MockResizeObserver {
+      targets: Element[] = []
+      constructor(public cb: ResizeObserverCallback) {}
+      observe(t: Element) {
+        this.targets.push(t)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    let observer: MockResizeObserver | undefined
+    class CapturingResizeObserver extends MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        super(cb)
+        observer = this
+      }
+    }
+    vi.stubGlobal("ResizeObserver", CapturingResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const userInteractedAtRef = { current: 0 }
+      const harness = renderScrollHook(opts({ itemCount: 50, getFirstKey: () => "e10", userInteractedAtRef }))
+      const content = document.createElement("div")
+      harness.current.contentRef.current = content
+      const el = makeScrollerDiv({ scrollHeight: 5000, clientHeight: 800, scrollTop: 800 })
+      act(() => harness.current.registerScroller(el))
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
+
+      // A genuine scroller gesture just landed.
+      userInteractedAtRef.current = performance.now()
+
+      // Content grows moments later (still inside the grace window) — a new
+      // message, a session card, or the composer footer spacer resizing.
+      Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 5200 })
+      act(() => observer!.cb([], observer as unknown as ResizeObserver))
+
+      // Skipped: an active scroll is not fought, so no snap yet.
+      expect(el.scrollTop).toBe(800)
+
+      // Grace window elapses with no further resize or scroll.
+      act(() => vi.advanceTimersByTime(300))
+
+      // Still following → the deferred recheck catches it up to the new bottom.
+      expect(el.scrollTop).toBe(5200)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not catch up if the user genuinely detached from the tail before the grace window elapsed", () => {
+    class MockResizeObserver {
+      targets: Element[] = []
+      constructor(public cb: ResizeObserverCallback) {}
+      observe(t: Element) {
+        this.targets.push(t)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    let observer: MockResizeObserver | undefined
+    class CapturingResizeObserver extends MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        super(cb)
+        observer = this
+      }
+    }
+    vi.stubGlobal("ResizeObserver", CapturingResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const userInteractedAtRef = { current: 0 }
+      const harness = renderScrollHook(opts({ itemCount: 50, getFirstKey: () => "e10", userInteractedAtRef }))
+      const content = document.createElement("div")
+      harness.current.contentRef.current = content
+      const el = makeScrollerDiv({ scrollHeight: 5000, clientHeight: 800, scrollTop: 800 })
+      act(() => harness.current.registerScroller(el))
+
+      userInteractedAtRef.current = performance.now()
+      Object.defineProperty(el, "scrollHeight", { configurable: true, get: () => 5200 })
+      act(() => observer!.cb([], observer as unknown as ResizeObserver))
+      expect(el.scrollTop).toBe(800)
+
+      // The user deliberately scrolls away from the tail before the grace
+      // window elapses — the deferred recheck must respect that, not override it.
+      harness.current.disableAutoScroll()
+
+      act(() => vi.advanceTimersByTime(300))
+      expect(el.scrollTop).toBe(800)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -192,7 +192,7 @@ export function useTimelineScroll({
   const prevScrollTopRef = useRef(0)
   const prevScrollHeightRef = useRef(0)
   const initialSettleRafRef = useRef(0)
-  const initialSettleCleanupRef = useRef<(() => void) | null>(null)
+  const initialSettleCleanupRef = useRef<((reveal?: boolean) => void) | null>(null)
 
   // Reset all scroll state synchronously when the stream changes, before the
   // shift computation below runs for the new stream's first render. A layout
@@ -294,7 +294,13 @@ export function useTimelineScroll({
   // idempotent pinToBottom the ResizeObserver uses, so the two never disagree.
   const settleToBottom = useCallback(
     (maxMs: number) => {
-      initialSettleCleanupRef.current?.()
+      // Supersede a settle still in flight from a stream navigated away from
+      // before it converged (resetKey changed while its RAF loop was still
+      // ticking) — cancel it without revealing through its closure. Reveal
+      // would strip the mask this call is about to raise again, exposing
+      // whatever unsettled position the new stream is still mid-measurement
+      // at: the exact bounce the mask exists to hide.
+      initialSettleCleanupRef.current?.(false)
       const el = scrollerRef.current
       if (!el) {
         setIsInitialSettling(false)
@@ -311,22 +317,23 @@ export function useTimelineScroll({
           setIsInitialSettling(false)
         }
       }
-      const cleanup = () => {
+      const cleanup = (shouldReveal = true) => {
         aborted = true
-        reveal()
+        if (shouldReveal) reveal()
         if (initialSettleRafRef.current) cancelAnimationFrame(initialSettleRafRef.current)
         initialSettleRafRef.current = 0
-        el.removeEventListener("wheel", cleanup)
-        el.removeEventListener("touchmove", cleanup)
-        el.removeEventListener("pointerdown", cleanup)
-        el.removeEventListener("keydown", cleanup)
+        el.removeEventListener("wheel", onGesture)
+        el.removeEventListener("touchmove", onGesture)
+        el.removeEventListener("pointerdown", onGesture)
+        el.removeEventListener("keydown", onGesture)
         initialSettleCleanupRef.current = null
       }
+      const onGesture = () => cleanup()
       initialSettleCleanupRef.current = cleanup
-      el.addEventListener("wheel", cleanup, { passive: true })
-      el.addEventListener("touchmove", cleanup, { passive: true })
-      el.addEventListener("pointerdown", cleanup, { passive: true })
-      el.addEventListener("keydown", cleanup)
+      el.addEventListener("wheel", onGesture, { passive: true })
+      el.addEventListener("touchmove", onGesture, { passive: true })
+      el.addEventListener("pointerdown", onGesture, { passive: true })
+      el.addEventListener("keydown", onGesture)
 
       const tick = () => {
         if (aborted) return

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -470,6 +470,13 @@ export function useTimelineScroll({
     if (!scroller || !content) return
 
     let prevClientHeight = scroller.clientHeight
+    let pendingRecheck = 0
+    const clearPendingRecheck = () => {
+      if (pendingRecheck) {
+        window.clearTimeout(pendingRecheck)
+        pendingRecheck = 0
+      }
+    }
     const observer = new ResizeObserver((entries) => {
       const el = scrollerRef.current
       if (!el) return
@@ -482,11 +489,27 @@ export function useTimelineScroll({
         // user-scroll-driven (the composer tap lands on the floating composer,
         // not the scroller, so the gesture stamp stays stale), so keyboard-follow
         // is unaffected.
-        const userScrolling = performance.now() - (userInteractedAtRef?.current ?? 0) < USER_SCROLL_GRACE_MS
+        const elapsedSinceGesture = performance.now() - (userInteractedAtRef?.current ?? 0)
+        const userScrolling = elapsedSinceGesture < USER_SCROLL_GRACE_MS
         if (!hasViewportEntry && userScrolling) {
           prevClientHeight = el.clientHeight
+          // The resize itself is real — a message, session card, or the composer
+          // genuinely changed size — we're only holding off because a scroller
+          // gesture landed a moment ago. If that's the only resize this content
+          // change ever fires, skipping it here would miss it forever, so
+          // re-check once the grace window actually elapses and catch up if
+          // we're still following.
+          clearPendingRecheck()
+          pendingRecheck = window.setTimeout(
+            () => {
+              pendingRecheck = 0
+              if (isFollowingTailRef.current) pinToBottom()
+            },
+            Math.max(0, USER_SCROLL_GRACE_MS - elapsedSinceGesture)
+          )
           return
         }
+        clearPendingRecheck()
         pinToBottom()
         prevClientHeight = el.clientHeight
         return
@@ -526,6 +549,7 @@ export function useTimelineScroll({
 
     return () => {
       observer.disconnect()
+      clearPendingRecheck()
       vv?.removeEventListener("resize", pinIfFollowing)
       vv?.removeEventListener("scroll", pinIfFollowing)
     }


### PR DESCRIPTION
## Problem

The message composer is a floating, bottom-anchored overlay. The timeline reserves space for it via a `--composer-height` CSS var, applied as either a trailing spacer (virtualized channels/DMs) or `padding-bottom` on the scroll container (threads). When that reservation isn't correctly applied, or the cold-load mask that hides the initial positioning bounce lifts too early, the composer's top edge (or a premature reveal) ends up over whatever was last visible above it — hiding the message being replied to, or the newest content.

Three distinct, unrelated gaps turned out to cause this. All three are fixed here.

## Fix 1 — threads never got the resize callback at all

`apps/frontend/src/components/timeline/stream-content.tsx:2301` wired the composer's resize callback conditionally:

```tsx
onComposerHeightChange={useVirtualized ? handleComposerHeightChange : undefined}
```

`useVirtualized` is `false` for any thread (main-pane thread view, or the reply side panel), so `MessageInput`'s `useComposerHeightPublish` had no callback to invoke on resize there — the height still updated `--composer-height` (so the first paint/mount is correct), but no runtime re-pin ever ran. Channels and DMs were unaffected — `useVirtualized` is `true` there, so the callback was already wired.

**Fix:** wire it unconditionally. `handleComposerHeightChange` (`stream-content.tsx:1222`) already branches internally on `useVirtualized` (and on `draftScrollRef` for the empty-scratchpad/thread-draft case) to call the right scroll-to-bottom ref — it just was never being invoked for the plain-scroll (thread) path.

**Verified live**: reproduced the exact overlap on the pre-fix code (stashed the diff) in a running dev stack, confirmed it's gone with the fix.

## Fix 2 — a resize skipped during an active scroll had no follow-up

Reported separately, in a channel/scratchpad (a stream where Fix 1 doesn't apply — the callback was already wired). The one real, code-confirmed hole in `apps/frontend/src/hooks/use-timeline-scroll.ts`'s single ResizeObserver:

```ts
if (!hasViewportEntry && userScrolling) {
  prevClientHeight = el.clientHeight
  return   // <-- skipped, and nothing ever re-checks it
}
```

A content resize (new message, agent-session card, composer growth) landing within `USER_SCROLL_GRACE_MS` (300ms) of a genuine scroller gesture — wheel, touch, pointerdown, keydown — is deliberately skipped, so an active scroll isn't fought. But if that's the only resize the change ever fires, skipping it here missed it forever: the tail never re-pinned, and the last row stayed stranded behind the composer.

**Fix:** when the resize is skipped for this reason, schedule a deferred recheck for the moment the grace window actually elapses. If still following the tail by then, pin.

**Not reproduced live** — my own tool calls take longer than 300ms wall-clock, so I can't land a synthetic gesture and a resize inside the same window. Exercised instead by two new unit tests that simulate the ResizeObserver firing while `userInteractedAtRef` is fresh.

## Fix 3 — switching streams before the previous one's cold-load settle converged stripped the new stream's mask early

Reported as the actual trigger for the "sometimes" case: **navigating between streams**, not content growth, and "hard to make happen until it always happens" — i.e. needs a wide-enough timing window, not a resize race.

On a stream's first load, `settleToBottom` (`use-timeline-scroll.ts`) pins to the bottom every animation frame behind a skeleton mask while virtua measures real item heights, revealing only once the height holds steady for a few frames — hiding the measurement bounce from the user. Switching to a new stream re-arms this mask and starts a fresh settle, which first supersedes any settle still running for the stream just left:

```ts
const settleToBottom = useCallback((maxMs) => {
  initialSettleCleanupRef.current?.()   // <-- the PREVIOUS stream's cleanup — always reveals
  ...
```

That supersede call invoked the previous settle's `cleanup()` unconditionally, which **always reveals** (`setIsInitialSettling(false)`) — even though the new stream's mask had just been raised again moments earlier and hadn't run a single frame of its own convergence. If you navigated away from a stream before its own settle converged, arriving at the next stream stripped its mask immediately, exposing whatever unsettled position virtua was still mid-measurement at — the last row parked behind the composer, with nothing left to correct it afterward.

**Fix:** split cancel from reveal. Superseding a stale settle now cancels its RAF loop and listeners without revealing through it, since the caller is about to raise its own mask right after. Genuine paths — a user gesture aborting, or a settle converging naturally — still reveal as before.

**Not reproduced visually live** — local dev settles in a handful of frames (~50-100ms), too fast to reliably outrun via scripted browser clicking (each of my automated actions already takes longer than that). Proven directly instead: a new test drives the exact RAF sequence with `requestAnimationFrame` mocked to manual control, and fails on the prior code (`isInitialSettling` flips to `false` mid-switch, before the new stream's settle has run once) and passes with the fix. In production, with real network/DB latency and larger histories, the settle window is plausibly wide enough to hit this on ordinary fast navigation — matching "hard to make happen [in a fast local test] until it always happens [in real use]."

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Fix 1: always pass `handleComposerHeightChange` to `MessageInput`'s `onComposerHeightChange`, instead of only when `useVirtualized` |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | Fix 2: schedule a deferred `pinToBottom()` recheck when a resize is skipped for a just-landed scroller gesture. Fix 3: `settleToBottom`'s supersede path cancels a stale settle without revealing through its closure |
| `apps/frontend/src/hooks/use-timeline-scroll.test.tsx` | Three new tests: the deferred recheck catches up once the grace window elapses; it does not override a genuine detach from the tail; superseding an in-flight settle from a stream switch does not prematurely reveal the destination |

## Test plan

- [x] `use-timeline-scroll.test.tsx` — 25 pass (22 existing + 3 new)
- [x] `stream-content.test.ts`, `use-scroll-behavior.test.tsx`, `use-composer-height-publish.test.tsx`, `message-input.test.tsx`, `use-timeline-scroll.test.tsx` together — 107 pass
- [x] `tsc --noEmit` (frontend workspace) — clean
- [x] Fix 1 verified live in a running dev stack: grew a thread's composer from 1 to 4 lines while parked at the bottom. Pre-fix (stashed the diff): last reply hidden behind the composer. Post-fix: thread scrolls in lockstep, last message stays visible.
- [ ] Fix 2's underlying 300ms race not reproduced live — covered by two new unit tests that exercise the exact ResizeObserver code path deterministically instead.
- [ ] Fix 3's underlying settle-window race not reproduced live (local dev settles too fast to outrun via scripted clicking) — proven directly with a new test that fails on the prior code and passes with the fix, driving the exact RAF sequence under manual control.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
