### PR TITLE
fix(frontend): stream-header chip strip scrolls on phone widths instead of overlapping the header actions

### DIFF
--- a/apps/frontend/src/components/encryption/invite-actor-button.tsx
+++ b/apps/frontend/src/components/encryption/invite-actor-button.tsx
@@ -5,7 +5,10 @@ import { useInviteActor, canInviteActor, isActorInvited, E2E_ACTOR_LABELS } from
 import type { E2eActorKind } from "@threa/types"
 import type { VirtualStream } from "@/hooks/use-stream-or-draft"
 
-const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+// `shrink-0` + nowrap: these pills live in the header's scrollable chip strip —
+// they must keep their size and let the strip scroll, not squish or wrap.
+const pillBase =
+  "inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2.5 py-0.5 text-xs font-semibold"
 
 interface InviteActorButtonProps {
   workspaceId: string

--- a/apps/frontend/src/components/encryption/invite-bot-button.tsx
+++ b/apps/frontend/src/components/encryption/invite-bot-button.tsx
@@ -19,7 +19,10 @@ import { useInputMode } from "@/hooks/use-input-mode"
 import { StreamTypes } from "@threa/types"
 import type { VirtualStream } from "@/hooks/use-stream-or-draft"
 
-const pillBase = "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-semibold"
+// `shrink-0` + nowrap: these pills live in the header's scrollable chip strip —
+// they must keep their size and let the strip scroll, not squish or wrap.
+const pillBase =
+  "inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2.5 py-0.5 text-xs font-semibold"
 const overflowPillClass =
   "shrink-0 border-border bg-secondary text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
 // Invited-bot pills share the scratchpad header row with the title, labels, and
@@ -80,7 +83,7 @@ export function InviteBotButton({ workspaceId, stream }: InviteBotButtonProps) {
               <span
                 className={cn(
                   pillBase,
-                  "min-w-0 border-border bg-secondary",
+                  "border-border bg-secondary",
                   canRead(bot.id) ? "text-foreground" : "border-dashed text-muted-foreground"
                 )}
                 aria-label={label}

--- a/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
+++ b/apps/frontend/src/components/encryption/stream-encryption-affordance.tsx
@@ -196,9 +196,11 @@ export function StreamHeaderEncryptionAction({
 }) {
   const action = useStreamEncryptionAction(workspaceId, encrypted)
 
+  // `shrink-0`: these live in the header's scrollable chip strip — keep their
+  // size and let the strip scroll rather than squishing the label.
   if (action?.kind === "setup") {
     return (
-      <Button size="sm" variant="outline" className="h-7 gap-1 px-2" onClick={() => action.unlock.openSetup()}>
+      <Button size="sm" variant="outline" className="h-7 shrink-0 gap-1 px-2" onClick={() => action.unlock.openSetup()}>
         <ShieldPlus className="h-3.5 w-3.5" />
         Set up encryption
       </Button>
@@ -209,7 +211,7 @@ export function StreamHeaderEncryptionAction({
       <Button
         size="sm"
         variant="outline"
-        className="h-7 gap-1 px-2"
+        className="h-7 shrink-0 gap-1 px-2"
         disabled={action.pending}
         onClick={() => action.unlock.openUnlock()}
       >
@@ -234,7 +236,7 @@ function StreamHeaderRepairAction({ workspaceId, streamId }: { workspaceId: stri
     <Button
       size="sm"
       variant="outline"
-      className="h-7 gap-1 px-2"
+      className="h-7 shrink-0 gap-1 px-2"
       disabled={repair.pending}
       onClick={() => repair.repair()}
     >

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -606,27 +606,40 @@ export function StreamPage() {
           <SidebarToggle location="page" />
           {headerTitle}
           {companionModeIndicator}
-          {stream && !isDraft && (
-            <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.STREAM} resourceId={streamId} />
-          )}
-          {isEncryptedScratchpad && !isDraft && (
-            <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
-          )}
-          {stream && isScratchpad && !isDraft && (
-            <>
-              <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
-              <InviteBotButton workspaceId={workspaceId!} stream={stream} />
-            </>
-          )}
-          {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
-            <Badge variant="secondary">{getStreamTypeLabel(stream.type)}</Badge>
-          )}
-          {isArchived && (
-            <Badge variant="secondary" className="gap-1">
-              <ArchiveX className="h-3 w-3" />
-              Archived
-            </Badge>
-          )}
+          {/* Chip strip. The chips are non-shrinking (`shrink-0` leaves), so on a
+              phone-width header they would otherwise overflow the flex box and
+              paint under the search/panel actions — the strip scrolls instead,
+              same recipe as PageHeaderTabs' tab strip. */}
+          <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none">
+            {stream && !isDraft && (
+              <LabelStack
+                workspaceId={workspaceId}
+                resourceType={LabelableResourceTypes.STREAM}
+                resourceId={streamId}
+                className="shrink-0"
+              />
+            )}
+            {isEncryptedScratchpad && !isDraft && (
+              <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
+            )}
+            {stream && isScratchpad && !isDraft && (
+              <>
+                <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
+                <InviteBotButton workspaceId={workspaceId!} stream={stream} />
+              </>
+            )}
+            {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
+              <Badge variant="secondary" className="shrink-0">
+                {getStreamTypeLabel(stream.type)}
+              </Badge>
+            )}
+            {isArchived && (
+              <Badge variant="secondary" className="gap-1 shrink-0">
+                <ArchiveX className="h-3 w-3" />
+                Archived
+              </Badge>
+            )}
+          </div>
         </div>
         <div className="flex items-center gap-1 ml-1">
           {!isThread && !isDraft && (

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -67,6 +67,61 @@ test.describe("E2E encrypted scratchpads", () => {
     await expect(page.getByText("This scratchpad is encrypted")).toHaveCount(0, { timeout: 15_000 })
   })
 
+  test("phone-width header: the chip strip scrolls and Invite agent stays tappable (no overlap)", async ({ page }) => {
+    await loginAndCreateWorkspace(page, "e2e-mobile")
+    const workspaceId = page.url().match(/\/w\/(ws_[^/?#]+)/)?.[1]
+    expect(workspaceId).toBeTruthy()
+
+    // A workspace bot makes the header render the "Invite agent" trigger.
+    const botRes = await page.request.post(`/api/workspaces/${workspaceId}/bots`, {
+      // Shared: the header's invite picker lists workspace-shared bots only.
+      data: {
+        type: "shared",
+        name: "Smoke Harness",
+        slug: "smoke-harness",
+        traits: ["active-scratchpad", "mentionable"],
+      },
+    })
+    expect(botRes.ok()).toBe(true)
+
+    // Create the encrypted scratchpad at desktop width (the create menu lives
+    // in the sidebar); the mobile assertions come after the viewport shrinks.
+    await page.getByRole("button", { name: "New", exact: true }).click()
+    await page.getByRole("menuitem", { name: /New Encrypted Scratchpad/i }).click()
+    const setup = page.getByRole("dialog")
+    await expect(setup.getByText("Set up encrypted scratchpads")).toBeVisible({ timeout: 10_000 })
+    await setup.locator("#e2e-passphrase").fill(PASSPHRASE)
+    await setup.locator("#e2e-passphrase-confirm").fill(PASSPHRASE)
+    await setup.locator("#e2e-acknowledged").check()
+    const trustDevice = setup.locator("#e2e-setup-trust-device")
+    if (await trustDevice.isChecked()) await trustDevice.uncheck()
+    await setup.getByRole("button", { name: "Enable encryption" }).click()
+    await expect(page.getByRole("button", { name: /End-to-end encrypted/i })).toBeVisible({ timeout: 15_000 })
+
+    // The reported state: phone width + locked (reload; device untrusted), where
+    // the header shows Unlock + Ariadne + Invite agent all at once.
+    await page.setViewportSize({ width: 412, height: 915 })
+    await page.reload()
+    await expect(page.getByText("This scratchpad is encrypted")).toBeVisible({ timeout: 15_000 })
+
+    const invite = page.getByRole("button", { name: "Invite an agent to this scratchpad" })
+    await invite.scrollIntoViewIfNeeded()
+    await expect(invite).toBeVisible()
+
+    // Containment: the invite trigger may sit in a scrollable strip, but it must
+    // never paint under the header's search action (the regression: overflow
+    // painted the pills beneath the right-side icons, eating their taps).
+    const inviteBox = await invite.boundingBox()
+    const searchBox = await page.getByRole("button", { name: "Search in conversation" }).boundingBox()
+    expect(inviteBox).not.toBeNull()
+    expect(searchBox).not.toBeNull()
+    expect(inviteBox!.x + inviteBox!.width).toBeLessThanOrEqual(searchBox!.x + 1)
+
+    // And it actually works: tapping opens the bot picker.
+    await invite.click()
+    await expect(page.getByRole("menuitem", { name: /Smoke Harness/ })).toBeVisible()
+  })
+
   test("creating an encrypted scratchpad while locked unlocks inline, then creates", async ({ page }) => {
     await loginAndCreateWorkspace(page, "e2e-enc-locked")
 


### PR DESCRIPTION
**Reported live:** on a phone-width locked encrypted scratchpad, the header chips overflow and the search/panel icons paint on top of "Invite agent" — taps meant for the invite hit the icons, so the invite is unusable on mobile (Kris's Android screenshot).

## Problem

The stream header's left region (`stream.tsx`) is a `flex-1 min-w-0` row holding the title plus a run of chips: `StreamHeaderEncryptionAction` (Unlock / Set up / Finish setup), the `InviteActorButton` Ariadne pill, `InviteBotButton` (invited pills + "Invite agent" trigger), `LabelStack`, and type/archived badges. The title truncates, but the chips can't shrink below their text width and the container has no overflow handling — on a ~412px viewport the chips spill past the container and paint under the right-side header actions. Nothing is tappable in the overlap zone.

## Solution

The chips move into a horizontally scrollable strip — `min-w-0 overflow-x-auto scrollbar-none` — the same recipe `PageHeaderTabs` already uses for its tab strip (its comment describes this exact failure mode: "the non-shrinking chips would otherwise swallow the title"). Chip leaves get `shrink-0` + `whitespace-nowrap` (invite pills via `pillBase`, the three encryption-action buttons, both badges, `LabelStack` via its `className` prop) so the strip scrolls instead of squishing labels. Title truncation and the fixed `h-12` header height are unchanged (INV-21 — no layout shift, no new geometry).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/stream.tsx` | Chip region wrapped in the scrollable strip; badges get `shrink-0` |
| `apps/frontend/src/components/encryption/invite-actor-button.tsx` | `shrink-0` + nowrap in `pillBase` |
| `apps/frontend/src/components/encryption/invite-bot-button.tsx` | Same; invited pill drops its now-moot `min-w-0` |
| `apps/frontend/src/components/encryption/stream-encryption-affordance.tsx` | `shrink-0` on the setup/unlock/repair buttons |
| `tests/browser/e2e-encrypted-scratchpads.spec.ts` | New phone-width regression test |

## Test plan

- [x] New Playwright test at 412×915: recreates the reported state (locked encrypted scratchpad, workspace bot present), asserts the invite trigger's box never crosses the search action's box, and taps it to open the picker — **verified to fail on the pre-fix code** (stashed fix → 1 failed; restored → passes)
- [x] Full `e2e-encrypted-scratchpads.spec.ts`: 5/5 pass (the other tests mount the same header)
- [x] Touched component unit tests (`invite-bot-button`, `stream-encryption-affordance`): 16 pass
- [x] Frontend `tsc --noEmit` clean; lint via pre-commit hook

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785835767&installation_id=129946197&pr_number=1184&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1184&signature=d73a82eccf3fb54b6bf8c39e73b0b31d16c1f79a31106448c321f889534f0248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->