### PR TITLE
fix(frontend): invite-agent picker lists your own personal bots, not just shared ones

### DIFF
--- a/apps/frontend/src/components/encryption/invite-bot-button.test.tsx
+++ b/apps/frontend/src/components/encryption/invite-bot-button.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { StreamTypes } from "@threa/types"
 import { TooltipProvider } from "@/components/ui/tooltip"
-import * as botsApiModule from "@/api/bots"
+import * as workspaceStoreModule from "@/stores/workspace-store"
 import * as inviteActorModule from "@/hooks/use-invite-actor"
 import * as inputModeModule from "@/hooks/use-input-mode"
 import type { VirtualStream } from "@/hooks/use-stream-or-draft"
@@ -15,16 +15,18 @@ import { InviteBotButton } from "./invite-bot-button"
 // exercised here: the copy must track wrap state (a bot invited while locked is
 // pending, not yet a reader), and the overflow must be reachable by keyboard /
 // touch (a focusable button + a tap drawer), not a hover-only tooltip.
+// The bot list is the bootstrap-synced store (shared + the viewer's own
+// personal bots), so a personal harness bot must reach the picker too.
 
 const BOTS = [
-  { id: "bot_wrapped", name: "Pi", archivedAt: null, avatarEmoji: "🤖" },
-  { id: "bot_pending", name: "Claude", archivedAt: null, avatarEmoji: "🤖" },
-  { id: "bot_overflow", name: "Ariadne", archivedAt: null, avatarEmoji: "🤖" },
-  { id: "bot_free", name: "Scout", archivedAt: null, avatarEmoji: "🤖" },
-] as unknown as Awaited<ReturnType<typeof botsApiModule.botsApi.list>>
+  { id: "bot_wrapped", name: "Pi", type: "personal", archivedAt: null, avatarEmoji: "🤖" },
+  { id: "bot_pending", name: "Claude", type: "personal", archivedAt: null, avatarEmoji: "🤖" },
+  { id: "bot_overflow", name: "Ariadne", type: "shared", archivedAt: null, avatarEmoji: "🤖" },
+  { id: "bot_free", name: "Scout", type: "personal", archivedAt: null, avatarEmoji: "🤖" },
+] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceBots>
 
 function arrange(inputMode: "mouse" | "touch") {
-  vi.spyOn(botsApiModule.botsApi, "list").mockResolvedValue(BOTS)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue(BOTS)
   vi.spyOn(inviteActorModule, "useInviteActor").mockReturnValue({
     invite: vi.fn(),
     isInviting: false,
@@ -86,8 +88,12 @@ describe("InviteBotButton", () => {
     await waitFor(() => expect(within(drawer as HTMLElement).getByText("Ariadne")).toBeInTheDocument())
   })
 
-  it("offers the un-invited bot in the picker", async () => {
+  it("offers the un-invited bot in the picker, including a personal one", async () => {
     arrange("mouse")
-    expect(await screen.findByRole("button", { name: "Invite an agent to this scratchpad" })).toBeInTheDocument()
+    const trigger = await screen.findByRole("button", { name: "Invite an agent to this scratchpad" })
+    // Scout is a PERSONAL bot — the regression was the picker querying the
+    // shared-only bots endpoint, which hid an owner's own harness bots.
+    await userEvent.click(trigger)
+    expect(await screen.findByRole("menuitem", { name: /Scout/ })).toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/encryption/invite-bot-button.tsx
+++ b/apps/frontend/src/components/encryption/invite-bot-button.tsx
@@ -1,6 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
 import { Bot as BotIcon } from "lucide-react"
-import type { Bot } from "@threa/types"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,9 +11,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "@/components/ui/drawer"
 import { cn } from "@/lib/utils"
-import { botsApi } from "@/api/bots"
 import { useInviteActor } from "@/hooks/use-invite-actor"
 import { useInputMode } from "@/hooks/use-input-mode"
+import { useWorkspaceBots, type CachedBot } from "@/stores/workspace-store"
 import { StreamTypes } from "@threa/types"
 import type { VirtualStream } from "@/hooks/use-stream-or-draft"
 
@@ -54,12 +52,12 @@ interface InviteBotButtonProps {
 export function InviteBotButton({ workspaceId, stream }: InviteBotButtonProps) {
   const { invite, isInviting } = useInviteActor(workspaceId, stream.id)
   const eligible = stream.type === StreamTypes.SCRATCHPAD && !stream.isDraft && stream.e2eEnabled === true
-  const { data: bots } = useQuery({
-    queryKey: ["bots", workspaceId],
-    queryFn: () => botsApi.list(workspaceId),
-    enabled: eligible,
-    staleTime: 60_000,
-  })
+  // Bootstrap-synced visibility: shared bots plus the viewer's OWN personal
+  // bots (`listVisibleTo` server-side). The `GET /bots` endpoint this used to
+  // query is deliberately shared-only (it feeds the settings tab's shared
+  // section), which silently hid personal harness bots — the primary thing an
+  // owner invites — from this picker.
+  const bots = useWorkspaceBots(workspaceId)
 
   if (!eligible) return null
 
@@ -67,8 +65,8 @@ export function InviteBotButton({ workspaceId, stream }: InviteBotButtonProps) {
   const wrappedById = new Map(
     (stream.e2eActors ?? []).filter((a) => a.kind === "bot").map((a) => [a.actorId, Boolean(a.keyId)])
   )
-  const invited = (bots ?? []).filter((bot) => wrappedById.has(bot.id))
-  const candidates = (bots ?? []).filter((bot) => !bot.archivedAt && !wrappedById.has(bot.id))
+  const invited = bots.filter((bot) => wrappedById.has(bot.id))
+  const candidates = bots.filter((bot) => !bot.archivedAt && !wrappedById.has(bot.id))
   const visibleInvited = invited.slice(0, VISIBLE_CAP)
   const overflowInvited = invited.slice(VISIBLE_CAP)
   const canRead = (botId: string) => wrappedById.get(botId) === true
@@ -140,7 +138,7 @@ export function InviteBotButton({ workspaceId, stream }: InviteBotButtonProps) {
  * touch and a `HoverCard` on mouse — the same input-mode branch `LabelStack`
  * uses — with a focusable `<button>` trigger for keyboard access.
  */
-function InvitedBotsOverflow({ bots, canRead }: { bots: Bot[]; canRead: (botId: string) => boolean }) {
+function InvitedBotsOverflow({ bots, canRead }: { bots: CachedBot[]; canRead: (botId: string) => boolean }) {
   const isTouch = useInputMode() === "touch"
   const names = bots.map((b) => b.name).join(", ")
   const trigger = (

--- a/apps/frontend/src/stores/workspace-store.ts
+++ b/apps/frontend/src/stores/workspace-store.ts
@@ -26,7 +26,7 @@ import {
 // Re-exported so components/pages can type the values these store hooks return
 // (e.g. `useWorkspaceStreams(): CachedStream[]`) without importing `@/db`
 // directly, which the component layer is barred from (INV-15).
-export type { CachedStream } from "@/db"
+export type { CachedBot, CachedStream } from "@/db"
 
 // In-memory cache — populated by applyWorkspaceBootstrap, used as the default
 // value for useLiveQuery so the first synchronous render returns real data

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -72,9 +72,11 @@ test.describe("E2E encrypted scratchpads", () => {
     const workspaceId = page.url().match(/\/w\/(ws_[^/?#]+)/)?.[1]
     expect(workspaceId).toBeTruthy()
 
-    // A workspace bot makes the header render the "Invite agent" trigger.
-    const botRes = await page.request.post(`/api/workspaces/${workspaceId}/bots`, {
-      // Shared: the header's invite picker lists workspace-shared bots only.
+    // Workspace bots make the header render the "Invite agent" trigger. One
+    // shared and one PERSONAL: the picker reads bootstrap visibility (shared +
+    // the viewer's own personal bots) — a personal harness bot missing from the
+    // picker was a reported bug.
+    const sharedRes = await page.request.post(`/api/workspaces/${workspaceId}/bots`, {
       data: {
         type: "shared",
         name: "Smoke Harness",
@@ -82,7 +84,16 @@ test.describe("E2E encrypted scratchpads", () => {
         traits: ["active-scratchpad", "mentionable"],
       },
     })
-    expect(botRes.ok()).toBe(true)
+    expect(sharedRes.ok()).toBe(true)
+    const personalRes = await page.request.post(`/api/workspaces/${workspaceId}/bots`, {
+      data: {
+        type: "personal",
+        name: "My Own Harness",
+        slug: "my-own-harness",
+        traits: ["active-scratchpad", "mentionable"],
+      },
+    })
+    expect(personalRes.ok()).toBe(true)
 
     // Create the encrypted scratchpad at desktop width (the create menu lives
     // in the sidebar); the mobile assertions come after the viewport shrinks.
@@ -117,9 +128,11 @@ test.describe("E2E encrypted scratchpads", () => {
     expect(searchBox).not.toBeNull()
     expect(inviteBox!.x + inviteBox!.width).toBeLessThanOrEqual(searchBox!.x + 1)
 
-    // And it actually works: tapping opens the bot picker.
+    // And it actually works: tapping opens the bot picker, which lists BOTH the
+    // shared bot and the viewer's own personal bot.
     await invite.click()
     await expect(page.getByRole("menuitem", { name: /Smoke Harness/ })).toBeVisible()
+    await expect(page.getByRole("menuitem", { name: /My Own Harness/ })).toBeVisible()
   })
 
   test("creating an encrypted scratchpad while locked unlocks inline, then creates", async ({ page }) => {


### PR DESCRIPTION
**Reported live** (from the sealed-attachments smoke): the "Invite agent" picker on an encrypted scratchpad listed only the shared GitHub bot — none of the owner's own harness bots. Stacked on #1184 (both touch `invite-bot-button.tsx`).

## Problem

`InviteBotButton` fetched its bot list from `GET /api/workspaces/:id/bots`, which is deliberately **shared-only** (`BotRepository.listByWorkspace(pool, workspaceId, { type: SHARED })` — it feeds the settings tab's shared-bots section). Personal bots — the self-hosted harnesses that are the primary thing an owner invites into an encrypted scratchpad (design §2.6) — never appeared. The invite endpoint itself (`streamService.inviteActor` → `resolvePinnedActorId`) already accepts any non-archived workspace bot, so listing was the only gap.

## Solution

The picker reads `useWorkspaceBots(workspaceId)` — the bootstrap-synced store whose contents are the server's `listVisibleTo` rule: all shared bots plus the viewer's **own** personal bots (other users' personal bots stay invisible). This drops the component's private query entirely; the list is live via bootstrap sync, and the picker now matches the visibility rule every other bot surface uses. `workspace-store` re-exports `CachedBot` so the component types the hook's rows without importing `@/db` (INV-15).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/encryption/invite-bot-button.tsx` | `useWorkspaceBots` replaces the `botsApi.list` query; `CachedBot` replaces the wire `Bot` type |
| `apps/frontend/src/stores/workspace-store.ts` | Re-export `CachedBot` beside `CachedStream` |
| `apps/frontend/src/components/encryption/invite-bot-button.test.tsx` | Spies on the store hook; new assertion that a personal bot reaches the picker |
| `tests/browser/e2e-encrypted-scratchpads.spec.ts` | Phone-width test now creates a shared + a personal bot and asserts both are listed |

## Test plan

- [x] Component tests: 4 pass, including the new personal-bot-in-picker assertion
- [x] Browser phone-width test (real bootstrap → store → picker): both bots listed — 1 pass
- [x] Frontend `tsc --noEmit` clean; lint via pre-commit hook

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785836511&installation_id=129946197&pr_number=1185&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1185&signature=c704f71d0a8a31d044270697be6537b664d15dbe02fb669862d8c838efa857bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->