### PR TITLE
fix(channel): ship assistant narration unredacted in trace steps (pi parity)

### DIFF
--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -176,13 +176,9 @@ Sealed-turn differences: `THREA_ATTACH:` files are encrypted locally under a fre
 
 ## Limitations
 
-- A channel only sees the inbound message and Claude's `send`/`reply` calls, not its individual tool calls, so the Threa trace card shows a single "working" step rather than the per-tool trace a Pi session produces.
+- The per-tool trace comes from tailing the session transcript (`~/.claude/projects/<cwd>/<session>.jsonl`), not from lifecycle hooks like Pi's. On plaintext turns tool payloads are redacted to headlines + size telemetry and thinking bodies are withheld; Claude's own narration (the prose it writes between tool calls, including a final message on a turn that ends without `reply`) ships in full, matching Pi. Sealed turns ship full tool detail (it's ciphertext to the server; opt back out with `sealedFullTrace: false`).
 - Claude can't `send` a heartbeat while blocked on a single long tool call (e.g. a 40-minute test run). The idle timeout must exceed your longest single operation — raise `THREA_IDLE_TIMEOUT_MS` if needed. A turn that goes idle without a `reply` is force-closed (silently if it already `send`-ed something, otherwise with a short "ended without a reply" notice).
 - One turn at a time: a message sent while Claude is still working is handled after the current reply (a permission verdict is the exception and goes through immediately).
-
-## Roadmap (parity with `pi-remote`)
-
-- Per-tool trace steps — a channel can't observe Claude's tool calls, so matching Pi's rich trace needs a different mechanism than Pi's lifecycle hooks.
 
 ## Troubleshooting
 

--- a/extensions/claude-code-remote/src/transcript-trace.test.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.test.ts
@@ -112,7 +112,7 @@ describe("mapTranscriptLine redaction (headline mode)", () => {
     expect(JSON.stringify(steps)).not.toContain("secret traceback")
   })
 
-  test("thinking and narration ship size only, never the body", () => {
+  test("thinking ships size only; narration ships its body (pi parity)", () => {
     const steps = mapTranscriptLine(
       assistantLine([
         { type: "thinking", thinking: "the user's token is sk-hidden, better not repeat it", signature: "x" },
@@ -123,9 +123,22 @@ describe("mapTranscriptLine redaction (headline mode)", () => {
     expect(steps).toHaveLength(2)
     const serialized = JSON.stringify(steps)
     expect(serialized).toContain("Thinking content omitted for safety. Captured locally: 51 characters.")
-    expect(serialized).toContain("Assistant narration omitted for safety.")
     expect(serialized).not.toContain("sk-hidden")
-    expect(serialized).not.toContain("check the config")
+    // Narration is stream-facing prose: the body ships even in headline mode,
+    // so a turn that ends without `reply` still reads in the trace.
+    expect(serialized).toContain("Now I'll check the config.")
+    expect(serialized).not.toContain("Assistant narration omitted")
+  })
+
+  test("narration scrubs THREA_ATTACH local paths", () => {
+    const steps = mapTranscriptLine(
+      assistantLine([{ type: "text", text: "Report attached.\nTHREA_ATTACH: /Users/k/private/report.md" }]),
+      ctx()
+    )
+    expect(steps).toHaveLength(1)
+    expect(steps[0]!.content).toContain("Report attached.")
+    expect(steps[0]!.content).toContain("THREA_ATTACH: [local path omitted]")
+    expect(steps[0]!.content).not.toContain("/Users/k/private")
   })
 
   test("the channel's own send/reply tools and their results are skipped entirely", () => {

--- a/extensions/claude-code-remote/src/transcript-trace.ts
+++ b/extensions/claude-code-remote/src/transcript-trace.ts
@@ -12,15 +12,18 @@ import { basename, join } from "node:path"
  * module maps to Threa trace steps and ships through the SDK's `recordSteps`
  * (over the /bot socket) while a turn is in flight.
  *
- * Privacy model (mirrors pi-remote's, one notch stricter): in the default
- * `headline` mode nothing user-generated leaves the machine — tool calls ship
- * a category headline plus at most a file *basename*; shell commands, file
- * contents, tool outputs, and thinking bodies are replaced with "omitted for
- * safety" markers carrying only size telemetry. Thinking is withheld entirely
- * (pi ships its narration because pi's narration is stream-bound anyway;
- * Claude's thinking is internal and can quote file contents wholesale). The
- * `full` mode exists for E2EE-backed session links, where complete steps can
- * ship encrypted — nothing wires it up until then.
+ * Privacy model (mirrors pi-remote's): in the default `headline` mode no tool
+ * payload leaves the machine — tool calls ship a category headline plus at
+ * most a file *basename*; shell commands, file contents, tool outputs, and
+ * thinking bodies are replaced with "omitted for safety" markers carrying only
+ * size telemetry. Assistant narration ships in FULL in both modes, exactly as
+ * pi ships its narration: it is prose the model writes for the stream's
+ * reader, and it is the only surviving record of a turn's final message when
+ * the model ends without calling `reply` (Kris's ruling — redacting it left
+ * such turns showing nothing but an "omitted" stub). Thinking stays withheld
+ * in headline mode: it is internal and can quote file contents wholesale. The
+ * `full` mode ships everything; the channel enables it per-turn for sealed
+ * (E2EE) turns, whose steps are ciphertext to the server.
  */
 
 // Wire format shared with pi-remote and parsed by the frontend trace dialog
@@ -220,8 +223,13 @@ function summarizeToolOutput(output: string): string {
   return `Tool output omitted for safety. Captured locally: ${text.length} characters across ${lines} ${lines === 1 ? "line" : "lines"}.`
 }
 
-function withheldBody(kind: "Thinking content" | "Assistant narration", length: number): string {
-  return `${kind} omitted for safety. Captured locally: ${length} characters.`
+function withheldThinking(length: number): string {
+  return `Thinking content omitted for safety. Captured locally: ${length} characters.`
+}
+
+/** Ported from pi-remote's sanitizeTraceText: a THREA_ATTACH directive carries a local filesystem path. */
+function sanitizeNarration(text: string): string {
+  return text.replace(/^THREA_ATTACH:\s*.+$/gm, "THREA_ATTACH: [local path omitted]")
 }
 
 /** The channel's own MCP tools — their payloads land in the stream as real messages, so trace rows would be noise. */
@@ -303,15 +311,16 @@ export function mapTranscriptLine(raw: string, ctx: MapContext): MappedStep[] {
       if (!text) continue
       steps.push({
         stepType: "thinking",
-        content: ctx.mode === "full" ? truncateForTrace(text) : withheldBody("Thinking content", text.length),
+        content: ctx.mode === "full" ? truncateForTrace(text) : withheldThinking(text.length),
         statusText: "Thinking…",
       })
     } else if (type === "assistant" && part.type === "text" && typeof part.text === "string") {
       const text = part.text.trim()
       if (!text) continue
+      // Narration ships unredacted in both modes (see the privacy model above).
       steps.push({
         stepType: "thinking",
-        content: ctx.mode === "full" ? truncateForTrace(text) : withheldBody("Assistant narration", text.length),
+        content: truncateForTrace(sanitizeNarration(text)),
         statusText: "Composing response…",
       })
     } else if (type === "assistant" && part.type === "tool_use") {


### PR DESCRIPTION
## Problem

The Claude channel's transcript tracer (`extensions/claude-code-remote/src/transcript-trace.ts`) redacted assistant narration in the default `headline` mode: every assistant `text` part mapped to `"Assistant narration omitted for safety. Captured locally: N characters."` When a turn ends with a final text message but no `mcp__threa__reply` call — which happens regularly — the scratchpad shows no message at all and the trace's last step is that stub. The message exists on the machine; the mapper withheld it.

Kris's ruling: "Let's not redact the messages, that's not how the Pi harness works." Pi-remote has always shipped narration verbatim as `thinking` trace steps (`threa-remote.ts` `message_end` → `recordTraceStep("thinking", sanitizeTraceText(...))`) — and reuses the final narration as the posted reply, so a pi turn can't even end message-less. The channel copied pi's privacy model "one notch stricter" and lumped narration in with thinking; but narration is stream-facing prose written for the reader, not internal reasoning.

## Solution

Assistant `text` parts now ship their body in **both** trace modes — truncated to the trace budget, with pi's `THREA_ATTACH: <local path>` scrub ported (`sanitizeNarration`). Everything else is unchanged: tool arguments/outputs stay redacted to headlines + size telemetry on plaintext turns, thinking bodies stay withheld in `headline` mode (they can quote file contents wholesale; current Claude Code persists them empty anyway), and sealed turns still run `full`. `withheldBody` shrinks to `withheldThinking` since narration no longer uses it.

Also refreshes two stale README entries that predate the transcript tracer: the "single working step, no per-tool trace" limitation and the "per-tool trace steps" roadmap item (now describing the actual model: transcript tailing, headline redaction, narration in full, `sealedFullTrace: false` opt-out — default `true` per `remote-session/src/identity.ts:190`).

## Files changed

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/transcript-trace.ts` | Narration ships unredacted (both modes) via `truncateForTrace(sanitizeNarration(text))`; new `sanitizeNarration` THREA_ATTACH scrub; `withheldBody` → `withheldThinking`; privacy-model doc block updated |
| `extensions/claude-code-remote/src/transcript-trace.test.ts` | Redaction test split: thinking ships size-only, narration ships its body; new THREA_ATTACH scrub test |
| `extensions/claude-code-remote/README.md` | Limitations/Roadmap entries updated to the shipped trace model |

## Out of scope (deliberate)

- Making the channel post a turn's final narration as the reply when no `reply` lands (pi's behavior). The channel is an MCP server without pi's `agent_end` lifecycle hook — detecting turn end from the transcript tail is a separate design. This PR makes such turns *readable*; closing them with a real message is a follow-up if wanted.
- Tool args/outputs and thinking on plaintext turns stay redacted — the ask was the messages.

## Test plan

- [x] `bun test` in `extensions/claude-code-remote` — 48 pass (6 files)
- [x] `bunx tsc --noEmit` in the extension — clean
- [x] Repo-wide lint/typecheck via pre-commit hook — clean
- [ ] Live channel verify needs a channel restart to pick up the built extension — noted to Kris; the running channel serves this very session

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785840234&installation_id=129946197&pr_number=1186&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1186&signature=638f1554dc30e8468d731620d50b5aea5c9831c7c5d3466548f9bc819de8276f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->