### PR TITLE
feat(conversations): eval-driven boundary + memory overhaul — live-session pivots, rolling summaries, staleness sweep, memo supersession

### DIFF
--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -14,8 +14,14 @@ bun run eval -- -s companion
 # Run specific test case
 bun run eval -- -s companion -c scratchpad-companion-greeting-001
 
+# Repeat every case 6 times and read per-case pass rates (see "Variance")
+bun run eval -- -s boundary-extraction -r 6 --min-pass-rate 0.8
+
 # Compare models
 bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-5.4-nano
+
+# Machine-readable results (per-case pass rates, usage, executed models)
+bun run eval -- -s memo-classifier -r 3 --json results.json
 
 # Run from config file
 bun run eval -- --config evals/example-config.yaml
@@ -28,8 +34,28 @@ bun run eval -- --config evals/example-config.yaml
 | `companion`           | Full companion agent with tools     |
 | `stream-naming`       | Stream name generation              |
 | `boundary-extraction` | Conversation boundary detection     |
+| `multimodal-vision`   | Vision/attachment understanding     |
 | `memo-classifier`     | Knowledge-worthiness classification |
 | `memorizer`           | Memo generation from messages       |
+
+## Variance: tune against tallies, not single runs
+
+The components under test are stochastic even at low temperature — borderline
+cases flip run-to-run, and a single green run is not evidence (a fully green
+single-run suite once masked every live failure mode these suites now encode).
+Use `--runs N` when tuning prompts or comparing models: each case reports a
+pass rate ("4/6"), run-level evaluators aggregate across all runs, and
+`--min-pass-rate` sets the threshold a case must clear for the exit code.
+
+## Model overrides are verified at runtime
+
+`-m` genuinely overrides the model for components that read their config via
+`ConfigResolver` (INV-44) — the runner wraps the resolver with the permutation
+model. The summary prints an `Executed:` line with the model ids the AI layer
+actually ran and their call counts, and the run **fails loudly** if a `-m`
+override never executed (that would be a silently-invalid comparison). Suites
+whose sub-components intentionally use other models pass as long as the
+requested model executed.
 
 ## Key Principle: Config Co-location (INV-44)
 
@@ -141,9 +167,12 @@ Options:
   -h, --help            Show help message
   -s, --suite <name>    Run specific suite
   -c, --case <id>       Run specific case(s), comma-separated
-  -m, --model <ids>     Override model(s), comma-separated
+  -m, --model <ids>     Override model(s), comma-separated (runtime-verified)
   -t, --temperature <n> Override temperature (0.0-1.0)
   -p, --parallel <n>    Parallel workers (default: 1)
+  -r, --runs <n>        Repeat every case n times, report per-case pass rates
+  --min-pass-rate <n>   Pass-rate a case must clear when runs > 1 (default: 1.0)
+  --json <file>         Write machine-readable results JSON to <file>
   --config <file>       Run from YAML config file
   --no-langfuse         Disable Langfuse recording
   -v, --verbose         Verbose output

--- a/apps/backend/evals/fixtures/memo.ts
+++ b/apps/backend/evals/fixtures/memo.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared fixtures for the memo-classifier and memorizer suites: production-
+ * shaped message rendering and minimal Conversation/Memo rows built from eval
+ * case data.
+ */
+
+import { ulid } from "ulid"
+import type { Memo } from "../../src/features/memos"
+import type { Conversation } from "../../src/features/conversations"
+import { MemoStatuses, MemoTypes, ConversationStatuses } from "@threa/types"
+import type { EvalClassifierMessage } from "../suites/memo-classifier/types"
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+}
+
+/**
+ * Render messages exactly as MessageFormatter.formatMessages does in
+ * production (the classifier counts messages by splitting on "<message"), but
+ * from eval fixtures instead of DB rows.
+ */
+export function formatEvalMessages(messages: EvalClassifierMessage[], now: Date): string {
+  const rendered = messages.map((m, i) => {
+    const id = m.id ?? `msg_${ulid()}`
+    const createdAt = new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000)
+    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
+  })
+  return `<messages>\n${rendered.join("\n")}\n</messages>`
+}
+
+export function toConversation(input: { topicSummary: string | null; participantIds: string[] }): Conversation {
+  const now = new Date()
+  return {
+    id: `conv_${ulid()}`,
+    streamId: `stream_${ulid()}`,
+    workspaceId: `ws_${ulid()}`,
+    messageIds: [],
+    participantIds: input.participantIds,
+    secondaryMessageIds: [],
+    topicSummary: input.topicSummary,
+    summary: null,
+    completenessScore: 5,
+    confidence: 0.9,
+    status: ConversationStatuses.ACTIVE,
+    parentConversationId: null,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export function toMemo(m: { title: string; abstract: string; createdDaysAgo?: number }, conversationId: string): Memo {
+  const createdAt = new Date(Date.now() - (m.createdDaysAgo ?? 1) * 24 * 60 * 60 * 1000)
+  return {
+    id: `memo_${ulid()}`,
+    workspaceId: "ws_eval",
+    memoType: MemoTypes.CONVERSATION,
+    sourceMessageId: null,
+    sourceConversationId: conversationId,
+    title: m.title,
+    abstract: m.abstract,
+    keyPoints: [],
+    sourceMessageIds: [],
+    participantIds: [],
+    knowledgeType: "context",
+    tags: [],
+    parentMemoId: null,
+    status: MemoStatuses.ACTIVE,
+    version: 1,
+    revisionReason: null,
+    createdAt,
+    updatedAt: createdAt,
+    archivedAt: null,
+  }
+}

--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -110,11 +110,13 @@ function createUsageTrackingAI(ai: AI, accumulator: UsageAccumulator): AI {
   return {
     ...ai,
     async generateText(options: GenerateTextOptions) {
+      accumulator.recordModel(options.model)
       const result = await ai.generateText(options)
       accumulator.recordUsage(result.usage)
       return result
     },
     async generateObject<T extends import("zod").ZodType>(options: GenerateObjectOptions<T>) {
+      accumulator.recordModel(options.model)
       const result = await ai.generateObject(options)
       accumulator.recordUsage(result.usage)
       return result
@@ -233,7 +235,21 @@ async function runPermutation<TInput, TOutput, TExpected>(
   // Create config resolver with eval overrides applied
   // Base resolver has production defaults; eval resolver applies componentOverrides
   const baseResolver = createStaticConfigResolver()
-  const configResolver = createEvalConfigResolverFromYaml(baseResolver, options.componentOverrides)
+  const yamlResolver = createEvalConfigResolverFromYaml(baseResolver, options.componentOverrides)
+  // A -m/-t permutation override must reach components that read their model
+  // from the co-located config via ConfigResolver (INV-44) — boundary
+  // extraction, memo classifier/memorizer. Without this wrap the CLI flag
+  // silently relabels the run while the production model still executes.
+  const hasCliPermutation = Boolean(options.model)
+  const configResolver: typeof yamlResolver = hasCliPermutation
+    ? {
+        resolve: async (path: string) => ({
+          ...(await yamlResolver.resolve(path)),
+          modelId: permutation.model,
+          ...(permutation.temperature !== undefined ? { temperature: permutation.temperature } : {}),
+        }),
+      }
+    : yamlResolver
 
   // Create context for this permutation
   const ctx: EvalContext = {
@@ -255,38 +271,46 @@ async function runPermutation<TInput, TOutput, TExpected>(
     await suite.setup(ctx)
   }
 
-  // Run each case sequentially
+  // Run each case sequentially; with --runs N the whole set repeats so
+  // per-case pass rates can be tallied (stochastic components flip borderline
+  // cases run-to-run — single-run green is not evidence).
+  const runs = Math.max(1, options.runs ?? 1)
   const totalCases = casesToRun.length
-  for (let i = 0; i < casesToRun.length; i++) {
-    const caseItem = casesToRun[i]
-    const caseNum = i + 1
+  for (let run = 1; run <= runs; run++) {
+    if (runs > 1) {
+      console.log(`  ${colors.cyan}— run ${run}/${runs} —${colors.reset}`)
+    }
+    for (let i = 0; i < casesToRun.length; i++) {
+      const caseItem = casesToRun[i]
+      const caseNum = i + 1
 
-    // Always show progress
-    process.stdout.write(`  ${colors.dim}[${caseNum}/${totalCases}]${colors.reset} ${caseItem.name}... `)
+      // Always show progress
+      process.stdout.write(`  ${colors.dim}[${caseNum}/${totalCases}]${colors.reset} ${caseItem.name}... `)
 
-    const result = await runCase(suite, caseItem, ctx, options)
-    cases.push(result)
+      const result = await runCase(suite, caseItem, ctx, options)
+      cases.push(result)
 
-    // Show result status
-    const passed = !result.error && result.evaluations.every((e) => e.passed)
-    const status = result.error
-      ? `${colors.red}ERROR${colors.reset}`
-      : passed
-        ? `${colors.green}PASS${colors.reset}`
-        : `${colors.red}FAIL${colors.reset}`
-    console.log(`${status} ${colors.dim}(${formatDuration(result.durationMs)})${colors.reset}`)
+      // Show result status
+      const passed = !result.error && result.evaluations.every((e) => e.passed)
+      const status = result.error
+        ? `${colors.red}ERROR${colors.reset}`
+        : passed
+          ? `${colors.green}PASS${colors.reset}`
+          : `${colors.red}FAIL${colors.reset}`
+      console.log(`${status} ${colors.dim}(${formatDuration(result.durationMs)})${colors.reset}`)
 
-    // Show inline details for failures
-    if (result.error) {
-      console.log(`    ${colors.red}${result.error.message}${colors.reset}`)
-      if (NoObjectGeneratedError.isInstance(result.error) && result.error.text) {
-        console.log(`    ${colors.dim}Raw response: ${formatValue(result.error.text, 200)}${colors.reset}`)
-      }
-    } else if (!passed) {
-      for (const evaluation of result.evaluations.filter((e) => !e.passed)) {
-        console.log(
-          `    ${colors.yellow}${evaluation.name}: ${evaluation.details || `score=${evaluation.score}`}${colors.reset}`
-        )
+      // Show inline details for failures
+      if (result.error) {
+        console.log(`    ${colors.red}${result.error.message}${colors.reset}`)
+        if (NoObjectGeneratedError.isInstance(result.error) && result.error.text) {
+          console.log(`    ${colors.dim}Raw response: ${formatValue(result.error.text, 200)}${colors.reset}`)
+        }
+      } else if (!passed) {
+        for (const evaluation of result.evaluations.filter((e) => !e.passed)) {
+          console.log(
+            `    ${colors.yellow}${evaluation.name}: ${evaluation.details || `score=${evaluation.score}`}${colors.reset}`
+          )
+        }
       }
     }
   }
@@ -301,11 +325,25 @@ async function runPermutation<TInput, TOutput, TExpected>(
 
   // Get accumulated usage
   const totalUsage = usageAccumulator.getTotal()
+  const executedModels = usageAccumulator.getModels()
+
+  // A -m override that never executed is a silently-invalid comparison (the
+  // exact bug this guard exists for) — fail loudly (INV-11). Suites whose
+  // sub-components legitimately call other models still pass as long as the
+  // requested model executed at least once.
+  if (options.model && Object.keys(executedModels).length > 0 && !(permutation.model in executedModels)) {
+    throw new Error(
+      `Model override ${permutation.model} never executed — AI calls used: ${Object.keys(executedModels).join(", ")}. ` +
+        `The comparison would be invalid; check the ConfigResolver wiring.`
+    )
+  }
 
   return {
     permutation,
     cases,
     runEvaluations,
+    runs,
+    executedModels,
     totalDurationMs: Date.now() - startTime,
     usage: {
       inputTokens: totalUsage.inputTokens,
@@ -436,6 +474,46 @@ function printSummary<TOutput, TExpected>(result: SuiteResult<TOutput, TExpected
     console.log(
       `\n  ${colors.green}Passed: ${passedCases.length}${colors.reset}  ${colors.red}Failed: ${failedCases.length}${colors.reset}  ${colors.dim}Duration: ${formatDuration(totalDurationMs)}${colors.reset}`
     )
+
+    const executedEntries = Object.entries(permResult.executedModels ?? {})
+    if (executedEntries.length > 0) {
+      console.log(
+        `  ${colors.dim}Executed: ${executedEntries.map(([m, n]) => `${m} (${n} calls)`).join(", ")}${colors.reset}`
+      )
+    }
+
+    // With repeat runs, the per-case tally is the readable unit — one line per
+    // case with its pass rate — instead of N repeated lines.
+    if (permResult.runs > 1) {
+      console.log(`\n  Cases (pass rate over ${permResult.runs} runs):`)
+      const byCase = new Map<string, { name: string; passes: number; total: number }>()
+      for (const caseResult of cases) {
+        const passed = !caseResult.error && caseResult.evaluations.every((e) => e.passed)
+        const agg = byCase.get(caseResult.caseId) ?? { name: caseResult.caseName, passes: 0, total: 0 }
+        agg.passes += passed ? 1 : 0
+        agg.total += 1
+        byCase.set(caseResult.caseId, agg)
+      }
+      for (const [caseId, agg] of byCase) {
+        const rate = agg.passes / agg.total
+        const mark =
+          rate === 1
+            ? `${colors.green}✓${colors.reset}`
+            : rate === 0
+              ? `${colors.red}✗${colors.reset}`
+              : `${colors.yellow}~${colors.reset}`
+        console.log(`    ${mark} ${agg.passes}/${agg.total} ${agg.name} ${colors.dim}(${caseId})${colors.reset}`)
+      }
+      if (permResult.runEvaluations.length > 0) {
+        console.log("\n  Run Evaluations (across all runs):")
+        for (const evaluation of permResult.runEvaluations) {
+          const status = evaluation.passed ? colors.green : colors.red
+          console.log(`    ${status}${evaluation.name}: ${evaluation.score}${colors.reset}`)
+          if (evaluation.details) console.log(`      ${colors.dim}${evaluation.details}${colors.reset}`)
+        }
+      }
+      continue
+    }
 
     // Show all cases
     console.log("\n  Cases:")

--- a/apps/backend/evals/framework/types.ts
+++ b/apps/backend/evals/framework/types.ts
@@ -21,8 +21,12 @@ import type { ComponentOverrides } from "./config-types"
 export interface UsageAccumulator {
   /** Record usage from an AI call */
   recordUsage(usage: { promptTokens?: number; completionTokens?: number; totalTokens?: number; cost?: number }): void
+  /** Record the model id an AI call actually executed with */
+  recordModel(modelId: string): void
   /** Get accumulated totals */
   getTotal(): { inputTokens: number; outputTokens: number; totalCost: number }
+  /** Executed model ids → call counts. The ground truth a -m override is verified against. */
+  getModels(): Record<string, number>
 }
 
 /**
@@ -32,6 +36,7 @@ export function createUsageAccumulator(): UsageAccumulator {
   let inputTokens = 0
   let outputTokens = 0
   let totalCost = 0
+  const models: Record<string, number> = {}
 
   return {
     recordUsage(usage) {
@@ -39,8 +44,14 @@ export function createUsageAccumulator(): UsageAccumulator {
       outputTokens += usage.completionTokens ?? 0
       totalCost += usage.cost ?? 0
     },
+    recordModel(modelId) {
+      models[modelId] = (models[modelId] ?? 0) + 1
+    },
     getTotal() {
       return { inputTokens, outputTokens, totalCost }
+    },
+    getModels() {
+      return { ...models }
     },
   }
 }
@@ -183,8 +194,13 @@ export interface CaseResult<TOutput, TExpected> {
  */
 export interface PermutationResult<TOutput, TExpected> {
   permutation: EvalPermutation
+  /** All case results; with --runs N each case appears N times (group by caseId to aggregate). */
   cases: CaseResult<TOutput, TExpected>[]
   runEvaluations: EvaluatorResult[]
+  /** Number of repeat runs the cases were executed for (1 = single pass). */
+  runs: number
+  /** Model ids the AI layer actually executed, with call counts. */
+  executedModels: Record<string, number>
   /** Total duration in milliseconds */
   totalDurationMs: number
   /** Token usage stats */
@@ -269,6 +285,19 @@ export interface RunnerOptions {
   temperature?: number
   /** Number of parallel workers (default: 1) */
   parallel?: number
+  /**
+   * Repeat every case this many times and report per-case pass rates
+   * (default 1). Stochastic components flip borderline cases run-to-run —
+   * single-run green is not evidence; tune against tallies.
+   */
+  runs?: number
+  /**
+   * Pass-rate threshold a case must clear when runs > 1 (0..1, default 1).
+   * A case passing 5/6 runs clears 0.8 but fails the default.
+   */
+  minPassRate?: number
+  /** Write machine-readable results JSON to this path. */
+  jsonOutput?: string
   /** Disable Langfuse recording */
   noLangfuse?: boolean
   /** Verbose output */

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -53,6 +53,9 @@ Options:
   -m, --model <ids>     Override model(s), comma-separated for comparison
   -t, --temperature <n> Override temperature (0.0-1.0)
   -p, --parallel <n>    Number of parallel workers (default: 1)
+  -r, --runs <n>        Repeat every case n times, report per-case pass rates (default: 1)
+  --min-pass-rate <n>   Pass-rate a case must clear when runs > 1 (0.0-1.0, default: 1.0)
+  --json <file>         Write machine-readable results JSON to <file>
   --config <file>       Run from YAML config file (ignores -s, -m flags)
   --no-langfuse         Disable Langfuse recording
   -v, --verbose         Verbose output
@@ -109,6 +112,9 @@ async function main(): Promise<void> {
       model: { type: "string", short: "m" },
       temperature: { type: "string", short: "t" },
       parallel: { type: "string", short: "p" },
+      runs: { type: "string", short: "r" },
+      "min-pass-rate": { type: "string" },
+      json: { type: "string" },
       config: { type: "string" },
       "no-langfuse": { type: "boolean" },
       verbose: { type: "boolean", short: "v" },
@@ -135,6 +141,9 @@ async function main(): Promise<void> {
     model: values.model,
     temperature: values.temperature ? parseFloat(values.temperature) : undefined,
     parallel: values.parallel ? parseInt(values.parallel, 10) : undefined,
+    runs: values.runs ? parseInt(values.runs, 10) : undefined,
+    minPassRate: values["min-pass-rate"] ? parseFloat(values["min-pass-rate"]) : undefined,
+    jsonOutput: values.json,
     noLangfuse: values["no-langfuse"],
     verbose: values.verbose,
   }
@@ -142,6 +151,16 @@ async function main(): Promise<void> {
   // Validate temperature
   if (options.temperature !== undefined && (options.temperature < 0 || options.temperature > 1)) {
     console.error("Error: Temperature must be between 0.0 and 1.0")
+    process.exit(1)
+  }
+
+  if (options.runs !== undefined && (!Number.isInteger(options.runs) || options.runs < 1)) {
+    console.error("Error: --runs must be a positive integer")
+    process.exit(1)
+  }
+
+  if (options.minPassRate !== undefined && (options.minPassRate < 0 || options.minPassRate > 1)) {
+    console.error("Error: --min-pass-rate must be between 0.0 and 1.0")
     process.exit(1)
   }
 
@@ -216,9 +235,16 @@ async function main(): Promise<void> {
     // can't unify different generic instantiations. Each suite is processed independently.
     const results = await runSuites(allSuites as any, options)
 
-    // Determine exit code based on results
+    if (options.jsonOutput) {
+      await Bun.write(options.jsonOutput, JSON.stringify(toJsonReport(results), null, 2))
+      console.log(`\nResults written to ${options.jsonOutput}`)
+    }
+
+    // A case passes when its pass rate over the repeat runs clears the
+    // threshold (default 1 = every run, matching single-run behavior).
+    const minPassRate = options.minPassRate ?? 1
     const hasFailures = results.some((r) =>
-      r.permutations.some((p) => p.cases.some((c) => c.error || c.evaluations.some((e) => !e.passed)))
+      r.permutations.some((p) => aggregateCases(p).some((c) => c.passes / c.total < minPassRate))
     )
 
     process.exit(hasFailures ? 1 : 0)
@@ -226,6 +252,64 @@ async function main(): Promise<void> {
     console.error("\nEvaluation failed with error:")
     console.error(error)
     process.exit(1)
+  }
+}
+
+interface CaseAggregate {
+  caseId: string
+  caseName: string
+  passes: number
+  total: number
+  /** Failing evaluator details from the most recent failing run, for the JSON report. */
+  lastFailure?: { name: string; details?: string }[]
+}
+
+function aggregateCases(p: {
+  cases: Array<{ caseId: string; caseName: string; error?: Error; evaluations: Array<any> }>
+}): CaseAggregate[] {
+  const byCase = new Map<string, CaseAggregate>()
+  for (const c of p.cases) {
+    const passed = !c.error && c.evaluations.every((e) => e.passed)
+    const agg = byCase.get(c.caseId) ?? { caseId: c.caseId, caseName: c.caseName, passes: 0, total: 0 }
+    agg.passes += passed ? 1 : 0
+    agg.total += 1
+    if (!passed) {
+      agg.lastFailure = c.error
+        ? [{ name: "error", details: c.error.message }]
+        : c.evaluations.filter((e) => !e.passed).map((e) => ({ name: e.name, details: e.details }))
+    }
+    byCase.set(c.caseId, agg)
+  }
+  return [...byCase.values()]
+}
+
+function toJsonReport(results: Array<any>) {
+  return {
+    suites: results.map((r) => ({
+      suiteName: r.suiteName,
+      permutations: r.permutations.map((p: any) => ({
+        model: p.permutation.model,
+        temperature: p.permutation.temperature ?? null,
+        runs: p.runs,
+        executedModels: p.executedModels,
+        usage: p.usage ?? null,
+        totalDurationMs: p.totalDurationMs,
+        runEvaluations: p.runEvaluations.map((e: any) => ({
+          name: e.name,
+          score: e.score,
+          passed: e.passed,
+          details: e.details ?? null,
+        })),
+        cases: aggregateCases(p).map((c) => ({
+          caseId: c.caseId,
+          caseName: c.caseName,
+          passes: c.passes,
+          runs: c.total,
+          passRate: c.passes / c.total,
+          lastFailure: c.lastFailure ?? null,
+        })),
+      })),
+    })),
   }
 }
 

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -17,10 +17,19 @@ import { companionSuite } from "./suites/companion/suite"
 import { streamNamingSuite } from "./suites/stream-naming/suite"
 import { boundaryExtractionSuite } from "./suites/boundary-extraction/suite"
 import { multimodalVisionSuite } from "./suites/multimodal-vision/suite"
+import { memoClassifierSuite } from "./suites/memo-classifier/suite"
+import { memorizerSuite } from "./suites/memorizer/suite"
 import { isConfigFilePath } from "./framework/config-loader"
 
 // All available suites
-const allSuites = [companionSuite, streamNamingSuite, boundaryExtractionSuite, multimodalVisionSuite]
+const allSuites = [
+  companionSuite,
+  streamNamingSuite,
+  boundaryExtractionSuite,
+  multimodalVisionSuite,
+  memoClassifierSuite,
+  memorizerSuite,
+]
 
 function printHelp(): void {
   const suiteNames = allSuites.map((s) => s.name).join(", ")

--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -834,4 +834,707 @@ Any ideas what's causing this?`,
       minConfidence: 0.6,
     },
   },
+
+  // ── Live-session pivots ──────────────────────────────────────────────────
+  // Modeled on real prod failures in a long-running DM: an all-day live
+  // session drifts through many subjects, and the extractor glued every one
+  // of them onto a single conversation (79 messages / 6 days / ~8 topics).
+  // A session is not a conversation — a pivot mid-session must start a new
+  // conversation even though the last message is only minutes old.
+
+  {
+    id: "live-pivot-btw-001",
+    name: "Live pivot: 'btw' question mid-session opens a new conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "btw, hur många timmar har jag dig imorgon? :laughing:",
+      },
+      activeConversations: [
+        {
+          id: "conv_cleanup01",
+          topicSummary: "Stora deletes i monorepot",
+          messageCount: 9,
+          lastMessagePreview: "Man mår så bra av stora deletes!",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 4,
+          lastActivityMinutesAgo: 2,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "det känns som en `rm -rf *` ju haha",
+          minutesAgo: 4,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Hehe galet mycket skräp bara, mest gamla testdumpar",
+          minutesAgo: 3,
+        },
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "ah, men ändå, känns bra",
+          minutesAgo: 2,
+        },
+      ],
+      streamType: "dm",
+      category: "topic-shift",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["imorgon", "timmar", "träff", "planer"],
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "live-pivot-new-subject-001",
+    name: "Live pivot: pasted diff stats mid-banter opens a new conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Detta känns fint `98 files changed, 214 insertions(+), 7402 deletions(-)`",
+      },
+      activeConversations: [
+        {
+          id: "conv_fashion01",
+          topicSummary: "Absurda designerpriser",
+          messageCount: 11,
+          lastMessagePreview: "Inte ens särskilt speciell liksom",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 4,
+          lastActivityMinutesAgo: 3,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "även om man har cash, varför betala 14000 för en t-shirt? wtf",
+          minutesAgo: 6,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Ingen som helst aning om varför",
+          minutesAgo: 4,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Inte ens särskilt speciell liksom",
+          minutesAgo: 3,
+        },
+      ],
+      streamType: "dm",
+      category: "topic-shift",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["delet", "cleanup", "rensning", "files", "diff", "kod"],
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "live-pivot-mid-blob-001",
+    name: "Live pivot: new subject does not join the sprawling live conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Shit vad remote pi är nice",
+      },
+      activeConversations: [
+        {
+          id: "conv_blob01",
+          topicSummary: "Smögen imorgon eftermiddag",
+          messageCount: 72,
+          lastMessagePreview: "De har väl själva frångått det också?",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 30,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "ye, de hade ju stämt någon för namnet, visste inte ens att de brydde sig",
+          minutesAgo: 35,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Helt sjukt",
+          minutesAgo: 31,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "De har väl själva frångått det också?",
+          minutesAgo: 30,
+        },
+      ],
+      streamType: "dm",
+      category: "topic-shift",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["remote pi", "pi"],
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "live-reaction-continues-001",
+    name: "Live continuity: bare ':shrug:' seconds after an exchange is not a singleton",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown: ":shrug:",
+      },
+      activeConversations: [
+        {
+          id: "conv_oldpc01",
+          topicSummary: "Gamla stationära som hemmaserver",
+          messageCount: 6,
+          lastMessagePreview: "Om man bara inte startar om den så är det väl fine",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 3,
+          lastActivityMinutesAgo: 1,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Har en gammal gamingdator från typ 2016 som inte är särskilt pigg längre",
+          minutesAgo: 3,
+        },
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "kör en lätt distro på den bara så puttrar den nog fint",
+          minutesAgo: 2,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Om man bara inte startar om den så är det väl fine",
+          minutesAgo: 1,
+        },
+      ],
+      streamType: "dm",
+      category: "continuity",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_oldpc01",
+      minConfidence: 0.5,
+    },
+  },
+
+  // ── Merge resistance ─────────────────────────────────────────────────────
+  // The reassignment instruction ("move the smaller one into the larger")
+  // must not let a sprawling conversation swallow a focused one just because
+  // they share a session and participants.
+
+  {
+    id: "no-merge-focused-into-blob-001",
+    name: "Merge resistance: focused conversation is not folded into the live blob",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown: "Testade med lists=200 nu, recall uppe på 0.94 utan att latensen stack iväg",
+      },
+      activeConversations: [
+        {
+          id: "conv_blob02",
+          topicSummary: "Helgplaner och AI-nyheter",
+          messageCount: 64,
+          lastMessagePreview: "haha ja, vi får se på söndag",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 8,
+          contextMessageIds: ["msg_blob_001"],
+        },
+        {
+          id: "conv_pgvector01",
+          topicSummary: "pgvector index-tuning",
+          messageCount: 4,
+          lastMessagePreview: "ivfflat med fler lists borde hjälpa",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 3,
+          lastActivityMinutesAgo: 12,
+          contextMessageIds: ["msg_pgv_001", "msg_pgv_002"],
+        },
+      ],
+      recentMessages: [
+        {
+          id: "msg_pgv_001",
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "recall på embedding-sökningen ligger på typ 0.71, känns lågt",
+          minutesAgo: 20,
+        },
+        {
+          id: "msg_pgv_002",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "ivfflat med fler lists borde hjälpa",
+          minutesAgo: 12,
+        },
+        {
+          id: "msg_blob_001",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "haha ja, vi får se på söndag",
+          minutesAgo: 8,
+        },
+      ],
+      streamType: "dm",
+      category: "merge-resistance",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_pgvector01",
+      expectNoReassignments: true,
+      minConfidence: 0.6,
+    },
+  },
+
+  {
+    id: "split-out-sandwich-001",
+    name: "Sandwich split: follow-up reveals a mid-exchange message opened a new topic",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Ja! Deras pad thai är helt sjukt bra, tog den två gånger förra veckan",
+      },
+      activeConversations: [
+        {
+          id: "conv_deploy02",
+          topicSummary: "Staging-deployen som failar",
+          messageCount: 6,
+          lastMessagePreview: "Har någon testat nya thai-stället på Hornsgatan?",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 3,
+          lastActivityMinutesAgo: 2,
+          contextMessageIds: ["msg_dep_001", "msg_dep_002", "msg_thai_001"],
+        },
+      ],
+      recentMessages: [
+        {
+          id: "msg_dep_001",
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "staging failar fortfarande på migrations-steget",
+          minutesAgo: 6,
+        },
+        {
+          id: "msg_dep_002",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "kolla om det är samma lock-timeout som sist",
+          minutesAgo: 5,
+        },
+        {
+          id: "msg_thai_001",
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Har någon testat nya thai-stället på Hornsgatan?",
+          minutesAgo: 2,
+        },
+      ],
+      streamType: "dm",
+      category: "merge-resistance",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["thai", "Hornsgatan", "lunch", "mat"],
+      expectReassignedMessageIds: ["msg_thai_001"],
+      minConfidence: 0.5,
+    },
+  },
+
+  // ── Session gaps against a large stale conversation ─────────────────────
+  // The prod blob absorbed messages across >24h gaps. A big candidate with a
+  // stale trip-planning title must not attract an unrelated opener; an
+  // explicit by-name resume must still find its (smaller, older) topic.
+
+  {
+    id: "gap-26h-new-opener-001",
+    name: "Session gap: new subject 26h later leaves the big trip conversation alone",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown:
+          "Är inte det här helt sjukt. Claude har alltså ätit 3.9GB data på 5G den här månaden. Det är bara text!",
+      },
+      activeConversations: [
+        {
+          id: "conv_trip01",
+          topicSummary: "Smögen imorgon eftermiddag",
+          messageCount: 16,
+          lastMessagePreview: "oh, nice",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 1560,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Inte än, men vi ska till Hälsingland idag",
+          minutesAgo: 1980,
+        },
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "oh, nice",
+          minutesAgo: 1560,
+        },
+      ],
+      streamType: "dm",
+      category: "session-gap",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["Claude", "data", "5G"],
+      minConfidence: 0.6,
+    },
+  },
+
+  {
+    id: "gap-explicit-resume-001",
+    name: "Session gap: by-name question resumes the right stale conversation, not the blob",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Har du fortfarande opencode go?",
+      },
+      activeConversations: [
+        {
+          id: "conv_blob03",
+          topicSummary: "Smögen imorgon eftermiddag",
+          messageCount: 24,
+          lastMessagePreview: "Jag hade inte varit förvånad om de glömt slå på gzip",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 1740,
+        },
+        {
+          id: "conv_opencode01",
+          topicSummary: "opencode go setup",
+          messageCount: 9,
+          lastMessagePreview: "kör den via tmux så länge, funkar förvånansvärt bra",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 4,
+          status: "stalled",
+          lastActivityMinutesAgo: 4320,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Och jag skulle gissa att varje load drar ner ALLT också",
+          minutesAgo: 1750,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Jag hade inte varit förvånad om de glömt slå på gzip",
+          minutesAgo: 1740,
+        },
+      ],
+      streamType: "dm",
+      category: "session-gap",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_opencode01",
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "gap-4h-topic-reference-001",
+    name: "Session gap: 4h-late reply that names the topic continues its conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "vadå, köper folk i tech de där tröjorna på riktigt?",
+      },
+      activeConversations: [
+        {
+          id: "conv_fashion02",
+          topicSummary: "Absurda designerpriser",
+          messageCount: 5,
+          lastMessagePreview: "Tänk att få gräsfläckar på en sån",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 3,
+          lastActivityMinutesAgo: 240,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Eller fuck, 14000kr https://example.com/quadrige-embroidered-t-shirt",
+          minutesAgo: 245,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Tänk att få gräsfläckar på en sån",
+          minutesAgo: 240,
+        },
+      ],
+      streamType: "dm",
+      category: "session-gap",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_fashion02",
+      minConfidence: 0.5,
+    },
+  },
+
+  // ── Summary-bearing variants ─────────────────────────────────────────────
+  // Same volatile scenarios, but candidates carry the rolling "covers:"
+  // summary the extractor now maintains. Measures whether summaries firm up
+  // the live-pivot and merge decisions the title-only variants get wrong.
+
+  {
+    id: "live-pivot-new-subject-sum-001",
+    name: "Live pivot with summaries: pasted diff stats mid-banter opens a new conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Detta känns fint `98 files changed, 214 insertions(+), 7402 deletions(-)`",
+      },
+      activeConversations: [
+        {
+          id: "conv_fashion01",
+          topicSummary: "Absurda designerpriser",
+          summary:
+            "Skämt om absurda designerpriser: en broderad t-shirt för 14000kr och vem som egentligen köper sånt. Rent skvaller, inget beslut.",
+          messageCount: 11,
+          lastMessagePreview: "Inte ens särskilt speciell liksom",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 4,
+          lastActivityMinutesAgo: 3,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "även om man har cash, varför betala 14000 för en t-shirt? wtf",
+          minutesAgo: 6,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Ingen som helst aning om varför",
+          minutesAgo: 4,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Inte ens särskilt speciell liksom",
+          minutesAgo: 3,
+        },
+      ],
+      streamType: "dm",
+      category: "topic-shift",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["delet", "cleanup", "rensning", "files", "diff", "kod"],
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "live-pivot-mid-blob-sum-001",
+    name: "Live pivot with summaries: new subject does not join the sprawling conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "Shit vad remote pi är nice",
+      },
+      activeConversations: [
+        {
+          id: "conv_blob01",
+          topicSummary: "Smögen imorgon eftermiddag",
+          summary:
+            "Började som helgplaner kring Smögen, gled över i modellnyheter och sedan AI-bolagens VD:ar och stämningen kring dem. Spretigt, inget avslut.",
+          messageCount: 72,
+          lastMessagePreview: "De har väl själva frångått det också?",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 30,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "ye, de hade ju stämt någon för namnet, visste inte ens att de brydde sig",
+          minutesAgo: 35,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Helt sjukt",
+          minutesAgo: 31,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "De har väl själva frångått det också?",
+          minutesAgo: 30,
+        },
+      ],
+      streamType: "dm",
+      category: "topic-shift",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      topicContains: ["remote pi", "pi"],
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "no-merge-focused-into-blob-sum-001",
+    name: "Merge resistance with summaries: focused conversation stays separate",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown: "Testade med lists=200 nu, recall uppe på 0.94 utan att latensen stack iväg",
+      },
+      activeConversations: [
+        {
+          id: "conv_blob02",
+          topicSummary: "Helgplaner och AI-nyheter",
+          summary:
+            "Löst snack om helgplaner (söndag nämnd) blandat med reaktioner på veckans AI-nyheter. Inget konkret bestämt.",
+          messageCount: 64,
+          lastMessagePreview: "haha ja, vi får se på söndag",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 8,
+          contextMessageIds: ["msg_blob_001"],
+        },
+        {
+          id: "conv_pgvector01",
+          topicSummary: "pgvector index-tuning",
+          summary:
+            "Embedding-sökningens recall låg på 0.71; ivfflat med fler lists föreslogs som fix. Väntar på testresultat.",
+          messageCount: 4,
+          lastMessagePreview: "ivfflat med fler lists borde hjälpa",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 3,
+          lastActivityMinutesAgo: 12,
+          contextMessageIds: ["msg_pgv_001", "msg_pgv_002"],
+        },
+      ],
+      recentMessages: [
+        {
+          id: "msg_pgv_001",
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "recall på embedding-sökningen ligger på typ 0.71, känns lågt",
+          minutesAgo: 20,
+        },
+        {
+          id: "msg_pgv_002",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "ivfflat med fler lists borde hjälpa",
+          minutesAgo: 12,
+        },
+        {
+          id: "msg_blob_001",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "haha ja, vi får se på söndag",
+          minutesAgo: 8,
+        },
+      ],
+      streamType: "dm",
+      category: "merge-resistance",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_pgvector01",
+      expectNoReassignments: true,
+      minConfidence: 0.6,
+    },
+  },
+
+  {
+    id: "resolution-settled-plan-sv-001",
+    name: "Resolution: agreed plan marks the conversation settled (Swedish)",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "det låter som en plan :+1:",
+      },
+      activeConversations: [
+        {
+          id: "conv_meetup01",
+          topicSummary: "Träff imorgon kväll",
+          messageCount: 7,
+          lastMessagePreview: "Och kanske vara i Slussen halv sex?",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 1,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "btw, hur många timmar har jag dig imorgon? :laughing:",
+          minutesAgo: 5,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Haha inte för sent, men kan säkert ta en buss runt nio?",
+          minutesAgo: 3,
+        },
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "Och kanske vara i Slussen halv sex?",
+          minutesAgo: 1,
+        },
+      ],
+      streamType: "dm",
+      category: "resolution",
+    },
+    expectedOutput: {
+      expectConversationId: "conv_meetup01",
+      expectCompletenessUpdate: [{ conversationId: "conv_meetup01", minScore: 6 }],
+      minConfidence: 0.6,
+    },
+  },
 ]

--- a/apps/backend/evals/suites/boundary-extraction/evaluators.ts
+++ b/apps/backend/evals/suites/boundary-extraction/evaluators.ts
@@ -172,6 +172,49 @@ export const completenessUpdateEvaluator: Evaluator<BoundaryExtractionOutput, Bo
 }
 
 /**
+ * Evaluator for reassignment behavior: merge-resistance cases assert no
+ * collateral moves; sandwich-split cases assert specific messages moved.
+ */
+export const reassignmentEvaluator: Evaluator<BoundaryExtractionOutput, BoundaryExtractionExpected> = {
+  name: "reassignment",
+  evaluate: (output: BoundaryExtractionOutput, expected: BoundaryExtractionExpected): EvaluatorResult => {
+    if (!expected.expectNoReassignments && !expected.expectReassignedMessageIds?.length) {
+      return { name: "reassignment", score: 1, passed: true, details: "No reassignment requirements" }
+    }
+
+    // Ignore no-op moves (target = the conversation that already owns the
+    // message); the production service skips those before persisting.
+    const ownerByMessageId = new Map<string, string>()
+    for (const conv of output.input.activeConversations ?? []) {
+      for (const id of conv.contextMessageIds ?? []) ownerByMessageId.set(id, conv.id)
+    }
+    const moves = (output.reassignments || []).filter(
+      (m) => m.toConversationId === null || ownerByMessageId.get(m.messageId) !== m.toConversationId
+    )
+
+    if (expected.expectNoReassignments && moves.length > 0) {
+      const described = moves.map((m) => `${m.messageId}→${m.toConversationId ?? "new"}`).join(", ")
+      return { name: "reassignment", score: 0, passed: false, details: `Unexpected reassignments: ${described}` }
+    }
+
+    if (expected.expectReassignedMessageIds?.length) {
+      const movedIds = new Set(moves.map((m) => m.messageId))
+      const missing = expected.expectReassignedMessageIds.filter((id) => !movedIds.has(id))
+      if (missing.length > 0) {
+        return {
+          name: "reassignment",
+          score: 0,
+          passed: false,
+          details: `Expected reassignment of: ${missing.join(", ")} (got: ${moves.map((m) => m.messageId).join(", ") || "none"})`,
+        }
+      }
+    }
+
+    return { name: "reassignment", score: 1, passed: true }
+  },
+}
+
+/**
  * Run-level evaluator that checks overall accuracy.
  */
 export const accuracyEvaluator: RunEvaluator<BoundaryExtractionOutput, BoundaryExtractionExpected> = {

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -37,6 +37,7 @@ import {
   topicNotContainsEvaluator,
   confidenceEvaluator,
   completenessUpdateEvaluator,
+  reassignmentEvaluator,
   accuracyEvaluator,
   decisionAccuracyEvaluator,
   averageConfidenceEvaluator,
@@ -71,7 +72,7 @@ function toMessage(
 ): Message {
   const minutesAgo = evalMsg.minutesAgo ?? defaultMinutesAgo
   return {
-    id: `msg_${ulid()}`,
+    id: evalMsg.id ?? `msg_${ulid()}`,
     streamId,
     sequence: BigInt(sequence),
     authorId: evalMsg.authorId,
@@ -109,14 +110,15 @@ function buildExtractionContext(input: BoundaryExtractionInput, workspaceId: str
       toMessage(m, streamId, i + 2, now, DEFAULT_RECENT_MESSAGE_MINUTES_AGO)
     ),
     activeConversations: (input.activeConversations || []).map((c) => {
-      const { lastActivityMinutesAgo, ...summary } = c
+      const { lastActivityMinutesAgo, contextMessageIds, ...summary } = c
       return {
         ...summary,
+        summary: c.summary ?? null,
         status: c.status ?? "active",
         lastActivityAt: new Date(
           now.getTime() - (lastActivityMinutesAgo ?? DEFAULT_CONVERSATION_LAST_ACTIVITY_MINUTES_AGO) * 60_000
         ),
-        contextMessageIds: [],
+        contextMessageIds: contextMessageIds ?? [],
       }
     }),
     replyTargets: input.replyTargets,
@@ -151,6 +153,10 @@ async function runBoundaryExtractionTask(
       conversationId: primary.conversationId,
       newConversationTopic: result.newConversationTopic,
       completenessUpdates: result.completenessUpdates,
+      reassignments: result.reassignments?.map((r) => ({
+        messageId: r.messageId,
+        toConversationId: r.toConversationId,
+      })),
       confidence: result.confidence,
     }
   } catch (error) {
@@ -184,6 +190,7 @@ export const boundaryExtractionSuite: EvalSuite<
     topicNotContainsEvaluator,
     confidenceEvaluator,
     completenessUpdateEvaluator,
+    reassignmentEvaluator,
   ],
 
   runEvaluators: [accuracyEvaluator, decisionAccuracyEvaluator, averageConfidenceEvaluator],

--- a/apps/backend/evals/suites/boundary-extraction/suite.ts
+++ b/apps/backend/evals/suites/boundary-extraction/suite.ts
@@ -110,9 +110,9 @@ function buildExtractionContext(input: BoundaryExtractionInput, workspaceId: str
       toMessage(m, streamId, i + 2, now, DEFAULT_RECENT_MESSAGE_MINUTES_AGO)
     ),
     activeConversations: (input.activeConversations || []).map((c) => {
-      const { lastActivityMinutesAgo, contextMessageIds, ...summary } = c
+      const { lastActivityMinutesAgo, contextMessageIds, ...fields } = c
       return {
-        ...summary,
+        ...fields,
         summary: c.summary ?? null,
         status: c.status ?? "active",
         lastActivityAt: new Date(

--- a/apps/backend/evals/suites/boundary-extraction/types.ts
+++ b/apps/backend/evals/suites/boundary-extraction/types.ts
@@ -10,6 +10,8 @@ import type { ConversationStatus } from "@threa/types"
 export interface EvalConversationSummary {
   id: string
   topicSummary: string | null
+  /** Rolling prose summary of what the conversation covers; null/omitted = not yet summarized. */
+  summary?: string | null
   messageCount: number
   lastMessagePreview: string
   participantIds: string[]
@@ -21,12 +23,23 @@ export interface EvalConversationSummary {
    * Defaults to 5 minutes (a live conversation) when omitted.
    */
   lastActivityMinutesAgo?: number
+  /**
+   * Ids of recent messages (EvalMessage.id) this conversation owns. Renders
+   * as the conversation's in-context message ids, making ownership visible to
+   * the model — required for reassignment (merge/split) cases.
+   */
+  contextMessageIds?: string[]
 }
 
 /**
  * Simplified message for eval input.
  */
 export interface EvalMessage {
+  /**
+   * Stable id so conversations can claim the message via contextMessageIds
+   * and reassignment expectations can name it. Random when omitted.
+   */
+  id?: string
   authorId: string
   authorType: "user" | "persona"
   contentMarkdown: string
@@ -73,6 +86,7 @@ export interface BoundaryExtractionInput {
     | "reply"
     | "continuity"
     | "session-gap"
+    | "merge-resistance"
 }
 
 /**
@@ -90,6 +104,11 @@ export interface BoundaryExtractionOutput {
     conversationId: string
     score: number
     status: ConversationStatus
+  }>
+  /** Prior messages the extractor chose to move between conversations */
+  reassignments?: Array<{
+    messageId: string
+    toConversationId: string | null
   }>
   /** Confidence in classification (0-1) */
   confidence: number
@@ -118,4 +137,11 @@ export interface BoundaryExtractionExpected {
     maxScore?: number
     status?: ConversationStatus
   }[]
+  /**
+   * No prior message may be reassigned (merge-resistance: a correct
+   * classification must not come with collateral merges into a blob).
+   */
+  expectNoReassignments?: boolean
+  /** These message ids MUST be reassigned (sandwich-split correction). */
+  expectReassignedMessageIds?: string[]
 }

--- a/apps/backend/evals/suites/memo-classifier/cases.ts
+++ b/apps/backend/evals/suites/memo-classifier/cases.ts
@@ -9,8 +9,8 @@
 import type { EvalCase } from "../../framework/types"
 import type { MemoClassifierInput, MemoClassifierExpected } from "./types"
 
-const KRIS = { authorId: "usr_eval_kris", authorType: "user" as const, authorName: "Kim" }
-const PIERRE = { authorId: "usr_eval_pierre", authorType: "user" as const, authorName: "Pelle" }
+const KRIS = { authorId: "usr_eval_a", authorType: "user" as const, authorName: "Kim" }
+const PIERRE = { authorId: "usr_eval_b", authorType: "user" as const, authorName: "Pelle" }
 
 export const memoClassifierCases: EvalCase<MemoClassifierInput, MemoClassifierExpected>[] = [
   {

--- a/apps/backend/evals/suites/memo-classifier/cases.ts
+++ b/apps/backend/evals/suites/memo-classifier/cases.ts
@@ -1,0 +1,221 @@
+/**
+ * Memo Classifier Test Cases
+ *
+ * Derived from real production failures: a long-running Swedish DM where the
+ * classifier let news hot-takes, model-release chatter, and trip logistics
+ * through as "knowledge" (all paraphrased — no verbatim user content).
+ */
+
+import type { EvalCase } from "../../framework/types"
+import type { MemoClassifierInput, MemoClassifierExpected } from "./types"
+
+const KRIS = { authorId: "usr_eval_kris", authorType: "user" as const, authorName: "Kim" }
+const PIERRE = { authorId: "usr_eval_pierre", authorType: "user" as const, authorName: "Pelle" }
+
+export const memoClassifierCases: EvalCase<MemoClassifierInput, MemoClassifierExpected>[] = [
+  {
+    id: "news-hot-takes-001",
+    name: "News reactions: CEO gossip is not knowledge",
+    input: {
+      topicSummary: "AI-bolagens VD:ar",
+      category: "news-reactions",
+      messages: [
+        { ...PIERRE, contentMarkdown: "shit vad jag inte gillar deras VD dock", minutesAgo: 20 },
+        { ...KRIS, contentMarkdown: "Han är weird", minutesAgo: 18 },
+        { ...PIERRE, contentMarkdown: "börjar klaga på open-weight modeller etc", minutesAgo: 17 },
+        { ...KRIS, contentMarkdown: "Jävla savior complex också", minutesAgo: 15 },
+        {
+          ...PIERRE,
+          contentMarkdown: "Inte läst att de stoppade sin AI som övervakade alla anställda? Helt absurt",
+          minutesAgo: 12,
+        },
+        { ...KRIS, contentMarkdown: "Hade hatat att jobba där tror jag", minutesAgo: 10 },
+        { ...PIERRE, contentMarkdown: "Samma här, aldrig varit ett företag av intresse", minutesAgo: 9 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: false },
+  },
+
+  {
+    id: "model-release-chatter-001",
+    name: "News reactions: model release hot-takes are not knowledge",
+    input: {
+      topicSummary: "Nya modellsläpp",
+      category: "news-reactions",
+      messages: [
+        { ...PIERRE, contentMarkdown: "Nya modellen verkar lite meh?", minutesAgo: 30 },
+        { ...KRIS, contentMarkdown: "Inte testat än, ska kika imorgon", minutesAgo: 25 },
+        {
+          ...KRIS,
+          contentMarkdown: "vem bryr sig när vi strax får tillbaka flaggskeppet? https://example.com/news/redeploy",
+          minutesAgo: 20,
+        },
+        { ...PIERRE, contentMarkdown: "såg det, trist med 50% av weekly usage bara", minutesAgo: 15 },
+        { ...KRIS, contentMarkdown: "Ja verkligen, antar att de sett folk maxxa quotan", minutesAgo: 12 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: false },
+  },
+
+  {
+    id: "trip-logistics-001",
+    name: "Logistics: settled meetup plans are ephemeral, not knowledge",
+    input: {
+      topicSummary: "Träff imorgon kväll",
+      category: "logistics",
+      messages: [
+        { ...PIERRE, contentMarkdown: "btw, hur många timmar har jag dig imorgon? :laughing:", minutesAgo: 20 },
+        { ...KRIS, contentMarkdown: "Haha inte för sent, men kan säkert ta en buss runt nio?", minutesAgo: 18 },
+        { ...KRIS, contentMarkdown: "Och kanske vara i stan halv sex?", minutesAgo: 16 },
+        { ...PIERRE, contentMarkdown: "det låter som en plan", minutesAgo: 14 },
+        { ...PIERRE, contentMarkdown: "Något med uteservering om det är bra väder", minutesAgo: 12 },
+        { ...KRIS, contentMarkdown: "100%, kan kika på vilka som verkar rimliga", minutesAgo: 10 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: false },
+  },
+
+  {
+    id: "greeting-banter-001",
+    name: "Chatter: reactions and banter produce no memo",
+    input: {
+      topicSummary: "Vardagssnack",
+      category: "chatter",
+      messages: [
+        { ...KRIS, contentMarkdown: "haha, damn", minutesAgo: 10 },
+        { ...PIERRE, contentMarkdown: "eller hur hahah", minutesAgo: 8 },
+        { ...KRIS, contentMarkdown: ":shrug:", minutesAgo: 6 },
+        { ...PIERRE, contentMarkdown: "sant, rip", minutesAgo: 4 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: false },
+  },
+
+  {
+    id: "procedure-setup-001",
+    name: "Knowledge: a working setup with the how is worth keeping",
+    input: {
+      topicSummary: "pi-remote setup",
+      category: "knowledge",
+      messages: [
+        { ...KRIS, contentMarkdown: "Funderar på om man kan köra en liten VPS med agenten?", minutesAgo: 30 },
+        {
+          ...PIERRE,
+          contentMarkdown: "klart, jag satte upp https://github.com/example/pi-remote — funkar direkt",
+          minutesAgo: 28,
+        },
+        { ...KRIS, contentMarkdown: "Kör du den lokalt då eller på VPS?", minutesAgo: 25 },
+        {
+          ...PIERRE,
+          contentMarkdown: "jag kör det lokalt på min stationära, via tailscale. Noll config utöver auth-nyckeln",
+          minutesAgo: 22,
+        },
+        { ...KRIS, contentMarkdown: "Ah smart, då slipper man exponera något publikt", minutesAgo: 20 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: true },
+  },
+
+  {
+    id: "decision-measured-001",
+    name: "Knowledge: a measured decision with rationale is worth keeping",
+    input: {
+      topicSummary: "pgvector index-tuning",
+      category: "knowledge",
+      messages: [
+        { ...KRIS, contentMarkdown: "recall på embedding-sökningen ligger på typ 0.71, känns lågt", minutesAgo: 40 },
+        { ...PIERRE, contentMarkdown: "ivfflat med fler lists borde hjälpa", minutesAgo: 35 },
+        {
+          ...KRIS,
+          contentMarkdown: "Testade med lists=200 nu, recall uppe på 0.94 utan att latensen stack iväg",
+          minutesAgo: 10,
+        },
+        { ...PIERRE, contentMarkdown: "nice, kör på det", minutesAgo: 8 },
+        { ...KRIS, contentMarkdown: "Yes, sätter 200 som default i migrationen", minutesAgo: 5 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: true },
+  },
+
+  {
+    id: "mixed-banter-one-fact-001",
+    name: "Mixed: mostly banter with one durable fact is still worthy (memorizer selects)",
+    input: {
+      topicSummary: "Remote-agent snack",
+      category: "mixed",
+      messages: [
+        { ...PIERRE, contentMarkdown: "Shit vad remote-setupen är nice", minutesAgo: 30 },
+        { ...KRIS, contentMarkdown: "haha ja det ser ballt ut", minutesAgo: 28 },
+        { ...PIERRE, contentMarkdown: "Ehh den första blev fel lol, det var något scam-mail", minutesAgo: 26 },
+        { ...KRIS, contentMarkdown: "Kul med scams dock haha", minutesAgo: 24 },
+        {
+          ...PIERRE,
+          contentMarkdown:
+            "men alltså: den kör lokalt på min stationära via tailscale, så telefonen når den utan publik endpoint",
+          minutesAgo: 20,
+        },
+        { ...KRIS, contentMarkdown: "det är ju exakt vad jag behöver för min gamla burk", minutesAgo: 18 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: true },
+  },
+
+  {
+    id: "revision-no-new-001",
+    name: "Revision: rephrased already-captured facts do not warrant revision",
+    input: {
+      topicSummary: "Modellnyheter",
+      category: "revision",
+      existingMemos: [
+        {
+          title: "Flaggskeppsmodellen återlanseras med 50% weekly usage",
+          abstract:
+            "Modellen kommer tillbaka efter pausen men med halverad weekly quota; Kim och Pelle tror det beror på att folk maxxade flera subscriptions.",
+          createdDaysAgo: 0,
+        },
+        {
+          title: "Labbet har frångått sitt gamla modellnamn",
+          abstract: "Labbet verkar själva ha slutat använda det gamla modellnamnet de tidigare stämt andra kring.",
+          createdDaysAgo: 0,
+        },
+      ],
+      messages: [
+        { ...KRIS, contentMarkdown: "alltså 50% quota känns fortfarande snålt", minutesAgo: 10 },
+        { ...PIERRE, contentMarkdown: "ja fast bättre än inget, den är ju tillbaka iaf", minutesAgo: 8 },
+        { ...KRIS, contentMarkdown: "sant. Och lol att de inte ens använder namnet själva längre", minutesAgo: 5 },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: false, expectReviseExisting: false },
+  },
+
+  {
+    id: "revision-new-fact-001",
+    name: "Revision: a genuinely new durable fact warrants revision",
+    input: {
+      topicSummary: "pi-remote setup",
+      category: "revision",
+      existingMemos: [
+        {
+          title: "Pelle kör pi-remote lokalt via Tailscale",
+          abstract: "Pelle kör pi-remote på sin stationära och når den via Tailscale, ingen publik endpoint behövs.",
+          createdDaysAgo: 1,
+        },
+      ],
+      messages: [
+        {
+          ...PIERRE,
+          contentMarkdown:
+            "uppdatering: flyttade pi-remote till en Hetzner-VPS igår, den stationära lät för mycket på natten",
+          minutesAgo: 15,
+        },
+        { ...KRIS, contentMarkdown: "haha rimligt. Samma tailscale-upplägg?", minutesAgo: 12 },
+        {
+          ...PIERRE,
+          contentMarkdown: "yes, exakt samma, bara en annan nod i tailnetet. CX22:an räcker gott",
+          minutesAgo: 10,
+        },
+      ],
+    },
+    expectedOutput: { expectKnowledgeWorthy: true, expectReviseExisting: true },
+  },
+]

--- a/apps/backend/evals/suites/memo-classifier/evaluators.ts
+++ b/apps/backend/evals/suites/memo-classifier/evaluators.ts
@@ -1,0 +1,78 @@
+/**
+ * Memo Classifier Evaluators
+ */
+
+import type { Evaluator, EvaluatorResult, RunEvaluator, CaseResult } from "../../framework/types"
+import type { MemoClassifierOutput, MemoClassifierExpected } from "./types"
+
+/** Core gate: did the classifier make the right knowledge-worthiness call? */
+export const worthinessEvaluator: Evaluator<MemoClassifierOutput, MemoClassifierExpected> = {
+  name: "worthiness",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (output.error) {
+      return { name: "worthiness", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const passed = output.isKnowledgeWorthy === expected.expectKnowledgeWorthy
+    return {
+      name: "worthiness",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed
+        ? undefined
+        : `Expected isKnowledgeWorthy=${expected.expectKnowledgeWorthy}, got ${output.isKnowledgeWorthy} (confidence ${output.confidence.toFixed(2)})`,
+    }
+  },
+}
+
+/** Revision gate, asserted only when the case defines it. */
+export const revisionEvaluator: Evaluator<MemoClassifierOutput, MemoClassifierExpected> = {
+  name: "revision",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (expected.expectReviseExisting === undefined) {
+      return { name: "revision", score: 1, passed: true, details: "No revision requirement" }
+    }
+    if (output.error) {
+      return { name: "revision", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const passed = output.shouldReviseExisting === expected.expectReviseExisting
+    return {
+      name: "revision",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed
+        ? undefined
+        : `Expected shouldReviseExisting=${expected.expectReviseExisting}, got ${output.shouldReviseExisting}`,
+    }
+  },
+}
+
+export const accuracyEvaluator: RunEvaluator<MemoClassifierOutput, MemoClassifierExpected> = {
+  name: "accuracy",
+  evaluate: (cases: CaseResult<MemoClassifierOutput, MemoClassifierExpected>[]): EvaluatorResult => {
+    const passed = cases.filter((c) => !c.error && c.evaluations.every((e) => e.passed))
+    const score = cases.length > 0 ? passed.length / cases.length : 0
+    return { name: "accuracy", score, passed: score >= 0.8, details: `${passed.length}/${cases.length} cases passed` }
+  },
+}
+
+/**
+ * The production failure mode this suite exists for: chatter classified as
+ * knowledge. Measures how much of the not-worthy set leaks through.
+ */
+export const garbageLeakRateEvaluator: RunEvaluator<MemoClassifierOutput, MemoClassifierExpected> = {
+  name: "garbage-leak-rate",
+  evaluate: (cases: CaseResult<MemoClassifierOutput, MemoClassifierExpected>[]): EvaluatorResult => {
+    const notWorthy = cases.filter((c) => c.expectedOutput?.expectKnowledgeWorthy === false && c.output)
+    if (notWorthy.length === 0) {
+      return { name: "garbage-leak-rate", score: 1, passed: true, details: "No not-worthy cases in run" }
+    }
+    const leaked = notWorthy.filter((c) => c.output!.isKnowledgeWorthy)
+    const rate = leaked.length / notWorthy.length
+    return {
+      name: "garbage-leak-rate",
+      score: 1 - rate,
+      passed: rate === 0,
+      details: `${leaked.length}/${notWorthy.length} chatter conversations classified as knowledge`,
+    }
+  },
+}

--- a/apps/backend/evals/suites/memo-classifier/index.ts
+++ b/apps/backend/evals/suites/memo-classifier/index.ts
@@ -1,0 +1,2 @@
+export { memoClassifierSuite } from "./suite"
+export * from "./types"

--- a/apps/backend/evals/suites/memo-classifier/suite.ts
+++ b/apps/backend/evals/suites/memo-classifier/suite.ts
@@ -17,80 +17,13 @@
  * - garbage-leak-rate (run-level): share of chatter classified as knowledge
  */
 
-import { ulid } from "ulid"
 import type { EvalSuite, EvalContext } from "../../framework/types"
 import { memoClassifierCases } from "./cases"
-import type { MemoClassifierInput, MemoClassifierOutput, MemoClassifierExpected, EvalClassifierMessage } from "./types"
+import type { MemoClassifierInput, MemoClassifierOutput, MemoClassifierExpected } from "./types"
 import { worthinessEvaluator, revisionEvaluator, accuracyEvaluator, garbageLeakRateEvaluator } from "./evaluators"
 import { MemoClassifier, MEMO_CLASSIFIER_MODEL_ID, MEMO_TEMPERATURES } from "../../../src/features/memos"
-import type { Memo } from "../../../src/features/memos"
-import type { Conversation } from "../../../src/features/conversations"
 import { MessageFormatter } from "../../../src/lib/ai/message-formatter"
-import { MemoStatuses, MemoTypes, ConversationStatuses } from "@threa/types"
-
-function escapeXml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-}
-
-/**
- * Render messages exactly as MessageFormatter.formatMessages does in
- * production (the classifier counts messages by splitting on "<message"), but
- * from eval fixtures instead of DB rows.
- */
-export function formatEvalMessages(messages: EvalClassifierMessage[], now: Date): string {
-  const rendered = messages.map((m, i) => {
-    const id = m.id ?? `msg_${ulid()}`
-    const createdAt = new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000)
-    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
-  })
-  return `<messages>\n${rendered.join("\n")}\n</messages>`
-}
-
-export function toConversation(input: { topicSummary: string | null; participantIds: string[] }): Conversation {
-  const now = new Date()
-  return {
-    id: `conv_${ulid()}`,
-    streamId: `stream_${ulid()}`,
-    workspaceId: `ws_${ulid()}`,
-    messageIds: [],
-    participantIds: input.participantIds,
-    secondaryMessageIds: [],
-    topicSummary: input.topicSummary,
-    summary: null,
-    completenessScore: 5,
-    confidence: 0.9,
-    status: ConversationStatuses.ACTIVE,
-    parentConversationId: null,
-    lastActivityAt: now,
-    createdAt: now,
-    updatedAt: now,
-  }
-}
-
-export function toMemo(m: { title: string; abstract: string; createdDaysAgo?: number }, conversationId: string): Memo {
-  const createdAt = new Date(Date.now() - (m.createdDaysAgo ?? 1) * 24 * 60 * 60 * 1000)
-  return {
-    id: `memo_${ulid()}`,
-    workspaceId: "ws_eval",
-    memoType: MemoTypes.CONVERSATION,
-    sourceMessageId: null,
-    sourceConversationId: conversationId,
-    title: m.title,
-    abstract: m.abstract,
-    keyPoints: [],
-    sourceMessageIds: [],
-    participantIds: [],
-    knowledgeType: "context",
-    tags: [],
-    parentMemoId: null,
-    status: MemoStatuses.ACTIVE,
-    version: 1,
-    revisionReason: null,
-    createdAt,
-    updatedAt: createdAt,
-    archivedAt: null,
-  }
-}
+import { formatEvalMessages, toConversation, toMemo } from "../../fixtures/memo"
 
 async function runClassifierTask(input: MemoClassifierInput, ctx: EvalContext): Promise<MemoClassifierOutput> {
   const classifier = new MemoClassifier(ctx.ai, ctx.configResolver, new MessageFormatter())

--- a/apps/backend/evals/suites/memo-classifier/suite.ts
+++ b/apps/backend/evals/suites/memo-classifier/suite.ts
@@ -1,0 +1,147 @@
+/**
+ * Memo Classifier Evaluation Suite
+ *
+ * Tests the knowledge-worthiness gate: does a settled conversation deserve
+ * memos at all, and should existing memos be revised? Runs the production
+ * MemoClassifier (INV-45) with production config (INV-44).
+ *
+ * ## Usage
+ *
+ *   bun run eval -- -s memo-classifier
+ *   bun run eval -- -s memo-classifier -c news-hot-takes-001
+ *
+ * ## Key Evaluators
+ *
+ * - worthiness: Correct isKnowledgeWorthy decision?
+ * - revision: Correct shouldReviseExisting decision (revision cases)?
+ * - garbage-leak-rate (run-level): share of chatter classified as knowledge
+ */
+
+import { ulid } from "ulid"
+import type { EvalSuite, EvalContext } from "../../framework/types"
+import { memoClassifierCases } from "./cases"
+import type { MemoClassifierInput, MemoClassifierOutput, MemoClassifierExpected, EvalClassifierMessage } from "./types"
+import { worthinessEvaluator, revisionEvaluator, accuracyEvaluator, garbageLeakRateEvaluator } from "./evaluators"
+import { MemoClassifier, MEMO_CLASSIFIER_MODEL_ID, MEMO_TEMPERATURES } from "../../../src/features/memos"
+import type { Memo } from "../../../src/features/memos"
+import type { Conversation } from "../../../src/features/conversations"
+import { MessageFormatter } from "../../../src/lib/ai/message-formatter"
+import { MemoStatuses, MemoTypes, ConversationStatuses } from "@threa/types"
+
+function escapeXml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+/**
+ * Render messages exactly as MessageFormatter.formatMessages does in
+ * production (the classifier counts messages by splitting on "<message"), but
+ * from eval fixtures instead of DB rows.
+ */
+export function formatEvalMessages(messages: EvalClassifierMessage[], now: Date): string {
+  const rendered = messages.map((m, i) => {
+    const id = m.id ?? `msg_${ulid()}`
+    const createdAt = new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000)
+    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
+  })
+  return `<messages>\n${rendered.join("\n")}\n</messages>`
+}
+
+export function toConversation(input: { topicSummary: string | null; participantIds: string[] }): Conversation {
+  const now = new Date()
+  return {
+    id: `conv_${ulid()}`,
+    streamId: `stream_${ulid()}`,
+    workspaceId: `ws_${ulid()}`,
+    messageIds: [],
+    participantIds: input.participantIds,
+    secondaryMessageIds: [],
+    topicSummary: input.topicSummary,
+    summary: null,
+    completenessScore: 5,
+    confidence: 0.9,
+    status: ConversationStatuses.ACTIVE,
+    parentConversationId: null,
+    lastActivityAt: now,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export function toMemo(m: { title: string; abstract: string; createdDaysAgo?: number }, conversationId: string): Memo {
+  const createdAt = new Date(Date.now() - (m.createdDaysAgo ?? 1) * 24 * 60 * 60 * 1000)
+  return {
+    id: `memo_${ulid()}`,
+    workspaceId: "ws_eval",
+    memoType: MemoTypes.CONVERSATION,
+    sourceMessageId: null,
+    sourceConversationId: conversationId,
+    title: m.title,
+    abstract: m.abstract,
+    keyPoints: [],
+    sourceMessageIds: [],
+    participantIds: [],
+    knowledgeType: "context",
+    tags: [],
+    parentMemoId: null,
+    status: MemoStatuses.ACTIVE,
+    version: 1,
+    revisionReason: null,
+    createdAt,
+    updatedAt: createdAt,
+    archivedAt: null,
+  }
+}
+
+async function runClassifierTask(input: MemoClassifierInput, ctx: EvalContext): Promise<MemoClassifierOutput> {
+  const classifier = new MemoClassifier(ctx.ai, ctx.configResolver, new MessageFormatter())
+  const conversation = toConversation({
+    topicSummary: input.topicSummary,
+    participantIds: [...new Set(input.messages.map((m) => m.authorId))],
+  })
+  const formattedMessages = formatEvalMessages(input.messages, new Date())
+  const existingMemos = (input.existingMemos ?? []).map((m) => toMemo(m, conversation.id))
+
+  try {
+    const result = await classifier.classifyConversation(conversation, formattedMessages, existingMemos, {
+      workspaceId: ctx.workspaceId,
+    })
+    return {
+      input,
+      isKnowledgeWorthy: result.isKnowledgeWorthy,
+      shouldReviseExisting: result.shouldReviseExisting,
+      confidence: result.confidence,
+      containsActionItems: result.containsActionItems,
+    }
+  } catch (error) {
+    return {
+      input,
+      isKnowledgeWorthy: false,
+      shouldReviseExisting: false,
+      confidence: 0,
+      containsActionItems: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export const memoClassifierSuite: EvalSuite<MemoClassifierInput, MemoClassifierOutput, MemoClassifierExpected> = {
+  name: "memo-classifier",
+  description: "Tests the memo knowledge-worthiness classifier",
+
+  cases: memoClassifierCases,
+
+  task: runClassifierTask,
+
+  evaluators: [worthinessEvaluator, revisionEvaluator],
+
+  runEvaluators: [accuracyEvaluator, garbageLeakRateEvaluator],
+
+  defaultPermutations: [
+    {
+      model: MEMO_CLASSIFIER_MODEL_ID,
+      temperature: MEMO_TEMPERATURES.classification,
+    },
+  ],
+}
+
+export default memoClassifierSuite

--- a/apps/backend/evals/suites/memo-classifier/types.ts
+++ b/apps/backend/evals/suites/memo-classifier/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Memo Classifier Evaluation Types
+ */
+
+export interface EvalClassifierMessage {
+  /** Stable id rendered in the prompt; generated when omitted. */
+  id?: string
+  authorId: string
+  authorType: "user" | "persona"
+  authorName: string
+  contentMarkdown: string
+  /** Minutes before "now" this message was sent. Defaults to spacing 2min apart. */
+  minutesAgo?: number
+}
+
+export interface EvalExistingMemo {
+  title: string
+  abstract: string
+  /** Age of the memo; defaults to 1 day. */
+  createdDaysAgo?: number
+}
+
+export interface MemoClassifierInput {
+  /** Conversation topic title, as boundary extraction would have set it. */
+  topicSummary: string | null
+  messages: EvalClassifierMessage[]
+  /** Active memos already sourced from this conversation (revision path). */
+  existingMemos?: EvalExistingMemo[]
+  category?: "chatter" | "news-reactions" | "logistics" | "knowledge" | "mixed" | "revision"
+}
+
+export interface MemoClassifierOutput {
+  input: MemoClassifierInput
+  isKnowledgeWorthy: boolean
+  shouldReviseExisting: boolean
+  confidence: number
+  containsActionItems: boolean
+  error?: string
+}
+
+export interface MemoClassifierExpected {
+  expectKnowledgeWorthy: boolean
+  /** Only asserted when the case provides existingMemos. */
+  expectReviseExisting?: boolean
+}

--- a/apps/backend/evals/suites/memorizer/cases.ts
+++ b/apps/backend/evals/suites/memorizer/cases.ts
@@ -9,8 +9,8 @@
 import type { EvalCase } from "../../framework/types"
 import type { MemorizerInput, MemorizerExpected } from "./types"
 
-const KRIS = { authorId: "usr_eval_kris", authorType: "user" as const, authorName: "Kim" }
-const PIERRE = { authorId: "usr_eval_pierre", authorType: "user" as const, authorName: "Pelle" }
+const KRIS = { authorId: "usr_eval_a", authorType: "user" as const, authorName: "Kim" }
+const PIERRE = { authorId: "usr_eval_b", authorType: "user" as const, authorName: "Pelle" }
 
 export const memorizerCases: EvalCase<MemorizerInput, MemorizerExpected>[] = [
   {

--- a/apps/backend/evals/suites/memorizer/cases.ts
+++ b/apps/backend/evals/suites/memorizer/cases.ts
@@ -1,0 +1,152 @@
+/**
+ * Memorizer Test Cases
+ *
+ * Derived from real production failures: hot-takes stored as "learnings",
+ * the same fact re-captured in new words on every re-extraction pass, and
+ * banter memos ("Remote pi är riktigt nice" as a learning). Paraphrased.
+ */
+
+import type { EvalCase } from "../../framework/types"
+import type { MemorizerInput, MemorizerExpected } from "./types"
+
+const KRIS = { authorId: "usr_eval_kris", authorType: "user" as const, authorName: "Kim" }
+const PIERRE = { authorId: "usr_eval_pierre", authorType: "user" as const, authorName: "Pelle" }
+
+export const memorizerCases: EvalCase<MemorizerInput, MemorizerExpected>[] = [
+  {
+    id: "mixed-extracts-only-fact-001",
+    name: "Selectivity: banter around one durable fact yields only the fact",
+    input: {
+      category: "selectivity",
+      messages: [
+        { ...PIERRE, contentMarkdown: "Shit vad remote-setupen är nice", minutesAgo: 30 },
+        { ...KRIS, contentMarkdown: "haha ja det ser ballt ut", minutesAgo: 28 },
+        { ...PIERRE, contentMarkdown: "Ehh den första blev fel lol, det var något scam-mail", minutesAgo: 26 },
+        { ...KRIS, contentMarkdown: "Kul med scams dock haha", minutesAgo: 24 },
+        {
+          ...PIERRE,
+          contentMarkdown:
+            "men alltså: den kör lokalt på min stationära via tailscale, så telefonen når den utan publik endpoint",
+          minutesAgo: 20,
+        },
+        { ...KRIS, contentMarkdown: "det är ju exakt vad jag behöver för min gamla burk", minutesAgo: 18 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 2,
+      minMemos: 1,
+      mustCoverAny: [["tailscale", "lokalt", "stationära"]],
+      mustNotContain: ["nice", "scam", "ballt"],
+    },
+  },
+
+  {
+    id: "news-hot-takes-yields-nothing-001",
+    name: "Selectivity: news reactions yield no memos even if classified worthy",
+    input: {
+      category: "selectivity",
+      messages: [
+        { ...PIERRE, contentMarkdown: "shit vad jag inte gillar deras VD dock", minutesAgo: 20 },
+        { ...KRIS, contentMarkdown: "Han är weird, jävla savior complex", minutesAgo: 18 },
+        {
+          ...PIERRE,
+          contentMarkdown: "Inte läst att de stoppade sin AI som övervakade alla anställda? Helt absurt",
+          minutesAgo: 15,
+        },
+        { ...KRIS, contentMarkdown: "Hade hatat att jobba där", minutesAgo: 12 },
+        { ...PIERRE, contentMarkdown: "Samma här, aldrig varit ett företag av intresse", minutesAgo: 10 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 0,
+    },
+  },
+
+  {
+    id: "revision-all-covered-001",
+    name: "Revision: rephrased already-captured facts yield an empty set",
+    input: {
+      category: "revision",
+      existingMemos: [
+        {
+          title: "Flaggskeppsmodellen återlanseras med 50% weekly usage",
+          abstract:
+            "Modellen kommer tillbaka efter pausen men med halverad weekly quota; Kim och Pelle tror det beror på att folk maxxade flera subscriptions.",
+          createdDaysAgo: 0,
+        },
+        {
+          title: "Pelle kör pi-remote lokalt via Tailscale",
+          abstract: "Pelle kör pi-remote på sin stationära och når den via Tailscale utan publik endpoint.",
+          createdDaysAgo: 0,
+        },
+      ],
+      messages: [
+        { ...KRIS, contentMarkdown: "alltså 50% quota känns fortfarande snålt", minutesAgo: 10 },
+        { ...PIERRE, contentMarkdown: "ja fast bättre än inget, den är ju tillbaka iaf", minutesAgo: 8 },
+        { ...KRIS, contentMarkdown: "och din tailscale-setup rullar fint fortfarande?", minutesAgo: 6 },
+        { ...PIERRE, contentMarkdown: "yes, stationära + tailscale, inga problem", minutesAgo: 4 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 0,
+    },
+  },
+
+  {
+    id: "revision-one-new-fact-001",
+    name: "Revision: only the genuinely new fact is captured",
+    input: {
+      category: "revision",
+      existingMemos: [
+        {
+          title: "Pelle kör pi-remote lokalt via Tailscale",
+          abstract: "Pelle kör pi-remote på sin stationära och når den via Tailscale utan publik endpoint.",
+          createdDaysAgo: 1,
+        },
+      ],
+      messages: [
+        {
+          ...PIERRE,
+          contentMarkdown:
+            "uppdatering: flyttade pi-remote till en Hetzner-VPS igår, den stationära lät för mycket på natten",
+          minutesAgo: 15,
+        },
+        { ...KRIS, contentMarkdown: "haha rimligt. Samma tailscale-upplägg?", minutesAgo: 12 },
+        {
+          ...PIERRE,
+          contentMarkdown: "yes, exakt samma, bara en annan nod i tailnetet. CX22:an räcker gott",
+          minutesAgo: 10,
+        },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 2,
+      minMemos: 1,
+      mustCoverAny: [["Hetzner", "VPS"]],
+    },
+  },
+
+  {
+    id: "procedure-capture-001",
+    name: "Extraction: a worked-out procedure is captured tersely, in Swedish",
+    input: {
+      category: "extraction",
+      messages: [
+        { ...KRIS, contentMarkdown: "recall på embedding-sökningen ligger på typ 0.71, känns lågt", minutesAgo: 40 },
+        { ...PIERRE, contentMarkdown: "ivfflat med fler lists borde hjälpa", minutesAgo: 35 },
+        {
+          ...KRIS,
+          contentMarkdown: "Testade med lists=200 nu, recall uppe på 0.94 utan att latensen stack iväg",
+          minutesAgo: 10,
+        },
+        { ...PIERRE, contentMarkdown: "nice, kör på det", minutesAgo: 8 },
+        { ...KRIS, contentMarkdown: "Yes, sätter 200 som default i migrationen", minutesAgo: 5 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 2,
+      minMemos: 1,
+      mustCoverAny: [["lists", "ivfflat", "200"], ["recall"]],
+    },
+  },
+]

--- a/apps/backend/evals/suites/memorizer/evaluators.ts
+++ b/apps/backend/evals/suites/memorizer/evaluators.ts
@@ -1,0 +1,108 @@
+/**
+ * Memorizer Evaluators
+ */
+
+import type { Evaluator, EvaluatorResult, RunEvaluator, CaseResult } from "../../framework/types"
+import type { MemorizerOutput, MemorizerExpected } from "./types"
+
+function memoText(m: { title: string; abstract: string }): string {
+  return `${m.title} ${m.abstract}`.toLowerCase()
+}
+
+export const memoCountEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> = {
+  name: "memo-count",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (output.error) {
+      return { name: "memo-count", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const count = output.memos.length
+    const max = expected.maxMemos ?? Infinity
+    const min = expected.minMemos ?? 0
+    const passed = count <= max && count >= min
+    return {
+      name: "memo-count",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed
+        ? undefined
+        : `Got ${count} memos (expected ${min}–${max === Infinity ? "∞" : max}): ${output.memos.map((m) => m.title).join(" | ")}`,
+    }
+  },
+}
+
+export const coverageEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> = {
+  name: "coverage",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (!expected.mustCoverAny || expected.mustCoverAny.length === 0) {
+      return { name: "coverage", score: 1, passed: true, details: "No coverage requirements" }
+    }
+    if (output.error) {
+      return { name: "coverage", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const texts = output.memos.map(memoText)
+    const unmet = expected.mustCoverAny.filter(
+      (group) => !texts.some((t) => group.some((word) => t.includes(word.toLowerCase())))
+    )
+    const passed = unmet.length === 0
+    return {
+      name: "coverage",
+      score: expected.mustCoverAny.length === 0 ? 1 : 1 - unmet.length / expected.mustCoverAny.length,
+      passed,
+      details: passed ? undefined : `No memo covers: ${unmet.map((g) => g.join("/")).join("; ")}`,
+    }
+  },
+}
+
+export const exclusionEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> = {
+  name: "exclusion",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (!expected.mustNotContain || expected.mustNotContain.length === 0) {
+      return { name: "exclusion", score: 1, passed: true, details: "No exclusion requirements" }
+    }
+    if (output.error) {
+      return { name: "exclusion", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const offenders: string[] = []
+    for (const memo of output.memos) {
+      const text = memoText(memo)
+      for (const word of expected.mustNotContain) {
+        if (text.includes(word.toLowerCase())) offenders.push(`"${memo.title}" contains "${word}"`)
+      }
+    }
+    const passed = offenders.length === 0
+    return {
+      name: "exclusion",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed ? undefined : offenders.join("; "),
+    }
+  },
+}
+
+export const accuracyEvaluator: RunEvaluator<MemorizerOutput, MemorizerExpected> = {
+  name: "accuracy",
+  evaluate: (cases: CaseResult<MemorizerOutput, MemorizerExpected>[]): EvaluatorResult => {
+    const passed = cases.filter((c) => !c.error && c.evaluations.every((e) => e.passed))
+    const score = cases.length > 0 ? passed.length / cases.length : 0
+    return { name: "accuracy", score, passed: score >= 0.8, details: `${passed.length}/${cases.length} cases passed` }
+  },
+}
+
+/** Run-level: memos emitted on cases expecting none — the re-capture/noise metric. */
+export const overCaptureRateEvaluator: RunEvaluator<MemorizerOutput, MemorizerExpected> = {
+  name: "over-capture-rate",
+  evaluate: (cases: CaseResult<MemorizerOutput, MemorizerExpected>[]): EvaluatorResult => {
+    const expectEmpty = cases.filter((c) => c.expectedOutput.maxMemos === 0 && c.output)
+    if (expectEmpty.length === 0) {
+      return { name: "over-capture-rate", score: 1, passed: true, details: "No expect-empty cases in run" }
+    }
+    const leaked = expectEmpty.filter((c) => c.output.memos.length > 0)
+    const rate = leaked.length / expectEmpty.length
+    return {
+      name: "over-capture-rate",
+      score: 1 - rate,
+      passed: rate === 0,
+      details: `${leaked.length}/${expectEmpty.length} expect-empty conversations produced memos`,
+    }
+  },
+}

--- a/apps/backend/evals/suites/memorizer/evaluators.ts
+++ b/apps/backend/evals/suites/memorizer/evaluators.ts
@@ -46,7 +46,7 @@ export const coverageEvaluator: Evaluator<MemorizerOutput, MemorizerExpected> = 
     const passed = unmet.length === 0
     return {
       name: "coverage",
-      score: expected.mustCoverAny.length === 0 ? 1 : 1 - unmet.length / expected.mustCoverAny.length,
+      score: 1 - unmet.length / expected.mustCoverAny.length,
       passed,
       details: passed ? undefined : `No memo covers: ${unmet.map((g) => g.join("/")).join("; ")}`,
     }

--- a/apps/backend/evals/suites/memorizer/index.ts
+++ b/apps/backend/evals/suites/memorizer/index.ts
@@ -1,0 +1,2 @@
+export { memorizerSuite } from "./suite"
+export * from "./types"

--- a/apps/backend/evals/suites/memorizer/suite.ts
+++ b/apps/backend/evals/suites/memorizer/suite.ts
@@ -1,0 +1,127 @@
+/**
+ * Memorizer Evaluation Suite
+ *
+ * Tests memo generation quality from settled conversations: selectivity (only
+ * durable knowledge, no banter/hot-takes), revision discipline (already-covered
+ * topics are not re-emitted), and terseness. Runs the production Memorizer
+ * (INV-45) with production config (INV-44).
+ *
+ * ## Usage
+ *
+ *   bun run eval -- -s memorizer
+ *   bun run eval -- -s memorizer -c revision-all-covered-001
+ *
+ * ## Key Evaluators
+ *
+ * - memo-count: within expected min/max (0 = must return nothing)
+ * - coverage: durable facts are captured
+ * - exclusion: banter/hot-take words never appear in memos
+ * - over-capture-rate (run-level): memos emitted where none were warranted
+ */
+
+import { ulid } from "ulid"
+import type { EvalSuite, EvalContext } from "../../framework/types"
+import { memorizerCases } from "./cases"
+import type { MemorizerInput, MemorizerOutput, MemorizerExpected } from "./types"
+import {
+  memoCountEvaluator,
+  coverageEvaluator,
+  exclusionEvaluator,
+  accuracyEvaluator,
+  overCaptureRateEvaluator,
+} from "./evaluators"
+import { Memorizer, MEMO_MEMORIZER_MODEL_ID, MEMO_TEMPERATURES } from "../../../src/features/memos"
+import { MessageFormatter } from "../../../src/lib/ai/message-formatter"
+import { formatEvalMessages, toMemo } from "../memo-classifier/suite"
+import type { Message } from "../../../src/features/messaging"
+
+/**
+ * Minimal Message rows matching the ids rendered into the prompt, so the
+ * production source-citation resolution has real ids to validate against.
+ */
+function toMessages(input: MemorizerInput, now: Date): { messages: Message[]; formatted: string } {
+  const withIds = input.messages.map((m) => ({ ...m, id: m.id ?? `msg_${ulid()}` }))
+  const formatted = formatEvalMessages(withIds, now)
+  const messages = withIds.map(
+    (m, i) =>
+      ({
+        id: m.id,
+        streamId: "stream_eval",
+        sequence: BigInt(i + 1),
+        authorId: m.authorId,
+        authorType: m.authorType,
+        contentJson: { type: "doc", content: [] },
+        contentMarkdown: m.contentMarkdown,
+        replyCount: 0,
+        reactions: {},
+        metadata: {},
+        conversationIntent: null,
+        clientMessageId: null,
+        sentVia: null,
+        editedAt: null,
+        deletedAt: null,
+        createdAt: new Date(now.getTime() - (m.minutesAgo ?? (withIds.length - i) * 2) * 60_000),
+        ciphertext: null,
+        envelope: null,
+        e2eVersion: null,
+      }) satisfies Message
+  )
+  return { messages, formatted }
+}
+
+async function runMemorizerTask(input: MemorizerInput, ctx: EvalContext): Promise<MemorizerOutput> {
+  const memorizer = new Memorizer(ctx.ai, ctx.configResolver, new MessageFormatter())
+  const now = new Date()
+  const { messages, formatted } = toMessages(input, now)
+  const conversationId = `conv_${ulid()}`
+  const existingMemos = (input.existingMemos ?? []).map((m) => toMemo(m, conversationId))
+
+  const context = {
+    memoryContext: input.memoryContext ?? [],
+    content: messages,
+    existingMemos,
+    workspaceId: ctx.workspaceId,
+  }
+
+  try {
+    const memos =
+      existingMemos.length > 0
+        ? await memorizer.reviseMemo(formatted, context)
+        : await memorizer.memorizeConversation(formatted, context)
+
+    return {
+      input,
+      memos: memos.map((m) => ({
+        title: m.title,
+        abstract: m.abstract,
+        knowledgeType: m.knowledgeType,
+        keyPoints: m.keyPoints,
+        tags: m.tags,
+      })),
+    }
+  } catch (error) {
+    return { input, memos: [], error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export const memorizerSuite: EvalSuite<MemorizerInput, MemorizerOutput, MemorizerExpected> = {
+  name: "memorizer",
+  description: "Tests memo generation selectivity and revision discipline",
+
+  cases: memorizerCases,
+
+  task: runMemorizerTask,
+
+  evaluators: [memoCountEvaluator, coverageEvaluator, exclusionEvaluator],
+
+  runEvaluators: [accuracyEvaluator, overCaptureRateEvaluator],
+
+  defaultPermutations: [
+    {
+      model: MEMO_MEMORIZER_MODEL_ID,
+      temperature: MEMO_TEMPERATURES.memorization,
+    },
+  ],
+}
+
+export default memorizerSuite

--- a/apps/backend/evals/suites/memorizer/suite.ts
+++ b/apps/backend/evals/suites/memorizer/suite.ts
@@ -32,7 +32,7 @@ import {
 } from "./evaluators"
 import { Memorizer, MEMO_MEMORIZER_MODEL_ID, MEMO_TEMPERATURES } from "../../../src/features/memos"
 import { MessageFormatter } from "../../../src/lib/ai/message-formatter"
-import { formatEvalMessages, toMemo } from "../memo-classifier/suite"
+import { formatEvalMessages, toMemo } from "../../fixtures/memo"
 import type { Message } from "../../../src/features/messaging"
 
 /**

--- a/apps/backend/evals/suites/memorizer/types.ts
+++ b/apps/backend/evals/suites/memorizer/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Memorizer Evaluation Types
+ */
+
+import type { EvalClassifierMessage, EvalExistingMemo } from "../memo-classifier/types"
+
+export interface MemorizerInput {
+  messages: EvalClassifierMessage[]
+  /** Prior stream memo abstracts (vocabulary context). */
+  memoryContext?: string[]
+  /** Existing memos for this conversation — presence selects the revision path. */
+  existingMemos?: EvalExistingMemo[]
+  category?: "extraction" | "revision" | "selectivity"
+}
+
+export interface MemorizerOutputMemo {
+  title: string
+  abstract: string
+  knowledgeType: string
+  keyPoints: string[]
+  tags: string[]
+}
+
+export interface MemorizerOutput {
+  input: MemorizerInput
+  memos: MemorizerOutputMemo[]
+  error?: string
+}
+
+export interface MemorizerExpected {
+  /** Exact upper bound on returned memos. */
+  maxMemos?: number
+  /** At least this many memos. */
+  minMemos?: number
+  /**
+   * Each inner list is an OR-group: some memo's title+abstract must contain at
+   * least one of its words. All groups must be satisfied.
+   */
+  mustCoverAny?: string[][]
+  /** No memo's title or abstract may contain any of these words. */
+  mustNotContain?: string[]
+}

--- a/apps/backend/src/db/migrations/20260705141300_conversation_summary.sql
+++ b/apps/backend/src/db/migrations/20260705141300_conversation_summary.sql
@@ -1,0 +1,9 @@
+-- Rolling content summary on conversations.
+--
+-- topic_summary is a 2-5 word title; it cannot tell the boundary extractor
+-- (or the board card) what a conversation actually covers. summary is a short
+-- prose description maintained by the boundary extractor itself on every pass
+-- that touches the conversation — no separate summarizer flow.
+
+ALTER TABLE conversations
+ADD COLUMN IF NOT EXISTS summary TEXT;

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -259,13 +259,18 @@ export class BoundaryExtractionService {
     let decision: ConversationDecision
 
     if (stream.type === StreamTypes.SCRATCHPAD) {
-      const activeConversation = scratchpadConversations?.find((c) => c.status === ConversationStatuses.ACTIVE)
-      decision = activeConversation
+      // Scratchpad = one conversation, by decision (board-view-design.md). The
+      // staleness sweep may have faded it to stalled/resolved, so fall back to
+      // the most-recently-active conversation and let the assignment
+      // reactivation flip it — never mint a second same-named conversation.
+      const existingConversation =
+        scratchpadConversations?.find((c) => c.status === ConversationStatuses.ACTIVE) ?? scratchpadConversations?.[0]
+      decision = existingConversation
         ? {
-            assignments: [{ conversationId: activeConversation.id, isPrimary: true }],
+            assignments: [{ conversationId: existingConversation.id, isPrimary: true }],
             confidence: 1.0,
             reassignments: [],
-            validUpdateTargets: new Set([activeConversation.id]),
+            validUpdateTargets: new Set([existingConversation.id]),
           }
         : {
             assignments: [{ conversationId: null, isPrimary: true }],
@@ -472,6 +477,11 @@ export class BoundaryExtractionService {
             messageId,
             message.authorId
           )
+          // A stalled/resolved conversation gaining a message is live again
+          // (sweep fades must not stick to conversations that resume). Runs
+          // before completenessUpdates, so an explicit resolve in the same
+          // pass still wins.
+          await ConversationRepository.reactivateIfInactive(client, workspaceId, a.conversationId)
         } else {
           await ConversationRepository.addSecondaryMessage(client, workspaceId, a.conversationId, messageId)
         }
@@ -609,10 +619,18 @@ export class BoundaryExtractionService {
       // conversation (mirrors the scratchpad create path's stream lock, INV-20).
       await client.query(sql`SELECT id FROM streams WHERE id = ${stream.id} FOR UPDATE`)
 
-      const active = (await ConversationRepository.findActiveByStream(client, stream.id))[0]
-      const isNew = !active
+      // Scratchpads keep one conversation for the stream's lifetime, so a
+      // sweep-faded conversation is reused (and reactivated below) rather than
+      // shadowed by a fresh mint; elsewhere a fully-faded stream means a new
+      // session and a new conversation is correct.
+      const existing =
+        (await ConversationRepository.findActiveByStream(client, stream.id))[0] ??
+        (stream.type === StreamTypes.SCRATCHPAD
+          ? (await ConversationRepository.findByStream(client, stream.id, { limit: 1 }))[0]
+          : undefined)
+      const isNew = !existing
       const conversation =
-        active ??
+        existing ??
         (await ConversationRepository.insert(client, {
           id: conversationId(),
           streamId: stream.id,
@@ -622,6 +640,7 @@ export class BoundaryExtractionService {
         }))
 
       await ConversationRepository.addPrimaryMessage(client, workspaceId, conversation.id, message.id, message.authorId)
+      await ConversationRepository.reactivateIfInactive(client, workspaceId, conversation.id)
       await ConversationRepository.bumpActivityForIds(client, workspaceId, [conversation.id])
 
       // Same per-message membership emit the declared-send path uses (INV-35/37);

--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -29,6 +29,7 @@ const MESSAGES_AFTER = 2
 interface ConversationDecision {
   assignments: MessageAssignment[]
   newTopic?: string
+  newSummary?: string
   confidence: number
   reassignments: Reassignment[]
   completenessUpdates?: CompletenessUpdate[]
@@ -294,6 +295,7 @@ export class BoundaryExtractionService {
       decision = {
         assignments: result.assignments,
         newTopic: result.newConversationTopic,
+        newSummary: result.newConversationSummary,
         confidence: result.confidence,
         reassignments: result.reassignments ?? [],
         completenessUpdates: result.completenessUpdates,
@@ -332,6 +334,7 @@ export class BoundaryExtractionService {
               streamId,
               workspaceId,
               topicSummary: decision.newTopic,
+              summary: decision.newSummary,
               confidence: decision.confidence,
               status: ConversationStatuses.ACTIVE,
             })
@@ -488,6 +491,7 @@ export class BoundaryExtractionService {
           await ConversationRepository.update(client, workspaceId, update.conversationId, {
             completenessScore: update.score,
             status: update.status,
+            summary: update.summary,
           })
           touchedConversationIds.add(update.conversationId)
         }
@@ -653,6 +657,7 @@ export class BoundaryExtractionService {
       return {
         id: c.id,
         topicSummary: c.topicSummary,
+        summary: c.summary,
         messageCount: c.messageIds.length,
         lastMessagePreview: lastMessage?.contentMarkdown.slice(0, 100) ?? "",
         participantIds: c.participantIds,

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -3,6 +3,10 @@
 import { z } from "zod"
 import { CONVERSATION_STATUSES } from "@threa/types"
 
+// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
+// was fixed) showed nano failing systematically — sandwich-split and
+// gap-resume cases in every round (30-33/35 vs mini's 33-35/35). See
+// docs/model-reference.md.
 export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 /** Low temperature for classification consistency. */

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -42,13 +42,19 @@ Some messages above may include an indented \`[attachment <filename> (<kind>)]:\
 ## Time
 Messages carry an age like "(5m ago)" or "(2d ago)" and conversations carry "last active …", all relative to the new message ("just now" = within the last minute). Treat time as first-class evidence. Chat happens in sessions: turns minutes apart are one live exchange; a gap of several hours — an afternoon, overnight, a weekend — usually means the participants came back for a NEW conversation, even in the same stream between the same people.
 
+## Conversation summaries
+Conversations may carry a "covers:" summary of what has actually been discussed in them. Judge continuity against the summary, not just the title: continue a conversation only when the new message advances something the summary (or its recent messages) actually covers. A summary that already spans several loosely-related subjects is evidence the conversation has been over-extended — do NOT use its breadth as a reason to attach yet another subject; prefer a new conversation and let reassignment split things later.
+
 ## Choosing a conversation
 Decide in this order:
 
 1. **Explicit reply?** If the "Explicit reply" section lists a quoted conversation, assign primary to it (see the rule there). This overrides everything below.
 
 2. **Session check.** How old is the newest message in Recent Messages?
-   - **Minutes old → you are inside a LIVE session.** Judge by flow and topic. Prefer continuing the active exchange: a short reply, agreement, reaction, joke, or follow-up from EITHER participant ("samma här", "haha", "100%", ":fire:", "what?", "nice") continues it — it does not start its own conversation, and which participant sent it is irrelevant. Both sides of one live exchange belong in the SAME conversation; never split an exchange so one participant's turns sit in a different conversation than the other's. When a short or ambiguous message plausibly continues the live exchange, keep it there rather than spawning a singleton — if a later message reveals it actually began a new topic, the reassignment mechanism below will split it out then. Within a live session a message can still open a clearly distinct new topic (a new question or unrelated aside that is not the next turn of any listed exchange) — that starts a new conversation.
+   - **Minutes old → you are inside a LIVE session.** A session is NOT a conversation: one sitting routinely holds several conversations back-to-back, and the most damaging mistake is gluing a whole session into one ever-growing conversation. Recency tells you which exchange is live; it is never by itself a reason to attach a message to it. Decide by what the message DOES:
+     - **It takes the next turn of the live exchange** — answers, agrees, reacts, jokes back, or follows up on what was just said ("samma här", "haha", "100%", ":fire:", "what?", "nice") — from EITHER participant: continue that conversation. Both sides of one live exchange belong in the SAME conversation; never split an exchange so one participant's turns sit in a different conversation than the other's. When a short or ambiguous message plausibly continues the live exchange, keep it there rather than spawning a singleton — if a later message reveals it actually began a new topic, the reassignment mechanism below will split it out then.
+     - **It changes the subject** — asks about something the live exchange was not about, starts making plans, or pivots with a marker like "btw", "oh en annan grej", "unrelated but" — start a NEW conversation, even if the last message landed seconds ago. The test: would this message read as the next line of the listed exchange? If not, it is not part of it, no matter how fresh the exchange is.
+     - **Show-and-tell is a subject change.** A pasted artifact — screenshot, code block, diff output, link — wrapped in a first-person comment ("look at this", "detta känns fint", "är inte det här sjukt") opens a NEW conversation about the artifact's subject unless the artifact is about the live exchange's own topic. The comment's tone matching the banter does not make it the same conversation; judge the artifact, not the tone.
    - **Hours or days old → this message OPENS A NEW SESSION.** Default to a NEW conversation. Continue a stale conversation ONLY if the new message explicitly picks up its specific topic — answers its open question, or names its concrete subject ("do you still have X running?" resumes the days-old conversation about X). Everything else — including short excited bursts ("nice", "haha wow", a one-line observation) — is a fresh opener about something new, NOT a late reaction to a conversation that ended hours ago. Never attach to a stale conversation because it is the most recent thing on screen or the only candidate listed; between the same two people, a new session usually means a new conversation. Be decisive here: reassignment can only fix mistakes while messages are still in the recent window, so a wrong "continue" across a gap quickly becomes permanent absorption.
 
 3. **Resolved conversations stay closed.** Do not attach a message to a conversation whose status is "resolved" unless it directly reopens that exact topic.
@@ -62,7 +68,7 @@ A message can belong to more than one conversation. If this new message clearly 
 If this new message reveals that one or more of the *Recent Messages* or messages from the *Active Conversations* was placed in the wrong conversation, move them. Each move needs a one-line reason. You can ONLY move messages whose IDs appear in this prompt — never any other. Examples of when to reassign:
 - The new message reveals the prior 1-2 messages were the start of a different topic (sandwich case).
 - The new message reopens a conversation that was prematurely marked resolved.
-- The new message shows two adjacent conversations are actually the same topic — move the smaller one into the larger.
+- The new message shows two adjacent conversations are actually the same specific topic — move the smaller one into the larger. Same participants, same session, or "both are casual chat" is NOT the same topic: never fold a focused conversation into a broader or busier one, and never merge to tidy up. When in doubt, do not merge.
 
 Reassignment is *the* mechanism for fixing classification mistakes, and it works in both directions — it is how conversations settle as more context arrives:
 - MERGE: the new message shows two threads are really one topic, or that an earlier message belongs with the current exchange — move it in.
@@ -73,9 +79,11 @@ Use it whenever the new message gives you evidence the prior placement was wrong
 ## Output Requirements
 - assignments: Array of {conversationId, isPrimary}. At least one entry with isPrimary=true. conversationId=null means "create a new conversation" (set newConversationTopic).
 - newConversationTopic: Topic summary if any assignment has conversationId=null. Required in that case. See "Naming new conversations" below.
+- newConversationSummary: One sentence stating what the new conversation is about, in the conversation's own language. Required whenever newConversationTopic is set.
 - reassignments: Array of {messageId, toConversationId, reason, confidence}. messageId must be from this prompt. toConversationId=null means "move into the new conversation being created this turn" (only valid if assignments includes a conversationId=null primary).
-- completenessUpdates: Array of {conversationId, score (1-7), status} for conversations whose completeness changed.
+- completenessUpdates: Array of {conversationId, score (1-7), status, summary} for conversations whose completeness, status, or content moved on.
   - status must be one of: "active", "stalled", "resolved"
+  - summary: a refreshed "covers:" summary for the conversation — max ~40 words, plain prose in the conversation's own language, stating what has been discussed and where it landed. Include it whenever the conversation gained content this pass (at minimum for the conversation the new message joined); pass null to keep the stored summary.
 - confidence: 0.0 to 1.0 confidence in this classification overall.
 
 ## Naming new conversations
@@ -115,6 +123,12 @@ export const extractionResponseSchema = z.object({
     .describe(
       "2-5 word topic title; required when any assignment has conversationId=null. Name the topic directly with no framing ('Discussion about'), no language label ('in Swedish'), in the conversation's own language, keeping proper nouns verbatim"
     ),
+  newConversationSummary: z
+    .string()
+    .nullable()
+    .describe(
+      "One-sentence summary of what the new conversation is about, in the conversation's own language; required when any assignment has conversationId=null"
+    ),
   reassignments: z.array(reassignmentSchema).nullable().describe("Prior messages to move, or null"),
   completenessUpdates: z
     .array(
@@ -125,11 +139,17 @@ export const extractionResponseSchema = z.object({
           status: z
             .enum(CONVERSATION_STATUSES)
             .describe(`Conversation status: ${CONVERSATION_STATUSES.map((s) => `"${s}"`).join(" | ")}`),
+          summary: z
+            .string()
+            .nullable()
+            .describe(
+              "Refreshed conversation summary (max ~40 words, the conversation's own language), or null to keep the stored one"
+            ),
         })
         .strict()
     )
     .nullable()
-    .describe("Updates to completeness scores for affected conversations, or null if none"),
+    .describe("Updates to completeness/status/summary for affected conversations, or null if none"),
   confidence: z.number().min(0).max(1).describe("Overall confidence in this classification (0.0 to 1.0)"),
   reasoning: z.string().nullable().describe("Brief explanation of the classification decision"),
 })

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -59,6 +59,7 @@ function createMockConversation(overrides: Partial<ConversationSummary> = {}): C
   return {
     id: "conv_existing123",
     topicSummary: "Existing conversation topic",
+    summary: null,
     messageCount: 5,
     lastMessagePreview: "Last message preview",
     participantIds: ["usr_test"],

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -127,7 +127,8 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
               const tag = c.isParent ? " [parent-thread]" : ""
               const contextIds =
                 c.contextMessageIds.length > 0 ? `, in-context messages: [${c.contextMessageIds.join(", ")}]` : ""
-              return `- ${c.id}${tag}: "${c.topicSummary ?? "No topic yet"}" (status: ${c.status}, last active ${formatRelativeAge(c.lastActivityAt, now)}, ${c.messageCount} messages, completeness: ${c.completenessScore}/7, participants: ${c.participantIds.length}${contextIds})`
+              const summaryLine = c.summary ? `\n  covers: ${c.summary}` : ""
+              return `- ${c.id}${tag}: "${c.topicSummary ?? "No topic yet"}" (status: ${c.status}, last active ${formatRelativeAge(c.lastActivityAt, now)}, ${c.messageCount} messages, completeness: ${c.completenessScore}/7, participants: ${c.participantIds.length}${contextIds})${summaryLine}`
             })
             .join("\n")
         : "No active conversations in this stream yet."
@@ -203,8 +204,9 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
       return {
         assignments: [{ conversationId: null, isPrimary: true }],
         newConversationTopic: parsed.newConversationTopic ?? this.truncateAsTopic(context.newMessage),
+        newConversationSummary: parsed.newConversationSummary ?? undefined,
         reassignments: undefined,
-        completenessUpdates: parsed.completenessUpdates ?? undefined,
+        completenessUpdates: this.normalizeCompletenessUpdates(parsed),
         confidence: parsed.confidence,
       }
     }
@@ -274,10 +276,22 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
     return {
       assignments: validAssignments,
       newConversationTopic,
+      newConversationSummary: hasNullAssignment ? (parsed.newConversationSummary ?? undefined) : undefined,
       reassignments: validReassignments.length > 0 ? validReassignments : undefined,
-      completenessUpdates: parsed.completenessUpdates ?? undefined,
+      completenessUpdates: this.normalizeCompletenessUpdates(parsed),
       confidence: parsed.confidence,
     }
+  }
+
+  /** Wire completeness updates carry `summary: string | null`; internal shape uses optional. */
+  private normalizeCompletenessUpdates(parsed: ExtractionResponse): ExtractionResult["completenessUpdates"] {
+    if (!parsed.completenessUpdates) return undefined
+    return parsed.completenessUpdates.map((u) => ({
+      conversationId: u.conversationId,
+      score: u.score,
+      status: u.status,
+      summary: u.summary ?? undefined,
+    }))
   }
 
   private truncateAsTopic(message: Message): string {

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -49,6 +49,11 @@ const completenessUpdateSchema = z.object({
   conversationId: z.string(),
   score: z.number(),
   status: z.enum(CONVERSATION_STATUSES),
+  /**
+   * Refreshed rolling summary of what the conversation covers, when its
+   * content moved on this pass. Undefined leaves the stored summary untouched.
+   */
+  summary: z.string().optional(),
 })
 
 const extractionResultSchema = z.object({
@@ -59,6 +64,8 @@ const extractionResultSchema = z.object({
   assignments: z.array(messageAssignmentSchema),
   /** Topic summary; required when any assignment has `conversationId: null`. */
   newConversationTopic: z.string().optional(),
+  /** Rolling prose summary for the new conversation, set alongside the topic. */
+  newConversationSummary: z.string().optional(),
   reassignments: z.array(reassignmentSchema).optional(),
   completenessUpdates: z.array(completenessUpdateSchema).optional(),
   confidence: z.number(),
@@ -72,6 +79,12 @@ export type ExtractionResult = z.infer<typeof extractionResultSchema>
 export interface ConversationSummary {
   id: string
   topicSummary: string | null
+  /**
+   * Rolling prose summary of what the conversation covers, maintained by
+   * prior extraction passes. Null for conversations the extractor has not
+   * summarized yet (pre-migration rows, sync-assigned conversations).
+   */
+  summary: string | null
   messageCount: number
   lastMessagePreview: string
   participantIds: string[]

--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -42,7 +42,7 @@ describe("conversationAssigner — threadFromMessage", () => {
   beforeEach(() => {
     insert = spyOn(ConversationRepository, "insert").mockResolvedValue({ id: "conv_new" } as never)
     addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
-    spyOn(ConversationRepository, "reactivateIfResolved").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "reactivateIfInactive").mockResolvedValue(undefined as never)
     spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
     emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
     findByIdForUpdate = spyOn(ConversationRepository, "findByIdForUpdate")
@@ -128,7 +128,7 @@ describe("conversationAssigner — existing (same-root guard)", () => {
 
   beforeEach(() => {
     addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
-    spyOn(ConversationRepository, "reactivateIfResolved").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "reactivateIfInactive").mockResolvedValue(undefined as never)
     spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
     emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
     findByIdForUpdate = spyOn(ConversationRepository, "findByIdForUpdate")

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -69,7 +69,7 @@ export const conversationAssigner: ConversationAssigner = {
     }
     await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, message.id, message.authorId)
     // Attaching a message to a resolved conversation revives it — it has activity again.
-    await ConversationRepository.reactivateIfResolved(client, workspaceId, target.id)
+    await ConversationRepository.reactivateIfInactive(client, workspaceId, target.id)
     await ConversationRepository.bumpActivityForIds(client, workspaceId, [target.id])
     await emitAssignmentEvents(client, {
       workspaceId,
@@ -134,7 +134,7 @@ async function attachThreadReplyToSource(
     return false
   }
   await ConversationRepository.addPrimaryMessage(client, workspaceId, source.id, message.id, message.authorId)
-  await ConversationRepository.reactivateIfResolved(client, workspaceId, source.id)
+  await ConversationRepository.reactivateIfInactive(client, workspaceId, source.id)
   await ConversationRepository.bumpActivityForIds(client, workspaceId, [source.id])
   await emitAssignmentEvents(client, {
     workspaceId,

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -68,7 +68,7 @@ export const conversationAssigner: ConversationAssigner = {
       }
     }
     await ConversationRepository.addPrimaryMessage(client, workspaceId, target.id, message.id, message.authorId)
-    // Attaching a message to a resolved conversation revives it — it has activity again.
+    // Attaching a message to a stalled/resolved conversation revives it — it has activity again.
     await ConversationRepository.reactivateIfInactive(client, workspaceId, target.id)
     await ConversationRepository.bumpActivityForIds(client, workspaceId, [target.id])
     await emitAssignmentEvents(client, {

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -34,6 +34,13 @@ export type { BoundaryExtractionHandlerConfig } from "./boundary-extraction-outb
 export { createBoundaryExtractionWorker } from "./boundary-extraction-worker"
 export type { BoundaryExtractionWorkerDeps } from "./boundary-extraction-worker"
 
+export {
+  createStalenessSweepWorker,
+  SWEEP_STALLED_AFTER_SECONDS,
+  SWEEP_RESOLVED_AFTER_SECONDS,
+} from "./staleness-sweep-worker"
+export type { StalenessSweepWorkerDeps } from "./staleness-sweep-worker"
+
 export { ConversationRepository } from "./repository"
 export { ConversationFeedbackRepository } from "./feedback-repository"
 export type { Conversation, InsertConversationParams, UpdateConversationParams } from "./repository"

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -86,6 +86,7 @@ interface ConversationRow {
   stream_id: string
   workspace_id: string
   topic_summary: string | null
+  summary: string | null
   completeness_score: number
   confidence: number
   status: string
@@ -119,6 +120,7 @@ export interface Conversation {
   participantIds: string[]
   secondaryMessageIds: string[]
   topicSummary: string | null
+  summary: string | null
   completenessScore: number
   confidence: number
   status: ConversationStatus
@@ -133,6 +135,7 @@ export interface InsertConversationParams {
   streamId: string
   workspaceId: string
   topicSummary?: string
+  summary?: string
   completenessScore?: number
   confidence?: number
   status?: ConversationStatus
@@ -141,6 +144,7 @@ export interface InsertConversationParams {
 
 export interface UpdateConversationParams {
   topicSummary?: string
+  summary?: string
   completenessScore?: number
   confidence?: number
   status?: ConversationStatus
@@ -156,6 +160,7 @@ function mapRowToConversation(row: ConversationRow): Conversation {
     participantIds: row.participant_ids,
     secondaryMessageIds: row.secondary_message_ids,
     topicSummary: row.topic_summary,
+    summary: row.summary,
     completenessScore: row.completeness_score,
     confidence: row.confidence,
     status: row.status as ConversationStatus,
@@ -169,7 +174,7 @@ function mapRowToConversation(row: ConversationRow): Conversation {
 const SELECT_FIELDS = `
   id, stream_id, workspace_id,
   message_ids, participant_ids, secondary_message_ids,
-  topic_summary, completeness_score, confidence, status, parent_conversation_id,
+  topic_summary, summary, completeness_score, confidence, status, parent_conversation_id,
   last_activity_at, created_at, updated_at
 `
 
@@ -461,13 +466,14 @@ export const ConversationRepository = {
     const result = await db.query<ConversationRow>(sql`
       INSERT INTO conversations (
         id, stream_id, workspace_id,
-        topic_summary, completeness_score, confidence, status, parent_conversation_id
+        topic_summary, summary, completeness_score, confidence, status, parent_conversation_id
       )
       VALUES (
         ${params.id},
         ${params.streamId},
         ${params.workspaceId},
         ${params.topicSummary ?? null},
+        ${params.summary ?? null},
         ${params.completenessScore ?? 1},
         ${params.confidence ?? 0.5},
         ${params.status ?? "active"},
@@ -496,6 +502,10 @@ export const ConversationRepository = {
     if (params.topicSummary !== undefined) {
       updates.push(`topic_summary = $${paramIndex++}`)
       values.push(params.topicSummary)
+    }
+    if (params.summary !== undefined) {
+      updates.push(`summary = $${paramIndex++}`)
+      values.push(params.summary)
     }
     if (params.completenessScore !== undefined) {
       updates.push(`completeness_score = $${paramIndex++}`)

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -667,6 +667,57 @@ export const ConversationRepository = {
     `)
   },
 
+  /**
+   * Fade idle conversations: active → stalled after `stalledAfterSeconds` of
+   * silence, active/stalled → resolved after `resolvedAfterSeconds`. The LLM
+   * extractor only sees (and can only close) conversations still inside its
+   * message window, so anything that scrolls out would otherwise stay "active"
+   * forever — this sweep is the out-of-window counterpart.
+   *
+   * Set-based (INV-56) and cross-workspace by design: it is a system
+   * maintenance job like queue internals, and every returned row still carries
+   * its workspace for scoped event emission. `SKIP LOCKED` keeps the sweep
+   * from blocking on rows a live extraction holds; `limit` bounds the
+   * transaction so the first run over a large backlog drains in slices.
+   * Returns the transitioned conversations for outbox emission.
+   */
+  async sweepStale(
+    db: Querier,
+    params: { stalledAfterSeconds: number; resolvedAfterSeconds: number; limit: number }
+  ): Promise<Conversation[]> {
+    const result = await db.query<ConversationRow>(sql`
+      WITH candidates AS (
+        SELECT id,
+          CASE
+            WHEN last_activity_at < NOW() - make_interval(secs => ${params.resolvedAfterSeconds})
+              THEN ${ConversationStatuses.RESOLVED}
+            ELSE ${ConversationStatuses.STALLED}
+          END AS next_status
+        FROM conversations
+        WHERE (
+          status = ${ConversationStatuses.ACTIVE}
+            AND last_activity_at < NOW() - make_interval(secs => ${params.stalledAfterSeconds})
+        ) OR (
+          status = ${ConversationStatuses.STALLED}
+            AND last_activity_at < NOW() - make_interval(secs => ${params.resolvedAfterSeconds})
+        )
+        ORDER BY last_activity_at
+        LIMIT ${params.limit}
+        FOR UPDATE SKIP LOCKED
+      )
+      UPDATE conversations c
+      SET status = candidates.next_status, updated_at = NOW()
+      FROM candidates
+      WHERE c.id = candidates.id
+      RETURNING ${sql.raw(
+        SELECT_FIELDS.split(",")
+          .map((f) => `c.${f.trim()}`)
+          .join(", ")
+      )}
+    `)
+    return result.rows.map(mapRowToConversation)
+  },
+
   /** Bump last_activity_at on many conversations in one round-trip. Workspace-scoped (INV-8). */
   async bumpActivityForIds(db: Querier, workspaceId: string, ids: string[]): Promise<void> {
     if (ids.length === 0) return

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -651,19 +651,19 @@ export const ConversationRepository = {
   },
 
   /**
-   * Flip a resolved conversation back to active. Applied whenever a message
-   * moves into a resolved conversation — gaining a message means it has
-   * activity again, whether it was resolved by a normal workflow or
-   * auto-resolved on becoming empty (which keeps the emptied conversation
-   * usable as an undo target). Conditional in SQL (INV-20), so it no-ops for
-   * active/stalled conversations.
+   * Flip a stalled or resolved conversation back to active. Applied whenever a
+   * message moves into one — gaining a message means it has activity again,
+   * whether it was resolved by a normal workflow, auto-resolved on becoming
+   * empty (which keeps the emptied conversation usable as an undo target), or
+   * faded by the staleness sweep. Conditional in SQL (INV-20), so it no-ops
+   * for active conversations.
    */
-  async reactivateIfResolved(db: Querier, workspaceId: string, conversationId: string): Promise<void> {
+  async reactivateIfInactive(db: Querier, workspaceId: string, conversationId: string): Promise<void> {
     await db.query(sql`
       UPDATE conversations
       SET status = ${ConversationStatuses.ACTIVE}, updated_at = NOW()
       WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
-        AND status = ${ConversationStatuses.RESOLVED}
+        AND status IN (${ConversationStatuses.RESOLVED}, ${ConversationStatuses.STALLED})
     `)
   },
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -399,7 +399,7 @@ export class ConversationService {
       // Deliberately unconditional, not just for the undo path: a user moving
       // a message into ANY resolved conversation is declaring it has activity
       // again, so it returns to the active lifecycle.
-      await ConversationRepository.reactivateIfResolved(client, workspaceId, target.id)
+      await ConversationRepository.reactivateIfInactive(client, workspaceId, target.id)
 
       await ConversationFeedbackRepository.insert(client, {
         id: conversationFeedbackId(),

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import { ConversationStatuses } from "@threa/types"
+import * as dbModule from "../../db"
+import { StreamRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+import { ConversationRepository, type Conversation } from "./repository"
+import { createStalenessSweepWorker } from "./staleness-sweep-worker"
+
+function makeConversation(overrides: Partial<Conversation>): Conversation {
+  return {
+    id: "conv_1",
+    streamId: "stream_1",
+    workspaceId: "ws_1",
+    messageIds: ["msg_1"],
+    participantIds: ["usr_1"],
+    secondaryMessageIds: [],
+    topicSummary: "Idle topic",
+    summary: null,
+    completenessScore: 3,
+    confidence: 0.8,
+    status: ConversationStatuses.STALLED,
+    parentConversationId: null,
+    lastActivityAt: new Date("2026-06-01T00:00:00Z"),
+    createdAt: new Date("2026-05-30T00:00:00Z"),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+const job = { id: "job_1", name: "conversation.staleness-sweep", data: { workspaceId: "system" } }
+
+describe("createStalenessSweepWorker", () => {
+  afterEach(() => mock.restore())
+
+  function arrange(swept: Conversation[]) {
+    spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: unknown) => unknown) =>
+      fn({})) as typeof dbModule.withTransaction)
+    spyOn(ConversationRepository, "sweepStale").mockResolvedValue(swept)
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_1",
+      type: "dm",
+      visibility: "private",
+    } as never)
+    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+    return { worker: createStalenessSweepWorker({ pool: {} as never }), insert }
+  }
+
+  it("emits a sweep-tagged conversation:updated per transitioned conversation", async () => {
+    const { worker, insert } = arrange([
+      makeConversation({ id: "conv_a", status: ConversationStatuses.STALLED }),
+      makeConversation({ id: "conv_b", status: ConversationStatuses.RESOLVED }),
+    ])
+
+    await worker(job)
+
+    expect(insert).toHaveBeenCalledTimes(2)
+    expect(insert.mock.calls.map((c) => c[1])).toEqual(["conversation:updated", "conversation:updated"])
+    expect(insert.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        conversationId: "conv_a",
+        origin: "staleness-sweep",
+        conversation: expect.objectContaining({ id: "conv_a", status: ConversationStatuses.STALLED }),
+      })
+    )
+  })
+
+  it("emits nothing when the sweep transitions nothing", async () => {
+    const { worker, insert } = arrange([])
+
+    await worker(job)
+
+    expect(insert).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.test.ts
@@ -36,41 +36,46 @@ describe("createStalenessSweepWorker", () => {
     spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: unknown) => unknown) =>
       fn({})) as typeof dbModule.withTransaction)
     spyOn(ConversationRepository, "sweepStale").mockResolvedValue(swept)
-    spyOn(StreamRepository, "findById").mockResolvedValue({
-      id: "stream_1",
-      type: "dm",
-      visibility: "private",
-    } as never)
-    const insert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
-    return { worker: createStalenessSweepWorker({ pool: {} as never }), insert }
+    spyOn(StreamRepository, "findByIds").mockResolvedValue([
+      {
+        id: "stream_1",
+        type: "dm",
+        visibility: "private",
+      },
+    ] as never)
+    const insertMany = spyOn(OutboxRepository, "insertMany").mockResolvedValue([] as never)
+    return { worker: createStalenessSweepWorker({ pool: {} as never }), insertMany }
   }
 
   it("emits a sweep-tagged conversation:updated per transitioned conversation", async () => {
-    const { worker, insert } = arrange([
+    const { worker, insertMany } = arrange([
       makeConversation({ id: "conv_a", status: ConversationStatuses.STALLED }),
       makeConversation({ id: "conv_b", status: ConversationStatuses.RESOLVED }),
     ])
 
     await worker(job)
 
-    expect(insert).toHaveBeenCalledTimes(2)
-    expect(insert.mock.calls.map((c) => c[1])).toEqual(["conversation:updated", "conversation:updated"])
-    expect(insert.mock.calls[0][2]).toEqual(
-      expect.objectContaining({
+    expect(insertMany).toHaveBeenCalledTimes(1)
+    const entries = insertMany.mock.calls[0][1]
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toEqual({
+      eventType: "conversation:updated",
+      payload: expect.objectContaining({
         workspaceId: "ws_1",
         streamId: "stream_1",
         conversationId: "conv_a",
         origin: "staleness-sweep",
         conversation: expect.objectContaining({ id: "conv_a", status: ConversationStatuses.STALLED }),
-      })
-    )
+      }),
+    })
+    expect(entries[1].payload).toEqual(expect.objectContaining({ conversationId: "conv_b" }))
   })
 
   it("emits nothing when the sweep transitions nothing", async () => {
-    const { worker, insert } = arrange([])
+    const { worker, insertMany } = arrange([])
 
     await worker(job)
 
-    expect(insert).not.toHaveBeenCalled()
+    expect(insertMany).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.ts
@@ -1,0 +1,74 @@
+import type { Pool } from "pg"
+import type { ConversationStalenessSweepJobData, JobHandler } from "../../lib/queue"
+import { withTransaction } from "../../db"
+import { StreamRepository } from "../streams"
+import { OutboxRepository } from "../../lib/outbox"
+import { ConversationRepository } from "./repository"
+import { addStalenessFields } from "./staleness"
+import { resolveConversationDelivery } from "./conversation-delivery"
+import { logger } from "../../lib/logger"
+
+/** Idle time before an active conversation fades to stalled: one missed session. */
+export const SWEEP_STALLED_AFTER_SECONDS = 24 * 60 * 60
+/** Idle time before a stalled (or long-idle active) conversation resolves. */
+export const SWEEP_RESOLVED_AFTER_SECONDS = 7 * 24 * 60 * 60
+/** Per-run cap so the first sweep over a months-old backlog drains in slices. */
+export const SWEEP_BATCH_LIMIT = 200
+
+export interface StalenessSweepWorkerDeps {
+  pool: Pool
+}
+
+/**
+ * Cron-driven fade for conversations the extractor can no longer see: the LLM
+ * only closes conversations inside its message window, so out-of-window ones
+ * would stay "active" forever (prod audit: hundreds of months-old actives).
+ *
+ * Transitions + their outbox events commit in one transaction (INV-4/7). The
+ * events carry `origin: "staleness-sweep"` so the memo accumulator can ignore
+ * pure status fades — re-queueing an idle conversation for memo processing
+ * would re-run extraction over months-old content.
+ */
+export function createStalenessSweepWorker(
+  deps: StalenessSweepWorkerDeps
+): JobHandler<ConversationStalenessSweepJobData> {
+  const { pool } = deps
+
+  return async (job) => {
+    const swept = await withTransaction(pool, async (client) => {
+      const transitioned = await ConversationRepository.sweepStale(client, {
+        stalledAfterSeconds: SWEEP_STALLED_AFTER_SECONDS,
+        resolvedAfterSeconds: SWEEP_RESOLVED_AFTER_SECONDS,
+        limit: SWEEP_BATCH_LIMIT,
+      })
+      if (transitioned.length === 0) return 0
+
+      // Route each event by its conversation's own access root (INV-62). One
+      // resolve per distinct stream — sweeps often hit many conversations in
+      // the same stream.
+      const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+      for (const conv of transitioned) {
+        let delivery = deliveryByStreamId.get(conv.streamId)
+        if (!delivery) {
+          const stream = await StreamRepository.findById(client, conv.streamId)
+          delivery = await resolveConversationDelivery(client, stream)
+          deliveryByStreamId.set(conv.streamId, delivery)
+        }
+        await OutboxRepository.insert(client, "conversation:updated", {
+          workspaceId: conv.workspaceId,
+          streamId: conv.streamId,
+          conversationId: conv.id,
+          conversation: addStalenessFields(conv),
+          parentStreamId: delivery.parentStreamId,
+          streamVisibility: delivery.streamVisibility,
+          origin: "staleness-sweep",
+        })
+      }
+      return transitioned.length
+    })
+
+    if (swept > 0) {
+      logger.info({ jobId: job.id, swept }, "Staleness sweep transitioned idle conversations")
+    }
+  }
+}

--- a/apps/backend/src/features/conversations/staleness-sweep-worker.ts
+++ b/apps/backend/src/features/conversations/staleness-sweep-worker.ts
@@ -43,27 +43,36 @@ export function createStalenessSweepWorker(
       })
       if (transitioned.length === 0) return 0
 
-      // Route each event by its conversation's own access root (INV-62). One
-      // resolve per distinct stream — sweeps often hit many conversations in
-      // the same stream.
+      // Route each event by its conversation's own access root (INV-62).
+      // Streams are batch-fetched and delivery resolved once per distinct
+      // stream; the events land in one insertMany (INV-56) so the transaction
+      // holds the connection for two round-trips plus thread-parent lookups,
+      // not one insert per row.
+      const streamIds = [...new Set(transitioned.map((c) => c.streamId))]
+      const streams = await StreamRepository.findByIds(client, streamIds)
+      const streamById = new Map(streams.map((s) => [s.id, s]))
       const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
-      for (const conv of transitioned) {
-        let delivery = deliveryByStreamId.get(conv.streamId)
-        if (!delivery) {
-          const stream = await StreamRepository.findById(client, conv.streamId)
-          delivery = await resolveConversationDelivery(client, stream)
-          deliveryByStreamId.set(conv.streamId, delivery)
-        }
-        await OutboxRepository.insert(client, "conversation:updated", {
-          workspaceId: conv.workspaceId,
-          streamId: conv.streamId,
-          conversationId: conv.id,
-          conversation: addStalenessFields(conv),
-          parentStreamId: delivery.parentStreamId,
-          streamVisibility: delivery.streamVisibility,
-          origin: "staleness-sweep",
-        })
+      for (const id of streamIds) {
+        deliveryByStreamId.set(id, await resolveConversationDelivery(client, streamById.get(id) ?? null))
       }
+      await OutboxRepository.insertMany(
+        client,
+        transitioned.map((conv) => {
+          const delivery = deliveryByStreamId.get(conv.streamId)
+          return {
+            eventType: "conversation:updated" as const,
+            payload: {
+              workspaceId: conv.workspaceId,
+              streamId: conv.streamId,
+              conversationId: conv.id,
+              conversation: addStalenessFields(conv),
+              parentStreamId: delivery?.parentStreamId,
+              streamVisibility: delivery?.streamVisibility,
+              origin: "staleness-sweep" as const,
+            },
+          }
+        })
+      )
       return transitioned.length
     })
 

--- a/apps/backend/src/features/memos/accumulator-outbox-handler.test.ts
+++ b/apps/backend/src/features/memos/accumulator-outbox-handler.test.ts
@@ -111,4 +111,16 @@ describe("MemoAccumulatorHandler memory gate", () => {
     expect(queue).not.toHaveBeenCalled()
     expect(activity).not.toHaveBeenCalled()
   })
+
+  it("skips staleness-sweep status fades — no new content to memoize", async () => {
+    const { handler, queue, activity } = arrange(() => makeStream({ id: "stream_x", memoryMode: MemoryModes.AUTO }))
+
+    const event = conversationEvent("stream_x")
+    ;(event.payload as unknown as Record<string, unknown>).origin = "staleness-sweep"
+    ;(event as { eventType: string }).eventType = "conversation:updated"
+    await handler.run(event)
+
+    expect(queue).not.toHaveBeenCalled()
+    expect(activity).not.toHaveBeenCalled()
+  })
 })

--- a/apps/backend/src/features/memos/accumulator-outbox-handler.ts
+++ b/apps/backend/src/features/memos/accumulator-outbox-handler.ts
@@ -43,6 +43,12 @@ export class MemoAccumulatorHandler extends DebouncedOutboxHandler {
       return
     }
 
+    // Staleness-sweep fades carry no new content: re-queueing here would re-run
+    // memo extraction over an idle (possibly months-old) conversation.
+    if (payload.origin === "staleness-sweep") {
+      return
+    }
+
     const { streamId, workspaceId, conversationId } = payload as {
       streamId: string
       workspaceId: string

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -7,6 +7,10 @@ import { z } from "zod"
 import { KNOWLEDGE_TYPES, type KnowledgeType, type StreamType } from "@threa/types"
 import { formatDate } from "../../lib/temporal"
 
+// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
+// was fixed) showed nano classifying real knowledge as not-worthy in every
+// round (6/9 with the same three misses) — silent knowledge loss, the worst
+// GAM failure mode. See docs/model-reference.md.
 export const MEMO_CLASSIFIER_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 export const MEMO_MEMORIZER_MODEL_ID = "openrouter:openai/gpt-5.4-mini"

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -47,6 +47,18 @@ export const MEMO_MAX_PER_CONVERSATION = 5
 export const MEMO_DEDUP_DISTANCE = 0.15
 
 /**
+ * Same-conversation supersession threshold (pgvector cosine distance). When a
+ * revision pass emits a memo within this distance of an existing active memo
+ * from the SAME conversation, the old memo is superseded and the new one links
+ * to it via parentMemoId — a paraphrased re-capture replaces its predecessor
+ * instead of stacking next to it. Looser than MEMO_DEDUP_DISTANCE because
+ * observed prod re-captures ("framstår som sjuka" vs "helt galna") land in the
+ * 0.15–0.35 band; scoping to one conversation keeps the looser cutoff from
+ * merging genuinely distinct topics.
+ */
+export const MEMO_SUPERSEDE_DISTANCE = 0.35
+
+/**
  * B2 structural boost. A multiplicative factor on the fused RRF score,
  * applied in the *outer* stage of hybrid search (after the inner
  * access-scoped scan — never before it, §3.1). The factor is structural
@@ -233,7 +245,7 @@ How to write memos:
 1. ONE TOPIC PER MEMO. If a conversation settles two unrelated things (e.g. a deployment decision and a hiring update), produce two separate memos. Never blend topics into a single memo.
 2. EXTRACT, DON'T SUMMARIZE. Capture the durable conclusion — the decision, the answer, the fact, the procedure that was worked out — not a play-by-play of the discussion. A memo is what someone would want to recall in six months, never a transcript of who said what.
 3. BE TERSE. An abstract is a few sentences at most. If it reads like a recap of the conversation, rewrite it down to the bare conclusion.
-4. OMIT THE FORGETTABLE. Greetings, status pings, back-and-forth, and unresolved tangents produce no memo. Returning very few memos — or only the one thing that actually mattered — is correct and expected.
+4. OMIT THE FORGETTABLE. Greetings, status pings, back-and-forth, and unresolved tangents produce no memo. Opinions, hot takes, gossip, and reactions to news or third-party products are NEVER memos, no matter how strongly worded or how long the exchange — commentary about the world is not knowledge the participants produced. Recasting the commentary as a fact about the participants ("they dislike X", "they found Y impressive") does not rescue it: sentiment toward external things is still commentary, memo-worthy only when it fixes a concrete choice with consequences (a tool adopted, a vendor rejected for a project). Likewise, facts about the outside world picked up from news, links, or hearsay are re-findable and go stale — no memo unless the participants acted on them. A "learning" is something the participants discovered, validated, or decided themselves. Returning very few memos — none at all when the conversation is commentary — is correct and expected.
 {{MEMO_LANGUAGE_RULE}}
 6. BE FACTUAL. State the knowledge directly. No meta-commentary like "this memo captures..." or "the team discussed...".
 7. Use consistent vocabulary with prior memos when the same concept reappears.
@@ -278,6 +290,8 @@ export const MEMORIZER_CONVERSATION_PROMPT = `Extract the memos worth rememberin
 Return one memo per distinct topic worth remembering, each terse and self-contained. Most conversations yield one or two; return fewer rather than padding, and return none if nothing here is worth keeping. For each memo, set sourceMessageIds to only the messages that topic draws from.`
 
 export const MEMORIZER_REVISION_PROMPT = `This conversation already has memos. Capture only what is NEW or has CHANGED since them. Do NOT re-create memos for topics the existing memos already cover unchanged.
+
+Treat the existing memos as authoritative coverage: a topic that is restated, rephrased, elaborated with opinions, or met with agreement in the new messages is COVERED — emit nothing for it. Only a changed conclusion (a decision reversed, a setup replaced, a fact corrected) or a genuinely new topic earns a memo. Returning an empty set is the expected common case when a conversation is re-processed after a few new messages.
 
 ## Memory Context (prior memos for vocabulary consistency)
 {{MEMORY_CONTEXT}}

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -450,13 +450,13 @@ export const MemoRepository = {
     return result.rows.map((row) => ({ memo: mapRowToMemo(row), distance: row.distance }))
   },
 
-  /** Mark memos superseded in one round-trip (INV-56). */
-  async markSuperseded(db: Querier, ids: string[], revisionReason: string): Promise<void> {
+  /** Mark memos superseded in one round-trip (INV-56). Workspace-scoped (INV-8). */
+  async markSuperseded(db: Querier, workspaceId: string, ids: string[], revisionReason: string): Promise<void> {
     if (ids.length === 0) return
     await db.query(sql`
       UPDATE memos
       SET status = 'superseded', revision_reason = ${revisionReason}, updated_at = NOW()
-      WHERE id = ANY(${ids}::text[]) AND status = 'active'
+      WHERE workspace_id = ${workspaceId} AND id = ANY(${ids}::text[]) AND status = 'active'
     `)
   },
 

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -417,6 +417,49 @@ export const MemoRepository = {
     return { memo: mapRowToMemo(row), distance: row.distance }
   },
 
+  /**
+   * Active memos from ONE conversation near an embedding — the supersession
+   * probe: a revised capture of a topic replaces the conversation's earlier
+   * memo on that topic (see MEMO_SUPERSEDE_DISTANCE). `excludeIds` keeps memos
+   * inserted earlier in the same batch from superseding each other. Ordered
+   * nearest-first so the caller can link parentMemoId to the closest match.
+   */
+  async findSameConversationNear(
+    db: Querier,
+    params: {
+      workspaceId: string
+      conversationId: string
+      embedding: number[]
+      maxDistance: number
+      excludeIds?: string[]
+    }
+  ): Promise<{ memo: Memo; distance: number }[]> {
+    const embeddingLiteral = `[${params.embedding.join(",")}]`
+    const result = await db.query<MemoRow & { distance: number }>(sql`
+      SELECT ${sql.raw(SELECT_FIELDS_PREFIXED)},
+             m.embedding <=> ${embeddingLiteral}::vector AS distance
+      FROM memos m
+      WHERE m.workspace_id = ${params.workspaceId}
+        AND m.source_conversation_id = ${params.conversationId}
+        AND m.status = 'active'
+        AND m.embedding IS NOT NULL
+        AND m.embedding <=> ${embeddingLiteral}::vector < ${params.maxDistance}
+        AND m.id <> ALL(${params.excludeIds ?? []}::text[])
+      ORDER BY distance ASC
+    `)
+    return result.rows.map((row) => ({ memo: mapRowToMemo(row), distance: row.distance }))
+  },
+
+  /** Mark memos superseded in one round-trip (INV-56). */
+  async markSuperseded(db: Querier, ids: string[], revisionReason: string): Promise<void> {
+    if (ids.length === 0) return
+    await db.query(sql`
+      UPDATE memos
+      SET status = 'superseded', revision_reason = ${revisionReason}, updated_at = NOW()
+      WHERE id = ANY(${ids}::text[]) AND status = 'active'
+    `)
+  },
+
   async insert(db: Querier, params: InsertMemoParams): Promise<Memo> {
     const result = await db.query<MemoRow>(sql`
       INSERT INTO memos (

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -95,6 +95,8 @@ function setupService(options: { memoContents: MemoContent[] }) {
   spyOn(MemoRepository, "getAllTags").mockResolvedValue([])
   spyOn(MemoRepository, "findActiveBySourceConversation").mockResolvedValue([])
   spyOn(MemoRepository, "findNearDuplicate").mockResolvedValue(null)
+  spyOn(MemoRepository, "findSameConversationNear").mockResolvedValue([])
+  spyOn(MemoRepository, "markSuperseded").mockResolvedValue(undefined as never)
   spyOn(WorkspaceSettingsRepository, "findOverrides").mockResolvedValue([])
   spyOn(MemoRepository, "insert").mockResolvedValue(undefined as never)
   spyOn(MemoRepository, "updateEmbedding").mockResolvedValue(undefined as never)
@@ -225,5 +227,36 @@ describe("MemoService.processBatch — memos:captured timeline event (INV-62)", 
       embedding: expect.any(Array),
       maxDistance: expect.any(Number),
     })
+  })
+
+  it("supersedes the conversation's prior memo when a revised capture lands near it", async () => {
+    const { service } = setupService({ memoContents: [memoContent] })
+
+    // A paraphrased re-capture: outside the dedup gate (0.15) but inside the
+    // supersede band — the prod failure where rewordings stacked forever.
+    const prior = { ...memoContent, id: "memo_prior", sourceConversationId: CONVERSATION_ID } as never
+    const findNear = spyOn(MemoRepository, "findSameConversationNear").mockResolvedValue([
+      { memo: prior, distance: 0.22 },
+    ])
+    const markSuperseded = spyOn(MemoRepository, "markSuperseded").mockResolvedValue(undefined as never)
+    const insert = spyOn(MemoRepository, "insert").mockResolvedValue(undefined as never)
+
+    const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(result.memosCreated).toBe(1)
+    expect(findNear).toHaveBeenCalledWith(expect.anything(), {
+      workspaceId: WORKSPACE_ID,
+      conversationId: CONVERSATION_ID,
+      embedding: expect.any(Array),
+      maxDistance: expect.any(Number),
+      excludeIds: [],
+    })
+    expect(markSuperseded).toHaveBeenCalledWith(
+      expect.anything(),
+      ["memo_prior"],
+      expect.stringContaining("Superseded by revised capture")
+    )
+    // The new memo links back to the memo it replaced.
+    expect(insert).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ parentMemoId: "memo_prior" }))
   })
 })

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -253,10 +253,37 @@ describe("MemoService.processBatch — memos:captured timeline event (INV-62)", 
     })
     expect(markSuperseded).toHaveBeenCalledWith(
       expect.anything(),
+      WORKSPACE_ID,
       ["memo_prior"],
       expect.stringContaining("Superseded by revised capture")
     )
     // The new memo links back to the memo it replaced.
     expect(insert).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ parentMemoId: "memo_prior" }))
+  })
+
+  it("supersedes every near match but links parentMemoId to the nearest", async () => {
+    const { service } = setupService({ memoContents: [memoContent] })
+
+    // Two prior captures of the same drifting topic; both retire, the new
+    // memo's lineage points at the closest one.
+    const nearest = { ...memoContent, id: "memo_nearest", sourceConversationId: CONVERSATION_ID } as never
+    const farther = { ...memoContent, id: "memo_farther", sourceConversationId: CONVERSATION_ID } as never
+    spyOn(MemoRepository, "findSameConversationNear").mockResolvedValue([
+      { memo: nearest, distance: 0.18 },
+      { memo: farther, distance: 0.31 },
+    ])
+    const markSuperseded = spyOn(MemoRepository, "markSuperseded").mockResolvedValue(undefined as never)
+    const insert = spyOn(MemoRepository, "insert").mockResolvedValue(undefined as never)
+
+    const result = await service.processBatch(WORKSPACE_ID, STREAM_ID)
+
+    expect(result.memosCreated).toBe(1)
+    expect(markSuperseded).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      ["memo_nearest", "memo_farther"],
+      expect.stringContaining("Superseded by revised capture")
+    )
+    expect(insert).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ parentMemoId: "memo_nearest" }))
   })
 })

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -15,7 +15,12 @@ import type { EmbeddingServiceLike } from "./embedding-service"
 import { memoId, eventId } from "../../lib/id"
 import { logger } from "../../lib/logger"
 import { MemoTypes, MemoStatuses, AuthorTypes, type MemosCapturedEventPayload } from "@threa/types"
-import { MEMO_GEM_CONFIDENCE_FLOOR, MEMO_SINGLE_MESSAGE_AGE_GATE_MS, MEMO_DEDUP_DISTANCE } from "./config"
+import {
+  MEMO_GEM_CONFIDENCE_FLOOR,
+  MEMO_SINGLE_MESSAGE_AGE_GATE_MS,
+  MEMO_DEDUP_DISTANCE,
+  MEMO_SUPERSEDE_DISTANCE,
+} from "./config"
 
 const MEMORY_CONTEXT_LIMIT = 20
 const MIN_CONVERSATION_MESSAGES = 1
@@ -67,6 +72,8 @@ interface MemoToCreate {
   tags: string[]
   status: import("@threa/types").MemoStatus
   embedding: number[]
+  /** Set at save time when this memo supersedes a prior capture from its conversation. */
+  parentMemoId?: string
 }
 
 export interface MemoServiceLike {
@@ -449,6 +456,38 @@ export class MemoService implements MemoServiceLike {
           continue
         }
 
+        // Same-conversation supersession: a revised capture of a topic
+        // replaces the conversation's earlier memo on it (paraphrases in the
+        // dedup–supersede band would otherwise stack forever — the observed
+        // prod failure). Nearest old memo becomes the parent; all matches are
+        // retired. Batch-mates are excluded so two new memos can't supersede
+        // each other.
+        const toSupersede = memoData.sourceConversationId
+          ? await MemoRepository.findSameConversationNear(client, {
+              workspaceId,
+              conversationId: memoData.sourceConversationId,
+              embedding: memoData.embedding,
+              maxDistance: MEMO_SUPERSEDE_DISTANCE,
+              excludeIds: createdMemos.map((m) => m.id),
+            })
+          : []
+        if (toSupersede.length > 0) {
+          memoData.parentMemoId = toSupersede[0].memo.id
+          await MemoRepository.markSuperseded(
+            client,
+            toSupersede.map((s) => s.memo.id),
+            `Superseded by revised capture ${memoData.id}`
+          )
+          logger.info(
+            {
+              conversationId: memoData.sourceConversationId,
+              memoId: memoData.id,
+              supersededIds: toSupersede.map((s) => s.memo.id),
+            },
+            "Revised memo superseded prior capture(s) from the same conversation"
+          )
+        }
+
         const { embedding, ...memoFields } = memoData
         await MemoRepository.insert(client, memoFields)
         await MemoRepository.updateEmbedding(client, memoData.id, embedding)
@@ -554,7 +593,7 @@ export class MemoService implements MemoServiceLike {
       participantIds: memoData.participantIds,
       knowledgeType: memoData.knowledgeType,
       tags: memoData.tags,
-      parentMemoId: null,
+      parentMemoId: memoData.parentMemoId ?? null,
       status: memoData.status,
       version: 1,
       revisionReason: null,

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -475,6 +475,7 @@ export class MemoService implements MemoServiceLike {
           memoData.parentMemoId = toSupersede[0].memo.id
           await MemoRepository.markSuperseded(
             client,
+            workspaceId,
             toSupersede.map((s) => s.memo.id),
             `Superseded by revised capture ${memoData.id}`
           )

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -426,6 +426,12 @@ export interface ConversationUpdatedOutboxPayload extends StreamScopedPayload {
   parentStreamId?: string
   /** See {@link ConversationCreatedOutboxPayload.streamVisibility}. */
   streamVisibility?: Visibility
+  /**
+   * Set when the update is a pure status fade from the staleness sweep — no
+   * new content. The memo accumulator skips these instead of re-queueing the
+   * conversation for extraction.
+   */
+  origin?: "staleness-sweep"
 }
 
 /**

--- a/apps/backend/src/lib/queue/index.ts
+++ b/apps/backend/src/lib/queue/index.ts
@@ -17,6 +17,7 @@ export {
   type NamingJobData,
   type EmbeddingJobData,
   type BoundaryExtractionJobData,
+  type ConversationStalenessSweepJobData,
   type MemoBatchCheckJobData,
   type MemoBatchProcessJobData,
   type CommandExecuteJobData,

--- a/apps/backend/src/lib/queue/job-queue.ts
+++ b/apps/backend/src/lib/queue/job-queue.ts
@@ -11,6 +11,7 @@ export const JobQueues = {
   NAMING_GENERATE: "naming.generate",
   EMBEDDING_GENERATE: "embedding.generate",
   BOUNDARY_EXTRACT: "boundary.extract",
+  CONVERSATION_STALENESS_SWEEP: "conversation.staleness-sweep",
   MEMO_BATCH_CHECK: "memo.batch-check",
   MEMO_BATCH_PROCESS: "memo.batch-process",
   COMMAND_EXECUTE: "command.execute",
@@ -97,6 +98,10 @@ export interface BoundaryExtractionJobData {
   messageId: string
   streamId: string
   workspaceId: string
+}
+
+export interface ConversationStalenessSweepJobData {
+  workspaceId: string // Use "system" for system-wide cron job
 }
 
 export interface MemoBatchCheckJobData {
@@ -297,6 +302,7 @@ export interface JobDataMap {
   [JobQueues.NAMING_GENERATE]: NamingJobData
   [JobQueues.EMBEDDING_GENERATE]: EmbeddingJobData
   [JobQueues.BOUNDARY_EXTRACT]: BoundaryExtractionJobData
+  [JobQueues.CONVERSATION_STALENESS_SWEEP]: ConversationStalenessSweepJobData
   [JobQueues.MEMO_BATCH_CHECK]: MemoBatchCheckJobData
   [JobQueues.MEMO_BATCH_PROCESS]: MemoBatchProcessJobData
   [JobQueues.COMMAND_EXECUTE]: CommandExecuteJobData

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -72,6 +72,7 @@ import {
   BoundaryExtractionService,
   BoundaryExtractionHandler,
   createBoundaryExtractionWorker,
+  createStalenessSweepWorker,
   LLMBoundaryExtractor,
   StubBoundaryExtractor,
 } from "./features/conversations"
@@ -885,6 +886,14 @@ export async function startServer(): Promise<ServerInstance> {
     fairness: QueueFairness.NONE,
   })
 
+  // Cron-driven fade for conversations the extractor's window can no longer
+  // see (active → stalled → resolved on idle). No AI involved.
+  const stalenessSweepWorker = createStalenessSweepWorker({ pool })
+  jobQueue.registerHandler(JobQueues.CONVERSATION_STALENESS_SWEEP, stalenessSweepWorker, {
+    tier: QueueTiers.LIGHT,
+    fairness: QueueFairness.NONE,
+  })
+
   // Memo (GAM) processing — batched extraction, heavy LLM work
   const memoService = config.useStubAI
     ? new StubMemoService()
@@ -1142,6 +1151,11 @@ export async function startServer(): Promise<ServerInstance> {
   // payload workspaceId "system" = system-wide check; schedule workspaceId null = global schedule
   if (!config.useStubAI) {
     await jobQueue.schedule(JobQueues.MEMO_BATCH_CHECK, 30, { workspaceId: "system" }, null)
+  }
+  // Status fade is pure SQL (no AI), but stays off in stub/test stacks so
+  // long-running e2e fixtures never fade mid-test.
+  if (!config.useStubAI) {
+    await jobQueue.schedule(JobQueues.CONVERSATION_STALENESS_SWEEP, 600, { workspaceId: "system" }, null)
   }
 
   // Outbox dispatcher - single LISTEN connection fans out to all handlers

--- a/apps/backend/tests/integration/boundary-extraction-service.test.ts
+++ b/apps/backend/tests/integration/boundary-extraction-service.test.ts
@@ -18,6 +18,7 @@ import { MessageRepository } from "../../src/features/messaging"
 import { ConversationRepository } from "../../src/features/conversations"
 import { BoundaryExtractionService } from "../../src/features/conversations"
 import { setupTestDatabase, testMessageContent } from "./setup"
+import { sql } from "../../src/db"
 import { userId, workspaceId, streamId, messageId, conversationId } from "../../src/lib/id"
 import { ConversationStatuses } from "@threa/types"
 import type { BoundaryExtractor, ExtractionContext, ExtractionResult } from "../../src/features/conversations"
@@ -961,6 +962,55 @@ describe("BoundaryExtractionService", () => {
 
       // Extractor should never have been called
       expect(stubExtractor.extractCallCount).toBe(0)
+    })
+
+    test("reuses and reactivates a sweep-faded scratchpad conversation instead of minting a second", async () => {
+      const localStreamId = streamId()
+      const msg1Id = messageId()
+      const msg2Id = messageId()
+
+      await withTransaction(pool, async (client) => {
+        await StreamRepository.insert(client, {
+          id: localStreamId,
+          workspaceId: testWorkspaceId,
+          type: "scratchpad",
+          displayName: "Long-lived notes",
+          visibility: "private",
+          companionMode: "off",
+          createdBy: testUserId,
+        })
+        await MessageRepository.insert(client, {
+          id: msg1Id,
+          streamId: localStreamId,
+          sequence: BigInt(1),
+          authorId: testUserId,
+          authorType: "user",
+          ...testMessageContent("First note"),
+        })
+      })
+
+      const result1 = await service.processMessage(msg1Id, localStreamId, testWorkspaceId)
+      const conversationId1 = result1!.id
+
+      // The staleness sweep faded the scratchpad's conversation.
+      await withTransaction(pool, async (client) => {
+        await client.query(sql`UPDATE conversations SET status = 'stalled' WHERE id = ${conversationId1}`)
+        await MessageRepository.insert(client, {
+          id: msg2Id,
+          streamId: localStreamId,
+          sequence: BigInt(2),
+          authorId: testUserId,
+          authorType: "user",
+          ...testMessageContent("Back after a week"),
+        })
+      })
+
+      const result2 = await service.processMessage(msg2Id, localStreamId, testWorkspaceId)
+
+      // Same conversation, live again — never a second same-named card.
+      expect(result2?.id).toBe(conversationId1)
+      expect(result2?.status).toBe("active")
+      expect(result2?.messageIds).toContain(msg2Id)
     })
 
     test("uses stream display name as conversation topic", async () => {

--- a/apps/backend/tests/integration/conversation-repository.test.ts
+++ b/apps/backend/tests/integration/conversation-repository.test.ts
@@ -16,6 +16,7 @@ import { StreamRepository } from "../../src/features/streams"
 import { MessageRepository } from "../../src/features/messaging"
 import { ConversationRepository } from "../../src/features/conversations"
 import { MemoRepository } from "../../src/features/memos"
+import { sql } from "../../src/db"
 import { setupTestDatabase, testMessageContent } from "./setup"
 import { userId, workspaceId, streamId, messageId, conversationId, memoId } from "../../src/lib/id"
 import { ConversationStatuses } from "@threa/types"
@@ -985,6 +986,72 @@ describe("ConversationRepository", () => {
       })
 
       expect(deleted).toBe(false)
+    })
+  })
+
+  describe("sweepStale", () => {
+    const DAY_SECONDS = 24 * 60 * 60
+    const WEEK_SECONDS = 7 * DAY_SECONDS
+
+    async function insertIdleConversation(status: string, idleHours: number): Promise<string> {
+      const convId = conversationId()
+      await withTransaction(pool, async (client) => {
+        await ConversationRepository.insert(client, {
+          id: convId,
+          streamId: testStreamId,
+          workspaceId: testWorkspaceId,
+          status: status as "active" | "stalled" | "resolved",
+        })
+        await client.query(sql`
+          UPDATE conversations
+          SET last_activity_at = NOW() - make_interval(hours => ${idleHours})
+          WHERE id = ${convId}
+        `)
+      })
+      return convId
+    }
+
+    function sweep() {
+      return withTransaction(pool, async (client) =>
+        ConversationRepository.sweepStale(client, {
+          stalledAfterSeconds: DAY_SECONDS,
+          resolvedAfterSeconds: WEEK_SECONDS,
+          limit: 100,
+        })
+      )
+    }
+
+    test("fades idle conversations by idle time and leaves live ones alone", async () => {
+      const liveActive = await insertIdleConversation(ConversationStatuses.ACTIVE, 1)
+      const idleActive = await insertIdleConversation(ConversationStatuses.ACTIVE, 25)
+      const longIdleActive = await insertIdleConversation(ConversationStatuses.ACTIVE, 8 * 24)
+      const longIdleStalled = await insertIdleConversation(ConversationStatuses.STALLED, 8 * 24)
+      const recentStalled = await insertIdleConversation(ConversationStatuses.STALLED, 48)
+
+      const swept = await sweep()
+      const byId = new Map(swept.map((c) => [c.id, c]))
+
+      expect(byId.get(idleActive)?.status).toBe(ConversationStatuses.STALLED)
+      expect(byId.get(longIdleActive)?.status).toBe(ConversationStatuses.RESOLVED)
+      expect(byId.get(longIdleStalled)?.status).toBe(ConversationStatuses.RESOLVED)
+      // Live and recently-stalled rows are not transitioned.
+      expect(byId.has(liveActive)).toBe(false)
+      expect(byId.has(recentStalled)).toBe(false)
+
+      const untouched = await withTransaction(pool, async (client) =>
+        ConversationRepository.findById(client, liveActive)
+      )
+      expect(untouched?.status).toBe(ConversationStatuses.ACTIVE)
+    })
+
+    test("is idempotent: a second sweep transitions nothing new", async () => {
+      await insertIdleConversation(ConversationStatuses.ACTIVE, 30)
+
+      const first = await sweep()
+      expect(first.length).toBeGreaterThan(0)
+
+      const second = await sweep()
+      expect(second).toEqual([])
     })
   })
 })

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -58,6 +58,7 @@ function makeConversation(): ConversationWithStaleness {
     participantIds: ["usr_me"],
     secondaryMessageIds: [],
     topicSummary: "CC Teams tokens",
+    summary: null,
     completenessScore: 4,
     confidence: 0.8,
     status: "active",

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.test.ts
@@ -17,6 +17,7 @@ function makeConversation(overrides: Partial<ConversationWithStaleness>): Conver
     participantIds: [],
     secondaryMessageIds: [],
     topicSummary: null,
+    summary: null,
     completenessScore: 1,
     confidence: 0.5,
     status: "active",

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -27,6 +27,7 @@ function makeConversation(overrides: Partial<ConversationWithStaleness> = {}): C
     participantIds: ["usr_me"],
     secondaryMessageIds: [],
     topicSummary: "CC Teams tokens",
+    summary: null,
     completenessScore: 4,
     confidence: 0.8,
     status: "active",

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -15,6 +15,7 @@ function makeConversation(id: string, lastActivityAt: string): ConversationWithS
     participantIds: ["usr_1"],
     secondaryMessageIds: [],
     topicSummary: id,
+    summary: null,
     completenessScore: 4,
     confidence: 0.8,
     status: "active",

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -188,7 +188,7 @@ All models use `provider:modelPath` format:
 - Cost-sensitive workloads where quality bar is low
 - Self-hosted inference on single H100
 
-**Note:** Previously used for memo classification, memorization, and researcher agent. Replaced by `claude-haiku-4.5` (researcher), `gpt-5.4-mini` (memo classifier/memorizer — see `MEMO_CLASSIFIER_MODEL_ID`/`MEMO_MEMORIZER_MODEL_ID` in `apps/backend/src/features/memos/config.ts`) due to unreliable tail latency on OpenRouter's patchwork provider backing and insufficient quality for structured extraction.
+**Note:** History: originally ran memo classification, memorization, and the researcher agent; replaced by `claude-haiku-4.5` (researcher) and `gpt-5.4-mini` (memo classifier/memorizer) in spring 2026 due to unreliable tail latency on OpenRouter's patchwork provider backing and insufficient quality for structured extraction. **Re-tested July 2026 against the boundary-extraction / memo-classifier / memorizer eval suites and rejected again**: nano systematically classified real knowledge as not-worthy (6/9 with the same three misses every round — silent knowledge loss) and failed sandwich-split/gap-resume boundary cases every round (30-33/35 vs mini's 33-35/35). The ~3.6x price gap does not buy back those failure modes. Caution for future comparisons: the eval CLI's `-m` flag did not reach ConfigResolver-backed components until the July 2026 runner fix — earlier "nano" comparisons silently ran the production model.
 
 ---
 

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -638,6 +638,13 @@ export interface Conversation {
    */
   secondaryMessageIds: string[]
   topicSummary: string | null
+  /**
+   * Rolling prose summary of what the conversation covers, maintained by the
+   * boundary extractor on every pass that touches the conversation. Richer
+   * than the 2-5 word topicSummary title; null until the extractor first
+   * revisits the conversation.
+   */
+  summary: string | null
   completenessScore: number
   confidence: number
   status: ConversationStatus


### PR DESCRIPTION
## Problem

A prod audit of the long-running two-person DM (`stream_01KJMS…Y2JD`, 3,796 messages) found both halves of the conversation→memory pipeline failing, with a direct causal chain between them:

**Conversations.** 456 conversations in one stream, 277 still `active` — some untouched since March. Status transitions only happen through the LLM's `completenessUpdates`, and those can only target conversations inside the 5-before/2-after extraction window, so anything that scrolls out stays `active` forever. Scratchpads never use the LLM at all (128/128 active). Meanwhile live sessions overgrow: a 79-message conversation titled "Öland imorgon eftermiddag" ran 6 days and absorbed ~8 unrelated topics (trip plans → Claude data usage → pi-remote → model releases → Meta news), because the prompt's session rule ("minutes apart = one live exchange, prefer continuing") had no counterweight for topic pivots *inside* a live session. A 247-message March conversation is literally titled "General chat or reaction message".

**Memos.** All 16 memos created 2026-07-01 trace to that single overgrown conversation. Every new message re-arms a processed conversation (`ON CONFLICT … SET processed_at = NULL`), extraction re-ran 6× that day, and each pass re-captured the same facts reworded — "Meta verkar ha frångått Llama-namnet" ×3, "Fable 5 återlanseras med 50% weekly usage" ×2 + 1 rewording. The only guard is the 0.15-cosine dedup gate, which paraphrases sail past; supersession (`parentMemoId`, `superseded` status) existed in schema but was never written. News hot-takes were stored as "learnings" ("Remote pi är riktigt nice").

The existing boundary-extraction eval suite passed 22/22 with accuracy 1.0 against this visibly broken prod — it tested none of the real failure modes. The README listed `memo-classifier` and `memorizer` suites that did not exist.

## Solution

Evals first: extend the boundary suite with cases derived from the actual prod failure windows (paraphrased — no verbatim DM content lands in the repo), create the two missing memo suites, reproduce every failure mode against production config, then fix each with the failing cases as the bar. Four commits, in dependency order:

### 1. Live-session pivot rules + rolling conversation summaries (boundary extraction)

- **Prompt restructure** (`boundary-extraction/config.ts`): the minutes-old branch now leads with *"a session is NOT a conversation"* — recency locates the live exchange but never by itself attaches a message to it. Two explicit sub-rules: "takes the next turn" (continue; keeps the anti-fragmentation protections — ":shrug:" seconds after an exchange still doesn't become a singleton) vs "changes the subject" (new conversation even seconds later), plus a show-and-tell rule: a pasted artifact (screenshot/diff/link) wrapped in a first-person comment opens a new conversation about the artifact's subject. The merge instruction gains a counterweight: "same participants, same session, or 'both casual chat' is NOT the same topic; never fold a focused conversation into a broader or busier one."
- **`conversations.summary`** (Kris's suggestion, implemented the cheap way): a new nullable column holding a ~40-word rolling "covers:" summary **maintained by the extractor itself** — `newConversationSummary` on creation, optional `summary` per `completenessUpdates` entry on revisit. Zero extra LLM calls, output tokens only. Candidates render it as a `covers:` line in the prompt, so post-gap resume and within-session split decisions judge actual content instead of a 5-word title. The prompt also warns that a sprawling summary is evidence to split, not absorb — the failure mode where a summary would legitimize the blob. The board's card-summary want gets the same field for free.
- Migration `20260705141300_conversation_summary.sql` (additive, `IF NOT EXISTS`). Existing rows fill lazily as the extractor revisits them.

### 2. Staleness sweep (conversations)

New cron worker (`staleness-sweep-worker.ts`, every 600s): `active → stalled` after 24h idle, `active|stalled → resolved` after 7d, via one set-based `UPDATE … FROM (SELECT … FOR UPDATE SKIP LOCKED LIMIT 200)` (INV-56, INV-20) in `ConversationRepository.sweepStale`. Transitions and their `conversation:updated` outbox events commit in one transaction (INV-4/7), routed per-conversation through `resolveConversationDelivery` (INV-62). Events carry `origin: "staleness-sweep"` and the memo accumulator **skips** them — a pure status fade must not re-queue a months-old conversation for memo extraction. The 277-zombie backlog drains at ≤200/run. Scheduling is gated on `!useStubAI` so long-running e2e fixtures never fade mid-test; `SKIP LOCKED` keeps the sweep from ever blocking live extractions.

### 3. Memo eval suites + supersession + anti-gossip rules (memos)

- **`memo-classifier` suite** (9 cases): news hot-takes, model-release chatter, settled trip logistics, pure banter → not worthy; working setups, measured decisions, mixed-banter-one-fact → worthy; two revision cases (rephrased-only → no revise, genuinely-new fact → revise). Runs the production `MemoClassifier` (INV-45). Run-level `garbage-leak-rate` metric.
- **`memorizer` suite** (5 cases): selectivity (banter around one fact yields only the fact; gossip yields nothing), revision discipline (all-covered → empty set; one-new-fact → only it), procedure capture in the conversation's language. Run-level `over-capture-rate` metric. Baseline reproduced both prod failures 3/3.
- **Same-conversation supersession** (`service.ts` save transaction, under the existing per-stream advisory lock): before inserting, each candidate probes `MemoRepository.findSameConversationNear` — active memos of the *same conversation* within `MEMO_SUPERSEDE_DISTANCE = 0.35`. Matches are `markSuperseded` (status + `revisionReason`) and the new memo links to the nearest via `parentMemoId`. Effective band is (0.15, 0.35): closer than 0.15 the dedup gate already drops the candidate, keeping the old memo. Batch-mates are excluded (`excludeIds`) so two new memos can't supersede each other. This turns "re-capture reworded" from stacking into replacement.
- **Memorizer prompt**: opinions/hot-takes/news commentary never produce memos, *including recast as participant sentiment* ("they dislike X" — the loophole the model actually used); facts picked up from news/links are re-findable and go stale — no memo unless the participants acted on them; the revision prompt now treats existing memos as authoritative coverage and names the empty set as the expected common case.

### 4. Reactivation on resume (self-review finding)

The correctness review flagged that the sweep silently changed scratchpad semantics: a faded scratchpad conversation meant the next message minted a second same-named conversation, breaking the "scratchpad = one conversation, by decision" ruling (board-view-design.md). Fixed: the scratchpad path (and `assignAgentReply` for scratchpads) falls back to the most-recent conversation when none is active, and `reactivateIfResolved` became `reactivateIfInactive` (also covers `stalled`), now called on every primary assignment in the extractor's persist phase — a faded conversation gaining a message is live again. It runs before `completenessUpdates`, so an explicit resolve in the same pass still wins.

### Key design decisions

**1. The extractor maintains summaries; no summarizer flow.** A separate summarizer would add a call per conversation-touch and a new worker. The extractor already reads the window and returns per-conversation updates — the summary rides the same call. Rejected: summarize-on-close (the board wants summaries on live cards too).

**2. Sweep fades rather than judges.** The sweep is pure SQL on idle time — no AI pass over months-old content. `resolved` stays reopenable (`reactivateIfInactive` flips it back on new activity), so a wrong fade costs nothing. Thresholds (24h/7d) match the observed session grain of the failing DM; constants in `staleness-sweep-worker.ts`, not config sprawl.

**3. Supersession is surgical, not wholesale.** Rejected: "revision replaces the conversation's whole memo set" — that requires the revision prompt to re-emit unchanged topics (more tokens) and would silently kill un-emitted topics. The embedding-scoped replace keeps unchanged memos untouched and only retires what a new capture demonstrably replaces. Scoping the 0.35 cutoff to one conversation is what makes the looser threshold safe — cross-conversation dedup stays at 0.15.

**4. Real-data eval cases, paraphrased.** Cases keep the structure of the actual failure windows (timing gaps, turn-taking, Swedish code-switching, marker words like "btw") but rewrite specifics — no verbatim private messages in the repo.

**5. Tuned against 6-run tallies, not single runs.** gpt-5.4-mini at temp 0.2/0.3 is visibly stochastic; single-run green was exactly how the old suite hid the prod failures. Measured deltas below are N-run pass counts.

### Measured results (production config, gpt-5.4-mini)

| Case | Before | After |
| ---- | ------ | ----- |
| btw-pivot mid-session | fail | 6/6 |
| pasted-diff pivot | ~3/6 | 6/6 (with summaries) |
| mid-blob pivot | 4/6 | 5/6 (with summaries) |
| merge resistance | — | 6/6 |
| memorizer: revision re-capture | 0/6 | 6/6 |
| memorizer: gossip yields nothing | 0/6 | 4/6 (classifier gates it 9/9 upstream) |
| classifier suite | — | 9/9, garbage-leak-rate 0 |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260705141300_conversation_summary.sql` | Additive `summary TEXT` on conversations |
| `apps/backend/src/features/conversations/staleness-sweep-worker.ts` | Cron fade for out-of-window conversations |
| `apps/backend/src/features/conversations/staleness-sweep-worker.test.ts` | Sweep event emission unit tests |
| `apps/backend/evals/suites/memo-classifier/*` | Knowledge-worthiness suite (9 cases, garbage-leak-rate) |
| `apps/backend/evals/suites/memorizer/*` | Memo generation suite (5 cases, over-capture-rate) |

## Modified files

| File | Change |
| ---- | ------ |
| `conversations/boundary-extraction/config.ts` | Live-session pivot rules, merge caution, summaries section, `newConversationSummary` + per-update `summary` in schema |
| `conversations/boundary-extraction/llm-extractor.ts` | Renders `covers:` line; normalizes wire→internal summary fields |
| `conversations/boundary-extraction/types.ts` | `summary` on `ConversationSummary`; new result fields |
| `conversations/boundary-extraction-service.ts` | Persists summaries; scratchpad reuse-not-mint; reactivate-on-assign; agent-reply scratchpad fallback |
| `conversations/repository.ts` | `summary` plumbing; `sweepStale`; `reactivateIfResolved` → `reactivateIfInactive` (+stalled) |
| `conversations/conversation-assigner.ts`, `conversations/service.ts` | Renamed reactivation call sites |
| `conversations/index.ts` | Sweep worker exports |
| `memos/config.ts` | `MEMO_SUPERSEDE_DISTANCE`; anti-gossip/anti-news rule 4; revision-prompt coverage discipline |
| `memos/repository.ts` | `findSameConversationNear`, `markSuperseded` |
| `memos/service.ts` | Supersession in the save transaction; `parentMemoId` on wire memos |
| `memos/accumulator-outbox-handler.ts` | Skips `origin: "staleness-sweep"` events |
| `lib/outbox/repository.ts` | `origin` field on `ConversationUpdatedOutboxPayload` |
| `lib/queue/job-queue.ts`, `lib/queue/index.ts`, `server.ts` | `CONVERSATION_STALENESS_SWEEP` queue + registration + 600s schedule |
| `evals/suites/boundary-extraction/*` | 13 new cases (live pivots, merge resistance, sandwich split, gap resumes, summary variants); reassignment evaluator; message ids + conversation ownership in eval inputs |
| `packages/types/src/domain.ts` | `summary` on wire `Conversation` |
| `tests/integration/*` | `sweepStale` fade/idempotence tests; faded-scratchpad reuse test |
| 4 frontend test factories, `llm-extractor.test.ts` | `summary: null` fixture field |

## Out of scope (deliberate)

- **UI for `summary`** — board/card rendering is the board plan's item; this PR only makes the field exist and stay fresh.
- **Backfill of summaries / statuses beyond the sweep** — summaries fill lazily; the sweep drains the zombie backlog on its own schedule.
- **`--runs N` flag for the eval runner** — variance-aware tallies were done by looping the CLI; institutionalizing repeat-runs is a small framework follow-up.
- **`conversation_feedback` collection** (0 rows ever) and the dead `isGem`/`MemoTypes.MESSAGE` path in `memos/repair.ts` — separate cleanups.
- **Memo re-queue cadence** (`processed_at = NULL` re-arm on every message) — left as-is; supersession + revision discipline neutralize its failure mode, and capture promptness (INV-62 in-situ visibility) depends on it.
- **Pre-existing dedup edge** (review finding, not this diff): a changed-conclusion memo whose embedding lands within 0.15 of the outdated one is dropped by the dedup gate (negations embed close). Worth a follow-up.

## Test plan

- [x] Boundary eval suite: 33/35 full-suite (2 known-stochastic cases pass in isolation), volatile subset tallied 6× (table above)
- [x] `memo-classifier` eval: 9/9, garbage-leak-rate 0; `memorizer` eval: 6-run tally above
- [x] Backend unit: conversations 58 + memos 53 pass (incl. new supersession, sweep-emission, accumulator-skip tests)
- [x] Backend integration: 557 pass (incl. `sweepStale` fade/idempotence + faded-scratchpad reuse)
- [x] Backend e2e: 321 pass
- [x] Frontend (vitest): 53 pass across the 4 touched test files
- [x] `bun run typecheck` monorepo clean; lint + migration checks green (pre-commit)
- [x] Pre-PR review (1 correctness agent over the diff): no confirmed correctness bugs; 1 finding — sweep broke "scratchpad = one conversation" — fixed in commit 4; sweepStale SQL/locking, INV-8 event scoping, supersession lock ordering, and summary-flow guards verified clean
- [ ] Live prod verify of the sweep drain + first summary writes — needs a deploy; the 277-active count in `stream_01KJMS…Y2JD` should fall to ~0 within a few sweep cycles

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785849342&installation_id=129946197&pr_number=1187&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1187&signature=07ab20321e0b71e017cf59d32d2b70faf9983dafceb4bcf6e4ef5b7fe46f3f92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->