### PR TITLE
fix(board): card rows never hide or flicker as messages land

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -15,8 +15,7 @@ import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
 import { conversationKeys } from "@/hooks/use-conversations"
-import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
-import { RECENT_PREVIEW_CAP } from "@/stores/board-store"
+import { useBoardCardMessages, useStableReplyWindow } from "@/hooks/use-board-card-messages"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 interface BoardCardProps {
@@ -104,11 +103,16 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     staleTime: 60_000,
   })
 
+  // Collapsed cards preview an append-only window over the local rail: trailing
+  // replies at first reveal, growing (never sliding) as new ones land, so a
+  // visible reply is never evicted back under the "N more" gap.
+  const collapsedReplies = useStableReplyWindow(conversation.id, railReplies)
+
   // Expanded: the full conversation minus the opening (server backfill when the
-  // local rail is incomplete, else the rail itself). Collapsed: the trailing
+  // local rail is incomplete, else the rail itself). Collapsed: the stable
   // window of the local rail. Flat if-chain, not a nested ternary (INV-47).
   let replies: RenderableMessage[]
-  if (!expanded) replies = railReplies.slice(-RECENT_PREVIEW_CAP)
+  if (!expanded) replies = collapsedReplies
   // Prefer the server backfill only while the local rail is still incomplete;
   // once the rail catches up, fall through to it so live edits keep flowing (the
   // backfill's `data` lingers after `enabled` goes false).

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import { db, type CachedEvent } from "@/db"
+import { createDraftPanelId } from "@/contexts/panel-context"
 import type { BoardViewPost } from "./use-stable-board-view"
-import { useBoardCardMessages, __clearBoardRailRegistry } from "./use-board-card-messages"
+import {
+  useBoardCardMessages,
+  useStableReplyWindow,
+  __clearBoardRailRegistry,
+  type BoardCardMessages,
+} from "./use-board-card-messages"
+import type { RenderableMessage } from "@/components/message/message-item"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -418,5 +425,314 @@ describe("useBoardCardMessages", () => {
 
     await waitFor(() => expect(result.current.source).toBe("events"))
     expect(result.current.replies.map((m) => m.id)).toEqual(["r2"])
+  })
+})
+
+// Frame-recording stability suite: every committed render is captured, so a
+// transient regression (a projection flash, a reply blinking out for one frame)
+// fails the test even though a final `waitFor` would have settled past it.
+describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
+  function renderRecorded(initial: BoardViewPost, hostStreamType?: string) {
+    const frames: BoardCardMessages[] = []
+    const rendered = renderHook(
+      (p: BoardViewPost) => {
+        const view = useBoardCardMessages(p, hostStreamType)
+        frames.push(view)
+        return view
+      },
+      { initialProps: initial }
+    )
+    return { frames, ...rendered }
+  }
+
+  const shownBodies = (v: BoardCardMessages) => [...v.replies, ...v.pendingReplies].map((m) => m.contentMarkdown)
+
+  it("never regresses to the projection when streamIds widen over an already-live thread", async () => {
+    const THREAD = "stream_assign_churn"
+    await db.streams.put({
+      id: THREAD,
+      workspaceId: WS,
+      type: "thread",
+      parentMessageId: "m1",
+      rootStreamId: STREAM,
+      parentStreamId: STREAM,
+    } as never)
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "thread reply", 2, THREAD)])
+    const before = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      streamIds: [STREAM],
+      recentMessages: [projectionMessage("r1", THREAD)],
+    })
+    const { frames, result, rerender } = renderRecorded(before)
+    await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
+    const from = frames.length
+
+    // conversation:message_assigned lands: the thread moves from a discovered
+    // (extra) rail to a server-known (gating) one. The re-subscription must not
+    // tear the live rails down and flash the stale projection bodies.
+    rerender(
+      makePost({
+        messageIds: ["m1", "r1"],
+        openingId: "m1",
+        streamIds: [STREAM, THREAD],
+        recentMessages: [projectionMessage("r1", THREAD)],
+      })
+    )
+    await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
+
+    for (const frame of frames.slice(from)) {
+      expect(frame.source).toBe("events")
+      expect(frame.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"])
+      expect(frame.openingMessage?.contentMarkdown).toBe("the opening")
+    }
+  })
+
+  it("keeps the first reply and the opening visible through every frame of the convert-to-thread hand-off", async () => {
+    const THREAD = "stream_convert_thread"
+    const PANEL = createDraftPanelId(STREAM, "m1")
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM)])
+    const lone = makePost({ messageIds: ["m1"], openingId: "m1", streamIds: [STREAM] })
+    const { frames, result, rerender } = renderRecorded(lone, "channel")
+    await waitFor(() => expect(result.current.source).toBe("events"))
+
+    // 1) The viewer's optimistic convert reply, tagged, under the draft panel.
+    await db.events.put({
+      id: "temp_c",
+      workspaceId: WS,
+      streamId: PANEL,
+      sequence: "1700000000001",
+      _sequenceNum: 1700000000001,
+      eventType: "message_created",
+      payload: { messageId: "temp_c", contentMarkdown: "my convert reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+    await waitFor(() => expect(shownBodies(result.current)).toEqual(["my convert reply"]))
+    const from = frames.length
+
+    // 2) Promotion: the real thread stream exists; the optimistic event moves from
+    //    the draft panel onto it (use-message-queue promoteDraft).
+    await db.streams.put({
+      id: THREAD,
+      workspaceId: WS,
+      type: "thread",
+      parentMessageId: "m1",
+      rootStreamId: STREAM,
+      parentStreamId: STREAM,
+    } as never)
+    const optimistic = await db.events.get("temp_c")
+    await db.events.put({ ...optimistic!, streamId: THREAD })
+    await waitFor(() => expect(shownBodies(result.current)).toEqual(["my convert reply"]))
+
+    // 3) Server echo (stream-sync swap): real event replaces the optimistic one in
+    //    one transaction, tag carried forward.
+    await db.transaction("rw", db.events, async () => {
+      await db.events.put({
+        id: "msg_real_c",
+        workspaceId: WS,
+        streamId: THREAD,
+        sequence: "2",
+        _sequenceNum: 2,
+        eventType: "message_created",
+        payload: {
+          messageId: "msg_real_c",
+          contentMarkdown: "my convert reply",
+          reactions: {},
+          conversationId: "conv_1",
+        },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: new Date(4).toISOString(),
+        _cachedAt: 4,
+      } as CachedEvent)
+      await db.events.delete("temp_c")
+    })
+    await waitFor(() =>
+      expect([...result.current.replies, ...result.current.pendingReplies].map((m) => m.id)).toEqual(["msg_real_c"])
+    )
+
+    // 4) conversation:updated widens messageIds (drops the draft panel from the
+    //    card's watched set) …
+    rerender(makePost({ messageIds: ["m1", "msg_real_c"], openingId: "m1", streamIds: [STREAM] }))
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["msg_real_c"]))
+
+    // 5) … then conversation:message_assigned widens streamIds over the thread.
+    rerender(makePost({ messageIds: ["m1", "msg_real_c"], openingId: "m1", streamIds: [STREAM, THREAD] }))
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["msg_real_c"]))
+
+    // The reply body renders in EVERY frame (exactly once — no double-render at
+    // the echo hand-off), and the opening never flashes back to the projection.
+    for (const frame of frames.slice(from)) {
+      expect(frame.source).toBe("events")
+      expect(shownBodies(frame)).toEqual(["my convert reply"])
+      expect(frame.openingMessage?.contentMarkdown).toBe("the opening")
+    }
+  })
+
+  it("shows no phantom '1 more' gap when conversation:updated beats the message echo", async () => {
+    // Live-observed order (dev repro): the server's conversation aggregate lands
+    // BEFORE the echo swaps the optimistic row, so messageIds lists a real id the
+    // rail hasn't seen while the same message is still on screen under its client
+    // id. The card must not count that id as a hidden message above the very
+    // reply it refers to.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM)])
+    const lone = makePost({ messageIds: ["m1"], openingId: "m1", streamIds: [STREAM] })
+    const { frames, result, rerender } = renderRecorded(lone, "channel")
+    await waitFor(() => expect(result.current.source).toBe("events"))
+
+    await db.events.put({
+      id: "temp_p",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "1700000000002",
+      _sequenceNum: 1700000000002,
+      eventType: "message_created",
+      payload: { messageId: "temp_p", contentMarkdown: "my racing reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+    await waitFor(() => expect(shownBodies(result.current)).toEqual(["my racing reply"]))
+    const from = frames.length
+
+    // conversation:updated first: the real id joins messageIds, echo not yet in.
+    rerender(makePost({ messageIds: ["m1", "msg_real_p"], openingId: "m1", streamIds: [STREAM] }))
+    await waitFor(() => expect(shownBodies(result.current)).toEqual(["my racing reply"]))
+
+    // Echo swap second.
+    await db.transaction("rw", db.events, async () => {
+      await db.events.put({
+        id: "msg_real_p",
+        workspaceId: WS,
+        streamId: STREAM,
+        sequence: "2",
+        _sequenceNum: 2,
+        eventType: "message_created",
+        payload: {
+          messageId: "msg_real_p",
+          contentMarkdown: "my racing reply",
+          reactions: {},
+          conversationId: "conv_1",
+        },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: new Date(4).toISOString(),
+        _cachedAt: 4,
+      } as CachedEvent)
+      await db.events.delete("temp_p")
+    })
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["msg_real_p"]))
+
+    // In every frame: the reply renders exactly once, and nothing reads as hidden
+    // (a phantom gap would be totalReplies exceeding the rendered reply rows).
+    for (const frame of frames.slice(from)) {
+      expect(shownBodies(frame)).toEqual(["my racing reply"])
+      expect(Math.max(0, frame.totalReplies - frame.replies.length)).toBe(0)
+    }
+  })
+
+  it("holds the last live view (not the projection) while a brand-new gating rail loads", async () => {
+    const THREAD = "stream_fresh_gating"
+    // The thread's reply is synced, but the thread is NOT discoverable from
+    // db.streams (no stream row yet) — the card learns of it only when streamIds
+    // widen, so the widened set brings in a never-before-subscribed gating rail.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "thread reply", 2, THREAD)])
+    const before = makePost({
+      messageIds: ["m1", "r1"],
+      openingId: "m1",
+      streamIds: [STREAM],
+      recentMessages: [projectionMessage("r1", THREAD)],
+    })
+    const { frames, result, rerender } = renderRecorded(before)
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    const from = frames.length
+
+    rerender(
+      makePost({
+        messageIds: ["m1", "r1"],
+        openingId: "m1",
+        streamIds: [STREAM, THREAD],
+        recentMessages: [projectionMessage("r1", THREAD)],
+      })
+    )
+    await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
+
+    // While the fresh thread rail resolves, the card must keep its live view —
+    // the opening body must never flash back to the stale projection copy.
+    for (const frame of frames.slice(from)) {
+      expect(frame.source).toBe("events")
+      expect(frame.openingMessage?.contentMarkdown).toBe("the opening")
+    }
+  })
+})
+
+describe("useStableReplyWindow", () => {
+  function reply(id: string): RenderableMessage {
+    return {
+      id,
+      streamId: STREAM,
+      authorId: "usr_1",
+      authorType: "user",
+      contentMarkdown: id,
+      reactions: {},
+      createdAt: new Date(0).toISOString(),
+      editedAt: null,
+    } as RenderableMessage
+  }
+  const ids = (messages: RenderableMessage[]) => messages.map((m) => m.id)
+
+  function renderWindow(convId: string, replies: RenderableMessage[]) {
+    return renderHook(
+      (p: { convId: string; replies: RenderableMessage[] }) => useStableReplyWindow(p.convId, p.replies),
+      {
+        initialProps: { convId, replies },
+      }
+    )
+  }
+
+  it("previews the trailing cap at first reveal", () => {
+    const { result } = renderWindow("conv_1", ["r1", "r2", "r3", "r4", "r5"].map(reply))
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+  })
+
+  it("grows on a new arrival instead of evicting the oldest visible reply", () => {
+    const { result, rerender } = renderWindow("conv_1", ["r1", "r2", "r3", "r4", "r5"].map(reply))
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+
+    rerender({ convId: "conv_1", replies: ["r1", "r2", "r3", "r4", "r5", "r6"].map(reply) })
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5", "r6"])
+
+    rerender({ convId: "conv_1", replies: ["r1", "r2", "r3", "r4", "r5", "r6", "r7"].map(reply) })
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5", "r6", "r7"])
+  })
+
+  it("re-anchors on the oldest surviving shown reply when the anchor is deleted", () => {
+    const { result, rerender } = renderWindow("conv_1", ["r1", "r2", "r3", "r4", "r5"].map(reply))
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+
+    rerender({ convId: "conv_1", replies: ["r1", "r2", "r4", "r5"].map(reply) })
+    expect(ids(result.current)).toEqual(["r4", "r5"])
+  })
+
+  it("keeps a late-syncing older reply under the gap instead of pushing shown rows down", () => {
+    const { result, rerender } = renderWindow("conv_1", ["r3", "r4", "r5"].map(reply))
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+
+    rerender({ convId: "conv_1", replies: ["r2", "r3", "r4", "r5"].map(reply) })
+    expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+  })
+
+  it("resets the shown window when recycled onto another conversation", () => {
+    const { result, rerender } = renderWindow("conv_1", ["r1", "r2", "r3", "r4"].map(reply))
+    expect(ids(result.current)).toEqual(["r2", "r3", "r4"])
+
+    rerender({ convId: "conv_2", replies: ["x1", "x2", "x3", "x4"].map(reply) })
+    expect(ids(result.current)).toEqual(["x2", "x3", "x4"])
   })
 })

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { renderHook, waitFor } from "@testing-library/react"
 import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
@@ -7,6 +7,7 @@ import {
   useBoardCardMessages,
   useStableReplyWindow,
   __clearBoardRailRegistry,
+  __boardRailRegistrySize,
   type BoardCardMessages,
 } from "./use-board-card-messages"
 import type { RenderableMessage } from "@/components/message/message-item"
@@ -458,12 +459,11 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
       parentStreamId: STREAM,
     } as never)
     await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "thread reply", 2, THREAD)])
-    const before = makePost({
-      messageIds: ["m1", "r1"],
-      openingId: "m1",
-      streamIds: [STREAM],
-      recentMessages: [projectionMessage("r1", THREAD)],
-    })
+    // No recentMessages naming THREAD: the thread must enter via db.streams
+    // discovery (an EXTRA rail) so the widen below genuinely moves it into the
+    // gating set and re-subscribes — a preview row would make it gating from the
+    // first render and the test would never exercise the churn.
+    const before = makePost({ messageIds: ["m1", "r1"], openingId: "m1", streamIds: [STREAM] })
     const { frames, result, rerender } = renderRecorded(before)
     await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
     const from = frames.length
@@ -471,14 +471,7 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
     // conversation:message_assigned lands: the thread moves from a discovered
     // (extra) rail to a server-known (gating) one. The re-subscription must not
     // tear the live rails down and flash the stale projection bodies.
-    rerender(
-      makePost({
-        messageIds: ["m1", "r1"],
-        openingId: "m1",
-        streamIds: [STREAM, THREAD],
-        recentMessages: [projectionMessage("r1", THREAD)],
-      })
-    )
+    rerender(makePost({ messageIds: ["m1", "r1"], openingId: "m1", streamIds: [STREAM, THREAD] }))
     await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
 
     for (const frame of frames.slice(from)) {
@@ -698,30 +691,43 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
     }
   })
 
+  it("tears a drained rail down once the grace elapses (no subscription leak)", async () => {
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1)])
+    const post = makePost({ messageIds: ["m1"], openingId: "m1" })
+    const { result, unmount } = renderHook(() => useBoardCardMessages(post))
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect(__boardRailRegistrySize()).toBeGreaterThan(0)
+
+    // Fake timers only around the unmount so the teardown setTimeout is
+    // controllable; the async rail setup above ran under real timers.
+    vi.useFakeTimers()
+    try {
+      unmount()
+      // The grace holds the rail briefly after the last subscriber leaves…
+      expect(__boardRailRegistrySize()).toBeGreaterThan(0)
+      // …and the deadline actually drains it (the leak half of the contract).
+      vi.advanceTimersByTime(60_000)
+      expect(__boardRailRegistrySize()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("holds the last live view (not the projection) while a brand-new gating rail loads", async () => {
     const THREAD = "stream_fresh_gating"
     // The thread's reply is synced, but the thread is NOT discoverable from
     // db.streams (no stream row yet) — the card learns of it only when streamIds
     // widen, so the widened set brings in a never-before-subscribed gating rail.
     await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM), msgEvent("r1", "thread reply", 2, THREAD)])
-    const before = makePost({
-      messageIds: ["m1", "r1"],
-      openingId: "m1",
-      streamIds: [STREAM],
-      recentMessages: [projectionMessage("r1", THREAD)],
-    })
+    // No recentMessages naming THREAD (that would gate it from the first render
+    // and defeat the widen): the card knows nothing of the thread until the
+    // rerender introduces it as a brand-new, never-subscribed gating rail.
+    const before = makePost({ messageIds: ["m1", "r1"], openingId: "m1", streamIds: [STREAM] })
     const { frames, result, rerender } = renderRecorded(before)
     await waitFor(() => expect(result.current.source).toBe("events"))
     const from = frames.length
 
-    rerender(
-      makePost({
-        messageIds: ["m1", "r1"],
-        openingId: "m1",
-        streamIds: [STREAM, THREAD],
-        recentMessages: [projectionMessage("r1", THREAD)],
-      })
-    )
+    rerender(makePost({ messageIds: ["m1", "r1"], openingId: "m1", streamIds: [STREAM, THREAD] }))
     await waitFor(() => expect(result.current.replies.map((m) => m.contentMarkdown)).toEqual(["thread reply"]))
 
     // While the fresh thread rail resolves, the card must keep its live view —
@@ -787,6 +793,17 @@ describe("useStableReplyWindow", () => {
 
     rerender({ convId: "conv_1", replies: ["r2", "r3", "r4", "r5"].map(reply) })
     expect(ids(result.current)).toEqual(["r3", "r4", "r5"])
+  })
+
+  it("keeps a late-syncing mid-window reply under the gap instead of inserting between shown rows", () => {
+    const { result, rerender } = renderWindow("conv_1", ["r3", "r5", "r6"].map(reply))
+    expect(ids(result.current)).toEqual(["r3", "r5", "r6"])
+
+    // r4 syncs late, landing BETWEEN shown rows — revealing it would push r5/r6
+    // down. It stays under the "N more" gap; only rows after the last shown
+    // reply may append.
+    rerender({ convId: "conv_1", replies: ["r3", "r4", "r5", "r6"].map(reply) })
+    expect(ids(result.current)).toEqual(["r3", "r5", "r6"])
   })
 
   it("resets the shown window when recycled onto another conversation", () => {

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -637,6 +637,67 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
     }
   })
 
+  it("keeps counting unsynced older history while a send is in flight (discount only covers episode arrivals)", async () => {
+    // The conversation has a real reply the device never synced (r_old): the card
+    // honestly shows "1 more". Sending a new reply must NOT discount r_old — only
+    // an id that JOINS messageIds during the pending episode can be the pending
+    // row's server identity.
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM)])
+    const before = makePost({ messageIds: ["m1", "r_old"], openingId: "m1", streamIds: [STREAM] })
+    const { frames, result, rerender } = renderRecorded(before, "channel")
+    await waitFor(() => expect(result.current.source).toBe("events"))
+    expect(result.current.totalReplies).toBe(1)
+    const from = frames.length
+
+    // Viewer sends: optimistic pending row appears (tagged, not in messageIds).
+    await db.events.put({
+      id: "temp_q",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "1700000000003",
+      _sequenceNum: 1700000000003,
+      eventType: "message_created",
+      payload: { messageId: "temp_q", contentMarkdown: "my new reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(5).toISOString(),
+      _cachedAt: 5,
+      _status: "pending",
+    } as CachedEvent)
+    await waitFor(() => expect(result.current.pendingReplies.map((m) => m.id)).toEqual(["temp_q"]))
+
+    // conversation:updated for the new reply (echo race): its real id joins
+    // messageIds while the rail hasn't seen it.
+    rerender(makePost({ messageIds: ["m1", "r_old", "msg_new_q"], openingId: "m1", streamIds: [STREAM] }))
+    await waitFor(() => expect([...result.current.replies, ...result.current.pendingReplies].length).toBeGreaterThan(0))
+
+    // Echo swap.
+    await db.transaction("rw", db.events, async () => {
+      await db.events.put({
+        id: "msg_new_q",
+        workspaceId: WS,
+        streamId: STREAM,
+        sequence: "2",
+        _sequenceNum: 2,
+        eventType: "message_created",
+        payload: { messageId: "msg_new_q", contentMarkdown: "my new reply", reactions: {}, conversationId: "conv_1" },
+        actorId: "usr_1",
+        actorType: "user",
+        createdAt: new Date(6).toISOString(),
+        _cachedAt: 6,
+      } as CachedEvent)
+      await db.events.delete("temp_q")
+    })
+    await waitFor(() => expect(result.current.replies.map((m) => m.id)).toEqual(["msg_new_q"]))
+
+    // In every frame the unsynced older reply keeps its honest "1 more" slot:
+    // total minus rendered replies is exactly 1 (r_old) — the in-flight send
+    // never zeroes it out, and the new id never double-counts.
+    for (const frame of frames.slice(from)) {
+      expect(Math.max(0, frame.totalReplies - frame.replies.length)).toBe(1)
+    }
+  })
+
   it("holds the last live view (not the projection) while a brand-new gating rail loads", async () => {
     const THREAD = "stream_fresh_gating"
     // The thread's reply is synced, but the thread is NOT discoverable from

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -344,6 +344,13 @@ function useChildThreadStreamIds(workspaceId: string, parentMessageIds: string[]
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
+/** How many stream rails the registry currently holds — for tests, to prove a
+ *  drained rail is actually torn down once its grace elapses (the leak half of
+ *  the grace-teardown contract). */
+export function __boardRailRegistrySize(): number {
+  return railRegistry.size
+}
+
 /** Tear down every shared stream subscription — for tests, so a module-level
  *  registry can't leak a liveQuery (or a snapshot) across cases. */
 export function __clearBoardRailRegistry(): void {
@@ -610,10 +617,11 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
  * sliding it, so a reply the viewer has seen never drops back under the "N
  * more" gap and rows never move under the eye (INV-61's no-motion rule,
  * extended inside the card). A deleted reply still leaves (a real removal, not
- * instability); the window re-anchors on its oldest surviving shown reply. An
- * older reply that syncs in late stays under the gap — revealing it would push
- * every shown row down. The shown set resets when the hook instance is recycled
- * onto another conversation.
+ * instability). A reply that syncs in late — older than the first shown row OR
+ * landing between shown rows — stays under the gap: revealing it would push
+ * shown rows around, so only rows strictly after the last shown reply append.
+ * The shown set resets when the hook instance is recycled onto another
+ * conversation.
  */
 export function useStableReplyWindow(conversationId: string, replies: RenderableMessage[]): RenderableMessage[] {
   const shownRef = useRef<{ conversationId: string; ids: Set<string> }>({ conversationId, ids: new Set() })
@@ -621,8 +629,11 @@ export function useStableReplyWindow(conversationId: string, replies: Renderable
   const window = useMemo(() => {
     const shown = shownRef.current.conversationId === conversationId ? shownRef.current.ids : null
     if (shown) {
-      const anchor = replies.findIndex((message) => shown.has(message.id))
-      if (anchor !== -1) return replies.slice(anchor)
+      let lastShownIndex = -1
+      for (let i = 0; i < replies.length; i++) if (shown.has(replies[i].id)) lastShownIndex = i
+      if (lastShownIndex !== -1) {
+        return replies.filter((message, index) => shown.has(message.id) || index > lastShownIndex)
+      }
     }
     return replies.slice(-RECENT_PREVIEW_CAP)
   }, [conversationId, replies])

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "r
 import { liveQuery, type Subscription } from "dexie"
 import { db, type CachedEvent } from "@/db"
 import { createDraftPanelId } from "@/contexts/panel-context"
+import { RECENT_PREVIEW_CAP } from "@/stores/board-store"
 import type { RenderableMessage } from "@/components/message/message-item"
 import { StreamTypes, type AuthorType } from "@threa/types"
 import type { BoardViewPost } from "./use-stable-board-view"
@@ -98,7 +99,22 @@ interface StreamRailEntry {
   listeners: Set<() => void>
   subscription: Subscription
   refCount: number
+  /** Pending grace-period teardown, armed when the last subscriber leaves. */
+  teardown: ReturnType<typeof setTimeout> | null
 }
+
+/**
+ * How long a rail outlives its last subscriber. A card's stream-id set changes
+ * in place as its conversation grows (a thread is discovered, the draft panel
+ * drops once messageIds widen, `message_assigned` moves the thread into the
+ * gating set), and `useSyncExternalStore` re-subscribes by tearing the old
+ * subscription down before attaching the new one — an immediate teardown would
+ * destroy every rail at each of those steps and recreate them unresolved,
+ * flashing the card back to its stale projection while the fresh liveQueries
+ * run their first read. The grace keeps the rail (and its resolved data) alive
+ * across the swap; a genuinely abandoned rail still drains when the timer fires.
+ */
+const RAIL_TEARDOWN_GRACE_MS = 5000
 
 // INV-9 exception: one shared Dexie subscription per stream, ref-counted across
 // every board card in that stream. The board is workspace-wide and renders many
@@ -118,6 +134,7 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
       listeners: new Set(),
       refCount: 0,
       subscription: { unsubscribe() {} } as Subscription,
+      teardown: null,
     }
     // Register BEFORE subscribing so `getSnapshot` (and any synchronous first
     // emission) observes the entry consistently; the callback re-reads the live
@@ -133,6 +150,10 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
     })
     entry = created
   }
+  if (entry.teardown) {
+    clearTimeout(entry.teardown)
+    entry.teardown = null
+  }
   entry.listeners.add(listener)
   entry.refCount += 1
   return () => {
@@ -140,11 +161,23 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
     if (!current) return
     current.listeners.delete(listener)
     current.refCount -= 1
-    if (current.refCount <= 0) {
-      current.subscription.unsubscribe()
-      railRegistry.delete(streamId)
+    if (current.refCount <= 0 && !current.teardown) {
+      current.teardown = setTimeout(() => {
+        const live = railRegistry.get(streamId)
+        if (!live || live.refCount > 0) return
+        live.subscription.unsubscribe()
+        railRegistry.delete(streamId)
+      }, RAIL_TEARDOWN_GRACE_MS)
     }
   }
+}
+
+/** A card's merged view over its rails. `resolved` gates the projection fallback
+ *  (gating rails only); `allResolved` is false while ANY rail — including a
+ *  discovered thread or the draft panel — is mid-load, the window where a row the
+ *  card was showing can transiently sit in a rail that hasn't read yet. */
+interface MergedRail extends StreamRail {
+  allResolved: boolean
 }
 
 /** Union several stream rails into one. A conversation can span its root + the
@@ -154,8 +187,8 @@ function subscribeStreamRail(streamId: string, listener: () => void): () => void
  *  opportunistically-discovered threads (and the optimistic draft panel) that
  *  CONTRIBUTE content but must not drag the card back to its projection while they
  *  load — otherwise discovering a new thread re-flashes an already-live card. */
-function mergeRails(rails: StreamRail[], gatingCount: number): StreamRail {
-  if (rails.length === 1) return rails[0]
+function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
+  if (rails.length === 1) return { ...rails[0], allResolved: rails[0].resolved }
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
@@ -163,8 +196,12 @@ function mergeRails(rails: StreamRail[], gatingCount: number): StreamRail {
   // doesn't count, so the card keeps its live view instead of dropping to the
   // projection the instant a thread appears.
   let resolved = true
+  let allResolved = true
   rails.forEach((rail, i) => {
-    if (i < gatingCount && !rail.resolved) resolved = false
+    if (!rail.resolved) {
+      allResolved = false
+      if (i < gatingCount) resolved = false
+    }
     for (const [id, message] of rail.messages) messages.set(id, message)
     for (const id of rail.seen) seen.add(id)
     for (const [conversationId, list] of rail.taggedByConversation) {
@@ -176,7 +213,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): StreamRail {
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, taggedByConversation, resolved }
+  return { messages, seen, taggedByConversation, resolved, allResolved }
 }
 
 /**
@@ -189,13 +226,13 @@ function mergeRails(rails: StreamRail[], gatingCount: number): StreamRail {
  * references changes — `useSyncExternalStore` requires a stable snapshot, so
  * re-merging on every read would loop.
  */
-function useMergedStreamRail(gatingStreamIds: string[], extraStreamIds: string[]): StreamRail {
+function useMergedStreamRail(gatingStreamIds: string[], extraStreamIds: string[]): MergedRail {
   const gatingCount = gatingStreamIds.length
   const gatingKey = gatingStreamIds.join(",")
   const extraKey = extraStreamIds.join(",")
   const streamIds = useMemo(() => [...gatingStreamIds, ...extraStreamIds], [gatingKey, extraKey])
   const key = gatingKey + "|" + extraKey
-  const cacheRef = useRef<{ inputs: StreamRail[]; merged: StreamRail } | null>(null)
+  const cacheRef = useRef<{ inputs: StreamRail[]; merged: MergedRail } | null>(null)
 
   const subscribe = useCallback(
     (onChange: () => void) => {
@@ -310,7 +347,10 @@ function useChildThreadStreamIds(workspaceId: string, parentMessageIds: string[]
 /** Tear down every shared stream subscription — for tests, so a module-level
  *  registry can't leak a liveQuery (or a snapshot) across cases. */
 export function __clearBoardRailRegistry(): void {
-  for (const entry of railRegistry.values()) entry.subscription.unsubscribe()
+  for (const entry of railRegistry.values()) {
+    if (entry.teardown) clearTimeout(entry.teardown)
+    entry.subscription.unsubscribe()
+  }
   railRegistry.clear()
   for (const entry of threadIndexRegistry.values()) entry.subscription.unsubscribe()
   threadIndexRegistry.clear()
@@ -340,6 +380,8 @@ export interface BoardCardMessages {
 }
 
 const NO_PENDING: RenderableMessage[] = []
+
+type BoardCardView = BoardCardMessages & { nextRetained: RenderableMessage[] }
 
 /**
  * A board card's messages, read OFFLINE-FIRST from the same `db.events` store the
@@ -421,12 +463,29 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   // would blink out / collapse under "1 more". Holding the last-shown copy bridges
   // that window until the real row renders.
   const retainedPendingRef = useRef<RenderableMessage[]>(NO_PENDING)
+  // The last events-sourced view, held so an unresolved-rails beat re-renders
+  // exactly what was on screen instead of a shrunken derivation or the stale
+  // projection. The merged rail passes through `allResolved: false` whenever a
+  // rail is mid-first-read — the card's stream-id set changed (re-subscription),
+  // a thread was just discovered, or `message_assigned` named a fresh gating
+  // stream — all transient. A genuine cold read (rails resolved, ids unseen)
+  // still falls through to the projection.
+  const lastLiveRef = useRef<{ conversationId: string; view: BoardCardView } | null>(null)
 
   const view = useMemo(() => {
     // The retained copy is read here but written only after commit (the effect
     // below) — mutating a ref during render is unsafe under concurrent rendering,
     // where a discarded render could clear the bridge before it paints.
     const retained = retainedPendingRef.current
+
+    // Any rail mid-load — a re-subscription after the card's stream-id set
+    // changed, or a just-discovered thread running its first read — is a window
+    // where a row this card was showing can be absent from every readable rail.
+    // Hold the last live view perfectly still for that beat instead of
+    // re-deriving a shrunken one or flashing the projection (INV-61's no-motion
+    // rule, inside the card).
+    const lastLive = lastLiveRef.current
+    if (!rail.allResolved && lastLive?.conversationId === conversationId) return lastLive.view
 
     // Replies for this conversation the card knows from the rail but the server
     // `messageIds` doesn't list yet — the optimistic row, and the swapped real
@@ -492,7 +551,24 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     // below what's already on screen (a bridged reply fills its own slot, so it
     // mustn't also leave a phantom "1 more").
     const fullySynced = replyIds.every((id) => rail.seen.has(id))
-    const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal, replies.length)
+    // `conversation:updated` can land BEFORE the message echo swaps the optimistic
+    // row: `messageIds` then lists a real id the rail hasn't seen while the same
+    // message is still on screen as a pending row under its client id. Counting
+    // that id into the total would pop a phantom "1 more" gap above the very reply
+    // it refers to (and flip the run's continuation grouping) for the beat until
+    // the echo lands. Discount unsynced ids at the TAIL of `replyIds` (in-flight /
+    // just-arrived appends) up to the pending rows standing in for them; unsynced
+    // ids BEFORE the last synced one are genuinely-missing older history and keep
+    // counting toward the gap.
+    let lastSyncedIdx = -1
+    for (let i = replyIds.length - 1; i >= 0; i--) {
+      if (rail.seen.has(replyIds[i])) {
+        lastSyncedIdx = i
+        break
+      }
+    }
+    const coveredTail = Math.min(pendingReplies.length, replyIds.length - 1 - lastSyncedIdx)
+    const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal - coveredTail, replies.length)
 
     // Retain a fresh pending row; keep the retained copy while it's still bridging;
     // forget it once the live rows cover it.
@@ -507,7 +583,44 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   // Commit the bridge bookkeeping after render, never during it.
   useEffect(() => {
     retainedPendingRef.current = view.nextRetained
-  }, [view])
+    if (view.source === "events") lastLiveRef.current = { conversationId, view }
+  }, [view, conversationId])
 
   return view
+}
+
+/**
+ * The collapsed card's reply window: the trailing `RECENT_PREVIEW_CAP` replies
+ * at first reveal, then append-only. A new arrival GROWS the window instead of
+ * sliding it, so a reply the viewer has seen never drops back under the "N
+ * more" gap and rows never move under the eye (INV-61's no-motion rule,
+ * extended inside the card). A deleted reply still leaves (a real removal, not
+ * instability); the window re-anchors on its oldest surviving shown reply. An
+ * older reply that syncs in late stays under the gap — revealing it would push
+ * every shown row down. The shown set resets when the hook instance is recycled
+ * onto another conversation.
+ */
+export function useStableReplyWindow(conversationId: string, replies: RenderableMessage[]): RenderableMessage[] {
+  const shownRef = useRef<{ conversationId: string; ids: Set<string> }>({ conversationId, ids: new Set() })
+
+  const window = useMemo(() => {
+    const shown = shownRef.current.conversationId === conversationId ? shownRef.current.ids : null
+    if (shown) {
+      const anchor = replies.findIndex((message) => shown.has(message.id))
+      if (anchor !== -1) return replies.slice(anchor)
+    }
+    return replies.slice(-RECENT_PREVIEW_CAP)
+  }, [conversationId, replies])
+
+  // Record what's shown after commit, never during render (concurrent-safe,
+  // same discipline as the pending-reply bridge above).
+  useEffect(() => {
+    if (shownRef.current.conversationId !== conversationId) {
+      shownRef.current = { conversationId, ids: new Set(window.map((message) => message.id)) }
+      return
+    }
+    for (const message of window) shownRef.current.ids.add(message.id)
+  }, [conversationId, window])
+
+  return window
 }

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -471,6 +471,13 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   // stream — all transient. A genuine cold read (rails resolved, ids unseen)
   // still falls through to the projection.
   const lastLiveRef = useRef<{ conversationId: string; view: BoardCardView } | null>(null)
+  // The reply ids the conversation already listed when the current in-flight
+  // send began. Only an id that JOINS `messageIds` during the episode can be the
+  // pending row's server-side identity (the echo race the phantom-gap discount
+  // below covers); an id already listed before the send is unsynced older
+  // history and must keep counting toward the "N more" gap. Snapshot on the
+  // pending 0→N transition, cleared when the episode drains.
+  const pendingEpisodeRef = useRef<{ conversationId: string; baseline: Set<string> } | null>(null)
 
   const view = useMemo(() => {
     // The retained copy is read here but written only after commit (the effect
@@ -556,19 +563,17 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     // message is still on screen as a pending row under its client id. Counting
     // that id into the total would pop a phantom "1 more" gap above the very reply
     // it refers to (and flip the run's continuation grouping) for the beat until
-    // the echo lands. Discount unsynced ids at the TAIL of `replyIds` (in-flight /
-    // just-arrived appends) up to the pending rows standing in for them; unsynced
-    // ids BEFORE the last synced one are genuinely-missing older history and keep
-    // counting toward the gap.
-    let lastSyncedIdx = -1
-    for (let i = replyIds.length - 1; i >= 0; i--) {
-      if (rail.seen.has(replyIds[i])) {
-        lastSyncedIdx = i
-        break
-      }
-    }
-    const coveredTail = Math.min(pendingReplies.length, replyIds.length - 1 - lastSyncedIdx)
-    const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal - coveredTail, replies.length)
+    // the echo lands. Discount unseen ids that JOINED `replyIds` during the
+    // current pending episode (they can only be in-flight sends or simultaneous
+    // arrivals the pending rows visually stand in for), up to the pending row
+    // count; ids already listed when the episode began are unsynced older history
+    // and keep counting toward the gap.
+    const episode = pendingEpisodeRef.current
+    const baseline = episode && episode.conversationId === conversationId ? episode.baseline : null
+    let episodeArrivals = 0
+    if (baseline) for (const id of replyIds) if (!rail.seen.has(id) && !baseline.has(id)) episodeArrivals++
+    const covered = Math.min(pendingReplies.length, episodeArrivals)
+    const totalReplies = fullySynced ? liveReplies.length : Math.max(serverTotal - covered, replies.length)
 
     // Retain a fresh pending row; keep the retained copy while it's still bridging;
     // forget it once the live rows cover it.
@@ -584,7 +589,17 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   useEffect(() => {
     retainedPendingRef.current = view.nextRetained
     if (view.source === "events") lastLiveRef.current = { conversationId, view }
-  }, [view, conversationId])
+    if (view.pendingReplies.length > 0) {
+      const episode = pendingEpisodeRef.current
+      // Snapshot only on the 0→N transition — re-snapshotting mid-episode would
+      // fold the send's just-arrived id into the baseline and kill its discount.
+      if (!episode || episode.conversationId !== conversationId) {
+        pendingEpisodeRef.current = { conversationId, baseline: new Set(replyIds) }
+      }
+    } else {
+      pendingEpisodeRef.current = null
+    }
+  }, [view, conversationId, replyIds])
 
   return view
 }


### PR DESCRIPTION
## Problem

A message visible on a board card could become hidden, and card content flickered as messages landed — worst when the first reply arrived on a lone channel post (the convert-to-thread shape). Four distinct mechanics, all in the card's message engine:

1. **Rail-registry churn.** `useBoardCardMessages` reads messages from shared per-stream Dexie liveQuery rails (`railRegistry` in `use-board-card-messages.ts`). A card's stream-id set changes in place as its conversation grows — the thread is discovered in `db.streams`, the draft panel drops when `messageIds` goes 1→2, `conversation:message_assigned` moves the thread from the extra to the gating set. Each change makes `useSyncExternalStore` re-subscribe by tearing the old subscription down *before* attaching the new one; for the sole subscribing card that dropped every rail's refCount to 0, deleted the registry entries, and recreated them as unresolved `LOADING_RAIL` — flipping `conversationSeen` false and regressing the card to the stale server projection until the fresh liveQueries finished their first IDB read. One convert-to-thread reply churns the set three times; each churn was a visible flash of stale bodies.
2. **No latch for mid-load rails.** Even without churn, a brand-new gating rail (`message_assigned` naming a thread whose rail never read) or a lagging extra rail could momentarily hide a row that had already graduated to confirmed — the `retainedPendingRef` bridge only covers *pending* rows, and it forgets a reply once live rows cover it.
3. **Recency-cap slide.** The collapsed card sliced `railReplies.slice(-RECENT_PREVIEW_CAP)` live (`board-card.tsx`), so a new arrival slid the trailing-3 window: the oldest visible reply dropped back under a growing "N more" gap — a visible message becoming hidden, with the rows regrouping under the eye.
4. **Phantom "1 more" gap (found in live verify).** On the real server `conversation:updated` lands *before* the message echo, so for a beat `messageIds` lists a real id the local rail hasn't seen while the same message is still on screen as a pending row under its client id. `totalReplies` counted that id as hidden → a "⌄ 1 more message" gap popped above the very reply it referred to (breaking the run's continuation grouping), then collapsed when the echo swapped the row. This is exactly the flicker dogfooding reported; jsdom tests missed it because fake-indexeddb resolves within the same microtask flush.

## Solution

Extend INV-61's no-motion rule *inside* the card: rows that were shown stay shown, loading beats re-render exactly what was last on screen, and counts never claim a displayed message as hidden.

### How it works

1. **Grace-period rail teardown** (`RAIL_TEARDOWN_GRACE_MS = 5000`): when a rail's refCount hits 0 the teardown is scheduled, not executed; a re-subscription within the grace cancels it. The unsubscribe→resubscribe swap now reuses the live entry with its resolved data, so churn produces no unresolved beat at all. A genuinely abandoned rail still drains when the timer fires; `__clearBoardRailRegistry` clears pending timers for tests.
2. **Last-live-view latch**: `mergeRails` now returns `MergedRail` with `allResolved` — false while *any* rail (gating or extra) is mid-first-read. In that window the hook returns the previously committed events-sourced view verbatim (`lastLiveRef`, written post-commit, keyed by conversation id) — frozen for the beat instead of a shrunken derivation or the projection. A genuine cold read (rails resolved, ids unseen) still falls through to the projection. Either mechanism alone passes the frame suite (verified by disabling each in turn); together they cover real-browser IDB latency, which is far worse than fake-indexeddb's same-microtask resolution.
3. **`useStableReplyWindow`** (exported from `use-board-card-messages.ts`, wired into the collapsed branch of `board-card.tsx`): trailing `RECENT_PREVIEW_CAP` (3) replies at first reveal, then append-only — the window anchors on the oldest shown reply still present and slices from there, so a new arrival grows the window instead of evicting. A deleted reply leaves (re-anchors on the oldest survivor); a late-syncing *older* reply stays under the gap rather than pushing shown rows down. The shown-ids ref resets when the hook instance is recycled onto another conversation (cards are keyed by conversation id, so this is the unmount/remount path).
4. **Phantom-gap discount, scoped to the send episode**: when a pending row first appears, the hook snapshots the conversation's current `replyIds` (`pendingEpisodeRef`, cleared when the episode drains). Only an unseen id that *joined* `messageIds` during the episode is discounted from `totalReplies` (capped at the pending-row count) — it can only be an in-flight send's server identity or a simultaneous arrival the pending row visually stands in for. Ids already listed when the send began are unsynced older history and keep their honest "N more" slot.

### Key design decisions

**1. Two redundant mechanisms for the loading beat (grace + latch), not one.** The grace keeps data alive across same-card churn; the latch covers rails that never existed before (a fresh gating stream id from `message_assigned`). Disabling the latch alone still passes jsdom (grace suffices there); disabling the grace alone initially *failed* — gating rails re-resolved fast while the extra thread rail lagged, and a confirmed reply has no pending-bridge — which is what drove the latch from gating-only `resolved` to `allResolved`. Each now covers the whole class independently.

**2. Freeze, don't derive, during loading beats.** When `allResolved` is false the hook returns the last committed view object untouched. Deriving from partial rails can only shrink (that was the bug); a one-beat-stale frozen view is invisible, and the memo recomputes the moment the rails emit.

**3. Append-only window over buffer-and-pill.** The board's stable view buffers *reorderings* behind an "N new" pill; inside a card, a new reply appending at the bottom shifts nothing above it, so appending directly is motion-safe and matches the timeline's semantics. Evicting the top of the window is the only motion, so that's what's forbidden.

**4. Episode-scoped discount over tail-position heuristics (design evolution, self-review).** The first version discounted unseen ids positioned after the last rail-seen reply. Pre-PR review (correctness reviewer) caught its hole: with *zero* synced replies, `lastSyncedIdx = -1` made genuinely-missing older history indistinguishable from a tail race — an in-flight send would briefly hide a real "1 more" gap (self-correcting at echo, but a lie while it lasted). The episode snapshot distinguishes the two exactly: an id present before the send began can never be the pending row's identity. A blanket `pendingReplies.length` subtraction was rejected for the same reason (10-reply card, 7 unsynced older, 1 in-flight → the gap must stay 7).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | Grace-period rail teardown; `MergedRail.allResolved` + last-live-view latch; episode-scoped phantom-gap discount; new `useStableReplyWindow` |
| `apps/frontend/src/components/board/board-card.tsx` | Collapsed branch renders `useStableReplyWindow(conversation.id, railReplies)` instead of `railReplies.slice(-RECENT_PREVIEW_CAP)` |
| `apps/frontend/src/hooks/use-board-card-messages.test.tsx` | Frame-recording stability suite (every committed render captured) + `useStableReplyWindow` unit tests |

## Out of scope (deliberate)

- **Incoming first reply from *another* user with nothing synced yet** still shows a brief "1 more message" that resolves into the row when the thread catches up — there is no local pending row to stand in for it, and suppressing the count there would understate a genuinely unsynced conversation (offline, slow sync). Follow-up if dogfooding still surfaces it.
- **Row identity across the echo swap**: the optimistic row's `RenderableMessage.id` changes client-id→server-id at the echo, remounting that one `MessageItem`. Same behavior as the timeline; not observed as visible flicker.
- **`threadIndexRegistry` grace**: its subscribe callback is keyed on `workspaceId` only, which never churns in place — no teardown/recreate cycle to bridge.

## Test plan

- [x] `bunx vitest run src/hooks/use-board-card-messages.test.tsx` — 26 pass (16 existing + 5 frame-recorder stability tests + 5 `useStableReplyWindow` tests). The convert-to-thread frame test fails on `main` with a `projection` frame; the phantom-gap test fails without its discount; the unsynced-older-history test pins the discount from the other side — all bite.
- [x] Mechanism redundancy verified: latch disabled → green via grace alone; grace disabled → initially 1 failure, green after the `allResolved` latch generalization.
- [x] `bunx vitest run src/components/board` + consumers (conversation panel, sync, board hooks) — pass.
- [x] Frontend `tsc --noEmit` clean; full monorepo lint+typecheck via pre-commit hook green.
- [x] Full frontend suite: zero new failures (136 failures are pre-existing on the local machine — Node v25's experimental `localStorage` clashes with the jsdom setup; identical set on a clean `origin/main` tree. CI is the authoritative run.)
- [x] Live verify (dev:test + Chrome): posted a lone channel message from the board, replied from the card (convert-to-thread) — no projection flash, no phantom gap post-fix, reply stayed put through promotion/echo/messageIds/streamIds; 5 replies on a cap-3 card kept the first reply visible (window grows, never evicts). The phantom-gap bug was *found* in this pass (pre-fix build showed the gap-pop live) and re-verified fixed after a hard reload.
- [x] Pre-PR review (3 reviewer agents: spec-compliance, correctness, design): 1 finding, fixed (the episode-scoped discount above, with a regression test); spec + design clean.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785854563&installation_id=129946197&pr_number=1188&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1188&signature=59c6ff4479974cc0350c79a24332178f9e209036da687010ed1e19e4ee5e9d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->