### PR TITLE
feat(evals): trustworthy model comparisons — verified -m overrides, --runs pass-rate tallies, --json; nano re-test stays mini

### DIFF
--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -14,8 +14,14 @@ bun run eval -- -s companion
 # Run specific test case
 bun run eval -- -s companion -c scratchpad-companion-greeting-001
 
+# Repeat every case 6 times and read per-case pass rates (see "Variance")
+bun run eval -- -s boundary-extraction -r 6 --min-pass-rate 0.8
+
 # Compare models
 bun run eval -- -s companion -m openrouter:anthropic/claude-haiku-4.5,openrouter:openai/gpt-5.4-nano
+
+# Machine-readable results (per-case pass rates, usage, executed models)
+bun run eval -- -s memo-classifier -r 3 --json results.json
 
 # Run from config file
 bun run eval -- --config evals/example-config.yaml
@@ -28,8 +34,28 @@ bun run eval -- --config evals/example-config.yaml
 | `companion`           | Full companion agent with tools     |
 | `stream-naming`       | Stream name generation              |
 | `boundary-extraction` | Conversation boundary detection     |
+| `multimodal-vision`   | Vision/attachment understanding     |
 | `memo-classifier`     | Knowledge-worthiness classification |
 | `memorizer`           | Memo generation from messages       |
+
+## Variance: tune against tallies, not single runs
+
+The components under test are stochastic even at low temperature — borderline
+cases flip run-to-run, and a single green run is not evidence (a fully green
+single-run suite once masked every live failure mode these suites now encode).
+Use `--runs N` when tuning prompts or comparing models: each case reports a
+pass rate ("4/6"), run-level evaluators aggregate across all runs, and
+`--min-pass-rate` sets the threshold a case must clear for the exit code.
+
+## Model overrides are verified at runtime
+
+`-m` genuinely overrides the model for components that read their config via
+`ConfigResolver` (INV-44) — the runner wraps the resolver with the permutation
+model. The summary prints an `Executed:` line with the model ids the AI layer
+actually ran and their call counts, and the run **fails loudly** if a `-m`
+override never executed (that would be a silently-invalid comparison). Suites
+whose sub-components intentionally use other models pass as long as the
+requested model executed.
 
 ## Key Principle: Config Co-location (INV-44)
 
@@ -141,9 +167,12 @@ Options:
   -h, --help            Show help message
   -s, --suite <name>    Run specific suite
   -c, --case <id>       Run specific case(s), comma-separated
-  -m, --model <ids>     Override model(s), comma-separated
+  -m, --model <ids>     Override model(s), comma-separated (runtime-verified)
   -t, --temperature <n> Override temperature (0.0-1.0)
   -p, --parallel <n>    Parallel workers (default: 1)
+  -r, --runs <n>        Repeat every case n times, report per-case pass rates
+  --min-pass-rate <n>   Pass-rate a case must clear when runs > 1 (default: 1.0)
+  --json <file>         Write machine-readable results JSON to <file>
   --config <file>       Run from YAML config file
   --no-langfuse         Disable Langfuse recording
   -v, --verbose         Verbose output

--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -233,7 +233,21 @@ async function runPermutation<TInput, TOutput, TExpected>(
   // Create config resolver with eval overrides applied
   // Base resolver has production defaults; eval resolver applies componentOverrides
   const baseResolver = createStaticConfigResolver()
-  const configResolver = createEvalConfigResolverFromYaml(baseResolver, options.componentOverrides)
+  const yamlResolver = createEvalConfigResolverFromYaml(baseResolver, options.componentOverrides)
+  // A -m/-t permutation override must reach components that read their model
+  // from the co-located config via ConfigResolver (INV-44) — boundary
+  // extraction, memo classifier/memorizer. Without this wrap the CLI flag
+  // silently relabels the run while the production model still executes.
+  const hasCliPermutation = Boolean(options.model)
+  const configResolver: typeof yamlResolver = hasCliPermutation
+    ? {
+        resolve: async (path: string) => ({
+          ...(await yamlResolver.resolve(path)),
+          modelId: permutation.model,
+          ...(permutation.temperature !== undefined ? { temperature: permutation.temperature } : {}),
+        }),
+      }
+    : yamlResolver
 
   // Create context for this permutation
   const ctx: EvalContext = {

--- a/apps/backend/evals/framework/runner.ts
+++ b/apps/backend/evals/framework/runner.ts
@@ -110,11 +110,13 @@ function createUsageTrackingAI(ai: AI, accumulator: UsageAccumulator): AI {
   return {
     ...ai,
     async generateText(options: GenerateTextOptions) {
+      accumulator.recordModel(options.model)
       const result = await ai.generateText(options)
       accumulator.recordUsage(result.usage)
       return result
     },
     async generateObject<T extends import("zod").ZodType>(options: GenerateObjectOptions<T>) {
+      accumulator.recordModel(options.model)
       const result = await ai.generateObject(options)
       accumulator.recordUsage(result.usage)
       return result
@@ -269,38 +271,46 @@ async function runPermutation<TInput, TOutput, TExpected>(
     await suite.setup(ctx)
   }
 
-  // Run each case sequentially
+  // Run each case sequentially; with --runs N the whole set repeats so
+  // per-case pass rates can be tallied (stochastic components flip borderline
+  // cases run-to-run — single-run green is not evidence).
+  const runs = Math.max(1, options.runs ?? 1)
   const totalCases = casesToRun.length
-  for (let i = 0; i < casesToRun.length; i++) {
-    const caseItem = casesToRun[i]
-    const caseNum = i + 1
+  for (let run = 1; run <= runs; run++) {
+    if (runs > 1) {
+      console.log(`  ${colors.cyan}— run ${run}/${runs} —${colors.reset}`)
+    }
+    for (let i = 0; i < casesToRun.length; i++) {
+      const caseItem = casesToRun[i]
+      const caseNum = i + 1
 
-    // Always show progress
-    process.stdout.write(`  ${colors.dim}[${caseNum}/${totalCases}]${colors.reset} ${caseItem.name}... `)
+      // Always show progress
+      process.stdout.write(`  ${colors.dim}[${caseNum}/${totalCases}]${colors.reset} ${caseItem.name}... `)
 
-    const result = await runCase(suite, caseItem, ctx, options)
-    cases.push(result)
+      const result = await runCase(suite, caseItem, ctx, options)
+      cases.push(result)
 
-    // Show result status
-    const passed = !result.error && result.evaluations.every((e) => e.passed)
-    const status = result.error
-      ? `${colors.red}ERROR${colors.reset}`
-      : passed
-        ? `${colors.green}PASS${colors.reset}`
-        : `${colors.red}FAIL${colors.reset}`
-    console.log(`${status} ${colors.dim}(${formatDuration(result.durationMs)})${colors.reset}`)
+      // Show result status
+      const passed = !result.error && result.evaluations.every((e) => e.passed)
+      const status = result.error
+        ? `${colors.red}ERROR${colors.reset}`
+        : passed
+          ? `${colors.green}PASS${colors.reset}`
+          : `${colors.red}FAIL${colors.reset}`
+      console.log(`${status} ${colors.dim}(${formatDuration(result.durationMs)})${colors.reset}`)
 
-    // Show inline details for failures
-    if (result.error) {
-      console.log(`    ${colors.red}${result.error.message}${colors.reset}`)
-      if (NoObjectGeneratedError.isInstance(result.error) && result.error.text) {
-        console.log(`    ${colors.dim}Raw response: ${formatValue(result.error.text, 200)}${colors.reset}`)
-      }
-    } else if (!passed) {
-      for (const evaluation of result.evaluations.filter((e) => !e.passed)) {
-        console.log(
-          `    ${colors.yellow}${evaluation.name}: ${evaluation.details || `score=${evaluation.score}`}${colors.reset}`
-        )
+      // Show inline details for failures
+      if (result.error) {
+        console.log(`    ${colors.red}${result.error.message}${colors.reset}`)
+        if (NoObjectGeneratedError.isInstance(result.error) && result.error.text) {
+          console.log(`    ${colors.dim}Raw response: ${formatValue(result.error.text, 200)}${colors.reset}`)
+        }
+      } else if (!passed) {
+        for (const evaluation of result.evaluations.filter((e) => !e.passed)) {
+          console.log(
+            `    ${colors.yellow}${evaluation.name}: ${evaluation.details || `score=${evaluation.score}`}${colors.reset}`
+          )
+        }
       }
     }
   }
@@ -315,11 +325,25 @@ async function runPermutation<TInput, TOutput, TExpected>(
 
   // Get accumulated usage
   const totalUsage = usageAccumulator.getTotal()
+  const executedModels = usageAccumulator.getModels()
+
+  // A -m override that never executed is a silently-invalid comparison (the
+  // exact bug this guard exists for) — fail loudly (INV-11). Suites whose
+  // sub-components legitimately call other models still pass as long as the
+  // requested model executed at least once.
+  if (options.model && Object.keys(executedModels).length > 0 && !(permutation.model in executedModels)) {
+    throw new Error(
+      `Model override ${permutation.model} never executed — AI calls used: ${Object.keys(executedModels).join(", ")}. ` +
+        `The comparison would be invalid; check the ConfigResolver wiring.`
+    )
+  }
 
   return {
     permutation,
     cases,
     runEvaluations,
+    runs,
+    executedModels,
     totalDurationMs: Date.now() - startTime,
     usage: {
       inputTokens: totalUsage.inputTokens,
@@ -450,6 +474,46 @@ function printSummary<TOutput, TExpected>(result: SuiteResult<TOutput, TExpected
     console.log(
       `\n  ${colors.green}Passed: ${passedCases.length}${colors.reset}  ${colors.red}Failed: ${failedCases.length}${colors.reset}  ${colors.dim}Duration: ${formatDuration(totalDurationMs)}${colors.reset}`
     )
+
+    const executedEntries = Object.entries(permResult.executedModels ?? {})
+    if (executedEntries.length > 0) {
+      console.log(
+        `  ${colors.dim}Executed: ${executedEntries.map(([m, n]) => `${m} (${n} calls)`).join(", ")}${colors.reset}`
+      )
+    }
+
+    // With repeat runs, the per-case tally is the readable unit — one line per
+    // case with its pass rate — instead of N repeated lines.
+    if (permResult.runs > 1) {
+      console.log(`\n  Cases (pass rate over ${permResult.runs} runs):`)
+      const byCase = new Map<string, { name: string; passes: number; total: number }>()
+      for (const caseResult of cases) {
+        const passed = !caseResult.error && caseResult.evaluations.every((e) => e.passed)
+        const agg = byCase.get(caseResult.caseId) ?? { name: caseResult.caseName, passes: 0, total: 0 }
+        agg.passes += passed ? 1 : 0
+        agg.total += 1
+        byCase.set(caseResult.caseId, agg)
+      }
+      for (const [caseId, agg] of byCase) {
+        const rate = agg.passes / agg.total
+        const mark =
+          rate === 1
+            ? `${colors.green}✓${colors.reset}`
+            : rate === 0
+              ? `${colors.red}✗${colors.reset}`
+              : `${colors.yellow}~${colors.reset}`
+        console.log(`    ${mark} ${agg.passes}/${agg.total} ${agg.name} ${colors.dim}(${caseId})${colors.reset}`)
+      }
+      if (permResult.runEvaluations.length > 0) {
+        console.log("\n  Run Evaluations (across all runs):")
+        for (const evaluation of permResult.runEvaluations) {
+          const status = evaluation.passed ? colors.green : colors.red
+          console.log(`    ${status}${evaluation.name}: ${evaluation.score}${colors.reset}`)
+          if (evaluation.details) console.log(`      ${colors.dim}${evaluation.details}${colors.reset}`)
+        }
+      }
+      continue
+    }
 
     // Show all cases
     console.log("\n  Cases:")

--- a/apps/backend/evals/framework/types.ts
+++ b/apps/backend/evals/framework/types.ts
@@ -21,8 +21,12 @@ import type { ComponentOverrides } from "./config-types"
 export interface UsageAccumulator {
   /** Record usage from an AI call */
   recordUsage(usage: { promptTokens?: number; completionTokens?: number; totalTokens?: number; cost?: number }): void
+  /** Record the model id an AI call actually executed with */
+  recordModel(modelId: string): void
   /** Get accumulated totals */
   getTotal(): { inputTokens: number; outputTokens: number; totalCost: number }
+  /** Executed model ids → call counts. The ground truth a -m override is verified against. */
+  getModels(): Record<string, number>
 }
 
 /**
@@ -32,6 +36,7 @@ export function createUsageAccumulator(): UsageAccumulator {
   let inputTokens = 0
   let outputTokens = 0
   let totalCost = 0
+  const models: Record<string, number> = {}
 
   return {
     recordUsage(usage) {
@@ -39,8 +44,14 @@ export function createUsageAccumulator(): UsageAccumulator {
       outputTokens += usage.completionTokens ?? 0
       totalCost += usage.cost ?? 0
     },
+    recordModel(modelId) {
+      models[modelId] = (models[modelId] ?? 0) + 1
+    },
     getTotal() {
       return { inputTokens, outputTokens, totalCost }
+    },
+    getModels() {
+      return { ...models }
     },
   }
 }
@@ -183,8 +194,13 @@ export interface CaseResult<TOutput, TExpected> {
  */
 export interface PermutationResult<TOutput, TExpected> {
   permutation: EvalPermutation
+  /** All case results; with --runs N each case appears N times (group by caseId to aggregate). */
   cases: CaseResult<TOutput, TExpected>[]
   runEvaluations: EvaluatorResult[]
+  /** Number of repeat runs the cases were executed for (1 = single pass). */
+  runs: number
+  /** Model ids the AI layer actually executed, with call counts. */
+  executedModels: Record<string, number>
   /** Total duration in milliseconds */
   totalDurationMs: number
   /** Token usage stats */
@@ -269,6 +285,19 @@ export interface RunnerOptions {
   temperature?: number
   /** Number of parallel workers (default: 1) */
   parallel?: number
+  /**
+   * Repeat every case this many times and report per-case pass rates
+   * (default 1). Stochastic components flip borderline cases run-to-run —
+   * single-run green is not evidence; tune against tallies.
+   */
+  runs?: number
+  /**
+   * Pass-rate threshold a case must clear when runs > 1 (0..1, default 1).
+   * A case passing 5/6 runs clears 0.8 but fails the default.
+   */
+  minPassRate?: number
+  /** Write machine-readable results JSON to this path. */
+  jsonOutput?: string
   /** Disable Langfuse recording */
   noLangfuse?: boolean
   /** Verbose output */

--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -53,6 +53,9 @@ Options:
   -m, --model <ids>     Override model(s), comma-separated for comparison
   -t, --temperature <n> Override temperature (0.0-1.0)
   -p, --parallel <n>    Number of parallel workers (default: 1)
+  -r, --runs <n>        Repeat every case n times, report per-case pass rates (default: 1)
+  --min-pass-rate <n>   Pass-rate a case must clear when runs > 1 (0.0-1.0, default: 1.0)
+  --json <file>         Write machine-readable results JSON to <file>
   --config <file>       Run from YAML config file (ignores -s, -m flags)
   --no-langfuse         Disable Langfuse recording
   -v, --verbose         Verbose output
@@ -109,6 +112,9 @@ async function main(): Promise<void> {
       model: { type: "string", short: "m" },
       temperature: { type: "string", short: "t" },
       parallel: { type: "string", short: "p" },
+      runs: { type: "string", short: "r" },
+      "min-pass-rate": { type: "string" },
+      json: { type: "string" },
       config: { type: "string" },
       "no-langfuse": { type: "boolean" },
       verbose: { type: "boolean", short: "v" },
@@ -135,6 +141,9 @@ async function main(): Promise<void> {
     model: values.model,
     temperature: values.temperature ? parseFloat(values.temperature) : undefined,
     parallel: values.parallel ? parseInt(values.parallel, 10) : undefined,
+    runs: values.runs ? parseInt(values.runs, 10) : undefined,
+    minPassRate: values["min-pass-rate"] ? parseFloat(values["min-pass-rate"]) : undefined,
+    jsonOutput: values.json,
     noLangfuse: values["no-langfuse"],
     verbose: values.verbose,
   }
@@ -142,6 +151,16 @@ async function main(): Promise<void> {
   // Validate temperature
   if (options.temperature !== undefined && (options.temperature < 0 || options.temperature > 1)) {
     console.error("Error: Temperature must be between 0.0 and 1.0")
+    process.exit(1)
+  }
+
+  if (options.runs !== undefined && (!Number.isInteger(options.runs) || options.runs < 1)) {
+    console.error("Error: --runs must be a positive integer")
+    process.exit(1)
+  }
+
+  if (options.minPassRate !== undefined && (options.minPassRate < 0 || options.minPassRate > 1)) {
+    console.error("Error: --min-pass-rate must be between 0.0 and 1.0")
     process.exit(1)
   }
 
@@ -216,9 +235,16 @@ async function main(): Promise<void> {
     // can't unify different generic instantiations. Each suite is processed independently.
     const results = await runSuites(allSuites as any, options)
 
-    // Determine exit code based on results
+    if (options.jsonOutput) {
+      await Bun.write(options.jsonOutput, JSON.stringify(toJsonReport(results), null, 2))
+      console.log(`\nResults written to ${options.jsonOutput}`)
+    }
+
+    // A case passes when its pass rate over the repeat runs clears the
+    // threshold (default 1 = every run, matching single-run behavior).
+    const minPassRate = options.minPassRate ?? 1
     const hasFailures = results.some((r) =>
-      r.permutations.some((p) => p.cases.some((c) => c.error || c.evaluations.some((e) => !e.passed)))
+      r.permutations.some((p) => aggregateCases(p).some((c) => c.passes / c.total < minPassRate))
     )
 
     process.exit(hasFailures ? 1 : 0)
@@ -226,6 +252,64 @@ async function main(): Promise<void> {
     console.error("\nEvaluation failed with error:")
     console.error(error)
     process.exit(1)
+  }
+}
+
+interface CaseAggregate {
+  caseId: string
+  caseName: string
+  passes: number
+  total: number
+  /** Failing evaluator details from the most recent failing run, for the JSON report. */
+  lastFailure?: { name: string; details?: string }[]
+}
+
+function aggregateCases(p: {
+  cases: Array<{ caseId: string; caseName: string; error?: Error; evaluations: Array<any> }>
+}): CaseAggregate[] {
+  const byCase = new Map<string, CaseAggregate>()
+  for (const c of p.cases) {
+    const passed = !c.error && c.evaluations.every((e) => e.passed)
+    const agg = byCase.get(c.caseId) ?? { caseId: c.caseId, caseName: c.caseName, passes: 0, total: 0 }
+    agg.passes += passed ? 1 : 0
+    agg.total += 1
+    if (!passed) {
+      agg.lastFailure = c.error
+        ? [{ name: "error", details: c.error.message }]
+        : c.evaluations.filter((e) => !e.passed).map((e) => ({ name: e.name, details: e.details }))
+    }
+    byCase.set(c.caseId, agg)
+  }
+  return [...byCase.values()]
+}
+
+function toJsonReport(results: Array<any>) {
+  return {
+    suites: results.map((r) => ({
+      suiteName: r.suiteName,
+      permutations: r.permutations.map((p: any) => ({
+        model: p.permutation.model,
+        temperature: p.permutation.temperature ?? null,
+        runs: p.runs,
+        executedModels: p.executedModels,
+        usage: p.usage ?? null,
+        totalDurationMs: p.totalDurationMs,
+        runEvaluations: p.runEvaluations.map((e: any) => ({
+          name: e.name,
+          score: e.score,
+          passed: e.passed,
+          details: e.details ?? null,
+        })),
+        cases: aggregateCases(p).map((c) => ({
+          caseId: c.caseId,
+          caseName: c.caseName,
+          passes: c.passes,
+          runs: c.total,
+          passRate: c.passes / c.total,
+          lastFailure: c.lastFailure ?? null,
+        })),
+      })),
+    })),
   }
 }
 

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -3,6 +3,10 @@
 import { z } from "zod"
 import { CONVERSATION_STATUSES } from "@threa/types"
 
+// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
+// was fixed) showed nano failing systematically — sandwich-split and
+// gap-resume cases in every round (30-33/35 vs mini's 33-35/35). See
+// docs/model-reference.md.
 export const BOUNDARY_EXTRACTION_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 /** Low temperature for classification consistency. */

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -7,6 +7,10 @@ import { z } from "zod"
 import { KNOWLEDGE_TYPES, type KnowledgeType, type StreamType } from "@threa/types"
 import { formatDate } from "../../lib/temporal"
 
+// Mini over nano is deliberate: the July 2026 re-test (after -m eval wiring
+// was fixed) showed nano classifying real knowledge as not-worthy in every
+// round (6/9 with the same three misses) — silent knowledge loss, the worst
+// GAM failure mode. See docs/model-reference.md.
 export const MEMO_CLASSIFIER_MODEL_ID = "openrouter:openai/gpt-5.4-mini"
 
 export const MEMO_MEMORIZER_MODEL_ID = "openrouter:openai/gpt-5.4-mini"

--- a/docs/model-reference.md
+++ b/docs/model-reference.md
@@ -188,7 +188,7 @@ All models use `provider:modelPath` format:
 - Cost-sensitive workloads where quality bar is low
 - Self-hosted inference on single H100
 
-**Note:** Previously used for memo classification, memorization, and researcher agent. Replaced by `claude-haiku-4.5` (researcher), `gpt-5.4-mini` (memo classifier/memorizer — see `MEMO_CLASSIFIER_MODEL_ID`/`MEMO_MEMORIZER_MODEL_ID` in `apps/backend/src/features/memos/config.ts`) due to unreliable tail latency on OpenRouter's patchwork provider backing and insufficient quality for structured extraction.
+**Note:** History: originally ran memo classification, memorization, and the researcher agent; replaced by `claude-haiku-4.5` (researcher) and `gpt-5.4-mini` (memo classifier/memorizer) in spring 2026 due to unreliable tail latency on OpenRouter's patchwork provider backing and insufficient quality for structured extraction. **Re-tested July 2026 against the boundary-extraction / memo-classifier / memorizer eval suites and rejected again**: nano systematically classified real knowledge as not-worthy (6/9 with the same three misses every round — silent knowledge loss) and failed sandwich-split/gap-resume boundary cases every round (30-33/35 vs mini's 33-35/35). The ~3.6x price gap does not buy back those failure modes. Caution for future comparisons: the eval CLI's `-m` flag did not reach ConfigResolver-backed components until the July 2026 runner fix — earlier "nano" comparisons silently ran the production model.
 
 ---
 


### PR DESCRIPTION
## Problem

Two eval-framework deficiencies surfaced during the nano-vs-mini exploration:

1. **`-m` was a silent no-op for ConfigResolver components.** The runner built its `ConfigResolver` from production static config only, so components that read their model through it per INV-44 (`LLMBoundaryExtractor`, `MemoClassifier`, `Memorizer`) always executed the production model; `-m` only changed the permutation label. Every past model comparison for these suites was silently invalid — discovered when flipping production config to `gpt-5.4-nano` produced dramatically worse results than the "nano" `-m` runs that had just scored identically to mini (they *were* mini).
2. **No variance tooling.** The components are stochastic even at low temperature; tuning methodology was "loop the CLI in a shell and grep the tallies". Single-run green once masked every live failure mode the boundary suite now encodes.

## Solution

### `-m` fix + runtime verification
- When `-m`/`-t` is set, the runner wraps the resolver so the override genuinely executes (temperature only when explicitly passed — comparisons run at production temps by default).
- The usage accumulator now records the model ids the AI layer **actually executed**; the summary prints `Executed: <model> (N calls)` and the run **fails loudly (INV-11)** if a `-m` override never executed. Suites whose sub-components intentionally call other models pass as long as the requested model ran. This makes the bug class structurally impossible to miss again.

### `--runs` / `--min-pass-rate` / `--json`
- `-r/--runs N` repeats every case and reports per-case pass rates (`~ 4/6 case-name`); run-level evaluators aggregate across all runs; `--min-pass-rate` sets the exit-code threshold (default 1.0 = old behavior).
- `--json <file>` writes machine-readable results: per-case pass rates + last-failure details, executed models, usage, run evaluations.
- README: variance-methodology section ("tune against tallies, not single runs"), runtime-verified `-m` semantics, new flags, `multimodal-vision` added to the suite table it was missing from.

### Nano re-test verdict (the exploration that exposed all this)
With the fix, the honest nano-vs-mini comparison (3 rounds × 3 suites, production temps):

| Suite | gpt-5.4-mini | gpt-5.4-nano |
| --- | --- | --- |
| boundary-extraction (35) | 35, 34, 33 (known-wobbly only) | 30–33, sandwich-split + gap-resume failing **every round** |
| memo-classifier (9) | 9/9 ×3 | **6/9 ×3, same three real-knowledge misses each round** (silent knowledge loss) |
| memorizer (5) | 5,4,3 | 5,4,5 (comparable) |

Verdict: nano's ~3.6× price advantage does not buy back systematic classifier false negatives. **Model ids stay on `gpt-5.4-mini`**; config comments + `docs/model-reference.md` record the verdict and the `-m` caveat.

## Files changed

| File | Change |
| ---- | ------ |
| `evals/framework/runner.ts` | Resolver wrap for `-m`/`-t`; runs loop; executed-model recording + fail-loud check; pass-rate summary |
| `evals/framework/types.ts` | `recordModel`/`getModels` on the accumulator; `runs`/`executedModels` on `PermutationResult`; new `RunnerOptions` |
| `evals/run.ts` | `-r/--runs`, `--min-pass-rate`, `--json` flags; aggregated exit-code logic; JSON report |
| `evals/README.md` | Variance methodology, verified `-m` semantics, flags, suite table fix |
| `conversations/boundary-extraction/config.ts`, `memos/config.ts` | Why-mini comments (no id change) |
| `docs/model-reference.md` | Nano note: July 2026 re-test verdict + `-m` wiring caveat |

## Test plan

- [x] Live smoke: `-s memo-classifier -r 3 --min-pass-rate 0.6 --json` — run headers, 9× 3/3 tally, `Executed: gpt-5.4-mini (27 calls)`, valid JSON, exit 0
- [x] The 18-run nano/mini comparison exercised both the fixed `-m` path and the default path
- [x] `eval-config-resolver.test.ts` 8 pass; backend typecheck clean
- [ ] No unit test on the resolver wrap or aggregation (the eval framework has no test harness beyond the resolver test); verified by the live runs above

**Stacked on** `feat/conversation-boundaries` (#1187) — merge after it.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
