### PR TITLE
fix(board): declared-id chip falls back to successor when the declared conversation is a retired shell

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -432,6 +432,49 @@ describe("annotateConversationRevivals", () => {
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
   })
+
+  it("falls back to the membership map when the declared conversation was merged into a retired shell", () => {
+    // conv_x (declared) was emptied + resolved by a later extraction pass; the
+    // messages now live in conv_successor. The chip must route + label from the
+    // successor, not deep-link the dead shell.
+    const conversationsById = new Map<string, ConversationWithStaleness>([
+      [
+        "conv_x",
+        { status: "resolved", messageIds: [] as string[], topicSummary: "Pizza (old)" } as ConversationWithStaleness,
+      ],
+      [
+        "conv_successor",
+        { status: "active", messageIds: ["msg_a", "msg_c"], topicSummary: "Pizza" } as ConversationWithStaleness,
+      ],
+    ])
+    const membership = new Map([
+      ["msg_a", "conv_successor"],
+      ["msg_b", "conv_y"],
+      ["msg_c", "conv_successor"],
+    ])
+    const items = annotateConversationRevivals(scattered(true), membership, conversationsById)
+
+    expect(revivalOf(items[2])).toEqual({
+      conversationId: "conv_successor",
+      topicSummary: "Pizza",
+      previousActivityAt: "2026-02-19T00:00:00.000Z",
+    })
+  })
+
+  it("keeps the declared id when its conversation is resolved but still holds messages", () => {
+    // A legitimately-resolved topic (not an empty merge shell) — the declared id
+    // is still its real home, so the fallback must NOT fire.
+    const conversationsById = new Map<string, ConversationWithStaleness>([
+      [
+        "conv_x",
+        { status: "resolved", messageIds: ["msg_a", "msg_c"], topicSummary: "Pizza" } as ConversationWithStaleness,
+      ],
+    ])
+    const membership = new Map([["msg_c", "conv_other"]])
+    const items = annotateConversationRevivals(scattered(true), membership, conversationsById)
+
+    expect(revivalOf(items[2])?.conversationId).toBe("conv_x")
+  })
 })
 
 describe("findMessageItemIndex", () => {

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from "react"
 import {
   COMMAND_EVENT_TYPES,
+  ConversationStatuses,
   type CommandEventType,
   type StreamEvent,
   type CommandDispatchedPayload,
@@ -254,7 +255,21 @@ export function annotateConversationRevivals(
     // messages (Mechanism A). The topic label still resolves from
     // `conversationsById` (loaded per-stream); a declared-but-not-yet-listed
     // conversation shows the generic label until the list catches up.
-    const conversationId = payload.declaredConversationId ?? membership.get(messageId) ?? null
+    //
+    // Fallback exception (resolved decision 3, board-view-design.md): a later
+    // extraction pass can merge/retire the declared conversation into an empty
+    // `resolved` shell — still present in `conversationsById` (the read query
+    // returns it) but holding no messages. Deep-linking that shell points at a
+    // dead conversation, so fall back to the membership map, which after a merge
+    // resolves the message to its surviving home. A declared id merely not-yet-
+    // listed (absent from `conversationsById`) is NOT retired — keep it, so the
+    // flicker-free just-sent case still wins over a not-yet-loaded list. The
+    // `status` check runs before `.messageIds` so a row missing that field can't
+    // be misread as retired.
+    const declared = payload.declaredConversationId
+    const declaredRow = declared != null ? conversationsById.get(declared) : undefined
+    const declaredRetired = declaredRow?.status === ConversationStatuses.RESOLVED && declaredRow.messageIds.length === 0
+    const conversationId = (declaredRetired ? undefined : declared) ?? membership.get(messageId) ?? null
     let revival: ConversationRevival | undefined
     if (conversationId != null) {
       const blockStart = conversationId !== previousConversationId


### PR DESCRIPTION
## Summary

Roadmap next-up #3 (board-view-design.md, "resolved decision 3"). The on-message provenance chip prefers a message's send-time `declaredConversationId` (#1146) so it renders instantly, before the async conversation list loads. But a later extraction pass can merge/retire that conversation into an empty `resolved` shell — still returned by the per-stream read query, so still present in `conversationsById` — and the chip then deep-links `?panel=conv:<dead-shell>` instead of the message's surviving home.

## The fix

One guarded predicate in `annotateConversationRevivals` (`event-list.tsx`): when the declared id resolves to a **positively-observed empty resolved shell**, fall back to the async membership map (which, after a merge, holds the message's successor conversation). Two needles threaded:

- A declared id merely **not-yet-listed** (absent from `conversationsById`) is **not** retired — it still wins, so the flicker-free just-sent case is unchanged.
- A **resolved-but-non-empty** topic keeps its declared id — no over-eager fallback.

The `status === RESOLVED` check runs before `.messageIds` so a row missing that field can't be misclassified. Uses `ConversationStatuses.RESOLVED` (INV-33, no magic string).

## Scope

Read-side annotation only — **no** backend / migration / mutation / table / toast (INV-36). The shell staying in the read query is load-bearing (other surfaces need it), not a bug to fix here. `annotateConversationRows` (overlay coloring) reads only the membership map, never the declared id, so it's untouched.

## Tests

Two cases added to `event-list.test.ts`: merged-away declared id routes **and** labels from the successor; a resolved-but-non-empty topic keeps its declared id. 57 tests green — the flicker-free and declared-over-stale-membership cases still pass.

> Stacked on #1179 (shares `event-list.tsx`). Base retargets to `main` when #1179 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785862060&installation_id=129946197&pr_number=1191&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1191&signature=4167414d0ce3c6f4faacf04f9c8fbc6948029b72ab89d5584cbb02eab0420018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->