### PR TITLE
fix(bot-runtimes): missing-link notice must not re-trigger the invocation handler (prod disk-eating loop)

### DIFF
--- a/apps/backend/src/db/migrations/20260705165837_soft_delete_missing_link_notice_flood.sql
+++ b/apps/backend/src/db/migrations/20260705165837_soft_delete_missing_link_notice_flood.sql
@@ -1,0 +1,35 @@
+-- One-time cleanup of the missing-session-link notice feedback loop.
+--
+-- Before the guard in BotInvocationOutboxHandler.processMessageCreated
+-- (same PR), the "… is not linked to this scratchpad" system notice was
+-- itself a message:created event that re-entered the handler and produced
+-- another notice, flooding the affected scratchpad with thousands of
+-- system messages (~3/s in production).
+--
+-- Soft-delete, not hard-delete: the notices' message_created stream_events
+-- keep their broadcast_sequence slots, so the per-stream broadcast chain
+-- stays dense (INV-61) and clients render deleted placeholders instead of
+-- detecting phantom holes. The only sanctioned slot-vacating mechanism is
+-- the messages:moved tombstone, which this is not. Derived volume (outbox,
+-- sync_log, queue_messages) is aged out by the existing retention workers
+-- and is not touched here.
+--
+-- Targets exactly the rows the handler stamped: system-authored messages
+-- carrying the bot_runtime.notice=missing_session_link metadata (uses the
+-- idx_messages_metadata_gin index). Legitimate future notices are still
+-- posted for user-authored messages; deleting all historical ones is fine —
+-- they are transient guidance, not content.
+--
+-- No user_activity sweep is needed: the activity outbox handler already
+-- skips system-authored messages (features/activity/outbox-handler.ts), so
+-- these notices never created unread rows.
+--
+-- Idempotent (deleted_at guard). Runs before the server accepts
+-- connections, so no outbox events are emitted; live clients converge on
+-- their next reconnect bootstrap (INV-53).
+
+UPDATE messages
+SET deleted_at = NOW()
+WHERE author_type = 'system'
+  AND metadata @> '{"bot_runtime.notice":"missing_session_link"}'::jsonb
+  AND deleted_at IS NULL;

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -286,6 +286,34 @@ describe("BotInvocationOutboxHandler active-scratchpad session-link policy", () 
     )
   })
 
+  // Reproduces the prod feedback loop: the missing-link notice is itself a
+  // system-authored message:created event, so without the system guard the
+  // handler answers its own notice with another notice, forever.
+  it("ignores a system-authored message — no notice, no dispatch", async () => {
+    const { createInvocation, createMessage } = setupActiveScratchpad({
+      instance: { runtimeKind: "claude-code-channel" },
+    })
+
+    await runProcessMessageCreated({
+      workspaceId: "ws_1",
+      streamId: "stream_1",
+      event: {
+        id: "evt_2",
+        sequence: "2",
+        actorType: "system",
+        actorId: "system",
+        payload: {
+          messageId: "msg_2",
+          contentMarkdown: "**Scout is not linked to this scratchpad.** Start Claude Code…",
+          contentJson: docWithText("Scout is not linked to this scratchpad."),
+        },
+      },
+    })
+
+    expect(createMessage).not.toHaveBeenCalled()
+    expect(createInvocation).not.toHaveBeenCalled()
+  })
+
   it("posts the Claude Code channel notice and skips dispatch when an unlinked claude-code-channel bot is active", async () => {
     const { createInvocation, createMessage } = setupActiveScratchpad({
       instance: { runtimeKind: "claude-code-channel" },

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -126,6 +126,11 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
     const message = parseMessagePayload(payload)
     if (!message) return
     if (!message.event.actorId) return
+    // System-authored messages never trigger a bot turn. Critically, the
+    // missing-link notice below is itself a system message:created — reacting
+    // to it would feed this handler its own output forever (notice → event →
+    // notice …), flooding the stream and every per-message pipeline behind it.
+    if (message.event.actorType === AuthorTypes.SYSTEM) return
 
     const stream = await StreamRepository.findById(this.pool, message.streamId)
     if (!stream || stream.workspaceId !== message.workspaceId || stream.archivedAt) return


### PR DESCRIPTION
## Problem

Production incident (workspace `ws_01KJDZZV5H57W3H2SJ11PA554B`, scratchpad `stream_01KWRBWCQ9K9YX6WKV034438JH`): `BotInvocationOutboxHandler` feeds itself its own output.

The chain: a message lands in a scratchpad whose active bot has a `sessionLinking: "required"` runtime kind (`claude-code-channel` / `pi-local`) but no active session link → `createMissingLinkNotice` posts the system message "**… is not linked to this scratchpad.**". That notice is itself a `message:created` outbox event. It passes every guard in `processMessageCreated` — the self-message check at the top of the active-scratchpad section only skips messages authored by the active *bot*, and the notice's `clientMessageId` is keyed on `sourceMessageId`, which is new each round — so the handler answers its own notice with another notice, forever.

Measured in prod: ~3.3 notices/second, 3,408 system messages in ~17 minutes, each fanning out `boundary.extract` + `link_preview.extract` + embedding jobs plus outbox and sync_log rows (sync_log 177 MB, outbox 150 MB, queue_messages 143 MB at time of diagnosis). The loop stopped at 16:31 UTC when the scratchpad was archived (the handler skips archived streams).

## Solution

Two parts: a guard that breaks the cycle, and a one-time migration that cleans up the flood it already produced.

**Guard.** Early-return in `processMessageCreated` for system-authored messages (`actorType === AuthorTypes.SYSTEM`), before any stream lookup or dispatch. `EventService.createMessage` stamps the outbox event's `actorType` from `authorType` (`event-service.ts:605`), so the notice reliably arrives at the handler as `system` and the guard breaks the cycle at its first link. Precedent: the activity outbox handler has this exact guard (`features/activity/outbox-handler.ts:148`) — system messages produce no activity rows for the same reason.

This also means system messages no longer dispatch active-scratchpad turns to a *linked* runtime (previously they rode the "A non-user message was posted…" prompt wrapper). Deliberate: every system message is an infra notice; spending a bot turn on them is cost without value, and the unlinked case is an unbounded loop.

**Cleanup migration** (`20260705165837_soft_delete_missing_link_notice_flood.sql`). Soft-deletes all system-authored messages carrying `bot_runtime.notice: missing_session_link` metadata (3,408 rows, all in the one affected stream — verified against prod via the read proxy; the predicate uses `idx_messages_metadata_gin`).

### Key design decisions

**1. Soft-delete, not hard-delete.** The notices' `message_created` stream_events keep their `broadcast_sequence` slots, so the per-stream broadcast chain stays dense (INV-61) and clients render deleted placeholders instead of detecting phantom holes. The only sanctioned slot-vacating mechanism is the `messages:moved` tombstone — its payload requires destination-stream fields and per-message previews, so faking one for cleanup would misrender ("moved N messages" for messages that went nowhere). Rejected.

**2. No derived-table pruning in the migration.** Outbox, sync_log, and completed queue rows all have existing retention workers (`packages/backend-common/src/outbox/retention-worker.ts`, `features/sync/retention-worker.ts`, queue `deleteOldMessages`); the bloat ages out and autovacuum reclaims the space. Hand-pruning them mid-window risks catch-up correctness for no lasting benefit.

**3. No `user_activity` sweep.** The activity handler already skips system-authored messages, so the notices never created unread rows (verified: 0 matching rows in prod).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | System-authored `message:created` events return before mention/active-scratchpad dispatch |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts` | Regression test: system-authored message in an unlinked `claude-code-channel` scratchpad produces no notice and no invocation (fails without the guard) |
| `apps/backend/src/db/migrations/20260705165837_soft_delete_missing_link_notice_flood.sql` | One-time soft-delete of the notice flood; idempotent, predicate-based (survives any stragglers written between migration run and old-instance shutdown) |

## Out of scope (deliberate)

- Rate-limit/circuit-breaker hardening on `createMissingLinkNotice` (e.g. one notice per root stream per link-state change). The guard removes the only self-feeding input; debouncing user-triggered notices is a UX question, not a correctness one.
- The archived scratchpad itself — after the migration its timeline shows deleted-message placeholders where the flood was. It was archived mid-incident; un-archiving it is the user's call.

## Test plan

- [x] `bun test apps/backend/src/features/bot-runtimes/` — 96 pass (new test fails without the fix: notice created for a system-authored payload)
- [x] `bun run typecheck` — all workspaces clean (also re-run by pre-commit hook, plus `check:migrations`: 186 clean)
- [x] Migration predicate validated against prod via the read-only proxy: `SELECT count(*)` with the exact WHERE clause matches 3,408 rows, all in the affected stream
- [ ] Migration not executed against a live DB — no local Postgres in this session; it is a single predicate-guarded UPDATE (idempotent) mirroring the soft-delete `EventService.deleteMessage` performs
- [ ] Not exercised against a live outbox loop — only reachable with an unlinked `claude-code-channel` active bot; the regression test drives `processMessageCreated` with the exact payload shape the notice produces

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01TdDiDNbUKcrCsmFT1Hxi5S