### PR TITLE
feat(board): Mine lens — conversations you're in or mentioned in

### DIFF
--- a/apps/backend/src/features/activity/repository.ts
+++ b/apps/backend/src/features/activity/repository.ts
@@ -357,6 +357,29 @@ export const ActivityRepository = {
    * read clears exactly its messages' activity, never the stream's other
    * topics (contrast `markStreamAsRead`, the whole-stream open coupling).
    */
+  /**
+   * Of `messageIds`, which ones `@`-mentioned `userId` — the Mine-lens signal
+   * (board `buildBoardPosts`). One batched presence read (INV-56), index-backed by
+   * `idx_user_activity_dedup (user_id, message_id, activity_type, actor_id)`.
+   * Workspace-scoped (INV-8); `ActivityTypes.MENTION`, not a literal (INV-33).
+   */
+  async findMentionedMessageIds(
+    db: Querier,
+    workspaceId: string,
+    userId: string,
+    messageIds: string[]
+  ): Promise<Set<string>> {
+    if (messageIds.length === 0) return new Set()
+    const result = await db.query<{ message_id: string }>(sql`
+      SELECT DISTINCT message_id FROM user_activity
+      WHERE workspace_id = ${workspaceId}
+        AND user_id = ${userId}
+        AND activity_type = ${ActivityTypes.MENTION}
+        AND message_id = ANY(${messageIds}::text[])
+    `)
+    return new Set(result.rows.map((row) => row.message_id))
+  },
+
   async markMessagesAsRead(db: Querier, workspaceId: string, userId: string, messageIds: string[]): Promise<number> {
     if (messageIds.length === 0) return 0
     const result = await db.query(sql`

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -202,7 +202,7 @@ export function createConversationHandlers({ conversationService, streamService,
       // validateStreamAccess handles public visibility + thread root membership
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
-      const post = await conversationService.getBoardPostById(workspaceId, conversationId)
+      const post = await conversationService.getBoardPostById(workspaceId, conversationId, userId)
       if (!post) {
         return res.status(404).json({ error: "Conversation not found" })
       }

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -1,6 +1,7 @@
 import { sql, composeSql, type Querier } from "../../db"
 import { streamAccessPredicateSql } from "../streams"
 import {
+  ActivityTypes,
   ConversationStatuses,
   type ConversationStatus,
   type BoardLens,
@@ -15,9 +16,27 @@ import {
  * same `BOARD_LENS_*` thresholds. `all` (and absent) adds nothing — the default
  * home shows everything.
  */
-function boardLensCondSql(lens: BoardLens | undefined) {
+function boardLensCondSql(lens: BoardLens | undefined, userId: string) {
   if (lens === "active") {
     return composeSql`AND status = ${ConversationStatuses.ACTIVE}`
+  }
+  if (lens === "mine") {
+    // The viewer's own conversations: authored/participating (`participant_ids`,
+    // GIN-indexed) OR `@`-mentioned on a primary message (`user_activity`,
+    // index-backed). Pinned to `conversations.message_ids` — the SAME set the JS
+    // half folds over in `buildBoardPosts` — so the seed boundary and the
+    // client's `isMine` render authority can't disagree. Workspace-scoped inside
+    // the EXISTS (INV-8); `ActivityTypes.MENTION`, not a literal (INV-33).
+    return composeSql`AND (
+      participant_ids @> ARRAY[${userId}]::text[]
+      OR EXISTS (
+        SELECT 1 FROM user_activity ua
+        WHERE ua.workspace_id = conversations.workspace_id
+          AND ua.user_id = ${userId}
+          AND ua.activity_type = ${ActivityTypes.MENTION}
+          AND ua.message_id = ANY(conversations.message_ids)
+      )
+    )`
   }
   if (lens === "needs-resolution") {
     // A `resolved` conversation is done — never a loose end — even if its LLM
@@ -432,7 +451,7 @@ export const ConversationRepository = {
     const fields = sql`${sql.raw(SELECT_FIELDS)}`
     const access = streamAccessPredicateSql(workspaceId, userId, "conversations.stream_id")
     const statusCond = options?.status ? composeSql`AND status = ${options.status}` : sql``
-    const lensCond = boardLensCondSql(options?.lens)
+    const lensCond = boardLensCondSql(options?.lens, userId)
     const scopeCond = boardScopeCondSql(options?.scopeStreamIds)
     const typeCond = boardTypeCondSql(options?.scopeStreamTypes)
     // Keyset on `date_trunc('milliseconds', last_activity_at)` — NOT the raw

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -77,6 +77,8 @@ export interface BoardPost {
   streamIds: string[]
   /** Whether an active memo was captured from this conversation — the Decisions lens signal. */
   hasCapturedMemo: boolean
+  /** Whether the requesting viewer authored/participates in or was @-mentioned in this conversation — the Mine lens signal. */
+  isMine: boolean
   /** Effective root of the anchor (`COALESCE(root_stream_id, id)`) — the client's stream-scope filter matches on this. */
   rootStreamId: string
   /** That root's type (never `thread`) — the client's stream-type filter matches on this. */
@@ -137,7 +139,7 @@ export class ConversationService {
     })
     const conversations = rows.map(addStalenessFields)
 
-    const posts = await this.buildBoardPosts(workspaceId, conversations)
+    const posts = await this.buildBoardPosts(workspaceId, conversations, userId)
 
     // A full page means there may be more; the last row's (activity, id) is the
     // next cursor — matching the repo's `(last_activity_at, id) DESC` order.
@@ -155,10 +157,10 @@ export class ConversationService {
    * workspace or has no messages (an emptied conversation is no longer a card,
    * mirroring the board feed's `cardinality(message_ids) > 0` filter).
    */
-  async getBoardPostById(workspaceId: string, conversationId: string): Promise<BoardPost | null> {
+  async getBoardPostById(workspaceId: string, conversationId: string, userId: string): Promise<BoardPost | null> {
     const conversation = await ConversationRepository.findById(this.pool, conversationId)
     if (!conversation || conversation.workspaceId !== workspaceId || conversation.messageIds.length === 0) return null
-    const [post] = await this.buildBoardPosts(workspaceId, [addStalenessFields(conversation)])
+    const [post] = await this.buildBoardPosts(workspaceId, [addStalenessFields(conversation)], userId)
     return post ?? null
   }
 
@@ -171,7 +173,11 @@ export class ConversationService {
    * have already enforced access (SQL filter for the feed, single-root check for
    * the single fetch); this does no access work of its own.
    */
-  private async buildBoardPosts(workspaceId: string, conversations: ConversationWithStaleness[]): Promise<BoardPost[]> {
+  private async buildBoardPosts(
+    workspaceId: string,
+    conversations: ConversationWithStaleness[],
+    userId: string
+  ): Promise<BoardPost[]> {
     if (conversations.length === 0) return []
 
     // Resolve each conversation's stream so a thread post can show its true
@@ -252,6 +258,16 @@ export class ConversationService {
       conversations.map((c) => c.id)
     )
 
+    // The Mine lens signal: which of these conversations' primary messages
+    // `@`-mentioned the viewer. Participation (`participant_ids`) is checked
+    // in-memory below (zero query); only the mention set costs one batched read
+    // (INV-56). Pinned to primary `message_ids` — the SAME set the SQL half
+    // (`boardLensCondSql` mine branch) tests — so the seed boundary and the
+    // rendered `isMine` can't disagree.
+    const mentionedMessageIds = await ActivityRepository.findMentionedMessageIds(this.pool, workspaceId, userId, [
+      ...new Set(conversations.flatMap((c) => c.messageIds)),
+    ])
+
     const posts: BoardPost[] = conversations.map((conversation) => {
       const plan = planByConversation.get(conversation.id)!
       const opening = plan.originId ? hydratedById.get(plan.originId) : undefined
@@ -277,6 +293,9 @@ export class ConversationService {
         totalReplies: plan.totalReplies,
         streamIds,
         hasCapturedMemo: conversationIdsWithMemos.has(conversation.id),
+        isMine:
+          conversation.participantIds.includes(userId) ||
+          conversation.messageIds.some((id) => mentionedMessageIds.has(id)),
         // Effective root of the anchor (and its type) — the client's stream-scope
         // and stream-type filters match on these, mirroring the SQL
         // `COALESCE(root_stream_id, id)` rule.

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
-import { BookMarked, Check, ChevronDown, CircleDashed, Hash, Layers, LayoutGrid, X, Zap } from "lucide-react"
+import { BookMarked, Check, ChevronDown, CircleDashed, Hash, Layers, LayoutGrid, User, X, Zap } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 import {
   BOARD_LENSES,
@@ -47,6 +47,12 @@ export const BOARD_LENS_DEFS: Record<BoardLens, BoardLensDef> = {
     label: "Decisions",
     description: "Settled — captured as a memo",
     icon: BookMarked,
+  },
+  mine: {
+    value: "mine",
+    label: "Mine",
+    description: "Conversations you're in or mentioned in",
+    icon: User,
   },
 }
 

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -80,6 +80,7 @@ function makePost(): BoardPost {
     totalReplies: 1,
     streamIds: ["stream_1"],
     hasCapturedMemo: false,
+    isMine: false,
   }
 }
 

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -432,6 +432,49 @@ describe("annotateConversationRevivals", () => {
       previousActivityAt: "2026-02-19T00:00:00.000Z",
     })
   })
+
+  it("falls back to the membership map when the declared conversation was merged into a retired shell", () => {
+    // conv_x (declared) was emptied + resolved by a later extraction pass; the
+    // messages now live in conv_successor. The chip must route + label from the
+    // successor, not deep-link the dead shell.
+    const conversationsById = new Map<string, ConversationWithStaleness>([
+      [
+        "conv_x",
+        { status: "resolved", messageIds: [] as string[], topicSummary: "Pizza (old)" } as ConversationWithStaleness,
+      ],
+      [
+        "conv_successor",
+        { status: "active", messageIds: ["msg_a", "msg_c"], topicSummary: "Pizza" } as ConversationWithStaleness,
+      ],
+    ])
+    const membership = new Map([
+      ["msg_a", "conv_successor"],
+      ["msg_b", "conv_y"],
+      ["msg_c", "conv_successor"],
+    ])
+    const items = annotateConversationRevivals(scattered(true), membership, conversationsById)
+
+    expect(revivalOf(items[2])).toEqual({
+      conversationId: "conv_successor",
+      topicSummary: "Pizza",
+      previousActivityAt: "2026-02-19T00:00:00.000Z",
+    })
+  })
+
+  it("keeps the declared id when its conversation is resolved but still holds messages", () => {
+    // A legitimately-resolved topic (not an empty merge shell) — the declared id
+    // is still its real home, so the fallback must NOT fire.
+    const conversationsById = new Map<string, ConversationWithStaleness>([
+      [
+        "conv_x",
+        { status: "resolved", messageIds: ["msg_a", "msg_c"], topicSummary: "Pizza" } as ConversationWithStaleness,
+      ],
+    ])
+    const membership = new Map([["msg_c", "conv_other"]])
+    const items = annotateConversationRevivals(scattered(true), membership, conversationsById)
+
+    expect(revivalOf(items[2])?.conversationId).toBe("conv_x")
+  })
 })
 
 describe("findMessageItemIndex", () => {

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from "react"
 import {
   COMMAND_EVENT_TYPES,
+  ConversationStatuses,
   type CommandEventType,
   type StreamEvent,
   type CommandDispatchedPayload,
@@ -253,7 +254,21 @@ export function annotateConversationRevivals(
     // messages (Mechanism A). The topic label still resolves from
     // `conversationsById` (loaded per-stream); a declared-but-not-yet-listed
     // conversation shows the generic label until the list catches up.
-    const conversationId = payload.declaredConversationId ?? membership.get(messageId) ?? null
+    //
+    // Fallback exception (resolved decision 3, board-view-design.md): a later
+    // extraction pass can merge/retire the declared conversation into an empty
+    // `resolved` shell — still present in `conversationsById` (the read query
+    // returns it) but holding no messages. Deep-linking that shell points at a
+    // dead conversation, so fall back to the membership map, which after a merge
+    // resolves the message to its surviving home. A declared id merely not-yet-
+    // listed (absent from `conversationsById`) is NOT retired — keep it, so the
+    // flicker-free just-sent case still wins over a not-yet-loaded list. The
+    // `status` check runs before `.messageIds` so a row missing that field can't
+    // be misread as retired.
+    const declared = payload.declaredConversationId
+    const declaredRow = declared != null ? conversationsById.get(declared) : undefined
+    const declaredRetired = declaredRow?.status === ConversationStatuses.RESOLVED && declaredRow.messageIds.length === 0
+    const conversationId = (declaredRetired ? undefined : declared) ?? membership.get(messageId) ?? null
     let revival: ConversationRevival | undefined
     if (conversationId != null) {
       const blockStart = conversationId !== previousConversationId

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -83,14 +83,28 @@ function makePost(
       ]),
     ],
     hasCapturedMemo: false,
+    isMine: false,
   }
 }
 
 function mountBoard(
   posts: BoardPost[],
-  opts: { nextCursor?: string | null; fail?: boolean; boardFlag?: "on" | "off"; failMessages?: boolean } = {}
+  opts: {
+    nextCursor?: string | null
+    fail?: boolean
+    boardFlag?: "on" | "off"
+    failMessages?: boolean
+    /** URL to mount at — set `/w/<ws>/board/<lens>` to exercise a lens segment. */
+    entry?: string
+  } = {}
 ) {
-  const { nextCursor = null, fail = false, boardFlag = "on", failMessages = false } = opts
+  const {
+    nextCursor = null,
+    fail = false,
+    boardFlag = "on",
+    failMessages = false,
+    entry = `/w/${WORKSPACE_ID}/board`,
+  } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
     return { posts, nextCursor }
@@ -112,10 +126,10 @@ function mountBoard(
       <TooltipProvider>
         <ServicesProvider services={{ conversations: { listByWorkspace, getBoardMessages } as never }}>
           <SidebarProvider>
-            <MemoryRouter initialEntries={[`/w/${WORKSPACE_ID}/board`]}>
+            <MemoryRouter initialEntries={[entry]}>
               <PanelProvider>
                 <Routes>
-                  <Route path="/w/:workspaceId/board" element={<BoardPage />} />
+                  <Route path="/w/:workspaceId/board/:lens?" element={<BoardPage />} />
                 </Routes>
               </PanelProvider>
             </MemoryRouter>
@@ -170,6 +184,18 @@ describe("BoardPage", () => {
   it("renders the opening-message body", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     expect(await screen.findByText("Rotate the tokens before Friday.")).toBeTruthy()
+  })
+
+  it("shows only the viewer's own conversations on the Mine lens", async () => {
+    // Server precomputes `isMine`; the Mine lens is wired into the same
+    // client filter (`matchesBoardLens`) the other lenses ride, keyed off the
+    // `/board/mine` URL segment.
+    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
+    const notMine = { ...makePost({ id: "conv_other" }, { contentMarkdown: "Someone else's topic." }), isMine: false }
+    mountBoard([mine, notMine], { entry: `/w/${WORKSPACE_ID}/board/mine` })
+
+    expect(await screen.findByText("My own topic.")).toBeTruthy()
+    expect(screen.queryByText("Someone else's topic.")).toBeNull()
   })
 
   it("offers an inline reply affordance on each post", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -56,6 +56,10 @@ const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {
     title: "No decisions captured yet",
     body: "When a conversation produces a memo — a decision, a fact worth keeping — it surfaces here as settled knowledge.",
   },
+  mine: {
+    title: "Nothing here for you yet",
+    body: "Conversations you start, join, or get mentioned in surface here — the slice of the board that's yours.",
+  },
 }
 
 /** Copy for an empty stream-scoped view, whatever the lens — the filters, not the

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -53,6 +53,7 @@ function makePost(id: string, lastActivityAt: string, recentMessages: BoardPostM
     totalReplies: recentMessages.length,
     streamIds: [...new Set([conversation.streamId, openingMessage.streamId, ...recentMessages.map((m) => m.streamId)])],
     hasCapturedMemo: false,
+    isMine: false,
   }
 }
 

--- a/packages/types/src/board-lens.test.ts
+++ b/packages/types/src/board-lens.test.ts
@@ -10,6 +10,7 @@ function post(overrides: {
   hoursIdle?: number
   completenessScore?: number
   hasCapturedMemo?: boolean
+  isMine?: boolean
 }): BoardPost {
   const hoursIdle = overrides.hoursIdle ?? 0
   return {
@@ -20,6 +21,7 @@ function post(overrides: {
       lastActivityAt: new Date(NOW - hoursIdle * 3_600_000).toISOString(),
     },
     hasCapturedMemo: overrides.hasCapturedMemo ?? false,
+    isMine: overrides.isMine ?? false,
   } as unknown as BoardPost
 }
 
@@ -39,6 +41,14 @@ describe("matchesBoardLens", () => {
   it("decisions accepts only captured-memo posts", () => {
     expect(matchesBoardLens(post({ hasCapturedMemo: true }), "decisions", NOW)).toBe(true)
     expect(matchesBoardLens(post({ hasCapturedMemo: false }), "decisions", NOW)).toBe(false)
+  })
+
+  it("mine accepts only the viewer's own posts (server-precomputed isMine)", () => {
+    expect(matchesBoardLens(post({ isMine: true }), "mine", NOW)).toBe(true)
+    expect(matchesBoardLens(post({ isMine: false }), "mine", NOW)).toBe(false)
+    // Mine narrows; it must not leak into the default home — `all` still takes an
+    // isMine:false post.
+    expect(matchesBoardLens(post({ isMine: false }), "all", NOW)).toBe(true)
   })
 
   it("needs-resolution accepts an explicitly stalled conversation regardless of age", () => {

--- a/packages/types/src/board-lens.ts
+++ b/packages/types/src/board-lens.ts
@@ -14,6 +14,8 @@ import type { BoardPost } from "./domain"
  *  - `needs-resolution` — explicitly stalled, or gone quiet (≥ stale hours) while
  *    still incomplete (< max completeness). Loose ends.
  *  - `decisions` — produced a captured memo (`hasCapturedMemo`). What got settled.
+ *  - `mine` — the viewer authored/participates in it or was `@`-mentioned
+ *    (`isMine`, precomputed server-side like `hasCapturedMemo`). For you.
  *
  * `nowMs` is passed in (not read via `Date.now()`) so the filter is pure and
  * testable; callers pass the current time at render.
@@ -26,6 +28,8 @@ export function matchesBoardLens(post: BoardPost, lens: BoardLens, nowMs: number
       return post.conversation.status === "active"
     case "decisions":
       return post.hasCapturedMemo === true
+    case "mine":
+      return post.isMine === true
     case "needs-resolution": {
       const { status, lastActivityAt, completenessScore } = post.conversation
       if (status === "stalled") return true

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -346,7 +346,7 @@ export const ConversationStatuses = {
  * must opt out of. Same signal for every viewer (personal lenses like Mine
  * come later). Ordered as they render in the lens picker.
  */
-export const BOARD_LENSES = ["all", "active", "needs-resolution", "decisions"] as const
+export const BOARD_LENSES = ["all", "active", "needs-resolution", "decisions", "mine"] as const
 export type BoardLens = (typeof BOARD_LENSES)[number]
 
 /** The board's home view: everything, newest activity first, nothing hidden. */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -745,6 +745,16 @@ export interface BoardPost {
    */
   hasCapturedMemo: boolean
   /**
+   * Whether this conversation is "mine" to the requesting viewer — they authored
+   * or participate in it (`participant_ids`) or were `@`-mentioned on one of its
+   * messages. The Mine lens signal. Like {@link hasCapturedMemo} this is a
+   * board-level, viewer-scoped field computed per fetch (not on the conversation
+   * aggregate the `conversation:*` events carry), so it is only as fresh as the
+   * last board fetch — a viewer newly added/mentioned flips into Mine on the next
+   * mount/reconnect reseed (INV-53), not live.
+   */
+  isMine: boolean
+  /**
    * The effective root of the conversation's anchor stream (a top-level anchor
    * is its own root; a thread anchor resolves to its root channel/DM). The
    * board's stream-scope filter matches on this, so a thread-anchored


### PR DESCRIPTION
## Summary

Roadmap next-up #6 (board-view-design.md — the **Mine** half of the personal lenses). A new `mine` lens surfaces the viewer's own slice of the board: conversations they **authored/participate in** (`participant_ids`) or were **`@`-mentioned in**.

Follows the Decisions-lens precedent exactly: a server-precomputed per-post boolean (`isMine` on `BoardPost`, next to `hasCapturedMemo`), client predicate stays pure.

## How it works

- **Client:** `matchesBoardLens` gains `case "mine": return post.isMine === true`. `/board/mine` is a valid URL segment for free (`VALID_LENSES = BOARD_LENSES`, INV-59). The exhaustive `Record<BoardLens>` maps (`BOARD_LENS_DEFS` picker, `LENS_EMPTY_COPY`) are compiler-forced to cover it.
- **Server:** `buildBoardPosts(…, userId)` computes `isMine` — participation is an **in-memory** check (zero query); the mention signal is **one batched read** (`ActivityRepository.findMentionedMessageIds`, INV-56), index-backed by `idx_user_activity_dedup`. The SQL seed boundary (`boardLensCondSql`) gets a `userId`-parameterized `mine` branch.
- **Lockstep:** both halves pin the mention signal to `conversations.message_ids`, so the server's pagination boundary and the client's rendered `isMine` can't disagree (the SQL/JS lockstep the lens system already documents in-code).

## Notes

- **No migration** — `participant_ids` GIN + `user_activity` indexes already exist.
- **Read-only, no outbox** — `isMine` rides the existing `conversation:*` seed/merge path and survives merges (board-store spreads `...existing`), inheriting `hasCapturedMemo`'s "as fresh as last fetch" lifecycle. A newly-mentioned viewer flips into Mine on the next mount/reconnect reseed (INV-53), not live — same accepted behavior as `hasCapturedMemo`.
- **Access still enforced** — the `mine` SQL is `AND`-composed with `streamAccessPredicateSql`, so a mention in an inaccessible stream can't leak (INV-62). `ActivityTypes.MENTION`, not a literal (INV-33).

## Scope guard (INV-36)

Deferred: the saved-suggestion "quiet-collector to-do" 4th Mine signal, and user-saved **custom lenses** (design captured in the planning trail — a `board_views` table storing the lens+scope+types triple as a named URL bookmark; explicitly *not* built here).

## Tests

- `board-lens.test.ts` — mine accepts/rejects; `all` still takes an `isMine:false` post (Mine narrows, doesn't leak).
- Real-mount board test at `/board/mine` — only the viewer's cards render (INV-39).
- 9 types + 40 frontend + 100 backend conversation/activity tests green.
- Follow-up: a DB-backed SQL-parity test once the conversations feature grows a DB test harness (there is none today).

> Stacked on #1191 → #1179. Base retargets as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785862817&installation_id=129946197&pr_number=1193&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1193&signature=c1a98ffb0c3d19fd7bf84141ad7eee502a8e33eca96638883bac13d4dfcb7d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->