### PR TITLE
feat(board): rename topic + mark resolved from the board card and conversation panel

### DIFF
--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -37,6 +37,7 @@ describe("Conversation Handlers", () => {
   const mockGetById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
   const mockGetBoardPostById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
+  const mockUpdateConversation = mock(() => Promise.resolve({ conversation: {} as Record<string, unknown> }))
   const mockGetFlag = mock(() => Promise.resolve("on" as string))
 
   const handlers = createConversationHandlers({
@@ -46,6 +47,7 @@ describe("Conversation Handlers", () => {
       getById: mockGetById,
       getMessages: mockGetMessages,
       getBoardPostById: mockGetBoardPostById,
+      updateConversation: mockUpdateConversation,
     } as never,
     streamService: {
       validateStreamAccess: mockValidateStreamAccess,
@@ -62,7 +64,11 @@ describe("Conversation Handlers", () => {
     mockGetById.mockReset()
     mockGetMessages.mockReset()
     mockGetBoardPostById.mockReset()
+    mockUpdateConversation.mockReset()
     mockGetFlag.mockReset()
+    mockUpdateConversation.mockResolvedValue({
+      conversation: { id: "conv_1", topicSummary: "Renamed", status: "active" },
+    })
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
@@ -288,6 +294,61 @@ describe("Conversation Handlers", () => {
       const res = mockRes()
       await handlers.getBoardPost(mockReq({ params: { conversationId: "conv_1" } }), res)
       expect((res as unknown as { body: unknown }).body).toEqual({ post })
+    })
+  })
+
+  describe("updateConversation", () => {
+    const req = (body: unknown) => mockReq({ params: { conversationId: "conv_1" }, body })
+
+    test("renames the topic and returns the updated conversation", async () => {
+      const res = mockRes()
+      await handlers.updateConversation(req({ topicSummary: "New topic" }), res)
+      expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+      expect(mockUpdateConversation).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        topicSummary: "New topic",
+        status: undefined,
+      })
+      expect((res as unknown as { body: unknown }).body).toEqual({
+        conversation: { id: "conv_1", topicSummary: "Renamed", status: "active" },
+      })
+    })
+
+    test("marks the conversation resolved", async () => {
+      const res = mockRes()
+      await handlers.updateConversation(req({ status: "resolved" }), res)
+      expect(mockUpdateConversation).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: "conv_1", status: "resolved" })
+      )
+    })
+
+    test("rejects an empty body with a 400", async () => {
+      await expect(handlers.updateConversation(req({}), mockRes())).rejects.toMatchObject({ status: 400 })
+      expect(mockUpdateConversation).not.toHaveBeenCalled()
+    })
+
+    test("rejects a non-user status (stalled) with a 400", async () => {
+      await expect(handlers.updateConversation(req({ status: "stalled" }), mockRes())).rejects.toMatchObject({
+        status: 400,
+      })
+      expect(mockUpdateConversation).not.toHaveBeenCalled()
+    })
+
+    test("404s a conversation in another workspace before writing", async () => {
+      mockGetById.mockResolvedValue({ id: "conv_1", streamId: "stream_1", workspaceId: "other_ws" })
+      const res = mockRes()
+      await handlers.updateConversation(req({ topicSummary: "x" }), res)
+      expect((res as unknown as { statusCode: number }).statusCode).toBe(404)
+      expect(mockUpdateConversation).not.toHaveBeenCalled()
+    })
+
+    test("propagates a stream-access rejection (INV-62) before writing", async () => {
+      mockValidateStreamAccess.mockRejectedValue(new Error("Stream not found"))
+      await expect(handlers.updateConversation(req({ topicSummary: "x" }), mockRes())).rejects.toThrow(
+        "Stream not found"
+      )
+      expect(mockUpdateConversation).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -3,7 +3,14 @@ import type { Request, Response } from "express"
 import type { ConversationService } from "./service"
 import type { StreamService } from "../streams"
 import type { FeatureFlagService } from "../feature-flags"
-import { CONVERSATION_STATUSES, BOARD_LENSES, BOARD_SCOPE_STREAM_TYPES, MAX_BOARD_SCOPE_STREAMS } from "@threa/types"
+import {
+  CONVERSATION_STATUSES,
+  ConversationStatuses,
+  MAX_CONVERSATION_TOPIC_LENGTH,
+  BOARD_LENSES,
+  BOARD_SCOPE_STREAM_TYPES,
+  MAX_BOARD_SCOPE_STREAMS,
+} from "@threa/types"
 import { validateRequest } from "../../lib/validation"
 import { HttpError } from "../../lib/errors"
 
@@ -65,6 +72,21 @@ const markReadSchema = z.object({
 const markUnreadSchema = z.object({
   fromMessageId: z.string().min(1),
 })
+
+const updateConversationParamsSchema = z.object({
+  conversationId: z.string().min(1),
+})
+
+// Status is restricted to the two the user can set — reopen (`active`) or resolve
+// (`resolved`). `stalled` is a derived/LLM lifecycle state, never user-assignable.
+const updateConversationBodySchema = z
+  .object({
+    topicSummary: z.string().trim().min(1).max(MAX_CONVERSATION_TOPIC_LENGTH).optional(),
+    status: z.enum([ConversationStatuses.ACTIVE, ConversationStatuses.RESOLVED]).optional(),
+  })
+  .refine((body) => body.topicSummary !== undefined || body.status !== undefined, {
+    message: "Provide topicSummary or status",
+  })
 
 interface Dependencies {
   conversationService: ConversationService
@@ -229,6 +251,31 @@ export function createConversationHandlers({ conversationService, streamService,
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const result = await conversationService.reassignMessage({ workspaceId, conversationId, messageId, userId })
+      res.json(result)
+    },
+
+    /**
+     * User edit of a conversation from the board card / panel: rename the topic
+     * and/or mark it resolved/reopened. Ungated (like reassign/read/unread — only
+     * the board *read* endpoints gate on the flag). Access via the conversation's
+     * root stream (INV-62).
+     */
+    async updateConversation(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { conversationId } = validateRequest(updateConversationParamsSchema, req.params)
+      const { topicSummary, status } = validateRequest(updateConversationBodySchema, req.body)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.updateConversation({ workspaceId, conversationId, topicSummary, status })
       res.json(result)
     },
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -492,6 +492,42 @@ export class ConversationService {
   }
 
   /**
+   * User edit of a conversation's own fields from the board card / panel: rename
+   * the topic (`topicSummary`) and/or mark it resolved/reopened (`status`). The
+   * atomic `UPDATE … RETURNING` is race-safe on its own (INV-20) — no lock, no
+   * check-then-act — and `topic_summary` is written only at insert by the
+   * extractor (never on an existing conversation), so a user title is never
+   * clobbered by a later extraction pass. Emits `conversation:updated` in the same
+   * transaction (INV-7); the update touches `updated_at`, not `last_activity_at`,
+   * so the card changes in place without re-sorting the board (stable view).
+   */
+  async updateConversation(params: {
+    workspaceId: string
+    conversationId: string
+    topicSummary?: string
+    status?: ConversationStatus
+  }): Promise<{ conversation: ConversationWithStaleness }> {
+    const { workspaceId, conversationId, topicSummary, status } = params
+    return withTransaction(this.pool, async (client) => {
+      const updated = await ConversationRepository.update(client, workspaceId, conversationId, { topicSummary, status })
+      if (!updated) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      const stream = await StreamRepository.findById(client, updated.streamId)
+      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+      await OutboxRepository.insert(client, "conversation:updated", {
+        workspaceId,
+        streamId: updated.streamId,
+        conversationId: updated.id,
+        conversation: addStalenessFields(updated),
+        parentStreamId,
+        streamVisibility,
+      })
+      return { conversation: addStalenessFields(updated) }
+    })
+  }
+
+  /**
    * Mark a conversation read through `throughMessageId` (inclusive). Read truth is
    * message-granular and stream-anchored (docs/sparse-read-overlay-design.md):
    * the conversation's member messages are snapshotted to concrete ids at write

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -499,6 +499,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     conversation.getBoardMessages
   )
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId/board-post", ...authed, conversation.getBoardPost)
+  app.patch("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.updateConversation)
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/reassign",
     ...authed,

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -150,4 +150,17 @@ export const conversationsApi = {
   ): Promise<{ conversation: ConversationWithStaleness; previousConversation: ConversationWithStaleness | null }> {
     return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/messages/${messageId}/reassign`)
   },
+
+  /**
+   * User edit of a conversation from the board card / panel: rename the topic
+   * (`topicSummary`) and/or mark it resolved/reopened (`status`). At least one
+   * field required; `status` is limited to `active`/`resolved`.
+   */
+  async updateConversation(
+    workspaceId: string,
+    conversationId: string,
+    body: { topicSummary?: string; status?: "active" | "resolved" }
+  ): Promise<{ conversation: ConversationWithStaleness }> {
+    return api.patch(`/api/workspaces/${workspaceId}/conversations/${conversationId}`, body)
+  },
 }

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPostMessage } from "@threa/types"
@@ -37,7 +38,7 @@ function openingMessage(overrides: Partial<BoardPostMessage> = {}): BoardPostMes
   }
 }
 
-function makePost(): BoardViewPost {
+function makePost(conversation: Record<string, unknown> = {}): BoardViewPost {
   const opening = openingMessage()
   return {
     id: "conv_1",
@@ -50,6 +51,7 @@ function makePost(): BoardViewPost {
       streamId: STREAM,
       messageIds: ["m_open"],
       lastActivityAt: "2026-06-22T12:00:00.000Z",
+      ...conversation,
     },
     openingMessage: opening,
     recentMessages: [],
@@ -57,16 +59,16 @@ function makePost(): BoardViewPost {
   } as unknown as BoardViewPost
 }
 
-function mountCard() {
+function mountCard(post: BoardViewPost = makePost(), conversations: Record<string, unknown> = {}) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
-        <ServicesProvider services={{ conversations: {} as never }}>
+        <ServicesProvider services={{ conversations: conversations as never }}>
           <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
             <TraceProvider>
               <PanelProvider>
-                <BoardCard workspaceId={WS} post={makePost()} contextLabel="#general" streamType="channel" />
+                <BoardCard workspaceId={WS} post={post} contextLabel="#general" streamType="channel" />
               </PanelProvider>
             </TraceProvider>
           </MemoryRouter>
@@ -203,5 +205,41 @@ describe("BoardCard agent activity", () => {
     mountCard()
     await screen.findByText("Opening body.")
     expect(screen.queryByText("Session complete")).toBeNull()
+  })
+})
+
+describe("BoardCard conversation actions", () => {
+  beforeEach(() => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => false,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+  })
+
+  it("shows the topic title when the conversation has one", async () => {
+    mountCard(makePost({ topicSummary: "Rotate the API tokens", status: "active" }))
+    expect(await screen.findByText("Rotate the API tokens")).toBeTruthy()
+  })
+
+  it("renders the resolved treatment on a resolved conversation", async () => {
+    mountCard(makePost({ topicSummary: "Shipped the redesign", status: "resolved" }))
+    await screen.findByText("Shipped the redesign")
+    expect(screen.getByLabelText("Resolved")).toBeTruthy()
+  })
+
+  it("marks the conversation resolved from the ⋯ menu", async () => {
+    const user = userEvent.setup()
+    const updateConversation = vi.fn().mockResolvedValue({
+      conversation: { id: "conv_1", status: "resolved", messageIds: ["m_open"] },
+    })
+    mountCard(makePost({ topicSummary: "Rotate the API tokens", status: "active" }), { updateConversation })
+
+    await user.click(await screen.findByRole("button", { name: "Conversation actions" }))
+    await user.click(await screen.findByText("Mark resolved"))
+
+    expect(updateConversation).toHaveBeenCalledWith(WS, "conv_1", { status: "resolved" })
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,13 +1,24 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
-import { Hash, FileEdit, User, MessageSquareText, ChevronDown, PanelRight, type LucideIcon } from "lucide-react"
+import {
+  Hash,
+  FileEdit,
+  User,
+  MessageSquareText,
+  ChevronDown,
+  CircleCheck,
+  PanelRight,
+  type LucideIcon,
+} from "lucide-react"
 import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
+import { cn } from "@/lib/utils"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
@@ -250,7 +261,34 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
               </TooltipTrigger>
               <TooltipContent side="bottom">Open conversation</TooltipContent>
             </Tooltip>
+            <ConversationActionsMenu
+              workspaceId={workspaceId}
+              conversationId={conversation.id}
+              topicSummary={conversation.topicSummary}
+              status={conversation.status}
+              triggerClassName="shrink-0"
+            />
           </div>
+
+          {/* The conversation's topic — a quiet single-line label, shown only when
+            the extractor (or a rename) set one, so a message-led card stays
+            message-led when it hasn't. A resolved topic reads muted with a small
+            marker; the card also drops out of the Active lens (its own signal). */}
+          {conversation.topicSummary && (
+            <div className="mt-2 flex items-center gap-1.5">
+              {conversation.status === "resolved" && (
+                <CircleCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="Resolved" />
+              )}
+              <span
+                className={cn(
+                  "truncate text-sm font-medium",
+                  conversation.status === "resolved" && "text-muted-foreground line-through decoration-1"
+                )}
+              >
+                {conversation.topicSummary}
+              </span>
+            </div>
+          )}
 
           <div className="mt-3 [&>*:first-child]:mt-0">
             {contiguous ? (

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react"
+import { CircleCheck, EllipsisVertical, Pencil, RotateCcw } from "lucide-react"
+import { ConversationStatuses, MAX_CONVERSATION_TOPIC_LENGTH } from "@threa/types"
+import { Button } from "@/components/ui/button"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { Input } from "@/components/ui/input"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogBody,
+  ResponsiveDialogContent,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { cn } from "@/lib/utils"
+import { useUpdateConversation } from "@/hooks/use-conversations"
+
+interface ConversationActionsMenuProps {
+  workspaceId: string
+  conversationId: string
+  /** Current topic — prefilled into the rename dialog; null renders as empty. */
+  topicSummary: string | null
+  /** Current status — selects the resolve vs. reopen item. */
+  status: string
+  /** Extra classes for the trigger, so each surface can size it to its icon cluster. */
+  triggerClassName?: string
+}
+
+/**
+ * The `⋯` overflow on a board card / conversation panel: rename the topic and
+ * mark the conversation resolved (or reopen it). Both edits go through
+ * {@link useUpdateConversation} — optimistic, silent on success (the title/label
+ * change is the confirmation, INV-63). Rename opens a {@link RenameConversationDialog}
+ * rather than editing inline, so the card never shifts layout mid-edit (INV-21).
+ */
+export function ConversationActionsMenu({
+  workspaceId,
+  conversationId,
+  topicSummary,
+  status,
+  triggerClassName,
+}: ConversationActionsMenuProps) {
+  const [renameOpen, setRenameOpen] = useState(false)
+  const update = useUpdateConversation(workspaceId)
+  const resolved = status === ConversationStatuses.RESOLVED
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn("h-8 w-8 text-muted-foreground hover:text-foreground", triggerClassName)}
+            aria-label="Conversation actions"
+          >
+            <EllipsisVertical className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onSelect={(event) => {
+              // Defer the dialog until the menu has closed so Radix returns focus
+              // to the trigger before the dialog claims it.
+              event.preventDefault()
+              setRenameOpen(true)
+            }}
+          >
+            <Pencil className="h-4 w-4" />
+            Rename topic…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() =>
+              update.mutate({
+                conversationId,
+                status: resolved ? ConversationStatuses.ACTIVE : ConversationStatuses.RESOLVED,
+              })
+            }
+          >
+            {resolved ? <RotateCcw className="h-4 w-4" /> : <CircleCheck className="h-4 w-4" />}
+            {resolved ? "Reopen" : "Mark resolved"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <RenameConversationDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        initialTopic={topicSummary ?? ""}
+        onSave={(next) => update.mutate({ conversationId, topicSummary: next })}
+      />
+    </>
+  )
+}
+
+interface RenameConversationDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialTopic: string
+  onSave: (topic: string) => void
+}
+
+function RenameConversationDialog({ open, onOpenChange, initialTopic, onSave }: RenameConversationDialogProps) {
+  const [value, setValue] = useState(initialTopic)
+  // Re-seed on each open (a different card, or a re-open after cancel).
+  useEffect(() => {
+    if (open) setValue(initialTopic)
+  }, [open, initialTopic])
+
+  const trimmed = value.trim()
+  const canSave = trimmed.length > 0 && trimmed !== initialTopic.trim()
+
+  const save = () => {
+    if (!canSave) return
+    onSave(trimmed)
+    onOpenChange(false)
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent>
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle>Rename topic</ResponsiveDialogTitle>
+        </ResponsiveDialogHeader>
+        <ResponsiveDialogBody>
+          <Input
+            autoFocus
+            value={value}
+            maxLength={MAX_CONVERSATION_TOPIC_LENGTH}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault()
+                save()
+              }
+            }}
+            placeholder="Topic name"
+          />
+        </ResponsiveDialogBody>
+        <ResponsiveDialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={save} disabled={!canSave}>
+            Save
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -2,7 +2,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { ChevronLeft, Hash, FileEdit, User, MessageSquareText, Link2, Check, type LucideIcon } from "lucide-react"
+import {
+  ChevronLeft,
+  Hash,
+  FileEdit,
+  User,
+  MessageSquareText,
+  Link2,
+  Check,
+  CircleCheck,
+  type LucideIcon,
+} from "lucide-react"
 import {
   SidePanel,
   SidePanelHeader,
@@ -17,6 +27,8 @@ import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
 import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
+import { cn } from "@/lib/utils"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
@@ -195,7 +207,19 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
         </Button>
         <SidePanelTitle className="flex min-w-0 flex-1 items-center gap-1.5">
           <ContextGlyph className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="truncate">{locator}</span>
+          {post?.conversation.status === "resolved" && (
+            <CircleCheck className="h-4 w-4 shrink-0 text-muted-foreground" aria-label="Resolved" />
+          )}
+          {/* The topic is the conversation's identity — show it when set, falling
+            back to the stream locator (the pre-topic behavior). */}
+          <span
+            className={cn(
+              "truncate",
+              post?.conversation.status === "resolved" && "text-muted-foreground line-through decoration-1"
+            )}
+          >
+            {post?.conversation.topicSummary ?? locator}
+          </span>
           {post && (
             <RelativeTime
               date={post.conversation.lastActivityAt}
@@ -204,6 +228,15 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
             />
           )}
         </SidePanelTitle>
+        {post && (
+          <ConversationActionsMenu
+            workspaceId={workspaceId}
+            conversationId={post.conversation.id}
+            topicSummary={post.conversation.topicSummary}
+            status={post.conversation.status}
+            triggerClassName="shrink-0"
+          />
+        )}
         {conversationId && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -72,6 +72,7 @@ export interface ConversationService {
   markRead: typeof conversationsApi.markRead
   markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
+  updateConversation: typeof conversationsApi.updateConversation
 }
 
 export interface ActivityService {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -7,8 +7,10 @@ import {
   useSocketReconnectCount,
   createDraftPanelId,
 } from "@/contexts"
+import { toast } from "sonner"
+import { db } from "@/db"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import { seedBoardPosts, useBoardPost } from "@/stores/board-store"
+import { seedBoardPosts, useBoardPost, mergeBoardConversation } from "@/stores/board-store"
 import type { BoardViewPost } from "./use-stable-board-view"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
@@ -585,6 +587,72 @@ export function useReassignConversationMessage(workspaceId: string, streamId: st
       queryClient.invalidateQueries({ queryKey: conversationKeys.messages(conversation.id) })
       if (previousConversation) {
         queryClient.invalidateQueries({ queryKey: conversationKeys.messages(previousConversation.id) })
+      }
+    },
+  })
+}
+
+/**
+ * Rename a conversation's topic and/or mark it resolved/reopened from the board
+ * card or conversation panel. Optimistic + self-reconciling: the change shows the
+ * instant it's dispatched and settles on the HTTP response, no socket wait.
+ *
+ * Patches WHICHEVER cache holds the row — the board-seeded IDB card
+ * (`db.conversations`) AND/OR the by-id `boardPost` query cache a deep-linked
+ * panel reads (that panel is deliberately not seeded into IDB, so a rename from
+ * it would otherwise show nothing until a `conversation:updated` echo that, for a
+ * private/DM/scratchpad conversation, is never broadcast workspace-wide). On
+ * success `mergeBoardConversation` runs the same idempotent authoritative write
+ * the socket echo would (clearing the optimistic `_status`); on error both caches
+ * roll back and a single `toast.error` fires (INV-63 — success is silent).
+ */
+export function useUpdateConversation(workspaceId: string) {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      conversationId,
+      topicSummary,
+      status,
+    }: {
+      conversationId: string
+      topicSummary?: string
+      status?: "active" | "resolved"
+    }) => conversationService.updateConversation(workspaceId, conversationId, { topicSummary, status }),
+    onMutate: async ({ conversationId, topicSummary, status }) => {
+      const patch = {
+        ...(topicSummary !== undefined ? { topicSummary } : {}),
+        ...(status !== undefined ? { status } : {}),
+      }
+      const prevRow = await db.conversations.get(conversationId)
+      if (prevRow) {
+        await db.conversations.put({
+          ...prevRow,
+          conversation: { ...prevRow.conversation, ...patch },
+          _status: "pending",
+        })
+      }
+      const boardPostKey = conversationKeys.boardPost(conversationId)
+      const prevQuery = queryClient.getQueryData<BoardPost>(boardPostKey)
+      if (prevQuery) {
+        queryClient.setQueryData<BoardPost>(boardPostKey, {
+          ...prevQuery,
+          conversation: { ...prevQuery.conversation, ...patch },
+        })
+      }
+      return { prevRow, prevQuery, conversationId }
+    },
+    onError: (_error, _vars, ctx) => {
+      if (ctx?.prevRow) void db.conversations.put(ctx.prevRow)
+      if (ctx?.prevQuery) queryClient.setQueryData(conversationKeys.boardPost(ctx.conversationId), ctx.prevQuery)
+      toast.error("Couldn't update the conversation")
+    },
+    onSuccess: ({ conversation }, { conversationId }) => {
+      void mergeBoardConversation(conversationId, conversation)
+      const boardPostKey = conversationKeys.boardPost(conversationId)
+      if (queryClient.getQueryData(boardPostKey)) {
+        queryClient.setQueryData<BoardPost>(boardPostKey, (prev) => (prev ? { ...prev, conversation } : prev))
       }
     },
   })

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -338,6 +338,14 @@ export const ConversationStatuses = {
 } as const satisfies Record<string, ConversationStatus>
 
 /**
+ * Max length of a user-set conversation topic (the board card / panel rename).
+ * A generous cap — the LLM's own topic prompt targets ≤5 words, but a person
+ * renaming a card gets more room. Shared by the write endpoint's Zod schema and
+ * the rename dialog input (INV-33, one source of truth).
+ */
+export const MAX_CONVERSATION_TOPIC_LENGTH = 120
+
+/**
  * Structural lenses over the workspace board (board-view-design.md § "Lenses").
  * Each is a true filter over signals Threa already computes — the board gives
  * the dials, it doesn't decide what matters. `all` is the default and always

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -71,6 +71,7 @@ export {
   CONVERSATION_STATUSES,
   type ConversationStatus,
   ConversationStatuses,
+  MAX_CONVERSATION_TOPIC_LENGTH,
   // Board lenses
   BOARD_LENSES,
   type BoardLens,


### PR DESCRIPTION
## Summary

Roadmap next-up #7. A `⋯` overflow menu on the board card and the conversation panel lets a user **rename the topic** and **mark the conversation resolved** (or reopen it), and both surfaces now show the topic title.

## Backend — `PATCH /api/workspaces/:ws/conversations/:id` `{ topicSummary?, status? }`

- Reuses `ConversationRepository.update` — **no migration** (columns exist), no new repo code. The atomic `UPDATE … RETURNING` is race-safe on its own (INV-20): no lock, no check-then-act.
- New `ConversationService.updateConversation` owns the transaction and emits `conversation:updated` in it (INV-6/7); delivery routing is free (the board already receives that event). The update touches `updated_at`, **not** `last_activity_at`, so the card changes in place without re-sorting (stable view).
- Zod body (INV-55): `status` restricted to `active`/`resolved` — `stalled` is a derived LLM state, never user-set (INV-11). Thin handler (INV-34), access via the root stream (INV-62), ungated like reassign/read.

**Correctness (load-bearing):** the boundary extractor writes `topic_summary` only at conversation INSERT, never on an existing one — so a user rename is never clobbered by a later extraction pass. No pin column needed (INV-36). *Follow-up:* a DB-backed extraction-guard regression test (the feature has no extraction test harness yet).

## Frontend

- **`useUpdateConversation`** — optimistic + self-reconciling. Patches **whichever cache holds the row**: the board-seeded IDB card AND/OR the by-id `boardPost` query cache a **deep-linked panel** reads (that panel isn't seeded into IDB, and a private/DM `conversation:updated` isn't broadcast workspace-wide, so patching only IDB would look broken from a permalinked panel). On success `mergeBoardConversation` runs the same authoritative write the socket echo would; on error both caches roll back + one `toast.error`. Otherwise silent (INV-63) — the title/label is the confirmation.
- **`ConversationActionsMenu` + `RenameConversationDialog`** — one component reused by card + panel (INV-35). Rename is a dialog, not inline, so the card never shifts mid-edit (INV-21). Shadcn primitives (INV-14).
- The card grows a **quiet single-line topic title, shown only when set** (a message-led card stays message-led when there's no topic); the panel header shows the topic, falling back to the stream locator. Resolved reads muted + struck-through with a small marker, and the card drops out of the Active lens.
- `MAX_CONVERSATION_TOPIC_LENGTH` shared constant (INV-33).

**Product note:** I floated keeping the card message-led with a panel-only title, but the feature (and the board being a topic-card view) really needs the title visible on the card — so I added a compact, understated title line rather than a heading. One-line revert if you'd rather it stay panel-only.

## Scope guard (INV-36)

Merge/split stays backlog; per-card hide + stream mute is its own PR (next).

## Tests

- Backend handler: rename, resolve, empty→400, `stalled`→400, cross-workspace→404, access-reject-before-write, outbox emit.
- Frontend real-mount (INV-39): topic title renders, resolved treatment renders, "Mark resolved" wires to `updateConversation` through the menu.
- 0 typecheck errors across 3 packages; 47 frontend + 69 backend conversation tests green.

> Stacked on #1193 → #1191 → #1179. Base retargets as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785863808&installation_id=129946197&pr_number=1194&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1194&signature=69a1f2757c796b96692315316a9af51345b7cb893f2d22d667500f1b4e8af377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->