### PR TITLE
fix(timeline): dock the tail out of the composer dead band + heal silent viewport overshoot

### DIFF
--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -683,6 +683,32 @@ describe("useTimelineScroll — dead-band dock (downward release short of the bo
       vi.useRealTimers()
     }
   })
+
+  it("waits for the mouse button to release before docking", () => {
+    // Mouse mirror of the finger-lift case: a held button (text-selection drag,
+    // scrollbar-adjacent press) must not dock mid-gesture. The release is
+    // listened on window, not the scroller — a drag can end with the cursor
+    // outside it.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      gestureScrollTo(harness, el, userInteractedAtRef, 3800)
+      el.dispatchEvent(new Event("mousedown"))
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      // Button still held: the settle window elapsing must not dock.
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(4140)
+      // Release (on window — cursor may have left the scroller) → dock.
+      window.dispatchEvent(new Event("mouseup"))
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(5000)
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
 })
 
 describe("useTimelineScroll — cold-load settle across a stream switch", () => {

--- a/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
+++ b/apps/frontend/src/hooks/use-timeline-scroll.test.tsx
@@ -49,6 +49,14 @@ function makeScrollerDiv(metrics: { scrollHeight: number; clientHeight: number; 
       scrollTop = v
     },
   })
+  // jsdom has no Element.scrollTo — the smooth dead-band dock path uses it.
+  Object.defineProperty(el, "scrollTo", {
+    configurable: true,
+    value: (options?: ScrollToOptions | number) => {
+      if (typeof options === "object" && options?.top !== undefined) el.scrollTop = options.top
+      else if (typeof options === "number") el.scrollTop = options
+    },
+  })
   return el
 }
 
@@ -529,6 +537,147 @@ describe("useTimelineScroll — deferred re-check after a resize skipped for an 
 
       act(() => vi.advanceTimersByTime(300))
       expect(el.scrollTop).toBe(800)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe("useTimelineScroll — dead-band dock (downward release short of the bottom)", () => {
+  class MockResizeObserver {
+    constructor(public cb: ResizeObserverCallback) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  /** Mounts the hook with a registered scroller, cold-load settle already
+   *  converged (immediate-rAF mock), parked at the pinned bottom. */
+  function mountAtBottom(overrides: Partial<Options> = {}) {
+    const userInteractedAtRef = { current: 0 }
+    const raf = vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(performance.now())
+      return 0
+    })
+    const harness = renderScrollHook(opts({ itemCount: 0, getFirstKey: () => null, userInteractedAtRef, ...overrides }))
+    const content = document.createElement("div")
+    harness.current.contentRef.current = content
+    const el = makeScrollerDiv({ scrollHeight: 5000, clientHeight: 800 })
+    el.style.setProperty("--composer-height", "70px")
+    act(() => harness.current.registerScroller(el))
+    // First window lands: the initial pin + cold-load settle converge
+    // synchronously under the immediate-rAF mock and reveal the content —
+    // the dock must see a *settled* timeline, exactly like the real flow.
+    harness.rerender(opts({ itemCount: 50, getFirstKey: () => "e10", userInteractedAtRef, ...overrides }))
+    raf.mockRestore()
+    expect(harness.current.isInitialSettling).toBe(false)
+    // The mock scroller doesn't browser-clamp the pin's scrollTop=scrollHeight
+    // write; park at the real maximum (distance 0) and re-baseline.
+    el.scrollTop = 4200
+    act(() => harness.current.handleScroll())
+    expect(harness.current.isFollowingTailRef.current).toBe(true)
+    return { harness, el, userInteractedAtRef }
+  }
+
+  /** A user gesture moving scrollTop, as the browser delivers it: stamp + scroll. */
+  function gestureScrollTo(
+    harness: { current: HookApi },
+    el: HTMLDivElement,
+    userInteractedAtRef: { current: number },
+    top: number
+  ) {
+    userInteractedAtRef.current = performance.now()
+    el.scrollTop = top
+    act(() => harness.current.handleScroll())
+    el.dispatchEvent(new Event("scroll"))
+  }
+
+  it("docks to the bottom when a downward gesture settles inside the composer dead band", () => {
+    // The mobile overlap bug: the bottom --composer-height px of scroll range
+    // sit behind the floating pill, so a touch drag back toward the bottom
+    // that releases inside that band parks the tail clipped by the composer —
+    // and nothing corrects it (follow was disarmed by the gesture, the
+    // at-bottom re-arm band is narrower than the dead band, jump-to-latest
+    // needs 600px). Once the scroll settles, the dock must finish the gesture:
+    // ease to the true bottom and re-arm follow.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      // Scrolls up out of the band (reading history) — follow disarms.
+      gestureScrollTo(harness, el, userInteractedAtRef, 3800)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+      // Drags back down, releasing 60px short of max — inside the 70+32 band.
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+      // Scroll events go quiet — the settle window elapses.
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(5000)
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("leaves an upward nudge inside the dead band alone", () => {
+    // Nudging up a little to read context while typing is a deliberate
+    // position — docking it would scroll away exactly what the nudge revealed.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(4140)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not dock after programmatic positioning with no user gesture", () => {
+    // Divider/deep-link scrolls position the view without any gesture; a
+    // target that happens to land near the tail must stay where it was put.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el } = mountAtBottom()
+      act(() => harness.current.disableAutoScroll())
+      // Programmatic positioning into the dead band — no gesture stamp.
+      el.scrollTop = 4140
+      act(() => harness.current.handleScroll())
+      el.dispatchEvent(new Event("scroll"))
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(4140)
+      expect(harness.current.isFollowingTailRef.current).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+      vi.useRealTimers()
+    }
+  })
+
+  it("waits for the finger to lift before docking", () => {
+    // A resting finger emits no scroll events, so the quiet window alone would
+    // elapse mid-gesture and yank the content out from under the touch.
+    vi.stubGlobal("ResizeObserver", MockResizeObserver)
+    vi.useFakeTimers()
+    try {
+      const { harness, el, userInteractedAtRef } = mountAtBottom()
+      gestureScrollTo(harness, el, userInteractedAtRef, 3800)
+      el.dispatchEvent(new Event("touchstart"))
+      gestureScrollTo(harness, el, userInteractedAtRef, 4140)
+      // Finger still down: the settle window elapsing must not dock.
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(4140)
+      // Finger lifts → the dock completes the gesture.
+      el.dispatchEvent(Object.assign(new Event("touchend"), { touches: [] }))
+      act(() => vi.advanceTimersByTime(200))
+      expect(el.scrollTop).toBe(5000)
+      expect(harness.current.isFollowingTailRef.current).toBe(true)
     } finally {
       vi.unstubAllGlobals()
       vi.useRealTimers()

--- a/apps/frontend/src/hooks/use-timeline-scroll.ts
+++ b/apps/frontend/src/hooks/use-timeline-scroll.ts
@@ -8,6 +8,11 @@ const JUMP_TO_LATEST_PX = 600
 /** A scroll-away-from-bottom only disarms follow if a real user gesture landed
  *  within this window; otherwise it's content growth and the tail re-pins. */
 const USER_SCROLL_GRACE_MS = 300
+/** Scroll-event silence that marks a user scroll (incl. momentum) as settled,
+ *  after which a downward release inside the composer dead band docks to the
+ *  true bottom. Longer than any inter-event gap of an active scroll; short
+ *  enough that the dock reads as part of the gesture. */
+const DEAD_BAND_DOCK_SETTLE_MS = 200
 /** Consecutive frames of unchanged scrollHeight that mark the cold-load settle
  *  as converged, so the content can be revealed without a visible bounce. */
 const SETTLE_STABLE_FRAMES = 3
@@ -194,6 +199,18 @@ export function useTimelineScroll({
   const initialSettleRafRef = useRef(0)
   const initialSettleCleanupRef = useRef<((reveal?: boolean) => void) | null>(null)
 
+  // Direction of the last GESTURE-DRIVEN scroll movement (null until one
+  // happens). Only gesture-fresh, height-stable deltas record here: momentum
+  // events after a flick carry no fresh gesture stamp but only ever continue
+  // the drag's direction, so the drag-phase value stays correct through them —
+  // while programmatic positioning (divider/deep-link scrolls, our pins, the
+  // observer's viewport shifts) and browser clamps never register. The
+  // dead-band dock below consults this so it only ever completes a gesture
+  // that was heading TOWARD the bottom; an upward nudge (peeking at context
+  // while typing) is a position the user chose, and docking it would undo
+  // what they just revealed at the top of the viewport.
+  const lastGestureScrollDirRef = useRef<"up" | "down" | null>(null)
+
   // Reset all scroll state synchronously when the stream changes, before the
   // shift computation below runs for the new stream's first render. A layout
   // effect would run a render too late and mis-detect the first window as a
@@ -206,6 +223,7 @@ export function useTimelineScroll({
     prevScrollTopRef.current = 0
     prevScrollHeightRef.current = 0
     didInitialScrollRef.current = false
+    lastGestureScrollDirRef.current = null
     isFollowingTailRef.current = !skipInitialScroll
     // Re-mask for the new stream's cold-load settle (a no-op when it converges
     // instantly, e.g. revisiting an already-measured stream).
@@ -394,6 +412,10 @@ export function useTimelineScroll({
     // Secondary signal for a touch/wheel gesture that hasn't moved scrollTop yet.
     const now = performance.now()
     const userGestured = now - (userInteractedAtRef?.current ?? 0) < USER_SCROLL_GRACE_MS
+    if (heightStable && userGestured) {
+      if (el.scrollTop > prevTop + 1) lastGestureScrollDirRef.current = "down"
+      else if (el.scrollTop < prevTop - 1) lastGestureScrollDirRef.current = "up"
+    }
     // The composer footer spacer is dead space at the very bottom. During the
     // initial cold-load settle we keep the generous composer-height band so a
     // slightly-undershoot landing doesn't disarm follow before convergence; once
@@ -594,6 +616,88 @@ export function useTimelineScroll({
       el.removeEventListener("keydown", mark)
     }
   }, [scrollerEl, userInteractedAtRef])
+
+  // Dead-band dock. The bottom `--composer-height` px of scroll range sit
+  // behind the floating composer, so any scroll position resting in that band
+  // shows the tail clipped by the pill — and nothing ever corrects it: the
+  // gesture disarmed follow, the at-bottom re-arm band (AT_BOTTOM_PX) is
+  // narrower than the dead band, and jump-to-latest needs 600px. A mouse wheel
+  // overshoots and clamps at the true max (which re-arms follow), which is why
+  // this parked state is a touch-drag/trackpad problem: a finger releases
+  // wherever it stops. So once user scrolling settles (scroll events quiet,
+  // no finger/button held) with the last gesture heading DOWN — the user was
+  // returning to the bottom and undershot — ease the rest of the way and let
+  // the pin re-arm follow. Upward releases in the band are left alone: that is
+  // the deliberate "nudge up to read context" position, and the direction ref
+  // never records programmatic positioning (deep-link/divider scrolls), so a
+  // jump target near the tail is never yanked from under the user either.
+  useEffect(() => {
+    const el = scrollerEl
+    if (!el) return
+    let settleTimer = 0
+    // A held press must not dock mid-gesture (a still finger emits no scroll
+    // events, so the quiet window alone would elapse under it). Tracked via
+    // touch events, not pointer events — browsers fire pointercancel when a
+    // touch scroll takes over, which would read as "released" while the finger
+    // is still dragging. Mouse-side, a held selection drag is the same hazard.
+    let touchHeld = false
+    let mouseHeld = false
+    const clearSettle = () => {
+      if (settleTimer) {
+        window.clearTimeout(settleTimer)
+        settleTimer = 0
+      }
+    }
+    const evaluate = () => {
+      settleTimer = 0
+      if (touchHeld || mouseHeld) return
+      if (isJumpMode || isInitialSettlingRef.current) return
+      if (lastGestureScrollDirRef.current !== "down") return
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+      if (distanceFromBottom <= 1) return
+      if (distanceFromBottom > readComposerHeight(el) + AT_BOTTOM_PX) return
+      scrollToBottom({ force: true, behavior: "smooth" })
+    }
+    const schedule = () => {
+      clearSettle()
+      settleTimer = window.setTimeout(evaluate, DEAD_BAND_DOCK_SETTLE_MS)
+    }
+    const onScroll = () => schedule()
+    const onTouchStart = () => {
+      touchHeld = true
+      clearSettle()
+    }
+    const onTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length > 0) return
+      touchHeld = false
+      schedule()
+    }
+    const onMouseDown = () => {
+      mouseHeld = true
+      clearSettle()
+    }
+    const onMouseUp = () => {
+      if (!mouseHeld) return
+      mouseHeld = false
+      schedule()
+    }
+    el.addEventListener("scroll", onScroll, { passive: true })
+    el.addEventListener("touchstart", onTouchStart, { passive: true })
+    el.addEventListener("touchend", onTouchEnd, { passive: true })
+    el.addEventListener("touchcancel", onTouchEnd, { passive: true })
+    el.addEventListener("mousedown", onMouseDown, { passive: true })
+    // window, not el: a drag can end with the cursor outside the scroller.
+    window.addEventListener("mouseup", onMouseUp, { passive: true })
+    return () => {
+      clearSettle()
+      el.removeEventListener("scroll", onScroll)
+      el.removeEventListener("touchstart", onTouchStart)
+      el.removeEventListener("touchend", onTouchEnd)
+      el.removeEventListener("touchcancel", onTouchEnd)
+      el.removeEventListener("mousedown", onMouseDown)
+      window.removeEventListener("mouseup", onMouseUp)
+    }
+  }, [scrollerEl, isJumpMode, scrollToBottom])
 
   // Abort an in-flight cold-load settle when the hook unmounts. Kept separate
   // from the ResizeObserver effect above so that effect can re-run when the

--- a/apps/frontend/src/hooks/use-visual-viewport.test.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.test.ts
@@ -501,6 +501,74 @@ describe("useVisualViewport", () => {
     search.remove()
   })
 
+  it("corrects a close overshoot that settles back without a final resize event", async () => {
+    // Chrome Android's keyboard-close overshoot (753px reported on a 725px
+    // screen) can settle back to the real height WITHOUT emitting another
+    // resize. A lone per-event measurement writes the overshoot and never
+    // hears the correction — --viewport-height sticks taller than the screen
+    // and the bottom-anchored composer sits below the fold indefinitely (the
+    // "no composer at all" state). Every resize must therefore start a short
+    // poll window that reads the silent settle.
+    const getVH = () => document.documentElement.style.getPropertyValue("--viewport-height")
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+    // Keyboard-open steady state (resizes-content: both viewports track).
+    // No focusout is involved — this is the back-button close, where focus
+    // stays on the composer and no optimistic-restore freeze applies.
+    setInnerHeight(436)
+    fakeVV.height = 436
+    renderHook(() => useVisualViewport(true))
+    expect(getVH()).toBe("436px")
+
+    // The close reports one chunk: the overshoot — and then goes silent.
+    await act(async () => {
+      setInnerHeight(753)
+      fakeVV.height = 753
+      fakeVV.emitResize()
+      // Growth debounce elapses with the overshoot still current → written.
+      await sleep(200)
+    })
+    expect(getVH()).toBe("753px")
+
+    // The viewport settles on the real height with NO further resize event.
+    // Only the poll window started by the last resize can observe this.
+    await act(async () => {
+      setInnerHeight(725)
+      fakeVV.height = 725
+      for (let i = 0; i < 4; i++) await nextFrame()
+    })
+    expect(getVH()).toBe("725px")
+  })
+
+  it("re-measures when the app is foregrounded again (visibilitychange)", async () => {
+    // Foregrounding a standalone PWA fires no pageshow (the page never entered
+    // the BFCache), but Chrome resumes it with equally stale viewport state.
+    const getVH = () => document.documentElement.style.getPropertyValue("--viewport-height")
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    fakeVV.height = 800
+    renderHook(() => useVisualViewport(true))
+    expect(getVH()).toBe("800px")
+
+    const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState")
+    Object.defineProperty(document, "visibilityState", { configurable: true, get: () => "visible" })
+    try {
+      await act(async () => {
+        // Viewport changed while backgrounded; no resize fires on resume.
+        setInnerHeight(712)
+        fakeVV.height = 712
+        document.dispatchEvent(new Event("visibilitychange"))
+        for (let i = 0; i < 4; i++) await nextFrame()
+        // Shrink applies synchronously in the poll; nothing else to wait out.
+      })
+      expect(getVH()).toBe("712px")
+    } finally {
+      if (originalVisibility) Object.defineProperty(Document.prototype, "visibilityState", originalVisibility)
+      Reflect.deleteProperty(document, "visibilityState")
+    }
+  })
+
   it("cleans up listeners and removes --viewport-height on unmount", () => {
     fakeVV.height = 800
     const { unmount } = renderHook(() => useVisualViewport(true))

--- a/apps/frontend/src/hooks/use-visual-viewport.ts
+++ b/apps/frontend/src/hooks/use-visual-viewport.ts
@@ -327,6 +327,24 @@ export function useVisualViewport(enabled: boolean): boolean {
       pollForDuration(POLL_DURATION)
     }
 
+    // Every viewport resize report starts a short poll window, not just a
+    // single measurement. Chrome Android's keyboard-close overshoot (a report
+    // PAST the real screen height) can settle back down WITHOUT emitting a
+    // final resize — a lone per-event update() writes the overshoot and then
+    // never hears the correction, leaving `--viewport-height` taller than the
+    // screen and the bottom-anchored composer below the fold until the next
+    // keyboard/focus event happens to re-measure. Polling a beat past the last
+    // report (plus pollForDuration's trailing settle re-measure) reads the
+    // silent settle and shrinks synchronously. This also backstops the
+    // optimistic-close reconcile, which takes exactly one measurement and can
+    // itself catch the overshoot instant.
+    const onViewportResize = () => {
+      // Synchronous first measure — a keyboard-open shrink must reveal the
+      // composer this frame, not one rAF later when the poll's loop starts.
+      update()
+      pollForDuration(POLL_DURATION)
+    }
+
     // Re-measure when the page is restored (BFCache restore, tab refocus).
     // Chrome Android's dvh is routinely stale here and `resize` events may
     // not fire, so poll briefly to catch the URL bar animation too.
@@ -335,17 +353,26 @@ export function useVisualViewport(enabled: boolean): boolean {
       pollForDuration(POLL_DURATION)
     }
 
+    // Foregrounding a standalone PWA does not fire `pageshow` (the page was
+    // never in the BFCache), but Chrome resumes it with equally stale viewport
+    // state — re-measure through the same poll. update() refreshes the
+    // baseline itself once the keyboard is confirmed closed.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") pollForDuration(POLL_DURATION)
+    }
+
     update()
 
     if (vv) {
-      vv.addEventListener("resize", update)
+      vv.addEventListener("resize", onViewportResize)
       vv.addEventListener("scroll", onScroll)
     }
     // Also listen to window resize (Firefox fires this when keyboard changes innerHeight)
-    window.addEventListener("resize", update)
+    window.addEventListener("resize", onViewportResize)
     document.addEventListener("focusin", onEditableFocusChange)
     document.addEventListener("focusout", onEditableFocusChange)
     window.addEventListener("pageshow", onPageShow)
+    document.addEventListener("visibilitychange", onVisibilityChange)
 
     return () => {
       cancelAnimationFrame(pollRafId.current)
@@ -355,13 +382,14 @@ export function useVisualViewport(enabled: boolean): boolean {
       clearTimeout(reconcileTimeoutId)
       cancelPendingGrowth()
       if (vv) {
-        vv.removeEventListener("resize", update)
+        vv.removeEventListener("resize", onViewportResize)
         vv.removeEventListener("scroll", onScroll)
       }
-      window.removeEventListener("resize", update)
+      window.removeEventListener("resize", onViewportResize)
       document.removeEventListener("focusin", onEditableFocusChange)
       document.removeEventListener("focusout", onEditableFocusChange)
       window.removeEventListener("pageshow", onPageShow)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
       docEl.style.removeProperty(VIEWPORT_HEIGHT_VAR)
     }
   }, [enabled])


### PR DESCRIPTION
## Problem

Two mobile reports of the composer overlapping (or vanishing under) the timeline, both screenshotted on Android after #1183 shipped:

1. **Tail parked behind the composer.** The bottom `--composer-height` px of the timeline's scroll range sit behind the floating pill — a scroll position resting in that band shows the last message clipped, with newer content invisible. A touch drag back toward the bottom that releases short of max parks there **permanently**: the gesture disarmed follow (`handleScroll`'s `userGestured` branch), the at-bottom re-arm band (`AT_BOTTOM_PX` = 32) is narrower than the dead band (composer ≈ 163px), jump-to-latest needs 600px, and with the stream quiet no resize ever re-pins. Desktop wheels overshoot and clamp at max scroll — which re-arms follow — so the parked state is a touch/trackpad symptom, which is why it kept reading as "mobile-only". Reproduced on current `main` in a dev stack: release 60px short → still 60px short indefinitely, last message clipped. #1183 fixed re-pin races; this is a design hole, not a race.

2. **Composer gone entirely.** `use-visual-viewport.ts` already documents Chrome Android's keyboard-close overshoot (753px reported on a 725px screen) and that the viewport can settle back "without always emitting a resize". The listener wiring did one `update()` per resize event: if the overshoot chunk is the *last* event Chrome emits (or the optimistic-close reconcile's single measurement lands on the overshoot instant), the too-tall value is written and the silent settle is never heard — `--viewport-height` sticks taller than the screen and the bottom-anchored composer (`FloatingComposerShell`, `absolute bottom-0`) sits below the fold until some later focus event re-measures.

## Solution

Two mechanisms, one per bug: a **dead-band dock** in the scroll engine, and a **poll window after every viewport resize** in the visual-viewport hook.

### How it works

**Dead-band dock** (`use-timeline-scroll.ts`):

1. `handleScroll` records the direction of the last *gesture-driven* movement in `lastGestureScrollDirRef` — only when the delta is height-stable **and** a scroller gesture is fresh (`userInteractedAtRef` within `USER_SCROLL_GRACE_MS`). Momentum events after a flick carry a stale stamp but only ever continue the drag's direction, so the drag-phase value stays correct through them; programmatic positioning (divider/deep-link scrolls, pins, the observer's viewport shifts) and browser clamps never register.
2. A new effect on the scroller listens natively: `scroll` (debounce `DEAD_BAND_DOCK_SETTLE_MS` = 200ms), `touchstart/touchend/touchcancel` and `mousedown`/window-`mouseup` (a resting finger emits no scroll events, so the quiet window alone would elapse under it — no dock while a press is held).
3. When scrolling settles: if not in jump mode, not cold-load settling, last gesture direction is **down**, and `1 < distanceFromBottom ≤ composerHeight + AT_BOTTOM_PX`, it calls `scrollToBottom({ force: true, behavior: "smooth" })` — eases to the true bottom and re-arms follow.

**Viewport silent-settle** (`use-visual-viewport.ts`):

1. `vv.resize` / `window.resize` now run a synchronous `update()` (keyboard-open shrink must land this frame) **plus** `pollForDuration(POLL_DURATION)` — the existing 600ms rAF poll + trailing settle re-measure, previously wired only to focus transitions and `pageshow`. A silent settle after the last resize report is read by the poll and shrink-corrects synchronously. This also backstops the optimistic-close reconcile, whose single measurement can itself catch the overshoot instant.
2. `visibilitychange → visible` triggers the same poll — foregrounding a standalone PWA fires no `pageshow` (the page never entered the BFCache), but Chrome resumes it with equally stale viewport state.

### Key design decisions

**1. Direction-gated, not band-gated alone.** Docking any park inside the band would break the deliberate "nudge up a little to read context while typing" position — the dock would scroll away exactly what the nudge revealed. Direction comes only from gesture-fresh deltas, so deep-link/divider positioning that lands near the tail is never yanked either (`does not dock after programmatic positioning` test).

**2. Touch events, not pointer events, for the held-press guard.** Browsers fire `pointercancel` when a touch scroll takes over, which would read as "released" while the finger is still dragging — docking would then yank content out from under the touch. `touchend`/`touchcancel` with `e.touches.length === 0` is the reliable all-fingers-lifted signal.

**3. Debounced scroll-quiet instead of `scrollend`.** `scrollend` isn't available on older iOS Safari; one debounce path (200ms, longer than any inter-event gap of an active scroll, including momentum) behaves identically everywhere and is deterministic under fake timers (INV-43: one path).

**4. Reuse `pollForDuration` rather than a new watcher.** The overshoot fix wires the existing focus-transition poll to resize events instead of introducing a parallel settle mechanism — same rAF loop, same trailing re-measure, no new state.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-timeline-scroll.ts` | Gesture-direction tracking in `handleScroll`; dead-band dock effect (scroll-settle debounce + touch/mouse held-press tracking); `DEAD_BAND_DOCK_SETTLE_MS` constant |
| `apps/frontend/src/hooks/use-timeline-scroll.test.tsx` | 4 dock tests (dock on downward release, upward nudge respected, programmatic positioning ignored, waits for finger lift); `makeScrollerDiv` gains a `scrollTo` mock for the smooth path |
| `apps/frontend/src/hooks/use-visual-viewport.ts` | Resize events start a poll window (sync `update()` + `pollForDuration`); `visibilitychange` re-measures on PWA foregrounding |
| `apps/frontend/src/hooks/use-visual-viewport.test.ts` | 2 regression tests: silent-settle overshoot correction, visibilitychange re-measure |

## Out of scope (deliberate)

- **Scrollbar drags** never stamp a gesture (no wheel/touch/pointer events — the known desktop gap noted in the existing tests), so they don't record direction and don't dock. Desktop scrollbar parks behave exactly as before.
- The **plain-scroll thread path** (`useScrollBehavior`) has the same floating composer geometry but a different, smaller scroll engine; threads load all events and re-pin on more triggers. Not touched here — if the parked state reproduces on a thread, it's a follow-up.
- The 32px `AT_BOTTOM_PX` armed-but-unpinned residual (follow re-armed inside the band but nothing pins until the next resize) is covered by the dock only for downward gestures; left otherwise unchanged.

## Test plan

- [x] `use-timeline-scroll` 29 pass, `use-visual-viewport` 21 pass, `use-composer-height-publish` 7 pass (57 total)
- [x] All 6 new tests fail with the two source files stashed (4 failures — the 2 behavior-guard tests pass on both, as intended)
- [x] **Live verification** (Playwright Chromium, trusted CDP wheel input, dev:test stack): pinned → wheel up 400px parks reading (no dock, correct) → wheel back down releasing 60px short → docks to `dist=0` within ~400ms and re-arms follow; a 60px upward nudge stays parked at `dist=60`
- [x] `bun run typecheck` clean across the monorepo
- [x] Full frontend vitest: 3503 pass; 136 failures in 14 files are the documented pre-existing Node-25 localStorage reds on this machine (fail identically with this diff stashed); one `use-board-card-messages` parallel-run flake also fails pre-fix and passes standalone
- [ ] Not verified on a physical Android device — the touch path (`touchstart`/`touchend` tracking) is unit-tested and the full pipeline verified live via wheel; needs Kris's on-device confirmation after deploy (note: the PWA serves the old bundle until reloaded)
- [ ] Browser E2E suite not run locally (ports occupied by two dev stacks); CI runs it on this PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785864846&installation_id=129946197&pr_number=1195&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1195&signature=80d01165ef758a51232dba72710e12939f804ac9324e4097d89bd241d9f7fc6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->