### PR TITLE
feat(board): hide a card + mute a stream from the board (per-viewer)

### DIFF
--- a/apps/backend/src/db/migrations/20260705120000_board_view_exclusions.sql
+++ b/apps/backend/src/db/migrations/20260705120000_board_view_exclusions.sql
@@ -1,0 +1,33 @@
+-- Per-viewer board exclusions (board-view-design.md § "Hide & mute").
+-- Two grains, deliberately separate: hide one conversation card, or mute a whole
+-- stream from the board. Both are per-(user, target) state — no FK (INV-1),
+-- composite PK like stream_members (INV-2 exception, no surrogate ULID), no enum
+-- (INV-3), workspace_id scoped (INV-8).
+
+CREATE TABLE IF NOT EXISTS board_hidden_conversations (
+    workspace_id    TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    user_id         TEXT NOT NULL,
+    -- Snooze watermark: the card reappears once the conversation's
+    -- last_activity_at passes hidden_at (last_activity_at is monotonic, so a
+    -- genuine revival un-hides permanently). Re-hiding upserts hidden_at = NOW().
+    hidden_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (conversation_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_board_hidden_conversations_user
+    ON board_hidden_conversations (workspace_id, user_id);
+
+CREATE TABLE IF NOT EXISTS board_muted_streams (
+    workspace_id TEXT NOT NULL,
+    -- The effective ROOT stream id — mute is root-grain, mirroring the board's
+    -- stream scope (a thread-anchored conversation is muted via its root).
+    stream_id    TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (stream_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_board_muted_streams_user
+    ON board_muted_streams (workspace_id, user_id);

--- a/apps/backend/src/features/conversations/board-exclusion-repository.ts
+++ b/apps/backend/src/features/conversations/board-exclusion-repository.ts
@@ -1,0 +1,67 @@
+import type { Querier } from "../../db"
+import { sql } from "../../db"
+
+/** A hidden conversation for the bootstrap read. */
+export interface HiddenConversation {
+  conversationId: string
+  hiddenAt: Date
+}
+
+/**
+ * Per-viewer board exclusions: hidden conversation cards and muted streams
+ * (board-view-design.md § "Hide & mute"). Every write is a race-safe upsert/delete
+ * (INV-20); reads are single-query, so callers pass `pool` (INV-30).
+ */
+export const BoardExclusionRepository = {
+  /** Hide (or re-hide) a conversation for a viewer. Returns the snooze watermark. */
+  async hideConversation(
+    db: Querier,
+    params: { workspaceId: string; conversationId: string; userId: string }
+  ): Promise<{ hiddenAt: Date }> {
+    const result = await db.query<{ hidden_at: Date }>(sql`
+      INSERT INTO board_hidden_conversations (workspace_id, conversation_id, user_id)
+      VALUES (${params.workspaceId}, ${params.conversationId}, ${params.userId})
+      ON CONFLICT (conversation_id, user_id) DO UPDATE SET hidden_at = NOW()
+      RETURNING hidden_at
+    `)
+    return { hiddenAt: result.rows[0]!.hidden_at }
+  },
+
+  async unhideConversation(db: Querier, workspaceId: string, conversationId: string, userId: string): Promise<void> {
+    await db.query(sql`
+      DELETE FROM board_hidden_conversations
+      WHERE workspace_id = ${workspaceId} AND conversation_id = ${conversationId} AND user_id = ${userId}
+    `)
+  },
+
+  async muteStream(db: Querier, params: { workspaceId: string; streamId: string; userId: string }): Promise<void> {
+    await db.query(sql`
+      INSERT INTO board_muted_streams (workspace_id, stream_id, user_id)
+      VALUES (${params.workspaceId}, ${params.streamId}, ${params.userId})
+      ON CONFLICT (stream_id, user_id) DO NOTHING
+    `)
+  },
+
+  async unmuteStream(db: Querier, workspaceId: string, streamId: string, userId: string): Promise<void> {
+    await db.query(sql`
+      DELETE FROM board_muted_streams
+      WHERE workspace_id = ${workspaceId} AND stream_id = ${streamId} AND user_id = ${userId}
+    `)
+  },
+
+  async listHiddenConversations(db: Querier, workspaceId: string, userId: string): Promise<HiddenConversation[]> {
+    const result = await db.query<{ conversation_id: string; hidden_at: Date }>(sql`
+      SELECT conversation_id, hidden_at FROM board_hidden_conversations
+      WHERE workspace_id = ${workspaceId} AND user_id = ${userId}
+    `)
+    return result.rows.map((row) => ({ conversationId: row.conversation_id, hiddenAt: row.hidden_at }))
+  },
+
+  async listMutedStreamIds(db: Querier, workspaceId: string, userId: string): Promise<string[]> {
+    const result = await db.query<{ stream_id: string }>(sql`
+      SELECT stream_id FROM board_muted_streams
+      WHERE workspace_id = ${workspaceId} AND user_id = ${userId}
+    `)
+    return result.rows.map((row) => row.stream_id)
+  },
+}

--- a/apps/backend/src/features/conversations/board-exclusion-service.ts
+++ b/apps/backend/src/features/conversations/board-exclusion-service.ts
@@ -1,0 +1,97 @@
+import { Pool } from "pg"
+import { withTransaction } from "../../db"
+import { OutboxRepository } from "../../lib/outbox"
+import { BoardExclusionRepository, type HiddenConversation } from "./board-exclusion-repository"
+
+export interface BoardExclusions {
+  hiddenConversations: { conversationId: string; hiddenAt: string }[]
+  mutedStreamIds: string[]
+}
+
+/**
+ * Per-viewer board exclusions (board-view-design.md § "Hide & mute"): hide/unhide
+ * a conversation card, mute/unmute a stream from the board. Each mutation writes
+ * its row and emits a user-scoped outbox event in the same transaction (INV-7) so
+ * the viewer's other devices reconcile; there is no stream delivery (these are
+ * private board state, not shared events).
+ */
+export class BoardExclusionService {
+  constructor(private pool: Pool) {}
+
+  async hideConversation(params: {
+    workspaceId: string
+    conversationId: string
+    userId: string
+  }): Promise<{ hiddenAt: string }> {
+    const { workspaceId, conversationId, userId } = params
+    return withTransaction(this.pool, async (client) => {
+      const { hiddenAt } = await BoardExclusionRepository.hideConversation(client, {
+        workspaceId,
+        conversationId,
+        userId,
+      })
+      await OutboxRepository.insert(client, "board:conversation_hide_changed", {
+        targetUserId: userId,
+        workspaceId,
+        conversationId,
+        active: true,
+        hiddenAt: hiddenAt.toISOString(),
+      })
+      return { hiddenAt: hiddenAt.toISOString() }
+    })
+  }
+
+  async unhideConversation(params: { workspaceId: string; conversationId: string; userId: string }): Promise<void> {
+    const { workspaceId, conversationId, userId } = params
+    await withTransaction(this.pool, async (client) => {
+      await BoardExclusionRepository.unhideConversation(client, workspaceId, conversationId, userId)
+      await OutboxRepository.insert(client, "board:conversation_hide_changed", {
+        targetUserId: userId,
+        workspaceId,
+        conversationId,
+        active: false,
+      })
+    })
+  }
+
+  async muteStream(params: { workspaceId: string; streamId: string; userId: string }): Promise<void> {
+    const { workspaceId, streamId, userId } = params
+    await withTransaction(this.pool, async (client) => {
+      await BoardExclusionRepository.muteStream(client, { workspaceId, streamId, userId })
+      await OutboxRepository.insert(client, "board:stream_mute_changed", {
+        targetUserId: userId,
+        workspaceId,
+        streamId,
+        active: true,
+      })
+    })
+  }
+
+  async unmuteStream(params: { workspaceId: string; streamId: string; userId: string }): Promise<void> {
+    const { workspaceId, streamId, userId } = params
+    await withTransaction(this.pool, async (client) => {
+      await BoardExclusionRepository.unmuteStream(client, workspaceId, streamId, userId)
+      await OutboxRepository.insert(client, "board:stream_mute_changed", {
+        targetUserId: userId,
+        workspaceId,
+        streamId,
+        active: false,
+      })
+    })
+  }
+
+  /** The viewer's full exclusion set — the board bootstrap read. Single queries, INV-30. */
+  async getExclusions(workspaceId: string, userId: string): Promise<BoardExclusions> {
+    const [hidden, mutedStreamIds] = await Promise.all([
+      BoardExclusionRepository.listHiddenConversations(this.pool, workspaceId, userId),
+      BoardExclusionRepository.listMutedStreamIds(this.pool, workspaceId, userId),
+    ])
+    return {
+      hiddenConversations: hidden.map((row: HiddenConversation) => ({
+        conversationId: row.conversationId,
+        hiddenAt: row.hiddenAt.toISOString(),
+      })),
+      mutedStreamIds,
+    }
+  }
+}

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -38,6 +38,16 @@ describe("Conversation Handlers", () => {
   const mockGetMessages = mock(() => Promise.resolve([] as Record<string, unknown>[]))
   const mockGetBoardPostById = mock(() => Promise.resolve(null as Record<string, unknown> | null))
   const mockUpdateConversation = mock(() => Promise.resolve({ conversation: {} as Record<string, unknown> }))
+  const mockHideConversation = mock(() => Promise.resolve({ hiddenAt: "2026-07-05T00:00:00.000Z" }))
+  const mockUnhideConversation = mock(() => Promise.resolve())
+  const mockMuteStream = mock(() => Promise.resolve())
+  const mockUnmuteStream = mock(() => Promise.resolve())
+  const mockGetExclusions = mock(() =>
+    Promise.resolve({
+      hiddenConversations: [] as { conversationId: string; hiddenAt: string }[],
+      mutedStreamIds: [] as string[],
+    })
+  )
   const mockGetFlag = mock(() => Promise.resolve("on" as string))
 
   const handlers = createConversationHandlers({
@@ -48,6 +58,13 @@ describe("Conversation Handlers", () => {
       getMessages: mockGetMessages,
       getBoardPostById: mockGetBoardPostById,
       updateConversation: mockUpdateConversation,
+    } as never,
+    boardExclusionService: {
+      hideConversation: mockHideConversation,
+      unhideConversation: mockUnhideConversation,
+      muteStream: mockMuteStream,
+      unmuteStream: mockUnmuteStream,
+      getExclusions: mockGetExclusions,
     } as never,
     streamService: {
       validateStreamAccess: mockValidateStreamAccess,
@@ -65,10 +82,17 @@ describe("Conversation Handlers", () => {
     mockGetMessages.mockReset()
     mockGetBoardPostById.mockReset()
     mockUpdateConversation.mockReset()
+    mockHideConversation.mockReset()
+    mockUnhideConversation.mockReset()
+    mockMuteStream.mockReset()
+    mockUnmuteStream.mockReset()
+    mockGetExclusions.mockReset()
     mockGetFlag.mockReset()
     mockUpdateConversation.mockResolvedValue({
       conversation: { id: "conv_1", topicSummary: "Renamed", status: "active" },
     })
+    mockHideConversation.mockResolvedValue({ hiddenAt: "2026-07-05T00:00:00.000Z" })
+    mockGetExclusions.mockResolvedValue({ hiddenConversations: [], mutedStreamIds: [] })
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
@@ -349,6 +373,49 @@ describe("Conversation Handlers", () => {
         "Stream not found"
       )
       expect(mockUpdateConversation).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("board exclusions", () => {
+    test("hideConversation gates on the board flag, checks access, then delegates", async () => {
+      const res = mockRes()
+      await handlers.hideConversation(mockReq({ params: { conversationId: "conv_1" } }), res)
+      expect(mockGetFlag).toHaveBeenCalledWith("ws_1", "usr_1", "board-view")
+      expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+      expect(mockHideConversation).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        userId: "usr_1",
+      })
+      expect((res as unknown as { body: unknown }).body).toEqual({ hiddenAt: "2026-07-05T00:00:00.000Z" })
+    })
+
+    test("hideConversation 404s without the board-view flag before writing", async () => {
+      mockGetFlag.mockResolvedValue("off")
+      await expect(
+        handlers.hideConversation(mockReq({ params: { conversationId: "conv_1" } }), mockRes())
+      ).rejects.toMatchObject({ status: 404 })
+      expect(mockHideConversation).not.toHaveBeenCalled()
+    })
+
+    test("muteStream validates the target stream then delegates", async () => {
+      const res = mockRes()
+      await handlers.muteStream(mockReq({ params: { streamId: "stream_9" } }), res)
+      expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_9", "ws_1", "usr_1")
+      expect(mockMuteStream).toHaveBeenCalledWith({ workspaceId: "ws_1", streamId: "stream_9", userId: "usr_1" })
+    })
+
+    test("getBoardExclusions returns the viewer's hidden + muted sets", async () => {
+      mockGetExclusions.mockResolvedValue({
+        hiddenConversations: [{ conversationId: "conv_1", hiddenAt: "2026-07-05T00:00:00.000Z" }],
+        mutedStreamIds: ["stream_9"],
+      })
+      const res = mockRes()
+      await handlers.getBoardExclusions(mockReq({ query: {} }), res)
+      expect((res as unknown as { body: unknown }).body).toEqual({
+        hiddenConversations: [{ conversationId: "conv_1", hiddenAt: "2026-07-05T00:00:00.000Z" }],
+        mutedStreamIds: ["stream_9"],
+      })
     })
   })
 })

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import type { ConversationService } from "./service"
+import type { BoardExclusionService } from "./board-exclusion-service"
 import type { StreamService } from "../streams"
 import type { FeatureFlagService } from "../feature-flags"
 import {
@@ -88,13 +89,22 @@ const updateConversationBodySchema = z
     message: "Provide topicSummary or status",
   })
 
+const hideConversationParamsSchema = z.object({ conversationId: z.string().min(1) })
+const muteStreamParamsSchema = z.object({ streamId: z.string().min(1) })
+
 interface Dependencies {
   conversationService: ConversationService
+  boardExclusionService: BoardExclusionService
   streamService: StreamService
   featureFlagService: FeatureFlagService
 }
 
-export function createConversationHandlers({ conversationService, streamService, featureFlagService }: Dependencies) {
+export function createConversationHandlers({
+  conversationService,
+  boardExclusionService,
+  streamService,
+  featureFlagService,
+}: Dependencies) {
   return {
     /**
      * Cross-stream board feed. Access is enforced inside the query (INV-62), so
@@ -277,6 +287,77 @@ export function createConversationHandlers({ conversationService, streamService,
 
       const result = await conversationService.updateConversation({ workspaceId, conversationId, topicSummary, status })
       res.json(result)
+    },
+
+    /**
+     * Per-viewer board exclusions (board-view-design.md § "Hide & mute"). All are
+     * board-flag-gated (404 without `board-view`, like the feed). Hide/unhide gate
+     * on the conversation's root-stream access (INV-62); mute/unmute on the target
+     * stream.
+     */
+    async hideConversation(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+      const { conversationId } = validateRequest(hideConversationParamsSchema, req.params)
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+      const result = await boardExclusionService.hideConversation({ workspaceId, conversationId, userId })
+      res.json(result)
+    },
+
+    async unhideConversation(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+      const { conversationId } = validateRequest(hideConversationParamsSchema, req.params)
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+      await boardExclusionService.unhideConversation({ workspaceId, conversationId, userId })
+      res.json({ ok: true })
+    },
+
+    async muteStream(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+      const { streamId } = validateRequest(muteStreamParamsSchema, req.params)
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
+      await boardExclusionService.muteStream({ workspaceId, streamId, userId })
+      res.json({ ok: true })
+    },
+
+    async unmuteStream(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+      const { streamId } = validateRequest(muteStreamParamsSchema, req.params)
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
+      await boardExclusionService.unmuteStream({ workspaceId, streamId, userId })
+      res.json({ ok: true })
+    },
+
+    async getBoardExclusions(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      if ((await featureFlagService.getFlag(workspaceId, userId, "board-view")) !== "on") {
+        throw new HttpError("Not found", { status: 404, code: "NOT_FOUND" })
+      }
+      res.json(await boardExclusionService.getExclusions(workspaceId, userId))
     },
 
     /**

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -5,6 +5,10 @@ export { conversationAssigner } from "./conversation-assigner"
 export { ConversationService } from "./service"
 export type { ConversationWithStaleness, ListConversationsOptions } from "./service"
 
+export { BoardExclusionService } from "./board-exclusion-service"
+export type { BoardExclusions } from "./board-exclusion-service"
+export { BoardExclusionRepository } from "./board-exclusion-repository"
+
 export { BoundaryExtractionService } from "./boundary-extraction-service"
 
 export { LLMBoundaryExtractor } from "./boundary-extraction/llm-extractor"

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -100,6 +100,41 @@ function boardTypeCondSql(scopeStreamTypes: string[] | undefined) {
   )`
 }
 
+/**
+ * Per-viewer hide exclusion (board-view-design.md § "Hide & mute"). A hidden
+ * conversation is suppressed UNLESS it revived — `last_activity_at` passing the
+ * `hidden_at` watermark un-hides it (mirrored client-side in
+ * `use-stable-board-view`; keep the `<=` boundary identical to avoid the SQL/JS
+ * lockstep drift Map C flags).
+ */
+function boardHiddenExcludeSql(userId: string) {
+  return composeSql`AND NOT EXISTS (
+    SELECT 1 FROM board_hidden_conversations h
+    WHERE h.conversation_id = conversations.id
+      AND h.user_id = ${userId}
+      AND h.workspace_id = conversations.workspace_id
+      AND conversations.last_activity_at <= h.hidden_at
+  )`
+}
+
+/**
+ * Per-viewer stream mute exclusion, matched by effective ROOT
+ * (`COALESCE(root_stream_id, id)`, mirroring `boardScopeCondSql`). Skipped when
+ * `applyMute` is false: an explicit `?in=` stream scope names streams the viewer
+ * asked for, so mute doesn't fight it; mute still applies under no-scope and
+ * under a type (`?is=`) scope.
+ */
+function boardMutedExcludeSql(userId: string, applyMute: boolean) {
+  if (!applyMute) return sql``
+  return composeSql`AND NOT EXISTS (
+    SELECT 1 FROM board_muted_streams m
+    JOIN streams ms ON ms.id = conversations.stream_id
+      AND ms.workspace_id = conversations.workspace_id
+      AND COALESCE(ms.root_stream_id, ms.id) = m.stream_id
+    WHERE m.user_id = ${userId} AND m.workspace_id = conversations.workspace_id
+  )`
+}
+
 interface ConversationRow {
   id: string
   stream_id: string
@@ -454,6 +489,9 @@ export const ConversationRepository = {
     const lensCond = boardLensCondSql(options?.lens, userId)
     const scopeCond = boardScopeCondSql(options?.scopeStreamIds)
     const typeCond = boardTypeCondSql(options?.scopeStreamTypes)
+    const hiddenCond = boardHiddenExcludeSql(userId)
+    // Mute is skipped when the viewer named explicit streams via `?in=`.
+    const mutedCond = boardMutedExcludeSql(userId, !options?.scopeStreamIds?.length)
     // Keyset on `date_trunc('milliseconds', last_activity_at)` — NOT the raw
     // column — because the cursor is minted from a JS Date (ms precision) while
     // timestamptz stores microseconds. Comparing the raw µs value against an
@@ -473,6 +511,8 @@ export const ConversationRepository = {
         ${lensCond}
         ${scopeCond}
         ${typeCond}
+        ${hiddenCond}
+        ${mutedCond}
         ${cursorCond}
         AND ${access}
       ORDER BY date_trunc('milliseconds', last_activity_at) DESC, id DESC

--- a/apps/backend/src/lib/outbox/delivery-groups.test.ts
+++ b/apps/backend/src/lib/outbox/delivery-groups.test.ts
@@ -60,6 +60,34 @@ describe("resolveDeliveryGroups — enclave re-wrap nudges", () => {
   })
 })
 
+describe("resolveDeliveryGroups — board exclusions (hide & mute)", () => {
+  it("routes a hide change to the viewer's user group only, never the workspace", () => {
+    const groups = resolveDeliveryGroups(
+      event("board:conversation_hide_changed", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_1",
+        conversationId: "conv_1",
+        active: true,
+        hiddenAt: "2026-07-05T00:00:00.000Z",
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_1")])
+    expect(groups).not.toContain("workspace")
+  })
+
+  it("routes a mute change to the viewer's user group only", () => {
+    const groups = resolveDeliveryGroups(
+      event("board:stream_mute_changed", {
+        workspaceId: "ws_1",
+        targetUserId: "usr_1",
+        streamId: "stream_1",
+        active: true,
+      })
+    )
+    expect(groups).toEqual([userGroup("usr_1")])
+  })
+})
+
 describe("resolveDeliveryGroups — label assignments", () => {
   // Labels are owner-scoped, so an assignment routes only to the owning actor's
   // user group — never a stream group, even when the labeled resource is a

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -54,6 +54,8 @@ export type OutboxEventType =
   | "conversation:updated"
   | "conversation:message_assigned"
   | "conversation:message_reassigned"
+  | "board:conversation_hide_changed"
+  | "board:stream_mute_changed"
   | "memo:created"
   | "command:dispatched"
   | "command:completed"
@@ -727,6 +729,25 @@ export interface DraftDeletedOutboxPayload extends WorkspaceScopedPayload {
   draftId: string
 }
 
+// Per-viewer board exclusions (board-view-design.md § "Hide & mute"). Both are
+// user-scoped — a hide/mute is one viewer's private board state, delivered only
+// to `user:{targetUserId}` for multi-device reconcile, never a timeline row.
+export interface BoardConversationHideChangedOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  conversationId: string
+  /** true = hidden, false = un-hidden. */
+  active: boolean
+  /** The snooze watermark (ISO), present only when `active`. */
+  hiddenAt?: string
+}
+
+export interface BoardStreamMuteChangedOutboxPayload extends WorkspaceScopedPayload {
+  targetUserId: string
+  streamId: string
+  /** true = muted, false = un-muted. */
+  active: boolean
+}
+
 // Proactive owner re-wrap nudges. When an enclave turn can't be served because
 // no live EIK holds the stream's SSK wrap, only the owner's unlocked device can
 // re-wrap (INV-E7). `enclave:rewrap_needed` is user-scoped — it reaches the
@@ -895,6 +916,8 @@ export interface OutboxEventPayloadMap {
   "conversation:updated": ConversationUpdatedOutboxPayload
   "conversation:message_assigned": ConversationMessageAssignedOutboxPayload
   "conversation:message_reassigned": ConversationMessageReassignedOutboxPayload
+  "board:conversation_hide_changed": BoardConversationHideChangedOutboxPayload
+  "board:stream_mute_changed": BoardStreamMuteChangedOutboxPayload
   "memo:created": MemoCreatedOutboxPayload
   "command:dispatched": CommandDispatchedOutboxPayload
   "command:completed": CommandCompletedOutboxPayload
@@ -1053,6 +1076,8 @@ export type UserScopedEventType =
   | "scheduled_message:cancelled"
   | "draft:upserted"
   | "draft:deleted"
+  | "board:conversation_hide_changed"
+  | "board:stream_mute_changed"
   | "feature_flags:updated"
   | "enclave:rewrap_needed"
 
@@ -1067,6 +1092,8 @@ const USER_SCOPED_EVENTS: UserScopedEventType[] = [
   "scheduled_message:cancelled",
   "draft:upserted",
   "draft:deleted",
+  "board:conversation_hide_changed",
+  "board:stream_mute_changed",
   "feature_flags:updated",
   "enclave:rewrap_needed",
 ]

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -21,7 +21,7 @@ import { createAttachmentHandlers } from "./features/attachments"
 import { createSearchHandlers } from "./features/search"
 import { createMemoHandlers } from "./features/memos"
 import { createEmojiHandlers } from "./features/emoji"
-import { createConversationHandlers } from "./features/conversations"
+import { createConversationHandlers, BoardExclusionService } from "./features/conversations"
 import { CommandAvailabilityService, createCommandHandlers } from "./features/commands"
 import { createUserPreferencesHandlers } from "./features/user-preferences"
 import { createWorkspaceSettingsHandlers } from "./features/workspace-settings"
@@ -273,7 +273,13 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const search = createSearchHandlers({ pool, searchService })
   const memo = createMemoHandlers({ pool, memoExplorerService })
   const emoji = createEmojiHandlers()
-  const conversation = createConversationHandlers({ conversationService, streamService, featureFlagService })
+  const boardExclusionService = new BoardExclusionService(pool)
+  const conversation = createConversationHandlers({
+    conversationService,
+    boardExclusionService,
+    streamService,
+    featureFlagService,
+  })
   const command = createCommandHandlers({ pool, commandAvailabilityService, botRuntimeService })
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
   const workspaceSettings = createWorkspaceSettingsHandlers({ workspaceSettingsService })
@@ -500,6 +506,15 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   )
   app.get("/api/workspaces/:workspaceId/conversations/:conversationId/board-post", ...authed, conversation.getBoardPost)
   app.patch("/api/workspaces/:workspaceId/conversations/:conversationId", ...authed, conversation.updateConversation)
+  app.get("/api/workspaces/:workspaceId/board/exclusions", ...authed, conversation.getBoardExclusions)
+  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/hide", ...authed, conversation.hideConversation)
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/unhide",
+    ...authed,
+    conversation.unhideConversation
+  )
+  app.post("/api/workspaces/:workspaceId/streams/:streamId/board-mute", ...authed, conversation.muteStream)
+  app.post("/api/workspaces/:workspaceId/streams/:streamId/board-unmute", ...authed, conversation.unmuteStream)
   app.post(
     "/api/workspaces/:workspaceId/conversations/:conversationId/messages/:messageId/reassign",
     ...authed,

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -163,4 +163,27 @@ export const conversationsApi = {
   ): Promise<{ conversation: ConversationWithStaleness }> {
     return api.patch(`/api/workspaces/${workspaceId}/conversations/${conversationId}`, body)
   },
+
+  // Per-viewer board exclusions (board-view-design.md § "Hide & mute").
+  async hideConversation(workspaceId: string, conversationId: string): Promise<{ hiddenAt: string }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/hide`)
+  },
+
+  async unhideConversation(workspaceId: string, conversationId: string): Promise<{ ok: true }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/unhide`)
+  },
+
+  async muteStream(workspaceId: string, streamId: string): Promise<{ ok: true }> {
+    return api.post(`/api/workspaces/${workspaceId}/streams/${streamId}/board-mute`)
+  },
+
+  async unmuteStream(workspaceId: string, streamId: string): Promise<{ ok: true }> {
+    return api.post(`/api/workspaces/${workspaceId}/streams/${streamId}/board-unmute`)
+  },
+
+  async getBoardExclusions(
+    workspaceId: string
+  ): Promise<{ hiddenConversations: { conversationId: string; hiddenAt: string }[]; mutedStreamIds: string[] }> {
+    return api.get(`/api/workspaces/${workspaceId}/board/exclusions`)
+  },
 }

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -242,4 +242,15 @@ describe("BoardCard conversation actions", () => {
 
     expect(updateConversation).toHaveBeenCalledWith(WS, "conv_1", { status: "resolved" })
   })
+
+  it("hides the conversation from the board via the ⋯ menu", async () => {
+    const user = userEvent.setup()
+    const hideConversation = vi.fn().mockResolvedValue({ hiddenAt: "2026-07-05T00:00:00.000Z" })
+    mountCard(makePost({ topicSummary: "Rotate the API tokens", status: "active" }), { hideConversation })
+
+    await user.click(await screen.findByRole("button", { name: "Conversation actions" }))
+    await user.click(await screen.findByText("Hide from board"))
+
+    expect(hideConversation).toHaveBeenCalledWith(WS, "conv_1")
+  })
 })

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -1,6 +1,19 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
-import { BookMarked, Check, ChevronDown, CircleDashed, Hash, Layers, LayoutGrid, User, X, Zap } from "lucide-react"
+import {
+  Bell,
+  BellOff,
+  BookMarked,
+  Check,
+  ChevronDown,
+  CircleDashed,
+  Hash,
+  Layers,
+  LayoutGrid,
+  User,
+  X,
+  Zap,
+} from "lucide-react"
 import type { LucideIcon } from "lucide-react"
 import {
   BOARD_LENSES,
@@ -109,6 +122,10 @@ interface BoardFilterBarProps {
   scopeStreamTypes: BoardScopeStreamType[]
   /** Rewrites the type scope; the page owns the URL write. */
   onTypesChange: (types: BoardScopeStreamType[]) => void
+  /** Root streams the viewer muted from the board (board-view-design.md § "Hide & mute"). */
+  mutedStreamIds?: ReadonlySet<string>
+  /** Toggle a stream's board mute; the page owns the write. */
+  onToggleMute?: (streamId: string, mute: boolean) => void
 }
 
 /**
@@ -131,6 +148,8 @@ export function BoardFilterBar({
   onScopeChange,
   scopeStreamTypes,
   onTypesChange,
+  mutedStreamIds,
+  onToggleMute,
 }: BoardFilterBarProps) {
   const location = useLocation()
   const streams = useWorkspaceStreams(workspaceId)
@@ -152,6 +171,8 @@ export function BoardFilterBar({
         scopeStreamIds={scopeStreamIds}
         onScopeChange={onScopeChange}
         labelFor={labelFor}
+        mutedStreamIds={mutedStreamIds}
+        onToggleMute={onToggleMute}
       />
       <BoardTypePicker scopeStreamTypes={scopeStreamTypes} onTypesChange={onTypesChange} />
       {scopeStreamTypes.map((type) => {
@@ -316,11 +337,15 @@ function BoardScopePicker({
   scopeStreamIds,
   onScopeChange,
   labelFor,
+  mutedStreamIds,
+  onToggleMute,
 }: {
   workspaceId: string
   scopeStreamIds: string[]
   onScopeChange: (streamIds: string[]) => void
   labelFor: (streamId: string) => string
+  mutedStreamIds?: ReadonlySet<string>
+  onToggleMute?: (streamId: string, mute: boolean) => void
 }) {
   const isTouch = useInputMode() === "touch"
   const [open, setOpen] = useState(false)
@@ -370,20 +395,39 @@ function BoardScopePicker({
         ) : (
           entries.map(({ stream, label }) => {
             const checked = selected.has(stream.id)
+            const isMuted = mutedStreamIds?.has(stream.id) ?? false
             const Icon = STREAM_ICONS[stream.type]
             return (
-              <button
+              <div
                 key={stream.id}
-                type="button"
-                onClick={() => toggle(stream.id)}
-                aria-pressed={checked}
-                disabled={!checked && atCap}
-                className="mx-1 flex w-[calc(100%-0.5rem)] items-center gap-2 rounded-item px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted disabled:opacity-50"
+                className="mx-1 flex w-[calc(100%-0.5rem)] items-center rounded-item pr-1 transition-colors hover:bg-muted"
               >
-                <Checkbox checked={checked} tabIndex={-1} aria-hidden className="pointer-events-none" />
-                <Icon className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="flex-1 truncate">{label}</span>
-              </button>
+                <button
+                  type="button"
+                  onClick={() => toggle(stream.id)}
+                  aria-pressed={checked}
+                  disabled={!checked && atCap}
+                  className="flex flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm disabled:opacity-50"
+                >
+                  <Checkbox checked={checked} tabIndex={-1} aria-hidden className="pointer-events-none" />
+                  <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="flex-1 truncate">{label}</span>
+                </button>
+                {onToggleMute && (
+                  <button
+                    type="button"
+                    onClick={() => onToggleMute(stream.id, !isMuted)}
+                    aria-pressed={isMuted}
+                    aria-label={isMuted ? `Unmute ${label} on the board` : `Mute ${label} from the board`}
+                    className={cn(
+                      "shrink-0 rounded p-1 transition-colors",
+                      isMuted ? "text-foreground" : "text-muted-foreground/60 hover:text-foreground"
+                    )}
+                  >
+                    {isMuted ? <BellOff className="h-3.5 w-3.5" /> : <Bell className="h-3.5 w-3.5" />}
+                  </button>
+                )}
+              </div>
             )
           })
         )}

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useState } from "react"
-import { CircleCheck, EllipsisVertical, Pencil, RotateCcw } from "lucide-react"
+import { CircleCheck, Eye, EyeOff, EllipsisVertical, Pencil, RotateCcw } from "lucide-react"
 import { ConversationStatuses, MAX_CONVERSATION_TOPIC_LENGTH } from "@threa/types"
 import { Button } from "@/components/ui/button"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import {
   ResponsiveDialog,
@@ -13,7 +19,7 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 import { cn } from "@/lib/utils"
-import { useUpdateConversation } from "@/hooks/use-conversations"
+import { useUpdateConversation, useHideConversation, useUnhideConversation } from "@/hooks/use-conversations"
 
 interface ConversationActionsMenuProps {
   workspaceId: string
@@ -22,6 +28,9 @@ interface ConversationActionsMenuProps {
   topicSummary: string | null
   /** Current status — selects the resolve vs. reopen item. */
   status: string
+  /** Whether this conversation is currently hidden from the viewer's board —
+   *  selects "Unhide" vs "Hide from board". */
+  isHidden?: boolean
   /** Extra classes for the trigger, so each surface can size it to its icon cluster. */
   triggerClassName?: string
 }
@@ -38,10 +47,13 @@ export function ConversationActionsMenu({
   conversationId,
   topicSummary,
   status,
+  isHidden = false,
   triggerClassName,
 }: ConversationActionsMenuProps) {
   const [renameOpen, setRenameOpen] = useState(false)
   const update = useUpdateConversation(workspaceId)
+  const hide = useHideConversation(workspaceId)
+  const unhide = useUnhideConversation(workspaceId)
   const resolved = status === ConversationStatuses.RESOLVED
 
   return (
@@ -79,6 +91,11 @@ export function ConversationActionsMenu({
           >
             {resolved ? <RotateCcw className="h-4 w-4" /> : <CircleCheck className="h-4 w-4" />}
             {resolved ? "Reopen" : "Mark resolved"}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => (isHidden ? unhide.mutate(conversationId) : hide.mutate(conversationId))}>
+            {isHidden ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+            {isHidden ? "Unhide from board" : "Hide from board"}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -28,6 +28,7 @@ import { MessageItem, type RenderableMessage } from "@/components/message/messag
 import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
+import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
 import { cn } from "@/lib/utils"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
@@ -73,6 +74,9 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
   const { panelId } = usePanel()
   const conversationId = panelId ? parseConversationPanel(panelId) : null
   const { post, isLoading, notFound, refetch } = useConversationBoardPost(workspaceId, conversationId)
+  // Hidden set — the panel is reachable for a hidden conversation (deep-link,
+  // search, Saved), so it offers "Unhide" when the open one is hidden.
+  const hiddenConversations = useBoardHiddenConversations(workspaceId)
 
   // "Reply in conversation" opened this panel with the intent to reply, not just
   // read — pick up its one-shot signal (queued before this panel mounted, or
@@ -234,6 +238,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
             conversationId={post.conversation.id}
             topicSummary={post.conversation.topicSummary}
             status={post.conversation.status}
+            isHidden={hiddenConversations.has(post.conversation.id)}
             triggerClassName="shrink-0"
           />
         )}

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -73,6 +73,11 @@ export interface ConversationService {
   markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
   updateConversation: typeof conversationsApi.updateConversation
+  hideConversation: typeof conversationsApi.hideConversation
+  unhideConversation: typeof conversationsApi.unhideConversation
+  muteStream: typeof conversationsApi.muteStream
+  unmuteStream: typeof conversationsApi.unmuteStream
+  getBoardExclusions: typeof conversationsApi.getBoardExclusions
 }
 
 export interface ActivityService {

--- a/apps/frontend/src/db/database.ts
+++ b/apps/frontend/src/db/database.ts
@@ -835,6 +835,22 @@ export interface CachedBoardPost extends BoardPost {
   _status?: "pending"
 }
 
+/** A conversation the viewer hid from the board (board-view-design.md § "Hide & mute").
+ *  `id` is the conversation id; `hiddenAt` (ms) is the snooze watermark. */
+export interface CachedBoardHiddenConversation {
+  id: string
+  workspaceId: string
+  hiddenAt: number
+  _cachedAt: number
+}
+
+/** A stream the viewer muted from the board. `id` is the root stream id. */
+export interface CachedBoardMutedStream {
+  id: string
+  workspaceId: string
+  _cachedAt: number
+}
+
 export class ThreaDatabase extends Dexie {
   workspaces!: EntityTable<CachedWorkspace, "id">
   workspaceUsers!: EntityTable<CachedWorkspaceUser, "id">
@@ -863,6 +879,8 @@ export class ThreaDatabase extends Dexie {
   e2eDeviceKeys!: EntityTable<CachedE2eDeviceKey, "id">
   sidebarConfigs!: EntityTable<CachedSidebarConfig, "id">
   conversations!: EntityTable<CachedBoardPost, "id">
+  boardHiddenConversations!: EntityTable<CachedBoardHiddenConversation, "id">
+  boardMutedStreams!: EntityTable<CachedBoardMutedStream, "id">
 
   constructor(name: string) {
     super(name)
@@ -1258,6 +1276,15 @@ export class ThreaDatabase extends Dexie {
     // (`streamMemberships.lastReadSequence`) are unindexed value fields on
     // existing rows, so the bump only guards the added shape — no schema delta.
     this.version(37).stores({})
+
+    // v38: per-viewer board exclusions (board-view-design.md § "Hide & mute").
+    // Keyed by the excluded id (conversationId / root streamId) so a reactive
+    // read is a single get; `[workspaceId+hiddenAt]` lets the snooze-revival
+    // check scan a viewer's hidden set without loading rows one by one.
+    this.version(38).stores({
+      boardHiddenConversations: "id, workspaceId, [workspaceId+hiddenAt]",
+      boardMutedStreams: "id, workspaceId",
+    })
 
     this.workspaceUsers = this.table(WORKSPACE_USERS_STORE) as EntityTable<CachedWorkspaceUser, "id">
   }

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -11,6 +11,7 @@ import { toast } from "sonner"
 import { db } from "@/db"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { seedBoardPosts, useBoardPost, mergeBoardConversation } from "@/stores/board-store"
+import { seedBoardExclusions, putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
 import type { BoardViewPost } from "./use-stable-board-view"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
@@ -654,6 +655,98 @@ export function useUpdateConversation(workspaceId: string) {
       if (queryClient.getQueryData(boardPostKey)) {
         queryClient.setQueryData<BoardPost>(boardPostKey, (prev) => (prev ? { ...prev, conversation } : prev))
       }
+    },
+  })
+}
+
+/**
+ * Bootstrap the viewer's board exclusions (hidden cards + muted streams) into IDB
+ * (subscribe-then-fetch, INV-53; `refetchOnReconnect` closes the gap after a drop).
+ * The reactive store then drives the board filter live; socket `board:*` events
+ * (workspace-sync) patch IDB between fetches.
+ */
+export function useBoardExclusions(workspaceId: string) {
+  const conversationService = useConversationService()
+  const query = useQuery({
+    queryKey: [...conversationKeys.all, "exclusions", workspaceId] as const,
+    queryFn: () => conversationService.getBoardExclusions(workspaceId),
+    refetchOnReconnect: true,
+    staleTime: 60_000,
+  })
+  useEffect(() => {
+    if (query.data) void seedBoardExclusions(workspaceId, query.data)
+  }, [query.data, workspaceId])
+  return query
+}
+
+/**
+ * Hide a conversation card from the board (snooze until it revives). Optimistic:
+ * the exclusion store write drops the card immediately; the server `hiddenAt`
+ * reconciles the watermark on success. No success toast — the card vanishing is
+ * the signal (INV-63); errors roll back and `toast.error`.
+ */
+export function useHideConversation(workspaceId: string) {
+  const conversationService = useConversationService()
+  return useMutation({
+    mutationFn: (conversationId: string) => conversationService.hideConversation(workspaceId, conversationId),
+    onMutate: async (conversationId: string) => {
+      const prev = await db.boardHiddenConversations.get(conversationId)
+      await putHidden(workspaceId, conversationId, Date.now())
+      return { conversationId, prev }
+    },
+    onError: (_error, conversationId, ctx) => {
+      if (ctx?.prev) void putHidden(workspaceId, conversationId, ctx.prev.hiddenAt)
+      else void deleteHidden(conversationId)
+      toast.error("Couldn't hide from the board")
+    },
+    onSuccess: ({ hiddenAt }, conversationId) => {
+      void putHidden(workspaceId, conversationId, Date.parse(hiddenAt))
+    },
+  })
+}
+
+export function useUnhideConversation(workspaceId: string) {
+  const conversationService = useConversationService()
+  return useMutation({
+    mutationFn: (conversationId: string) => conversationService.unhideConversation(workspaceId, conversationId),
+    onMutate: async (conversationId: string) => {
+      const prev = await db.boardHiddenConversations.get(conversationId)
+      await deleteHidden(conversationId)
+      return { conversationId, prev }
+    },
+    onError: (_error, conversationId, ctx) => {
+      if (ctx?.prev) void putHidden(workspaceId, conversationId, ctx.prev.hiddenAt)
+      toast.error("Couldn't unhide")
+    },
+  })
+}
+
+export function useMuteStream(workspaceId: string) {
+  const conversationService = useConversationService()
+  return useMutation({
+    mutationFn: (streamId: string) => conversationService.muteStream(workspaceId, streamId),
+    onMutate: (streamId: string) => {
+      void putMuted(workspaceId, streamId)
+      return { streamId }
+    },
+    onError: (_error, streamId) => {
+      void deleteMuted(streamId)
+      toast.error("Couldn't mute the stream")
+    },
+  })
+}
+
+export function useUnmuteStream(workspaceId: string) {
+  const conversationService = useConversationService()
+  return useMutation({
+    mutationFn: (streamId: string) => conversationService.unmuteStream(workspaceId, streamId),
+    onMutate: (streamId: string) => {
+      void deleteMuted(streamId)
+      return { streamId }
+    },
+    onError: (_error, streamId) => {
+      void putMuted(workspaceId, streamId)
+      toast.error("Couldn't unmute the stream")
     },
   })
 }

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -56,6 +56,11 @@ function lensPost(
   } as unknown as CachedBoardPost
 }
 
+/** A post anchored to a root stream, for mute tests. */
+function streamPost(id: string, activityMs: number, rootStreamId: string): CachedBoardPost {
+  return { ...post(id, activityMs), rootStreamId } as unknown as CachedBoardPost
+}
+
 /** Newest-first feed, matching what `useBoardPosts` returns. */
 function feed(...posts: CachedBoardPost[]): CachedBoardPost[] {
   return [...posts].sort((a, b) => b._lastActivityMs - a._lastActivityMs)
@@ -399,5 +404,59 @@ describe("useStableBoardView", () => {
     rerender({ filter: scopeFilter(["stream_two"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
     expect(result.current.newCount).toBe(0)
+  })
+})
+
+describe("useStableBoardView — hide & mute exclusions", () => {
+  let liveValue: CachedBoardPost[] | undefined
+  function mockLive(value: CachedBoardPost[] | undefined) {
+    liveValue = value
+    vi.spyOn(boardStoreModule, "useBoardPosts").mockImplementation(() => liveValue)
+  }
+  afterEach(() => vi.restoreAllMocks())
+
+  const NO_EXCL = { hidden: new Map<string, number>(), muted: new Set<string>(), muteActive: true }
+
+  it("drops a hidden card immediately — even after it was committed and retained (the crux)", () => {
+    mockLive(feed(post("a", 300), post("b", 200)))
+    const { result, rerender } = renderHook(({ excl }) => useStableBoardView("ws_1", ALL, excl), {
+      initialProps: { excl: NO_EXCL },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
+
+    // Hide "a" (watermark above its activity). It stays in the committed order and
+    // in `retainedRef`, so a filter that only touched `live` would keep rendering
+    // it — it must drop NOW, without a commit.
+    rerender({ excl: { hidden: new Map([["a", 400]]), muted: new Set<string>(), muteActive: true } })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+  })
+
+  it("revives a hidden card once its activity passes the watermark", () => {
+    const excl = { hidden: new Map([["a", 350]]), muted: new Set<string>(), muteActive: true }
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(({ e }) => useStableBoardView("ws_1", ALL, e), {
+      initialProps: { e: excl },
+    })
+    expect(result.current.posts.map((p) => p.id)).toEqual([])
+
+    act(() => mockLive(feed(post("a", 500))))
+    rerender({ e: excl })
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+  })
+
+  it("drops a muted stream's cards when mute is active", () => {
+    mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
+    const { result } = renderHook(() =>
+      useStableBoardView("ws_1", ALL, { hidden: new Map(), muted: new Set(["stream_x"]), muteActive: true })
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["b"])
+  })
+
+  it("keeps a muted stream's cards when mute is inactive (an explicit ?in= scope)", () => {
+    mockLive(feed(streamPost("a", 300, "stream_x"), streamPost("b", 200, "stream_y")))
+    const { result } = renderHook(() =>
+      useStableBoardView("ws_1", ALL, { hidden: new Map(), muted: new Set(["stream_x"]), muteActive: false })
+    )
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a", "b"])
   })
 })

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -66,6 +66,24 @@ export interface BoardViewFilter {
   types: BoardTypeScope | null
 }
 
+/**
+ * The viewer's per-board exclusions (board-view-design.md § "Hide & mute"),
+ * mirrored client-side so a hide/mute drops the card the instant it's written —
+ * the read-side twin of the server's `boardHiddenExcludeSql`/`boardMutedExcludeSql`
+ * (keep the boundaries identical to avoid SQL/JS drift). Both maps carry stable
+ * identity from the exclusions store, so they're safe in memo deps.
+ */
+export interface BoardExclusionState {
+  /** conversationId → `hiddenAt` (ms). A card revives when its activity passes it. */
+  hidden: Map<string, number>
+  /** Muted root-stream ids. */
+  muted: Set<string>
+  /** False when an explicit `?in=` scope is set — mute doesn't fight a stream the viewer named. */
+  muteActive: boolean
+}
+
+const NO_EXCLUSIONS: BoardExclusionState = { hidden: new Map(), muted: new Set(), muteActive: true }
+
 function matchesScope(post: CachedBoardPost, scope: BoardScope | null): boolean {
   if (!scope) return true
   // Cached rows predating `rootStreamId` fall back to the anchor itself — a
@@ -192,11 +210,30 @@ export interface StableBoardView {
  * body stays live off the message rails. Filters narrow what surfaces; they never
  * yank what's on screen.
  */
-export function useStableBoardView(workspaceId: string, filter: BoardViewFilter): StableBoardView {
+export function useStableBoardView(
+  workspaceId: string,
+  filter: BoardViewFilter,
+  exclusions: BoardExclusionState = NO_EXCLUSIONS
+): StableBoardView {
   const { lens, scope, types } = filter
+  const { hidden, muted, muteActive } = exclusions
   const rawLive = useBoardPosts(workspaceId)
-  // Filter the shared feed to the lens + scopes. Recomputed when the feed or
-  // filter changes; `Date.now()` is sampled then (the staleness signal for
+
+  // A hidden card is excluded until it revives (activity passes its `hiddenAt`
+  // watermark — mirrors the server `<=` boundary); a muted stream's cards are
+  // excluded unless the viewer named explicit streams via `?in=` (`muteActive`).
+  const isExcluded = useCallback(
+    (post: CachedBoardPost): boolean => {
+      const hiddenAt = hidden.get(post.conversation.id)
+      if (hiddenAt !== undefined && postMs(post) <= hiddenAt) return true
+      if (muteActive && muted.has(post.rootStreamId ?? post.conversation.streamId)) return true
+      return false
+    },
+    [hidden, muted, muteActive]
+  )
+
+  // Filter the shared feed to the lens + scopes + exclusions. Recomputed when the
+  // feed or filter changes; `Date.now()` is sampled then (the staleness signal for
   // `needs-resolution` only needs to be fresh at feed-change granularity, which
   // is frequent on a live board).
   const live = useMemo(
@@ -205,9 +242,12 @@ export function useStableBoardView(workspaceId: string, filter: BoardViewFilter)
         ? undefined
         : rawLive.filter(
             (post) =>
-              matchesBoardLens(post, lens, Date.now()) && matchesScope(post, scope) && matchesTypeScope(post, types)
+              matchesBoardLens(post, lens, Date.now()) &&
+              matchesScope(post, scope) &&
+              matchesTypeScope(post, types) &&
+              !isExcluded(post)
           ),
-    [rawLive, lens, scope, types]
+    [rawLive, lens, scope, types, isExcluded]
   )
   const [committed, setCommitted] = useState<CommittedView>(EMPTY_VIEW)
   const [buffered, setBuffered] = useState<string[]>([])
@@ -306,10 +346,17 @@ export function useStableBoardView(workspaceId: string, filter: BoardViewFilter)
     const out: CachedBoardPost[] = []
     for (const id of committed.order) {
       const post = liveById.get(id) ?? retainedRef.current.get(id)
-      if (post) out.push(post)
+      if (!post) continue
+      // A committed card renders from `retainedRef` even after it leaves `live`,
+      // so an involuntary drop (lost access, re-lensed by the viewer's own reply)
+      // doesn't shift rows below it. But a VOLUNTARY hide/mute must drop NOW, not
+      // wait for the next commit — so skip excluded ids here too, not just in the
+      // `live` filter. (The retained copy is pruned on the next `commit()`.)
+      if (isExcluded(post)) continue
+      out.push(post)
     }
     return out
-  }, [committed, live])
+  }, [committed, live, isExcluded])
 
   return {
     posts,

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -16,7 +16,13 @@ import { useWorkspaceStreams, useWorkspaceUsers, useWorkspaceDmPeers } from "@/s
 import { useStableBoardView, type BoardViewFilter, type BoardViewPost } from "@/hooks/use-stable-board-view"
 import { useBoardStreamSubscriptions } from "@/hooks/use-board-stream-subscriptions"
 import { BOARD_CARD_ATTR, useBoardScrollAnchor } from "@/hooks/use-board-scroll-anchor"
-import { useWorkspaceConversations } from "@/hooks/use-conversations"
+import {
+  useWorkspaceConversations,
+  useBoardExclusions,
+  useMuteStream,
+  useUnmuteStream,
+} from "@/hooks/use-conversations"
+import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardComposer } from "@/components/board/board-composer"
 import {
@@ -229,6 +235,20 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // timeline's insertion rule to the board's ordering).
   const { data, isLoading, isError, refetch, fetchNextPage, hasNextPage, isFetchingNextPage, isFetchNextPageError } =
     useWorkspaceConversations(workspaceId, { lens, streams: scopeStreamIds, types: scopeStreamTypes, limit: 50 })
+
+  // Per-viewer hide/mute (board-view-design.md § "Hide & mute"): bootstrap the
+  // exclusion sets into IDB, read them reactively, and fold them into the view.
+  // Mute is skipped under an explicit `?in=` stream scope (the viewer named those
+  // streams), matching the server's `applyMute` rule.
+  useBoardExclusions(workspaceId)
+  const hidden = useBoardHiddenConversations(workspaceId)
+  const muted = useBoardMutedStreamIds(workspaceId)
+  const muteStream = useMuteStream(workspaceId)
+  const unmuteStream = useUnmuteStream(workspaceId)
+  const exclusions = useMemo(
+    () => ({ hidden, muted, muteActive: scopeStreamIds.length === 0 }),
+    [hidden, muted, scopeStreamIds.length]
+  )
   const {
     posts,
     activityById,
@@ -236,7 +256,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
     commit,
     revealNext,
     isLoading: viewLoading,
-  } = useStableBoardView(workspaceId, filter)
+  } = useStableBoardView(workspaceId, filter, exclusions)
   // After a refetch settles, `isLoading` is already false but the seed effect
   // writes IDB on the next tick, so the IDB feed can be momentarily empty while
   // the query already holds posts. Treat that window as loading so the feed
@@ -418,6 +438,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         onScopeChange={setScope}
         scopeStreamTypes={scopeStreamTypes}
         onTypesChange={setTypes}
+        mutedStreamIds={muted}
+        onToggleMute={(streamId, mute) => (mute ? muteStream.mutate(streamId) : unmuteStream.mutate(streamId))}
       />
       <span className="sr-only" role="status" aria-live="polite">
         {newCount > 0 ? `${newCount} new ${newCount === 1 ? "post" : "posts"} available` : ""}

--- a/apps/frontend/src/stores/board-exclusions-store.test.ts
+++ b/apps/frontend/src/stores/board-exclusions-store.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { db } from "@/db"
+import { seedBoardExclusions, putHidden, deleteHidden, putMuted, deleteMuted } from "./board-exclusions-store"
+
+beforeEach(async () => {
+  await db.boardHiddenConversations.clear()
+  await db.boardMutedStreams.clear()
+})
+
+describe("board-exclusions-store", () => {
+  it("seeds hidden + muted rows and drops stale ones (bootstrap is authoritative)", async () => {
+    await putHidden("ws_1", "conv_stale", 100)
+    await putMuted("ws_1", "stream_stale")
+
+    await seedBoardExclusions("ws_1", {
+      hiddenConversations: [{ conversationId: "conv_1", hiddenAt: "2026-07-05T00:00:00.000Z" }],
+      mutedStreamIds: ["stream_1"],
+    })
+
+    expect((await db.boardHiddenConversations.get("conv_1"))?.hiddenAt).toBe(Date.parse("2026-07-05T00:00:00.000Z"))
+    expect(await db.boardMutedStreams.get("stream_1")).toBeDefined()
+    // Rows the server no longer returns are gone.
+    expect(await db.boardHiddenConversations.get("conv_stale")).toBeUndefined()
+    expect(await db.boardMutedStreams.get("stream_stale")).toBeUndefined()
+  })
+
+  it("round-trips optimistic put/delete for both grains", async () => {
+    await putHidden("ws_1", "conv_1", 500)
+    expect((await db.boardHiddenConversations.get("conv_1"))?.hiddenAt).toBe(500)
+    await deleteHidden("conv_1")
+    expect(await db.boardHiddenConversations.get("conv_1")).toBeUndefined()
+
+    await putMuted("ws_1", "stream_1")
+    expect(await db.boardMutedStreams.get("stream_1")).toBeDefined()
+    await deleteMuted("stream_1")
+    expect(await db.boardMutedStreams.get("stream_1")).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/stores/board-exclusions-store.ts
+++ b/apps/frontend/src/stores/board-exclusions-store.ts
@@ -1,0 +1,81 @@
+import { useMemo } from "react"
+import { useLiveQuery } from "dexie-react-hooks"
+import { db } from "@/db"
+
+/**
+ * The viewer's per-stream board mutes and per-conversation hides (board-view-design.md
+ * § "Hide & mute"), read reactively from IDB so the board re-filters the instant a
+ * hide/mute lands — locally (optimistic) or from another device (socket). Mirrors
+ * `board-store`'s IDB-observer pattern.
+ */
+
+/** Hidden conversations for a workspace as `conversationId → hiddenAt` (ms watermark).
+ *  Memoized on the live rows so the returned Map keeps a stable identity between
+ *  data changes — callers use it in `useMemo`/`useCallback` deps. */
+export function useBoardHiddenConversations(workspaceId: string): Map<string, number> {
+  const rows = useLiveQuery(
+    () => db.boardHiddenConversations.where("workspaceId").equals(workspaceId).toArray(),
+    [workspaceId]
+  )
+  return useMemo(() => new Map((rows ?? []).map((row) => [row.id, row.hiddenAt])), [rows])
+}
+
+/** Muted root-stream ids for a workspace (stable identity between data changes). */
+export function useBoardMutedStreamIds(workspaceId: string): Set<string> {
+  const rows = useLiveQuery(
+    () => db.boardMutedStreams.where("workspaceId").equals(workspaceId).toArray(),
+    [workspaceId]
+  )
+  return useMemo(() => new Set((rows ?? []).map((row) => row.id)), [rows])
+}
+
+export interface BoardExclusionsSeed {
+  hiddenConversations: { conversationId: string; hiddenAt: string }[]
+  mutedStreamIds: string[]
+}
+
+/**
+ * Replace the workspace's exclusion rows from a bootstrap fetch (subscribe-then-fetch,
+ * INV-53). Authoritative: rows the server no longer returns are dropped (a hide/mute
+ * removed on another device before this fetch), unlike the board feed's additive seed.
+ */
+export async function seedBoardExclusions(workspaceId: string, seed: BoardExclusionsSeed): Promise<void> {
+  const cachedAt = Date.now()
+  await db.transaction("rw", db.boardHiddenConversations, db.boardMutedStreams, async () => {
+    const [staleHidden, staleMuted] = await Promise.all([
+      db.boardHiddenConversations.where("workspaceId").equals(workspaceId).primaryKeys(),
+      db.boardMutedStreams.where("workspaceId").equals(workspaceId).primaryKeys(),
+    ])
+    await Promise.all([
+      db.boardHiddenConversations.bulkDelete(staleHidden),
+      db.boardMutedStreams.bulkDelete(staleMuted),
+    ])
+    await db.boardHiddenConversations.bulkPut(
+      seed.hiddenConversations.map((row) => ({
+        id: row.conversationId,
+        workspaceId,
+        hiddenAt: Date.parse(row.hiddenAt),
+        _cachedAt: cachedAt,
+      }))
+    )
+    await db.boardMutedStreams.bulkPut(
+      seed.mutedStreamIds.map((streamId) => ({ id: streamId, workspaceId, _cachedAt: cachedAt }))
+    )
+  })
+}
+
+export async function putHidden(workspaceId: string, conversationId: string, hiddenAt: number): Promise<void> {
+  await db.boardHiddenConversations.put({ id: conversationId, workspaceId, hiddenAt, _cachedAt: Date.now() })
+}
+
+export async function deleteHidden(conversationId: string): Promise<void> {
+  await db.boardHiddenConversations.delete(conversationId)
+}
+
+export async function putMuted(workspaceId: string, streamId: string): Promise<void> {
+  await db.boardMutedStreams.put({ id: streamId, workspaceId, _cachedAt: Date.now() })
+}
+
+export async function deleteMuted(streamId: string): Promise<void> {
+  await db.boardMutedStreams.delete(streamId)
+}

--- a/apps/frontend/src/sync/workspace-sync.ts
+++ b/apps/frontend/src/sync/workspace-sync.ts
@@ -23,6 +23,8 @@ import type {
   SavedUpsertedPayload,
   SavedDeletedPayload,
   SavedReminderFiredPayload,
+  BoardConversationHideChangedPayload,
+  BoardStreamMuteChangedPayload,
   SavedSuggestionUpsertedPayload,
   ScheduledMessageUpsertedPayload,
   ScheduledMessageSentPayload,
@@ -38,6 +40,7 @@ import type {
 import { persistSavedRows, removeSavedRow, savedKeys } from "@/hooks/use-saved"
 import { conversationKeys } from "@/hooks/use-conversations"
 import { mergeBoardConversation, addBoardConversationStream } from "@/stores/board-store"
+import { putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
 import { activityKeys } from "@/hooks/use-activity"
 import { memoKeys } from "@/hooks/use-memos"
 import { invitationKeys } from "@/api/invitations"
@@ -1592,6 +1595,21 @@ export function registerWorkspaceSocketHandlers(
     queryClient.invalidateQueries({ queryKey: savedKeys.list(workspaceId, "archived") })
   }
 
+  // Board hide/mute changed on another device — patch the exclusion store so the
+  // reactive board re-filters with no refetch (board-view-design.md § "Hide & mute").
+  const handleBoardHideChanged = (payload: BoardConversationHideChangedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+    if (payload.active)
+      void putHidden(workspaceId, payload.conversationId, payload.hiddenAt ? Date.parse(payload.hiddenAt) : Date.now())
+    else void deleteHidden(payload.conversationId)
+  }
+
+  const handleBoardMuteChanged = (payload: BoardStreamMuteChangedPayload) => {
+    if (payload.workspaceId !== workspaceId) return
+    if (payload.active) void putMuted(workspaceId, payload.streamId)
+    else void deleteMuted(payload.streamId)
+  }
+
   const handleSavedReminderFired = (payload: SavedReminderFiredPayload) => {
     if (payload.workspaceId !== workspaceId) return
     // Update the cached row so the badge flips to "reminded" immediately. The
@@ -1819,6 +1837,8 @@ export function registerWorkspaceSocketHandlers(
   socket.on("saved:upserted", handleSavedUpserted)
   socket.on("saved:deleted", handleSavedDeleted)
   socket.on("saved_reminder:fired", handleSavedReminderFired)
+  socket.on("board:conversation_hide_changed", handleBoardHideChanged)
+  socket.on("board:stream_mute_changed", handleBoardMuteChanged)
   socket.on("saved_suggestion:upserted", handleSavedSuggestionUpserted)
   socket.on("scheduled_message:upserted", handleScheduledUpserted)
   socket.on("scheduled_message:sent", handleScheduledSent)
@@ -1872,6 +1892,8 @@ export function registerWorkspaceSocketHandlers(
     socket.off("saved:upserted", handleSavedUpserted)
     socket.off("saved:deleted", handleSavedDeleted)
     socket.off("saved_reminder:fired", handleSavedReminderFired)
+    socket.off("board:conversation_hide_changed", handleBoardHideChanged)
+    socket.off("board:stream_mute_changed", handleBoardMuteChanged)
     socket.off("saved_suggestion:upserted", handleSavedSuggestionUpserted)
     socket.off("scheduled_message:upserted", handleScheduledUpserted)
     socket.off("scheduled_message:sent", handleScheduledSent)

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1774,6 +1774,26 @@ export interface SavedUpsertedPayload {
   saved: SavedMessageView
 }
 
+/** Wire payload on `board:conversation_hide_changed` (board-view-design.md § "Hide & mute"). */
+export interface BoardConversationHideChangedPayload {
+  workspaceId: string
+  targetUserId: string
+  conversationId: string
+  /** true = hidden, false = un-hidden. */
+  active: boolean
+  /** Snooze watermark (ISO), present only when `active`. */
+  hiddenAt?: string
+}
+
+/** Wire payload on `board:stream_mute_changed`. */
+export interface BoardStreamMuteChangedPayload {
+  workspaceId: string
+  targetUserId: string
+  streamId: string
+  /** true = muted, false = un-muted. */
+  active: boolean
+}
+
 /** Wire payload broadcast on `saved:deleted` socket events. */
 export interface SavedDeletedPayload {
   workspaceId: string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -514,6 +514,8 @@ export type {
   SavedUpsertedPayload,
   SavedDeletedPayload,
   SavedReminderFiredPayload,
+  BoardConversationHideChangedPayload,
+  BoardStreamMuteChangedPayload,
   // Saved suggestions
   SavedSuggestionView,
   SavedSuggestionListResponse,


### PR DESCRIPTION
## Summary

Roadmap next-up #4 + the stream-mute grain the scope work (#1178) left open (board-view-design.md § "Hide & mute"). Two per-viewer board exclusions:

- **Hide a card** — snooze one conversation until it revives (`last_activity_at` passes the `hidden_at` watermark; a genuine revival un-hides permanently).
- **Mute a stream** — never board-surface a whole stream (the higher-value grain given the floor data's one-DM concentration). Matched by effective root, **skipped under an explicit `?in=` scope** (the viewer named those streams).

## Backend

- Migration `board_view_exclusions`: two composite-PK tables, no FK/enum, `workspace_id` scoped (INV-1/2/3/8/17).
- `BoardExclusionRepository` (race-safe upsert/delete, INV-20) + `BoardExclusionService` (txn + a user-scoped outbox event per mutation, INV-6/7). 5 endpoints (hide / unhide / mute / unmute + a bootstrap GET), board-flag-gated, access-checked (INV-62).
- Exclusion predicates colocate with `boardLensCondSql` and splice into `findByWorkspaceForViewer`; the revival + mute-skip-under-scope rules mirror the client (documented lockstep).
- Two `board:*` outbox events registered `USER_SCOPED` — routed to `user:{targetUserId}` via the existing `targetUserId` path, **no delivery-groups change**.

## Frontend

- Dexie **v38** stores + a reactive `board-exclusions-store` (memoized reads → stable memo deps) + bootstrap (`useBoardExclusions`) + 4 optimistic mutation hooks (no success toast — the card vanishing is the signal, INV-63; error rolls back + `toast.error`).
- **The crux — `useStableBoardView`:** a hidden/muted card is excluded from **both** the `live` filter **and** the `posts` render walk. The stable view's retain mechanism keeps *involuntary* drops (lost access, re-lensed by your own reply) from shifting rows below them — but a *voluntary* hide must drop **now**, so it's evicted from the render even while it's still committed + retained. This is the piece the plan flagged as most likely to go wrong; it has a dedicated test.
- UI: **"Hide from board" / "Unhide"** join the existing conversation `⋯`-menu (card + panel, reusing #1194's menu); a per-stream **Bell/BellOff** mute toggle in the scope-picker rows; socket handlers patch IDB for multi-device reconcile.

## Tests

- Backend: handler gate/access/delegation; delivery-groups (both events → `userGroup`).
- Frontend: store seed-replace + optimistic round-trip; `use-stable-board-view` — **drops-immediately-when-retained** (the crux), revives-past-watermark, mute active vs inactive; board-card "Hide from board" wires to the API.
- 0 typecheck errors across 3 packages; **89 frontend** board/conversation + **136 backend** conversation/outbox tests green; the no-happy-path-success-toast guard still passes.

## Scope guard (INV-36)

Snooze-until-activity only (no `snoozed_until` / hide-forever); no hidden-items browser (unhide is via the panel). Follow-up: a DB-backed repo test for the revival + mute-by-root anti-joins (the feature has no DB test harness yet; the JS half is covered via `use-stable-board-view`).

> Final PR in the stack: #1194 → #1193 → #1191 → #1179. Base retargets as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785865513&installation_id=129946197&pr_number=1196&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1196&signature=08c37a31f6797cf8c03fc7309cd6e342ef3a1fbb2fb46af1fb7caa421626197c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->