### PR TITLE
feat(board): nested threads on the card — soft seams, branch stubs, bounded spanning tree

### DIFF
--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+
+const WS = "ws_1"
+
+function cachedStream(id: string, type: string, extra: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: type as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    archivedAt: null,
+    _cachedAt: 0,
+    ...extra,
+  }
+}
+
+interface PostOpts {
+  id: string
+  streamId: string
+  messageIds: string[]
+  opening: { id: string; streamId: string; content: string } | null
+  recentMessages?: Array<{ id: string; streamId: string; content: string; authorId?: string }>
+  totalReplies?: number
+  streamIds: string[]
+  rootStreamId: string
+  topicSummary: string | null
+}
+
+function makePost(opts: PostOpts): CachedBoardPost {
+  const opening = opts.opening
+    ? {
+        id: opts.opening.id,
+        streamId: opts.opening.streamId,
+        authorId: "usr_other",
+        authorType: "user",
+        contentMarkdown: opts.opening.content,
+        reactions: {},
+        attachments: [],
+        linkPreviews: [],
+        createdAt: "2026-06-22T12:00:00.000Z",
+        editedAt: null,
+      }
+    : null
+  return {
+    id: opts.id,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: opts.streamIds,
+    rootStreamId: opts.rootStreamId,
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: opts.id,
+      streamId: opts.streamId,
+      workspaceId: WS,
+      messageIds: opts.messageIds,
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: opts.topicSummary,
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+      createdAt: "2026-06-22T12:00:00.000Z",
+      updatedAt: "2026-06-22T12:00:00.000Z",
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: opening,
+    recentMessages: (opts.recentMessages ?? []).map((m) => ({
+      id: m.id,
+      streamId: m.streamId,
+      authorId: m.authorId ?? "usr_other",
+      authorType: "user",
+      contentMarkdown: m.content,
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+    })),
+    totalReplies: opts.totalReplies ?? 0,
+  } as unknown as CachedBoardPost
+}
+
+function messageEvent(id: string, streamId: string, seconds: number, content: string): CachedEvent {
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType: "message_created",
+    payload: { messageId: id, contentMarkdown: content, reactions: {} },
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
+function mount(post: CachedBoardPost) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+beforeEach(async () => {
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard branches", () => {
+  it("shows a true-thread stub on the parent card linking to the child conversation", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: ["c1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+
+    mount(parent)
+    // Stub text is the child conversation's topic, linking to its panel.
+    const stub = await screen.findByText("GPU budget")
+    const link = stub.closest("a")
+    expect(link?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
+  })
+
+  it("shows a 'branched from' provenance row on the child card", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: ["c1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Parent opening body." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+
+    mount(child)
+    const provenance = await screen.findByText("Branched from Hardware refresh")
+    expect(provenance.closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_parent")
+  })
+
+  it("renders a soft migration with a seam and no indent", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_soft", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "sr2",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("sr1", "stream_1", 10, "First in channel."),
+      messageEvent("sr2", "stream_1", 11, "Second in channel."),
+      messageEvent("st1", "thread_soft", 12, "Moved into the thread."),
+    ])
+    const post = makePost({
+      id: "conv_soft",
+      streamId: "stream_1",
+      messageIds: ["sr1", "sr2", "st1"],
+      opening: { id: "sr1", streamId: "stream_1", content: "First in channel." },
+      streamIds: ["stream_1", "thread_soft"],
+      totalReplies: 2,
+      rootStreamId: "stream_1",
+      topicSummary: "Soft migration",
+    })
+    await db.conversations.bulkPut([post])
+
+    const { container } = mount(post)
+    await screen.findByText("Moved into the thread.")
+    expect(await screen.findByText(/continued in/)).toBeTruthy()
+    // Soft renders flat: no indent wrapper (the spanning left rail).
+    expect(container.querySelector(".border-l-2")).toBeNull()
+  })
+
+  it("shows neither stub nor provenance for a thread-anchored conversation with no live source", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_legacy", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "gone_msg",
+      }),
+    ])
+    // No conversation contains `gone_msg`: the retired source resolves nothing.
+    const post = makePost({
+      id: "conv_legacy",
+      streamId: "thread_legacy",
+      messageIds: ["l1"],
+      opening: { id: "gone_msg", streamId: "stream_1", content: "Legacy opening body." },
+      streamIds: ["thread_legacy"],
+      rootStreamId: "stream_1",
+      topicSummary: "Legacy topic",
+    })
+    await db.conversations.bulkPut([post])
+
+    mount(post)
+    await screen.findByText("Legacy opening body.")
+    expect(screen.queryByText(/Branched from/)).toBeNull()
+    expect(screen.queryByText(/continued in/)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -8,6 +8,7 @@ import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
 import { db, type CachedEvent } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
@@ -102,7 +103,10 @@ const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), 
 
 beforeEach(async () => {
   __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
   await db.events.clear()
+  await db.conversations.clear()
+  await db.streams.clear()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -6,8 +6,16 @@ import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { groupBranches } from "@/lib/board/branch-grouping"
+import {
+  useConversationGraph,
+  useStreamStructuralIndex,
+  deriveBranchStubs,
+  deriveBranchProvenance,
+} from "@/hooks/use-conversation-graph"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
@@ -48,7 +56,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
-  const { openPanel } = usePanel()
+  const { openPanel, getPanelUrl } = usePanel()
   const [expanded, setExpanded] = useState(false)
   // Scopes text-selection quoting to this card so a selection routes into this
   // card's composer, not a sibling card's provider.
@@ -104,6 +112,47 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
     [railEvents, conversation.id, memberMessageIds]
   )
+
+  // Per-thread-boundary grouping: soft-thread seams, true-thread stubs, and
+  // "branched from" provenance derive from the stream graph + the shared
+  // conversation graph. Grouping runs over the already-displayed rows below, so
+  // the stable-window / allResolved machinery stays untouched.
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const occupiedStreamIds = useMemo(() => {
+    const set = new Set<string>([streamId])
+    for (const message of knownMessages) if (message.streamId) set.add(message.streamId)
+    return set
+  }, [streamId, knownMessages])
+  const stubsByForkMessageId = useMemo(
+    () =>
+      deriveBranchStubs({
+        conversationId: conversation.id,
+        memberMessages: knownMessages,
+        occupiedStreamIds,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, knownMessages, occupiedStreamIds, structuralIndex, conversationGraph]
+  )
+  const provenance = useMemo(
+    () =>
+      deriveBranchProvenance({
+        conversationId: conversation.id,
+        anchorStreamId: streamId,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, streamId, structuralIndex, conversationGraph]
+  )
+  const branchRows = (messages: RenderableMessage[]) =>
+    buildBranchedBoardRows(
+      groupBranches(messages, { streams: structuralIndex.streamsById, conversation: { streamId } }),
+      eventRows,
+      stubsByForkMessageId
+    )
+  // A spanning-overflow row from a card opens the whole conversation in the panel.
+  const continueThreadTo = () => getPanelUrl(createConversationPanelId(conversation.id))
 
   // The rail carries every locally-synced reply; older ones (or a wholly unsynced
   // stream — `source === "projection"`) may be missing, so on expand we backfill
@@ -253,15 +302,16 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
           </div>
 
           <div className="mt-3 [&>*:first-child]:mt-0">
+            {provenance && (
+              <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
+            )}
             {contiguous ? (
-              buildBoardRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies, eventRows).map(
-                (row) =>
-                  row.kind === "message" ? (
-                    renderMessage(row.message, row.continuation)
-                  ) : (
-                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-                  )
-              )
+              <BranchedBoardRows
+                rows={branchRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies)}
+                workspaceId={workspaceId}
+                renderMessage={renderMessage}
+                continueThreadTo={continueThreadTo}
+              />
             ) : (
               <>
                 {openingMessage && renderMessage(openingMessage, false)}
@@ -290,13 +340,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                     Couldn't load older messages. Retry.
                   </button>
                 )}
-                {buildBoardRows(displayedReplies, eventRows).map((row) =>
-                  row.kind === "message" ? (
-                    renderMessage(row.message, row.continuation)
-                  ) : (
-                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-                  )
-                )}
+                <BranchedBoardRows
+                  rows={branchRows(displayedReplies)}
+                  workspaceId={workspaceId}
+                  renderMessage={renderMessage}
+                  continueThreadTo={continueThreadTo}
+                />
               </>
             )}
           </div>

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest"
 import type { RenderableMessage } from "@/components/message/message-item"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
-import { buildBoardRows } from "./board-row-item"
+import { buildBoardRows, buildBranchedBoardRows } from "./board-row-item"
+import { groupBranches, type BranchStreamNode, type BranchStub } from "@/lib/board/branch-grouping"
 
-function msg(id: string, authorId: string, minute: number): RenderableMessage {
+function msg(id: string, authorId: string, minute: number, streamId?: string): RenderableMessage {
   return {
     id,
+    streamId,
     authorId,
     authorType: "user",
     contentMarkdown: id,
@@ -14,11 +16,18 @@ function msg(id: string, authorId: string, minute: number): RenderableMessage {
   }
 }
 
-// buildBoardRows only reads `kind` / `key` / `sortMs`, so the `event` field is a
-// stub — kept off `@/db` to leave this a pure-logic test (no persistence import).
-function memoEventRow(key: string, minute: number): BoardEventRow {
+// The builders only read `kind` / `key` / `sortMs` / `streamId`, so the `event`
+// field is a stub — kept off `@/db` to leave this a pure-logic test (no
+// persistence import).
+function memoEventRow(key: string, minute: number, streamId = "root"): BoardEventRow {
   const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
-  return { kind: "memo", key, sortMs: new Date(createdAt).getTime(), event: { id: key, createdAt } } as BoardEventRow
+  return {
+    kind: "memo",
+    key,
+    sortMs: new Date(createdAt).getTime(),
+    streamId,
+    event: { id: key, createdAt },
+  } as BoardEventRow
 }
 
 describe("buildBoardRows", () => {
@@ -50,5 +59,90 @@ describe("buildBoardRows", () => {
   it("places a message before an event that shares its exact timestamp", () => {
     const rows = buildBoardRows([msg("a", "u1", 3)], [memoEventRow("evt", 3)])
     expect(rows.map((r) => r.kind)).toEqual(["message", "event"])
+  })
+})
+
+describe("buildBranchedBoardRows continuation", () => {
+  function streamNode(
+    parentStreamId: string | null,
+    rootStreamId: string | null,
+    parentMessageId: string | null
+  ): BranchStreamNode {
+    return { parentStreamId, rootStreamId, parentMessageId }
+  }
+
+  it("a soft seam breaks a same-author continuation run", () => {
+    // Same author within the grouping window, but split across a soft thread
+    // boundary: the seam sits between the runs and the second run doesn't group.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 1, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "seam", "message"])
+    const second = rows[2]
+    expect(second.kind === "message" && second.continuation).toBe(false)
+  })
+
+  it("a branch stub breaks a same-author continuation run", () => {
+    // Two same-author messages that WOULD group, with a true-thread stub anchored
+    // to the first — the stub resets continuation exactly like an event row.
+    const streams = new Map([["root", streamNode(null, null, null)]])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 1, "root")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const stub: BranchStub = {
+      forkMessageId: "a",
+      childConversationId: "conv_child",
+      threadStreamId: "thread_x",
+      title: "GPU budget",
+    }
+    const rows = buildBranchedBoardRows(grouping, [], new Map([["a", [stub]]]))
+    expect(rows.map((r) => r.kind)).toEqual(["message", "branch-stub", "message"])
+    const second = rows[2]
+    expect(second.kind === "message" && second.continuation).toBe(false)
+  })
+
+  it("an event on a stream with no rendered group joins the base run chronologically", () => {
+    // A memo capture landed on a member stream whose messages sit in the hidden
+    // middle (or outside the occupied set entirely). It must still render — at
+    // the base level, in time order — not silently vanish.
+    const streams = new Map([["root", streamNode(null, null, null)]])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 4, "root")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [memoEventRow("evt", 2, "other_stream")], new Map())
+    expect(rows.map((r) => (r.kind === "message" ? r.message.id : r.kind))).toEqual(["a", "event", "b"])
+    const orphanRow = rows[1]
+    expect(orphanRow.kind === "event" && orphanRow.displayDepth).toBe(0)
+  })
+
+  it("splits orphan events across a soft seam by time", () => {
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u2", 4, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(
+      grouping,
+      [memoEventRow("early", 1, "elsewhere"), memoEventRow("late", 5, "elsewhere")],
+      new Map()
+    )
+    expect(rows.map((r) => (r.kind === "event" ? r.row.key : r.kind))).toEqual([
+      "message",
+      "early",
+      "seam",
+      "message",
+      "late",
+    ])
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -4,16 +4,25 @@ import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
+import type { BranchGrouping, BranchNode, BranchStub } from "@/lib/board/branch-grouping"
 
 /**
- * One row in a board card / conversation panel: either a member message (with its
- * same-author continuation flag) or an interleaved agent/memo/follow-up event row.
- * The board renders both through {@link buildBoardRows} so a conversation surface
- * is a second *view* of the stream's events, not a message-only parallel renderer.
+ * One row in a board card / conversation panel: a member message (with its
+ * same-author continuation flag), an interleaved agent/memo/follow-up event row,
+ * or one of the branch chrome rows (a soft-thread seam, a true-thread stub, a
+ * spanning-overflow "continue thread" link). The board renders all through
+ * {@link buildBoardRows} / {@link buildBranchedBoardRows} so a conversation
+ * surface is a second *view* of the stream's events, not a parallel renderer.
+ *
+ * `displayDepth` is the row's indent level (0–2); absent on the flat
+ * {@link buildBoardRows} output, which never indents.
  */
 export type BoardRow =
-  | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean }
-  | { kind: "event"; key: string; row: BoardEventRow }
+  | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean; displayDepth?: number }
+  | { kind: "event"; key: string; row: BoardEventRow; displayDepth?: number }
+  | { kind: "seam"; key: string; streamId: string; direction: "down" | "up"; displayDepth?: number }
+  | { kind: "branch-stub"; key: string; childConversationId: string; title: string; displayDepth?: number }
+  | { kind: "continue-thread"; key: string; streamId: string; hiddenCount: number; displayDepth?: number }
 
 /**
  * Interleave a chronological message list with the conversation's event rows by
@@ -62,6 +71,187 @@ export function buildBoardRows(messages: RenderableMessage[], eventRows: BoardEv
     }
   }
   return rows
+}
+
+function messageMs(message: RenderableMessage): number {
+  return new Date(message.createdAt).getTime()
+}
+
+function subtreeMessageCount(node: BranchNode): number {
+  let count = node.messages.length
+  for (const child of node.children) count += subtreeMessageCount(child)
+  return count
+}
+
+function earliestMessageMs(nodes: BranchNode[]): number {
+  let min = Number.POSITIVE_INFINITY
+  const walk = (node: BranchNode) => {
+    for (const message of node.messages) {
+      const t = messageMs(message)
+      if (t < min) min = t
+    }
+    for (const child of node.children) walk(child)
+  }
+  for (const node of nodes) walk(node)
+  return min === Number.POSITIVE_INFINITY ? Number.NEGATIVE_INFINITY : min
+}
+
+/**
+ * Flatten a {@link BranchGrouping} into ordered board rows, interleaving event
+ * rows into the group whose stream owns them and inserting branch chrome:
+ *
+ * - `soft` → the two runs with one `seam` row between them (no indent).
+ * - `spanning` → base messages chronological; each occupied thread rendered as
+ *   one contiguous group placed after its fork message's row (or anchored
+ *   chronologically when its fork message isn't rendered), indented by
+ *   `displayDepth`; a subtree past depth 2 collapses to one `continue-thread` row.
+ * - true-thread `stubs` land immediately after their fork message's row.
+ *
+ * Same-author continuation never spans a group boundary and is reset by any seam,
+ * stub, event, or overflow row — exactly like {@link buildBoardRows} resets on an
+ * interleaved event. Events earlier than the first rendered message are dropped
+ * (the collapsed card's hidden middle), matching {@link buildBoardRows}. An event
+ * on a stream with no rendered group (its messages sit in the hidden middle, or a
+ * capture landed outside the occupied streams) still shows — chronologically at
+ * the base level — never silently vanishing; only events under a collapsed
+ * overflow subtree stay hidden with it.
+ */
+export function buildBranchedBoardRows(
+  grouping: BranchGrouping,
+  eventRows: BoardEventRow[],
+  stubsByForkMessageId: Map<string, BranchStub[]>
+): BoardRow[] {
+  const firstMs = earliestMessageMs(grouping.roots)
+  const eventsByStream = new Map<string, BoardEventRow[]>()
+  for (const event of eventRows) {
+    if (event.sortMs < firstMs) continue
+    const list = eventsByStream.get(event.streamId)
+    if (list) list.push(event)
+    else eventsByStream.set(event.streamId, [event])
+  }
+
+  const groupedStreamIds = new Set<string>()
+  const collectStreamIds = (node: BranchNode) => {
+    groupedStreamIds.add(node.streamId)
+    for (const child of node.children) collectStreamIds(child)
+  }
+  for (const node of grouping.roots) collectStreamIds(node)
+  const orphanEvents: BoardEventRow[] = []
+  for (const [streamId, list] of eventsByStream) {
+    if (!groupedStreamIds.has(streamId)) orphanEvents.push(...list)
+  }
+
+  const out: BoardRow[] = []
+
+  const emitChild = (node: BranchNode) => {
+    if (node.overflow) {
+      out.push({
+        kind: "continue-thread",
+        key: `continue:${node.streamId}`,
+        streamId: node.streamId,
+        hiddenCount: subtreeMessageCount(node),
+        displayDepth: node.displayDepth,
+      })
+      return
+    }
+    emitRun([node])
+  }
+
+  function emitRun(nodes: BranchNode[], orphans: BoardEventRow[] = []): void {
+    const present = new Set<string>()
+    for (const node of nodes) for (const message of node.messages) present.add(message.id)
+
+    type Item = {
+      t: number
+      slot: number
+      depth: number
+      message?: RenderableMessage
+      event?: BoardEventRow
+      child?: BranchNode
+    }
+    const items: Item[] = []
+    for (const event of orphans) items.push({ t: event.sortMs, slot: 2, depth: 0, event })
+    const forkChildren = new Map<string, BranchNode[]>()
+    for (const node of nodes) {
+      for (const message of node.messages)
+        items.push({ t: messageMs(message), slot: 0, depth: node.displayDepth, message })
+      for (const event of eventsByStream.get(node.streamId) ?? [])
+        items.push({ t: event.sortMs, slot: 2, depth: node.displayDepth, event })
+      for (const child of node.children) {
+        if (child.forkMessageId && present.has(child.forkMessageId)) {
+          const list = forkChildren.get(child.forkMessageId)
+          if (list) list.push(child)
+          else forkChildren.set(child.forkMessageId, [child])
+        } else {
+          const anchor = child.messages.length > 0 ? messageMs(child.messages[0]) : Number.POSITIVE_INFINITY
+          items.push({ t: anchor, slot: 1, depth: child.displayDepth, child })
+        }
+      }
+    }
+    items.sort((a, b) => (a.t !== b.t ? a.t - b.t : a.slot - b.slot))
+
+    let prev: RenderableMessage | null = null
+    for (const item of items) {
+      if (item.message) {
+        const continuation = prev != null && isContinuation(prev, item.message)
+        out.push({
+          kind: "message",
+          key: item.message.id,
+          message: item.message,
+          continuation,
+          displayDepth: item.depth,
+        })
+        prev = item.message
+        for (const stub of stubsByForkMessageId.get(item.message.id) ?? []) {
+          out.push({
+            kind: "branch-stub",
+            key: `stub:${stub.childConversationId}`,
+            childConversationId: stub.childConversationId,
+            title: stub.title,
+            displayDepth: item.depth,
+          })
+          prev = null
+        }
+        for (const child of forkChildren.get(item.message.id) ?? []) {
+          emitChild(child)
+          prev = null
+        }
+      } else if (item.event) {
+        out.push({ kind: "event", key: item.event.key, row: item.event, displayDepth: item.depth })
+        prev = null
+      } else if (item.child) {
+        emitChild(item.child)
+        prev = null
+      }
+    }
+  }
+
+  if (grouping.kind === "soft" && grouping.softSeam) {
+    const [runA, runB] = grouping.roots
+    // Orphan events split at the seam so each lands in its chronological run.
+    const runBStart = runB && runB.messages.length > 0 ? messageMs(runB.messages[0]) : Number.POSITIVE_INFINITY
+    if (runA)
+      emitRun(
+        [runA],
+        orphanEvents.filter((event) => event.sortMs < runBStart)
+      )
+    out.push({
+      kind: "seam",
+      key: `seam:${grouping.softSeam.streamId}`,
+      streamId: grouping.softSeam.streamId,
+      direction: grouping.softSeam.direction,
+      displayDepth: 0,
+    })
+    if (runB)
+      emitRun(
+        [runB],
+        orphanEvents.filter((event) => event.sortMs >= runBStart)
+      )
+  } else {
+    emitRun(grouping.roots, orphanEvents)
+  }
+
+  return out
 }
 
 /**

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from "react"
+import { Link } from "react-router-dom"
+import { CornerDownRight, GitBranch, ArrowRight, MoveRight } from "lucide-react"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { usePanel, createConversationPanelId } from "@/contexts"
+import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/** Indent per thread boundary (spanning), applied on a wrapper so the shared
+ *  `MessageItem` stays untouched. A left rail reads the nesting Reddit-style. */
+const INDENT_CLASS: Record<number, string> = {
+  1: "ml-3 border-l-2 border-border pl-2 sm:pl-3",
+  2: "ml-6 border-l-2 border-border pl-2 sm:pl-3",
+}
+
+/**
+ * The "continued in …" divider for a soft thread (convert-to-thread, or the
+ * thread→root Slack case). Subtle and non-interactive: the thread is transport,
+ * not a branch, so it names where the conversation moved without pulling the
+ * reader out of the card.
+ */
+export function ThreadSeamRow({
+  workspaceId,
+  streamId,
+  direction,
+}: {
+  workspaceId: string
+  streamId: string
+  direction: "down" | "up"
+}) {
+  const label = useStreamName(workspaceId, streamId, "generic") ?? "thread"
+  const Icon = direction === "up" ? MoveRight : CornerDownRight
+  return (
+    <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">continued in {label}</span>
+    </div>
+  )
+}
+
+/**
+ * A true-thread branch stub on the parent card — "↳ <child topic>" at the fork
+ * point, linking to the child conversation panel (INV-40). The nesting survives
+ * *between* cards instead of inside one.
+ */
+export function BranchStubRow({ conversationId, title }: { conversationId: string; title: string }) {
+  const { getPanelUrl } = usePanel()
+  return (
+    <Link
+      to={getPanelUrl(createConversationPanelId(conversationId))}
+      className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <CornerDownRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{title}</span>
+    </Link>
+  )
+}
+
+/**
+ * "Branched from <parent topic>" provenance at the top of a child card, linking
+ * to the parent conversation panel (INV-40) — the conversation-grain mirror of
+ * the message-grain provenance chip.
+ */
+export function BranchProvenanceRow({ conversationId, title }: { conversationId: string; title: string }) {
+  const { getPanelUrl } = usePanel()
+  return (
+    <Link
+      to={getPanelUrl(createConversationPanelId(conversationId))}
+      className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <GitBranch className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">Branched from {title}</span>
+    </Link>
+  )
+}
+
+/**
+ * The spanning depth cap: a thread nested past two boundaries collapses to one
+ * link — into the conversation panel from a card, or into the thread's own panel
+ * from the conversation panel (`to` resolved by the surface, INV-40).
+ */
+export function ContinueThreadRow({ to, hiddenCount }: { to: string; hiddenCount: number }) {
+  return (
+    <Link
+      to={to}
+      aria-label={`Continue this thread (${hiddenCount} more)`}
+      className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">Continue this thread</span>
+    </Link>
+  )
+}
+
+interface BranchedBoardRowsProps {
+  rows: BoardRow[]
+  workspaceId: string
+  renderMessage: (message: RenderableMessage, continuation: boolean) => ReactNode
+  /** Where a spanning-overflow row links, given the deep thread's stream. */
+  continueThreadTo: (streamId: string) => string
+}
+
+function renderRowContent(
+  row: BoardRow,
+  { workspaceId, renderMessage, continueThreadTo }: BranchedBoardRowsProps
+): ReactNode {
+  switch (row.kind) {
+    case "message":
+      return renderMessage(row.message, row.continuation)
+    case "event":
+      return <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+    case "seam":
+      return <ThreadSeamRow key={row.key} workspaceId={workspaceId} streamId={row.streamId} direction={row.direction} />
+    case "branch-stub":
+      return <BranchStubRow key={row.key} conversationId={row.childConversationId} title={row.title} />
+    case "continue-thread":
+      return <ContinueThreadRow key={row.key} to={continueThreadTo(row.streamId)} hiddenCount={row.hiddenCount} />
+  }
+}
+
+/**
+ * Render a branch-grouped row list: message rows through the surface's own
+ * renderer, event/branch chrome through the components above, each indented by
+ * its `displayDepth` via a wrapper element (indent never touches `MessageItem`).
+ */
+export function BranchedBoardRows(props: BranchedBoardRowsProps) {
+  return (
+    <>
+      {props.rows.map((row) => {
+        const depth = row.displayDepth ?? 0
+        const content = renderRowContent(row, props)
+        if (depth === 0) return content
+        return (
+          <div key={row.key} className={INDENT_CLASS[depth]}>
+            {content}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -15,8 +15,16 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { groupBranches } from "@/lib/board/branch-grouping"
+import {
+  useConversationGraph,
+  useStreamStructuralIndex,
+  deriveBranchStubs,
+  deriveBranchProvenance,
+} from "@/hooks/use-conversation-graph"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
@@ -317,7 +325,62 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
     [railEvents, conversation.id, memberMessageIds]
   )
-  const rows = buildBoardRows(all, eventRows)
+
+  // Per-thread-boundary grouping — same derivation as the board card (the panel
+  // is the always-expanded peer). Overflow rows link into the thread's own stream
+  // panel here rather than back to this conversation.
+  const { getPanelUrl } = usePanel()
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const occupiedStreamIds = useMemo(() => {
+    const set = new Set<string>([conversation.streamId])
+    for (const message of all) if (message.streamId) set.add(message.streamId)
+    return set
+  }, [conversation.streamId, all])
+  const stubsByForkMessageId = useMemo(
+    () =>
+      deriveBranchStubs({
+        conversationId: conversation.id,
+        memberMessages: all,
+        occupiedStreamIds,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, all, occupiedStreamIds, structuralIndex, conversationGraph]
+  )
+  const provenance = useMemo(
+    () =>
+      deriveBranchProvenance({
+        conversationId: conversation.id,
+        anchorStreamId: conversation.streamId,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, conversation.streamId, structuralIndex, conversationGraph]
+  )
+  const rows = buildBranchedBoardRows(
+    groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
+    eventRows,
+    stubsByForkMessageId
+  )
+  const renderMessage = (message: RenderableMessage, continuation: boolean) => (
+    <MessageItem
+      key={message.id}
+      workspaceId={workspaceId}
+      // Each row renders against its own stream so reactions and the permalink
+      // target where the message actually lives (one root, many streams); fall
+      // back to the anchor.
+      streamId={message.streamId ?? conversation.streamId}
+      message={message}
+      authorName={getActorName(message.authorId, message.authorType)}
+      currentUserId={currentUserId}
+      continuation={continuation}
+      conversationId={conversation.id}
+      conversationRootStreamId={conversation.streamId}
+      isHighlighted={message.id === highlightMessageId}
+      surfaceClassName="bg-background"
+    />
+  )
   // The conversation's most-recently-active stream — the latest reply's own stream
   // (a thread under the root), so a continuation follows the conversation there
   // instead of re-interleaving the channel (board-view-design.md). Falls back to
@@ -350,28 +413,15 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
         <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
-          {rows.map((row) =>
-            row.kind === "message" ? (
-              <MessageItem
-                key={row.message.id}
-                workspaceId={workspaceId}
-                // Each row renders against its own stream so reactions and the
-                // permalink target where the message actually lives (one root, many
-                // streams); fall back to the anchor.
-                streamId={row.message.streamId ?? conversation.streamId}
-                message={row.message}
-                authorName={getActorName(row.message.authorId, row.message.authorType)}
-                currentUserId={currentUserId}
-                continuation={row.continuation}
-                conversationId={conversation.id}
-                conversationRootStreamId={conversation.streamId}
-                isHighlighted={row.message.id === highlightMessageId}
-                surfaceClassName="bg-background"
-              />
-            ) : (
-              <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-            )
+          {provenance && (
+            <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
           )}
+          <BranchedBoardRows
+            rows={rows}
+            workspaceId={workspaceId}
+            renderMessage={renderMessage}
+            continueThreadTo={(streamId) => getPanelUrl(streamId)}
+          />
           {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
           {backfillFailed && (
             <button

--- a/apps/frontend/src/hooks/use-conversation-graph.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.ts
@@ -1,0 +1,206 @@
+import { useCallback, useSyncExternalStore } from "react"
+import { liveQuery, type Subscription } from "dexie"
+import { StreamTypes } from "@threa/types"
+import { db, type CachedBoardPost, type CachedStream } from "@/db"
+import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
+import { streamLabel } from "@/lib/streams"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
+import type { RenderableMessage } from "@/components/message/message-item"
+import type { BranchStub } from "@/lib/board/branch-grouping"
+
+/**
+ * The board's cross-conversation lookups, derived once per workspace from the
+ * cached conversations and shared across every card:
+ *
+ * - `conversationByAnchorStreamId` — the conversation anchored to a **thread**
+ *   stream. Only thread-anchored conversations are indexed (a channel/DM anchor
+ *   is shared by many conversations), so a parent card can resolve the child
+ *   conversation a fork thread hosts. `rootStreamId !== anchor` marks the thread
+ *   anchor (a top-level anchor is its own root).
+ * - `conversationIdByMemberMessageId` — the conversation each message is a primary
+ *   member of, so a child card can find the parent conversation its opener thread
+ *   forked from.
+ * - `conversationById` — resolve a looked-up id back to its post (topic/anchor).
+ */
+export interface ConversationGraph {
+  conversationByAnchorStreamId: Map<string, CachedBoardPost>
+  conversationIdByMemberMessageId: Map<string, string>
+  conversationById: Map<string, CachedBoardPost>
+}
+
+const EMPTY_GRAPH: ConversationGraph = {
+  conversationByAnchorStreamId: new Map(),
+  conversationIdByMemberMessageId: new Map(),
+  conversationById: new Map(),
+}
+
+function buildGraph(posts: CachedBoardPost[]): ConversationGraph {
+  const conversationByAnchorStreamId = new Map<string, CachedBoardPost>()
+  const conversationIdByMemberMessageId = new Map<string, string>()
+  const conversationById = new Map<string, CachedBoardPost>()
+  for (const post of posts) {
+    conversationById.set(post.id, post)
+    const anchor = post.conversation.streamId
+    if (post.rootStreamId !== undefined && post.rootStreamId !== anchor) {
+      conversationByAnchorStreamId.set(anchor, post)
+    }
+    for (const messageId of post.conversation.messageIds) conversationIdByMemberMessageId.set(messageId, post.id)
+  }
+  return { conversationByAnchorStreamId, conversationIdByMemberMessageId, conversationById }
+}
+
+interface GraphEntry {
+  graph: ConversationGraph
+  listeners: Set<() => void>
+  subscription: Subscription
+  refCount: number
+}
+
+// INV-9 exception: one shared `db.conversations` liveQuery per workspace,
+// ref-counted across every board card. The board renders hundreds of cards over
+// hundreds of conversations; a per-card scan for "which conversation anchors this
+// thread / owns this message" would be O(cards × conversations). This collapses
+// it to one liveQuery per workspace whose derived index every card reads, torn
+// down when the last card unmounts (adjustment E). Mirrors `threadIndexRegistry`.
+const graphRegistry = new Map<string, GraphEntry>()
+
+function subscribeConversationGraph(workspaceId: string, listener: () => void): () => void {
+  let entry = graphRegistry.get(workspaceId)
+  if (!entry) {
+    const created: GraphEntry = {
+      graph: EMPTY_GRAPH,
+      listeners: new Set(),
+      refCount: 0,
+      subscription: { unsubscribe() {} } as Subscription,
+    }
+    // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
+    // the callback re-reads the live entry so a late emission after teardown no-ops.
+    graphRegistry.set(workspaceId, created)
+    created.subscription = liveQuery(() =>
+      db.conversations.where("workspaceId").equals(workspaceId).toArray()
+    ).subscribe((posts) => {
+      const live = graphRegistry.get(workspaceId)
+      if (!live) return
+      live.graph = buildGraph(posts)
+      for (const notify of live.listeners) notify()
+    })
+    entry = created
+  }
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  return () => {
+    const current = graphRegistry.get(workspaceId)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) {
+      current.subscription.unsubscribe()
+      graphRegistry.delete(workspaceId)
+    }
+  }
+}
+
+/** The shared conversation graph for a workspace, live from `db.conversations`. */
+export function useConversationGraph(workspaceId: string): ConversationGraph {
+  const subscribe = useCallback(
+    (onChange: () => void) => subscribeConversationGraph(workspaceId, onChange),
+    [workspaceId]
+  )
+  const getSnapshot = useCallback(() => graphRegistry.get(workspaceId)?.graph ?? EMPTY_GRAPH, [workspaceId])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** The board's structural stream index — parent pointers (for depth/branch
+ *  grouping) and threads keyed by their fork message (for stub discovery). */
+export interface StreamStructuralIndex {
+  streamsById: Map<string, CachedStream>
+  threadsByParentMessageId: Map<string, CachedStream>
+}
+
+// Cached by the raw streams array identity so every card shares one build; the
+// raw array reference is stable across cards until `db.streams` changes.
+const structuralIndexCache = new WeakMap<CachedStream[], StreamStructuralIndex>()
+
+function computeStructuralIndex(streams: CachedStream[]): StreamStructuralIndex {
+  const cached = structuralIndexCache.get(streams)
+  if (cached) return cached
+  const streamsById = new Map<string, CachedStream>()
+  const threadsByParentMessageId = new Map<string, CachedStream>()
+  for (const stream of streams) {
+    streamsById.set(stream.id, stream)
+    if (stream.type === StreamTypes.THREAD && stream.parentMessageId) {
+      threadsByParentMessageId.set(stream.parentMessageId, stream)
+    }
+  }
+  const index = { streamsById, threadsByParentMessageId }
+  structuralIndexCache.set(streams, index)
+  return index
+}
+
+export function useStreamStructuralIndex(workspaceId: string): StreamStructuralIndex {
+  const streams = useWorkspaceStreamsRaw(workspaceId)
+  return computeStructuralIndex(streams)
+}
+
+/**
+ * True-thread stubs for a parent card: for each of the conversation's member
+ * messages, a fork thread whose stream the conversation does NOT occupy (none of
+ * its messages are members — soft threads render inline, adjustment D) and which
+ * anchors another conversation. Keyed by fork message id for placement.
+ */
+export function deriveBranchStubs(params: {
+  conversationId: string
+  memberMessages: RenderableMessage[]
+  occupiedStreamIds: Set<string>
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+}): Map<string, BranchStub[]> {
+  const { conversationId, memberMessages, occupiedStreamIds, index, graph } = params
+  const stubs = new Map<string, BranchStub[]>()
+  const seen = new Set<string>()
+  for (const message of memberMessages) {
+    if (seen.has(message.id)) continue
+    seen.add(message.id)
+    const thread = index.threadsByParentMessageId.get(message.id)
+    if (!thread || occupiedStreamIds.has(thread.id)) continue
+    const childPost = graph.conversationByAnchorStreamId.get(thread.id)
+    if (!childPost || childPost.id === conversationId) continue
+    const title = stripMarkdownToInline(childPost.conversation.topicSummary ?? "") || streamLabel(thread, "generic")
+    stubs.set(message.id, [
+      { forkMessageId: message.id, childConversationId: childPost.id, threadStreamId: thread.id, title },
+    ])
+  }
+  return stubs
+}
+
+/**
+ * "Branched from …" provenance for a child card: present iff the conversation's
+ * opener stream is a thread whose fork message is a member of another non-empty
+ * conversation.
+ */
+export function deriveBranchProvenance(params: {
+  conversationId: string
+  anchorStreamId: string
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+}): { parentConversationId: string; title: string } | null {
+  const { conversationId, anchorStreamId, index, graph } = params
+  const anchor = index.streamsById.get(anchorStreamId)
+  if (!anchor || anchor.type !== StreamTypes.THREAD || !anchor.parentMessageId) return null
+  const parentId = graph.conversationIdByMemberMessageId.get(anchor.parentMessageId)
+  if (!parentId || parentId === conversationId) return null
+  const parentPost = graph.conversationById.get(parentId)
+  if (!parentPost || parentPost.conversation.messageIds.length === 0) return null
+  const parentAnchor = index.streamsById.get(parentPost.conversation.streamId)
+  const title =
+    stripMarkdownToInline(parentPost.conversation.topicSummary ?? "") ||
+    (parentAnchor ? streamLabel(parentAnchor, "generic") : "conversation")
+  return { parentConversationId: parentId, title }
+}
+
+/** Tear down every shared conversation-graph subscription — for tests, so a
+ *  module-level registry can't leak a liveQuery (or a snapshot) across cases. */
+export function __clearConversationGraphRegistry(): void {
+  for (const entry of graphRegistry.values()) entry.subscription.unsubscribe()
+  graphRegistry.clear()
+}

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -11,9 +11,9 @@ import { getSessionId, getTriggerMessageId } from "@/components/timeline/session
  * `bumps: false` contract in STREAM_ROW_SPEC).
  */
 export type BoardEventRow =
-  | { kind: "session"; key: string; sortMs: number; events: CachedEvent[] }
-  | { kind: "memo"; key: string; sortMs: number; event: CachedEvent }
-  | { kind: "followUp"; key: string; sortMs: number; event: CachedEvent; cancelled: boolean }
+  | { kind: "session"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
+  | { kind: "memo"; key: string; sortMs: number; streamId: string; event: CachedEvent }
+  | { kind: "followUp"; key: string; sortMs: number; streamId: string; event: CachedEvent; cancelled: boolean }
 
 export interface ResolveBoardEventRowsCtx {
   /** The conversation the card renders. */
@@ -72,13 +72,14 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
       const target = payload?.conversationId ?? payload?.sourceConversationId ?? null
       if (target !== ctx.conversationId) continue
       if (event.eventType === "memos:captured") {
-        rows.push({ kind: "memo", key: event.id, sortMs: timeMs(event), event })
+        rows.push({ kind: "memo", key: event.id, sortMs: timeMs(event), streamId: event.streamId, event })
       } else if (event.eventType === "agent:follow_up_scheduled") {
         const followUpId = (event.payload as { followUpId?: string })?.followUpId
         rows.push({
           kind: "followUp",
           key: event.id,
           sortMs: timeMs(event),
+          streamId: event.streamId,
           event,
           cancelled: followUpId ? cancelledFollowUpIds.has(followUpId) : false,
         })
@@ -89,7 +90,13 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
   for (const [sessionId, session] of sessions) {
     if (!session.trigger || !ctx.memberMessageIds.has(session.trigger)) continue
     const ordered = [...session.events].sort((a, b) => timeMs(a) - timeMs(b))
-    rows.push({ kind: "session", key: `session:${sessionId}`, sortMs: timeMs(ordered[0]), events: ordered })
+    rows.push({
+      kind: "session",
+      key: `session:${sessionId}`,
+      sortMs: timeMs(ordered[0]),
+      streamId: ordered[0].streamId,
+      events: ordered,
+    })
   }
 
   rows.sort((a, b) => a.sortMs - b.sortMs)

--- a/apps/frontend/src/lib/board/branch-grouping.test.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest"
+import type { RenderableMessage } from "@/components/message/message-item"
+import { groupBranches, type BranchStreamNode, type BranchGrouping } from "./branch-grouping"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+
+function msg(id: string, streamId: string, minute: number, authorId = "u1"): RenderableMessage {
+  return {
+    id,
+    streamId,
+    authorId,
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    createdAt: `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`,
+  }
+}
+
+function stream(
+  parentStreamId: string | null,
+  rootStreamId: string | null,
+  parentMessageId: string | null
+): BranchStreamNode {
+  return { parentStreamId, rootStreamId, parentMessageId }
+}
+
+describe("groupBranches", () => {
+  it("renders a single-stream conversation flat", () => {
+    const streams = new Map([["root", stream(null, null, null)]])
+    const messages = [msg("m1", "root", 0), msg("m2", "root", 1)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "flat",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages,
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it("classifies convert-to-thread (root→thread) as soft: one downward seam, no indent", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      ["thread", stream("root", "root", "m2")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "root", 1), msg("m3", "thread", 2), msg("m4", "thread", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "soft",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(0, 2),
+          children: [],
+        },
+        {
+          streamId: "thread",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(2),
+          children: [],
+        },
+      ],
+      softSeam: { streamId: "thread", afterMessageId: "m2", direction: "down" },
+    })
+  })
+
+  it("classifies the Slack case (thread→root) as soft with an upward seam", () => {
+    const streams = new Map([
+      ["thread", stream("root", "root", "p0")],
+      ["root", stream(null, null, null)],
+    ])
+    const messages = [msg("m1", "thread", 0), msg("m2", "thread", 1), msg("m3", "root", 2), msg("m4", "root", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "thread" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "soft",
+      roots: [
+        {
+          streamId: "thread",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(0, 2),
+          children: [],
+        },
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(2),
+          children: [],
+        },
+      ],
+      softSeam: { streamId: "root", afterMessageId: "m2", direction: "up" },
+    })
+  })
+
+  it("classifies a non-monotonic two-stream bounce as spanning, not soft", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      ["thread", stream("root", "root", "m1")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "thread", 1), msg("m3", "root", 2)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[2]],
+          children: [
+            {
+              streamId: "thread",
+              depth: 1,
+              displayDepth: 1,
+              overflow: false,
+              forkMessageId: "m1",
+              messages: [messages[1]],
+              children: [],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("places a 3-stream spanning conversation as a nested tree at fork messages", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      ["T1", stream("R", "R", "r2")],
+      ["T2", stream("T1", "R", "t1a")],
+    ])
+    const messages = [
+      msg("r1", "R", 0),
+      msg("r2", "R", 1),
+      msg("t1a", "T1", 2),
+      msg("t1b", "T1", 3),
+      msg("t2a", "T2", 4),
+    ]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "R",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[1]],
+          children: [
+            {
+              streamId: "T1",
+              depth: 1,
+              displayDepth: 1,
+              overflow: false,
+              forkMessageId: "r2",
+              messages: [messages[2], messages[3]],
+              children: [
+                {
+                  streamId: "T2",
+                  depth: 2,
+                  displayDepth: 2,
+                  overflow: false,
+                  forkMessageId: "t1a",
+                  messages: [messages[4]],
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("marks a subtree past depth 2 as overflow", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      ["T1", stream("R", "R", "r1")],
+      ["T2", stream("T1", "R", "t1a")],
+      ["T3", stream("T2", "R", "t2a")],
+    ])
+    const messages = [
+      msg("r1", "R", 0),
+      msg("t1a", "T1", 1),
+      msg("t2a", "T2", 2),
+      msg("t3a", "T3", 3),
+      msg("r2", "R", 4),
+    ]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    // Deep node T3 (relative depth 3) is capped at displayDepth 2 and flagged overflow.
+    const t1 = grouping.roots[0].children[0]
+    const t2 = t1.children[0]
+    const t3 = t2.children[0]
+    expect(t3).toEqual({
+      streamId: "T3",
+      depth: 3,
+      displayDepth: 2,
+      overflow: true,
+      forkMessageId: "t2a",
+      messages: [messages[3]],
+      children: [],
+    })
+    // The overflow node collapses to a single continue-thread row carrying its subtree count.
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    const overflow = rows.find((r) => r.kind === "continue-thread")
+    expect(overflow).toEqual({
+      kind: "continue-thread",
+      key: "continue:T3",
+      streamId: "T3",
+      hiddenCount: 1,
+      displayDepth: 2,
+    })
+  })
+
+  it("renders an unresolvable parent chain at the base level without crashing", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      // parentStreamId points at a stream absent from the cache.
+      ["orphan", stream("missing", "root", "x")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "orphan", 1), msg("m3", "root", 2)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[2]],
+          children: [],
+        },
+        {
+          streamId: "orphan",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[1]],
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it("anchors a child group chronologically when its fork message isn't rendered", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      // T1 forks off r2, which is NOT among the rendered messages.
+      ["T1", stream("R", "R", "r2")],
+    ])
+    const messages = [msg("r1", "R", 0), msg("t1a", "T1", 2), msg("r3", "R", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    // T1 still attaches under R (its occupied ancestor) with its true fork id.
+    expect(grouping.roots[0].children[0]).toMatchObject({ streamId: "T1", forkMessageId: "r2", displayDepth: 1 })
+    // The builder anchors it by its first message's time: r1, then t1a, then r3.
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => (r.kind === "message" ? { id: r.message.id, depth: r.displayDepth } : r.kind))).toEqual([
+      { id: "r1", depth: 0 },
+      { id: "t1a", depth: 1 },
+      { id: "r3", depth: 0 },
+    ])
+  })
+})

--- a/apps/frontend/src/lib/board/branch-grouping.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.ts
@@ -1,0 +1,233 @@
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/**
+ * The stream-graph fields grouping needs: the parent pointers that place a
+ * message's stream in the thread tree. `CachedStream` satisfies this
+ * structurally, so a card passes its cached streams straight through; tests pass
+ * plain objects.
+ */
+export interface BranchStreamNode {
+  parentStreamId: string | null
+  rootStreamId: string | null
+  /** The message this stream (a thread) forks off — its fork point in the parent stream. */
+  parentMessageId: string | null
+}
+
+/**
+ * One occupied stream's slot in a conversation's render tree. A `BranchNode`
+ * holds the conversation's own messages that live in `streamId` (chronological)
+ * and the child threads that fork off them.
+ */
+export interface BranchNode {
+  streamId: string
+  /** Parent-stream hops from `streamId` up to the conversation's effective root. */
+  depth: number
+  /** `min(depth - shallowest occupied depth, 2)` — the indent level; base renders at 0. */
+  displayDepth: number
+  /** `depth - shallowest occupied depth > 2`: collapse this subtree behind a "continue thread" row. */
+  overflow: boolean
+  /** The parent-stream message this node hangs off, or null for a base node / a
+   *  node whose fork point isn't rendered (then it anchors chronologically). */
+  forkMessageId: string | null
+  messages: RenderableMessage[]
+  children: BranchNode[]
+}
+
+/**
+ * How a card's already-displayed messages render across their streams:
+ *
+ * - `flat` — one occupied stream; render chronological, no indent.
+ * - `soft` — exactly two occupied streams crossed once (convert-to-thread, the
+ *   Slack thread→root case); render flat with a single "continued in …" seam,
+ *   no indent (the thread is transport, not a branch).
+ * - `spanning` — genuine back-and-forth across ≥2 boundaries; render Reddit-style
+ *   with each thread indented one level per boundary (capped at 2, deeper behind
+ *   an overflow row).
+ */
+export interface BranchGrouping {
+  kind: "flat" | "soft" | "spanning"
+  /** Base-level nodes (shallowest occupied depth), each carrying its subtree. */
+  roots: BranchNode[]
+  /** Present only for `soft`: the seam between the two runs. */
+  softSeam?: { streamId: string; afterMessageId: string | null; direction: "down" | "up" }
+}
+
+export interface BranchGroupingContext {
+  /** Every stream the conversation might occupy or walk through, by id. */
+  streams: Map<string, BranchStreamNode>
+  /** The conversation's anchor stream — its effective root terminates depth walks. */
+  conversation: { streamId: string }
+}
+
+function timeMs(message: RenderableMessage): number {
+  return new Date(message.createdAt).getTime()
+}
+
+const MAX_WALK = 64
+
+/**
+ * Group a conversation's rendered messages into its stream-boundary render tree.
+ * Pure: depends only on the messages (each carrying its own `streamId`), the
+ * stream graph, and the conversation's anchor. Never throws on an unresolvable
+ * parent chain — such a stream renders at the base level (see adjustment A).
+ */
+export function groupBranches(messages: RenderableMessage[], ctx: BranchGroupingContext): BranchGrouping {
+  const { streams, conversation } = ctx
+  const ordered = [...messages].sort((a, b) => timeMs(a) - timeMs(b))
+
+  // First-appearance order of the streams the conversation's messages occupy.
+  const occupied: string[] = []
+  const occupiedSet = new Set<string>()
+  for (const message of ordered) {
+    const streamId = message.streamId ?? conversation.streamId
+    if (!occupiedSet.has(streamId)) {
+      occupiedSet.add(streamId)
+      occupied.push(streamId)
+    }
+  }
+
+  const conversationRoot = streams.get(conversation.streamId)?.rootStreamId ?? conversation.streamId
+
+  const messagesByStream = new Map<string, RenderableMessage[]>()
+  for (const message of ordered) {
+    const streamId = message.streamId ?? conversation.streamId
+    const list = messagesByStream.get(streamId)
+    if (list) list.push(message)
+    else messagesByStream.set(streamId, [message])
+  }
+
+  const flatNode = (streamId: string): BranchNode => ({
+    streamId,
+    depth: 0,
+    displayDepth: 0,
+    overflow: false,
+    forkMessageId: null,
+    messages: messagesByStream.get(streamId) ?? [],
+    children: [],
+  })
+
+  if (occupied.length <= 1) {
+    return { kind: "flat", roots: [flatNode(occupied[0] ?? conversation.streamId)] }
+  }
+
+  // Number of stream boundaries the chronological sequence crosses.
+  let transitions = 0
+  for (let i = 1; i < ordered.length; i++) {
+    const prev = ordered[i - 1].streamId ?? conversation.streamId
+    const cur = ordered[i].streamId ?? conversation.streamId
+    if (prev !== cur) transitions++
+  }
+
+  if (occupied.length === 2 && transitions === 1) {
+    const firstStream = occupied[0]
+    let idx = ordered.findIndex((m) => (m.streamId ?? conversation.streamId) !== firstStream)
+    if (idx < 0) idx = ordered.length
+    const secondStream = (ordered[idx]?.streamId ?? conversation.streamId) as string
+    const run1 = ordered.slice(0, idx)
+    const run2 = ordered.slice(idx)
+    const dFirst = depthOf(firstStream, streams, conversationRoot)
+    const dSecond = depthOf(secondStream, streams, conversationRoot)
+    return {
+      kind: "soft",
+      roots: [
+        { ...flatNode(firstStream), messages: run1 },
+        { ...flatNode(secondStream), messages: run2 },
+      ],
+      softSeam: {
+        streamId: secondStream,
+        afterMessageId: run1.at(-1)?.id ?? null,
+        direction: dSecond >= dFirst ? "down" : "up",
+      },
+    }
+  }
+
+  // Spanning: place each occupied stream by its absolute depth, normalized so the
+  // shallowest occupied level renders at indent 0 (adjustment A).
+  const depths = new Map<string, number>()
+  for (const streamId of occupied) depths.set(streamId, depthOf(streamId, streams, conversationRoot))
+  let minOccupied = Infinity
+  for (const depth of depths.values()) if (depth < minOccupied) minOccupied = depth
+
+  const nodesByStream = new Map<string, BranchNode>()
+  for (const streamId of occupied) {
+    const depth = depths.get(streamId) ?? 0
+    const rel = depth - minOccupied
+    nodesByStream.set(streamId, {
+      streamId,
+      depth,
+      displayDepth: Math.min(rel, 2),
+      overflow: rel > 2,
+      forkMessageId: streams.get(streamId)?.parentMessageId ?? null,
+      messages: messagesByStream.get(streamId) ?? [],
+      children: [],
+    })
+  }
+
+  const roots: BranchNode[] = []
+  for (const streamId of occupied) {
+    if ((depths.get(streamId) ?? 0) !== minOccupied) continue
+    const node = nodesByStream.get(streamId)!
+    node.forkMessageId = null
+    roots.push(node)
+  }
+
+  for (const streamId of occupied) {
+    if ((depths.get(streamId) ?? 0) === minOccupied) continue
+    const node = nodesByStream.get(streamId)!
+    const ancestor = nearestOccupiedAncestor(streamId, streams, occupiedSet)
+    if (ancestor && nodesByStream.has(ancestor)) {
+      nodesByStream.get(ancestor)!.children.push(node)
+    } else {
+      // Fork point unrendered (no occupied ancestor): anchor chronologically at
+      // the base level, keeping its own indent.
+      node.forkMessageId = null
+      roots[0].children.push(node)
+    }
+  }
+
+  return { kind: "spanning", roots }
+}
+
+/** Parent-stream hops from `streamId` up to the conversation root. An unresolvable
+ *  chain (a stream not in cache, or a broken parent link) collapses to 0 — the
+ *  base level — never a throw (adjustment A). */
+function depthOf(streamId: string, streams: Map<string, BranchStreamNode>, conversationRoot: string): number {
+  let currentId = streamId
+  let depth = 0
+  for (let i = 0; i < MAX_WALK; i++) {
+    if (currentId === conversationRoot) return depth
+    const node = streams.get(currentId)
+    if (!node) return 0
+    if (node.parentStreamId == null) return depth
+    depth++
+    currentId = node.parentStreamId
+  }
+  return 0
+}
+
+/** The nearest ancestor stream (walking `parentStreamId`) that the conversation
+ *  also occupies, or null when none is occupied. */
+function nearestOccupiedAncestor(
+  streamId: string,
+  streams: Map<string, BranchStreamNode>,
+  occupied: Set<string>
+): string | null {
+  let currentId = streams.get(streamId)?.parentStreamId ?? null
+  for (let i = 0; i < MAX_WALK; i++) {
+    if (currentId == null) return null
+    if (occupied.has(currentId)) return currentId
+    const node = streams.get(currentId)
+    if (!node) return null
+    currentId = node.parentStreamId
+  }
+  return null
+}
+
+/** A true-thread child anchored at a rendered fork message: the parent card draws
+ *  it as a stub, the branch renderer inserts it after that message's row. */
+export interface BranchStub {
+  forkMessageId: string
+  childConversationId: string
+  threadStreamId: string
+  title: string
+}


### PR DESCRIPTION
**Stacked on #1179** (`feat/stream-row-spec-board-agents`) — this PR extends the row machinery that one introduces. Design source: `docs/board-view-design.md` § "Nested threads × conversations — soft vs true threads (2026-07-04)"; build item 5 of the roadmap. Frontend only — zero backend changes.

## Problem

The board card renders a conversation's messages flattened-chronological across the root + its threads. The flatten was an explicit v1 rendering choice, not a model constraint — thread structure lives in the stream graph (`parentStreamId`/`parentMessageId`), never in conversation membership, so the only place nesting can be lost is the renderer. Concretely:

- A conversation that migrated into a thread (convert-to-thread, quote-reply spillover) renders with no hint the stream changed mid-card.
- A true sub-topic — a thread the classifier minted its **own** conversation for — is invisible from the parent card, and the child card carries no pointer back. The nesting the timeline shows is silently absent from the overview surface.
- A conversation genuinely spanning nested threads renders as an unstructured interleave.

## Solution

The doc's rule, implemented: **topic decides membership; structure decides rendering.** The card and conversation panel group rows per thread boundary, with three named shapes and no depth special-case anywhere.

### How it works

1. **`groupBranches` (`lib/board/branch-grouping.ts`, new, pure)** classifies the surface's already-displayed rows (each `RenderableMessage` carries its `streamId`) against the cached stream graph into:
   - `flat` — one occupied stream; rendering unchanged.
   - `soft` — exactly two occupied streams crossed exactly once, **in either direction**: covers convert-to-thread (root→thread) *and* the doc's Slack case (topic lives in a thread, answered at top level, thread→root). Renders flat with one "continued in …" seam row, no indent — the thread is transport, not a branch.
   - `spanning` — genuine back-and-forth: a Reddit-style tree. Each occupied thread renders as one contiguous group placed immediately after its fork-point message, indent per thread boundary with depth normalized to the shallowest occupied stream, visible depth capped at 2; deeper subtrees collapse behind one "Continue this thread" link (card → conversation panel; panel → the thread's own panel). A growing branch updates in place — it never re-sorts siblings, so the stable-view rule extends naturally.
   - Depth walks are bounded (`MAX_WALK`) and an unresolvable parent chain renders at the base level — never a throw, never a hidden row.
2. **Branch stubs + provenance** derive from the graph with **no new column**, exactly as the doc specifies: a child conversation's anchor thread hangs off a `parentMessageId` that is a member of the parent conversation. `deriveBranchStubs` draws "↳ *child topic*" after the fork message on the parent card (only when **none** of the thread's messages are members of this conversation — a soft thread renders inline instead); `deriveBranchProvenance` draws "Branched from *parent topic*" at the top of the child card. Both link to the sibling conversation's panel (INV-40); titles go through `stripMarkdownToInline` (INV-60) with `streamLabel` fallback.
3. **One shared conversation-graph index (`hooks/use-conversation-graph.ts`, new)** — a module-level ref-counted `liveQuery` over `db.conversations` per workspace (`conversationByAnchorStreamId` for thread anchors, `conversationIdByMemberMessageId`, `conversationById`), consumed via `useSyncExternalStore`. Mirrors the `railRegistry`/`threadIndexRegistry` discipline in `use-board-card-messages.ts`. The board renders hundreds of cards over hundreds of conversations; per-card scans would be O(cards × conversations).
4. **`buildBranchedBoardRows` (`board-row-item.tsx`)** flattens the tree into the extended `BoardRow` union (`seam`, `branch-stub`, `continue-thread`, plus `displayDepth` on every kind), interleaving `BoardEventRow`s (agent sessions / memo captures / follow-ups) into the group whose stream owns them — `BoardEventRow` now carries its `streamId`. Same-author continuation resets at every seam/stub/boundary, exactly like #1179's reset on interleaved events. `buildBoardRows` is untouched.
5. **Surfaces**: `board-card.tsx` (collapsed + expanded paths) and `conversation-panel.tsx` (always expanded) both render through the shared `BranchedBoardRows` component; indent is a wrapper element (left-border rail), never a `MessageItem` change. Grouping runs over the already-stabilized displayed rows, so the `allResolved` latch, retained-pending bridge, and append-only stable reply window (#1188) are untouched.

### Key design decisions

**1. Soft vs spanning is a structural test, not an LLM call** — exactly two occupied streams + a single crossing ⇒ soft; anything else ⇒ spanning. This is the operational reading of the doc's "topically nothing branched" vs "genuinely across nested threads with back-and-forth." Direction-agnostic on purpose: the Slack case (thread→root) is the doc's own why-span-at-all example, and a monotonic-downward-only rule would misclassify it as spanning and indent the *channel* under a *thread*.

**2. Depth is normalized to the shallowest occupied stream, not the conversation anchor.** A legacy thread-anchored conversation (#1113 era) and the sibling-threads-only shape both render at indent 0 where anchoring depth to the opener would produce unreachable or nonsense walks. Cap lives on `displayDepth`; the true `depth` is kept on the node for the overflow decision.

**3. Spanning places each thread as one group at its fork message (tree), not as chronological segments.** Alternating segments would scatter one thread into N runs with N seams — the flatten critique in new clothes — and would append new segments as activity alternates. Tree placement gives each branch a stable home that grows in place.

**4. Stubs/provenance resolve through one shared index (INV-9-exception pattern), not per-card queries.** Same registry discipline as the existing rail/thread-index registries, with a `__clear*` test escape hatch.

**5. Seam rows are non-interactive.** INV-40 governs navigation affordances — stub/provenance/overflow are `<Link>`s; the soft seam is informational ("the conversation moved, nothing branched") and deliberately doesn't pull the reader out of the card. It is also the natural anchor for PR 3's "split this thread into its own topic" affordance.

### Design evolution (self-review)

The first version of `buildBranchedBoardRows` dropped event rows whose stream had no rendered group — a memo capture or agent session on a member stream whose messages sit in the collapsed hidden middle would silently vanish (old `buildBoardRows` interleaved every event ≥ first-message time regardless of stream). Fixed: such orphan events join the base run chronologically at depth 0, split across a soft seam by time; only events under a collapsed overflow subtree stay hidden with it. Two regression tests cover this.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/board/branch-grouping.ts` | Pure grouping module: flat/soft/spanning classification, normalized depth, overflow capping |
| `apps/frontend/src/lib/board/branch-grouping.test.ts` | 8 cases: flat, both soft directions, bounce→spanning, 3-stream tree, overflow, unresolvable chain, unrendered fork anchor |
| `apps/frontend/src/hooks/use-conversation-graph.ts` | Shared ref-counted conversation-graph index + `deriveBranchStubs`/`deriveBranchProvenance` |
| `apps/frontend/src/components/board/branch-rows.tsx` | `ThreadSeamRow`, `BranchStubRow`, `BranchProvenanceRow`, `ContinueThreadRow`, shared `BranchedBoardRows` mapper |
| `apps/frontend/src/components/board/board-card.branches.test.tsx` | Mount tests: stub, provenance, soft seam without indent, legacy thread-anchored shows neither |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-row-item.tsx` | `BoardRow` union extended; `buildBranchedBoardRows` added; `buildBoardRows` unchanged |
| `apps/frontend/src/lib/board/board-event-rows.ts` | `BoardEventRow` carries `streamId` for per-group placement |
| `apps/frontend/src/components/board/board-card.tsx` | Renders through grouping + provenance header; collapsed/expanded paths; card overflow → conversation panel |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Same grouping (always expanded); overflow → thread's own panel |
| `apps/frontend/src/components/board/board-row-item.test.ts` | Seam/stub continuation resets + 2 orphan-event regression tests |
| `apps/frontend/src/components/board/board-card.test.tsx` | Graph-registry/IDB cleanup for the new shared index |

## Out of scope (deliberate)

- **"New sub-topic" gesture** (declared `newSubtopic` directive, message-row action) — PR 2, stacks on this.
- **"Split this thread into its own topic"** (backend split + seam affordance) — PR 3.
- Backend: nothing. The renderer ships entirely on classifier-minted child conversations already in the data.
- Card header / ⋯-menu: untouched (concurrent retitle/hide-mute work owns those surfaces).
- The card's over-subscription to true-thread child rails (pre-existing via `extraStreamIds`) is now load-bearing for the none-member stub test and left as-is.

## Test plan

- [x] `bunx vitest run src/components/board src/lib/board src/components/conversations/conversation-panel.test.tsx` — 8 files, 53 pass (incl. 8 grouping, 4 branch mount, 2 orphan-event regressions)
- [x] `bunx vitest run src/hooks/use-board-card-messages.test.tsx src/lib/no-happy-path-success-toast.test.ts` — 29 pass (rail/stability machinery untouched)
- [x] `bun run typecheck` — monorepo clean (re-verified by pre-commit across all packages)
- [x] Pre-commit: eslint all apps, dockerfile/migration checks, api-docs check — green
- [ ] Live in-browser verify of the three shapes — pending; classifier-minted true threads exist in dogfood data, will verify on the dev stack alongside PR 2

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** roadmap item 5 — nested threads on the board card: soft-thread seam, true-thread branch stubs + "branched from" provenance, bounded spanning-tree rendering (docs/board-view-design.md § 2026-07-04).

**What was built:** pure `groupBranches` classification (flat/soft/spanning) over displayed rows + cached stream graph; tree flatten with per-group event interleave (`buildBranchedBoardRows`); graph-derived stubs/provenance via one shared ref-counted conversation index; both conversation surfaces wired.

**Design decisions:** structural soft-test in either direction (Slack case); depth normalized to shallowest occupied stream; tree placement over chronological segments for spanning; shared index over per-card scans; non-interactive seams.

**Design evolution:** orphan-event drop caught in self-review — events on streams without a rendered group now join the base run chronologically (2 regression tests).

**What's NOT included:** the two declared gestures (new sub-topic → PR 2, split thread → PR 3); any backend change; card-header/⋯-menu surfaces.

**Status:** complete, all targeted suites green, stacked on #1179.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785866628&installation_id=129946197&pr_number=1197&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1197&signature=fb133fa427ec190d780a2afdb3a0a62c8007429109ed79ff372a8bb438d1e314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->