### PR TITLE
fix(remote-control): /steer folds into the running turn instead of stopping it

### DIFF
--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -6,6 +6,19 @@ genuinely-novel tmux paths ($TMUX_PANE inheritance, Esc interrupt, `/model`) are
 Claude Code v2.1.193 (and live testing found + fixed two bugs — see the checklist); the full
 dispatch round-trip through a real scratchpad is still only unit-tested.
 
+> **Update 2026-07-05 (`feat/steer-correction`): steer no longer interrupts a running turn.**
+> The original interrupt-and-redeliver steer read badly in the UI: the running trace closed with
+> "Superseded by /steer", the continuation ran under the /steer invocation — which, as a
+> session-control claim, has **no agent session**, so its steps went nowhere — and the /steer
+> command spun until the whole turn ended. The corrected semantics mirror Pi's native
+> `deliverAs: "steer"`: with a turn in flight, the SDK records a `steer` step on the **running**
+> invocation's trace (carrying the folded text), injects the combined content into the running
+> turn via the connector's `steer` actuation (tmux bracketed paste + Enter — Claude Code's native
+> mid-turn steering, no Escape), closes swept queued messages no-response, and completes the
+> /steer command immediately so the command card resolves. The running invocation keeps its trace
+> and its eventual reply answers the steer. The interrupt path below remains the fallback for an
+> idle session (nothing to fold into) and for actuators without `steer` support.
+
 Implemented across: backend (`commands/availability.ts`, `commands/handlers.ts`, `commands/catalog.ts`,
 `bot-runtimes/service.ts` comment), channel (`claude-code-remote/src/tmux-control.ts` +
 `channel-server.ts`), and a harness-CLI bonus (`harness-daemon`: `interrupt`/`steer`/`keys` verbs).
@@ -99,22 +112,22 @@ Notes:
 | Command             | Key sequence                                                                                                   | Channel bookkeeping                                                                                                                                                                              |
 | ------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **stop**            | `Escape`                                                                                                       | Complete every in-flight invocation (interrupted), ack the stop invocation: "Stopped Claude."                                                                                                    |
-| **steer `<text>`**  | `Escape`, ~250 ms, then forward **one combined** payload through the **existing MCP channel path** (not typed) | Drain all pending msgs for the session + the steer text, combine into ONE turn; complete the interrupted turn + all swept msgs `noResponse`; the primary invocation gets Claude's single `reply` |
+| **steer `<text>`**  | Turn in flight: `Ctrl-U` + bracketed paste + `Enter` (Claude's native mid-turn steering, **no Escape**). Idle: the interrupt path below. | Turn in flight: record a `steer` step on the RUNNING invocation's trace, fold queued msgs + steer text into the injected block, close swept msgs `noResponse`, complete /steer immediately — the running turn keeps its trace and its `reply` answers the steer. Idle: drain + one combined turn under the /steer invocation (original semantics below) |
 | **model `<alias>`** | `typeLine("/model <alias>")`                                                                                   | Ack "Model set to `<alias>`." (best-effort)                                                                                                                                                      |
 | **compact**         | `typeLine("/compact")`                                                                                         | Ack                                                                                                                                                                                              |
 | **run `<cmd>`**     | `typeLine("/<cmd>")` (strip a leading slash if present)                                                        | Ack "Ran `/<cmd>`."                                                                                                                                                                              |
 
-**Steer is the interesting one.** Rather than blind-typing the steer text into the TUI (where the
-result would be orphaned with no invocation to reply to), we use tmux **only** for the `Escape`
-interrupt, then push the steer text through the channel's normal
-`notifications/claude/channel` notification using the steer invocation's own id. Claude treats it
-as a fresh turn and calls `reply(steerId)` → the work round-trips back into the scratchpad. This
-is exactly the user's "stop, then send another message," and it reuses the battle-tested
-reply/idle-timeout/attachment machinery instead of inventing a parallel path. (A plain follow-up
-message with no steer just queues behind the current turn as it does today — steer is the
-_interrupt-and-redirect_ variant.)
+**Steer is the interesting one.** The v1 design below treated typed-in text as unusable ("orphaned
+with no invocation to reply to") — true only when the steer is modeled as a NEW turn. The
+2026-07-05 correction models it as part of the RUNNING turn instead: the typed text folds into the
+turn Claude is already executing for an open invocation, so its eventual `reply` to that
+invocation covers the steer, nothing is orphaned, and the trace never breaks. The v1
+interrupt-and-redeliver mechanics below still apply verbatim when the session is **idle** or the
+actuator has no `steer` support: tmux sends `Escape`, then the steer text rides the channel's
+normal `notifications/claude/channel` notification under the steer invocation's own id, and
+Claude answers it with `reply(steerId)`.
 
-**Steer combines all pending messages into one turn (mirrors Pi).** Pi drains up to
+**Steer combines all pending messages into one payload (mirrors Pi) — in both paths.** Pi drains up to
 `STEER_DRAIN_LIMIT` (10) pending invocations while busy: the first becomes `pending`, the rest go
 into `steeredInvocations[]`, and on completion the primary gets the final `reply` while **every
 swept invocation closes `noResponse`** (`threa-remote.ts:2365-2404`) — N rapid messages → **one**

--- a/docs/claude-channel-session-control.md
+++ b/docs/claude-channel-session-control.md
@@ -127,18 +127,19 @@ actuator has no `steer` support: tmux sends `Escape`, then the steer text rides 
 normal `notifications/claude/channel` notification under the steer invocation's own id, and
 Claude answers it with `reply(steerId)`.
 
-**Steer combines all pending messages into one payload (mirrors Pi) — in both paths.** Pi drains up to
-`STEER_DRAIN_LIMIT` (10) pending invocations while busy: the first becomes `pending`, the rest go
-into `steeredInvocations[]`, and on completion the primary gets the final `reply` while **every
-swept invocation closes `noResponse`** (`threa-remote.ts:2365-2404`) — N rapid messages → **one**
-combined response, not N. The channel reproduces this without a native steer queue: on `/steer`,
-after the `Escape`, it drains all currently-pending invocations targeted at the session (plain
-messages the user queued while Claude was busy + the steer's own text), **concatenates them
-oldest→newest into a single `notifications/claude/channel` payload**, and delivers one turn. The
-triggering steer invocation is the primary (registered in `inflight`, receives Claude's `reply`);
-the interrupted turn and every swept message complete `noResponse`. Bounded by a drain limit; the
-existing `claiming` single-flight guard serialises concurrent steer handlers so rapid `/steer`s
-coalesce.
+**Steer combines all pending messages into one payload (mirrors Pi) — the sweep is shared, the
+primary differs per path.** Pi drains up to `STEER_DRAIN_LIMIT` (10) pending invocations while
+busy: the first becomes `pending`, the rest go into `steeredInvocations[]`, and on completion the
+primary gets the final `reply` while **every swept invocation closes `noResponse`**
+(`threa-remote.ts:2365-2404`) — N rapid messages → **one** combined response, not N. The SDK's
+`sweepQueuedForSteer` reproduces the drain for both paths (plain messages queued while Claude was
+busy + the steer's own text, concatenated oldest→newest), but who answers the combined payload
+depends on the path: with **native steer**, the already-running invocation stays the primary and
+receives Claude's `reply` — the /steer invocation closes `noResponse` immediately; in the
+**interrupt fallback**, the triggering steer invocation is the primary (registered in `inflight`,
+receives Claude's `reply`) and the interrupted turn closes with the supersede note. Every swept
+message completes `noResponse` in both. Bounded by a drain limit; the existing `claiming`
+single-flight guard serialises concurrent steer handlers so rapid `/steer`s coalesce.
 
 `model` / `compact` / `run` typed mid-turn are buffered by Claude Code's input queue and applied
 after the current turn — acceptable, documented. `/model` and other menu-opening commands are

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -14,7 +14,7 @@ import {
 import { z } from "zod"
 import { THINKING_LEVELS, modelSuggestions } from "./model-catalog"
 import { pushBranchAndScheduleRemoval } from "./archive-cleanup"
-import { interrupt, killOwnWindow, submitLine, tmuxAvailable } from "./tmux-control"
+import { interrupt, killOwnWindow, steerText, submitLine, tmuxAvailable } from "./tmux-control"
 import { TranscriptTracer } from "./transcript-trace"
 
 const RUNTIME_KIND = "claude-code-channel"
@@ -85,7 +85,7 @@ export function buildInstructions(permissionRelay: boolean): string {
 /**
  * Execute an advertised session-control command by typing its Claude Code
  * slash-command equivalent into the tmux pane. `stop`/`steer` never reach this
- * — the SDK actuates those itself via `interrupt`.
+ * — the SDK actuates those itself via `interrupt`/`steer`.
  */
 export async function runClaudeCommand(name: string, args: string): Promise<{ ok: boolean; message: string }> {
   switch (name) {
@@ -141,6 +141,10 @@ export function createClaudeSessionControl(): SessionControlActuator | undefined
     modelSuggestions: MODEL_SUGGESTIONS,
     thinkingLevels: [...THINKING_LEVELS],
     interrupt,
+    // The prefix tells the model mid-turn text came from the scratchpad, so it
+    // folds it into the open invocation's work rather than treating it as a
+    // side conversation at the terminal.
+    steer: (text) => steerText(`[Steer from the Threa scratchpad — fold into the current work]\n${text}`),
     runCommand: runClaudeCommand,
   }
 }

--- a/extensions/claude-code-remote/src/session-control.test.ts
+++ b/extensions/claude-code-remote/src/session-control.test.ts
@@ -37,6 +37,8 @@ describe("createClaudeSessionControl", () => {
       expect(actuator!.thinkingLevels).toEqual(["low", "medium", "high", "xhigh", "max", "ultracode"])
       expect(actuator!.modelSuggestions!.map((suggestion) => suggestion.value)).toContain("opus")
       expect(actuator!.modelSuggestions!.every((suggestion) => suggestion.label)).toBe(true)
+      // Native mid-turn steering: without this the SDK falls back to interrupt+redeliver.
+      expect(typeof actuator!.steer).toBe("function")
     })
   })
 })

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -112,6 +112,3 @@ export function killOwnWindow(): boolean {
     return false
   }
 }
-
-/** Milliseconds to wait after an interrupt before delivering the steer turn, so Claude has returned to idle. */
-export const STEER_SETTLE_MS = 250

--- a/extensions/claude-code-remote/src/tmux-control.ts
+++ b/extensions/claude-code-remote/src/tmux-control.ts
@@ -63,6 +63,42 @@ export async function submitLine(text: string, opts: { settleMs?: number } = {})
 }
 
 /**
+ * Fold text into the RUNNING turn without interrupting it — Claude Code's
+ * native steering: a message submitted while it works is injected into the
+ * current turn. Pasted as one bracketed block (load-buffer + paste-buffer -p)
+ * rather than typed with `-l`, so newlines in the text don't submit
+ * mid-message and a leading `/` can't open the slash menu. Clears the input
+ * line first (Ctrl-U) so residue doesn't concatenate into the steer.
+ */
+export async function steerText(text: string, opts: { settleMs?: number } = {}): Promise<boolean> {
+  const target = paneTarget()
+  if (!target) return false
+  const settleMs = opts.settleMs ?? 150
+  if (!sendKeys(["C-u"])) return false
+  if (!pasteText(target, text)) return false
+  if (settleMs > 0) await Bun.sleep(settleMs)
+  return sendKeys(["Enter"])
+}
+
+function pasteText(target: string, text: string): boolean {
+  try {
+    const load = Bun.spawnSync(["tmux", "load-buffer", "-b", "threa-steer", "-"], {
+      stdin: new TextEncoder().encode(text),
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    if (load.exitCode !== 0) return false
+    const paste = Bun.spawnSync(["tmux", "paste-buffer", "-d", "-p", "-b", "threa-steer", "-t", target], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    return paste.exitCode === 0
+  } catch {
+    return false
+  }
+}
+
+/**
  * Kill the tmux window this channel (and its Claude Code parent) lives in —
  * deliberate self-termination for the archived-scratchpad wind-down. The
  * channel dies with the window; callers do any last writes first.

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -609,6 +609,47 @@ describe("steer into the running turn (native steer support)", () => {
     ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
   })
 
+  test("empty steer still closes a swept foldless control command instead of stranding its claim", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    // A queued non-steer control command (double-command race): swept, contributes
+    // no foldable part, and must still be closed on the empty-parts return.
+    const queued = [
+      makeInvocation({
+        id: "binv_q_model",
+        trigger: "session-control",
+        promptMarkdown: "/model opus",
+        metadata: { command: { executionKind: "bot-runtime", id: "cmd_q", name: "model", args: "opus" } },
+      }),
+    ]
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["stop", "steer", "model"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () =>
+      queued.shift() ?? null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation(""))
+
+    expect(steered).toEqual([])
+    const sweptClose = calls.complete.find((entry) => entry.id === "binv_q_model")
+    expect(sweptClose?.body.noResponse).toBe(true)
+    const ack = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(ack?.body.finalMessageMarkdown).toContain("Nothing to steer with")
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
   test("failed actuation leaves the running turn alone and reports the failure", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -61,18 +61,21 @@ function makeFakeClient() {
 
 function makeFakeTransport() {
   const presence: Record<string, unknown>[] = []
+  const steps: Array<{ invocationId: string; frames: Array<{ stepType: string; content: string }> }> = []
   const transport = {
     connect: async () => {},
     disconnect: () => {},
     socketConnected: false,
     sendHello: () => {},
-    recordSteps: async () => {},
+    recordSteps: async (invocationId: string, _claimToken: string, frames: Array<{ stepType: string; content: string }>) => {
+      steps.push({ invocationId, frames })
+    },
     renewClaim: async () => ({ notFound: false }),
     updatePresence: async (body: Record<string, unknown>) => {
       presence.push(body)
     },
   }
-  return { transport: transport as unknown as BotRuntimeTransport, presence }
+  return { transport: transport as unknown as BotRuntimeTransport, presence, steps }
 }
 
 function makeSession(
@@ -449,7 +452,7 @@ describe("session control via the actuator", () => {
     expect(calls.complete[0]?.body.finalMessageMarkdown).toBe("Set model to `opus`.")
   })
 
-  test("steer always posts a supersede note carrying the steer text", async () => {
+  test("steer without native steer support interrupts and posts a supersede note carrying the steer text", async () => {
     const { client, calls } = makeFakeClient()
     const { transport } = makeFakeTransport()
     const delivered: string[] = []
@@ -483,5 +486,195 @@ describe("session control via the actuator", () => {
     expect(interruptedClose?.body.finalMessageMarkdown).toContain("now handling")
     expect(interruptedClose?.body.finalMessageMarkdown).toContain("look at the tests instead")
     expect(delivered).toEqual(["look at the tests instead"])
+  })
+})
+
+describe("steer into the running turn (native steer support)", () => {
+  function makeSteerInvocation(args: string): ClaimedInvocation {
+    return makeInvocation({
+      id: "binv_steer",
+      trigger: "session-control",
+      promptMarkdown: args ? `/steer ${args}` : "/steer",
+      metadata: { command: { executionKind: "bot-runtime", id: "cmd_2", name: "steer", args } },
+    })
+  }
+
+  test("folds into the running turn: steer step on its trace, no interrupt, command closes immediately", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport, steps } = makeFakeTransport()
+    const steered: string[] = []
+    let interrupted = false
+    const session = makeSession(client, transport, {
+      deliverTurn: async () => {
+        throw new Error("steer must not deliver a new turn")
+      },
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => {
+          interrupted = true
+          return true
+        },
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running", responseStreamId: "stream_turn" }))
+    ;(client as unknown as { claim: () => Promise<null> }).claim = async () => null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation("look at the tests instead"))
+
+    expect(interrupted).toBe(false)
+    expect(steered).toEqual(["look at the tests instead"])
+    // The running turn keeps its claim — it will answer the steer with its own reply.
+    expect((session as unknown as { inflight: Map<string, unknown> }).inflight.has("binv_running")).toBe(true)
+    expect(calls.complete.find((entry) => entry.id === "binv_running")).toBeUndefined()
+    // The steer is recorded on the RUNNING invocation's trace.
+    expect(steps).toEqual([
+      { invocationId: "binv_running", frames: [{ stepType: "steer", content: "look at the tests instead" }] },
+    ])
+    // The /steer command itself closes right away, silently (the step is the signal).
+    const steerClose = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(steerClose?.body.noResponse).toBe(true)
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
+  test("folds queued messages into the injected steer and closes them no-response", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const queued = [
+      makeInvocation({ id: "binv_q1", promptMarkdown: "also bump the deps" }),
+      makeInvocation({ id: "binv_q2", promptMarkdown: "and update the docs" }),
+    ]
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running", responseStreamId: "stream_turn" }))
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () =>
+      queued.shift() ?? null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation("the steer text"))
+
+    expect(steered).toHaveLength(1)
+    const combined = steered[0]!
+    expect(combined.indexOf("also bump the deps")).toBeLessThan(combined.indexOf("and update the docs"))
+    expect(combined.indexOf("and update the docs")).toBeLessThan(combined.indexOf("the steer text"))
+    const sweptCloses = calls.complete.filter((entry) => entry.id === "binv_q1" || entry.id === "binv_q2")
+    expect(sweptCloses).toHaveLength(2)
+    for (const close of sweptCloses) expect(close.body.noResponse).toBe(true)
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
+  test("acks without steering when there is no text and nothing queued", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const steered: string[] = []
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+    ;(client as unknown as { claim: () => Promise<null> }).claim = async () => null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation(""))
+
+    expect(steered).toEqual([])
+    expect((session as unknown as { inflight: Map<string, unknown> }).inflight.has("binv_running")).toBe(true)
+    const ack = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(ack?.body.finalMessageMarkdown).toContain("Nothing to steer with")
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
+  test("failed actuation leaves the running turn alone and reports the failure", async () => {
+    const { client, calls } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const failed: string[] = []
+    ;(client as unknown as { fail: (id: string) => Promise<void> }).fail = async (id: string) => {
+      failed.push(id)
+    }
+    const queued = [makeInvocation({ id: "binv_q1", promptMarkdown: "queued while busy" })]
+    const session = makeSession(client, transport, {
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => true,
+        steer: () => false,
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    seedInflight(session, makeInvocation({ id: "binv_running" }))
+    ;(client as unknown as { claim: () => Promise<ClaimedInvocation | null> }).claim = async () =>
+      queued.shift() ?? null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation("go left"))
+
+    expect((session as unknown as { inflight: Map<string, unknown> }).inflight.has("binv_running")).toBe(true)
+    expect(calls.complete.find((entry) => entry.id === "binv_running")).toBeUndefined()
+    // The swept message was claimed but never delivered — failed loudly, not silently closed.
+    expect(failed).toEqual(["binv_q1"])
+    const ack = calls.complete.find((entry) => entry.id === "binv_steer")
+    expect(ack?.body.finalMessageMarkdown).toContain("Could not steer")
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_running")
+  })
+
+  test("steer with native support but no running turn delivers a fresh turn (interrupt path)", async () => {
+    const { client } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const delivered: string[] = []
+    const steered: string[] = []
+    let interrupted = false
+    const session = makeSession(client, transport, {
+      deliverTurn: async (turn) => {
+        delivered.push(turn.content)
+      },
+      sessionControl: {
+        commands: ["stop", "steer"],
+        interrupt: () => {
+          interrupted = true
+          return true
+        },
+        steer: (text) => {
+          steered.push(text)
+          return true
+        },
+        runCommand: async () => ({ ok: true, message: "ok" }),
+      },
+    })
+    ;(client as unknown as { claim: () => Promise<null> }).claim = async () => null
+
+    await (
+      session as unknown as { handleSessionControl: (inv: ClaimedInvocation) => Promise<void> }
+    ).handleSessionControl(makeSteerInvocation("start with the readme"))
+
+    // Idle session: nothing to fold into — the steer arrives as a normal turn.
+    expect(steered).toEqual([])
+    expect(interrupted).toBe(true)
+    expect(delivered).toEqual(["start with the readme"])
+    ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_steer")
   })
 })

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -86,8 +86,8 @@ export interface DeliveredTurn {
 /**
  * How a connector drives its runtime for session control. `stop` and `steer`
  * are actuated by the SDK itself (they manipulate SDK-owned turn state) using
- * `interrupt()`; every other advertised command is routed to `runCommand`,
- * which returns the user-facing ack markdown.
+ * `interrupt()`/`steer()`; every other advertised command is routed to
+ * `runCommand`, which returns the user-facing ack markdown.
  */
 export interface SessionControlActuator {
   /** Command names to advertise (must be Threa catalog names, e.g. "model", "thinking", "compact", "run", "reload", "steer", "stop"). */
@@ -98,6 +98,14 @@ export interface SessionControlActuator {
   thinkingLevels?: readonly string[]
   /** Interrupt the runtime's current turn. False = control lost (e.g. pane gone). */
   interrupt(): boolean
+  /**
+   * Fold text into the RUNNING turn without interrupting it — the runtime's
+   * native mid-turn steering (typing into Claude Code while it works). When
+   * present and a turn is in flight, /steer steers in place: the running
+   * invocation keeps its trace and its reply. Absent, /steer falls back to
+   * interrupt + redeliver. False = control lost.
+   */
+  steer?(text: string): Promise<boolean> | boolean
   /** Execute an advertised non-steer/stop command. Returns the ack posted to the scratchpad. */
   runCommand(name: string, args: string): Promise<{ ok: boolean; message: string }>
 }
@@ -732,12 +740,73 @@ export class RemoteSession {
   }
 
   /**
+   * Route /steer. With a turn in flight and a steer-capable actuator, fold the
+   * text into the RUNNING turn (the running invocation keeps its trace and its
+   * reply). Otherwise fall back to interrupt + redeliver — the only option for
+   * an idle session (there is no turn to fold into) or a runtime without
+   * native mid-turn steering.
+   */
+  private async runSteer(invocation: ClaimedInvocation, actuator: SessionControlActuator, text: string): Promise<void> {
+    const steer = actuator.steer?.bind(actuator)
+    if (this.inflight.size > 0 && steer) {
+      return await this.steerRunningTurn(invocation, steer, text)
+    }
+    return await this.steerByInterrupt(invocation, actuator, text)
+  }
+
+  /**
+   * Steer in place: sweep any messages queued while busy, record a `steer`
+   * step on the running turn's trace (the visible record of what was folded
+   * in), and inject the combined text via the runtime's native mid-turn
+   * steering. The running invocation stays the primary — its eventual reply
+   * answers the steer — so the /steer command itself closes immediately
+   * (command_completed resolves the card) instead of spinning until the turn
+   * ends.
+   */
+  private async steerRunningTurn(
+    invocation: ClaimedInvocation,
+    steer: (text: string) => Promise<boolean> | boolean,
+    text: string
+  ): Promise<void> {
+    const { parts, swept } = await this.sweepQueuedForSteer(text)
+    if (parts.length === 0) {
+      await this.completeAck(invocation, "Nothing to steer with (no text, no queued messages); the turn continues.")
+      return
+    }
+    const combined = buildSteerContent(parts)
+    // Step before actuation so it sits ahead of the continuation's frames in
+    // the trace; a steer is also a sign of life for the turn it redirects.
+    for (const [id] of this.inflight) {
+      await this.recordSteps(id, [{ stepType: "steer", content: combined }])
+      this.touchIdleTimeout(id)
+    }
+    if (!(await steer(combined))) {
+      // Nothing was injected: the swept messages were claimed but not
+      // delivered — fail them loudly so they don't vanish into a silent close.
+      await Promise.all(
+        swept.map((item) => this.failInvocation(item, "Steer not delivered (runtime control unavailable); resend."))
+      )
+      await this.completeAck(invocation, "Could not steer the session (runtime control unavailable).")
+      return
+    }
+    await Promise.all(swept.map((item) => this.completeNoResponse(item)))
+    await this.completeTurn(invocation, {
+      noResponse: true,
+      metadata: { "remote.invocationId": invocation.id, "remote.sessionControl": "true", "remote.steered": "true" },
+    }).catch((error) => this.log(`steer close failed: ${this.summarize(error)}`))
+  }
+
+  /**
    * Interrupt the running turn, then fold the steer text + any messages queued
    * while the runtime was busy into ONE combined turn (mirrors Pi: N messages →
    * 1 response). The interrupt is the only actuation; the combined content
    * round-trips through the normal delivery path so the runtime replies to it.
    */
-  private async runSteer(invocation: ClaimedInvocation, actuator: SessionControlActuator, text: string): Promise<void> {
+  private async steerByInterrupt(
+    invocation: ClaimedInvocation,
+    actuator: SessionControlActuator,
+    text: string
+  ): Promise<void> {
     // If the interrupt can't be sent, bail before any destructive side-effect —
     // don't close the running turn or deliver the steer as a second concurrent
     // turn against a runtime we couldn't actually interrupt.
@@ -758,6 +827,23 @@ export class RemoteSession {
       { alwaysNote: true }
     )
 
+    const { parts, swept } = await this.sweepQueuedForSteer(text)
+
+    // Close every swept message with no response — its content is folded into the
+    // single combined turn the primary (this steer invocation) will answer.
+    await Promise.all(swept.map((item) => this.completeNoResponse(item)))
+
+    if (parts.length === 0) {
+      await this.completeAck(invocation, "Interrupted the session; nothing pending to steer with.")
+      await this.syncPresence()
+      return
+    }
+
+    await this.deliverTurn(invocation, buildSteerContent(parts))
+  }
+
+  /** Claim messages queued while the runtime was busy and fold their text in (steer text last). */
+  private async sweepQueuedForSteer(text: string): Promise<{ parts: string[]; swept: ClaimedInvocation[] }> {
     const parts: string[] = []
     const swept: ClaimedInvocation[] = []
     for (let i = 0; i < STEER_DRAIN_LIMIT; i++) {
@@ -774,18 +860,7 @@ export class RemoteSession {
       }
     }
     if (text) parts.push(text)
-
-    // Close every swept message with no response — its content is folded into the
-    // single combined turn the primary (this steer invocation) will answer.
-    await Promise.all(swept.map((item) => this.completeNoResponse(item)))
-
-    if (parts.length === 0) {
-      await this.completeAck(invocation, "Interrupted the session; nothing pending to steer with.")
-      await this.syncPresence()
-      return
-    }
-
-    await this.deliverTurn(invocation, buildSteerContent(parts))
+    return { parts, swept }
   }
 
   /**

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -770,6 +770,9 @@ export class RemoteSession {
   ): Promise<void> {
     const { parts, swept } = await this.sweepQueuedForSteer(text)
     if (parts.length === 0) {
+      // The sweep can still have claimed foldless invocations (a queued control
+      // command in the double-command race) — close them or they hang to TTL.
+      await Promise.all(swept.map((item) => this.completeNoResponse(item)))
       await this.completeAck(invocation, "Nothing to steer with (no text, no queued messages); the turn continues.")
       return
     }


### PR DESCRIPTION
## Problem

`/steer` on a busy remote-controlled Claude session reads as a stop, not a steer. `runSteer` in `extensions/remote-session/src/session.ts` sends `Escape`, closes the running turn with "_Superseded by /steer_", and redelivers the steer text as a **new** turn owned by the /steer invocation. Three visible consequences:

1. The running trace card terminates — the work the user wanted to redirect looks killed.
2. Session-control claims never create an agent session (`public-api/handlers.ts` gates `AgentSessionRepository.insertRunningOrSkip` on `!isSessionControl`), so the steered continuation has **no trace card at all**; its `recordSteps` frames go nowhere.
3. The /steer command card spins until the entire continuation ends, because the invocation only completes when the turn's final reply lands.

Net effect (Kris's report from a live session): "we seem to effectively stop it and then keep the steer slash command running until the agent's turn ends… hard to follow what's going on."

Pi never had this problem: `pi-remote` injects `pi.sendUserMessage(prompt, { deliverAs: "steer" })` mid-turn and records a `steer` trace step on the **running** invocation (`threa-remote.ts:2330-2333`). The SDK path predates a way to do the same for Claude Code.

## Solution

Mirror Pi: with a turn in flight, fold the steer **into** the running turn instead of replacing it. The running invocation keeps its trace and its reply; the /steer command resolves immediately.

### How it works

1. `SessionControlActuator` gains an optional `steer(text)` — inject text into the running turn without interrupting. `runSteer` routes: turn in flight **and** actuator has `steer` → steer in place; otherwise the original interrupt+redeliver path (`steerByInterrupt`, unchanged) — still correct for an idle session (nothing to fold into) and for connectors without native mid-turn steering.
2. `steerRunningTurn` sweeps messages queued while busy (`sweepQueuedForSteer`, extracted from the old path — same `STEER_DRAIN_LIMIT` 10, steer text last), records a `steer` step carrying the combined text on the **running** invocation's trace, touches its idle timeout (a steer is a sign of life), injects via `actuator.steer(combined)`, closes swept messages no-response, and completes the /steer invocation `noResponse` with `remote.sessionControl`/`remote.steered` metadata. The complete inserts `command_completed`, so the command card resolves at once; the steer step in the live trace is the visible confirmation (INV-63: success is signal-in-place, not a new message).
3. `steer` is `steer` on the steps wire already: `AGENT_STEP_TYPES` includes it, `socket-handler.ts` validates frames against that enum, and `step-config.ts` renders it ("Steering…", Navigation icon). On a sealed turn `recordSteps` seals the frame under the stream key like every other step. **No backend or frontend change.**
4. Claude actuation (`tmux-control.ts` `steerText`): `Ctrl-U` (clear residue) + `tmux load-buffer` from stdin + `paste-buffer -d -p` (bracketed paste) + settle + `Enter`. Claude Code's native steering folds a message submitted while it works into the current turn. Bracketed paste rather than `send-keys -l` so newlines can't submit mid-message and a leading `/` can't open the slash menu. The connector prefixes `[Steer from the Threa scratchpad — fold into the current work]` so the model attributes the mid-turn text to the scratchpad, not the terminal.
5. Failure is loud (INV-11): if `actuator.steer` returns false, nothing was injected — swept invocations are **failed** ("Steer not delivered … resend"), not silently closed, and the /steer command acks the failure.

### Key design decisions

**1. The running invocation stays the primary; /steer closes immediately.** Pi holds steered invocations open until turn end; here the /steer command completes as soon as injection succeeds. The turn's eventual reply already answers the original invocation — keeping the command open added nothing but the spinner Kris reported. `command_completed` on close is what resolves the card.

**2. Steer step recorded before actuation.** Keeps it positioned ahead of the continuation's frames in the trace. Cost: a failed actuation (tmux gone — the session is effectively dead) leaves a steer step followed by the failure ack. Chosen over record-after, which would misorder the trace on every successful steer to protect a rare dead-pane case.

**3. Interrupt path kept, not deleted.** It is the only semantics available when idle (deliver as a fresh turn under the /steer invocation, which the model answers via `reply`) and the fail-safe for actuators without `steer`. `steerByInterrupt` is the old `runSteer` body verbatim minus the extracted sweep.

**4. TranscriptTracer needs no change.** The injected user message maps to no frame (`transcript-trace.ts` emits only tool_result frames from user entries), so the explicit steer step is not double-reported, and the tracer keeps tailing the original invocation — the continuation lands in the same trace automatically.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/remote-session/src/session.ts` | Optional `steer` on `SessionControlActuator`; `runSteer` split into `steerRunningTurn` (new in-place path) / `steerByInterrupt` (old body); `sweepQueuedForSteer` extracted |
| `extensions/remote-session/src/session.test.ts` | Fake transport records steps; 5 new steer-in-place tests (fold + no-interrupt + immediate close, queued-message folding, empty-steer ack, failed actuation, idle fallback); old steer test renamed to the fallback it now covers |
| `extensions/claude-code-remote/src/tmux-control.ts` | `steerText` (Ctrl-U + bracketed paste + Enter); dead `STEER_SETTLE_MS` removed (remote-session owns its copy) |
| `extensions/claude-code-remote/src/channel-server.ts` | `steer` wired into the actuator with the provenance prefix |
| `extensions/claude-code-remote/src/session-control.test.ts` | Asserts the actuator advertises `steer` |
| `docs/claude-channel-session-control.md` | 2026-07-05 update note; steer row + prose corrected to the in-place semantics, v1 mechanics scoped to the fallback |

## Out of scope (deliberate)

- **Pi (`pi-remote`)** — already steers natively; untouched.
- **`harness-daemon`'s `steer` verb** — a manual CLI whose documented semantic is explicitly "interrupt, then type a follow-up"; not the Threa slash command path.
- **Turn-ends-during-steer race** — if the running turn completes between the /steer claim and the paste, the text submits as a local prompt at idle (its output stays in the terminal, not the scratchpad). The window is sub-second and `recordSteps` returning false means no phantom trace step; a TUI-state probe to close it fully isn't available from the channel.
- **Stop** — unchanged; interrupt remains its correct actuation.

## Test plan

- [x] `extensions/remote-session` `bun test` — 90 pass (5 new)
- [x] `extensions/claude-code-remote` `bun test` — 48 pass
- [x] `tsc --noEmit` clean in both extensions
- [x] **Live-verified the tmux mechanic** against a running Claude Code v2.1.201 pane mid-turn: the exact `steerText` sequence delivered a multi-line marker as a user message steered into the executing turn — newlines intact, no early submit, no interrupt, same trace
- [x] Self-review pass: 1 finding (dead `STEER_SETTLE_MS` export in tmux-control) fixed in commit 2
- [ ] Full scratchpad round-trip (`/steer` from the composer → steer step in the trace → command card resolves) needs a freshly spawned channel session running this code — the live session used for verification still runs the old channel binary; verify on the next spawned session

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01651bEgTFje9c9P7Tbo32XS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785868474&installation_id=129946197&pr_number=1201&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1201&signature=fc7a0376c655047d2fca708e3fd54bd9f52967a519467677c4c52f8ce1449a4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->