### PR TITLE
feat: wire trace controls to runtime commands

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.test.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.test.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { MemoryRouter, Route, Routes } from "react-router-dom"
 import type { AgentSession } from "@threa/types"
 import { TraceDialog } from "./trace-dialog"
@@ -7,10 +8,14 @@ import * as contextsModule from "@/contexts"
 import * as useAgentTraceModule from "@/hooks/use-agent-trace"
 import * as workspacesModule from "@/hooks/use-workspaces"
 import * as relativeTimeModule from "@/components/relative-time"
+import * as hooksModule from "@/hooks"
+import { commandsApi } from "@/api"
 
 let mockSessionId = "session_1"
 let mockSessionIndex = 0
-let mockSteps: Array<{ id: string; stepType: string }> = []
+let mockSteps: unknown[] = []
+let mockSession: AgentSession
+let mockRelatedSessions: AgentSession[]
 
 const relatedSessions: AgentSession[] = [
   {
@@ -45,19 +50,27 @@ const relatedSessions: AgentSession[] = [
   },
 ]
 
-function renderTrace() {
+function renderTrace(extra?: ReactNode) {
   return render(
-    <MemoryRouter initialEntries={["/w/ws_1"]}>
-      <Routes>
-        <Route path="/w/:workspaceId" element={<TraceDialog />} />
-      </Routes>
-    </MemoryRouter>
+    <div data-editor-zone="main">
+      <MemoryRouter initialEntries={["/w/ws_1"]}>
+        <Routes>
+          <Route path="/w/:workspaceId" element={<TraceDialog />} />
+        </Routes>
+      </MemoryRouter>
+      {extra}
+    </div>
   )
 }
 
 describe("TraceDialog", () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    mockSessionId = "session_1"
+    mockSessionIndex = 0
+    mockSteps = []
+    mockSession = relatedSessions[0]!
+    mockRelatedSessions = relatedSessions
 
     vi.spyOn(contextsModule, "useTrace").mockImplementation((() => ({
       sessionId: mockSessionId,
@@ -68,13 +81,16 @@ describe("TraceDialog", () => {
 
     vi.spyOn(useAgentTraceModule, "useAgentTrace").mockImplementation((() => ({
       steps: mockSteps,
-      session: relatedSessions[mockSessionIndex],
-      relatedSessions,
+      session: mockSession,
+      relatedSessions: mockRelatedSessions,
       persona: { id: "persona_1", name: "Ariadne", avatarUrl: null, avatarEmoji: "🜃" },
-      status: relatedSessions[mockSessionIndex].status,
+      status: mockSession.status,
       isLoading: false,
       error: null,
     })) as unknown as typeof useAgentTraceModule.useAgentTrace)
+
+    vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
+    vi.spyOn(commandsApi, "dispatch").mockResolvedValue({ success: true, commandId: "cmd_1", command: "stop", args: "" })
 
     vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((() => (
       <span>just now</span>
@@ -88,6 +104,8 @@ describe("TraceDialog", () => {
   it("shows superseded-by version hint for superseded sessions", () => {
     mockSessionId = "session_1"
     mockSessionIndex = 0
+    mockSession = relatedSessions[mockSessionIndex]!
+    mockRelatedSessions = relatedSessions
     mockSteps = []
     renderTrace()
 
@@ -97,6 +115,8 @@ describe("TraceDialog", () => {
   it("shows rerun reason when session was retriggered by follow-up edit", () => {
     mockSessionId = "session_2"
     mockSessionIndex = 1
+    mockSession = relatedSessions[mockSessionIndex]!
+    mockRelatedSessions = relatedSessions
     mockSteps = []
     renderTrace()
 
@@ -109,6 +129,8 @@ describe("TraceDialog", () => {
   it("counts message edits as sent responses in footer", () => {
     mockSessionId = "session_2"
     mockSessionIndex = 1
+    mockSession = relatedSessions[mockSessionIndex]!
+    mockRelatedSessions = relatedSessions
     mockSteps = [
       { id: "step_1", stepType: "thinking" },
       { id: "step_2", stepType: "message_edited" },
@@ -118,5 +140,79 @@ describe("TraceDialog", () => {
     renderTrace()
 
     expect(screen.getByText("3 steps • 1 message sent")).toBeInTheDocument()
+  })
+
+  it("keeps Redirect visible for regular running agents and focuses the composer", () => {
+    const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
+    mockSession = {
+      id: "session_run",
+      streamId: "stream_1",
+      personaId: "persona_1",
+      triggerMessageId: "msg_1",
+      status: "running",
+      sentMessageIds: [],
+      createdAt: "2026-02-19T10:00:00.000Z",
+    }
+    mockRelatedSessions = [mockSession]
+    mockSteps = [
+      {
+        id: "step_running",
+        sessionId: "session_run",
+        stepNumber: 1,
+        stepType: "thinking",
+        startedAt: "2026-02-19T10:00:01.000Z",
+      },
+    ]
+
+    renderTrace(<div data-testid="zone-editor" contentEditable />)
+
+    const zoneEditor = screen.getByTestId("zone-editor")
+    const rects = {
+      length: 1,
+      item: (index: number) => (index === 0 ? ({ width: 1, height: 1 } as DOMRect) : null),
+      0: { width: 1, height: 1 } as DOMRect,
+    } as unknown as DOMRectList
+    vi.spyOn(zoneEditor, "getClientRects").mockReturnValue(rects)
+
+    fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
+
+    expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor)
+    expect(commandsApi.dispatch).not.toHaveBeenCalled()
+  })
+
+  it("dispatches advertised runtime stop and steer commands from the running trace", async () => {
+    mockSession = {
+      id: "session_run",
+      streamId: "stream_1",
+      personaId: "bot_1",
+      triggerMessageId: "msg_1",
+      status: "running",
+      sentMessageIds: [],
+      createdAt: "2026-02-19T10:00:00.000Z",
+    }
+    mockRelatedSessions = [mockSession]
+    mockSteps = [
+      {
+        id: "step_running",
+        sessionId: "session_run",
+        stepNumber: 1,
+        stepType: "thinking",
+        startedAt: "2026-02-19T10:00:01.000Z",
+      },
+    ]
+    vi.mocked(commandsApi.listForStream).mockResolvedValue([
+      { name: "steer", description: "Steer", kind: "bot-runtime", scope: "stream" },
+      { name: "stop", description: "Stop", kind: "bot-runtime", scope: "stream" },
+    ])
+
+    renderTrace()
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Redirect" })).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }))
+
+    expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" })
+    expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" })
   })
 })

--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import {
   ResponsiveDialog,
@@ -10,13 +10,26 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { RelativeTime } from "@/components/relative-time"
 import { useTrace, useSocket } from "@/contexts"
-import { useAbortSession } from "@/hooks"
+import { focusAtEnd, useAbortSession } from "@/hooks"
 import { useAgentTrace } from "@/hooks/use-agent-trace"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { TraceStepList } from "./trace-step-list"
+import { commandsApi } from "@/api"
+import { findVisibleZoneEditor } from "@/components/timeline/message-event"
 import { X } from "lucide-react"
 import { formatDuration } from "@/lib/dates"
-import type { AgentSession, AgentSessionRerunContext, AgentSessionStatus } from "@threa/types"
+import { CommandKinds, type AgentSession, type AgentSessionRerunContext, type AgentSessionStatus } from "@threa/types"
+
+type SessionControlCommand = "steer" | "stop"
+
+function collectRuntimeSessionControlCommands(commands: Awaited<ReturnType<typeof commandsApi.listForStream>>) {
+  const advertised = new Set<SessionControlCommand>()
+  for (const command of commands) {
+    if (command.kind !== CommandKinds.BOT_RUNTIME) continue
+    if (command.name === "steer" || command.name === "stop") advertised.add(command.name)
+  }
+  return advertised
+}
 
 const STATUS_TEXT: Record<AgentSessionStatus, string> = {
   pending: "Session pending",
@@ -33,6 +46,7 @@ export function TraceDialog() {
   const { sessionId, highlightMessageId, getTraceUrl, closeTraceModal } = useTrace()
   const socket = useSocket()
   const abortSession = useAbortSession(socket)
+  const [runtimeCommands, setRuntimeCommands] = useState<ReadonlySet<SessionControlCommand>>(new Set())
   // Resolved once and threaded into the step list so each step can decrypt
   // sealed (enclave) content via the viewer's E2E session.
   const userId = useWorkspaceUserId(workspaceId!)
@@ -42,14 +56,69 @@ export function TraceDialog() {
     sessionId!
   )
 
-  // Bind workspace + session once here so the in-flight step card can invoke it
-  // without needing either identifier in its own scope. Only wired when the
-  // session is actively running — abort on a completed session is a no-op at
-  // the server so it's cheap, but there's no reason to show the button then.
+  useEffect(() => {
+    if (!workspaceId || !session?.streamId || status !== "running") {
+      setRuntimeCommands(new Set())
+      return
+    }
+
+    let cancelled = false
+    void commandsApi
+      .listForStream(workspaceId, session.streamId)
+      .then((commands) => {
+        if (cancelled) return
+        setRuntimeCommands(collectRuntimeSessionControlCommands(commands))
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        console.warn("[TraceDialog] failed to load runtime session-control commands", error)
+        setRuntimeCommands(new Set())
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId, session?.streamId, status])
+
+  // Bind workspace + session once here so the in-flight step card can invoke
+  // session-control without needing either identifier in its own scope.
   const handleStopSession = useCallback(() => {
     if (!sessionId || !workspaceId) return
-    abortSession({ sessionId, workspaceId })
-  }, [abortSession, sessionId, workspaceId])
+    void (async () => {
+      if (session?.streamId) {
+        let advertised = runtimeCommands
+        if (!advertised.has("stop")) {
+          advertised = await commandsApi
+            .listForStream(workspaceId, session.streamId)
+            .then(collectRuntimeSessionControlCommands)
+            .catch(() => new Set<SessionControlCommand>())
+        }
+        if (advertised.has("stop")) {
+          await commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/stop" })
+          return
+        }
+      }
+      abortSession({ sessionId, workspaceId })
+    })().catch((error: unknown) => {
+      console.warn("[TraceDialog] failed to stop session", error)
+    })
+  }, [abortSession, runtimeCommands, session?.streamId, sessionId, workspaceId])
+
+  const handleSteerSession = useCallback(() => {
+    if (workspaceId && session?.streamId && runtimeCommands.has("steer")) {
+      void commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/steer" }).catch((error: unknown) => {
+        console.warn("[TraceDialog] failed to dispatch /steer", error)
+      })
+      return
+    }
+
+    for (const zone of document.querySelectorAll<HTMLElement>("[data-editor-zone]")) {
+      const editor = findVisibleZoneEditor(zone)
+      if (!editor) continue
+      focusAtEnd(editor)
+      return
+    }
+  }, [runtimeCommands, session?.streamId, workspaceId])
 
   if (!sessionId) return null
 
@@ -115,6 +184,7 @@ export function TraceDialog() {
           streamId={session?.streamId ?? ""}
           userId={userId}
           onStopSession={status === "running" ? handleStopSession : undefined}
+          onSteerSession={status === "running" ? handleSteerSession : undefined}
         />
 
         {status && <TraceFooter status={status} stepCount={steps.length} messageCount={messageCount} />}
@@ -251,6 +321,7 @@ function TraceBody({
   streamId,
   userId,
   onStopSession,
+  onSteerSession,
 }: {
   isLoading: boolean
   error: Error | null
@@ -261,6 +332,7 @@ function TraceBody({
   streamId: string
   userId: string | null
   onStopSession?: () => void
+  onSteerSession?: () => void
 }) {
   let content = (
     <TraceStepList
@@ -271,6 +343,7 @@ function TraceBody({
       userId={userId}
       streamingSubsteps={streamingSubsteps}
       onStopSession={onStopSession}
+      onSteerSession={onSteerSession}
     />
   )
   if (isLoading) {

--- a/apps/frontend/src/components/trace/trace-step-list.tsx
+++ b/apps/frontend/src/components/trace/trace-step-list.tsx
@@ -17,12 +17,9 @@ interface TraceStepListProps {
    * history and post-refresh streaming entries.
    */
   streamingSubsteps?: Partial<Record<AgentStepType, StreamingSubstep[]>>
-  /**
-   * Callback to gracefully stop the running session. Passed only while the
-   * session is running; `TraceStep` renders a Stop button in the in-progress
-   * step's header so the user can interrupt from inside the trace dialog.
-   */
+  /** Running-session controls rendered on the in-progress step. */
   onStopSession?: () => void
+  onSteerSession?: () => void
 }
 
 export function TraceStepList({
@@ -33,6 +30,7 @@ export function TraceStepList({
   userId,
   streamingSubsteps,
   onStopSession,
+  onSteerSession,
 }: TraceStepListProps) {
   const highlightRef = useRef<HTMLDivElement>(null)
 
@@ -71,6 +69,7 @@ export function TraceStepList({
               userId={userId}
               liveSubsteps={liveSubsteps}
               onStopSession={onStopSession}
+              onSteerSession={onSteerSession}
             />
           </div>
         )

--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -29,7 +29,7 @@ import { formatContextRefLabel } from "@/lib/context-bag/format-label"
 import { buildContextRefSourceHref } from "@/lib/context-bag/source-link"
 import { stripMarkdownToInline } from "@/lib/markdown/strip"
 import { useDecryptedStepContent } from "@/hooks/use-decrypted-step-content"
-import { StopSessionButton } from "./session-action-buttons"
+import { RedirectSessionButton, StopSessionButton } from "./session-action-buttons"
 
 interface TraceStepProps {
   step: AgentSessionStep
@@ -49,15 +49,22 @@ interface TraceStepProps {
    */
   liveSubsteps?: Array<{ text: string; at: string }>
   /**
-   * When the step is in-flight, this callback is rendered as a Stop button in
-   * the step header. The trace dialog only passes this while
-   * `status === "running"`; Stop halts the whole session gracefully regardless
-   * of which tool is active (roadmap 2.1).
+   * In-flight session controls shown in the step header. The trace dialog only
+   * passes these while `status === "running"`.
    */
   onStopSession?: () => void
+  onSteerSession?: () => void
 }
 
-export function TraceStep({ step, workspaceId, streamId, userId, liveSubsteps, onStopSession }: TraceStepProps) {
+export function TraceStep({
+  step,
+  workspaceId,
+  streamId,
+  userId,
+  liveSubsteps,
+  onStopSession,
+  onSteerSession,
+}: TraceStepProps) {
   const config = STEP_DISPLAY_CONFIG[step.stepType]
   const Icon = config.icon
 
@@ -77,13 +84,12 @@ export function TraceStep({ step, workspaceId, streamId, userId, liveSubsteps, o
   const hueColor = `hsl(${config.hue} ${config.saturation}% ${config.lightness}%)`
 
   // In-progress steps replace the default timestamp + duration right-slot with
-  // a spinning loader + "Running…" label + optional Stop button. The
-  // stopPropagation prop is false here because TraceStep is not wrapped in a
-  // clickable Link (the trace dialog body is scrollable content, not a link).
+  // a spinning loader + "Running…" label + available session controls.
   const rightSlot = isInProgress ? (
     <>
       <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: hueColor }} />
       <span className="text-muted-foreground">Running…</span>
+      {onSteerSession && <RedirectSessionButton onClick={onSteerSession} />}
       {onStopSession && <StopSessionButton onClick={onStopSession} />}
     </>
   ) : undefined


### PR DESCRIPTION
## Problem

The trace dialog already showed Stop for running sessions, and the timeline card had Stop/Redirect affordances. Third-party runtime sessions advertise `/stop` and `/steer` through stream-effective commands, but the trace dialog only used the in-process socket abort path and did not expose runtime steering.

## Solution

Route running trace controls through the same stream command surface used by slash commands when the linked runtime advertises those commands.

### How it works

1. `TraceDialog` calls `commandsApi.listForStream(workspaceId, session.streamId)` while the selected session is running.
2. `collectRuntimeSessionControlCommands` keeps only `bot-runtime` commands named `stop` or `steer`.
3. Stop dispatches `/stop` with `commandsApi.dispatch(...)` when advertised; otherwise it falls back to `useAbortSession` for in-process sessions.
4. Redirect remains visible for running trace sessions. It dispatches `/steer` when advertised; otherwise it focuses the stream composer for normal in-process agents.
5. `TraceStepList` and `TraceStep` thread the optional steer handler to the in-progress trace step header.

### Key design decisions

**1. Reuse stream-effective command discovery** — `commandsApi.listForStream` is already scoped by workspace, stream access, linked runtime, and advertised capabilities. The trace uses that source instead of duplicating runtime-presence logic in the frontend.

**2. Keep Stop fallback** — in-process agent sessions still use the existing socket abort path when `/stop` is not advertised. That preserves current Ariadne behavior while enabling third-party runtimes.

**3. Preserve normal-agent steering** — Redirect stays visible for Ariadne/companion sessions and focuses the composer, matching the timeline card behavior. Third-party runtimes that advertise `/steer` receive a command dispatch instead.

## New files

None.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-dialog.tsx` | Loads advertised runtime session-control commands, dispatches `/stop`/`/steer` when available, and focuses the composer for normal-agent Redirect. |
| `apps/frontend/src/components/trace/trace-step.tsx` | Renders the existing Redirect control in the running step header when a steer handler is present. |
| `apps/frontend/src/components/trace/trace-step-list.tsx` | Threads the optional steer handler to each trace step. |
| `apps/frontend/src/components/trace/trace-dialog.test.tsx` | Covers advertised `/stop` and `/steer` dispatch from a running trace. |

## Deleted files

None.

## Out of scope

- No backend command-routing changes; existing `commandsApi.dispatch` and command availability already handle advertised third-party runtime commands.
- No new trace UI copy; the existing Redirect and Stop button components are reused.

## Test plan

- [x] `git diff --check` — clean
- [ ] `bun run --cwd apps/frontend test -- trace-dialog.test.tsx` — blocked locally: this worktree has no `node_modules`, and test startup fails resolving `vite` / Vite plugins

<details>
<summary>📋 Full implementation plan</summary>

Goal: make trace-dialog Stop and Redirect/Steer controls use advertised third-party runtime commands.

What was built:
- Discover stream-effective runtime commands for the running trace session.
- Dispatch `/stop` to the linked runtime when advertised.
- Dispatch `/steer` to the linked runtime when advertised.
- Preserve Redirect for normal in-process agents by focusing the composer.
- Preserve the existing socket abort fallback for sessions without advertised `/stop`.
- Add frontend test coverage for advertised command dispatch.

Schema changes: none.

What's NOT included:
- No runtime capability schema changes.
- No backend route changes.
- No dependency installation in this worktree.

Status: implemented and pushed; targeted test could not run because frontend dependencies are absent locally.

</details>

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785869983&installation_id=129946197&pr_number=1203&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1203&signature=ed5463630462335f5c2df296f95d505751761f2d969f3341f6da52cb337df894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
