### PR TITLE
fix: address trace runtime control review

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.test.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.test.tsx
@@ -10,6 +10,7 @@ import * as workspacesModule from "@/hooks/use-workspaces"
 import * as relativeTimeModule from "@/components/relative-time"
 import * as hooksModule from "@/hooks"
 import { commandsApi } from "@/api"
+import { toast } from "sonner"
 
 let mockSessionId = "session_1"
 let mockSessionIndex = 0
@@ -91,6 +92,7 @@ describe("TraceDialog", () => {
 
     vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
     vi.spyOn(commandsApi, "dispatch").mockResolvedValue({ success: true, commandId: "cmd_1", command: "stop", args: "" })
+    vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
 
     vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((() => (
       <span>just now</span>
@@ -142,8 +144,9 @@ describe("TraceDialog", () => {
     expect(screen.getByText("3 steps • 1 message sent")).toBeInTheDocument()
   })
 
-  it("keeps Redirect visible for regular running agents and focuses the composer", () => {
+  it("keeps Redirect visible for regular running agents and focuses the composer", async () => {
     const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
+    mockSessionId = "session_run"
     mockSession = {
       id: "session_run",
       streamId: "stream_1",
@@ -176,11 +179,44 @@ describe("TraceDialog", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
 
-    expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor)
+    await waitFor(() => expect(focusAtEnd).toHaveBeenCalledWith(zoneEditor))
+    expect(commandsApi.dispatch).not.toHaveBeenCalled()
+  })
+
+  it("does not re-fetch runtime commands on Stop after an empty command list is loaded", async () => {
+    mockSessionId = "session_run"
+    mockSession = {
+      id: "session_run",
+      streamId: "stream_1",
+      personaId: "persona_1",
+      triggerMessageId: "msg_1",
+      status: "running",
+      sentMessageIds: [],
+      createdAt: "2026-02-19T10:00:00.000Z",
+    }
+    mockRelatedSessions = [mockSession]
+    mockSteps = [
+      {
+        id: "step_running",
+        sessionId: "session_run",
+        stepNumber: 1,
+        stepType: "thinking",
+        startedAt: "2026-02-19T10:00:01.000Z",
+      },
+    ]
+
+    renderTrace()
+
+    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }))
+
+    expect(commandsApi.listForStream).toHaveBeenCalledTimes(1)
     expect(commandsApi.dispatch).not.toHaveBeenCalled()
   })
 
   it("dispatches advertised runtime stop and steer commands from the running trace", async () => {
+    mockSessionId = "session_run"
     mockSession = {
       id: "session_run",
       streamId: "stream_1",
@@ -212,7 +248,44 @@ describe("TraceDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
     fireEvent.click(screen.getByRole("button", { name: "Stop" }))
 
-    expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" })
-    expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" })
+    await waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" }))
+    await waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" }))
+  })
+
+  it("falls back to local Stop and surfaces a toast when advertised runtime stop fails", async () => {
+    const abortSession = vi.fn()
+    vi.spyOn(hooksModule, "useAbortSession").mockReturnValue(abortSession)
+    mockSessionId = "session_run"
+    mockSession = {
+      id: "session_run",
+      streamId: "stream_1",
+      personaId: "bot_1",
+      triggerMessageId: "msg_1",
+      status: "running",
+      sentMessageIds: [],
+      createdAt: "2026-02-19T10:00:00.000Z",
+    }
+    mockRelatedSessions = [mockSession]
+    mockSteps = [
+      {
+        id: "step_running",
+        sessionId: "session_run",
+        stepNumber: 1,
+        stepType: "thinking",
+        startedAt: "2026-02-19T10:00:01.000Z",
+      },
+    ]
+    vi.mocked(commandsApi.listForStream).mockResolvedValue([
+      { name: "stop", description: "Stop", kind: "bot-runtime", scope: "stream" },
+    ])
+    vi.mocked(commandsApi.dispatch).mockRejectedValue(new Error("network down"))
+
+    renderTrace()
+
+    await waitFor(() => expect(commandsApi.listForStream).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }))
+
+    await waitFor(() => expect(abortSession).toHaveBeenCalledWith({ sessionId: "session_run", workspaceId: "ws_1" }))
+    expect(toast.error).toHaveBeenCalledWith("Runtime stop failed — using local stop instead")
   })
 })

--- a/apps/frontend/src/components/trace/trace-dialog.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.tsx
@@ -17,6 +17,7 @@ import { TraceStepList } from "./trace-step-list"
 import { commandsApi } from "@/api"
 import { findVisibleZoneEditor } from "@/components/timeline/message-event"
 import { X } from "lucide-react"
+import { toast } from "sonner"
 import { formatDuration } from "@/lib/dates"
 import { CommandKinds, type AgentSession, type AgentSessionRerunContext, type AgentSessionStatus } from "@threa/types"
 
@@ -29,6 +30,25 @@ function collectRuntimeSessionControlCommands(commands: Awaited<ReturnType<typeo
     if (command.name === "steer" || command.name === "stop") advertised.add(command.name)
   }
   return advertised
+}
+
+async function resolveRuntimeCommands({
+  workspaceId,
+  streamId,
+  runtimeCommands,
+}: {
+  workspaceId: string
+  streamId: string
+  runtimeCommands: ReadonlySet<SessionControlCommand> | null
+}): Promise<ReadonlySet<SessionControlCommand>> {
+  if (runtimeCommands) return runtimeCommands
+  return commandsApi
+    .listForStream(workspaceId, streamId)
+    .then(collectRuntimeSessionControlCommands)
+    .catch((error: unknown) => {
+      console.warn("[TraceDialog] failed to resolve runtime session-control commands", error)
+      return new Set<SessionControlCommand>()
+    })
 }
 
 const STATUS_TEXT: Record<AgentSessionStatus, string> = {
@@ -46,7 +66,7 @@ export function TraceDialog() {
   const { sessionId, highlightMessageId, getTraceUrl, closeTraceModal } = useTrace()
   const socket = useSocket()
   const abortSession = useAbortSession(socket)
-  const [runtimeCommands, setRuntimeCommands] = useState<ReadonlySet<SessionControlCommand>>(new Set())
+  const [runtimeCommands, setRuntimeCommands] = useState<ReadonlySet<SessionControlCommand> | null>(null)
   // Resolved once and threaded into the step list so each step can decrypt
   // sealed (enclave) content via the viewer's E2E session.
   const userId = useWorkspaceUserId(workspaceId!)
@@ -58,7 +78,7 @@ export function TraceDialog() {
 
   useEffect(() => {
     if (!workspaceId || !session?.streamId || status !== "running") {
-      setRuntimeCommands(new Set())
+      setRuntimeCommands(null)
       return
     }
 
@@ -86,38 +106,44 @@ export function TraceDialog() {
     if (!sessionId || !workspaceId) return
     void (async () => {
       if (session?.streamId) {
-        let advertised = runtimeCommands
-        if (!advertised.has("stop")) {
-          advertised = await commandsApi
-            .listForStream(workspaceId, session.streamId)
-            .then(collectRuntimeSessionControlCommands)
-            .catch(() => new Set<SessionControlCommand>())
-        }
+        const advertised = await resolveRuntimeCommands({ workspaceId, streamId: session.streamId, runtimeCommands })
         if (advertised.has("stop")) {
-          await commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/stop" })
-          return
+          try {
+            await commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/stop" })
+            return
+          } catch (error) {
+            console.warn("[TraceDialog] /stop dispatch failed, falling back to abort", error)
+            toast.error("Runtime stop failed — using local stop instead")
+          }
         }
       }
       abortSession({ sessionId, workspaceId })
     })().catch((error: unknown) => {
       console.warn("[TraceDialog] failed to stop session", error)
+      toast.error("Failed to stop session")
     })
   }, [abortSession, runtimeCommands, session?.streamId, sessionId, workspaceId])
 
   const handleSteerSession = useCallback(() => {
-    if (workspaceId && session?.streamId && runtimeCommands.has("steer")) {
-      void commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/steer" }).catch((error: unknown) => {
-        console.warn("[TraceDialog] failed to dispatch /steer", error)
-      })
-      return
-    }
+    void (async () => {
+      if (workspaceId && session?.streamId) {
+        const advertised = await resolveRuntimeCommands({ workspaceId, streamId: session.streamId, runtimeCommands })
+        if (advertised.has("steer")) {
+          await commandsApi.dispatch(workspaceId, { streamId: session.streamId, command: "/steer" })
+          return
+        }
+      }
 
-    for (const zone of document.querySelectorAll<HTMLElement>("[data-editor-zone]")) {
-      const editor = findVisibleZoneEditor(zone)
-      if (!editor) continue
-      focusAtEnd(editor)
-      return
-    }
+      for (const zone of document.querySelectorAll<HTMLElement>("[data-editor-zone]")) {
+        const editor = findVisibleZoneEditor(zone)
+        if (!editor) continue
+        focusAtEnd(editor)
+        return
+      }
+    })().catch((error: unknown) => {
+      console.warn("[TraceDialog] failed to dispatch /steer", error)
+      toast.error("Failed to redirect session")
+    })
   }, [runtimeCommands, session?.streamId, workspaceId])
 
   if (!sessionId) return null


### PR DESCRIPTION
## Problem

CodeRabbit flagged two issues after #1203 merged:

1. `runtimeCommands` used an empty `Set` for both "not loaded yet" and "loaded with no advertised commands", so Stop could re-fetch command availability before falling back for normal Ariadne sessions.
2. Advertised `/stop` and `/steer` dispatch failures only logged to the console. `/stop` skipped the local abort fallback when dispatch threw, and neither path told the user the action failed.

## Solution

Track runtime command loading as `null | ReadonlySet<"stop" | "steer">`, and harden the command dispatch failure paths.

### How it works

1. `TraceDialog` initializes `runtimeCommands` as `null` while command availability is unknown.
2. `resolveRuntimeCommands` fetches only while the state is `null`; an empty set now means "loaded, unsupported".
3. Stop dispatches `/stop` when advertised. If that dispatch throws, it shows an error toast and falls back to `useAbortSession`.
4. Steer dispatches `/steer` when advertised. If dispatch throws, it shows an error toast.
5. Normal agents still use local behavior: Stop aborts locally, Redirect focuses the composer.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/trace/trace-dialog.tsx` | Separates unknown vs loaded-empty runtime commands; adds stop fallback and error toasts for failed runtime dispatch. |
| `apps/frontend/src/components/trace/trace-dialog.test.tsx` | Covers loaded-empty no-refetch behavior and failed advertised `/stop` fallback/toast. |

## Review comment disposition

| Source | Comment | Disposition |
| ---- | ---- | ---- |
| CodeRabbit on #1203 | Empty `runtimeCommands` conflated unknown with unsupported. | Accepted — fixed with `null` loading state and `resolveRuntimeCommands`. |
| CodeRabbit on #1203 | Failed `/stop`/`/steer` dispatch only logged. | Accepted — `/stop` falls back to local abort and both failure paths toast. |

## Test plan

- [x] `git diff --check` — clean
- [ ] `bun run --cwd apps/frontend test -- trace-dialog.test.tsx` — blocked locally: this worktree has no `node_modules`, and frontend test startup cannot resolve `vite` / Vite plugins

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785876201&installation_id=129946197&pr_number=1204&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1204&signature=b329cb5b43c88435a7a52c90d0ed73ac872ddf2c64128f7408a083084b194e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->