### PR TITLE
feat: add custom duration scheduling controls

### DIFF
--- a/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
@@ -72,12 +72,13 @@ describe("ScheduledMessagesPicker", () => {
     expect(mousedown.defaultPrevented).toBe(false)
   })
 
-  it("schedules with the inline custom duration", async () => {
+  it("schedules with the custom duration", async () => {
     const before = Date.now()
     const { onSchedule } = renderPicker()
 
     await userEvent.click(screen.getByRole("button", { name: /scheduled/i }))
     await userEvent.click(screen.getByRole("button", { name: /schedule send/i }))
+    await userEvent.click(screen.getByRole("button", { name: /custom duration/i }))
     await userEvent.clear(screen.getByRole("spinbutton", { name: /custom duration/i }))
     await userEvent.type(screen.getByRole("spinbutton", { name: /custom duration/i }), "30")
     await userEvent.click(screen.getByRole("button", { name: /^schedule$/i }))

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx
@@ -14,15 +14,18 @@ import * as editDialogModule from "@/components/scheduled/scheduled-edit-dialog"
 let isTouchMockValue = true
 
 function renderPicker() {
-  return render(
+  const onSchedule = vi.fn()
+  const result = render(
     <TooltipProvider>
-      <ScheduledMessagesPicker workspaceId="ws_1" streamId="stream_1" canSchedule onSchedule={vi.fn()} />
+      <ScheduledMessagesPicker workspaceId="ws_1" streamId="stream_1" canSchedule onSchedule={onSchedule} />
     </TooltipProvider>
   )
+  return { ...result, onSchedule }
 }
 
 describe("ScheduledMessagesPicker", () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
     isTouchMockValue = true
     vi.spyOn(inputModeModule, "useInputMode").mockImplementation(() => (isTouchMockValue ? "touch" : "mouse"))
@@ -67,5 +70,20 @@ describe("ScheduledMessagesPicker", () => {
     fireEvent(scheduleSend, mousedown)
 
     expect(mousedown.defaultPrevented).toBe(false)
+  })
+
+  it("schedules with the inline custom duration", async () => {
+    const before = Date.now()
+    const { onSchedule } = renderPicker()
+
+    await userEvent.click(screen.getByRole("button", { name: /scheduled/i }))
+    await userEvent.click(screen.getByRole("button", { name: /schedule send/i }))
+    await userEvent.clear(screen.getByRole("spinbutton", { name: /custom duration/i }))
+    await userEvent.type(screen.getByRole("spinbutton", { name: /custom duration/i }), "30")
+    await userEvent.click(screen.getByRole("button", { name: /^schedule$/i }))
+
+    const scheduledAt = onSchedule.mock.calls[0]?.[0] as Date
+    expect(scheduledAt.getTime()).toBeGreaterThanOrEqual(before + 30 * 60_000)
+    expect(scheduledAt.getTime()).toBeLessThanOrEqual(Date.now() + 30 * 60_000)
   })
 })

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -76,6 +76,7 @@ export function ScheduledMessagesPicker({
   const [customTime, setCustomTime] = useState<string>("")
   const [customMinDate, setCustomMinDate] = useState<string>("")
   const [showCustom, setShowCustom] = useState(false)
+  const [showDuration, setShowDuration] = useState(false)
   const [editing, setEditing] = useState<ScheduledMessageView | null>(null)
   // Lifted out of the row so the drawer stacks above the popover. Local
   // state inside `ScheduledRow` only worked when the popover stayed open,
@@ -119,6 +120,7 @@ export function ScheduledMessagesPicker({
   const resetToList = () => {
     setMode("list")
     setShowCustom(false)
+    setShowDuration(false)
     setCustomDate("")
     setCustomTime("")
   }
@@ -135,6 +137,7 @@ export function ScheduledMessagesPicker({
   const enterPickingMode = () => {
     setMode("picking")
     setShowCustom(false)
+    setShowDuration(false)
   }
 
   const handlePreset = (preset: ReminderPreset, overrideTz?: string) => {
@@ -249,6 +252,7 @@ export function ScheduledMessagesPicker({
               prefTimezone={prefTimezone}
               workSchedule={workSchedule}
               showCustom={showCustom}
+              showDuration={showDuration}
               customDate={customDate}
               customTime={customTime}
               customMinDate={customMinDate}
@@ -256,6 +260,7 @@ export function ScheduledMessagesPicker({
               onBack={resetToList}
               onPreset={handlePreset}
               onDurationSubmit={handleDurationSubmit}
+              onToggleDuration={() => setShowDuration((prev) => !prev)}
               onShowCustom={() => {
                 // Built fresh each time — the composer is mounted for the
                 // lifetime of a session, so a memoized seed would go stale.
@@ -263,6 +268,7 @@ export function ScheduledMessagesPicker({
                 setCustomMinDate(toDateInputValue(new Date()))
                 setCustomDate(toDateInputValue(seed))
                 setCustomTime(toTimeInputValue(seed))
+                setShowDuration(false)
                 setShowCustom(true)
               }}
               onCustomDateChange={setCustomDate}
@@ -387,6 +393,7 @@ interface PickingModeProps {
   prefTimezone: string | null
   workSchedule: WorkSchedule
   showCustom: boolean
+  showDuration: boolean
   customDate: string
   customTime: string
   customMinDate: string
@@ -394,6 +401,7 @@ interface PickingModeProps {
   onBack: () => void
   onPreset: (preset: ReminderPreset, overrideTz?: string) => void
   onDurationSubmit: (when: Date) => void
+  onToggleDuration: () => void
   onShowCustom: () => void
   onCustomDateChange: (value: string) => void
   onCustomTimeChange: (value: string) => void
@@ -405,6 +413,7 @@ function PickingMode({
   prefTimezone,
   workSchedule,
   showCustom,
+  showDuration,
   customDate,
   customTime,
   customMinDate,
@@ -412,6 +421,7 @@ function PickingMode({
   onBack,
   onPreset,
   onDurationSubmit,
+  onToggleDuration,
   onShowCustom,
   onCustomDateChange,
   onCustomTimeChange,
@@ -442,13 +452,24 @@ function PickingMode({
               onPreset={onPreset}
             />
           ))}
-          <CustomDurationPicker
-            onSubmit={onDurationSubmit}
-            submitLabel="Schedule"
-            preview={(date) => formatFutureTime(date, new Date(), { timezone })}
-            controlClassName="h-11"
-            buttonClassName="h-11"
-          />
+          <button
+            type="button"
+            onClick={onToggleDuration}
+            aria-expanded={showDuration}
+            className="rounded-md mx-1 px-2 py-1.5 text-left text-sm hover:bg-accent"
+          >
+            Custom duration…
+          </button>
+          {showDuration && (
+            <CustomDurationPicker
+              onSubmit={onDurationSubmit}
+              submitLabel="Schedule"
+              preview={(date) => formatFutureTime(date, new Date(), { timezone })}
+              className="mx-1"
+              controlClassName="h-11"
+              buttonClassName="h-11"
+            />
+          )}
           <button
             type="button"
             onClick={onShowCustom}

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -446,6 +446,8 @@ function PickingMode({
             onSubmit={onDurationSubmit}
             submitLabel="Schedule"
             preview={(date) => formatFutureTime(date, new Date(), { timezone })}
+            controlClassName="h-11"
+            buttonClassName="h-11"
           />
           <button
             type="button"

--- a/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
+++ b/apps/frontend/src/components/composer/scheduled-messages-picker.tsx
@@ -22,6 +22,7 @@ import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/da
 import { ScheduledEditDialog } from "@/components/scheduled/scheduled-edit-dialog"
 import { ScheduledActionDrawer } from "@/components/scheduled/scheduled-action-drawer"
 import { ScheduledActions } from "@/components/scheduled/scheduled-actions"
+import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 import { keepEditorFocusProps } from "@/lib/keep-editor-focus"
 import { useComposerAnchor } from "./use-composer-anchor"
 
@@ -144,6 +145,12 @@ export function ScheduledMessagesPicker({
     resetToList()
   }
 
+  const handleDurationSubmit = (when: Date) => {
+    onSchedule(when)
+    setOpen(false)
+    resetToList()
+  }
+
   const handleCustomSubmit = () => {
     const when = parseLocalDateTime(customDate, customTime)
     if (!when) return
@@ -248,6 +255,7 @@ export function ScheduledMessagesPicker({
               previewLabel={previewLabel}
               onBack={resetToList}
               onPreset={handlePreset}
+              onDurationSubmit={handleDurationSubmit}
               onShowCustom={() => {
                 // Built fresh each time — the composer is mounted for the
                 // lifetime of a session, so a memoized seed would go stale.
@@ -385,6 +393,7 @@ interface PickingModeProps {
   previewLabel: string | null
   onBack: () => void
   onPreset: (preset: ReminderPreset, overrideTz?: string) => void
+  onDurationSubmit: (when: Date) => void
   onShowCustom: () => void
   onCustomDateChange: (value: string) => void
   onCustomTimeChange: (value: string) => void
@@ -402,6 +411,7 @@ function PickingMode({
   previewLabel,
   onBack,
   onPreset,
+  onDurationSubmit,
   onShowCustom,
   onCustomDateChange,
   onCustomTimeChange,
@@ -432,6 +442,11 @@ function PickingMode({
               onPreset={onPreset}
             />
           ))}
+          <CustomDurationPicker
+            onSubmit={onDurationSubmit}
+            submitLabel="Schedule"
+            preview={(date) => formatFutureTime(date, new Date(), { timezone })}
+          />
           <button
             type="button"
             onClick={onShowCustom}

--- a/apps/frontend/src/components/notifications/pause-notifications-dialog.tsx
+++ b/apps/frontend/src/components/notifications/pause-notifications-dialog.tsx
@@ -34,13 +34,15 @@ export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: Pa
   )
 
   const [customOpen, setCustomOpen] = useState(false)
+  const [durationOpen, setDurationOpen] = useState(false)
   const [customDate, setCustomDate] = useState("")
   const [customTime, setCustomTime] = useState("")
 
-  // Reset the custom-time editor each time the dialog opens.
+  // Reset the custom editors each time the dialog opens.
   useEffect(() => {
     if (!open) return
     setCustomOpen(false)
+    setDurationOpen(false)
     const inAnHour = new Date(Date.now() + 60 * 60 * 1000)
     setCustomDate(toDateInputValue(inAnHour))
     setCustomTime(toTimeInputValue(inAnHour))
@@ -100,15 +102,30 @@ export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: Pa
               {timedOptions.map((option) => (
                 <PauseOptionRow key={option.id} label={option.label} disabled={busy} onClick={() => pauseFor(option)} />
               ))}
-              <CustomDurationPicker
-                onSubmit={pauseUntilDate}
+              <PauseOptionRow
+                label="Custom duration…"
                 disabled={busy}
-                submitLabel="Pause"
-                className="px-3"
-                controlClassName="h-11"
-                buttonClassName="h-11"
+                expanded={durationOpen}
+                onClick={() => setDurationOpen((prev) => !prev)}
               />
-              <PauseOptionRow label="Until a specific time…" disabled={busy} onClick={() => setCustomOpen(true)} />
+              {durationOpen && (
+                <CustomDurationPicker
+                  onSubmit={pauseUntilDate}
+                  disabled={busy}
+                  submitLabel="Pause"
+                  className="px-3"
+                  controlClassName="h-11"
+                  buttonClassName="h-11"
+                />
+              )}
+              <PauseOptionRow
+                label="Until a specific time…"
+                disabled={busy}
+                onClick={() => {
+                  setDurationOpen(false)
+                  setCustomOpen(true)
+                }}
+              />
               {indefiniteOptions.map((option) => (
                 <PauseOptionRow key={option.id} label={option.label} disabled={busy} onClick={() => pauseFor(option)} />
               ))}
@@ -120,12 +137,23 @@ export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: Pa
   )
 }
 
-function PauseOptionRow({ label, disabled, onClick }: { label: string; disabled: boolean; onClick: () => void }) {
+function PauseOptionRow({
+  label,
+  disabled,
+  onClick,
+  expanded,
+}: {
+  label: string
+  disabled: boolean
+  onClick: () => void
+  expanded?: boolean
+}) {
   return (
     <button
       type="button"
       disabled={disabled}
       onClick={onClick}
+      aria-expanded={expanded}
       className="flex w-full items-center rounded-md px-3 py-2 text-left text-sm hover:bg-muted/50 disabled:opacity-50"
     >
       {label}

--- a/apps/frontend/src/components/notifications/pause-notifications-dialog.tsx
+++ b/apps/frontend/src/components/notifications/pause-notifications-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { Button } from "@/components/ui/button"
 import { DateTimeField } from "@/components/forms/date-time-field"
+import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 import { useNotificationPauseControls } from "@/hooks/use-notification-pause-controls"
 import { toDateInputValue, toTimeInputValue } from "@/lib/dates"
 import { NOTIFICATION_PAUSE_OPTIONS, formatNotificationPauseLabel } from "@/lib/status"
@@ -27,7 +28,7 @@ interface PauseNotificationsDialogProps {
  * surface; only the chrome (a dialog vs. a settings section) differs.
  */
 export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: PauseNotificationsDialogProps) {
-  const { active, statusOnly, busy, pauseFor, pauseUntilLocal, resume } = useNotificationPauseControls(
+  const { active, statusOnly, busy, pauseFor, pauseUntilDate, pauseUntilLocal, resume } = useNotificationPauseControls(
     workspaceId,
     () => onOpenChange(false)
   )
@@ -49,7 +50,7 @@ export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: Pa
   const indefiniteOptions = NOTIFICATION_PAUSE_OPTIONS.filter((o) => o.duration === null)
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
       <ResponsiveDialogContent desktopClassName="sm:max-w-sm">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle>Pause notifications</ResponsiveDialogTitle>
@@ -99,6 +100,14 @@ export function PauseNotificationsDialog({ workspaceId, open, onOpenChange }: Pa
               {timedOptions.map((option) => (
                 <PauseOptionRow key={option.id} label={option.label} disabled={busy} onClick={() => pauseFor(option)} />
               ))}
+              <CustomDurationPicker
+                onSubmit={pauseUntilDate}
+                disabled={busy}
+                submitLabel="Pause"
+                className="px-3"
+                controlClassName="h-11"
+                buttonClassName="h-11"
+              />
               <PauseOptionRow label="Until a specific time…" disabled={busy} onClick={() => setCustomOpen(true)} />
               {indefiniteOptions.map((option) => (
                 <PauseOptionRow key={option.id} label={option.label} disabled={busy} onClick={() => pauseFor(option)} />

--- a/apps/frontend/src/components/scheduling/custom-duration-picker.test.ts
+++ b/apps/frontend/src/components/scheduling/custom-duration-picker.test.ts
@@ -4,7 +4,7 @@ import { customDurationToDate } from "./custom-duration-picker"
 describe("customDurationToDate", () => {
   const now = new Date("2026-01-01T12:00:00.000Z")
 
-  it("treats numbers as minutes by default surface unit", () => {
+  it("treats a bare amount as minutes", () => {
     expect(customDurationToDate(30, "minutes", now)?.toISOString()).toBe("2026-01-01T12:30:00.000Z")
   })
 

--- a/apps/frontend/src/components/scheduling/custom-duration-picker.test.ts
+++ b/apps/frontend/src/components/scheduling/custom-duration-picker.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { customDurationToDate } from "./custom-duration-picker"
+
+describe("customDurationToDate", () => {
+  const now = new Date("2026-01-01T12:00:00.000Z")
+
+  it("treats numbers as minutes by default surface unit", () => {
+    expect(customDurationToDate(30, "minutes", now)?.toISOString()).toBe("2026-01-01T12:30:00.000Z")
+  })
+
+  it("supports hours", () => {
+    expect(customDurationToDate(2, "hours", now)?.toISOString()).toBe("2026-01-01T14:00:00.000Z")
+  })
+
+  it("rejects non-positive durations", () => {
+    expect(customDurationToDate(0, "minutes", now)).toBeNull()
+  })
+
+  it("rejects date overflows", () => {
+    expect(customDurationToDate(9e15, "minutes", now)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
+++ b/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
@@ -60,9 +60,9 @@ export function CustomDurationPicker({
   }
 
   const handleUnitChange = (value: string) => {
-    const nextUnit = value as CustomDurationUnit
-    setUnit(nextUnit)
-    onDurationChange?.(parsedAmount, nextUnit)
+    if (value !== "minutes" && value !== "hours") return
+    setUnit(value)
+    onDurationChange?.(parsedAmount, value)
   }
 
   const submit = () => {

--- a/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
+++ b/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
@@ -1,0 +1,110 @@
+import { useState, type ReactNode } from "react"
+import { Clock } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+import { formatFutureTime } from "@/lib/dates"
+
+export type CustomDurationUnit = "minutes" | "hours"
+
+export function customDurationToDate(amount: number, unit: CustomDurationUnit, now: Date = new Date()): Date | null {
+  if (!Number.isFinite(amount) || amount <= 0) return null
+  const minutes = unit === "hours" ? amount * 60 : amount
+  const date = new Date(now.getTime() + minutes * 60_000)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+interface CustomDurationPickerProps {
+  onSubmit?: (date: Date) => void
+  disabled?: boolean
+  submitLabel?: string
+  showSubmit?: boolean
+  className?: string
+  controlClassName?: string
+  buttonClassName?: string
+  initialAmount?: number
+  initialUnit?: CustomDurationUnit
+  onDurationChange?: (amount: number, unit: CustomDurationUnit) => void
+  preview?: false | ((date: Date) => ReactNode)
+}
+
+export function CustomDurationPicker({
+  onSubmit,
+  disabled = false,
+  submitLabel = "Set",
+  showSubmit = true,
+  className,
+  controlClassName,
+  buttonClassName,
+  initialAmount = 30,
+  initialUnit = "minutes",
+  onDurationChange,
+  preview,
+}: CustomDurationPickerProps) {
+  const [amount, setAmount] = useState(String(initialAmount))
+  const [unit, setUnit] = useState<CustomDurationUnit>(initialUnit)
+  const parsedAmount = Number(amount)
+  const previewDate = customDurationToDate(parsedAmount, unit)
+  const validDuration = previewDate !== null
+  const canSubmit = !disabled && validDuration
+  let previewContent: ReactNode = null
+  if (previewDate && preview !== false) {
+    previewContent = preview ? preview(previewDate) : formatFutureTime(previewDate, new Date())
+  }
+
+  const handleAmountChange = (value: string) => {
+    const nextAmount = Number(value)
+    setAmount(value)
+    onDurationChange?.(nextAmount, unit)
+  }
+
+  const handleUnitChange = (value: string) => {
+    const nextUnit = value as CustomDurationUnit
+    setUnit(nextUnit)
+    onDurationChange?.(parsedAmount, nextUnit)
+  }
+
+  const submit = () => {
+    const date = customDurationToDate(parsedAmount, unit)
+    if (!date) return
+    onSubmit?.(date)
+  }
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1.5 px-2 py-1.5", className)}>
+      <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <Input
+        type="number"
+        inputMode="numeric"
+        min={1}
+        step={1}
+        value={amount}
+        onChange={(event) => handleAmountChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && onSubmit && canSubmit) submit()
+        }}
+        aria-label="Custom duration"
+        aria-invalid={!validDuration}
+        className={cn("h-8 w-16 px-2", controlClassName)}
+        disabled={disabled}
+      />
+      <Select value={unit} onValueChange={handleUnitChange} disabled={disabled}>
+        <SelectTrigger aria-label="Duration unit" className={cn("h-8 w-[104px] px-2 text-sm", controlClassName)}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="minutes">minutes</SelectItem>
+          <SelectItem value="hours">hours</SelectItem>
+        </SelectContent>
+      </Select>
+      {showSubmit && (
+        <Button size="sm" className={cn("h-8 px-2 text-xs", buttonClassName)} onClick={submit} disabled={!canSubmit}>
+          {submitLabel}
+        </Button>
+      )}
+      {previewContent && <span className="text-xs text-muted-foreground">{previewContent}</span>}
+      {!validDuration && <span className="text-xs text-destructive">Enter a positive duration</span>}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
+++ b/apps/frontend/src/components/scheduling/custom-duration-picker.tsx
@@ -26,7 +26,7 @@ interface CustomDurationPickerProps {
   initialAmount?: number
   initialUnit?: CustomDurationUnit
   onDurationChange?: (amount: number, unit: CustomDurationUnit) => void
-  preview?: false | ((date: Date) => ReactNode)
+  preview?: (date: Date) => ReactNode
 }
 
 export function CustomDurationPicker({
@@ -49,7 +49,7 @@ export function CustomDurationPicker({
   const validDuration = previewDate !== null
   const canSubmit = !disabled && validDuration
   let previewContent: ReactNode = null
-  if (previewDate && preview !== false) {
+  if (previewDate) {
     previewContent = preview ? preview(previewDate) : formatFutureTime(previewDate, new Date())
   }
 
@@ -103,8 +103,11 @@ export function CustomDurationPicker({
           {submitLabel}
         </Button>
       )}
-      {previewContent && <span className="text-xs text-muted-foreground">{previewContent}</span>}
-      {!validDuration && <span className="text-xs text-destructive">Enter a positive duration</span>}
+      {/* Own full-width line (basis-full) so the message swapping preview<->error
+          as the user types never reflows the control row above it (INV-21). */}
+      <span className={cn("basis-full text-xs", validDuration ? "text-muted-foreground" : "text-destructive")}>
+        {validDuration ? previewContent : "Enter a positive duration"}
+      </span>
     </div>
   )
 }

--- a/apps/frontend/src/components/settings/notifications-settings.tsx
+++ b/apps/frontend/src/components/settings/notifications-settings.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { DateTimeField } from "@/components/forms/date-time-field"
+import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 import { ApiError, api } from "@/api/client"
 import { usePreferences } from "@/contexts"
 import { usePushNotifications } from "@/hooks/use-push-notifications"
@@ -305,22 +306,32 @@ function resolveStatusInfo(args: {
  * this section also surfaces a status-driven pause and explains it.
  */
 function PauseNotificationsSection({ workspaceId }: { workspaceId: string }) {
-  // The "Custom…" path reveals an inline date/time field rather than pausing
-  // immediately, mirroring the status picker's custom expiry.
+  // The custom paths reveal inline fields rather than pausing immediately,
+  // mirroring the status picker's custom expiry.
   const [customOpen, setCustomOpen] = useState(false)
+  const [customDurationOpen, setCustomDurationOpen] = useState(false)
   const [customDate, setCustomDate] = useState("")
   const [customTime, setCustomTime] = useState("")
 
-  const { active, statusOnly, busy, pauseFor, pauseUntilLocal, resume } = useNotificationPauseControls(
+  const { active, statusOnly, busy, pauseFor, pauseUntilDate, pauseUntilLocal, resume } = useNotificationPauseControls(
     workspaceId,
-    () => setCustomOpen(false)
+    () => {
+      setCustomOpen(false)
+      setCustomDurationOpen(false)
+    }
   )
 
   const openCustom = () => {
+    setCustomDurationOpen(false)
     const inAnHour = new Date(Date.now() + 60 * 60 * 1000)
     setCustomDate(toDateInputValue(inAnHour))
     setCustomTime(toTimeInputValue(inAnHour))
     setCustomOpen(true)
+  }
+
+  const openCustomDuration = () => {
+    setCustomOpen(false)
+    setCustomDurationOpen(true)
   }
 
   const handleCustomPause = () => {
@@ -331,12 +342,13 @@ function PauseNotificationsSection({ workspaceId }: { workspaceId: string }) {
   // trigger and the "Change" trigger on an active pause. Timed options first,
   // then the custom-time path, then the indefinite option.
   const pauseMenuContent = (
-    <DropdownMenuContent align="start">
+    <DropdownMenuContent align="start" className="min-w-[260px]">
       {NOTIFICATION_PAUSE_OPTIONS.filter((o) => o.duration !== null).map((option) => (
         <DropdownMenuItem key={option.id} onSelect={() => pauseFor(option)}>
           {option.label}
         </DropdownMenuItem>
       ))}
+      <DropdownMenuItem onSelect={openCustomDuration}>Custom duration…</DropdownMenuItem>
       <DropdownMenuItem onSelect={openCustom}>Until a specific time…</DropdownMenuItem>
       {NOTIFICATION_PAUSE_OPTIONS.filter((o) => o.duration === null).map((option) => (
         <DropdownMenuItem key={option.id} onSelect={() => pauseFor(option)}>
@@ -347,9 +359,26 @@ function PauseNotificationsSection({ workspaceId }: { workspaceId: string }) {
   )
 
   // One ternary level (INV-47): pick the control via if/else, render it once.
-  // `customOpen` wins so the picker can adjust an already-active pause in place.
   let control: ReactNode
-  if (customOpen) {
+  if (customDurationOpen) {
+    control = (
+      <div className="space-y-3 rounded-lg border bg-card p-4">
+        <CustomDurationPicker
+          onSubmit={pauseUntilDate}
+          disabled={busy}
+          submitLabel="Pause"
+          className="px-0"
+          controlClassName="h-11"
+          buttonClassName="h-11"
+        />
+        <div className="flex justify-end">
+          <Button variant="ghost" size="sm" onClick={() => setCustomDurationOpen(false)} disabled={busy}>
+            Cancel
+          </Button>
+        </div>
+      </div>
+    )
+  } else if (customOpen) {
     control = (
       <div className="space-y-3 rounded-lg border bg-card p-4">
         <DateTimeField

--- a/apps/frontend/src/components/status/status-picker.tsx
+++ b/apps/frontend/src/components/status/status-picker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { BellOff, Smile, X } from "lucide-react"
 import { toast } from "sonner"
@@ -24,6 +24,11 @@ import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { DateTimeField } from "@/components/forms/date-time-field"
+import {
+  CustomDurationPicker,
+  customDurationToDate,
+  type CustomDurationUnit,
+} from "@/components/scheduling/custom-duration-picker"
 import { ReactionEmojiPicker } from "@/components/timeline/reaction-emoji-picker"
 import { useSetStatus, useClearStatus, workspaceKeys } from "@/hooks"
 import { useWorkspaceEmoji } from "@/hooks/use-workspace-emoji"
@@ -41,11 +46,37 @@ interface StatusPickerProps {
 }
 
 const CUSTOM_OPTION_ID = "custom"
+const CUSTOM_DURATION_OPTION_ID = "custom-duration"
 const NEW_PRESET_ID_PREFIX = "status_"
+
+function statusDurationOptionId(duration: StatusPreset["defaultDuration"]): string {
+  if (!duration) return "never"
+  const match = STATUS_DURATION_OPTIONS.find((o) => durationsEqual(o.duration, duration))
+  if (match) return match.id
+  return duration.kind === "duration" ? CUSTOM_DURATION_OPTION_ID : "never"
+}
+
+function customDurationState(duration: StatusPreset["defaultDuration"]): { amount: number; unit: CustomDurationUnit } {
+  if (duration?.kind !== "duration") return { amount: 30, unit: "minutes" }
+  if (duration.minutes % 60 === 0) return { amount: duration.minutes / 60, unit: "hours" }
+  return { amount: duration.minutes, unit: "minutes" }
+}
+
+function customStatusDuration(amount: number, unit: CustomDurationUnit): StatusPreset["defaultDuration"] {
+  if (!Number.isFinite(amount) || amount <= 0) return null
+  return { kind: "duration", minutes: unit === "hours" ? amount * 60 : amount }
+}
 
 /** Human label for a preset's default duration, shown beside it in the list. */
 function presetDurationLabel(preset: StatusPreset): string {
-  return STATUS_DURATION_OPTIONS.find((o) => durationsEqual(o.duration, preset.defaultDuration))?.label ?? "Don't clear"
+  const option = STATUS_DURATION_OPTIONS.find((o) => durationsEqual(o.duration, preset.defaultDuration))
+  if (option) return option.label
+  if (preset.defaultDuration?.kind === "duration") {
+    const { amount, unit } = customDurationState(preset.defaultDuration)
+    const label = amount === 1 ? unit.slice(0, -1) : unit
+    return `${amount} ${label}`
+  }
+  return "Don't clear"
 }
 
 // "Don't clear" reads best at the top of the menu (matches Slack); the rest
@@ -86,6 +117,9 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
   const [durationTouched, setDurationTouched] = useState(false)
   const [customDate, setCustomDate] = useState("")
   const [customTime, setCustomTime] = useState("")
+  const [customDurationAmount, setCustomDurationAmount] = useState(30)
+  const [customDurationUnit, setCustomDurationUnit] = useState<CustomDurationUnit>("minutes")
+  const [customDurationSeedKey, setCustomDurationSeedKey] = useState(0)
   const [pausesNotifications, setPausesNotifications] = useState(false)
 
   // Seed the editor from the user's current status each time the dialog opens.
@@ -96,6 +130,9 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
     setDurationId("never")
     setDurationTouched(false)
     setPausesNotifications(currentUser?.statusPausesNotifications ?? false)
+    setCustomDurationAmount(30)
+    setCustomDurationUnit("minutes")
+    setCustomDurationSeedKey((key) => key + 1)
     const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000)
     setCustomDate(toDateInputValue(tomorrow))
     setCustomTime(toTimeInputValue(tomorrow))
@@ -122,8 +159,11 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
     // Respect a clear-time the user explicitly chose; otherwise adopt the
     // preset's default duration.
     if (!durationTouched) {
-      const match = STATUS_DURATION_OPTIONS.find((o) => durationsEqual(o.duration, preset.defaultDuration))
-      setDurationId(match?.id ?? "never")
+      setDurationId(statusDurationOptionId(preset.defaultDuration))
+      const { amount, unit } = customDurationState(preset.defaultDuration)
+      setCustomDurationAmount(amount)
+      setCustomDurationUnit(unit)
+      setCustomDurationSeedKey((key) => key + 1)
     }
   }
 
@@ -134,7 +174,16 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
     setEmoji(toShortcode(picked))
   }
 
+  const handleCustomDurationChange = useCallback((amount: number, unit: CustomDurationUnit) => {
+    setCustomDurationAmount(amount)
+    setCustomDurationUnit(unit)
+    setDurationTouched(true)
+  }, [])
+
   const resolveExpiry = (): string | null => {
+    if (durationId === CUSTOM_DURATION_OPTION_ID) {
+      return customDurationToDate(customDurationAmount, customDurationUnit)?.toISOString() ?? null
+    }
     if (durationId === CUSTOM_OPTION_ID) {
       const when = parseLocalDateTime(customDate, customTime)
       return when ? when.toISOString() : null
@@ -147,6 +196,10 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
     if (!contentful) return
     // A "Custom" choice with an unparseable date/time must not silently fall
     // back to an indefinite status — abort and prompt for a valid time.
+    if (durationId === CUSTOM_DURATION_OPTION_ID && resolveExpiry() === null) {
+      toast.error("Pick a custom duration")
+      return
+    }
     if (durationId === CUSTOM_OPTION_ID && resolveExpiry() === null) {
       toast.error("Pick a valid custom date and time")
       return
@@ -175,13 +228,21 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
       return
     }
     const option = durationId === CUSTOM_OPTION_ID ? null : STATUS_DURATION_OPTIONS.find((o) => o.id === durationId)
+    const defaultDuration =
+      durationId === CUSTOM_DURATION_OPTION_ID
+        ? customStatusDuration(customDurationAmount, customDurationUnit)
+        : (option?.duration ?? null)
+    if (durationId === CUSTOM_DURATION_OPTION_ID && !defaultDuration) {
+      toast.error("Pick a custom duration")
+      return
+    }
     const preset: StatusPreset = {
       id: `${NEW_PRESET_ID_PREFIX}${crypto.randomUUID()}`,
       emoji,
       text: text.trim() || null,
       // Custom absolute times don't translate to a reusable preset duration, so
       // a preset saved from a custom time is indefinite.
-      defaultDuration: option?.duration ?? null,
+      defaultDuration,
       pausesNotifications,
     }
     try {
@@ -301,9 +362,26 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
                     {option.label}
                   </SelectItem>
                 ))}
-                <SelectItem value={CUSTOM_OPTION_ID}>Custom…</SelectItem>
+                <SelectItem value={CUSTOM_DURATION_OPTION_ID}>Custom duration…</SelectItem>
+                <SelectItem value={CUSTOM_OPTION_ID}>Custom time…</SelectItem>
               </SelectContent>
             </Select>
+            {durationId === CUSTOM_DURATION_OPTION_ID && (
+              <CustomDurationPicker
+                key={customDurationSeedKey}
+                onSubmit={() => {
+                  void handleSet()
+                }}
+                disabled={busy}
+                submitLabel="Set status"
+                initialAmount={customDurationAmount}
+                initialUnit={customDurationUnit}
+                onDurationChange={handleCustomDurationChange}
+                className="px-0"
+                controlClassName="h-11"
+                buttonClassName="h-11"
+              />
+            )}
             {durationId === CUSTOM_OPTION_ID && (
               <DateTimeField
                 date={customDate}

--- a/apps/frontend/src/components/status/status-picker.tsx
+++ b/apps/frontend/src/components/status/status-picker.tsx
@@ -372,14 +372,13 @@ export function StatusPicker({ workspaceId, open, onOpenChange }: StatusPickerPr
                 onSubmit={() => {
                   void handleSet()
                 }}
+                showSubmit={false}
                 disabled={busy}
-                submitLabel="Set status"
                 initialAmount={customDurationAmount}
                 initialUnit={customDurationUnit}
                 onDurationChange={handleCustomDurationChange}
                 className="px-0"
                 controlClassName="h-11"
-                buttonClassName="h-11"
               />
             )}
             {durationId === CUSTOM_OPTION_ID && (

--- a/apps/frontend/src/components/status/status-picker.tsx
+++ b/apps/frontend/src/components/status/status-picker.tsx
@@ -63,8 +63,12 @@ function customDurationState(duration: StatusPreset["defaultDuration"]): { amoun
 }
 
 function customStatusDuration(amount: number, unit: CustomDurationUnit): StatusPreset["defaultDuration"] {
-  if (!Number.isFinite(amount) || amount <= 0) return null
-  return { kind: "duration", minutes: unit === "hours" ? amount * 60 : amount }
+  const minutes = unit === "hours" ? amount * 60 : amount
+  // Reject anything that can't produce a valid expiry (overflow/non-finite),
+  // mirroring the customDurationToDate guard the set-status path already uses —
+  // otherwise a huge hours value persists an unusable preset duration.
+  if (!Number.isFinite(minutes) || minutes <= 0 || !customDurationToDate(amount, unit)) return null
+  return { kind: "duration", minutes }
 }
 
 /** Human label for a preset's default duration, shown beside it in the list. */

--- a/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
+++ b/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react"
-import { Bell, BellOff, Calendar as CalendarIcon, ChevronLeft } from "lucide-react"
+import { Bell, BellOff, Calendar as CalendarIcon, ChevronLeft, Clock } from "lucide-react"
 import { toast } from "sonner"
 import type { SavedMessageView } from "@threa/types"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
@@ -53,6 +53,7 @@ export function ReminderPickerSheet({
   const saveMutation = useSaveMessage(workspaceId)
   const updateMutation = useUpdateSaved(workspaceId)
   const [mode, setMode] = useState<"presets" | "custom">("presets")
+  const [durationOpen, setDurationOpen] = useState(false)
   const [customDate, setCustomDate] = useState("")
   const [customTime, setCustomTime] = useState("")
 
@@ -62,6 +63,7 @@ export function ReminderPickerSheet({
   const minDate = useMemo(() => toDateInputValue(new Date()), [open, mode])
 
   const openCustom = () => {
+    setDurationOpen(false)
     // If a reminder is already set, pre-populate with that; otherwise default
     // to now + 15 minutes so the picker opens on a sensible seed.
     const baseline = saved?.remindAt ? new Date(saved.remindAt) : new Date(Date.now() + 15 * 60_000)
@@ -72,6 +74,7 @@ export function ReminderPickerSheet({
 
   const resetAndClose = () => {
     setMode("presets")
+    setDurationOpen(false)
     setCustomDate("")
     setCustomTime("")
     onOpenChange(false)
@@ -115,6 +118,7 @@ export function ReminderPickerSheet({
     if (!nextOpen) {
       // Reset mode when drawer closes so the next open starts on the preset list.
       setMode("presets")
+      setDurationOpen(false)
       setCustomDate("")
       setCustomTime("")
     }
@@ -156,14 +160,20 @@ export function ReminderPickerSheet({
                   {preset.label}
                 </SheetMenuButton>
               ))}
-              <CustomDurationPicker
-                onSubmit={setReminder}
-                disabled={saveMutation.isPending || updateMutation.isPending}
-                submitLabel="Set reminder"
-                className="flex-wrap px-3 py-1.5"
-                controlClassName="h-11"
-                buttonClassName="h-11"
-              />
+              <SheetMenuButton onClick={() => setDurationOpen((prev) => !prev)}>
+                <Clock className="h-4 w-4 text-muted-foreground" />
+                Custom duration…
+              </SheetMenuButton>
+              {durationOpen && (
+                <CustomDurationPicker
+                  onSubmit={setReminder}
+                  disabled={saveMutation.isPending || updateMutation.isPending}
+                  submitLabel="Set reminder"
+                  className="flex-wrap px-3 py-1.5"
+                  controlClassName="h-11"
+                  buttonClassName="h-11"
+                />
+              )}
               <SheetMenuButton onClick={openCustom}>
                 <CalendarIcon className="h-4 w-4 text-muted-foreground" />
                 Pick a time…

--- a/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
+++ b/apps/frontend/src/components/timeline/reminder-picker-sheet.tsx
@@ -10,6 +10,7 @@ import { ReminderBadge } from "@/components/saved/reminder-badge"
 import { REMINDER_PRESETS, computeRemindAt } from "@/lib/reminder-presets"
 import { useEffectiveWorkSchedule } from "@/hooks/use-work-schedule"
 import { DateTimeField } from "@/components/forms/date-time-field"
+import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 import { parseLocalDateTime, toDateInputValue, toTimeInputValue } from "@/lib/dates"
 
 interface ReminderPickerSheetProps {
@@ -122,7 +123,7 @@ export function ReminderPickerSheet({
 
   return (
     <Drawer open={open} onOpenChange={handleOpenChange}>
-      <DrawerContent className="max-h-[85vh]">
+      <DrawerContent className="max-h-[85dvh] overflow-y-auto">
         <div className="flex flex-col px-5 pt-3 pb-6 pb-safe">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
@@ -155,6 +156,14 @@ export function ReminderPickerSheet({
                   {preset.label}
                 </SheetMenuButton>
               ))}
+              <CustomDurationPicker
+                onSubmit={setReminder}
+                disabled={saveMutation.isPending || updateMutation.isPending}
+                submitLabel="Set reminder"
+                className="flex-wrap px-3 py-1.5"
+                controlClassName="h-11"
+                buttonClassName="h-11"
+              />
               <SheetMenuButton onClick={openCustom}>
                 <CalendarIcon className="h-4 w-4 text-muted-foreground" />
                 Pick a time…

--- a/apps/frontend/src/components/timeline/reminder-popover-content.tsx
+++ b/apps/frontend/src/components/timeline/reminder-popover-content.tsx
@@ -29,6 +29,7 @@ export function ReminderPopoverContent({ workspaceId, messageId, conversationId,
   const updateMutation = useUpdateSaved(workspaceId)
   const deleteMutation = useDeleteSaved(workspaceId)
   const [customOpen, setCustomOpen] = useState(false)
+  const [durationOpen, setDurationOpen] = useState(false)
   const [customDateTime, setCustomDateTime] = useState("")
   // Grey out past times in the native picker. Computed once per open so the
   // boundary doesn't jitter as the minute rolls over mid-interaction; the
@@ -40,11 +41,17 @@ export function ReminderPopoverContent({ workspaceId, messageId, conversationId,
       setCustomOpen(false)
       return
     }
+    setDurationOpen(false)
     // Seed with the existing reminder when present, otherwise now + 15 minutes
     // — matches the mobile sheet so both entry points feel identical.
     const baseline = saved?.remindAt ? new Date(saved.remindAt) : new Date(Date.now() + 15 * 60_000)
     setCustomDateTime(toDateTimeLocal(baseline))
     setCustomOpen(true)
+  }
+
+  const toggleDuration = () => {
+    setCustomOpen(false)
+    setDurationOpen((prev) => !prev)
   }
 
   const setReminder = (date: Date | null) => {
@@ -123,11 +130,17 @@ export function ReminderPopoverContent({ workspaceId, messageId, conversationId,
             {preset.label}
           </PopoverMenuButton>
         ))}
-        <CustomDurationPicker
-          onSubmit={setReminder}
-          disabled={saveMutation.isPending || updateMutation.isPending}
-          submitLabel="Set reminder"
-        />
+        <PopoverMenuButton onClick={toggleDuration}>
+          <Clock className="h-3.5 w-3.5" />
+          Custom duration…
+        </PopoverMenuButton>
+        {durationOpen && (
+          <CustomDurationPicker
+            onSubmit={setReminder}
+            disabled={saveMutation.isPending || updateMutation.isPending}
+            submitLabel="Set reminder"
+          />
+        )}
         <PopoverMenuButton onClick={openCustom}>
           <Bell className="h-3.5 w-3.5" />
           Pick a time…

--- a/apps/frontend/src/components/timeline/reminder-popover-content.tsx
+++ b/apps/frontend/src/components/timeline/reminder-popover-content.tsx
@@ -8,6 +8,7 @@ import { useSaveMessage, useUpdateSaved, useDeleteSaved } from "@/hooks/use-save
 import { ReminderBadge } from "@/components/saved/reminder-badge"
 import { REMINDER_PRESETS, computeRemindAt } from "@/lib/reminder-presets"
 import { useEffectiveWorkSchedule } from "@/hooks/use-work-schedule"
+import { CustomDurationPicker } from "@/components/scheduling/custom-duration-picker"
 
 interface ReminderPopoverContentProps {
   workspaceId: string
@@ -122,6 +123,11 @@ export function ReminderPopoverContent({ workspaceId, messageId, conversationId,
             {preset.label}
           </PopoverMenuButton>
         ))}
+        <CustomDurationPicker
+          onSubmit={setReminder}
+          disabled={saveMutation.isPending || updateMutation.isPending}
+          submitLabel="Set reminder"
+        />
         <PopoverMenuButton onClick={openCustom}>
           <Bell className="h-3.5 w-3.5" />
           Pick a time…

--- a/apps/frontend/src/hooks/use-notification-pause-controls.ts
+++ b/apps/frontend/src/hooks/use-notification-pause-controls.ts
@@ -14,6 +14,8 @@ export interface NotificationPauseControls {
   busy: boolean
   /** Pause for a preset option (a relative/calendar duration, or `null` for indefinite). */
   pauseFor: (option: NotificationPauseOption) => void
+  /** Pause until a concrete date; returns false (and toasts) when the time is invalid or past. */
+  pauseUntilDate: (date: Date) => boolean
   /** Pause until a specific local date/time; returns false (and toasts) when the time is invalid or past. */
   pauseUntilLocal: (date: string, time: string) => boolean
   /** Resume notifications, clearing the manual pause. */
@@ -51,14 +53,18 @@ export function useNotificationPauseControls(workspaceId: string, onDone?: () =>
     void pauseUntil(option.duration ? statusDurationToExpiry(option.duration, timezone, schedule) : null)
   }
 
-  const pauseUntilLocal = (date: string, time: string): boolean => {
-    const when = parseLocalDateTime(date, time)
-    if (!when || when.getTime() <= Date.now()) {
+  const pauseUntilDate = (date: Date): boolean => {
+    if (Number.isNaN(date.getTime()) || date.getTime() <= Date.now()) {
       toast.error("Pick a time in the future")
       return false
     }
-    void pauseUntil(when.toISOString())
+    void pauseUntil(date.toISOString())
     return true
+  }
+
+  const pauseUntilLocal = (date: string, time: string): boolean => {
+    const when = parseLocalDateTime(date, time)
+    return when ? pauseUntilDate(when) : pauseUntilDate(new Date(Number.NaN))
   }
 
   const handleResume = async () => {
@@ -70,5 +76,5 @@ export function useNotificationPauseControls(workspaceId: string, onDone?: () =>
     }
   }
 
-  return { active, statusOnly, busy, pauseFor, pauseUntilLocal, resume: handleResume }
+  return { active, statusOnly, busy, pauseFor, pauseUntilDate, pauseUntilLocal, resume: handleResume }
 }


### PR DESCRIPTION
## Problem

Scheduling surfaces only offered fixed presets plus absolute date/time picking. A user wanting "30 minutes" or "2 hours" had to either choose a nearby preset or open the full time picker.

The affected surfaces shared the same scheduling concept but not one UI primitive: scheduled sends, saved-message reminders, notification pauses, and status expiry each had their own picker chrome.

## Solution

Add one minutes/hours duration picker and mount it inline before the absolute time picker on each scheduling surface.

### How it works

1. `CustomDurationPicker` in `apps/frontend/src/components/scheduling/custom-duration-picker.tsx` owns the numeric field, minutes/hours select, submit button, and `customDurationToDate` conversion.
2. Scheduled sends call `onSchedule(date)` from the inline duration row, then close/reset the existing popover state.
3. Reminder popover and mobile reminder drawer call the existing `setReminder(date)` path, so save/update behavior stays unchanged.
4. Notification pause dialog/settings call the new `pauseUntilDate(date)` helper in `useNotificationPauseControls`, sharing validation and mutation handling with `pauseUntilLocal`.
5. Status expiry adds a `Custom duration…` clear-after option; the user picks a minutes/hours duration, then applies the status through the existing `setStatus` mutation.

### Key design decisions

**1. Minutes/hours only** — Days are deliberately excluded per the user ruling. The picker exposes only `minutes` and `hours`.

**2. Shared UI primitive, surface-owned submit behavior** — `CustomDurationPicker` returns a `Date`; each surface decides whether that means schedule, save reminder, pause notifications, or set status expiry. This avoids duplicating duration math while preserving each surface's existing mutation/error behavior.

**3. Keep absolute time picking** — The inline duration row sits before `Pick a time…` / `Until a specific time…`. Absolute date/time flows stay available and unchanged.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/scheduling/custom-duration-picker.tsx` | Shared inline duration picker and duration-to-Date helper. |
| `apps/frontend/src/components/scheduling/custom-duration-picker.test.ts` | Unit coverage for minutes/hours conversion and invalid values. |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/composer/scheduled-messages-picker.tsx` | Adds inline custom duration before `Pick a time…`. |
| `apps/frontend/src/components/composer/scheduled-messages-picker.test.tsx` | Verifies scheduled sends accept the inline duration row. |
| `apps/frontend/src/components/timeline/reminder-popover-content.tsx` | Adds duration row to desktop reminders. |
| `apps/frontend/src/components/timeline/reminder-picker-sheet.tsx` | Adds duration row to mobile reminder drawer. |
| `apps/frontend/src/components/notifications/pause-notifications-dialog.tsx` | Adds duration row to pause-notifications dialog. |
| `apps/frontend/src/components/settings/notifications-settings.tsx` | Adds duration row to notification settings pause menu. |
| `apps/frontend/src/components/status/status-picker.tsx` | Adds `Custom duration…` status expiry option. |
| `apps/frontend/src/hooks/use-notification-pause-controls.ts` | Adds `pauseUntilDate` shared by notification pause surfaces. |
| `apps/frontend/src/components/trace/trace-dialog.test.tsx` | Updates command dispatch mock for the current `DispatchCommandResponse` contract; this unblocked repo typecheck after rebasing on `origin/main`. |

## Out of scope

- No days unit.
- No natural-language parsing like `30m` or `2h` in a single text field.
- No backend/API changes; all touched flows already accept absolute timestamps.

## Test plan

- [x] `bun run --cwd apps/frontend test:watch --run src/components/scheduling/custom-duration-picker.test.ts src/components/composer/scheduled-messages-picker.test.tsx src/hooks/use-notification-pause-controls.test.ts src/components/trace/trace-dialog.test.tsx` — 16 pass.
- [x] `bun run typecheck` — all workspaces clean.
- [x] Commit hooks on amend: repo lint, Dockerfile workspace check, migration check, typecheck, OpenAPI check all passed.
- [ ] `claude -p "/code-review"` — first attempt timed out at 300s before PR creation; rerunning after PR creation.

<details>
<summary>📋 Full implementation plan</summary>

Goal: Add an inline custom duration field wherever users schedule or pause something.

What was built:
- Shared `CustomDurationPicker` with default `30`, unit select for `minutes`/`hours`, and submit action.
- Scheduled send picker support on desktop composer popover.
- Reminder support on desktop popover and mobile drawer.
- Notification pause support in sidebar dialog and settings dropdown.
- Status clear-after support via a new `Custom duration…` option.

Design decisions:
- Keep duration parsing explicit: numeric input plus unit select, not natural-language parsing.
- Exclude days for now.
- Return absolute `Date` from the shared picker so existing mutation paths remain unchanged.

Schema changes: none.

Not included:
- Days / working-day semantics.
- Backend changes.
- Keyboard-only freeform strings like `30m`.

Status: implemented, committed, verified.
</details>

---

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785876846&installation_id=129946197&pr_number=1205&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1205&signature=9012b2a5462e5a9a319dc9caf5eef2ff825b311924b2b95a630cc2fb3a08ca8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->