### PR TITLE
feat(mobile): name-first stream topbar — everything else colocates in a stream sheet

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
+++ b/apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx
@@ -357,27 +357,31 @@ export function SidebarActionDrawer({
         <DrawerTitle className="sr-only">{title}</DrawerTitle>
         <DrawerDescription className="sr-only">{description}</DrawerDescription>
 
-        {streamName && (
-          <div className="px-4 pt-2 pb-1">
-            <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
-          </div>
-        )}
+        {/* min-h-0 so a tall header + action list scrolls within the 85dvh cap
+            instead of overflowing past the sheet's bottom edge. */}
+        <div className="min-h-0 overflow-y-auto">
+          {streamName && (
+            <div className="px-4 pt-2 pb-1">
+              <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
+            </div>
+          )}
 
-        {resolvedHeader}
+          {resolvedHeader}
 
-        {actions.length > 0 && (
-          <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
-            {actions.map((action) => (
-              <SidebarActionDrawerEntry
-                key={action.id}
-                action={action}
-                onClose={() => {
-                  onOpenChange(false)
-                }}
-              />
-            ))}
-          </div>
-        )}
+          {actions.length > 0 && (
+            <div className="px-2 pb-[max(12px,env(safe-area-inset-bottom))]">
+              {actions.map((action) => (
+                <SidebarActionDrawerEntry
+                  key={action.id}
+                  action={action}
+                  onClose={() => {
+                    onOpenChange(false)
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </DrawerContent>
     </Drawer>
   )

--- a/apps/frontend/src/components/stream-sheet.test.tsx
+++ b/apps/frontend/src/components/stream-sheet.test.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { Settings } from "lucide-react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { CompanionModes, StreamTypes } from "@threa/types"
+import { render, screen, spyOnExport, userEvent } from "@/test"
+import { StreamSheet } from "./stream-sheet"
+import type { SidebarActionItem } from "@/components/layout/sidebar/sidebar-actions"
+import type { VirtualStream } from "@/hooks/use-stream-or-draft"
+import * as drawerModule from "@/components/ui/drawer"
+import * as hooksModule from "@/hooks"
+import * as useStreamsModule from "@/hooks/use-streams"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as activeBotPresenceModule from "@/hooks/use-active-bot-presence"
+
+// The sheet is the mobile home for everything the phone-width topbar can't
+// keep inline. The contract under test: the full name and stream type are
+// always shown, a scratchpad colocates the agent settings (companion mode)
+// with the action list, a non-scratchpad doesn't, and action rows close the
+// sheet before running.
+
+function makeStream(overrides: Partial<VirtualStream> = {}): VirtualStream {
+  return {
+    id: "stream_1",
+    workspaceId: "ws_1",
+    type: StreamTypes.SCRATCHPAD,
+    slug: null,
+    displayName: "Big plans",
+    companionMode: CompanionModes.ON,
+    isDraft: false,
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    archivedAt: null,
+    ...overrides,
+  } as VirtualStream
+}
+
+const updateCompanionMode = vi.fn()
+
+function arrange({
+  stream = makeStream(),
+  actions = [],
+  onOpenChange = vi.fn(),
+}: {
+  stream?: VirtualStream
+  actions?: SidebarActionItem[]
+  onOpenChange?: (open: boolean) => void
+} = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <StreamSheet
+        open
+        onOpenChange={onOpenChange}
+        workspaceId="ws_1"
+        streamId={stream.id}
+        stream={stream}
+        streamName={stream.displayName ?? "Stream"}
+        actions={actions}
+      />
+    </QueryClientProvider>
+  )
+  return { onOpenChange }
+}
+
+describe("StreamSheet", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    updateCompanionMode.mockReset()
+
+    spyOnExport(drawerModule, "Drawer").mockReturnValue((({
+      open,
+      children,
+    }: {
+      open: boolean
+      children: ReactNode
+    }) => (
+      <div data-state={open ? "open" : "closed"}>{open ? children : null}</div>
+    )) as unknown as typeof drawerModule.Drawer)
+    spyOnExport(drawerModule, "DrawerContent").mockReturnValue((({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    )) as unknown as typeof drawerModule.DrawerContent)
+    spyOnExport(drawerModule, "DrawerTitle").mockReturnValue((({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    )) as unknown as typeof drawerModule.DrawerTitle)
+    spyOnExport(drawerModule, "DrawerDescription").mockReturnValue((({ children }: { children: ReactNode }) => (
+      <div>{children}</div>
+    )) as unknown as typeof drawerModule.DrawerDescription)
+
+    vi.spyOn(hooksModule, "useResourceLabelAssignments").mockReturnValue({ labels: [] } as unknown as ReturnType<
+      typeof hooksModule.useResourceLabelAssignments
+    >)
+    vi.spyOn(useStreamsModule, "useUpdateCompanionMode").mockReturnValue({
+      mutateAsync: updateCompanionMode,
+      isPending: false,
+    } as unknown as ReturnType<typeof useStreamsModule.useUpdateCompanionMode>)
+    vi.spyOn(useStreamsModule, "useUpdateToolPolicy").mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useStreamsModule.useUpdateToolPolicy>)
+    vi.spyOn(useWorkspacesModule, "useCurrentWorkspaceUser").mockReturnValue({ id: "usr_1" } as unknown as ReturnType<
+      typeof useWorkspacesModule.useCurrentWorkspaceUser
+    >)
+    vi.spyOn(activeBotPresenceModule, "useActiveBotPresence").mockReturnValue(null)
+  })
+
+  it("colocates the full name, type, and companion-mode settings for a scratchpad", async () => {
+    arrange()
+
+    expect(screen.getByText("Big plans")).toBeInTheDocument()
+    expect(screen.getByText("Scratchpad")).toBeInTheDocument()
+
+    // The agent settings the desktop pill hides behind a popover are inline.
+    const quiet = screen.getByRole("radio", { name: "Quiet" })
+    expect(screen.getByRole("radio", { name: "Companion" })).toBeChecked()
+    await userEvent.click(quiet)
+    expect(updateCompanionMode).toHaveBeenCalledWith(CompanionModes.OFF)
+  })
+
+  it("shows no agent section for a channel and surfaces the archived state", () => {
+    arrange({
+      stream: makeStream({
+        type: StreamTypes.CHANNEL,
+        slug: "general",
+        displayName: "#general",
+        archivedAt: "2026-07-01T00:00:00Z",
+      }),
+    })
+
+    expect(screen.getByText("Channel")).toBeInTheDocument()
+    expect(screen.getByText("Archived")).toBeInTheDocument()
+    expect(screen.queryByRole("radio", { name: "Companion" })).not.toBeInTheDocument()
+  })
+
+  it("closes the sheet and runs the selected action", async () => {
+    const onSelect = vi.fn()
+    const { onOpenChange } = arrange({
+      actions: [{ id: "stream-settings", label: "Settings", icon: Settings, onSelect }],
+    })
+
+    await userEvent.click(screen.getByRole("button", { name: "Settings" }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(onSelect).toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/stream-sheet.tsx
+++ b/apps/frontend/src/components/stream-sheet.tsx
@@ -1,0 +1,88 @@
+import { ArchiveX } from "lucide-react"
+import { LabelableResourceTypes, StreamTypes } from "@threa/types"
+import { Badge } from "@/components/ui/badge"
+import { SidebarActionDrawer, type SidebarActionItem } from "@/components/layout/sidebar/sidebar-actions"
+import { LiveAgentSettings } from "@/components/stream-settings/live-agent-settings"
+import { InviteActorButton, InviteBotButton } from "@/components/encryption"
+import { StreamHeaderEncryptionAction } from "@/components/encryption/stream-encryption-affordance"
+import { LabelStack } from "@/components/labels/label-stack"
+import { getStreamTypeLabel } from "@/lib/streams"
+import type { VirtualStream } from "@/hooks/use-stream-or-draft"
+
+interface StreamSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  workspaceId: string
+  streamId: string
+  /** Persisted stream only — drafts keep the inline header affordances. */
+  stream: VirtualStream
+  streamName: string
+  actions: SidebarActionItem[]
+}
+
+/**
+ * Mobile bottom sheet for the stream topbar: the single home for everything a
+ * phone-width header can't afford to keep inline — the full name (wraps, never
+ * truncates), type/archived/labels, the agent settings the header pill's
+ * popover holds on desktop (companion mode, tool access, external-agent
+ * status), invite + encryption affordances, and the action list.
+ */
+export function StreamSheet({
+  open,
+  onOpenChange,
+  workspaceId,
+  streamId,
+  stream,
+  streamName,
+  actions,
+}: StreamSheetProps) {
+  const isScratchpad = stream.type === StreamTypes.SCRATCHPAD
+  const isEncrypted = !!stream.e2eEnabled
+  const isArchived = stream.archivedAt != null
+
+  const header = (
+    <div className="flex flex-col gap-3 px-4 pt-2 pb-3">
+      <div>
+        <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-muted-foreground">{getStreamTypeLabel(stream.type)}</span>
+          {isArchived && (
+            <Badge variant="secondary" className="gap-1">
+              <ArchiveX className="h-3 w-3" />
+              Archived
+            </Badge>
+          )}
+          <LabelStack workspaceId={workspaceId} resourceType={LabelableResourceTypes.STREAM} resourceId={streamId} />
+        </div>
+      </div>
+      {isScratchpad && (
+        <div className="rounded-xl bg-muted/40 p-3">
+          <LiveAgentSettings
+            workspaceId={workspaceId}
+            streamId={streamId}
+            companionMode={stream.companionMode}
+            e2e={isEncrypted}
+          />
+          {isEncrypted && (
+            <div className="mt-4 flex flex-wrap items-center gap-2 border-t pt-3">
+              <InviteActorButton workspaceId={workspaceId} stream={stream} kind="enclave" />
+              <InviteBotButton workspaceId={workspaceId} stream={stream} />
+              <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <SidebarActionDrawer
+      open={open}
+      onOpenChange={onOpenChange}
+      actions={actions}
+      title="Stream details and actions"
+      description="Stream details, agent settings, and actions."
+      header={header}
+    />
+  )
+}

--- a/apps/frontend/src/lib/streams.ts
+++ b/apps/frontend/src/lib/streams.ts
@@ -16,6 +16,22 @@ export const STREAM_ICONS: Record<StreamType, ComponentType<{ className?: string
   [StreamTypes.SYSTEM]: Bell,
 }
 
+/** Human-readable label for a stream type ("Scratchpad", "Channel", …). */
+export function getStreamTypeLabel(type: StreamType): string {
+  switch (type) {
+    case StreamTypes.SCRATCHPAD:
+      return "Scratchpad"
+    case StreamTypes.CHANNEL:
+      return "Channel"
+    case StreamTypes.DM:
+      return "DM"
+    case StreamTypes.THREAD:
+      return "Thread"
+    default:
+      return type
+  }
+}
+
 /**
  * Returns the resolved display name for a stream, or null if the stream
  * has no name yet (draft scratchpad, new thread, etc.).

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -19,6 +19,7 @@ import {
   Layers,
   PanelRight,
   ChevronDown,
+  UserRound,
 } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { DraftAgentSettings } from "@/components/stream-settings/draft-agent-settings"
@@ -27,11 +28,7 @@ import { Button } from "@/components/ui/button"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
-import {
-  SidebarActionDrawer,
-  SidebarActionMenu,
-  type SidebarActionItem,
-} from "@/components/layout/sidebar/sidebar-actions"
+import { SidebarActionMenu, type SidebarActionItem } from "@/components/layout/sidebar/sidebar-actions"
 import { cn } from "@/lib/utils"
 import {
   useStreamOrDraft,
@@ -62,28 +59,14 @@ import { useInputMode } from "@/hooks/use-input-mode"
 import { ConversationList } from "@/components/conversations"
 import { StreamErrorView } from "@/components/stream-error-view"
 import { InviteActorButton, InviteBotButton } from "@/components/encryption"
-import { BotRuntimeStatuses, CompanionModes, LabelableResourceTypes, StreamTypes, type StreamType } from "@threa/types"
-import { getStreamName, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { BotRuntimeStatuses, CompanionModes, LabelableResourceTypes, StreamTypes } from "@threa/types"
+import { getStreamName, getStreamTypeLabel, streamFallbackLabel, streamLabel } from "@/lib/streams"
+import { StreamSheet } from "@/components/stream-sheet"
 import { StreamContextSurface, StreamContextGallery, useStreamGallery } from "@/components/stream-context"
 import { memoDeepLink } from "@/lib/memo-url"
 import { copyStreamLink } from "@/lib/stream-links"
 import { setPageStreamName } from "@/lib/page-title"
 import { dispatchStartBatchSelect } from "@/lib/batch-selection-events"
-
-function getStreamTypeLabel(type: StreamType): string {
-  switch (type) {
-    case StreamTypes.SCRATCHPAD:
-      return "Scratchpad"
-    case StreamTypes.CHANNEL:
-      return "Channel"
-    case StreamTypes.DM:
-      return "DM"
-    case StreamTypes.THREAD:
-      return "Thread"
-    default:
-      return type
-  }
-}
 
 export function StreamPage() {
   const { workspaceId, streamId } = useParams<{ workspaceId: string; streamId: string }>()
@@ -407,6 +390,44 @@ export function StreamPage() {
     )
   }
 
+  // Mobile stream sheet: view surfaces that are inline header icons on desktop
+  // (context panel, conversation views, DM profile) become sheet rows.
+  const sheetViewActions: SidebarActionItem[] = []
+  if (isMobile) {
+    if (isDm && dmPeerUserId) {
+      sheetViewActions.push({
+        id: "view-profile",
+        label: "View profile",
+        icon: UserRound,
+        onSelect: () => openUserProfile(dmPeerUserId),
+      })
+    }
+    if (!isThread) {
+      sheetViewActions.push({
+        id: "stream-context",
+        label: "In this stream",
+        description: "Links, files & memories",
+        icon: PanelRight,
+        onSelect: () => setContextOpen(true),
+      })
+    }
+    if (isChannel || isDm) {
+      sheetViewActions.push({
+        id: "conversation-overlay",
+        label: "Conversation overlay",
+        description: isConversationOverlayOn ? "On — tap to turn off" : null,
+        icon: Layers,
+        onSelect: () => setConversationOverlayOn(!isConversationOverlayOn),
+      })
+      sheetViewActions.push({
+        id: "conversations-list",
+        label: "Conversations list",
+        icon: MessageCircle,
+        onSelect: () => setConversationViewOpen(true),
+      })
+    }
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
       handleSaveRename()
@@ -431,14 +452,18 @@ export function StreamPage() {
   // server-persisted on creation, with no displayName until the user names
   // them, which is exactly why we render the pill on unnamed scratchpads too:
   // for encrypted ones the lock IS the only signal of their nature.)
+  const externalConnected =
+    activeBotPresence?.presence?.status === BotRuntimeStatuses.AVAILABLE ||
+    activeBotPresence?.presence?.status === BotRuntimeStatuses.BUSY
+
+  // On mobile the pill's content lives in the stream sheet instead — the bar
+  // keeps only a tiny state glyph beside the name. Drafts keep the pill (the
+  // sheet reads live caches that have no draft entries).
   let companionModeIndicator: React.ReactNode = null
-  if (stream && isScratchpad) {
+  if (stream && isScratchpad && (!isMobile || isDraft)) {
     const isEncrypted = !!stream.e2eEnabled
     const isExternal = !isEncrypted && !!activeBotPresence
     const isOn = !isEncrypted && !isExternal && stream.companionMode === CompanionModes.ON
-    const externalConnected =
-      activeBotPresence?.presence?.status === BotRuntimeStatuses.AVAILABLE ||
-      activeBotPresence?.presence?.status === BotRuntimeStatuses.BUSY
 
     let leadingVisual: React.ReactNode
     let modeLabel: string
@@ -539,6 +564,10 @@ export function StreamPage() {
     )
   }
 
+  // Same eligibility as the ⋯ trigger: persisted streams only, and archived
+  // non-scratchpads have no actions to offer.
+  const canOpenSheet = !!stream && !isDraft && !(isArchived && !isScratchpad)
+
   let headerTitle: React.ReactNode
   if (isEditing) {
     headerTitle = (
@@ -555,6 +584,40 @@ export function StreamPage() {
     )
   } else if (isThread && stream) {
     headerTitle = <ThreadHeader workspaceId={workspaceId} stream={stream} />
+  } else if (isMobile && canOpenSheet) {
+    // Mobile: the name is the hero — it takes the full remaining width and IS
+    // the sheet trigger. Live state survives as tiny glyphs beside it (lock =
+    // encrypted, dot = external agent connection, box = archived); their full
+    // affordances live in the sheet. Rename moved into the sheet's action list.
+    headerTitle = (
+      <StreamTitlePreview name={streamName}>
+        <button
+          type="button"
+          onClick={() => setIsMenuDrawerOpen(true)}
+          aria-label={`${streamName} — stream details and actions`}
+          aria-haspopup="dialog"
+          className="-ml-2 flex min-w-0 flex-1 items-center gap-1.5 rounded-md px-2 py-1 text-left transition-colors active:bg-accent/50"
+        >
+          {nameDecrypting && !pendingName ? (
+            <Skeleton className="h-5 w-40" />
+          ) : (
+            <h1 className="min-w-0 truncate font-semibold">{streamName}</h1>
+          )}
+          {isEncryptedScratchpad && <Lock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />}
+          {isScratchpad && !isEncryptedScratchpad && !!activeBotPresence && (
+            <span
+              className={cn(
+                "inline-block size-2 shrink-0 rounded-full",
+                externalConnected ? "bg-emerald-500" : "bg-muted-foreground/40"
+              )}
+              aria-hidden="true"
+            />
+          )}
+          {isArchived && <ArchiveX className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />}
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+        </button>
+      </StreamTitlePreview>
+    )
   } else if (isScratchpad) {
     headerTitle = (
       <StreamTitlePreview name={streamName}>
@@ -609,37 +672,41 @@ export function StreamPage() {
           {/* Chip strip. The chips are non-shrinking (`shrink-0` leaves), so on a
               phone-width header they would otherwise overflow the flex box and
               paint under the search/panel actions — the strip scrolls instead,
-              same recipe as PageHeaderTabs' tab strip. */}
-          <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none">
-            {stream && !isDraft && (
-              <LabelStack
-                workspaceId={workspaceId}
-                resourceType={LabelableResourceTypes.STREAM}
-                resourceId={streamId}
-                className="shrink-0"
-              />
-            )}
-            {isEncryptedScratchpad && !isDraft && (
-              <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
-            )}
-            {stream && isScratchpad && !isDraft && (
-              <>
-                <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
-                <InviteBotButton workspaceId={workspaceId!} stream={stream} />
-              </>
-            )}
-            {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
-              <Badge variant="secondary" className="shrink-0">
-                {getStreamTypeLabel(stream.type)}
-              </Badge>
-            )}
-            {isArchived && (
-              <Badge variant="secondary" className="gap-1 shrink-0">
-                <ArchiveX className="h-3 w-3" />
-                Archived
-              </Badge>
-            )}
-          </div>
+              same recipe as PageHeaderTabs' tab strip. On mobile the chips live
+              in the stream sheet; the strip only renders when there is no sheet
+              to hold them (drafts, archived non-scratchpads). */}
+          {(!isMobile || !canOpenSheet) && (
+            <div className="flex items-center gap-2 min-w-0 overflow-x-auto scrollbar-none">
+              {stream && !isDraft && (
+                <LabelStack
+                  workspaceId={workspaceId}
+                  resourceType={LabelableResourceTypes.STREAM}
+                  resourceId={streamId}
+                  className="shrink-0"
+                />
+              )}
+              {isEncryptedScratchpad && !isDraft && (
+                <StreamHeaderEncryptionAction workspaceId={workspaceId} encrypted streamId={streamId} />
+              )}
+              {stream && isScratchpad && !isDraft && (
+                <>
+                  <InviteActorButton workspaceId={workspaceId!} stream={stream} kind="enclave" />
+                  <InviteBotButton workspaceId={workspaceId!} stream={stream} />
+                </>
+              )}
+              {stream && !isThread && !isScratchpad && !isChannel && !isDraft && (
+                <Badge variant="secondary" className="shrink-0">
+                  {getStreamTypeLabel(stream.type)}
+                </Badge>
+              )}
+              {isArchived && (
+                <Badge variant="secondary" className="gap-1 shrink-0">
+                  <ArchiveX className="h-3 w-3" />
+                  Archived
+                </Badge>
+              )}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-1 ml-1">
           {!isThread && !isDraft && (
@@ -653,7 +720,7 @@ export function StreamPage() {
               <Search className="h-4 w-4" />
             </Button>
           )}
-          {stream && !isThread && !isDraft && (
+          {stream && !isThread && !isDraft && !isMobile && (
             <Button
               variant="ghost"
               size="icon"
@@ -666,7 +733,7 @@ export function StreamPage() {
               <PanelRight className="h-4 w-4" />
             </Button>
           )}
-          {(isChannel || isDm) && (
+          {(isChannel || isDm) && !isMobile && (
             // Split button (the `GroupedItem` pattern from message-context-menu):
             // primary tap toggles the conversation overlay; the chevron lists
             // every conversation view — overlay first (default, font-medium),
@@ -732,20 +799,19 @@ export function StreamPage() {
                 >
                   <MoreHorizontal className="h-4 w-4" />
                 </Button>
-                <SidebarActionDrawer
+                <StreamSheet
                   open={isMenuDrawerOpen}
                   onOpenChange={setIsMenuDrawerOpen}
-                  actions={streamMenuActions}
-                  title="Stream actions"
-                  description="Choose an action for this stream."
-                  header={
-                    <div className="px-4 pt-2 pb-3">
-                      <p className="break-words text-base font-semibold text-foreground">{streamName}</p>
-                      <p className="mt-0.5 text-xs text-muted-foreground">
-                        {stream ? getStreamTypeLabel(stream.type) : "Stream"} actions
-                      </p>
-                    </div>
-                  }
+                  workspaceId={workspaceId}
+                  streamId={streamId}
+                  stream={stream}
+                  streamName={streamName}
+                  actions={[
+                    ...sheetViewActions,
+                    ...streamMenuActions.map((action, i) =>
+                      i === 0 && sheetViewActions.length > 0 ? { ...action, separatorBefore: true } : action
+                    ),
+                  ]}
                 />
               </>
             ) : (


### PR DESCRIPTION
## Problem

On a phone-width header the stream name — the one thing that identifies where you are — was squeezed to a few characters. `pages/stream.tsx` rendered everything inline: the companion/External pill, the chip strip (labels, invite pills, encryption CTA, type/archived badges), then search, the "In this stream" button, the conversation split-button, and the overflow menu. A scratchpad with an external agent showed `CC - t…` while five icons and a pill sat fully visible. The chip strip already scrolled (#1184), but scrolling doesn't give the name its width back.

## Solution

On mobile (`isMobile` = narrow viewport or coarse pointer) the bar keeps four things: sidebar toggle · **name** · search · `⋯`. Everything else colocates in one bottom sheet — the new `StreamSheet` — opened by tapping the name (chevron affordance) or the `⋯` button. Desktop is untouched.

### How it works

1. **The name is the sheet trigger.** A new title branch in `pages/stream.tsx` (mobile + persisted stream only) renders the name as a full-width button with `aria-haspopup="dialog"`. Live state survives as tiny glyphs beside it: `Lock` (encrypted scratchpad), a green/grey presence dot (external agent connected/attached, driven by the same `useActiveBotPresence` + `BotRuntimeStatuses` check as the old pill), and `ArchiveX` (archived). The touch hold-to-preview (`StreamTitlePreview`) still works and swallows its trailing click, so holding to reveal a long name doesn't also open the sheet.
2. **`StreamSheet` (new, `components/stream-sheet.tsx`)** wraps `SidebarActionDrawer` with a rich header: full wrapping name, `getStreamTypeLabel` + archived badge + `LabelStack`, and — for scratchpads — the same `LiveAgentSettings` panel the desktop pill shows in a popover (companion mode, owner-only tool access, `ExternalAgentIndicator`), plus `InviteActorButton`/`InviteBotButton`/`StreamHeaderEncryptionAction` for E2E pads. All existing components, recomposed; no logic forked.
3. **View surfaces become sheet rows.** "In this stream" (`setContextOpen`), conversation overlay/list for channels & DMs (same URL-param setters as the desktop buttons, INV-59 semantics unchanged), and "View profile" for DMs (`openUserProfile`) are prepended to the existing `streamMenuActions` (settings, labels, copy link, move messages, browse files, rename, archive).
4. **Rename moves into the sheet.** Tap-title-to-rename was what ate the header (pencil affordance + tap target). The sheet's existing Rename action closes the drawer and drops into the same inline `Input` editor in the bar.
5. **`SidebarActionDrawer` body scrolls** (`min-h-0 overflow-y-auto`) inside its `max-h-[85dvh]` cap, since the sheet header (agent settings + tool policy) plus ~8 action rows can exceed a short viewport.

### Key design decisions

**1. One sheet, not per-affordance popovers.** The ask was colocation: agent settings, invites, and encryption state live in the same surface as the actions, so "everything about this stream" has one home on mobile. The pill's popover content (`LiveAgentSettings`) renders inline rather than nested a tap deeper.

**2. Drafts keep the old header.** The sheet reads live caches (`streamKeys.bootstrap`, labels, bot presence) that have no draft entries — the same reason the settings dialog is draft-inert. Drafts keep the pill (which writes to the local draft via `DraftAgentSettings`) and tap-to-rename; they have no chips to lose.

**3. Sheet eligibility mirrors the `⋯` trigger** (`canOpenSheet = stream && !isDraft && !(isArchived && !isScratchpad)`). Archived channels/DMs — which never had an action menu — keep the inline chip strip so the archived badge stays visible; everything else moves it into the sheet.

**4. State stays visible as glyphs, not chips.** Encrypted, external-connection, and archived are trust/liveness signals that shouldn't hide behind a tap. A 14px lock, an 8px dot, and a 14px archive icon beside the name carry them at ~1/10th the width of the pills they replace. The locked-state unlock CTA also still reaches the user without the sheet: `ComposerEncryptionNotice` renders the unlock button above the composer independently.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/stream-sheet.tsx` | Mobile bottom sheet: name/type/labels header, inline agent settings + invite/encryption affordances, action list |
| `apps/frontend/src/components/stream-sheet.test.tsx` | Sheet contract: colocation for scratchpads, no agent section for channels, archived surfaced, action rows close-then-run |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/stream.tsx` | Mobile title branch (sheet trigger + state glyphs), `sheetViewActions`, pill/chip-strip/context/conversation buttons gated to desktop, mobile `⋯` drawer replaced with `StreamSheet`, `externalConnected` hoisted |
| `apps/frontend/src/components/layout/sidebar/sidebar-actions.tsx` | Drawer body wrapped in `min-h-0 overflow-y-auto` so tall content scrolls within the 85dvh cap |
| `apps/frontend/src/lib/streams.ts` | `getStreamTypeLabel` moved here from `pages/stream.tsx` for reuse by the sheet |

## Out of scope (deliberate)

- Thread headers on mobile keep `ThreadHeader` (breadcrumb); threads get the sheet via `⋯` only.
- The `InvitedBotsOverflow` "+N" pill inside the sheet opens a nested vaul drawer (3+ invited bots on one E2E pad). Rare path, works, but not converted to `Drawer.NestedRoot`.
- Desktop header layout unchanged by design — no attempt to unify the two into one component.

## Test plan

- [x] `stream-sheet.test.tsx` — 3 pass (colocation, channel/archived, close-then-run)
- [x] Neighbours: `sidebar-actions`, `stream-item`, `invite-bot-button`, `label-*`, `stream-encryption-affordance`, `lib/streams` — 58 pass total
- [x] `tsc --noEmit` (all workspaces) + `eslint` clean (pre-commit hook)
- [x] Live-verified against the real stack at 390×844 (Playwright, touch): title tap → sheet; Quiet toggle mutates live; Rename → inline editor → renamed bar; "In this stream" opens the panel; channel sheet shows conversation rows; desktop at 1440×900 renders identically to before
- [x] Manual claim-verification pass over the diff: desktop paths untouched (all new gating behind `isMobile`), draft/thread/archived-channel edge cases traced, `SidebarActionDrawer`'s five other consumers unaffected by the scroll wrapper (short content ⇒ no scrollbar), no dead imports (eslint)
- [ ] Reviewer-agent pass not completed — both agents were cut off by a session rate limit; relying on the manual pass + CodeRabbit
- [ ] Not verified on a real device (Chrome-Android) — dev-stack Playwright emulation only; the sheet is standard vaul, same as the sidebar long-press drawers

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Make the stream name the hero of the mobile topbar; colocate agent settings (companion mode, tool access, invites, encryption) with stream actions in one surface.

**What was built:** A mobile-only bottom sheet (`StreamSheet`) triggered from the stream name or `⋯`; the bar reduced to toggle · name · search · `⋯`; live state kept as tiny glyphs beside the name; `SidebarActionDrawer` made scrollable.

**Design decisions:** one sheet over nested popovers; drafts excluded (cache-backed components); eligibility mirrors the existing `⋯` condition; trust/liveness state stays always-visible as glyphs; desktop untouched.

**What's NOT included:** thread title-trigger, real-device verification, nested-drawer polish for the invited-bots overflow.

**Status:** complete, live-verified at phone width against the dev stack.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785877156&installation_id=129946197&pr_number=1206&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1206&signature=a9d38495726fdea4286b702a66143f00be0cf248a3ae490e5d215958df19397a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->