### PR TITLE
fix(pi-remote): renew invocation claims on a dedicated timer so long turns don't lose their claim

### DIFF
--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test"
 import { __testing } from "./threa-remote"
 
 describe("Pi remote trace safety", () => {
@@ -839,5 +839,75 @@ describe("buildPersistedConfig", () => {
       {} as never
     )
     expect(result.streamCursors).toBeUndefined()
+  })
+})
+
+describe("claim renewal during a turn", () => {
+  const invocation = {
+    id: "binv_renew_1",
+    activeStreamId: "stream_a",
+    sourceMessageId: "msg_1",
+    promptMarkdown: "do the thing",
+    claimToken: "tok_1",
+    claimedInstanceId: "pi-test-1",
+    claimExpiresAt: null,
+  }
+
+  afterEach(() => {
+    __testing.clearPendingForTesting()
+    __testing.setConfigForTesting(undefined)
+  })
+
+  test("renew interval is comfortably inside the claim TTL", () => {
+    // Two consecutive missed renews must still leave the claim alive — the
+    // regression this guards: renewal riding on the 15-min WS backstop poll
+    // while the server-side claim TTL is 120s (any turn longer than the TTL
+    // lost its claim and the completion 404'd).
+    expect(__testing.CLAIM_RENEW_INTERVAL_MS * 3).toBeLessThanOrEqual(__testing.CLAIM_TTL_SECONDS * 1000)
+    expect(__testing.CLAIM_RENEW_INTERVAL_MS).toBeLessThan(__testing.WS_BACKSTOP_POLL_MS)
+  })
+
+  test("beginPendingInvocation starts the renew timer and clearing the turn stops it", () => {
+    expect(__testing.claimRenewTimerActive()).toBe(false)
+    __testing.beginPendingInvocation(invocation as never)
+    expect(__testing.claimRenewTimerActive()).toBe(true)
+    __testing.clearPendingForTesting()
+    expect(__testing.claimRenewTimerActive()).toBe(false)
+  })
+
+  test("renewActiveClaims posts a renew with the claim TTL for the pending invocation", async () => {
+    __testing.setConfigForTesting({
+      baseUrl: "https://app.threa.io",
+      workspaceId: "ws_123",
+      apiKey: "threa_bk_test",
+    })
+    __testing.beginPendingInvocation(invocation as never)
+    const renews: Array<Record<string, unknown>> = []
+    const fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (
+      input: string | URL | Request,
+      init?: RequestInit
+    ) => {
+      const url = String(input)
+      if (url.endsWith(`/bot-invocations/${invocation.id}/renew`)) {
+        renews.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+        return new Response(JSON.stringify({ data: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch)
+    try {
+      await __testing.renewActiveClaims()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+    expect(renews).toEqual([
+      {
+        instanceId: "pi-test-1",
+        claimToken: "tok_1",
+        claimTtlSeconds: __testing.CLAIM_TTL_SECONDS,
+      },
+    ])
   })
 })

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -55,6 +55,13 @@ const MAX_SEALED_ATTACHMENTS_PER_MESSAGE = 16
 const FETCH_TIMEOUT_MS = 30_000
 const MAX_FAILURE_POLL_MS = 60_000
 const BUSY_HEARTBEAT_MS = 15_000
+const CLAIM_TTL_SECONDS = 120
+// Renew at a third of the lease so a single transient renew failure can't let
+// the claim expire (two misses still leaves a full interval of margin).
+// Mirrors remote-session/src/session.ts. This dedicated timer is what keeps a
+// long turn's claim alive — the claim poll only backstops at 15 min while the
+// socket is up, far past the TTL, so renewal must never ride on it.
+const CLAIM_RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
 // Cadence the safety-backstop poll runs at while a `/bot` WebSocket is up.
 // Pushes deliver new invocations within a frame; the poll is only there to
 // catch the rare missed-emit / mid-flight-disconnect case (plan §5). Every
@@ -239,6 +246,7 @@ let pendingInvocationPrompt: string | undefined
 let pendingRetry: { timer: ReturnType<typeof setTimeout>; retryAt: number; attempts: number } | undefined
 let isWaitingForRetry = false
 let lastTraceHeartbeat: { text: string; at: number } | undefined
+let claimRenewTimer: ReturnType<typeof setInterval> | undefined
 let consecutivePollFailures = 0
 let lastPollFailureSummary: string | undefined
 let lastBusyHeartbeatAt = 0
@@ -1294,7 +1302,7 @@ async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<void
     // The transport doesn't reject (its HTTP fallback swallows); the `.catch` is
     // the safety boundary so a renew can never abort the surrounding claim pass.
     const { notFound } = await transport
-      .renewClaim(invocation.id, invocation.claimToken, 120, getInvocationInstanceId(invocation))
+      .renewClaim(invocation.id, invocation.claimToken, CLAIM_TTL_SECONDS, getInvocationInstanceId(invocation))
       .catch(() => ({ notFound: false }))
     if (notFound) {
       console.error(`[threa-remote] renew ${invocation.id}: claim gone server-side; turn will close on completion`)
@@ -1306,7 +1314,7 @@ async function renewInvocationClaim(invocation: ClaimedInvocation): Promise<void
     body: JSON.stringify({
       instanceId: getInvocationInstanceId(invocation),
       claimToken: invocation.claimToken,
-      claimTtlSeconds: 120,
+      claimTtlSeconds: CLAIM_TTL_SECONDS,
     }),
   }).catch(() => undefined)
 }
@@ -1315,6 +1323,21 @@ async function renewActiveClaims(): Promise<void> {
   if (!pending) return
   await renewInvocationClaim(pending)
   await Promise.all(steeredInvocations.map((item) => renewInvocationClaim(item.invocation)))
+}
+
+function startClaimRenewTimer(): void {
+  if (claimRenewTimer) return
+  claimRenewTimer = setInterval(() => {
+    // Fire-and-forget: renewInvocationClaim already swallows per-call errors,
+    // and a renew failure must never surface as an unhandled rejection.
+    void renewActiveClaims().catch(() => undefined)
+  }, CLAIM_RENEW_INTERVAL_MS)
+}
+
+function stopClaimRenewTimer(): void {
+  if (!claimRenewTimer) return
+  clearInterval(claimRenewTimer)
+  claimRenewTimer = undefined
 }
 
 function isEnabled(ctx: ExtensionContext): boolean {
@@ -1658,7 +1681,7 @@ function buildClaimInvocationPayload(
     instanceId,
     runtimeSessionId,
     supportedCapabilities,
-    claimTtlSeconds: 120,
+    claimTtlSeconds: CLAIM_TTL_SECONDS,
   }
 }
 
@@ -1949,6 +1972,7 @@ async function buildInvocationPrompt(
 
 function beginPendingInvocation(invocation: ClaimedInvocation, cursor?: string): void {
   pending = invocation
+  startClaimRenewTimer()
   pendingContextCursor = cursor
   pendingAssistantTexts = []
   pendingNonAssistantTexts = []
@@ -2388,6 +2412,15 @@ async function handleSessionControlInvocation(
     return
   }
 
+  // Session-control turns run outside `pending`, so the pending-turn renew
+  // timer doesn't cover them; a slow one (/compact of a large session) can
+  // outlive the claim TTL. Renewing an invocation the pending timer also
+  // covers (/skill hands off to a pending turn) is harmless — renew just
+  // extends the expiry again.
+  const renewTimer = setInterval(
+    () => void renewInvocationClaim(invocation).catch(() => undefined),
+    CLAIM_RENEW_INTERVAL_MS
+  )
   try {
     await heartbeat("busy", `Running /${command.name}…`, ctx)
     await recordInvocationTraceStep(
@@ -2428,6 +2461,8 @@ async function handleSessionControlInvocation(
     await failInvocation(invocation, error)
     lastBusyHeartbeatAt = 0
     await heartbeat("available", undefined, ctx).catch(() => undefined)
+  } finally {
+    clearInterval(renewTimer)
   }
 }
 
@@ -3002,6 +3037,7 @@ async function completePending(markdown: string, ctx: ExtensionContext): Promise
   await Promise.all(steered.map((item) => completeInvocationNoResponse(item.invocation)))
   advanceStreamCursor(invocation, ctx, pendingContextCursor)
   for (const item of steered) advanceStreamCursor(item.invocation, ctx, item.cursor)
+  stopClaimRenewTimer()
   pending = undefined
   steeredInvocations = []
   pendingContextCursor = undefined
@@ -3025,6 +3061,7 @@ async function failPending(error: unknown, ctx?: ExtensionContext): Promise<void
   const steered = steeredInvocations
   await failInvocation(invocation, error)
   await Promise.all(steered.map((item) => failInvocation(item.invocation, error)))
+  stopClaimRenewTimer()
   pending = undefined
   steeredInvocations = []
   pendingContextCursor = undefined
@@ -3088,6 +3125,17 @@ export const __testing = {
   MAX_AUTO_RETRY_MS,
   MAX_RETRY_ATTEMPTS,
   WS_BACKSTOP_POLL_MS,
+  CLAIM_TTL_SECONDS,
+  CLAIM_RENEW_INTERVAL_MS,
+  beginPendingInvocation,
+  stopClaimRenewTimer,
+  claimRenewTimerActive: () => claimRenewTimer !== undefined,
+  renewActiveClaims,
+  clearPendingForTesting: () => {
+    stopClaimRenewTimer()
+    pending = undefined
+    steeredInvocations = []
+  },
 }
 
 export default function (pi: ExtensionAPI): void {
@@ -3347,6 +3395,7 @@ export default function (pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (event, ctx) => {
     stopPolling()
+    stopClaimRenewTimer()
     teardownTransport()
     if (event.reason === "reload" && config && isEnabled(ctx)) {
       setRemoteStatus(ctx, "Threa remote: reloading…")


### PR DESCRIPTION
## Problem

Pi sessions "error out without much context" on long turns — reported against gpt-5.5, but the model is incidental (its turns are just long enough to trip it).

PR #1156 slowed the WS-backstop claim poll from 30s to 15 min in both `remote-session` and `pi-remote`. In `pi-remote`, claim renewal only ever ran inside that poll: `renewActiveClaims()` is called solely from `claimIfIdle()`, which fires on poll ticks and invocation pushes. The server-side claim TTL is 120s (`claimTtlSeconds` in `buildClaimInvocationPayload`), so before #1156 the 30s poll kept claims alive incidentally; after it, any turn longer than ~2 minutes loses its claim mid-turn:

- trace steps stop landing (`recordSteps` requires `claim_expires_at > NOW()`), so the trace goes dark;
- the invocation becomes claimable again and gets re-claimed (`attempts` bumps, the prompt is re-injected) or parked once attempts exhaust ("Claim attempts exhausted without completion");
- the eventual completion 404s: `Threa API 404: Not Found — Invocation claim not found [NOT_FOUND]`.

Prod evidence (workspace-scoped, since Jul 3 when #1156 merged): 6 invocations failed with the claim-not-found 404, 4 completed with `attempts = 2` (duplicate turn injections after expiry re-claim), 1 parked at `attempts = 5`. One failure was observed live in a running tmux pane while diagnosing.

The Claude channel was unaffected: the `remote-session` SDK renews on a dedicated `setInterval` at TTL/3 (`RENEW_INTERVAL_MS`, session.ts). `pi-remote` never got that timer.

## Solution

Give `pi-remote` the same dedicated renew timer the SDK has, plus a scoped one for session-control commands.

### How it works

- `CLAIM_TTL_SECONDS = 120` centralizes the TTL (was a magic `120` in three places); `CLAIM_RENEW_INTERVAL_MS = TTL/3` (40s) mirrors `remote-session/src/session.ts` — two consecutive missed renews still leave a full interval of margin.
- `startClaimRenewTimer()` runs `renewActiveClaims()` (pending + steered invocations) every 40s. Started in `beginPendingInvocation`, stopped in `completePending`, `failPending`, and unconditionally in `session_shutdown` (the reload branch returns before `failPending`, so the handler stops it explicitly).
- `handleSessionControlInvocation` gets its own scoped interval cleared in `finally`: session-control turns run outside `pending`, and a slow one (`/compact` of a large session is an AI call) can outlive the TTL too. Double-renewing an invocation the pending timer also covers (`/skill` hands off to a pending turn) is harmless — renew just extends expiry.
- Rate-limit retry waits (up to `MAX_AUTO_RETRY_MS` = 4h) keep `pending` set, so the timer also holds the claim through provider backoff — previously those turns lost their claim the same way.

### Key design decision

**Timer over faster poll.** Reverting the poll cadence would undo #1156's cost fix (the poll is a billed edge-Worker claim per tick; renew is a socket frame via `transport.renewClaim` with HTTP fallback). The SDK already proved the dedicated-timer shape; this brings pi-remote to parity instead of inventing a third mechanism.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/pi-remote/src/threa-remote.ts` | `CLAIM_TTL_SECONDS` / `CLAIM_RENEW_INTERVAL_MS` constants; `startClaimRenewTimer` / `stopClaimRenewTimer` wired into turn lifecycle + `session_shutdown`; scoped renew interval around session-control commands; `__testing` exports for the new surface |
| `extensions/pi-remote/src/threa-remote.test.ts` | 3 tests: renew interval sits inside the TTL (the regression guard), timer starts/stops with the turn, `renewActiveClaims` posts the renew with the TTL |

## Out of scope (deliberate)

- Server-side defense in depth (e.g. step recording also extending the claim) — would mask a dead runtime as alive; the runtime owning its lease is the intended contract.
- The `custom-duration-scheduling` session still runs the pre-fix extension mid-turn; it needs `/reload` once idle (installed copy is updated).

## Test plan

- [x] `bun test` in `extensions/pi-remote` — 97 pass (3 new)
- [x] Prod DB forensics confirm the failure signature and its Jul 3 onset (query in PR discussion if needed)
- [x] Updated extension installed via `install-local.ts`; idle `steer-stop-traces` Pi session reloaded and re-registered (presence row refreshed)
- [ ] Live >2-min turn through a Threa scratchpad — needs a user-posted message (read-only prod creds here); the next long Pi turn will exercise the timer

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785878076&installation_id=129946197&pr_number=1208&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1208&signature=75328cd3eb4ee3766c2270dff58747faef3c460470ec64c982de2ea5d74880f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->