### PR TITLE
fix(remote-control): self-healing /bot socket + no-socket poll backoff to stop the Cloudflare quota burn

### DIFF
--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import * as socketIoClient from "socket.io-client"
 import { BotRuntimeTransport } from "./transport"
 import { buildBotSocketUrl, parseWsHint } from "./ws-hint"
 
@@ -184,6 +185,97 @@ describe("WS frame sent but ack timed out (idempotency)", () => {
     })
 
     expect(calls.some((c) => c.url.includes("/bot-runtime/presence"))).toBe(true)
+  })
+})
+
+describe("socket self-heal (the wedge that burns the edge quota)", () => {
+  interface FakeSocket {
+    handlers: Record<string, (...args: unknown[]) => void>
+    connect: ReturnType<typeof mock>
+    disconnect: ReturnType<typeof mock>
+    removeAllListeners: ReturnType<typeof mock>
+    on: (event: string, cb: (...args: unknown[]) => void) => FakeSocket
+    emit: (...args: unknown[]) => void
+    timeout: () => { emit: (...args: unknown[]) => void }
+  }
+
+  function makeFakeSocket(): FakeSocket {
+    const socket: FakeSocket = {
+      handlers: {},
+      connect: mock(() => {}),
+      disconnect: mock(() => {}),
+      removeAllListeners: mock(() => {}),
+      on(event, cb) {
+        socket.handlers[event] = cb
+        return socket
+      },
+      emit: () => {},
+      timeout: () => ({ emit: () => {} }),
+    }
+    return socket
+  }
+
+  function stubHintFetch(): CapturedRequest[] {
+    return stubFetch(() => new Response(JSON.stringify({ wsUrl: "https://ws.example.test" }), { status: 200 }))
+  }
+
+  function makeSelfHealTransport(staleSocketRedialMs: number): BotRuntimeTransport {
+    return new BotRuntimeTransport({
+      baseUrl: "https://app.example.test",
+      workspaceId: "ws_1",
+      apiKey: "threa_bk_test",
+      hello: HELLO,
+      staleSocketRedialMs,
+    })
+  }
+
+  it("redials after a server-initiated disconnect (Socket.IO won't reconnect on its own)", async () => {
+    const fake = makeFakeSocket()
+    const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      const transport = makeSelfHealTransport(3 * 60 * 1000)
+      await transport.connect()
+      fake.handlers.connect!()
+      expect(transport.socketConnected).toBe(true)
+
+      fake.handlers.disconnect!("io server disconnect")
+      expect(transport.socketConnected).toBe(false)
+      expect(fake.connect).toHaveBeenCalledTimes(1)
+
+      // Client-side drops are left to Socket.IO's own retry loop.
+      fake.handlers.disconnect!("transport close")
+      expect(fake.connect).toHaveBeenCalledTimes(1)
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
+
+  it("connect() leaves a fresh outage to Socket.IO but tears down and redials a stale one", async () => {
+    const first = makeFakeSocket()
+    const second = makeFakeSocket()
+    const ioSpy = spyOn(socketIoClient, "io")
+      .mockReturnValueOnce(first as unknown as ReturnType<typeof socketIoClient.io>)
+      .mockReturnValueOnce(second as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      // Stale threshold 0: any disconnected socket counts as wedged immediately.
+      const transport = makeSelfHealTransport(0)
+      await transport.connect()
+      expect(ioSpy).toHaveBeenCalledTimes(1)
+
+      await transport.connect()
+      expect(first.removeAllListeners).toHaveBeenCalledTimes(1)
+      expect(first.disconnect).toHaveBeenCalledTimes(1)
+      expect(ioSpy).toHaveBeenCalledTimes(2)
+
+      // A connected socket is never redialed.
+      second.handlers.connect!()
+      await transport.connect()
+      expect(ioSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      ioSpy.mockRestore()
+    }
   })
 })
 

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -1,4 +1,7 @@
-import { io as openSocket, type Socket } from "socket.io-client"
+// Namespace import so tests can spyOn the `io` factory (INV-48) — the transport
+// is otherwise untestable without dialing a real Socket.IO server.
+import * as socketIoClient from "socket.io-client"
+import type { Socket } from "socket.io-client"
 import { THREA_CALLBACK_TOKEN_HEADER, type SealedStepFrame } from "./sealed"
 import { buildBotSocketUrl, isObject, parseWsHint, type WsHint } from "./ws-hint"
 import type {
@@ -12,6 +15,7 @@ import type {
 const DEFAULT_WS_ACK_TIMEOUT_MS = 5_000
 const DEFAULT_RECONNECTION_DELAY_MAX_MS = 30_000
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000
+const DEFAULT_STALE_SOCKET_REDIAL_MS = 3 * 60 * 1000
 
 /**
  * Owns the `/bot` WebSocket and the routing for a runtime's background writes.
@@ -41,12 +45,15 @@ export class BotRuntimeTransport {
   private readonly wsAckTimeoutMs: number
   private readonly reconnectionDelayMaxMs: number
   private readonly fetchTimeoutMs: number
+  private readonly staleSocketRedialMs: number
   private readonly logFn: (message: string) => void
 
   private socket: Socket | undefined
   private connected = false
   private connecting = false
   private stopped = false
+  /** When the current outage started: set at attach and on disconnect, cleared on connect. */
+  private disconnectedAt: number | undefined
   /** The cursor echoed by the last hello ack; re-sent on the next hello so the bootstrap only replays unseen events. */
   private cursor: string | undefined
 
@@ -59,6 +66,7 @@ export class BotRuntimeTransport {
     this.wsAckTimeoutMs = opts.wsAckTimeoutMs ?? DEFAULT_WS_ACK_TIMEOUT_MS
     this.reconnectionDelayMaxMs = opts.reconnectionDelayMaxMs ?? DEFAULT_RECONNECTION_DELAY_MAX_MS
     this.fetchTimeoutMs = opts.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
+    this.staleSocketRedialMs = opts.staleSocketRedialMs ?? DEFAULT_STALE_SOCKET_REDIAL_MS
     this.logFn = opts.log ?? (() => {})
   }
 
@@ -74,9 +82,23 @@ export class BotRuntimeTransport {
    * call and the first poll tick from opening two). The hint resolve is the only
    * HTTP the transport does on the hot path; a failure leaves the socket closed
    * and the caller keeps polling/HTTP-writing until the next `connect()`.
+   *
+   * An existing-but-disconnected socket is normally left to Socket.IO's own
+   * retry loop, EXCEPT when the outage has outlived `staleSocketRedialMs`: then
+   * the socket is wedged in a state retries can't fix (a stale ws hint after the
+   * backend moved, a dead retry loop) and the only cure is a teardown + fresh
+   * dial. Without this, one wedged socket leaves the runtime on the fast HTTP
+   * poll forever — the exact Cloudflare-quota burn the transport exists to avoid.
    */
   async connect(): Promise<void> {
-    if (this.socket || this.connecting || this.stopped) return
+    if (this.connecting || this.stopped) return
+    if (this.socket) {
+      if (this.connected) return
+      const outageMs = Date.now() - (this.disconnectedAt ?? Date.now())
+      if (outageMs < this.staleSocketRedialMs) return
+      this.logFn(`socket disconnected for ${Math.round(outageMs / 1000)}s; redialing from a fresh hint`)
+      this.teardownSocket()
+    }
     this.connecting = true
     try {
       let hint: WsHint | undefined
@@ -95,7 +117,7 @@ export class BotRuntimeTransport {
     if (this.socket || this.stopped) return
     let socket: Socket
     try {
-      socket = openSocket(buildBotSocketUrl(hint), {
+      socket = socketIoClient.io(buildBotSocketUrl(hint), {
         path: hint.path,
         auth: { token: this.apiKey },
         transports: ["websocket"],
@@ -107,15 +129,24 @@ export class BotRuntimeTransport {
       return
     }
     this.socket = socket
+    this.disconnectedAt = Date.now()
     socket.on("connect", () => {
       this.connected = true
+      this.disconnectedAt = undefined
       this.sendHello()
     })
-    socket.on("disconnect", () => {
+    socket.on("disconnect", (reason: string) => {
       this.connected = false
+      this.disconnectedAt ??= Date.now()
+      // Socket.IO's auto-reconnect covers every disconnect reason EXCEPT a
+      // server-initiated one (deploy drain, kick) — there the client stays down
+      // until someone calls connect(). Redial immediately; a flap lands on the
+      // normal reconnection backoff.
+      if (reason === "io server disconnect") socket.connect()
     })
     socket.on("connect_error", (error: unknown) => {
       this.connected = false
+      this.disconnectedAt ??= Date.now()
       this.logFn(`socket connect_error: ${summarize(error)}`)
     })
     socket.on("bot_invocation:available", () => this.callbacks.onInvocationAvailable?.())
@@ -154,7 +185,13 @@ export class BotRuntimeTransport {
   /** Tear the socket down (idempotent). After this the transport is HTTP-only and won't reconnect. */
   disconnect(): void {
     this.stopped = true
+    this.teardownSocket()
+  }
+
+  /** Drop the current socket without stopping the transport — the next `connect()` dials fresh. */
+  private teardownSocket(): void {
     this.connected = false
+    this.disconnectedAt = undefined
     const socket = this.socket
     this.socket = undefined
     if (socket) {

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -79,5 +79,12 @@ export interface BotRuntimeTransportOptions {
   reconnectionDelayMaxMs?: number
   /** HTTP fallback request timeout. Default 30s. */
   fetchTimeoutMs?: number
+  /**
+   * How long a socket may sit disconnected before `connect()` tears it down and
+   * redials from a fresh ws hint. Default 3 min. Socket.IO's own retry loop
+   * handles brief drops; this backstop catches the wedged states it can't — a
+   * stale ws hint after the backend moved, or a client stuck post-kick.
+   */
+  staleSocketRedialMs?: number
   log?: (message: string) => void
 }

--- a/extensions/pi-remote/src/threa-remote.test.ts
+++ b/extensions/pi-remote/src/threa-remote.test.ts
@@ -911,3 +911,17 @@ describe("claim renewal during a turn", () => {
     ])
   })
 })
+
+describe("nextQuietPollMs (no-socket idle backoff)", () => {
+  test("doubles empty idle ticks to the cap and resets cleanly", () => {
+    __testing.resetQuietPollsForTesting()
+    // No transport, no pending turn, default 3s pollMs.
+    expect(__testing.nextQuietPollMs()).toBe(3000)
+    expect(__testing.nextQuietPollMs()).toBe(6000)
+    expect(__testing.nextQuietPollMs()).toBe(12000)
+    for (let i = 0; i < 10; i++) __testing.nextQuietPollMs()
+    expect(__testing.nextQuietPollMs()).toBe(__testing.NO_SOCKET_POLL_CAP_MS)
+    __testing.resetQuietPollsForTesting()
+    expect(__testing.nextQuietPollMs()).toBe(3000)
+  })
+})

--- a/extensions/pi-remote/src/threa-remote.ts
+++ b/extensions/pi-remote/src/threa-remote.ts
@@ -70,6 +70,13 @@ const CLAIM_RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
 // day doing nothing; reconnects still drain immediately via the hello
 // bootstrap, so only a silently dropped push waits this long.
 const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
+// With NO socket the poll is the only delivery path, but an idle session
+// spinning at pollMs (3s) burns ~29k billed edge requests/day. Empty idle ticks
+// back off exponentially to this cap; a claim, an active turn, or a socket
+// reconnect resets to the fast cadence. Turns in flight never back off, so
+// steer/stop and queued follow-ups stay responsive mid-turn (renewal itself is
+// covered by the dedicated claim-renew timer either way).
+const NO_SOCKET_POLL_CAP_MS = 2 * 60 * 1000
 const WS_RECONNECTION_DELAY_MAX_MS = 30_000
 const TRACE_CONTENT_MAX_CHARS = 9_500
 // Sealed steps carry ciphertext the server never reads, so the plaintext step
@@ -248,6 +255,7 @@ let isWaitingForRetry = false
 let lastTraceHeartbeat: { text: string; at: number } | undefined
 let claimRenewTimer: ReturnType<typeof setInterval> | undefined
 let consecutivePollFailures = 0
+let consecutiveQuietPolls = 0
 let lastPollFailureSummary: string | undefined
 let lastBusyHeartbeatAt = 0
 let lastPollDebugSummary: string | undefined
@@ -1363,6 +1371,23 @@ function failurePollMs(): number {
   return Math.min(MAX_FAILURE_POLL_MS, basePollMs() * 2 ** Math.min(consecutivePollFailures - 1, 8))
 }
 
+/**
+ * Delay until the next poll tick, advancing the quiet-poll backoff. Socket up,
+ * turn in flight, or a fresh claim → fast cadence (steer/stop and queued
+ * follow-ups must stay responsive mid-turn). Idle AND socketless → double per
+ * empty tick up to {@link NO_SOCKET_POLL_CAP_MS}, so a wedged session can't
+ * burn the edge-request quota.
+ */
+function nextQuietPollMs(): number {
+  if (transport?.socketConnected || pending || steeredInvocations.length > 0) {
+    consecutiveQuietPolls = 0
+    return basePollMs()
+  }
+  const delay = Math.min(NO_SOCKET_POLL_CAP_MS, basePollMs() * 2 ** consecutiveQuietPolls)
+  consecutiveQuietPolls = Math.min(consecutiveQuietPolls + 1, 8)
+  return delay
+}
+
 function notePollSuccess(ctx: ExtensionContext): void {
   if (consecutivePollFailures === 0) return
   consecutivePollFailures = 0
@@ -1709,6 +1734,7 @@ async function claimNextInvocation(ctx: ExtensionContext): Promise<ClaimedInvoca
         : `no invocation in ${Date.now() - startedAt}ms`
     )
     if (!body.data) return null
+    consecutiveQuietPolls = 0
     const claimed = { ...body.data, claimedInstanceId: getSessionInstanceId(ctx) }
     if (claimed.sealedContext === undefined) return claimed
     return hydrateSealedClaim(claimed, ctx)
@@ -2783,6 +2809,7 @@ function startPolling(pi: ExtensionAPI, ctx: ExtensionContext): void {
       }
       const contactedServer = await claimIfIdle(pi, ctx)
       if (contactedServer) notePollSuccess(ctx)
+      delayMs = nextQuietPollMs()
     } catch (error) {
       notePollFailure(ctx, error)
       delayMs = failurePollMs()
@@ -3135,6 +3162,11 @@ export const __testing = {
     stopClaimRenewTimer()
     pending = undefined
     steeredInvocations = []
+  },
+  NO_SOCKET_POLL_CAP_MS,
+  nextQuietPollMs,
+  resetQuietPollsForTesting: () => {
+    consecutiveQuietPolls = 0
   },
 }
 

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -67,7 +67,11 @@ function makeFakeTransport() {
     disconnect: () => {},
     socketConnected: false,
     sendHello: () => {},
-    recordSteps: async (invocationId: string, _claimToken: string, frames: Array<{ stepType: string; content: string }>) => {
+    recordSteps: async (
+      invocationId: string,
+      _claimToken: string,
+      frames: Array<{ stepType: string; content: string }>
+    ) => {
       steps.push({ invocationId, frames })
     },
     renewClaim: async () => ({ notFound: false }),
@@ -717,5 +721,32 @@ describe("steer into the running turn (native steer support)", () => {
     expect(interrupted).toBe(true)
     expect(delivered).toEqual(["start with the readme"])
     ;(session as unknown as { clearInflight: (id: string) => void }).clearInflight("binv_steer")
+  })
+})
+
+describe("no-socket poll backoff", () => {
+  test("doubles empty socketless ticks to the cap; claim, socket, or reconnect resets", () => {
+    const { client } = makeFakeClient()
+    const { transport } = makeFakeTransport()
+    const session = makeSession(client, transport) as unknown as {
+      nextPollDelay: (claimed: boolean) => number
+    }
+
+    expect(session.nextPollDelay(false)).toBe(3000)
+    expect(session.nextPollDelay(false)).toBe(6000)
+    expect(session.nextPollDelay(false)).toBe(12000)
+    for (let i = 0; i < 10; i++) session.nextPollDelay(false)
+    expect(session.nextPollDelay(false)).toBe(120_000)
+
+    // Claimed work while socketless → back to the fast cadence.
+    expect(session.nextPollDelay(true)).toBe(3000)
+    expect(session.nextPollDelay(false)).toBe(3000)
+
+    // Socket up → slow backstop, and the backoff restarts fresh on the next outage.
+    for (let i = 0; i < 5; i++) session.nextPollDelay(false)
+    ;(transport as unknown as { socketConnected: boolean }).socketConnected = true
+    expect(session.nextPollDelay(false)).toBe(15 * 60 * 1000)
+    ;(transport as unknown as { socketConnected: boolean }).socketConnected = false
+    expect(session.nextPollDelay(false)).toBe(3000)
   })
 })

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -53,6 +53,12 @@ const RENEW_INTERVAL_MS = Math.floor((CLAIM_TTL_SECONDS * 1000) / 3)
 // ~100 requests/day/session; reconnects still drain immediately via the hello
 // bootstrap callback.
 const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
+// With NO socket, the poll is the only delivery path, but a fast fixed cadence
+// is how a single wedged session burned ~29k billed edge requests/day. Back off
+// empty ticks exponentially from config.pollMs to this cap; a claimed turn or a
+// socket reconnect resets to the fast cadence. Worst-case degraded latency for
+// a socketless session is one cap interval.
+const NO_SOCKET_POLL_CAP_MS = 2 * 60 * 1000
 const MAX_CLAIMS_PER_DRAIN = 20
 // Server-side cap on frames per bot:invocation:steps call (`stepsFrameSchema`
 // in apps/backend/src/features/bot-runtimes/socket-handler.ts).
@@ -295,6 +301,8 @@ export class RemoteSession {
   private stopped = false
   private pollTimer: ReturnType<typeof setTimeout> | undefined
   private renewTimer: ReturnType<typeof setInterval> | undefined
+  /** Consecutive empty poll ticks while the socket is down; drives the poll backoff. */
+  private emptyNoSocketPolls = 0
   private readonly inflight = new Map<string, Inflight>()
   // The invocation whose turn is executing — the stream a relayed permission
   // prompt belongs in. Set when a non-intercepted invocation is pushed to the
@@ -508,8 +516,10 @@ export class RemoteSession {
 
   // --- Claiming -------------------------------------------------------------
 
-  private async claimDrain(): Promise<void> {
-    if (this.stopped || this.claiming) return
+  /** Returns whether at least one invocation was claimed (feeds the poll backoff reset). */
+  private async claimDrain(): Promise<boolean> {
+    if (this.stopped || this.claiming) return false
+    let claimedAny = false
     this.claiming = true
     try {
       for (let i = 0; i < MAX_CLAIMS_PER_DRAIN; i++) {
@@ -524,6 +534,7 @@ export class RemoteSession {
         if (busy && !this.sessionControlEnabled) break
         const invocation = await this.claimNext(busy)
         if (!invocation) break
+        claimedAny = true
         if (isSessionControlInvocation(invocation)) {
           const isStop = parseSessionControlCommand(invocation)?.name === "stop"
           await this.handleSessionControl(invocation)
@@ -539,6 +550,7 @@ export class RemoteSession {
     } finally {
       this.claiming = false
     }
+    return claimedAny
   }
 
   /**
@@ -1317,11 +1329,30 @@ export class RemoteSession {
       if (this.stopped) return
       if (!this.link) await this.ensureLink()
       if (!this.transport.socketConnected) await this.transport.connect()
-      await this.claimDrain()
-      const delay = this.transport.socketConnected ? WS_BACKSTOP_POLL_MS : this.config.pollMs
-      this.pollTimer = setTimeout(() => void tick(), delay)
+      const claimed = await this.claimDrain()
+      this.pollTimer = setTimeout(() => void tick(), this.nextPollDelay(claimed))
     }
     this.pollTimer = setTimeout(() => void tick(), this.config.pollMs)
+  }
+
+  /**
+   * Socket up → slow backstop (pushes deliver work). Socket down → start at the
+   * configured fast cadence and double per empty tick up to the cap, so an
+   * active HTTP-only conversation stays snappy while an idle socketless session
+   * can't burn the edge-request quota. Claimed work resets the backoff.
+   */
+  private nextPollDelay(claimed: boolean): number {
+    if (this.transport.socketConnected) {
+      this.emptyNoSocketPolls = 0
+      return WS_BACKSTOP_POLL_MS
+    }
+    if (claimed) {
+      this.emptyNoSocketPolls = 0
+      return this.config.pollMs
+    }
+    const delay = Math.min(NO_SOCKET_POLL_CAP_MS, this.config.pollMs * 2 ** this.emptyNoSocketPolls)
+    this.emptyNoSocketPolls = Math.min(this.emptyNoSocketPolls + 1, 30)
+    return delay
   }
 
   // --- Helpers --------------------------------------------------------------

--- a/tests/browser/e2e-encrypted-scratchpads.spec.ts
+++ b/tests/browser/e2e-encrypted-scratchpads.spec.ts
@@ -113,13 +113,27 @@ test.describe("E2E encrypted scratchpads", () => {
 
     // Phone width + locked (reload; device untrusted). Since the mobile topbar
     // rework, the phone-width header keeps only the name-first bar — the chip
-    // strip (invite, encryption) moved into the stream sheet the name opens.
+    // strip (invite, encryption) moved into the stream sheet the name opens,
+    // so the old inline invite trigger must NOT render.
     await page.setViewportSize({ width: 412, height: 915 })
     await page.reload()
     await expect(page.getByText("This scratchpad is encrypted")).toBeVisible({ timeout: 15_000 })
 
     // The name IS the sheet trigger (aria-label "<name> — stream details and actions").
-    await page.getByRole("button", { name: /stream details and actions/ }).click()
+    const title = page.getByRole("button", { name: /stream details and actions/ })
+    await expect(title).toBeVisible()
+    await expect(page.getByRole("button", { name: "Invite an agent to this scratchpad" })).toHaveCount(0)
+
+    // Containment (the original #1184 regression, ported to the sheet-era bar):
+    // the name trigger takes the remaining width but must never paint under the
+    // header's search action, eating its tap.
+    const titleBox = await title.boundingBox()
+    const searchBox = await page.getByRole("button", { name: "Search in conversation" }).boundingBox()
+    expect(titleBox).not.toBeNull()
+    expect(searchBox).not.toBeNull()
+    expect(titleBox!.x + titleBox!.width).toBeLessThanOrEqual(searchBox!.x + 1)
+
+    await title.click()
     const sheet = page.getByRole("dialog", { name: "Stream details and actions" })
     await expect(sheet).toBeVisible({ timeout: 10_000 })
 


### PR DESCRIPTION
## Problem

Cloudflare emailed a 75%-of-quota warning: the account burned ~75k of the 100k free-plan Workers requests/day. The source was two channel runtimes (`threa.public-site-login-button`, `threa.improve-harness-tmux`, both up since Jul 3) running with **no `/bot` WebSocket** — with the socket down, the fallback poll POSTs `/bot-invocations/claim` through the billed edge Worker every 3s (`pollMs` default in `identity.ts`), ~28.8k requests/day per session, ~57.6k/day combined.

Two defects compound into that state:

1. **A server-initiated disconnect wedges the socket forever.** Socket.IO does not auto-reconnect when the server ends the connection (deploy drain, kick), and `BotRuntimeTransport.connect()` was a no-op whenever `this.socket` existed — so after one server-side disconnect the transport never redials, and the runtime falls back to fast HTTP polling permanently. Every session is one backend deploy away from becoming a quota burner.
2. **The no-socket poll has no backoff.** 3s is a fine catch-up cadence for the seconds a socket takes to dial, but a session that stays socketless keeps that rate indefinitely.

Steps/renew/presence were not the issue — they already ride the socket (#1067), and the healthy-socket poll backstop is already 15 min (#1156).

## Solution

Make the socket self-heal (so the socketless state is rare and brief), and make the socketless poll back off (so the state costs ~720 requests/day instead of ~28.8k when it does happen).

### How it works

- **`BotRuntimeTransport` redials after a server-initiated disconnect**: the `disconnect` handler checks `reason === "io server disconnect"` and calls `socket.connect()` — the one case Socket.IO's own retry loop never covers. Client-side drops are still left to the built-in reconnection (`reconnectionDelayMax` 30s).
- **`connect()` tears down a stale socket and redials from a fresh ws hint**: the transport tracks `disconnectedAt` (set at attach and on `disconnect`/`connect_error`, cleared on `connect`). When a poll tick calls `connect()` and the outage has outlived `staleSocketRedialMs` (default 3 min, injectable for tests), the wedged socket is torn down and a fresh hint is resolved — covering a ws hint gone stale after the backend moved, or any retry loop that silently died. Fresh outages are still left alone so the teardown never fights Socket.IO's own reconnect.
- **`RemoteSession` no-socket poll backoff**: `nextPollDelay(claimed)` doubles empty socketless ticks from `config.pollMs` (3s) to a 2-min cap (`NO_SOCKET_POLL_CAP_MS`); a claimed invocation resets to the fast cadence (an active HTTP-only conversation stays snappy), and a connected socket returns the existing 15-min backstop and resets the counter. `claimDrain()` now returns whether it claimed anything to feed that reset.
- **pi-remote gets the same backoff** via `nextQuietPollMs()`, with one extra guard: while a turn is in flight (`pending` or `steeredInvocations`), the poll never backs off — pi's claim renewal rides the poll (no dedicated renew timer on this branch) and must outpace the 120s claim TTL. A successful claim in `claimNextInvocation` also resets the counter.

Worst case for a permanently socketless idle session: one claim POST every 2 min plus one hint GET every ≥3 min ≈ 1.2k requests/day, vs 28.8k before. Worst-case degraded delivery latency while socketless and idle: one 2-min cap interval; steer/renew during turns keep the fast cadence.

### Key design decisions

**1. Fix the wedge, don't just slow the poll.** Backoff alone would leave sessions silently degraded (2-min latency) forever. The redial-on-server-disconnect + stale-teardown make the WS the reliably-primary path again, so the backoff is a rarely-hit safety net, not the steady state.

**2. Backoff exempts in-flight turns (pi) and resets on claimed work (both).** A flat slow poll was rejected: pi's claim renewal rides the poll (120s TTL would lapse at a 2-min cadence), and an HTTP-only conversation would feel 2-min laggy. The exponential-with-resets shape keeps the burn bounded while active use stays fast.

**3. Namespace import of `socket.io-client` in the transport** so tests can `spyOn(socketIoClient, "io")` (INV-48 scoped-spy pattern) instead of dialing a real server or adding a DI seam for tests only.

**4. Operational cleanup done outside this PR:** the two zombie sessions were killed (graceful shutdown via the #1176 lifecycle path — parent stdin close). Their worktrees ran pre-fix code, so this PR alone would not have healed them.

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/bot-runtime-client/src/transport.ts` | Redial on `io server disconnect`; `disconnectedAt` tracking; `connect()` stale-socket teardown + fresh-hint redial; `teardownSocket()` extracted from `disconnect()` |
| `extensions/bot-runtime-client/src/types.ts` | `staleSocketRedialMs` transport option |
| `extensions/bot-runtime-client/src/transport.test.ts` | Self-heal tests: server-disconnect redial, stale teardown + redial, connected socket never redialed |
| `extensions/remote-session/src/session.ts` | `nextPollDelay()` exponential no-socket backoff (3s → 2-min cap); `claimDrain()` returns claimed-any for the reset |
| `extensions/remote-session/src/session.test.ts` | Backoff sequence test (doubling, cap, claim/socket resets) |
| `extensions/pi-remote/src/threa-remote.ts` | `nextQuietPollMs()` backoff with in-flight-turn exemption; claim resets counter; wired into `startPolling` |
| `extensions/pi-remote/src/threa-remote.test.ts` | Backoff escalation/cap/reset test |
| `tests/browser/e2e-encrypted-scratchpads.spec.ts` | Update the phone-width invite-agent spec to the #1206 stream-sheet UI (main was red since #1206: no inline chip strip on mobile; invite lives in the sheet). Containment assertion ported to the name trigger; verified locally in 26s |

## Out of scope (deliberate)

- **pi dedicated renew timer** — tracked separately (PR #1208); the in-flight exemption here keeps renewal safe either way, and the two compose cleanly.
- **Presence/steps routing** — already WS-first since #1067; untouched.
- **Workers paid plan / quota alerting** — infra decision, not code.

## Test plan

- [x] `bot-runtime-client`: 49 pass (incl. 2 new self-heal tests), `tsc --noEmit` clean
- [x] `remote-session`: 92 pass (incl. new backoff test), `tsc --noEmit` clean
- [x] `pi-remote`: 95 pass (incl. new backoff test)
- [x] `claude-code-remote` (transport consumer): 48 pass, `tsc --noEmit` clean
- [x] Browser: `bunx playwright test tests/browser/e2e-encrypted-scratchpads.spec.ts -g "phone-width"` — 1 pass (26s) against the local dev:test stack
- [x] Rebased on latest main (#1208 pi renew timer, #1211 trace-dialog fix); pi-remote suite re-run post-merge — 98 pass
- [x] Repo pre-commit hook (all apps lint + typecheck) green on commit
- [x] Live evidence for the diagnosis: `lsof` across all 14 running runtimes — the only two without a backend WS were the two 3s HTTP pollers; the remaining 12 all hold the socket
- [ ] Live wedge reproduction (server-kick a runtime and watch it redial) — needs a backend deploy or manual socket kick; the reason-string path is covered by the fake-socket test

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785879679&installation_id=129946197&pr_number=1210&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1210&signature=2ef6f4a23d9d8874498f0fc03164ebdb9bab9186db3da1c0fe889e9a18847649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
