### PR TITLE
fix(frontend): unbreak main deploy — dispatch mock missing required event field

### DIFF
--- a/apps/frontend/src/components/trace/trace-dialog.test.tsx
+++ b/apps/frontend/src/components/trace/trace-dialog.test.tsx
@@ -91,7 +91,22 @@ describe("TraceDialog", () => {
     })) as unknown as typeof useAgentTraceModule.useAgentTrace)
 
     vi.spyOn(commandsApi, "listForStream").mockResolvedValue([])
-    vi.spyOn(commandsApi, "dispatch").mockResolvedValue({ success: true, commandId: "cmd_1", command: "stop", args: "" })
+    vi.spyOn(commandsApi, "dispatch").mockResolvedValue({
+      success: true,
+      commandId: "cmd_1",
+      command: "stop",
+      args: "",
+      event: {
+        id: "event_1",
+        streamId: "stream_1",
+        sequence: "1",
+        eventType: "command_dispatched",
+        payload: {},
+        actorId: "member_1",
+        actorType: "user",
+        createdAt: "2026-07-05T00:00:00.000Z",
+      },
+    })
     vi.spyOn(toast, "error").mockReturnValue("" as ReturnType<typeof toast.error>)
 
     vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation((() => (
@@ -248,8 +263,12 @@ describe("TraceDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
     fireEvent.click(screen.getByRole("button", { name: "Stop" }))
 
-    await waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" }))
-    await waitFor(() => expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" }))
+    await waitFor(() =>
+      expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/steer" })
+    )
+    await waitFor(() =>
+      expect(commandsApi.dispatch).toHaveBeenCalledWith("ws_1", { streamId: "stream_1", command: "/stop" })
+    )
   })
 
   it("falls back to local Stop and surfaces a toast when advertised runtime stop fails", async () => {


### PR DESCRIPTION
## Problem

`main` deploys have failed since #1203 landed (three consecutive red **Deploy Cloudflare** runs). The workflow's `tsc && vite build` fails on `src/components/trace/trace-dialog.test.tsx:94`: the `commandsApi.dispatch` mock omits `event`, which `DispatchCommandResponse` (`packages/types/src/api.ts`) requires. PR CI didn't catch it because the deploy workflow is the only one that runs `tsc` over the frontend test files on push.

## Solution

Add a minimal `command_dispatched` `StreamEvent` to the mock. No product code changed.

## Test plan

- [x] `tsc --noEmit` in `apps/frontend` clean (the failing check)
- [x] `bun run build` (`tsc && vite build`) passes locally
- [x] `bunx vitest run src/components/trace/trace-dialog.test.tsx` — 7 pass

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785880464&installation_id=129946197&pr_number=1211&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1211&signature=d5e5f48c6a96a83167e05debf34d8a8a6dcfa4a33941730ba657c96749baa2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->