### PR TITLE
feat(board): nested sub-topics — inline gestures, coordinated reveal, split thread

### DIFF
--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -121,6 +121,90 @@ describe("conversationAssigner — threadFromMessage", () => {
   })
 })
 
+describe("conversationAssigner — newSubtopic (declared branch, stream-locked mint)", () => {
+  // The assigner locks the thread stream row before find-or-mint, so the client
+  // needs a `query` that resolves (the real path runs `SELECT … FOR UPDATE`).
+  const LOCK_CLIENT = { query: mock(async () => ({ rows: [] })) } as never
+  let insert: ReturnType<typeof spyOn>
+  let addPrimaryMessage: ReturnType<typeof spyOn>
+  let bumpActivityForIds: ReturnType<typeof spyOn>
+  let emitAssignmentEvents: ReturnType<typeof spyOn>
+  let findActiveByStream: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    insert = spyOn(ConversationRepository, "insert").mockResolvedValue({ id: "conv_new" } as never)
+    addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    bumpActivityForIds = spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+    emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
+    findActiveByStream = spyOn(ConversationRepository, "findActiveByStream")
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  async function newSubtopic(reply = makeReply("thr_1")): Promise<void> {
+    await conversationAssigner.assignInTransaction(LOCK_CLIENT, {
+      workspaceId: WORKSPACE_ID,
+      message: reply,
+      directive: { intent: "newSubtopic" },
+    })
+  }
+
+  test("mints a fresh conversation anchored to the thread stream when none is active there", async () => {
+    findActiveByStream.mockResolvedValue([])
+
+    await newSubtopic()
+
+    // Locks the thread stream row before deciding (INV-20), then mints anchored to
+    // the thread — the branch relationship (thr_1.parentMessageId ∈ the parent
+    // conversation) is derivable from the graph, so no parent id is written.
+    expect((LOCK_CLIENT as { query: ReturnType<typeof mock> }).query).toHaveBeenCalled()
+    expect(insert).toHaveBeenCalledTimes(1)
+    expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
+    // The mint generates its own id; the reply joins that same conversation.
+    const mintedId = insert.mock.calls[0][1].id as string
+    expect(addPrimaryMessage).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, mintedId, "msg_reply", "usr_1")
+    expect(bumpActivityForIds).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, [mintedId])
+    expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
+      conversationId: mintedId,
+      created: true,
+      reason: "declared",
+    })
+  })
+
+  test("the minted child anchors to a thread whose fork message is a member of the parent conversation", async () => {
+    findActiveByStream.mockResolvedValue([])
+
+    await newSubtopic()
+
+    // The child is anchored to `message.streamId` (thr_1). The parent card renders
+    // the stub because thr_1's `parentMessageId` (msg_open) is a member message of
+    // the parent conversation — the graph link the PR1 renderer derives.
+    const mintedAnchor = insert.mock.calls[0][1].streamId as string
+    const thread = STREAMS[mintedAnchor] as { parentMessageId: string }
+    const parentConversation = makeSource() // messageIds: ["msg_open"]
+    expect(parentConversation.messageIds).toContain(thread.parentMessageId)
+  })
+
+  test("a second newSubtopic into the same thread attaches to the existing conversation (no double-mint)", async () => {
+    // The two-users race: the loser sees the winner's conversation via the
+    // stream lock + findActiveByStream and attaches instead of minting again.
+    findActiveByStream.mockResolvedValue([{ id: "conv_sub", streamId: "thr_1" } as unknown as Conversation])
+
+    await newSubtopic()
+
+    expect(insert).not.toHaveBeenCalled()
+    expect(addPrimaryMessage).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, "conv_sub", "msg_reply", "usr_1")
+    expect(bumpActivityForIds).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, ["conv_sub"])
+    expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
+      conversationId: "conv_sub",
+      created: false,
+      reason: "declared",
+    })
+  })
+})
+
 describe("conversationAssigner — existing (same-root guard)", () => {
   let addPrimaryMessage: ReturnType<typeof spyOn>
   let emitAssignmentEvents: ReturnType<typeof spyOn>

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -1,4 +1,5 @@
 import type { PoolClient } from "pg"
+import { sql } from "../../db"
 import { ConversationRepository } from "./repository"
 import type { ConversationAssigner, Message } from "../messaging"
 import { checkStreamAccess, StreamRepository } from "../streams"
@@ -28,6 +29,12 @@ import { HttpError } from "../../lib/errors"
  *    reply, one root). Stable conversation id, no card swap. Falls back to a
  *    fresh mint only when the source can't be verified, so the reply is never
  *    orphaned.
+ *  - `newSubtopic`: the declared branch gesture from the board — a fresh thread
+ *    was opened under a member message and this is its first reply. Mint a child
+ *    conversation anchored to the message's (thread) stream, or attach to the one
+ *    already anchored there when two users branch the same message concurrently
+ *    (INV-20). The branch relationship is derivable from the graph (the thread's
+ *    parentMessageId ∈ the parent conversation), so no parent id is written.
  */
 export const conversationAssigner: ConversationAssigner = {
   async assignInTransaction(client, { workspaceId, message, directive }) {
@@ -36,6 +43,11 @@ export const conversationAssigner: ConversationAssigner = {
         return
       }
       await mintConversationForMessage(client, workspaceId, message)
+      return
+    }
+
+    if (directive.intent === ConversationIntents.NEW_SUBTOPIC) {
+      await mintOrAttachSubtopicConversation(client, workspaceId, message)
       return
     }
 
@@ -98,6 +110,37 @@ async function mintConversationForMessage(client: PoolClient, workspaceId: strin
     message,
     conversationId: newId,
     created: true,
+    reason: "declared",
+  })
+}
+
+/**
+ * `newSubtopic` (board branch gesture): mint a child conversation anchored to the
+ * message's thread stream, or attach to the one already anchored there. Lock the
+ * thread stream row first (mirrors the agent-reply mint's stream lock, INV-20) so
+ * two users branching the same parent message — both landing in the one thread
+ * `insertThreadOrFind` returned — don't both mint: the loser waits on the lock and
+ * then sees the winner's conversation via `findActiveByStream`. No reactivate: a
+ * resolved conversation on the thread is left as-is and a fresh active one minted.
+ */
+async function mintOrAttachSubtopicConversation(
+  client: PoolClient,
+  workspaceId: string,
+  message: Message
+): Promise<void> {
+  await client.query(sql`SELECT id FROM streams WHERE id = ${message.streamId} FOR UPDATE`)
+  const active = (await ConversationRepository.findActiveByStream(client, message.streamId))[0]
+  if (!active) {
+    await mintConversationForMessage(client, workspaceId, message)
+    return
+  }
+  await ConversationRepository.addPrimaryMessage(client, workspaceId, active.id, message.id, message.authorId)
+  await ConversationRepository.bumpActivityForIds(client, workspaceId, [active.id])
+  await emitAssignmentEvents(client, {
+    workspaceId,
+    message,
+    conversationId: active.id,
+    created: false,
     reason: "declared",
   })
 }

--- a/apps/backend/src/features/conversations/feedback-repository.ts
+++ b/apps/backend/src/features/conversations/feedback-repository.ts
@@ -35,4 +35,29 @@ export const ConversationFeedbackRepository = {
       )
     `)
   },
+
+  /**
+   * Batch variant (INV-56): one multi-row insert for a correction that moves
+   * several messages at once (the thread-split flow records a feedback row per
+   * moved message). `from_conversation_id` may be null per row.
+   */
+  async insertMany(db: Querier, rows: InsertConversationFeedbackParams[]): Promise<void> {
+    if (rows.length === 0) return
+    await db.query(sql`
+      INSERT INTO conversation_feedback (
+        id, workspace_id, stream_id, message_id,
+        from_conversation_id, to_conversation_id, user_id
+      )
+      SELECT id, workspace_id, stream_id, message_id, from_conversation_id, to_conversation_id, user_id
+      FROM unnest(
+        ${rows.map((r) => r.id)}::text[],
+        ${rows.map((r) => r.workspaceId)}::text[],
+        ${rows.map((r) => r.streamId)}::text[],
+        ${rows.map((r) => r.messageId)}::text[],
+        ${rows.map((r) => r.fromConversationId)}::text[],
+        ${rows.map((r) => r.toConversationId)}::text[],
+        ${rows.map((r) => r.userId)}::text[]
+      ) AS t(id, workspace_id, stream_id, message_id, from_conversation_id, to_conversation_id, user_id)
+    `)
+  },
 }

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -49,6 +49,9 @@ describe("Conversation Handlers", () => {
     })
   )
   const mockGetFlag = mock(() => Promise.resolve("on" as string))
+  const mockSplitThread = mock(() =>
+    Promise.resolve({ conversation: { id: "conv_new" }, sourceConversation: { id: "conv_1" } })
+  )
 
   const handlers = createConversationHandlers({
     conversationService: {
@@ -58,6 +61,7 @@ describe("Conversation Handlers", () => {
       getMessages: mockGetMessages,
       getBoardPostById: mockGetBoardPostById,
       updateConversation: mockUpdateConversation,
+      splitThreadIntoConversation: mockSplitThread,
     } as never,
     boardExclusionService: {
       hideConversation: mockHideConversation,
@@ -93,6 +97,8 @@ describe("Conversation Handlers", () => {
     })
     mockHideConversation.mockResolvedValue({ hiddenAt: "2026-07-05T00:00:00.000Z" })
     mockGetExclusions.mockResolvedValue({ hiddenConversations: [], mutedStreamIds: [] })
+    mockSplitThread.mockReset()
+    mockSplitThread.mockResolvedValue({ conversation: { id: "conv_new" }, sourceConversation: { id: "conv_1" } })
 
     mockValidateStreamAccess.mockResolvedValue({ id: "stream_1", workspaceId: "ws_1" })
     mockListByStream.mockResolvedValue([])
@@ -315,6 +321,51 @@ describe("Conversation Handlers", () => {
       await handlers.getMessages(mockReq({ params: { conversationId: "conv_1" } }), res)
 
       expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+    })
+  })
+
+  describe("splitThread", () => {
+    const req = (overrides: Record<string, unknown> = {}) =>
+      mockReq({ params: { conversationId: "conv_1" }, body: { threadStreamId: "thr_1" }, ...overrides })
+
+    test("rejects a missing threadStreamId with a 400 (Zod)", async () => {
+      await expect(handlers.splitThread(req({ body: {} }), mockRes())).rejects.toMatchObject({ status: 400 })
+      expect(mockSplitThread).not.toHaveBeenCalled()
+    })
+
+    test("gates on the conversation's root via validateStreamAccess (INV-62)", async () => {
+      await handlers.splitThread(req(), mockRes())
+      expect(mockValidateStreamAccess).toHaveBeenCalledWith("stream_1", "ws_1", "usr_1")
+    })
+
+    test("propagates a stream-access rejection", async () => {
+      mockValidateStreamAccess.mockRejectedValue(new StreamNotFoundError())
+      await expect(handlers.splitThread(req(), mockRes())).rejects.toThrow("Stream not found")
+      expect(mockSplitThread).not.toHaveBeenCalled()
+    })
+
+    test("404s when the conversation is in another workspace", async () => {
+      mockGetById.mockResolvedValue({ id: "conv_1", streamId: "stream_1", workspaceId: "ws_other" })
+      const res = mockRes()
+      await handlers.splitThread(req(), res)
+      expect((res as unknown as { statusCode: number }).statusCode).toBe(404)
+      expect(mockValidateStreamAccess).not.toHaveBeenCalled()
+      expect(mockSplitThread).not.toHaveBeenCalled()
+    })
+
+    test("delegates to the service and returns its result", async () => {
+      const res = mockRes()
+      await handlers.splitThread(req(), res)
+      expect(mockSplitThread).toHaveBeenCalledWith({
+        workspaceId: "ws_1",
+        conversationId: "conv_1",
+        threadStreamId: "thr_1",
+        actorUserId: "usr_1",
+      })
+      expect((res as unknown as { body: unknown }).body).toEqual({
+        conversation: { id: "conv_new" },
+        sourceConversation: { id: "conv_1" },
+      })
     })
   })
 

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -78,6 +78,10 @@ const reassignMessageParamsSchema = z.object({
   messageId: z.string().min(1),
 })
 
+const splitThreadSchema = z.object({
+  threadStreamId: z.string().min(1),
+})
+
 const markReadSchema = z.object({
   throughMessageId: z.string().min(1),
 })
@@ -302,6 +306,37 @@ export function createConversationHandlers({
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const result = await conversationService.updateConversation({ workspaceId, conversationId, topicSummary, status })
+      res.json(result)
+    },
+
+    /**
+     * Split a soft thread out of its conversation into its own topic: move the
+     * thread's member messages (and any deeper sub-topics') to a freshly minted
+     * conversation anchored to the thread, recording each move as boundary
+     * feedback. Gated by the source conversation's single root (INV-62), matching
+     * {@link reassignMessage}.
+     */
+    async splitThread(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const { conversationId } = req.params
+
+      const { threadStreamId } = validateRequest(splitThreadSchema, req.body)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.splitThreadIntoConversation({
+        workspaceId,
+        conversationId,
+        threadStreamId,
+        actorUserId: userId,
+      })
       res.json(result)
     },
 

--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -812,6 +812,71 @@ export const ConversationRepository = {
   },
 
   /**
+   * Batch primary-membership move-out (INV-56): drop every id in `messageIds`
+   * from `message_ids` in one order-preserving statement, and SET
+   * `participant_ids` to the caller-recomputed set. Unlike the single-message
+   * {@link removePrimaryMessage} the caller here knows exactly who remains (it
+   * holds the full member→author map), so participants are recomputed rather
+   * than left stale. Workspace-scoped (INV-8).
+   */
+  async removePrimaryMessages(
+    db: Querier,
+    workspaceId: string,
+    conversationId: string,
+    messageIds: string[],
+    participantIds: string[]
+  ): Promise<void> {
+    await db.query(sql`
+      UPDATE conversations
+      SET message_ids = ARRAY(
+            SELECT e FROM unnest(message_ids) WITH ORDINALITY AS t(e, ord)
+            WHERE e <> ALL(${messageIds}::text[])
+            ORDER BY ord
+          ),
+          participant_ids = ${participantIds}::text[],
+          updated_at = NOW()
+      WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
+    `)
+  },
+
+  /**
+   * Batch primary-membership move-in (INV-56): append every id in `messageIds`
+   * to `message_ids` (idempotent — a dedup keeps first-occurrence order),
+   * clear them from `secondary_message_ids` (primary wins over secondary, as in
+   * {@link addPrimaryMessage}), and SET `participant_ids` to the caller-recomputed
+   * set. The caller must pass the FULL intended participant list. Workspace-scoped
+   * (INV-8); the target's prior primary in another conversation must already be
+   * removed (`removePrimaryMessages`).
+   */
+  async addPrimaryMessages(
+    db: Querier,
+    workspaceId: string,
+    conversationId: string,
+    messageIds: string[],
+    participantIds: string[]
+  ): Promise<void> {
+    await db.query(sql`
+      UPDATE conversations
+      SET message_ids = ARRAY(
+            SELECT e FROM (
+              SELECT e, MIN(ord) AS ord
+              FROM unnest(message_ids || ${messageIds}::text[]) WITH ORDINALITY AS t(e, ord)
+              GROUP BY e
+            ) deduped
+            ORDER BY ord
+          ),
+          participant_ids = ${participantIds}::text[],
+          secondary_message_ids = ARRAY(
+            SELECT e FROM unnest(secondary_message_ids) WITH ORDINALITY AS t(e, ord)
+            WHERE e <> ALL(${messageIds}::text[])
+            ORDER BY ord
+          ),
+          updated_at = NOW()
+      WHERE id = ${conversationId} AND workspace_id = ${workspaceId}
+    `)
+  },
+
+  /**
    * Resolve a conversation that no longer owns any primary messages. The
    * emptiness check runs inside the UPDATE (INV-20): a concurrent extraction
    * appending to `message_ids` between the caller's read and this write makes

--- a/apps/backend/src/features/conversations/service.split.test.ts
+++ b/apps/backend/src/features/conversations/service.split.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, spyOn, mock, test } from "bun:test"
+import type { PoolClient } from "pg"
+import { ConversationService } from "./service"
+import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationFeedbackRepository } from "./feedback-repository"
+import * as delivery from "./conversation-delivery"
+import { StreamRepository } from "../streams"
+import { MessageRepository, type Message } from "../messaging"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const ACTOR_ID = "usr_1"
+
+// `chan_1` is the root; `thr_1` hangs off `msg_open`; `thr_2` is a deeper
+// sub-topic under `thr_1` (a descendant thread whose members move with it).
+const STREAMS: Record<string, unknown> = {
+  chan_1: { id: "chan_1", type: "channel", parentStreamId: null, parentMessageId: null, rootStreamId: null },
+  thr_1: { id: "thr_1", type: "thread", parentStreamId: "chan_1", parentMessageId: "msg_open", rootStreamId: "chan_1" },
+  thr_2: { id: "thr_2", type: "thread", parentStreamId: "thr_1", parentMessageId: "msg_t1", rootStreamId: "chan_1" },
+  // A thread under a DIFFERENT root — the same-root guard's negative case.
+  thr_foreign: {
+    id: "thr_foreign",
+    type: "thread",
+    parentStreamId: "chan_2",
+    parentMessageId: "msg_x",
+    rootStreamId: "chan_2",
+  },
+}
+
+const MESSAGES: Record<string, { streamId: string; authorId: string }> = {
+  msg_open: { streamId: "chan_1", authorId: "usr_1" },
+  msg_root2: { streamId: "chan_1", authorId: "usr_2" },
+  msg_t1: { streamId: "thr_1", authorId: "usr_1" },
+  msg_t2: { streamId: "thr_1", authorId: "usr_2" },
+  msg_t2sub: { streamId: "thr_2", authorId: "usr_1" },
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_src",
+    streamId: "chan_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["msg_open", "msg_root2", "msg_t1", "msg_t2", "msg_t2sub"],
+    participantIds: ["usr_1", "usr_2"],
+    secondaryMessageIds: [],
+    topicSummary: "Parent topic",
+    summary: null,
+    completenessScore: 1,
+    confidence: 1,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function messageMap(ids: string[]): Map<string, Message> {
+  const map = new Map<string, Message>()
+  for (const id of ids) {
+    const base = MESSAGES[id]
+    if (base) map.set(id, { id, streamId: base.streamId, authorId: base.authorId } as unknown as Message)
+  }
+  return map
+}
+
+interface SplitSpies {
+  insert: ReturnType<typeof spyOn>
+  removePrimaryMessages: ReturnType<typeof spyOn>
+  addPrimaryMessages: ReturnType<typeof spyOn>
+  bumpActivityForIds: ReturnType<typeof spyOn>
+  feedbackInsertMany: ReturnType<typeof spyOn>
+  outboxInsert: ReturnType<typeof spyOn>
+}
+
+function setup(options?: {
+  source?: Conversation
+  streamOverrides?: Record<string, unknown>
+  subtree?: string[]
+}): SplitSpies {
+  const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
+  spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withTransaction)
+
+  const streams = { ...STREAMS, ...(options?.streamOverrides ?? {}) }
+  spyOn(StreamRepository, "findById").mockImplementation(
+    async (_c: unknown, id: string) => (streams[id] ?? null) as never
+  )
+  spyOn(StreamRepository, "listSelfAndDescendantIds").mockResolvedValue(options?.subtree ?? ["thr_1", "thr_2"])
+
+  const source = options?.source ?? makeConversation()
+  spyOn(ConversationRepository, "findByIdForUpdate").mockResolvedValue(source)
+  spyOn(ConversationRepository, "findById").mockImplementation(async (_c: unknown, id: string) => {
+    if (id === source.id) {
+      return makeConversation({
+        id: source.id,
+        messageIds: ["msg_open", "msg_root2"],
+        participantIds: ["usr_1", "usr_2"],
+      })
+    }
+    return makeConversation({
+      id,
+      streamId: "thr_1",
+      topicSummary: null,
+      messageIds: ["msg_t1", "msg_t2", "msg_t2sub"],
+      participantIds: ["usr_1", "usr_2"],
+    })
+  })
+
+  spyOn(MessageRepository, "findByIds").mockResolvedValue(messageMap(source.messageIds))
+  spyOn(MessageRepository, "findByIdsForUpdate").mockResolvedValue([])
+
+  spyOn(delivery, "resolveConversationDelivery").mockResolvedValue({
+    parentStreamId: "chan_1",
+    streamVisibility: "public",
+  })
+
+  const insert = spyOn(ConversationRepository, "insert").mockResolvedValue({ id: "conv_new" } as never)
+  const removePrimaryMessages = spyOn(ConversationRepository, "removePrimaryMessages").mockResolvedValue(
+    undefined as never
+  )
+  const addPrimaryMessages = spyOn(ConversationRepository, "addPrimaryMessages").mockResolvedValue(undefined as never)
+  const bumpActivityForIds = spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+  const feedbackInsertMany = spyOn(ConversationFeedbackRepository, "insertMany").mockResolvedValue(undefined as never)
+  const outboxInsert = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+  return { insert, removePrimaryMessages, addPrimaryMessages, bumpActivityForIds, feedbackInsertMany, outboxInsert }
+}
+
+function service(): ConversationService {
+  return new ConversationService({} as never)
+}
+
+async function split(threadStreamId = "thr_1", conversationId = "conv_src") {
+  return service().splitThreadIntoConversation({
+    workspaceId: WORKSPACE_ID,
+    conversationId,
+    threadStreamId,
+    actorUserId: ACTOR_ID,
+  })
+}
+
+describe("ConversationService.splitThreadIntoConversation", () => {
+  afterEach(() => mock.restore())
+
+  test("moves the thread's members (incl. a descendant thread's) to a new thread-anchored conversation", async () => {
+    const spies = setup()
+
+    const result = await split()
+
+    // Minted anchored to the thread, following the fresh-mint precedent — no
+    // copied parent title (adjustment F), status active, confidence 1.
+    expect(spies.insert).toHaveBeenCalledTimes(1)
+    expect(spies.insert.mock.calls[0][1]).toMatchObject({
+      streamId: "thr_1",
+      workspaceId: WORKSPACE_ID,
+      status: "active",
+      confidence: 1,
+    })
+    expect(spies.insert.mock.calls[0][1].topicSummary).toBeUndefined()
+
+    const newId = spies.insert.mock.calls[0][1].id as string
+    // The move set is the thread's own messages plus the descendant thread's.
+    expect(spies.addPrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      newId,
+      ["msg_t1", "msg_t2", "msg_t2sub"],
+      ["usr_1", "usr_2"]
+    )
+    // Source loses exactly the moved ids; participants recomputed from the rest.
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_src",
+      ["msg_t1", "msg_t2", "msg_t2sub"],
+      ["usr_1", "usr_2"]
+    )
+    expect(spies.bumpActivityForIds).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, ["conv_src", newId])
+
+    expect(result.conversation.streamId).toBe("thr_1")
+    // Source keeps its opener (stays a real card, still active).
+    expect(result.sourceConversation.messageIds).toEqual(["msg_open", "msg_root2"])
+    expect(result.sourceConversation.status).toBe("active")
+  })
+
+  test("writes a conversation_feedback row per moved message (from source → new)", async () => {
+    const spies = setup()
+
+    await split()
+
+    expect(spies.feedbackInsertMany).toHaveBeenCalledTimes(1)
+    const rows = spies.feedbackInsertMany.mock.calls[0][1] as Array<Record<string, unknown>>
+    expect(rows.map((r) => r.messageId)).toEqual(["msg_t1", "msg_t2", "msg_t2sub"])
+    expect(rows.every((r) => r.fromConversationId === "conv_src" && r.userId === ACTOR_ID)).toBe(true)
+    // Each row records the message's own stream (the thread / sub-thread).
+    expect(rows.map((r) => r.streamId)).toEqual(["thr_1", "thr_1", "thr_2"])
+  })
+
+  test("emits conversation:created, conversation:updated, and per-message reassigned events (by content)", async () => {
+    const spies = setup()
+
+    await split()
+
+    type Event = { type: string; payload: Record<string, any> }
+    const events: Event[] = spies.outboxInsert.mock.calls.map((c: unknown[]) => ({
+      type: c[1] as string,
+      payload: c[2] as Record<string, any>,
+    }))
+    const created = events.find((e: Event) => e.type === "conversation:created")
+    expect(created?.payload.conversation.streamId).toBe("thr_1")
+    const updated = events.find((e: Event) => e.type === "conversation:updated")
+    expect(updated?.payload.conversationId).toBe("conv_src")
+    // One move event per moved message, routed to the message's own stream.
+    const reassigned = events.filter((e: Event) => e.type === "conversation:message_reassigned")
+    expect(reassigned.map((e: Event) => e.payload.messageId).sort()).toEqual(["msg_t1", "msg_t2", "msg_t2sub"])
+    expect(
+      reassigned.every(
+        (e: Event) => e.payload.fromConversationId === "conv_src" && e.payload.reason === "user_correction"
+      )
+    ).toBe(true)
+  })
+
+  test("rejects a thread in a different root stream (same-root guard, 400)", async () => {
+    setup()
+    await expect(split("thr_foreign")).rejects.toMatchObject({ code: "CONVERSATION_NOT_IN_ROOT", status: 400 })
+  })
+
+  test("rejects when the thread's fork message is not a member of the conversation (400)", async () => {
+    // Source doesn't own `msg_open` (thr_1's parent message) as a member.
+    setup({ source: makeConversation({ messageIds: ["msg_root2", "msg_t1", "msg_t2"] }) })
+    await expect(split("thr_1")).rejects.toMatchObject({ code: "FORK_MESSAGE_NOT_MEMBER", status: 400 })
+  })
+
+  test("rejects when the thread has no member messages to move (empty set, 400)", async () => {
+    // Source's only members sit in the root — none in thr_1's subtree.
+    setup({ source: makeConversation({ messageIds: ["msg_open", "msg_root2"] }) })
+    await expect(split("thr_1")).rejects.toMatchObject({ code: "NO_THREAD_MEMBERS", status: 400 })
+  })
+
+  test("rejects a split target that is not a thread (400)", async () => {
+    setup()
+    await expect(split("chan_1")).rejects.toMatchObject({ code: "NOT_A_THREAD", status: 400 })
+  })
+})

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -11,9 +11,10 @@ import { MemoRepository } from "../memos"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
-import { conversationFeedbackId } from "../../lib/id"
+import { conversationFeedbackId, conversationId as generateConversationId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
 import {
+  ConversationStatuses,
   StreamTypes,
   type AttachmentSummary,
   type BoardLens,
@@ -106,6 +107,23 @@ export interface ReassignMessageResult {
   conversation: ConversationWithStaleness
   /** The conversation the message left, or null if it had no primary before. */
   previousConversation: ConversationWithStaleness | null
+}
+
+export interface SplitThreadParams {
+  workspaceId: string
+  /** The source conversation the thread is being split out of. */
+  conversationId: string
+  /** The thread stream to promote into its own conversation. */
+  threadStreamId: string
+  /** The correcting user — recorded with each moved message's feedback row. */
+  actorUserId: string
+}
+
+export interface SplitThreadResult {
+  /** The freshly minted conversation now anchoring the thread. */
+  conversation: ConversationWithStaleness
+  /** The source conversation the thread was split out of. */
+  sourceConversation: ConversationWithStaleness
 }
 
 /**
@@ -543,6 +561,163 @@ export class ConversationService {
   }
 
   /**
+   * User correction from the board: split a soft thread out of its parent
+   * conversation into its own topic. Reassigns the thread's member messages —
+   * and any deeper sub-topic thread's — to a freshly minted conversation
+   * anchored to the thread. The source keeps its opener and stays active; the
+   * board card re-forms the split-off thread as a nested branch group.
+   *
+   * Mirrors {@link reassignMessage}'s discipline: the source row is locked
+   * before its membership is read (INV-20), the moving message rows are locked
+   * in a deterministic order, and the membership move + feedback + outbox events
+   * all commit in one transaction (INV-6/7), delivered via the outbox (INV-4).
+   * The minted conversation follows the fresh-mint title precedent (no
+   * topicSummary — the extractor fills it), never copying the parent's title.
+   */
+  async splitThreadIntoConversation(params: SplitThreadParams): Promise<SplitThreadResult> {
+    const { workspaceId, conversationId, threadStreamId, actorUserId } = params
+
+    return withTransaction(this.pool, async (client) => {
+      // Lock the source: any op that removes a primary from it must UPDATE this
+      // row, so holding the lock keeps `messageIds` stable through the split and
+      // serializes a concurrent split (the loser re-reads an empty move set).
+      const source = await ConversationRepository.findByIdForUpdate(client, workspaceId, conversationId)
+      if (!source) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+
+      const threadStream = await StreamRepository.findById(client, threadStreamId)
+      if (!threadStream || threadStream.type !== StreamTypes.THREAD) {
+        throw new HttpError("Split target is not a thread", { status: 400, code: "NOT_A_THREAD" })
+      }
+
+      // One-root invariant (INV-62): the thread being promoted must share the
+      // source anchor's effective root — a thread is same-root by construction,
+      // so this only rejects a foreign/crafted `threadStreamId`.
+      const sourceStream = await StreamRepository.findById(client, source.streamId)
+      const threadRoot = threadStream.rootStreamId ?? threadStream.id
+      const sourceRoot = sourceStream?.rootStreamId ?? source.streamId
+      if (threadRoot !== sourceRoot) {
+        throw new HttpError("Thread is in a different root stream", {
+          status: 400,
+          code: "CONVERSATION_NOT_IN_ROOT",
+        })
+      }
+
+      // The thread's fork message must be a member of the source — it's the
+      // branch point the split heals into its own topic.
+      if (!threadStream.parentMessageId || !source.messageIds.includes(threadStream.parentMessageId)) {
+        throw new HttpError("Thread's fork message is not in the conversation", {
+          status: 400,
+          code: "FORK_MESSAGE_NOT_MEMBER",
+        })
+      }
+
+      // Move set: source members whose stream is the thread or one of its
+      // descendant threads (deeper sub-topics move with it). One recursive query
+      // for the subtree (INV-56), then filter members by their own stream.
+      const subtreeIds = new Set(await StreamRepository.listSelfAndDescendantIds(client, threadStreamId))
+      const memberMessages = await MessageRepository.findByIds(client, source.messageIds)
+      const moveIds = source.messageIds.filter((id) => {
+        const streamId = memberMessages.get(id)?.streamId
+        return streamId != null && subtreeIds.has(streamId)
+      })
+      if (moveIds.length === 0) {
+        throw new HttpError("Thread has no messages in this conversation", {
+          status: 400,
+          code: "NO_THREAD_MEMBERS",
+        })
+      }
+
+      // Lock the moving rows (INV-20) in a deterministic order — the batch
+      // counterpart to reassign's single-row `FOR UPDATE`.
+      await MessageRepository.findByIdsForUpdate(client, moveIds)
+
+      const movedSet = new Set(moveIds)
+      const remainingIds = source.messageIds.filter((id) => !movedSet.has(id))
+      const movedAuthors = distinctAuthors(moveIds, memberMessages)
+      const remainingAuthors = distinctAuthors(remainingIds, memberMessages)
+
+      const newId = generateConversationId()
+      await ConversationRepository.insert(client, {
+        id: newId,
+        streamId: threadStreamId,
+        workspaceId,
+        confidence: 1,
+        status: ConversationStatuses.ACTIVE,
+      })
+
+      await ConversationRepository.removePrimaryMessages(client, workspaceId, source.id, moveIds, remainingAuthors)
+      await ConversationRepository.addPrimaryMessages(client, workspaceId, newId, moveIds, movedAuthors)
+      await ConversationRepository.bumpActivityForIds(client, workspaceId, [source.id, newId])
+
+      // Feedback ground truth — one row per moved message (parity with
+      // {@link reassignMessage}), batched (INV-56).
+      await ConversationFeedbackRepository.insertMany(
+        client,
+        moveIds.map((messageId) => ({
+          id: conversationFeedbackId(),
+          workspaceId,
+          streamId: memberMessages.get(messageId)!.streamId,
+          messageId,
+          fromConversationId: source.id,
+          toConversationId: newId,
+          userId: actorUserId,
+        }))
+      )
+
+      // Re-read both rows post-write so the aggregate events carry final membership.
+      const newConversation = await ConversationRepository.findById(client, newId)
+      const updatedSource = await ConversationRepository.findById(client, source.id)
+      if (!newConversation || !updatedSource) {
+        // A row we just wrote vanished under our own transaction — fail loud (INV-11).
+        throw new Error(`Conversation vanished during split of ${source.id}`)
+      }
+
+      // Each aggregate event routes by its OWN access root (INV-62): the new
+      // conversation lives in the thread (parent-channel discoverability), the
+      // source in its anchor.
+      const threadDelivery = await resolveConversationDelivery(client, threadStream)
+      await OutboxRepository.insert(client, "conversation:created", {
+        workspaceId,
+        streamId: newConversation.streamId,
+        conversationId: newConversation.id,
+        conversation: addStalenessFields(newConversation),
+        parentStreamId: threadDelivery.parentStreamId,
+        streamVisibility: threadDelivery.streamVisibility,
+      })
+
+      const sourceDelivery = await resolveConversationDelivery(client, sourceStream)
+      await OutboxRepository.insert(client, "conversation:updated", {
+        workspaceId,
+        streamId: updatedSource.streamId,
+        conversationId: updatedSource.id,
+        conversation: addStalenessFields(updatedSource),
+        parentStreamId: sourceDelivery.parentStreamId,
+        streamVisibility: sourceDelivery.streamVisibility,
+      })
+
+      // Per-message move events route to each message's own stream (the thread),
+      // for the timeline membership map + extraction feedback.
+      for (const messageId of moveIds) {
+        await OutboxRepository.insert(client, "conversation:message_reassigned", {
+          workspaceId,
+          streamId: memberMessages.get(messageId)!.streamId,
+          messageId,
+          fromConversationId: source.id,
+          toConversationId: newId,
+          reason: "user_correction",
+        })
+      }
+
+      return {
+        conversation: addStalenessFields(newConversation),
+        sourceConversation: addStalenessFields(updatedSource),
+      }
+    })
+  }
+
+  /**
    * Mark a conversation read through `throughMessageId` (inclusive). Read truth is
    * message-granular and stream-anchored (docs/sparse-read-overlay-design.md):
    * the conversation's member messages are snapshotted to concrete ids at write
@@ -676,6 +851,21 @@ export class ConversationService {
     // Map keys are unique, so a strict less-than comparator totally orders them.
     return [...groups.entries()].sort(([a], [b]) => (a < b ? -1 : 1))
   }
+}
+
+/** Distinct non-null author ids of `ids`, in first-appearance order — the
+ *  recomputed `participant_ids` for a membership move. */
+function distinctAuthors(ids: string[], messages: Map<string, Message>): string[] {
+  const seen = new Set<string>()
+  const authors: string[] = []
+  for (const id of ids) {
+    const authorId = messages.get(id)?.authorId
+    if (authorId && !seen.has(authorId)) {
+      seen.add(authorId)
+      authors.push(authorId)
+    }
+  }
+  return authors
 }
 
 /** Project a full message + its hydrated rich content down to a board post message. */

--- a/apps/backend/src/features/messaging/content.test.ts
+++ b/apps/backend/src/features/messaging/content.test.ts
@@ -99,6 +99,15 @@ describe("createMessageSchema conversation directive", () => {
     expect(result.success).toBe(false)
   })
 
+  it("accepts a 'newSubtopic' directive with no id", () => {
+    const parsed = createMessageSchema.parse({
+      streamId: "stream_1",
+      contentJson: benignDoc,
+      conversation: { intent: "newSubtopic" },
+    })
+    expect(parsed).toMatchObject({ conversation: { intent: "newSubtopic" } })
+  })
+
   it("rejects an unknown intent", () => {
     const result = createMessageSchema.safeParse({
       streamId: "stream_1",

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -35,6 +35,7 @@ export const conversationDirectiveSchema = z.discriminatedUnion("intent", [
   z.object({ intent: z.literal("new") }),
   z.object({ intent: z.literal("existing"), conversationId: z.string().min(1) }),
   z.object({ intent: z.literal("threadFromMessage"), sourceConversationId: z.string().min(1) }),
+  z.object({ intent: z.literal("newSubtopic") }),
 ])
 
 // INV-31: this runtime schema is the wire guard; `ConversationDirective` in

--- a/apps/backend/src/features/streams/repository.ts
+++ b/apps/backend/src/features/streams/repository.ts
@@ -339,6 +339,24 @@ export const StreamRepository = {
   },
 
   /**
+   * `streamId` plus every stream nested beneath it (any depth), walking down
+   * `parent_stream_id` in one recursive CTE. Used by the thread-split flow to
+   * find the member messages that move with a thread: its own plus any deeper
+   * sub-topic threads. Always includes `streamId` itself.
+   */
+  async listSelfAndDescendantIds(db: Querier, streamId: string): Promise<string[]> {
+    const result = await db.query<{ id: string }>(sql`
+      WITH RECURSIVE subtree AS (
+        SELECT id FROM streams WHERE id = ${streamId}
+        UNION ALL
+        SELECT s.id FROM streams s JOIN subtree t ON s.parent_stream_id = t.id
+      )
+      SELECT id FROM subtree
+    `)
+    return result.rows.map((row) => row.id)
+  },
+
+  /**
    * Active thread ids whose top-level root is `rootStreamId` (any nesting
    * depth — `root_stream_id` points at the non-thread ancestor, INV-62).
    * Used to route root lifecycle events (`stream:archived` / `stream:unarchived`)

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -526,6 +526,11 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     conversation.reassignMessage
   )
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/split-thread",
+    ...authed,
+    conversation.splitThread
+  )
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/read", ...authed, conversation.markRead)
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/unread", ...authed, conversation.markUnread)
 

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -201,4 +201,19 @@ export const conversationsApi = {
   ): Promise<{ hiddenConversations: { conversationId: string; hiddenAt: string }[]; mutedStreamIds: string[] }> {
     return api.get(`/api/workspaces/${workspaceId}/board/exclusions`)
   },
+
+  /**
+   * Split a soft thread out of a conversation into its own topic — the board
+   * gesture that heals a sub-topic that outgrew its parent. The backend moves the
+   * thread's member messages (and any deeper sub-topics') to a freshly minted
+   * conversation anchored to the thread and records the correction as
+   * boundary-extraction feedback.
+   */
+  async splitThread(
+    workspaceId: string,
+    conversationId: string,
+    threadStreamId: string
+  ): Promise<{ conversation: ConversationWithStaleness; sourceConversation: ConversationWithStaleness }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/split-thread`, { threadStreamId })
+  },
 }

--- a/apps/frontend/src/components/board/board-card-auto-read.test.tsx
+++ b/apps/frontend/src/components/board/board-card-auto-read.test.tsx
@@ -14,6 +14,7 @@ import * as messageReactionsModule from "@/hooks/use-message-reactions"
 import * as userProfileModule from "@/components/user-profile"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -130,6 +131,12 @@ beforeEach(() => {
   vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // BoardCard hosts the inline branch composer, whose queue hook needs the
+  // pending-messages provider — stub the hook so the harness stays lean.
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
   vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
     addReaction: vi.fn(),
     removeReaction: vi.fn(),

--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -310,6 +310,41 @@ describe("BoardCard branches", () => {
     expect(container.querySelector(".border-l-2")).toBeNull()
   })
 
+  it("renders a convert-to-thread continuation with no seam or split chrome", async () => {
+    // A lone post whose first reply filed into a thread: the thread carries the
+    // whole conversation by design, so the reply is inline — no "continued in"
+    // seam, no split affordance, no indent.
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_conv", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "cr1",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("cr1", "stream_1", 10, "Lone post in channel."),
+      messageEvent("ct1", "thread_conv", 11, "First plain reply."),
+    ])
+    const post = makePost({
+      id: "conv_converted",
+      streamId: "stream_1",
+      messageIds: ["cr1", "ct1"],
+      opening: { id: "cr1", streamId: "stream_1", content: "Lone post in channel." },
+      streamIds: ["stream_1", "thread_conv"],
+      totalReplies: 1,
+      rootStreamId: "stream_1",
+      topicSummary: "Converted opener",
+    })
+    await db.conversations.bulkPut([post])
+
+    const { container } = mount(post)
+    await screen.findByText("First plain reply.")
+    expect(screen.queryByText(/continued in/)).toBeNull()
+    expect(screen.queryByRole("button", { name: "Split into its own topic" })).toBeNull()
+    expect(container.querySelector(".border-l-2")).toBeNull()
+  })
+
   it("shows neither stub nor provenance for a thread-anchored conversation with no live source", async () => {
     await db.streams.bulkPut([
       cachedStream("stream_1", StreamTypes.CHANNEL),

--- a/apps/frontend/src/components/board/board-card.branches.test.tsx
+++ b/apps/frontend/src/components/board/board-card.branches.test.tsx
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+
+function cachedStream(id: string, type: string, extra: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: type as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    archivedAt: null,
+    _cachedAt: 0,
+    ...extra,
+  }
+}
+
+interface PostOpts {
+  id: string
+  streamId: string
+  messageIds: string[]
+  opening: { id: string; streamId: string; content: string } | null
+  recentMessages?: Array<{ id: string; streamId: string; content: string; authorId?: string }>
+  totalReplies?: number
+  streamIds: string[]
+  rootStreamId: string
+  topicSummary: string | null
+}
+
+function makePost(opts: PostOpts): CachedBoardPost {
+  const opening = opts.opening
+    ? {
+        id: opts.opening.id,
+        streamId: opts.opening.streamId,
+        authorId: "usr_other",
+        authorType: "user",
+        contentMarkdown: opts.opening.content,
+        reactions: {},
+        attachments: [],
+        linkPreviews: [],
+        createdAt: "2026-06-22T12:00:00.000Z",
+        editedAt: null,
+      }
+    : null
+  return {
+    id: opts.id,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: opts.streamIds,
+    rootStreamId: opts.rootStreamId,
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: opts.id,
+      streamId: opts.streamId,
+      workspaceId: WS,
+      messageIds: opts.messageIds,
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: opts.topicSummary,
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+      createdAt: "2026-06-22T12:00:00.000Z",
+      updatedAt: "2026-06-22T12:00:00.000Z",
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: opening,
+    recentMessages: (opts.recentMessages ?? []).map((m) => ({
+      id: m.id,
+      streamId: m.streamId,
+      authorId: m.authorId ?? "usr_other",
+      authorType: "user",
+      contentMarkdown: m.content,
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+    })),
+    totalReplies: opts.totalReplies ?? 0,
+  } as unknown as CachedBoardPost
+}
+
+function messageEvent(id: string, streamId: string, seconds: number, content: string): CachedEvent {
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType: "message_created",
+    payload: { messageId: id, contentMarkdown: content, reactions: {} },
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
+function mount(post: CachedBoardPost) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+beforeEach(async () => {
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // BoardCard hosts the inline branch composer, whose queue hook needs the
+  // pending-messages provider — stub the hook so the harness stays lean.
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard branches", () => {
+  it("renders the child conversation nested under a branch header inside the parent card", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("c1", "thread_child", 10, "Child branch first message."),
+      messageEvent("c2", "thread_child", 11, "Child branch second message."),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: ["c1", "c2"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+
+    mount(parent)
+    // Branch header carries the child topic and links to the child's panel.
+    const header = await screen.findByText("GPU budget")
+    expect(header.closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_child")
+    // The child's own messages render nested INSIDE the parent card (one card,
+    // Reddit-style), indented under the header's left rail.
+    const nested = await screen.findByText("Child branch first message.")
+    expect(await screen.findByText("Child branch second message.")).toBeTruthy()
+    expect(nested.closest(".border-l-2")).not.toBeNull()
+    // The branch tail offers the inline Reply affordance (no navigation).
+    expect(screen.getByRole("button", { name: "Reply" })).toBeTruthy()
+  })
+
+  it("shows a 'branched from' provenance row on the child card", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_child", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "m_open",
+      }),
+    ])
+    const parent = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Hardware refresh opening." },
+      streamIds: ["stream_1"],
+      rootStreamId: "stream_1",
+      topicSummary: "Hardware refresh",
+    })
+    const child = makePost({
+      id: "conv_child",
+      streamId: "thread_child",
+      messageIds: ["c1"],
+      opening: { id: "m_open", streamId: "stream_1", content: "Parent opening body." },
+      streamIds: ["thread_child"],
+      rootStreamId: "stream_1",
+      topicSummary: "GPU budget",
+    })
+    await db.conversations.bulkPut([parent, child])
+
+    mount(child)
+    const provenance = await screen.findByText("Branched from Hardware refresh")
+    expect(provenance.closest("a")?.getAttribute("href")).toContain("panel=conv%3Aconv_parent")
+  })
+
+  it("renders a soft migration with a seam and no indent", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_soft", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "sr2",
+      }),
+    ])
+    await db.events.bulkPut([
+      messageEvent("sr1", "stream_1", 10, "First in channel."),
+      messageEvent("sr2", "stream_1", 11, "Second in channel."),
+      messageEvent("st1", "thread_soft", 12, "Moved into the thread."),
+    ])
+    const post = makePost({
+      id: "conv_soft",
+      streamId: "stream_1",
+      messageIds: ["sr1", "sr2", "st1"],
+      opening: { id: "sr1", streamId: "stream_1", content: "First in channel." },
+      streamIds: ["stream_1", "thread_soft"],
+      totalReplies: 2,
+      rootStreamId: "stream_1",
+      topicSummary: "Soft migration",
+    })
+    await db.conversations.bulkPut([post])
+
+    const { container } = mount(post)
+    await screen.findByText("Moved into the thread.")
+    expect(await screen.findByText(/continued in/)).toBeTruthy()
+    // Soft renders flat: no indent wrapper (the spanning left rail).
+    expect(container.querySelector(".border-l-2")).toBeNull()
+  })
+
+  it("shows neither stub nor provenance for a thread-anchored conversation with no live source", async () => {
+    await db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_legacy", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "gone_msg",
+      }),
+    ])
+    // No conversation contains `gone_msg`: the retired source resolves nothing.
+    const post = makePost({
+      id: "conv_legacy",
+      streamId: "thread_legacy",
+      messageIds: ["l1"],
+      opening: { id: "gone_msg", streamId: "stream_1", content: "Legacy opening body." },
+      streamIds: ["thread_legacy"],
+      rootStreamId: "stream_1",
+      topicSummary: "Legacy topic",
+    })
+    await db.conversations.bulkPut([post])
+
+    mount(post)
+    await screen.findByText("Legacy opening body.")
+    expect(screen.queryByText(/Branched from/)).toBeNull()
+    expect(screen.queryByText(/continued in/)).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider, createDraftPanelId } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+import { spyOnExport } from "@/test/spy"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real graph + structural index
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+import * as inlineComposerModule from "@/components/board/board-inline-composer"
+
+const WS = "ws_1"
+
+function cachedStream(id: string, type: string, extra: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: type as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    archivedAt: null,
+    _cachedAt: 0,
+    ...extra,
+  }
+}
+
+function makePost(opts: {
+  id: string
+  streamId: string
+  messageIds: string[]
+  topicSummary: string
+  streamIds: string[]
+}): CachedBoardPost {
+  return {
+    id: opts.id,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: opts.streamIds,
+    rootStreamId: "stream_1",
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: opts.id,
+      streamId: opts.streamId,
+      workspaceId: WS,
+      messageIds: opts.messageIds,
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: opts.topicSummary,
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+      createdAt: "2026-06-22T12:00:00.000Z",
+      updatedAt: "2026-06-22T12:00:00.000Z",
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: {
+      id: "m_open",
+      streamId: "stream_1",
+      authorId: "usr_other",
+      authorType: "user",
+      contentMarkdown: "Hardware refresh opening.",
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as CachedBoardPost
+}
+
+function messageEvent(id: string, streamId: string, seconds: number, content: string): CachedEvent {
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType: "message_created",
+    payload: { messageId: id, contentMarkdown: content, reactions: {} },
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  } as CachedEvent
+}
+
+function mount(post: CachedBoardPost) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: {} as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+const SENT_DOC = { type: "doc", content: [] }
+
+let queueDraftMessage: ReturnType<typeof vi.fn>
+
+beforeEach(async () => {
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // The queue seam: the inline composers' sends land here; each test asserts the
+  // exact directive the gesture queued.
+  queueDraftMessage = vi.fn().mockResolvedValue({ clientId: "client_1" })
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage,
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  // Swap the heavy editor form for a stub that surfaces its placeholder and a
+  // send button forwarding to `onSubmit` — the routing under test lives in the
+  // gesture hook, not the editor mechanics.
+  spyOnExport(inlineComposerModule, "InlineComposerForm").mockReturnValue(((props: {
+    placeholder: string
+    onSubmit: (input: { contentJson: unknown }) => Promise<void>
+  }) => (
+    <div>
+      <span>{props.placeholder}</span>
+      <button type="button" onClick={() => void props.onSubmit({ contentJson: SENT_DOC })}>
+        Send inline
+      </button>
+    </div>
+  )) as never)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+async function seedParentWithBranch() {
+  await db.streams.bulkPut([
+    cachedStream("stream_1", StreamTypes.CHANNEL),
+    cachedStream("thread_child", StreamTypes.THREAD, {
+      parentStreamId: "stream_1",
+      rootStreamId: "stream_1",
+      parentMessageId: "m_open",
+    }),
+  ])
+  await db.events.bulkPut([messageEvent("c1", "thread_child", 10, "Child branch message.")])
+  const parent = makePost({
+    id: "conv_parent",
+    streamId: "stream_1",
+    messageIds: ["m_open"],
+    topicSummary: "Hardware refresh",
+    streamIds: ["stream_1"],
+  })
+  const child = makePost({
+    id: "conv_child",
+    streamId: "thread_child",
+    messageIds: ["c1"],
+    topicSummary: "GPU budget",
+    streamIds: ["thread_child"],
+  })
+  await db.conversations.bulkPut([parent, child])
+  return { parent, child }
+}
+
+describe("BoardCard — inline sub-topic + branch reply", () => {
+  it("expands an inline composer on New sub-topic and queues the send with streamCreation + newSubtopic", async () => {
+    await db.streams.bulkPut([cachedStream("stream_1", StreamTypes.CHANNEL)])
+    const post = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      topicSummary: "Hardware refresh",
+      streamIds: ["stream_1"],
+    })
+    await db.conversations.bulkPut([post])
+
+    const user = userEvent.setup()
+    mount(post)
+    await screen.findByText("Hardware refresh opening.")
+
+    await user.click(screen.getByRole("button", { name: "Message actions" }))
+    await user.click(screen.getByText("New sub-topic"))
+
+    // No navigation, no panel: the composer expands in place under the row.
+    expect(await screen.findByText("Start a sub-topic…")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: "Send inline" }))
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      { contentJson: SENT_DOC },
+      {
+        workspaceId: WS,
+        streamId: createDraftPanelId("stream_1", "m_open"),
+        streamCreation: { type: StreamTypes.THREAD, parentStreamId: "stream_1", parentMessageId: "m_open" },
+        draftId: createDraftPanelId("stream_1", "m_open"),
+        conversation: { intent: "newSubtopic" },
+      }
+    )
+  })
+
+  it("hides New sub-topic on a message that already has a thread (adjustment D)", async () => {
+    const { parent } = await seedParentWithBranch()
+
+    const user = userEvent.setup()
+    mount(parent)
+    // The nested branch proves the thread is in the structural index, so the guard is live.
+    await screen.findByText("GPU budget")
+
+    const menus = screen.getAllByRole("button", { name: "Message actions" })
+    await user.click(menus[0])
+    expect(screen.queryByText("New sub-topic")).toBeNull()
+  })
+
+  it("expands an inline composer at the branch tail and queues the reply into the child conversation", async () => {
+    const { parent } = await seedParentWithBranch()
+
+    const user = userEvent.setup()
+    mount(parent)
+    await screen.findByText("Child branch message.")
+
+    await user.click(screen.getByRole("button", { name: "Reply" }))
+    expect(await screen.findByText("Reply…")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: "Send inline" }))
+    expect(queueDraftMessage).toHaveBeenCalledWith(
+      { contentJson: SENT_DOC },
+      {
+        workspaceId: WS,
+        streamId: "thread_child",
+        conversation: { intent: "existing", conversationId: "conv_child" },
+      }
+    )
+  })
+
+  it("renders the just-sent sub-topic message from the draft rail while the echo is pending", async () => {
+    await db.streams.bulkPut([cachedStream("stream_1", StreamTypes.CHANNEL)])
+    const post = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      topicSummary: "Hardware refresh",
+      streamIds: ["stream_1"],
+    })
+    await db.conversations.bulkPut([post])
+
+    const user = userEvent.setup()
+    mount(post)
+    await screen.findByText("Hardware refresh opening.")
+    await user.click(screen.getByRole("button", { name: "Message actions" }))
+    await user.click(screen.getByText("New sub-topic"))
+    await user.click(await screen.findByRole("button", { name: "Send inline" }))
+
+    // The real queue writes the optimistic event onto the draft-panel rail;
+    // simulate that write and assert the card renders it nested — the pending
+    // message must not vanish before the conversation echo lands.
+    await db.events.put(messageEvent("pend_1", createDraftPanelId("stream_1", "m_open"), 30, "Pending sub-topic body."))
+    expect(await screen.findByText("Pending sub-topic body.")).toBeTruthy()
+  })
+
+  it("keeps one inline composer open per card — opening another closes the first", async () => {
+    const { parent } = await seedParentWithBranch()
+
+    const user = userEvent.setup()
+    mount(parent)
+    await screen.findByText("Child branch message.")
+
+    // Open the branch-tail reply…
+    await user.click(screen.getByRole("button", { name: "Reply" }))
+    expect(await screen.findByText("Reply…")).toBeTruthy()
+
+    // …then open New sub-topic under the branch's message row: the reply
+    // composer closes (one inline composer per card).
+    const menus = screen.getAllByRole("button", { name: "Message actions" })
+    await user.click(menus[menus.length - 1])
+    await user.click(screen.getByText("New sub-topic"))
+    expect(await screen.findByText("Start a sub-topic…")).toBeTruthy()
+    expect(screen.queryByText("Reply…")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
@@ -165,9 +165,11 @@ beforeEach(async () => {
   // gesture hook, not the editor mechanics.
   spyOnExport(inlineComposerModule, "InlineComposerForm").mockReturnValue(((props: {
     placeholder: string
+    contextChip?: string
     onSubmit: (input: { contentJson: unknown }) => Promise<void>
   }) => (
     <div>
+      {props.contextChip && <span>{props.contextChip}</span>}
       <span>{props.placeholder}</span>
       <button type="button" onClick={() => void props.onSubmit({ contentJson: SENT_DOC })}>
         Send inline
@@ -283,6 +285,8 @@ describe("BoardCard — inline sub-topic + branch reply", () => {
 
     await user.click(screen.getByRole("button", { name: "Reply" }))
     expect(await screen.findByText("Reply…")).toBeTruthy()
+    // The chip names the reply target — the inline forms all look alike.
+    expect(screen.getByText("Replying in GPU budget")).toBeTruthy()
 
     await user.click(screen.getByRole("button", { name: "Send inline" }))
     expect(queueDraftMessage).toHaveBeenCalledWith(
@@ -291,6 +295,47 @@ describe("BoardCard — inline sub-topic + branch reply", () => {
         workspaceId: WS,
         streamId: "thread_child",
         conversation: { intent: "existing", conversationId: "conv_child" },
+      }
+    )
+  })
+
+  it("offers Reply on a pending branch and queues it through the idempotent sub-topic path", async () => {
+    // The child conversation echo hasn't landed (or was dropped by a flaky
+    // socket): the pending branch must still let the author continue — routed
+    // as another newSubtopic send, which mints-or-attaches server-side.
+    await db.streams.bulkPut([cachedStream("stream_1", StreamTypes.CHANNEL)])
+    const post = makePost({
+      id: "conv_parent",
+      streamId: "stream_1",
+      messageIds: ["m_open"],
+      topicSummary: "Hardware refresh",
+      streamIds: ["stream_1"],
+    })
+    await db.conversations.bulkPut([post])
+
+    const user = userEvent.setup()
+    mount(post)
+    await screen.findByText("Hardware refresh opening.")
+    await user.click(screen.getByRole("button", { name: "Message actions" }))
+    await user.click(screen.getByText("New sub-topic"))
+    await user.click(await screen.findByRole("button", { name: "Send inline" }))
+
+    // Simulate the queue's optimistic write so the pending branch renders.
+    await db.events.put(messageEvent("pend_1", createDraftPanelId("stream_1", "m_open"), 30, "Pending sub-topic body."))
+    await screen.findByText("Pending sub-topic body.")
+
+    await user.click(await screen.findByRole("button", { name: "Reply" }))
+    expect(await screen.findByText("Replying in New sub-topic")).toBeTruthy()
+    await user.click(screen.getByRole("button", { name: "Send inline" }))
+
+    expect(queueDraftMessage).toHaveBeenLastCalledWith(
+      { contentJson: SENT_DOC },
+      {
+        workspaceId: WS,
+        streamId: createDraftPanelId("stream_1", "m_open"),
+        streamCreation: { type: StreamTypes.THREAD, parentStreamId: "stream_1", parentMessageId: "m_open" },
+        draftId: createDraftPanelId("stream_1", "m_open"),
+        conversation: { intent: "newSubtopic" },
       }
     )
   })

--- a/apps/frontend/src/components/board/board-card.split.test.tsx
+++ b/apps/frontend/src/components/board/board-card.split.test.tsx
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes } from "@threa/types"
+import { BoardCard } from "./board-card"
+import type { BoardViewPost } from "@/hooks/use-stable-board-view"
+import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
+// eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail + graph read paths
+import { db, type CachedEvent, type CachedStream, type CachedBoardPost } from "@/db"
+import * as conversationReadModule from "@/components/message/conversation-read-context"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as useWorkspacesModule from "@/hooks/use-workspaces"
+import * as messageReactionsModule from "@/hooks/use-message-reactions"
+import * as userProfileModule from "@/components/user-profile"
+import * as syncEngineModule from "@/sync/sync-engine"
+import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+
+const WS = "ws_1"
+
+function cachedStream(id: string, type: string, extra: Partial<CachedStream> = {}): CachedStream {
+  return {
+    id,
+    workspaceId: WS,
+    type: type as CachedStream["type"],
+    displayName: null,
+    slug: null,
+    description: null,
+    visibility: "public",
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_me",
+    createdAt: "2026-06-22T12:00:00.000Z",
+    updatedAt: "2026-06-22T12:00:00.000Z",
+    archivedAt: null,
+    _cachedAt: 0,
+    ...extra,
+  }
+}
+
+function makePost(opts: {
+  id: string
+  streamId: string
+  messageIds: string[]
+  opening: { id: string; streamId: string; content: string }
+  streamIds: string[]
+  totalReplies: number
+}): CachedBoardPost {
+  return {
+    id: opts.id,
+    workspaceId: WS,
+    _lastActivityMs: 0,
+    _cachedAt: 0,
+    streamIds: opts.streamIds,
+    rootStreamId: "stream_1",
+    rootStreamType: "channel",
+    hasCapturedMemo: false,
+    conversation: {
+      id: opts.id,
+      streamId: opts.streamId,
+      workspaceId: WS,
+      messageIds: opts.messageIds,
+      participantIds: [],
+      secondaryMessageIds: [],
+      topicSummary: "Soft migration",
+      completenessScore: 0,
+      confidence: 1,
+      status: "active",
+      parentConversationId: null,
+      lastActivityAt: "2026-06-22T12:00:00.000Z",
+      createdAt: "2026-06-22T12:00:00.000Z",
+      updatedAt: "2026-06-22T12:00:00.000Z",
+      temporalStaleness: 0,
+      effectiveCompleteness: 0,
+    },
+    openingMessage: {
+      id: opts.opening.id,
+      streamId: opts.opening.streamId,
+      authorId: "usr_other",
+      authorType: "user",
+      contentMarkdown: opts.opening.content,
+      reactions: {},
+      attachments: [],
+      linkPreviews: [],
+      createdAt: "2026-06-22T12:00:00.000Z",
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: opts.totalReplies,
+  } as unknown as CachedBoardPost
+}
+
+function messageEvent(id: string, streamId: string, seconds: number, content: string): CachedEvent {
+  return {
+    id: `evt_${id}`,
+    workspaceId: WS,
+    streamId,
+    sequence: String(seconds),
+    _sequenceNum: seconds,
+    eventType: "message_created",
+    payload: { messageId: id, contentMarkdown: content, reactions: {} },
+    actorId: "usr_other",
+    actorType: "user",
+    createdAt: `2026-06-22T12:00:${String(seconds).padStart(2, "0")}.000Z`,
+    _cachedAt: seconds,
+  }
+}
+
+const splitThread = vi.fn().mockResolvedValue({
+  conversation: { id: "conv_new" },
+  sourceConversation: { id: "conv_soft" },
+})
+
+function mount(post: CachedBoardPost) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ServicesProvider services={{ conversations: { splitThread } as never }}>
+          <MemoryRouter initialEntries={[`/w/${WS}/board`]}>
+            <TraceProvider>
+              <PanelProvider>
+                <BoardCard workspaceId={WS} post={post as BoardViewPost} contextLabel="#general" streamType="channel" />
+              </PanelProvider>
+            </TraceProvider>
+          </MemoryRouter>
+        </ServicesProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  )
+}
+
+const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
+
+// A soft migration: two messages in the channel, then one in the thread — the
+// convert-to-thread "continued in …" seam, which carries the split affordance.
+function seedSoftMigration() {
+  return Promise.all([
+    db.streams.bulkPut([
+      cachedStream("stream_1", StreamTypes.CHANNEL),
+      cachedStream("thread_soft", StreamTypes.THREAD, {
+        parentStreamId: "stream_1",
+        rootStreamId: "stream_1",
+        parentMessageId: "sr2",
+      }),
+    ]),
+    db.events.bulkPut([
+      messageEvent("sr1", "stream_1", 10, "First in channel."),
+      messageEvent("sr2", "stream_1", 11, "Second in channel."),
+      messageEvent("st1", "thread_soft", 12, "Moved into the thread."),
+    ]),
+    db.conversations.bulkPut([
+      makePost({
+        id: "conv_soft",
+        streamId: "stream_1",
+        messageIds: ["sr1", "sr2", "st1"],
+        opening: { id: "sr1", streamId: "stream_1", content: "First in channel." },
+        streamIds: ["stream_1", "thread_soft"],
+        totalReplies: 2,
+      }),
+    ]),
+  ])
+}
+
+beforeEach(async () => {
+  splitThread.mockClear()
+  __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
+  await db.events.clear()
+  await db.streams.clear()
+  await db.conversations.clear()
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspacePersonas").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
+  vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
+  vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    toggleByEmoji: vi.fn(),
+  } as unknown as ReturnType<typeof messageReactionsModule.useMessageReactions>)
+  vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
+  vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
+    setBoardStreamIds: vi.fn(),
+  } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
+    preferences: { timezone: "UTC", locale: "en-US" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+    value: readValue,
+    hasUnread: () => false,
+    markReadSilently: () => Promise.resolve(),
+    setExplicitUnreadListener: () => {},
+    getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+  })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("BoardCard split-thread", () => {
+  it("offers the split affordance on a soft-thread seam and calls the API on confirm", async () => {
+    const user = userEvent.setup()
+    await seedSoftMigration()
+
+    mount(
+      makePost({
+        id: "conv_soft",
+        streamId: "stream_1",
+        messageIds: ["sr1", "sr2", "st1"],
+        opening: { id: "sr1", streamId: "stream_1", content: "First in channel." },
+        streamIds: ["stream_1", "thread_soft"],
+        totalReplies: 2,
+      })
+    )
+
+    // The soft seam shows the heal action.
+    await screen.findByText("Moved into the thread.")
+    const splitButton = await screen.findByRole("button", { name: "Split into its own topic" })
+
+    // Confirm-then-act: nothing fires until the dialog's Split is pressed.
+    await user.click(splitButton)
+    await screen.findByText("Split this thread into its own topic?")
+    expect(splitThread).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Split" }))
+    expect(splitThread).toHaveBeenCalledWith(WS, "conv_soft", "thread_soft")
+  })
+
+  it("does not call the API when the confirm dialog is cancelled", async () => {
+    const user = userEvent.setup()
+    await seedSoftMigration()
+
+    mount(
+      makePost({
+        id: "conv_soft",
+        streamId: "stream_1",
+        messageIds: ["sr1", "sr2", "st1"],
+        opening: { id: "sr1", streamId: "stream_1", content: "First in channel." },
+        streamIds: ["stream_1", "thread_soft"],
+        totalReplies: 2,
+      })
+    )
+
+    await user.click(await screen.findByRole("button", { name: "Split into its own topic" }))
+    await user.click(await screen.findByRole("button", { name: "Cancel" }))
+    expect(splitThread).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -9,6 +9,7 @@ import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 import { ServicesProvider, PanelProvider, TraceProvider } from "@/contexts"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { __clearBoardRailRegistry } from "@/hooks/use-board-card-messages"
+import { __clearConversationGraphRegistry } from "@/hooks/use-conversation-graph"
 // eslint-disable-next-line no-restricted-imports -- test seeds IDB directly to drive the real rail read path
 import { db, type CachedEvent } from "@/db"
 import * as conversationReadModule from "@/components/message/conversation-read-context"
@@ -18,6 +19,7 @@ import * as messageReactionsModule from "@/hooks/use-message-reactions"
 import * as userProfileModule from "@/components/user-profile"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -107,7 +109,10 @@ const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), 
 
 beforeEach(async () => {
   __clearBoardRailRegistry()
+  __clearConversationGraphRegistry()
   await db.events.clear()
+  await db.conversations.clear()
+  await db.streams.clear()
   vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
@@ -115,6 +120,12 @@ beforeEach(async () => {
   vi.spyOn(workspaceStoreModule, "useWorkspaceBots").mockReturnValue([] as never)
   vi.spyOn(workspaceStoreModule, "useWorkspaceMetadata").mockReturnValue(undefined as never)
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // BoardCard hosts the inline branch composer, whose queue hook needs the
+  // pending-messages provider — stub the hook so the harness stays lean.
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
   vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
     addReaction: vi.fn(),
     removeReaction: vi.fn(),

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import {
@@ -15,8 +15,16 @@ import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
+import {
+  useConversationGraph,
+  useStreamStructuralIndex,
+  deriveBranchConversations,
+  deriveBranchProvenance,
+} from "@/hooks/use-conversation-graph"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { cn } from "@/lib/utils"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
@@ -27,8 +35,9 @@ import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
 import { useWorkspaceUserId } from "@/hooks/use-workspaces"
 import { useConversationService, usePanel, createConversationPanelId } from "@/contexts"
-import { conversationKeys } from "@/hooks/use-conversations"
+import { conversationKeys, useSplitThread } from "@/hooks/use-conversations"
 import { useBoardCardMessages, useStableReplyWindow } from "@/hooks/use-board-card-messages"
+import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 interface BoardCardProps {
@@ -46,6 +55,10 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
   dm: User,
 }
 
+/** How many trailing messages a nested branch previews on a collapsed card; the
+ *  hidden rest sits behind an "N more replies" link into the child's panel. */
+const BRANCH_PREVIEW_CAP = 2
+
 /**
  * One board post: a conversation rendered as a feed post that reads like the
  * stream timeline. Messages use the same primitives (`ActorAvatar`,
@@ -59,11 +72,25 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
-  const { openPanel } = usePanel()
+  const { openPanel, getPanelUrl } = usePanel()
   const [expanded, setExpanded] = useState(false)
   // Scopes text-selection quoting to this card so a selection routes into this
   // card's composer, not a sibling card's provider.
   const cardRef = useRef<HTMLDivElement>(null)
+
+  // Shared graph + structural index, needed BEFORE the rail hook: the inline
+  // branch composer derives the branch thread streams (and any pending
+  // sub-topic draft rails) the card must subscribe to as extra rails.
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const inlineComposer = useInlineBranchComposer({
+    workspaceId,
+    conversationId: conversation.id,
+    memberMessageIds: conversation.messageIds,
+    index: structuralIndex,
+    graph: conversationGraph,
+  })
+  const { derivePendingBranches } = inlineComposer
 
   // Bodies ride the same `db.events` rail the timeline does — live and
   // offline-first — with the cached server projection as the cold-start fallback.
@@ -77,7 +104,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     pendingReplies,
     source,
     events: railEvents,
-  } = useBoardCardMessages(post, streamType)
+    messagesById,
+    taggedByConversation,
+  } = useBoardCardMessages(post, streamType, {
+    branchStreamIds: inlineComposer.branchStreamIds,
+    extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
+  })
 
   const streamId = conversation.streamId
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
@@ -115,6 +147,101 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
     [railEvents, conversation.id, memberMessageIds]
   )
+
+  // Per-thread-boundary grouping: soft-thread seams, nested branch conversations,
+  // and "branched from" provenance derive from the stream graph + the shared
+  // conversation graph. Grouping runs over the already-displayed rows below, so
+  // the stable-window / allResolved machinery stays untouched.
+  const occupiedStreamIds = useMemo(() => {
+    const set = new Set<string>([streamId])
+    for (const message of knownMessages) if (message.streamId) set.add(message.streamId)
+    return set
+  }, [streamId, knownMessages])
+  // A nested branch conversation's own bodies, resolved through this card's
+  // merged rail: its server `messageIds` unioned with the rows tagged with its
+  // id (a just-sent branch reply rides the tag through its echo window — the
+  // same union the card does for its own replies). A collapsed card previews a
+  // branch's last BRANCH_PREVIEW_CAP messages; the hidden rest links to the
+  // child's panel.
+  const resolveBranchMessages = useCallback(
+    (branchConversationId: string, branchMemberIds: string[]) => {
+      const rows: RenderableMessage[] = []
+      const seen = new Set<string>()
+      for (const id of branchMemberIds) {
+        const message = messagesById.get(id)
+        if (!message) continue
+        rows.push(message)
+        seen.add(id)
+      }
+      for (const tagged of taggedByConversation.get(branchConversationId) ?? []) {
+        if (!seen.has(tagged.id)) rows.push(tagged)
+      }
+      rows.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      const shown = expanded ? rows : rows.slice(-BRANCH_PREVIEW_CAP)
+      // Server-known members not shown (locally missing, or under the collapsed
+      // window) count toward the "N more replies" link into the child's panel.
+      const knownTotal = Math.max(branchMemberIds.length, rows.length)
+      return { messages: shown, hiddenCount: Math.max(0, knownTotal - shown.length) }
+    },
+    [messagesById, taggedByConversation, expanded]
+  )
+  const branchesByForkMessageId = useMemo(() => {
+    const branches = deriveBranchConversations({
+      conversationId: conversation.id,
+      memberMessageIds: conversation.messageIds,
+      index: structuralIndex,
+      graph: conversationGraph,
+      resolveMessages: resolveBranchMessages,
+      // A thread this conversation itself occupies renders inline (soft/spanning),
+      // never doubled as a branch group (mixed membership, adjustment D).
+      excludeThreadStreamIds: occupiedStreamIds,
+    })
+    const byFork = new Map<string, BranchConversationView[]>()
+    for (const branch of branches) {
+      const list = byFork.get(branch.forkMessageId)
+      if (list) list.push(branch)
+      else byFork.set(branch.forkMessageId, [branch])
+    }
+    // In-flight sub-topic sends render as synthetic pending branches until the
+    // graph takes over. A fork carries at most one thread, so a fork the graph
+    // already covers skips its pending twin (the one-render hand-off overlap).
+    for (const branch of derivePendingBranches(messagesById)) {
+      if (!byFork.has(branch.forkMessageId)) byFork.set(branch.forkMessageId, [branch])
+    }
+    return byFork
+  }, [
+    conversation.id,
+    conversation.messageIds,
+    structuralIndex,
+    conversationGraph,
+    resolveBranchMessages,
+    occupiedStreamIds,
+    derivePendingBranches,
+    messagesById,
+  ])
+  const provenance = useMemo(
+    () =>
+      deriveBranchProvenance({
+        conversationId: conversation.id,
+        anchorStreamId: streamId,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, streamId, structuralIndex, conversationGraph]
+  )
+  const branchRows = (messages: RenderableMessage[]) =>
+    buildBranchedBoardRows(
+      groupBranches(messages, { streams: structuralIndex.streamsById, conversation: { streamId } }),
+      eventRows,
+      branchesByForkMessageId
+    )
+  // A spanning-overflow row from a card opens the whole conversation in the panel.
+  const continueThreadTo = () => getPanelUrl(createConversationPanelId(conversation.id))
+  // Heal a soft-thread seam into its own topic (the card re-forms as a nested
+  // branch group via the conversation:created/updated sync).
+  const splitThread = useSplitThread(workspaceId)
+  const onSplitThread = (threadStreamId: string) =>
+    splitThread.mutate({ conversationId: conversation.id, threadStreamId })
 
   // The rail carries every locally-synced reply; older ones (or a wholly unsynced
   // stream — `source === "projection"`) may be missing, so on expand we backfill
@@ -194,32 +321,71 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     observer.observe(el)
     return () => observer.disconnect()
   }, [])
+  // The nested branches the card renders count as on-screen too — their content
+  // is read right here, so pushes for them must suppress as well.
   const cardVisibleStreamIds = useMemo(
-    () => (cardInViewport ? [...new Set([streamId, ...(post.streamIds ?? [])])] : []),
-    [cardInViewport, streamId, post.streamIds]
+    () =>
+      cardInViewport ? [...new Set([streamId, ...(post.streamIds ?? []), ...inlineComposer.branchStreamIds])] : [],
+    [cardInViewport, streamId, post.streamIds, inlineComposer.branchStreamIds]
   )
   useVisibleStreams(cardVisibleStreamIds)
 
-  const renderMessage = (message: RenderableMessage, continuation: boolean) => (
-    <MessageItem
-      key={message.id}
-      workspaceId={workspaceId}
-      // A conversation can span its root + threads (one root); render each row
-      // against its own stream so reactions and the permalink target where the
-      // message actually lives, falling back to the card's anchor stream.
-      streamId={message.streamId ?? streamId}
-      message={message}
-      authorName={getActorName(message.authorId, message.authorType)}
-      currentUserId={currentUserId}
-      continuation={continuation}
-      conversationId={conversation.id}
-      conversationRootStreamId={conversation.streamId}
-      // Break the row out of the card's p-3/p-4 padding and pad the content back in,
-      // so an actor accent fills to the card edges (stream-view look) with rows aligned.
-      surfaceClassName="bg-card px-3 sm:px-4"
-      rowInsetClassName="-mx-3 sm:-mx-4"
-    />
-  )
+  const renderMessage = (message: RenderableMessage, continuation: boolean) => {
+    // A conversation can span its root + threads (one root); render each row
+    // against its own stream so reactions and the permalink target where the
+    // message actually lives, falling back to the card's anchor stream.
+    const rowStreamId = message.streamId ?? streamId
+    // "New sub-topic" only where a fresh branch is valid: hide it once a thread
+    // already exists under the message (a populated thread would mix membership —
+    // "Split this thread" is the gesture there, adjustment D).
+    const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    return (
+      <MessageItem
+        key={message.id}
+        workspaceId={workspaceId}
+        streamId={rowStreamId}
+        message={message}
+        authorName={getActorName(message.authorId, message.authorType)}
+        currentUserId={currentUserId}
+        continuation={continuation}
+        conversationId={conversation.id}
+        conversationRootStreamId={conversation.streamId}
+        // Break the row out of the card's p-3/p-4 padding and pad the content back in,
+        // so an actor accent fills to the card edges (stream-view look) with rows aligned.
+        surfaceClassName="bg-card px-3 sm:px-4"
+        rowInsetClassName="-mx-3 sm:-mx-4"
+        onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
+      />
+    )
+  }
+
+  // A nested branch's rows are OUTSIDE this card's conversation: render-only
+  // here, so they're wrapped in a null read provider (no mark-read/unread, no
+  // auto-read, no unread-dot input — their read state belongs to the child's own
+  // surfaces) and identify as the CHILD conversation (copy-link opens its panel).
+  const renderBranchMessage = (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => {
+    const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    return (
+      <ConversationReadProvider value={null}>
+        <MessageItem
+          workspaceId={workspaceId}
+          streamId={message.streamId ?? branch.threadStreamId}
+          message={message}
+          authorName={getActorName(message.authorId, message.authorType)}
+          currentUserId={currentUserId}
+          continuation={continuation}
+          conversationId={branch.conversationId}
+          conversationRootStreamId={branch.threadStreamId}
+          surfaceClassName="bg-card"
+          onNewSubtopic={
+            canBranch
+              ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
+              : undefined
+          }
+        />
+      </ConversationReadProvider>
+    )
+  }
 
   return (
     // Scope quote reply to this card: a message row's "Quote reply" routes into
@@ -294,18 +460,26 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
           )}
 
           <div className="mt-3 [&>*:first-child]:mt-0">
+            {provenance && (
+              <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
+            )}
             {contiguous ? (
-              buildBoardRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies, eventRows).map(
-                (row) =>
-                  row.kind === "message" ? (
-                    renderMessage(row.message, row.continuation)
-                  ) : (
-                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-                  )
-              )
+              <BranchedBoardRows
+                rows={branchRows(openingMessage ? [openingMessage, ...displayedReplies] : displayedReplies)}
+                workspaceId={workspaceId}
+                renderMessage={renderMessage}
+                continueThreadTo={continueThreadTo}
+                onSplitThread={onSplitThread}
+                renderBranchMessage={renderBranchMessage}
+                renderBranchTail={inlineComposer.renderBranchTail}
+                renderAfterMessage={inlineComposer.renderAfterMessage}
+              />
             ) : (
               <>
                 {openingMessage && renderMessage(openingMessage, false)}
+                {/* The opening renders outside the row builder here, so its inline
+                    "new sub-topic" composer slot must be placed explicitly. */}
+                {openingMessage && inlineComposer.renderAfterMessage(openingMessage.id)}
                 {!expanded && hiddenCount > 0 && (
                   <button
                     type="button"
@@ -331,13 +505,16 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                     Couldn't load older messages. Retry.
                   </button>
                 )}
-                {buildBoardRows(displayedReplies, eventRows).map((row) =>
-                  row.kind === "message" ? (
-                    renderMessage(row.message, row.continuation)
-                  ) : (
-                    <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-                  )
-                )}
+                <BranchedBoardRows
+                  rows={branchRows(displayedReplies)}
+                  workspaceId={workspaceId}
+                  renderMessage={renderMessage}
+                  continueThreadTo={continueThreadTo}
+                  onSplitThread={onSplitThread}
+                  renderBranchMessage={renderBranchMessage}
+                  renderBranchTail={inlineComposer.renderBranchTail}
+                  renderAfterMessage={inlineComposer.renderAfterMessage}
+                />
               </>
             )}
           </div>

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react"
+import { CornerDownRight } from "lucide-react"
 import { toast } from "sonner"
 import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
 import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
@@ -36,6 +37,10 @@ interface InlineComposerFormProps {
   /** Draft persistence key (per target), so an escaped draft survives a reopen. */
   draftKey: string
   placeholder: string
+  /** Chip above the editor naming the reply target (e.g. "Replying in GPU
+   *  budget") — the inline forms all look alike, so the target must be legible
+   *  at the composer itself, not inferred from indentation. */
+  contextChip?: string
   autoFocus?: boolean
   pendingQuote?: QuoteReplyData | null
   onQuoteConsumed?: () => void
@@ -66,6 +71,7 @@ export function InlineComposerForm({
   memoAnchorStreamId,
   draftKey,
   placeholder,
+  contextChip,
   autoFocus = true,
   pendingQuote,
   onQuoteConsumed,
@@ -158,6 +164,12 @@ export function InlineComposerForm({
 
   return (
     <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
+      {contextChip && (
+        <div className="mb-1 flex w-fit max-w-full items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+          <CornerDownRight className="h-3 w-3 shrink-0" />
+          <span className="truncate">{contextChip}</span>
+        </div>
+      )}
       <MessageComposer
         composerRef={composerControlRef}
         content={composer.content}

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import { toast } from "sonner"
+import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
+import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
+import { useDraftComposer } from "@/hooks"
+import { usePreferences } from "@/contexts"
+import { useMentionStreamContext } from "@/hooks/use-mentionables"
+import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
+import { useStreamFromStore } from "@/stores/stream-store"
+import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
+import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
+import type { AttachmentSummary } from "@/hooks/create-optimistic-bootstrap"
+import type { JSONContent } from "@threa/types"
+
+// Focus moving into one of these means a composer popover is open (inline
+// suggestion lists are `[role="listbox"]`; emoji/format/link popovers are Radix
+// poppers; the mobile drawer is a dialog) — all portal outside the composer
+// subtree, so blur-to-collapse treats them as "still editing" rather than a
+// dismissal. Shared by every inline composer surface.
+const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
+
+export interface InlineComposerSubmit {
+  contentJson: JSONContent
+  attachmentIds?: string[]
+  attachments?: AttachmentSummary[]
+}
+
+interface InlineComposerFormProps {
+  workspaceId: string
+  /** Host stream backing mention autocomplete + attachment uploads. A thread host
+   *  may be absent from the workspace cache; the composer degrades (no mention
+   *  context) rather than failing. */
+  streamId: string | undefined
+  /** Memo/attachment anchor — the conversation's own stream. */
+  memoAnchorStreamId: string
+  /** Draft persistence key (per target), so an escaped draft survives a reopen. */
+  draftKey: string
+  placeholder: string
+  autoFocus?: boolean
+  pendingQuote?: QuoteReplyData | null
+  onQuoteConsumed?: () => void
+  /**
+   * When the resolved host is end-to-end-encrypted, block the send with this
+   * message instead of queuing a doomed plaintext write (the backend rejects a
+   * sealed send — INV-E1 — and the extractor skips E2E streams). The draft is
+   * kept so nothing typed is lost.
+   */
+  rejectE2e?: string
+  /** Perform the send. Throws to keep the composer open and restore the draft. */
+  onSubmit: (input: InlineComposerSubmit) => Promise<void>
+  /** Collapse the composer (Escape / after-send / blur-when-empty). */
+  onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
+}
+
+/**
+ * The shared inline-composer core (INV-35): a compact `MessageComposer` with
+ * draft persistence, blur-when-empty collapse, Escape collapse, quote-reply
+ * insertion, and clear-on-send — with the *send itself* left to `onSubmit`. The
+ * board card's bottom reply, a branch group's tail reply, and the "new sub-topic"
+ * gesture all mount this and supply their own routing, so the editor mechanics
+ * live in exactly one place.
+ */
+export function InlineComposerForm({
+  workspaceId,
+  streamId,
+  memoAnchorStreamId,
+  draftKey,
+  placeholder,
+  autoFocus = true,
+  pendingQuote,
+  onQuoteConsumed,
+  rejectE2e,
+  onSubmit,
+  onClose,
+}: InlineComposerFormProps) {
+  const { preferences } = usePreferences()
+  const streams = useWorkspaceStreams(workspaceId)
+  const hostStream = useMemo<CachedStream | undefined>(
+    () => (streamId ? streams.find((s) => s.id === streamId) : undefined),
+    [streams, streamId]
+  )
+  const streamContext = useMentionStreamContext(workspaceId, hostStream)
+  // E2E state from the synced IDB row as authority (a thread host is absent from
+  // the workspace cache but the board syncs its row), OR the workspace cache.
+  const idbHostStream = useStreamFromStore(streamId)
+  const hostIsE2e = hostStream?.e2eEnabled === true || idbHostStream?.e2eEnabled === true
+
+  const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
+
+  const composerControlRef = useRef<ComposerControlHandle | null>(null)
+  const composerRef = useRef(composer)
+  composerRef.current = composer
+  // Append a quote once the composer exists; defer a frame so a saved draft's
+  // late hydrate lands first (else our setContent would clobber it), matching the
+  // board reply composer's insertion timing.
+  useEffect(() => {
+    if (!pendingQuote || !composer.isLoaded) return
+    const raf = requestAnimationFrame(() => {
+      composerRef.current.setContent(appendQuoteReplyNode(composerRef.current.content, pendingQuote))
+      composerControlRef.current?.focusAfterQuoteReply()
+      onQuoteConsumed?.()
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [pendingQuote, composer.isLoaded, onQuoteConsumed])
+
+  const canSubmit = composer.canSend
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isEmptyRef = useRef(true)
+  isEmptyRef.current = isEmptyContent(composer.content) && composer.pendingAttachments.length === 0
+
+  const handleBlur = useCallback(() => {
+    requestAnimationFrame(() => {
+      const container = containerRef.current
+      if (!container) return
+      if (!document.hasFocus()) return
+      const active = document.activeElement
+      if (active && (container.contains(active) || active.closest(COMPOSER_POPOVER_SELECTOR))) return
+      if (!isEmptyRef.current) return
+      onClose()
+    })
+  }, [onClose])
+
+  const handleSubmit = async (editorContent?: JSONContent) => {
+    if (!composer.canSend) return
+
+    if (rejectE2e && hostIsE2e) {
+      toast.error(rejectE2e)
+      return
+    }
+
+    const pendingAttachments = composer.getPendingAttachmentsSnapshot()
+    const liveContent = editorContent ?? composer.content
+    const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
+    const attachments = extractUploadedAttachments(normalizedContent)
+    const attachmentIds = attachments.map((a) => a.id)
+
+    composer.setIsSending(true)
+    // Clear the editor up front so it empties in the same frame the optimistic
+    // row appears; restored on failure so nothing typed is lost.
+    composer.setContent(EMPTY_DOC)
+    try {
+      await onSubmit({
+        contentJson: normalizedContent,
+        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        attachments: attachments.length > 0 ? attachments : undefined,
+      })
+      await composer.resolveDraft()
+      composer.clearAttachments()
+      onClose({ refocus: true })
+    } catch {
+      composer.setContent(normalizedContent)
+      toast.error("Couldn't post. Please try again.")
+    } finally {
+      composer.setIsSending(false)
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
+      <MessageComposer
+        composerRef={composerControlRef}
+        content={composer.content}
+        onContentChange={composer.handleContentChange}
+        pendingAttachments={composer.pendingAttachments}
+        onRemoveAttachment={composer.handleRemoveAttachment}
+        workspaceId={workspaceId}
+        streamId={hostStream?.id}
+        memoAnchorStreamId={memoAnchorStreamId}
+        fileInputRef={composer.fileInputRef}
+        onFileSelect={composer.handleFileSelect}
+        onFileUpload={composer.uploadFile}
+        imageCount={composer.imageCount}
+        onSubmit={handleSubmit}
+        canSubmit={canSubmit}
+        isSubmitting={composer.isSending}
+        hasFailed={composer.hasFailed}
+        placeholder={placeholder}
+        messageSendMode={preferences?.messageSendMode ?? "enter"}
+        autoFocus={autoFocus}
+        initialMobileChromeOpen
+        scopeId={draftKey}
+        streamContext={streamContext}
+        onEscapeBlur={() => {
+          const hadContent = !isEmptyRef.current
+          void composer.flushDraft()
+          onClose({ refocus: true, hadContent })
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,31 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { toast } from "sonner"
-import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
-import { useQuoteReply, appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
-import { useDraftComposer } from "@/hooks"
-import { usePreferences } from "@/contexts"
-import { useMentionStreamContext } from "@/hooks/use-mentionables"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useQuoteReply, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
-import { useWorkspaceStreams, type CachedStream } from "@/stores/workspace-store"
-import { useStreamFromStore } from "@/stores/stream-store"
-import { EMPTY_DOC, isEmptyContent } from "@/lib/prosemirror-utils"
-import { extractUploadedAttachments, materializePendingAttachmentReferences } from "@/components/timeline/message-input"
-import type { BoardPost, JSONContent } from "@threa/types"
-
-// Focus moving into one of these means a composer popover is open (the inline
-// suggestion lists render as `[role="listbox"]`; emoji/format/link popovers are
-// Radix poppers; the mobile drawer is a dialog) — all portal outside the
-// composer subtree, so blur-to-collapse must treat them as "still editing"
-// rather than a dismissal. document-editor-modal.tsx guards its suggestion
-// popover the same way (`[role="listbox"]`); this set is broader to also cover
-// the Radix poppers and dialog.
-const COMPOSER_POPOVER_SELECTOR = '[role="listbox"],[data-radix-popper-content-wrapper],[role="dialog"]'
+import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
+import type { BoardPost } from "@threa/types"
 
 // Resting-affordance state. `draft` signals a persisted-but-collapsed reply, so
 // the user knows reopening restores it. Every reply — including a lone post's
-// convert-to-thread — now joins the same conversation and renders in place on the
-// card (board-view-design.md "Convert-to-thread, corrected"), so there is no card
-// swap to bridge: a successful send just returns the affordance to its invitation.
+// convert-to-thread — joins the same conversation and renders in place on the
+// card (board-view-design.md "Convert-to-thread, corrected"), so a successful
+// send just returns the affordance to its invitation.
 type RestingState = "idle" | "draft"
 const RESTING_LABEL: Record<RestingState, string> = {
   idle: "Write a reply…",
@@ -51,29 +34,19 @@ interface BoardReplyComposerProps {
 }
 
 /**
- * Inline reply affordance on a board card. Collapsed to a single resting line
- * so the feed stays scannable; tapping it mounts the real composer in place (the
- * heavy editor mounts only once a card is activated, so a feed of cards costs one
- * lightweight button each, not one composer each). The button deliberately
- * mirrors the composer's own container — same radius, border, surface, padding,
- * and placeholder — and the composer mounts already open (`initialMobileChromeOpen`)
- * so the tap lands straight in the toolbar view instead of stepping through the
- * mobile compacted phase. Routing — a lone channel/DM post converts to a thread,
- * everything else replies flat into the conversation (recency-biased — into the
- * thread the conversation moved to) — lives in {@link useReplyToBoardPost}.
- *
- * The resting affordance carries state (best-effort, in-session): it flags a
- * persisted draft after an Escape ("Continue reply…") so a collapse never reads
- * as an accidental discard.
+ * Inline reply affordance on a board card / conversation panel. Collapsed to a
+ * single resting line so the feed stays scannable; tapping it mounts the shared
+ * {@link InlineComposerForm} in place (the heavy editor mounts only once a card is
+ * activated). Routing — a lone channel/DM post converts to a thread, everything
+ * else replies flat into the conversation (recency-biased) — lives in
+ * {@link useReplyToBoardPost}. The resting affordance flags a persisted draft
+ * after an Escape ("Continue reply…") so a collapse never reads as a discard.
  */
 export function BoardReplyComposer(props: BoardReplyComposerProps) {
   const [open, setOpen] = useState(false)
   const [resting, setResting] = useState<RestingState>("idle")
   const buttonRef = useRef<HTMLButtonElement>(null)
 
-  // "Reply in conversation" opened the panel and asked it to land in the editor.
-  // Keyed on the nonce so each request re-opens the composer even after a manual
-  // collapse; `0`/absent is the resting default.
   const { openReplySignal } = props
   useEffect(() => {
     if (!openReplySignal) return
@@ -84,9 +57,7 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
   // Quote reply from a message row in this conversation lands here. The resting
   // affordance leaves the form unmounted while collapsed, so this always-mounted
   // outer owns the provider registration: it opens the form and stashes the quote
-  // for the form to consume on mount (or immediately, if already open). Scoped by
-  // the per-conversation QuoteReplyProvider the card/panel wraps around its rows +
-  // this composer.
+  // for the form to consume on mount.
   const quoteReplyCtx = useQuoteReply()
   const [pendingQuote, setPendingQuote] = useState<QuoteReplyData | null>(null)
   const onQuoteConsumed = useCallback(() => setPendingQuote(null), [])
@@ -98,10 +69,10 @@ export function BoardReplyComposer(props: BoardReplyComposerProps) {
       setOpen(true)
     })
   }, [quoteReplyCtx])
-  // Return focus to the resting button after an explicit collapse (Escape /
-  // after-send) so keyboard navigation isn't dropped onto <body> when the form
-  // unmounts. A blur-driven collapse passes refocus=false — the user already
-  // moved focus elsewhere, so we leave it where they put it.
+
+  // Return focus to the resting button after an explicit collapse so keyboard
+  // navigation isn't dropped onto <body>. A blur-driven collapse passes
+  // refocus=false — the user already moved focus elsewhere.
   const refocusOnCollapseRef = useRef(false)
   useEffect(() => {
     if (!open && refocusOnCollapseRef.current) {
@@ -153,180 +124,37 @@ function BoardReplyComposerForm({
   pendingQuote: QuoteReplyData | null
   onQuoteConsumed: () => void
 }) {
-  const { preferences } = usePreferences()
-  const streams = useWorkspaceStreams(workspaceId)
   const reply = useReplyToBoardPost(workspaceId)
-
   const streamId = post.conversation.streamId
-  // The host stream backs mention autocomplete + attachment uploads. A thread
-  // card's host may not be in the workspace stream cache; the composer degrades
-  // gracefully (no mention context) when it isn't.
-  const hostStream = useMemo<CachedStream | undefined>(
-    () => streams.find((s) => s.id === streamId),
-    [streams, streamId]
-  )
-  const streamContext = useMentionStreamContext(workspaceId, hostStream)
 
-  // Whether the host is end-to-end-encrypted. Read from the synced IDB stream row
-  // (`useStreamFromStore`) as the authority, NOT just the workspace cache: a
-  // thread card's host is absent from `useWorkspaceStreams` (it holds sidebar
-  // streams) but the board syncs every on-screen card's host into `db.streams`
-  // (useBoardStreamSubscriptions), so the IDB row carries `e2eEnabled` where the
-  // workspace cache has no row. Falling back to the cache alone would skip the
-  // block below for thread hosts.
-  const idbHostStream = useStreamFromStore(streamId)
-  const hostIsE2e = hostStream?.e2eEnabled === true || idbHostStream?.e2eEnabled === true
-
-  const draftKey = `board:reply:${post.conversation.id}`
-  const composer = useDraftComposer({ workspaceId, draftKey, scopeId: draftKey })
-
-  // Imperative handle for post-quote focus. A ref to the composer keeps the
-  // insertion off the un-memoized composer object (a fresh identity every render),
-  // so it fires only when a new quote arrives.
-  const composerControlRef = useRef<ComposerControlHandle | null>(null)
-  const composerRef = useRef(composer)
-  composerRef.current = composer
-  // Append the quote once its target composer exists. Gate on `isLoaded` and defer
-  // a frame: a quote from a collapsed card mounts this form fresh, and a saved
-  // draft late-hydrates into the empty editor on the load commit. Inserting in that
-  // same flush would run last and clobber the draft (our setContent wins over the
-  // hydrate's), so we wait for the draft body to land, then append onto it — the
-  // same preserve-what's-there append the stream composer does.
-  useEffect(() => {
-    if (!pendingQuote || !composer.isLoaded) return
-    const raf = requestAnimationFrame(() => {
-      composerRef.current.setContent(appendQuoteReplyNode(composerRef.current.content, pendingQuote))
-      composerControlRef.current?.focusAfterQuoteReply()
-      onQuoteConsumed()
-    })
-    return () => cancelAnimationFrame(raf)
-  }, [pendingQuote, composer.isLoaded, onQuoteConsumed])
-
-  const canSubmit = composer.canSend && !reply.isPending
-
-  // Collapse back to the one-line affordance when focus leaves an empty reply —
-  // the native composer feel. A draft with content (text or a pending upload)
-  // stays open and persists; abandoning means clearing it. The latest emptiness
-  // is read through a ref so the deferred check sees current state without
-  // re-binding the handler each keystroke.
-  const containerRef = useRef<HTMLDivElement>(null)
-  const isEmptyRef = useRef(true)
-  isEmptyRef.current = isEmptyContent(composer.content) && composer.pendingAttachments.length === 0
-
-  const handleBlur = useCallback(() => {
-    // Defer past the focusout: focus may be landing on a sibling control, or on
-    // a popover that portals out of this subtree (guarded above). Collapse only
-    // once focus has truly left and the draft is empty.
-    requestAnimationFrame(() => {
-      const container = containerRef.current
-      if (!container) return
-      // The page itself lost focus — a native file picker opened or the user
-      // switched tab/app. Keep the draft open; they're mid-action.
-      if (!document.hasFocus()) return
-      const active = document.activeElement
-      if (active && (container.contains(active) || active.closest(COMPOSER_POPOVER_SELECTOR))) return
-      if (!isEmptyRef.current) return
-      onClose()
-    })
-  }, [onClose])
-
-  const handleSubmit = async (editorContent?: JSONContent) => {
-    if (!composer.canSend) return
-
-    // Board replies into an end-to-end-encrypted host aren't supported: the send
-    // path here is plaintext (a sealed send is rejected by INV-E1), and the
-    // boundary extractor skips E2E streams so the reply couldn't be assigned to
-    // this conversation anyway. Surface it instead of queuing a doomed send —
-    // E2E board replies belong to the encrypted-streams workstream. The draft is
-    // kept so nothing the user typed is lost.
-    if (hostIsE2e) {
-      toast.error("Encrypted notes can't be replied to from the board yet — open the note to reply there.")
-      return
-    }
-
-    const pendingAttachments = composer.getPendingAttachmentsSnapshot()
-    const liveContent = editorContent ?? composer.content
-    const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
-    const attachments = extractUploadedAttachments(normalizedContent)
-    const attachmentIds = attachments.map((a) => a.id)
-
-    composer.setIsSending(true)
-    // Clear the editor up front so it empties in the same frame the optimistic
-    // reply appears on the card — otherwise the just-sent text lingers in the
-    // composer for a frame next to its own posted copy. Restored on failure so
-    // nothing the user typed is lost.
-    composer.setContent(EMPTY_DOC)
-    try {
-      // Eager + offline-first: the reply is enqueued as an optimistic event and
-      // the send drains in the background, so there's no created message to await.
-      // Every reply joins the same conversation and rides the card's own (merged)
-      // rail — an `intoConversation` reply shows in place, and a `convertToThread`
-      // reply shows in place too now that it stays one conversation (no card swap),
-      // so a successful send just collapses the affordance.
+  const onSubmit = useCallback(
+    async ({ contentJson, attachmentIds, attachments }: InlineComposerSubmit) => {
       await reply.mutateAsync({
         conversation: post.conversation,
         openingMessageId: post.openingMessage?.id ?? null,
         hostStreamType,
         messageCount: post.conversation.messageIds.length,
         lastActiveStreamId,
-        contentJson: normalizedContent,
-        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-        attachments: attachments.length > 0 ? attachments : undefined,
+        contentJson,
+        attachmentIds,
+        attachments,
       })
-      await composer.resolveDraft()
-      composer.clearAttachments()
-      onClose({ refocus: true })
-    } catch {
-      composer.setContent(normalizedContent)
-      toast.error("Couldn't post your reply. Please try again.")
-    } finally {
-      composer.setIsSending(false)
-    }
-  }
+    },
+    [reply, post.conversation, post.openingMessage, hostStreamType, lastActiveStreamId]
+  )
 
-  // The composer carries its own bordered, collapse-on-focus chrome and toolbar,
-  // so it sits directly on the card — no wrapper frame, which would double the
-  // border and leave an empty header strip. Dismissal instead of a cancel
-  // control: an empty reply collapses on blur (handleBlur); Escape collapses
-  // even a non-empty draft and returns focus to the trigger (onEscapeBlur).
   return (
-    <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
-      <MessageComposer
-        composerRef={composerControlRef}
-        content={composer.content}
-        onContentChange={composer.handleContentChange}
-        pendingAttachments={composer.pendingAttachments}
-        onRemoveAttachment={composer.handleRemoveAttachment}
-        workspaceId={workspaceId}
-        streamId={hostStream?.id}
-        memoAnchorStreamId={streamId}
-        fileInputRef={composer.fileInputRef}
-        onFileSelect={composer.handleFileSelect}
-        onFileUpload={composer.uploadFile}
-        imageCount={composer.imageCount}
-        onSubmit={handleSubmit}
-        canSubmit={canSubmit}
-        isSubmitting={composer.isSending}
-        hasFailed={composer.hasFailed}
-        placeholder="Write a reply…"
-        messageSendMode={preferences?.messageSendMode ?? "enter"}
-        autoFocus
-        initialMobileChromeOpen
-        scopeId={draftKey}
-        streamContext={streamContext}
-        // Escape (when no @/emoji/slash popup is open) collapses the reply and
-        // returns focus to the trigger — a keyboard cancel even with a draft,
-        // which the empty-only blur-collapse doesn't cover. Flush the draft to
-        // IDB FIRST: collapsing unmounts the form, which cancels the in-flight
-        // debounced save, so without this the just-typed draft would live only
-        // in localStorage (reconciled at startup) and a mid-session reopen would
-        // read an empty editor — a false "Continue reply…".
-        onEscapeBlur={() => {
-          const hadContent = !isEmptyRef.current
-          void composer.flushDraft()
-          onClose({ refocus: true, hadContent })
-        }}
-      />
-    </div>
+    <InlineComposerForm
+      workspaceId={workspaceId}
+      streamId={streamId}
+      memoAnchorStreamId={streamId}
+      draftKey={`board:reply:${post.conversation.id}`}
+      placeholder="Write a reply…"
+      pendingQuote={pendingQuote}
+      onQuoteConsumed={onQuoteConsumed}
+      rejectE2e="Encrypted notes can't be replied to from the board yet — open the note to reply there."
+      onSubmit={onSubmit}
+      onClose={onClose}
+    />
   )
 }

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest"
 import type { RenderableMessage } from "@/components/message/message-item"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
-import { buildBoardRows } from "./board-row-item"
+import { buildBoardRows, buildBranchedBoardRows } from "./board-row-item"
+import { groupBranches, type BranchStreamNode, type BranchConversationView } from "@/lib/board/branch-grouping"
 
-function msg(id: string, authorId: string, minute: number): RenderableMessage {
+function msg(id: string, authorId: string, minute: number, streamId?: string): RenderableMessage {
   return {
     id,
+    streamId,
     authorId,
     authorType: "user",
     contentMarkdown: id,
@@ -14,11 +16,18 @@ function msg(id: string, authorId: string, minute: number): RenderableMessage {
   }
 }
 
-// buildBoardRows only reads `kind` / `key` / `sortMs`, so the `event` field is a
-// stub — kept off `@/db` to leave this a pure-logic test (no persistence import).
-function memoEventRow(key: string, minute: number): BoardEventRow {
+// The builders only read `kind` / `key` / `sortMs` / `streamId`, so the `event`
+// field is a stub — kept off `@/db` to leave this a pure-logic test (no
+// persistence import).
+function memoEventRow(key: string, minute: number, streamId = "root"): BoardEventRow {
   const createdAt = `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`
-  return { kind: "memo", key, sortMs: new Date(createdAt).getTime(), event: { id: key, createdAt } } as BoardEventRow
+  return {
+    kind: "memo",
+    key,
+    sortMs: new Date(createdAt).getTime(),
+    streamId,
+    event: { id: key, createdAt },
+  } as BoardEventRow
 }
 
 describe("buildBoardRows", () => {
@@ -50,5 +59,116 @@ describe("buildBoardRows", () => {
   it("places a message before an event that shares its exact timestamp", () => {
     const rows = buildBoardRows([msg("a", "u1", 3)], [memoEventRow("evt", 3)])
     expect(rows.map((r) => r.kind)).toEqual(["message", "event"])
+  })
+})
+
+describe("buildBranchedBoardRows continuation", () => {
+  function streamNode(
+    parentStreamId: string | null,
+    rootStreamId: string | null,
+    parentMessageId: string | null
+  ): BranchStreamNode {
+    return { parentStreamId, rootStreamId, parentMessageId }
+  }
+
+  it("a soft seam breaks a same-author continuation run", () => {
+    // Same author within the grouping window, but split across a soft thread
+    // boundary: the seam sits between the runs and the second run doesn't group.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 1, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "seam", "message"])
+    const second = rows[2]
+    expect(second.kind === "message" && second.continuation).toBe(false)
+  })
+
+  it("a branch group lands after its fork message and breaks a same-author continuation run", () => {
+    // Two same-author messages that WOULD group, with a branch conversation
+    // forked off the first — the group resets continuation like an event row.
+    const streams = new Map([["root", streamNode(null, null, null)]])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 1, "root")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const branch: BranchConversationView = {
+      conversationId: "conv_child",
+      threadStreamId: "thread_x",
+      forkMessageId: "a",
+      title: "GPU budget",
+      displayDepth: 1,
+      overflow: false,
+      messages: [msg("c1", "u2", 2, "thread_x")],
+      hiddenCount: 0,
+      children: [],
+    }
+    const rows = buildBranchedBoardRows(grouping, [], new Map([["a", [branch]]]))
+    expect(rows.map((r) => r.kind)).toEqual(["message", "branch-group", "message"])
+    const second = rows[2]
+    expect(second.kind === "message" && second.continuation).toBe(false)
+  })
+
+  it("appends a branch whose fork message isn't rendered (hidden middle) after the run", () => {
+    const streams = new Map([["root", streamNode(null, null, null)]])
+    const grouping = groupBranches([msg("b", "u1", 4, "root")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const branch: BranchConversationView = {
+      conversationId: "conv_child",
+      threadStreamId: "thread_x",
+      forkMessageId: "hidden_msg",
+      title: "GPU budget",
+      displayDepth: 1,
+      overflow: false,
+      messages: [msg("c1", "u2", 2, "thread_x")],
+      hiddenCount: 0,
+      children: [],
+    }
+    const rows = buildBranchedBoardRows(grouping, [], new Map([["hidden_msg", [branch]]]))
+    expect(rows.map((r) => r.kind)).toEqual(["message", "branch-group"])
+  })
+
+  it("an event on a stream with no rendered group joins the base run chronologically", () => {
+    // A memo capture landed on a member stream whose messages sit in the hidden
+    // middle (or outside the occupied set entirely). It must still render — at
+    // the base level, in time order — not silently vanish.
+    const streams = new Map([["root", streamNode(null, null, null)]])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 4, "root")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [memoEventRow("evt", 2, "other_stream")], new Map())
+    expect(rows.map((r) => (r.kind === "message" ? r.message.id : r.kind))).toEqual(["a", "event", "b"])
+    const orphanRow = rows[1]
+    expect(orphanRow.kind === "event" && orphanRow.displayDepth).toBe(0)
+  })
+
+  it("splits orphan events across a soft seam by time", () => {
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u2", 4, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(
+      grouping,
+      [memoEventRow("early", 1, "elsewhere"), memoEventRow("late", 5, "elsewhere")],
+      new Map()
+    )
+    expect(rows.map((r) => (r.kind === "event" ? r.row.key : r.kind))).toEqual([
+      "message",
+      "early",
+      "seam",
+      "message",
+      "late",
+    ])
   })
 })

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -72,8 +72,25 @@ describe("buildBranchedBoardRows continuation", () => {
   }
 
   it("a soft seam breaks a same-author continuation run", () => {
-    // Same author within the grouping window, but split across a soft thread
-    // boundary: the seam sits between the runs and the second run doesn't group.
+    // A flat two-message discussion migrated into a thread: the seam sits
+    // between the runs and the post-seam message doesn't group.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "b")],
+    ])
+    const grouping = groupBranches(
+      [msg("a", "u1", 0, "root"), msg("b", "u1", 1, "root"), msg("c", "u1", 2, "thread")],
+      { streams, conversation: { streamId: "root" } }
+    )
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "message", "seam", "message"])
+    const afterSeam = rows[3]
+    expect(afterSeam.kind === "message" && afterSeam.continuation).toBe(false)
+  })
+
+  it("a lone opener continuing into a thread renders seamlessly (convert-to-thread)", () => {
+    // The first reply to a lone post files into a thread by design — the thread
+    // IS the conversation, so no seam row and continuation flows across.
     const streams = new Map([
       ["root", streamNode(null, null, null)],
       ["thread", streamNode("root", "root", "a")],
@@ -83,9 +100,45 @@ describe("buildBranchedBoardRows continuation", () => {
       conversation: { streamId: "root" },
     })
     const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "message"])
+    const reply = rows[1]
+    expect(reply.kind === "message" && reply.continuation).toBe(true)
+    expect(reply.kind === "message" && reply.displayDepth).toBe(0)
+  })
+
+  it("a converted opener stays seamless however large the thread grows", () => {
+    // Not a size threshold: the pre-boundary run stays opener-only, so the
+    // whole discussion renders as one flat run even with real back-and-forth.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches(
+      [
+        msg("a", "u1", 0, "root"),
+        msg("b", "u2", 1, "thread"),
+        msg("c", "u1", 2, "thread"),
+        msg("d", "u2", 3, "thread"),
+      ],
+      { streams, conversation: { streamId: "root" } }
+    )
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "message", "message", "message"])
+  })
+
+  it("an up-seam keeps its seam even when the first run is a single message", () => {
+    // Thread→root: the lone-opener rule is the convert-to-thread signature,
+    // which only exists on a down crossing — an up crossing always seams.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", null)],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "thread"), msg("b", "u1", 1, "root")], {
+      streams,
+      conversation: { streamId: "thread" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
     expect(rows.map((r) => r.kind)).toEqual(["message", "seam", "message"])
-    const second = rows[2]
-    expect(second.kind === "message" && second.continuation).toBe(false)
   })
 
   it("a branch group lands after its fork message and breaks a same-author continuation run", () => {
@@ -152,12 +205,12 @@ describe("buildBranchedBoardRows continuation", () => {
   it("splits orphan events across a soft seam by time", () => {
     const streams = new Map([
       ["root", streamNode(null, null, null)],
-      ["thread", streamNode("root", "root", "a")],
+      ["thread", streamNode("root", "root", "b")],
     ])
-    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u2", 4, "thread")], {
-      streams,
-      conversation: { streamId: "root" },
-    })
+    const grouping = groupBranches(
+      [msg("a", "u1", 0, "root"), msg("b", "u2", 2, "root"), msg("c", "u2", 4, "thread")],
+      { streams, conversation: { streamId: "root" } }
+    )
     const rows = buildBranchedBoardRows(
       grouping,
       [memoEventRow("early", 1, "elsewhere"), memoEventRow("late", 5, "elsewhere")],
@@ -166,6 +219,7 @@ describe("buildBranchedBoardRows continuation", () => {
     expect(rows.map((r) => (r.kind === "event" ? r.row.key : r.kind))).toEqual([
       "message",
       "early",
+      "message",
       "seam",
       "message",
       "late",

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -112,7 +112,11 @@ function branchAnchorMs(branch: BranchConversationView): number {
  * Flatten a {@link BranchGrouping} into ordered board rows, interleaving event
  * rows into the group whose stream owns them and inserting branch chrome:
  *
- * - `soft` → the two runs with one `seam` row between them (no indent).
+ * - `soft` → the two runs with one `seam` row between them (no indent). A
+ *   down-seam whose first run is just the opener is convert-to-thread transport
+ *   — the whole discussion lives in the thread by design — so it renders
+ *   seamlessly as one run: no seam row, no split chrome, regardless of thread
+ *   size. The seam marks only a flat discussion that migrated mid-conversation.
  * - `spanning` → base messages chronological; each occupied thread rendered as
  *   one contiguous group placed after its fork message's row (or anchored
  *   chronologically when its fork message isn't rendered), indented by
@@ -236,7 +240,16 @@ export function buildBranchedBoardRows(
     }
   }
 
-  if (grouping.kind === "soft" && grouping.softSeam) {
+  // A down-crossing whose pre-boundary run is the lone opener is the
+  // convert-to-thread signature (a first reply to a lone post files into a
+  // thread): the thread IS the conversation, so no seam ever — not a size
+  // threshold; the run stays opener-only however large the thread grows.
+  const convertedOpener =
+    grouping.kind === "soft" &&
+    grouping.softSeam?.direction === "down" &&
+    (grouping.roots[0]?.messages.length ?? 0) <= 1
+
+  if (grouping.kind === "soft" && grouping.softSeam && !convertedOpener) {
     const [runA, runB] = grouping.roots
     // Orphan events split at the seam so each lands in its chronological run.
     const runBStart = runB && runB.messages.length > 0 ? messageMs(runB.messages[0]) : Number.POSITIVE_INFINITY

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -4,16 +4,26 @@ import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
+import type { BranchGrouping, BranchNode, BranchConversationView } from "@/lib/board/branch-grouping"
 
 /**
- * One row in a board card / conversation panel: either a member message (with its
- * same-author continuation flag) or an interleaved agent/memo/follow-up event row.
- * The board renders both through {@link buildBoardRows} so a conversation surface
- * is a second *view* of the stream's events, not a message-only parallel renderer.
+ * One row in a board card / conversation panel: a member message (with its
+ * same-author continuation flag), an interleaved agent/memo/follow-up event row,
+ * or one of the branch chrome rows (a soft-thread seam, a nested branch
+ * conversation group, a spanning-overflow "continue thread" link). The board
+ * renders all through {@link buildBoardRows} / {@link buildBranchedBoardRows} so a
+ * conversation surface is a second *view* of the stream's events, not a parallel
+ * renderer.
+ *
+ * `displayDepth` is the row's indent level (0–2); absent on the flat
+ * {@link buildBoardRows} output, which never indents.
  */
 export type BoardRow =
-  | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean }
-  | { kind: "event"; key: string; row: BoardEventRow }
+  | { kind: "message"; key: string; message: RenderableMessage; continuation: boolean; displayDepth?: number }
+  | { kind: "event"; key: string; row: BoardEventRow; displayDepth?: number }
+  | { kind: "seam"; key: string; streamId: string; direction: "down" | "up"; displayDepth?: number }
+  | { kind: "branch-group"; key: string; branch: BranchConversationView; displayDepth?: number }
+  | { kind: "continue-thread"; key: string; streamId: string; hiddenCount: number; displayDepth?: number }
 
 /**
  * Interleave a chronological message list with the conversation's event rows by
@@ -62,6 +72,209 @@ export function buildBoardRows(messages: RenderableMessage[], eventRows: BoardEv
     }
   }
   return rows
+}
+
+function messageMs(message: RenderableMessage): number {
+  return new Date(message.createdAt).getTime()
+}
+
+function subtreeMessageCount(node: BranchNode): number {
+  let count = node.messages.length
+  for (const child of node.children) count += subtreeMessageCount(child)
+  return count
+}
+
+function earliestMessageMs(nodes: BranchNode[]): number {
+  let min = Number.POSITIVE_INFINITY
+  const walk = (node: BranchNode) => {
+    for (const message of node.messages) {
+      const t = messageMs(message)
+      if (t < min) min = t
+    }
+    for (const child of node.children) walk(child)
+  }
+  for (const node of nodes) walk(node)
+  return min === Number.POSITIVE_INFINITY ? Number.NEGATIVE_INFINITY : min
+}
+
+/** The earliest own-message time of a branch conversation view (top-level rows
+ *  only), for chronologically anchoring a branch whose fork message isn't drawn. */
+function branchAnchorMs(branch: BranchConversationView): number {
+  let min = Number.POSITIVE_INFINITY
+  for (const message of branch.messages) {
+    const t = messageMs(message)
+    if (t < min) min = t
+  }
+  return min
+}
+
+/**
+ * Flatten a {@link BranchGrouping} into ordered board rows, interleaving event
+ * rows into the group whose stream owns them and inserting branch chrome:
+ *
+ * - `soft` → the two runs with one `seam` row between them (no indent).
+ * - `spanning` → base messages chronological; each occupied thread rendered as
+ *   one contiguous group placed after its fork message's row (or anchored
+ *   chronologically when its fork message isn't rendered), indented by
+ *   `displayDepth`; a subtree past depth 2 collapses to one `continue-thread` row.
+ * - branch conversation groups land immediately after their fork message's row;
+ *   a branch whose fork message isn't drawn (the collapsed card's hidden middle)
+ *   is appended after the run, chronological by its own earliest message.
+ *
+ * Same-author continuation never spans a group boundary and is reset by any seam,
+ * branch group, event, or overflow row — exactly like {@link buildBoardRows}
+ * resets on an interleaved event. Events earlier than the first rendered message
+ * are dropped (the collapsed card's hidden middle), matching {@link buildBoardRows}.
+ * An event on a stream with no rendered group (its messages sit in the hidden
+ * middle, or a capture landed outside the occupied streams) still shows —
+ * chronologically at the base level — never silently vanishing; only events under
+ * a collapsed overflow subtree stay hidden with it.
+ */
+export function buildBranchedBoardRows(
+  grouping: BranchGrouping,
+  eventRows: BoardEventRow[],
+  branchesByForkMessageId: Map<string, BranchConversationView[]>
+): BoardRow[] {
+  const firstMs = earliestMessageMs(grouping.roots)
+  const renderedForkIds = new Set<string>()
+  const eventsByStream = new Map<string, BoardEventRow[]>()
+  for (const event of eventRows) {
+    if (event.sortMs < firstMs) continue
+    const list = eventsByStream.get(event.streamId)
+    if (list) list.push(event)
+    else eventsByStream.set(event.streamId, [event])
+  }
+
+  const groupedStreamIds = new Set<string>()
+  const collectStreamIds = (node: BranchNode) => {
+    groupedStreamIds.add(node.streamId)
+    for (const child of node.children) collectStreamIds(child)
+  }
+  for (const node of grouping.roots) collectStreamIds(node)
+  const orphanEvents: BoardEventRow[] = []
+  for (const [streamId, list] of eventsByStream) {
+    if (!groupedStreamIds.has(streamId)) orphanEvents.push(...list)
+  }
+
+  const out: BoardRow[] = []
+
+  const emitChild = (node: BranchNode) => {
+    if (node.overflow) {
+      out.push({
+        kind: "continue-thread",
+        key: `continue:${node.streamId}`,
+        streamId: node.streamId,
+        hiddenCount: subtreeMessageCount(node),
+        displayDepth: node.displayDepth,
+      })
+      return
+    }
+    emitRun([node])
+  }
+
+  function emitRun(nodes: BranchNode[], orphans: BoardEventRow[] = []): void {
+    const present = new Set<string>()
+    for (const node of nodes) for (const message of node.messages) present.add(message.id)
+
+    type Item = {
+      t: number
+      slot: number
+      depth: number
+      message?: RenderableMessage
+      event?: BoardEventRow
+      child?: BranchNode
+    }
+    const items: Item[] = []
+    for (const event of orphans) items.push({ t: event.sortMs, slot: 2, depth: 0, event })
+    const forkChildren = new Map<string, BranchNode[]>()
+    for (const node of nodes) {
+      for (const message of node.messages)
+        items.push({ t: messageMs(message), slot: 0, depth: node.displayDepth, message })
+      for (const event of eventsByStream.get(node.streamId) ?? [])
+        items.push({ t: event.sortMs, slot: 2, depth: node.displayDepth, event })
+      for (const child of node.children) {
+        if (child.forkMessageId && present.has(child.forkMessageId)) {
+          const list = forkChildren.get(child.forkMessageId)
+          if (list) list.push(child)
+          else forkChildren.set(child.forkMessageId, [child])
+        } else {
+          const anchor = child.messages.length > 0 ? messageMs(child.messages[0]) : Number.POSITIVE_INFINITY
+          items.push({ t: anchor, slot: 1, depth: child.displayDepth, child })
+        }
+      }
+    }
+    items.sort((a, b) => (a.t !== b.t ? a.t - b.t : a.slot - b.slot))
+
+    let prev: RenderableMessage | null = null
+    for (const item of items) {
+      if (item.message) {
+        const continuation = prev != null && isContinuation(prev, item.message)
+        out.push({
+          kind: "message",
+          key: item.message.id,
+          message: item.message,
+          continuation,
+          displayDepth: item.depth,
+        })
+        prev = item.message
+        for (const branch of branchesByForkMessageId.get(item.message.id) ?? []) {
+          renderedForkIds.add(item.message.id)
+          out.push({ kind: "branch-group", key: `branch:${branch.conversationId}`, branch, displayDepth: item.depth })
+          prev = null
+        }
+        for (const child of forkChildren.get(item.message.id) ?? []) {
+          emitChild(child)
+          prev = null
+        }
+      } else if (item.event) {
+        out.push({ kind: "event", key: item.event.key, row: item.event, displayDepth: item.depth })
+        prev = null
+      } else if (item.child) {
+        emitChild(item.child)
+        prev = null
+      }
+    }
+  }
+
+  if (grouping.kind === "soft" && grouping.softSeam) {
+    const [runA, runB] = grouping.roots
+    // Orphan events split at the seam so each lands in its chronological run.
+    const runBStart = runB && runB.messages.length > 0 ? messageMs(runB.messages[0]) : Number.POSITIVE_INFINITY
+    if (runA)
+      emitRun(
+        [runA],
+        orphanEvents.filter((event) => event.sortMs < runBStart)
+      )
+    out.push({
+      kind: "seam",
+      key: `seam:${grouping.softSeam.streamId}`,
+      streamId: grouping.softSeam.streamId,
+      direction: grouping.softSeam.direction,
+      displayDepth: 0,
+    })
+    if (runB)
+      emitRun(
+        [runB],
+        orphanEvents.filter((event) => event.sortMs >= runBStart)
+      )
+  } else {
+    emitRun(grouping.roots, orphanEvents)
+  }
+
+  // Branches whose fork message wasn't drawn (it sits in the collapsed card's
+  // hidden middle) still render — appended after the run, chronological by their
+  // own earliest message so a just-forked topic lands where its activity sits.
+  const unplaced: BranchConversationView[] = []
+  for (const [forkMessageId, branches] of branchesByForkMessageId) {
+    if (renderedForkIds.has(forkMessageId)) continue
+    unplaced.push(...branches)
+  }
+  unplaced.sort((a, b) => branchAnchorMs(a) - branchAnchorMs(b))
+  for (const branch of unplaced) {
+    out.push({ kind: "branch-group", key: `branch:${branch.conversationId}`, branch, displayDepth: 0 })
+  }
+
+  return out
 }
 
 /**

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -1,0 +1,303 @@
+import { Fragment, useState, type ReactNode } from "react"
+import { Link } from "react-router-dom"
+import { CornerDownRight, GitBranch, ArrowRight, MoveRight, ChevronDown, Scissors } from "lucide-react"
+import { useStreamName } from "@/hooks/use-stream-name"
+import { usePanel, createConversationPanelId } from "@/contexts"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
+import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
+
+/** Indent per thread boundary (spanning), applied on a wrapper so the shared
+ *  `MessageItem` stays untouched. A left rail reads the nesting Reddit-style. */
+const INDENT_CLASS: Record<number, string> = {
+  1: "ml-3 border-l-2 border-border pl-2 sm:pl-3",
+  2: "ml-6 border-l-2 border-border pl-2 sm:pl-3",
+}
+
+/**
+ * The "continued in …" divider for a soft thread (convert-to-thread, or the
+ * thread→root Slack case). Names where the conversation moved without pulling
+ * the reader out of the card. A "down" seam (the conversation continued INTO a
+ * thread) also carries the "split into its own topic" heal — an "up" seam names
+ * the root, which can't become a sub-topic, so it stays label-only.
+ */
+export function ThreadSeamRow({
+  workspaceId,
+  streamId,
+  direction,
+  onSplit,
+}: {
+  workspaceId: string
+  streamId: string
+  direction: "down" | "up"
+  /** Promote this thread into its own conversation. Absent ⇒ no split affordance. */
+  onSplit?: () => void
+}) {
+  const label = useStreamName(workspaceId, streamId, "generic") ?? "thread"
+  const Icon = direction === "up" ? MoveRight : CornerDownRight
+  return (
+    <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">continued in {label}</span>
+      {direction === "down" && onSplit && <SplitThreadAction label={label} onConfirm={onSplit} />}
+    </div>
+  )
+}
+
+/**
+ * The seam's "split into its own topic" affordance: an action button (INV-40) that
+ * confirms through a plain AlertDialog before promoting the thread — the move is
+ * a correction the user should mean, and the card visibly re-forms afterward
+ * (no success toast, INV-63).
+ */
+function SplitThreadAction({ label, onConfirm }: { label: string; onConfirm: () => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-muted-foreground/80 transition-colors hover:text-foreground"
+        >
+          <Scissors className="h-3 w-3 shrink-0" />
+          Split into its own topic
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Split this thread into its own topic?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {label} and its replies move out of this conversation into a new topic anchored to the thread. It stays on
+            the card as a nested branch.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Split</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+interface BranchGroupProps {
+  branch: BranchConversationView
+  /** Render one of the branch's own messages — render-only (its read state belongs
+   *  to the child conversation, not the parent card). Omitted ⇒ header only. */
+  renderBranchMessage?: (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => ReactNode
+  /** The inline reply affordance / composer at the branch's tail. */
+  renderBranchTail?: (branch: BranchConversationView) => ReactNode
+  /** The inline "new sub-topic" composer slot under a message row (parent or branch). */
+  renderAfterMessage?: (messageId: string) => ReactNode
+}
+
+/**
+ * A branch conversation nested inside a parent card (Kris dogfood ruling
+ * 2026-07-05, board-view-design.md): a "↳ <child topic>" header linking to the
+ * child conversation panel (INV-40), with the child's own messages rendered
+ * indented under it and grandchildren nested one level deeper (each adds a
+ * left rail). Reddit/Facebook-style nested comments — the nesting lives INSIDE
+ * one card, not between two. Beyond the depth cap the subtree collapses to a
+ * "Continue this thread" link into the branch's own panel.
+ */
+export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, renderAfterMessage }: BranchGroupProps) {
+  const { getPanelUrl } = usePanel()
+  const panelUrl = getPanelUrl(createConversationPanelId(branch.conversationId))
+  // A pending branch (sub-topic sent, conversation echo not landed) has no real
+  // conversation to open yet — its header is inert until the graph takes over.
+  const header = (
+    <>
+      <CornerDownRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{branch.title}</span>
+    </>
+  )
+  return (
+    <div className="mt-3">
+      {branch.pending ? (
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">{header}</div>
+      ) : (
+        <Link
+          to={panelUrl}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {header}
+        </Link>
+      )}
+      <div className="mt-1 border-l-2 border-border pl-2 sm:pl-3 [&>*:first-child]:mt-0">
+        {renderBranchMessage &&
+          branch.messages.map((message, index) => {
+            const prev = index > 0 ? branch.messages[index - 1] : null
+            const continuation = prev != null && isContinuation(prev, message)
+            return (
+              <Fragment key={message.id}>
+                {renderBranchMessage(branch, message, continuation)}
+                {renderAfterMessage?.(message.id)}
+              </Fragment>
+            )
+          })}
+        {branch.hiddenCount > 0 && (
+          <Link
+            to={panelUrl}
+            className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+            {branch.hiddenCount} more {branch.hiddenCount === 1 ? "reply" : "replies"}
+          </Link>
+        )}
+        {branch.children.map((child) => (
+          <BranchGroup
+            key={child.conversationId}
+            branch={child}
+            renderBranchMessage={renderBranchMessage}
+            renderBranchTail={renderBranchTail}
+            renderAfterMessage={renderAfterMessage}
+          />
+        ))}
+        {branch.overflow && (
+          <Link
+            to={panelUrl}
+            className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+            Continue this thread
+          </Link>
+        )}
+        {!branch.pending && renderBranchTail?.(branch)}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * "Branched from <parent topic>" provenance at the top of a child card, linking
+ * to the parent conversation panel (INV-40) — the conversation-grain mirror of
+ * the message-grain provenance chip.
+ */
+export function BranchProvenanceRow({ conversationId, title }: { conversationId: string; title: string }) {
+  const { getPanelUrl } = usePanel()
+  return (
+    <Link
+      to={getPanelUrl(createConversationPanelId(conversationId))}
+      className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <GitBranch className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">Branched from {title}</span>
+    </Link>
+  )
+}
+
+/**
+ * The spanning depth cap: a thread nested past two boundaries collapses to one
+ * link — into the conversation panel from a card, or into the thread's own panel
+ * from the conversation panel (`to` resolved by the surface, INV-40).
+ */
+export function ContinueThreadRow({ to, hiddenCount }: { to: string; hiddenCount: number }) {
+  return (
+    <Link
+      to={to}
+      aria-label={`Continue this thread (${hiddenCount} more)`}
+      className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">Continue this thread</span>
+    </Link>
+  )
+}
+
+interface BranchedBoardRowsProps {
+  rows: BoardRow[]
+  workspaceId: string
+  renderMessage: (message: RenderableMessage, continuation: boolean) => ReactNode
+  /** Where a spanning-overflow row links, given the deep thread's stream. */
+  continueThreadTo: (streamId: string) => string
+  /** Split a soft-thread seam into its own conversation. Absent ⇒ no seam split
+   *  affordance (a read-only surface). */
+  onSplitThread?: (threadStreamId: string) => void
+  /** Render a nested branch conversation's own message (render-only). Passed by the
+   *  card/panel so a branch group can draw the child's rows; omit ⇒ header only. */
+  renderBranchMessage?: (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => ReactNode
+  /** The inline reply affordance / composer at a branch group's tail. */
+  renderBranchTail?: (branch: BranchConversationView) => ReactNode
+  /** The inline "new sub-topic" composer slot rendered under a message row. */
+  renderAfterMessage?: (messageId: string) => ReactNode
+}
+
+function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNode {
+  const {
+    workspaceId,
+    renderMessage,
+    continueThreadTo,
+    renderBranchMessage,
+    renderBranchTail,
+    renderAfterMessage,
+    onSplitThread,
+  } = props
+  switch (row.kind) {
+    case "message":
+      return (
+        <Fragment key={row.key}>
+          {renderMessage(row.message, row.continuation)}
+          {renderAfterMessage?.(row.message.id)}
+        </Fragment>
+      )
+    case "event":
+      return <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+    case "seam":
+      return (
+        <ThreadSeamRow
+          key={row.key}
+          workspaceId={workspaceId}
+          streamId={row.streamId}
+          direction={row.direction}
+          onSplit={onSplitThread ? () => onSplitThread(row.streamId) : undefined}
+        />
+      )
+    case "branch-group":
+      return (
+        <BranchGroup
+          key={row.key}
+          branch={row.branch}
+          renderBranchMessage={renderBranchMessage}
+          renderBranchTail={renderBranchTail}
+          renderAfterMessage={renderAfterMessage}
+        />
+      )
+    case "continue-thread":
+      return <ContinueThreadRow key={row.key} to={continueThreadTo(row.streamId)} hiddenCount={row.hiddenCount} />
+  }
+}
+
+/**
+ * Render a branch-grouped row list: message rows through the surface's own
+ * renderer, event/branch chrome through the components above, each indented by
+ * its `displayDepth` via a wrapper element (indent never touches `MessageItem`).
+ * A branch group adds its own nested left rail INSIDE the row indent, so a
+ * branch off an already-indented spanning row nests one level deeper.
+ */
+export function BranchedBoardRows(props: BranchedBoardRowsProps) {
+  return (
+    <>
+      {props.rows.map((row) => {
+        const depth = row.displayDepth ?? 0
+        const content = renderRowContent(row, props)
+        if (depth === 0) return content
+        return (
+          <div key={row.key} className={INDENT_CLASS[depth]}>
+            {content}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -173,7 +173,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
             Continue this thread
           </Link>
         )}
-        {!branch.pending && renderBranchTail?.(branch)}
+        {renderBranchTail?.(branch)}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -152,7 +152,11 @@ export function useInlineBranchComposer(params: {
     [pendingSubtopics, index]
   )
 
-  const submitNewSubtopic = useCallback(
+  // The declared sub-topic send, shared by the opening gesture and a reply on a
+  // still-pending branch: the thread find-or-creates (`insertThreadOrFind`) and
+  // the conversation mints-or-attaches (INV-20), so repeated sends through this
+  // path converge on one child no matter which echo lands first.
+  const queueSubtopicSend = useCallback(
     async (streamId: string, messageId: string, input: InlineComposerSubmit) => {
       const draftPanelId = createDraftPanelId(streamId, messageId)
       await queueDraftMessage(input, {
@@ -162,20 +166,42 @@ export function useInlineBranchComposer(params: {
         draftId: draftPanelId,
         conversation: { intent: "newSubtopic" },
       })
-      setPendingSubtopics((prev) => [...prev, { streamId, messageId }])
     },
     [queueDraftMessage, workspaceId]
   )
 
+  const submitNewSubtopic = useCallback(
+    async (streamId: string, messageId: string, input: InlineComposerSubmit) => {
+      await queueSubtopicSend(streamId, messageId, input)
+      setPendingSubtopics((prev) => [...prev, { streamId, messageId }])
+    },
+    [queueSubtopicSend]
+  )
+
+  const pendingEntryFor = useCallback(
+    (branch: BranchConversationView) =>
+      branch.pending ? pendingSubtopics.find((p) => p.messageId === branch.forkMessageId) : undefined,
+    [pendingSubtopics]
+  )
+
   const submitBranchReply = useCallback(
     async (branch: BranchConversationView, input: InlineComposerSubmit) => {
+      // A pending branch's child conversation id isn't known yet (its echo
+      // hasn't landed — possibly never will on a dropped socket), so an
+      // `existing` directive has nothing real to name. Route through the
+      // sub-topic path instead; it converges on the same child.
+      const pendingEntry = pendingEntryFor(branch)
+      if (pendingEntry) {
+        await queueSubtopicSend(pendingEntry.streamId, pendingEntry.messageId, input)
+        return
+      }
       await queueDraftMessage(input, {
         workspaceId,
         streamId: branch.threadStreamId,
         conversation: { intent: "existing", conversationId: branch.conversationId },
       })
     },
-    [queueDraftMessage, workspaceId]
+    [queueDraftMessage, workspaceId, pendingEntryFor, queueSubtopicSend]
   )
 
   const renderAfterMessage = useCallback(
@@ -201,13 +227,17 @@ export function useInlineBranchComposer(params: {
   const renderBranchTail = useCallback(
     (branch: BranchConversationView): ReactNode => {
       if (openComposer?.kind === "branch-reply" && openComposer.conversationId === branch.conversationId) {
+        // A pending branch's thread may not exist yet — host the composer on the
+        // parent stream (mention context + E2E gate), like the opening gesture.
+        const hostStreamId = pendingEntryFor(branch)?.streamId ?? branch.threadStreamId
         return (
           <InlineComposerForm
             workspaceId={workspaceId}
-            streamId={branch.threadStreamId}
-            memoAnchorStreamId={branch.threadStreamId}
+            streamId={hostStreamId}
+            memoAnchorStreamId={hostStreamId}
             draftKey={`board:branch-reply:${branch.conversationId}`}
             placeholder="Reply…"
+            contextChip={`Replying in ${branch.title}`}
             rejectE2e={E2E_REPLY_MESSAGE}
             onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
             onClose={closeComposer}
@@ -225,7 +255,7 @@ export function useInlineBranchComposer(params: {
         </button>
       )
     },
-    [openComposer, workspaceId, submitBranchReply, closeComposer, openBranchReply]
+    [openComposer, workspaceId, submitBranchReply, closeComposer, openBranchReply, pendingEntryFor]
   )
 
   return {

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -1,0 +1,241 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { Reply } from "lucide-react"
+import { StreamTypes } from "@threa/types"
+import { useQueueDraftMessage } from "@/hooks/use-queue-draft-message"
+import { createDraftPanelId } from "@/contexts"
+import { collectBranchThreadStreamIds } from "@/hooks/use-conversation-graph"
+import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
+import type { ConversationGraph, StreamStructuralIndex } from "@/hooks/use-conversation-graph"
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/** The single inline composer a conversation surface has open (one per surface —
+ *  opening another closes the first). Either a "new sub-topic" gesture under a
+ *  message row, or a reply at a nested branch's tail. */
+export type OpenInlineComposer =
+  | { kind: "new-subtopic"; streamId: string; messageId: string }
+  | { kind: "branch-reply"; conversationId: string; threadStreamId: string }
+
+const E2E_REPLY_MESSAGE = "Encrypted notes can't be replied to from the board yet — open the note to reply there."
+const E2E_SUBTOPIC_MESSAGE = "Can't start a sub-topic in an encrypted note here."
+
+/**
+ * The inline reply + "new sub-topic" composers a conversation surface (board card
+ * / conversation panel) hosts, plus the branch-thread rail bookkeeping they need
+ * — extracted so both surfaces share one implementation (INV-35, Kris dogfood
+ * ruling 2026-07-05: replying happens inline on the card, never bouncing into a
+ * thread/panel view).
+ *
+ * Called BEFORE the surface's `useBoardCardMessages` so its outputs
+ * (`branchStreamIds`, `extraDraftPanelIds`) feed that hook's extra rails:
+ *
+ *  - **`branchStreamIds`** — every branch thread the card renders nested (graph
+ *    only), subscribed as EXTRA rails so their bodies load without gating.
+ *  - **`extraDraftPanelIds`** — the draft-panel rail of an open/pending "new
+ *    sub-topic" send, kept until its thread materializes so the optimistic
+ *    message doesn't blink out before the `conversation:created` echo.
+ *
+ * The send seams are the declared, determinable gestures (board-view-design.md):
+ * a branch reply queues `{ intent: "existing", conversationId }` into the
+ * branch's thread; a new sub-topic queues `streamCreation` + `{ intent:
+ * "newSubtopic" }`. Nothing is created until the user sends.
+ */
+export function useInlineBranchComposer(params: {
+  workspaceId: string
+  conversationId: string
+  /** The parent conversation's server member ids — the branch fork candidates. */
+  memberMessageIds: string[]
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+}): {
+  branchStreamIds: string[]
+  extraDraftPanelIds: string[]
+  openComposer: OpenInlineComposer | null
+  openNewSubtopic: (streamId: string, messageId: string) => void
+  openBranchReply: (branch: BranchConversationView) => void
+  renderAfterMessage: (messageId: string) => ReactNode
+  renderBranchTail: (branch: BranchConversationView) => ReactNode
+  /** Synthetic branch groups for in-flight sub-topic sends, resolved against the
+   *  card's merged rail — so the just-sent message renders nested immediately,
+   *  before the `conversation:created` echo hands rendering to the graph. */
+  derivePendingBranches: (messagesById: Map<string, RenderableMessage>) => BranchConversationView[]
+} {
+  const { workspaceId, conversationId, memberMessageIds, index, graph } = params
+  const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
+  const [openComposer, setOpenComposer] = useState<OpenInlineComposer | null>(null)
+  // Draft panels of "new sub-topic" sends still in flight — kept subscribed until
+  // their thread stream exists, so the optimistic message rides its draft rail
+  // across the pre-promotion window (mirrors the lone-post convert-to-thread).
+  const [pendingSubtopics, setPendingSubtopics] = useState<Array<{ streamId: string; messageId: string }>>([])
+
+  const closeComposer = useCallback(() => setOpenComposer(null), [])
+  const openNewSubtopic = useCallback(
+    (streamId: string, messageId: string) => setOpenComposer({ kind: "new-subtopic", streamId, messageId }),
+    []
+  )
+  const openBranchReply = useCallback(
+    (branch: BranchConversationView) =>
+      setOpenComposer({
+        kind: "branch-reply",
+        conversationId: branch.conversationId,
+        threadStreamId: branch.threadStreamId,
+      }),
+    []
+  )
+
+  const memberKey = memberMessageIds.join(",")
+  const branchStreamIds = useMemo(
+    () => collectBranchThreadStreamIds({ conversationId, memberMessageIds, index, graph }),
+    // memberMessageIds captured via memberKey (stable string, not the array ref).
+    [conversationId, memberKey, index, graph]
+  )
+
+  // A pending sub-topic is handed to the graph path only once BOTH its thread
+  // stream exists (promotion) AND the child conversation is cached — dropping it
+  // at thread creation alone would blank the message for the beat until the
+  // `conversation:created` echo lands.
+  const isGraphRendered = useCallback(
+    (p: { messageId: string }) => {
+      const threadId = index.threadsByParentMessageId.get(p.messageId)?.id
+      return !!threadId && graph.conversationByAnchorStreamId.has(threadId)
+    },
+    [index, graph]
+  )
+  useEffect(() => {
+    setPendingSubtopics((prev) => {
+      const next = prev.filter((p) => !isGraphRendered(p))
+      return next.length === prev.length ? prev : next
+    })
+  }, [isGraphRendered])
+
+  const extraDraftPanelIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (openComposer?.kind === "new-subtopic")
+      ids.add(createDraftPanelId(openComposer.streamId, openComposer.messageId))
+    for (const p of pendingSubtopics) {
+      // Both rails: the optimistic row starts on the draft panel and is swapped
+      // onto the real thread stream at promotion — subscribe across the hand-off.
+      ids.add(createDraftPanelId(p.streamId, p.messageId))
+      const threadId = index.threadsByParentMessageId.get(p.messageId)?.id
+      if (threadId) ids.add(threadId)
+    }
+    return [...ids]
+  }, [openComposer, pendingSubtopics, index])
+
+  const derivePendingBranches = useCallback(
+    (messagesById: Map<string, RenderableMessage>): BranchConversationView[] => {
+      const out: BranchConversationView[] = []
+      for (const p of pendingSubtopics) {
+        const draftPanelId = createDraftPanelId(p.streamId, p.messageId)
+        const threadId = index.threadsByParentMessageId.get(p.messageId)?.id
+        const rows: RenderableMessage[] = []
+        for (const message of messagesById.values()) {
+          if (message.streamId === draftPanelId || (threadId && message.streamId === threadId)) rows.push(message)
+        }
+        if (rows.length === 0) continue
+        rows.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+        out.push({
+          conversationId: draftPanelId,
+          threadStreamId: threadId ?? draftPanelId,
+          forkMessageId: p.messageId,
+          title: "New sub-topic",
+          displayDepth: 1,
+          overflow: false,
+          messages: rows,
+          hiddenCount: 0,
+          children: [],
+          pending: true,
+        })
+      }
+      return out
+    },
+    [pendingSubtopics, index]
+  )
+
+  const submitNewSubtopic = useCallback(
+    async (streamId: string, messageId: string, input: InlineComposerSubmit) => {
+      const draftPanelId = createDraftPanelId(streamId, messageId)
+      await queueDraftMessage(input, {
+        workspaceId,
+        streamId: draftPanelId,
+        streamCreation: { type: StreamTypes.THREAD, parentStreamId: streamId, parentMessageId: messageId },
+        draftId: draftPanelId,
+        conversation: { intent: "newSubtopic" },
+      })
+      setPendingSubtopics((prev) => [...prev, { streamId, messageId }])
+    },
+    [queueDraftMessage, workspaceId]
+  )
+
+  const submitBranchReply = useCallback(
+    async (branch: BranchConversationView, input: InlineComposerSubmit) => {
+      await queueDraftMessage(input, {
+        workspaceId,
+        streamId: branch.threadStreamId,
+        conversation: { intent: "existing", conversationId: branch.conversationId },
+      })
+    },
+    [queueDraftMessage, workspaceId]
+  )
+
+  const renderAfterMessage = useCallback(
+    (messageId: string): ReactNode => {
+      if (openComposer?.kind !== "new-subtopic" || openComposer.messageId !== messageId) return null
+      const { streamId } = openComposer
+      return (
+        <InlineComposerForm
+          workspaceId={workspaceId}
+          streamId={streamId}
+          memoAnchorStreamId={streamId}
+          draftKey={`board:subtopic:${streamId}:${messageId}`}
+          placeholder="Start a sub-topic…"
+          rejectE2e={E2E_SUBTOPIC_MESSAGE}
+          onSubmit={(sendInput) => submitNewSubtopic(streamId, messageId, sendInput)}
+          onClose={closeComposer}
+        />
+      )
+    },
+    [openComposer, workspaceId, submitNewSubtopic, closeComposer]
+  )
+
+  const renderBranchTail = useCallback(
+    (branch: BranchConversationView): ReactNode => {
+      if (openComposer?.kind === "branch-reply" && openComposer.conversationId === branch.conversationId) {
+        return (
+          <InlineComposerForm
+            workspaceId={workspaceId}
+            streamId={branch.threadStreamId}
+            memoAnchorStreamId={branch.threadStreamId}
+            draftKey={`board:branch-reply:${branch.conversationId}`}
+            placeholder="Reply…"
+            rejectE2e={E2E_REPLY_MESSAGE}
+            onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
+            onClose={closeComposer}
+          />
+        )
+      }
+      return (
+        <button
+          type="button"
+          onClick={() => openBranchReply(branch)}
+          className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <Reply className="h-3.5 w-3.5 shrink-0" />
+          Reply
+        </button>
+      )
+    },
+    [openComposer, workspaceId, submitBranchReply, closeComposer, openBranchReply]
+  )
+
+  return {
+    branchStreamIds,
+    extraDraftPanelIds,
+    openComposer,
+    openNewSubtopic,
+    openBranchReply,
+    renderAfterMessage,
+    renderBranchTail,
+    derivePendingBranches,
+  }
+}

--- a/apps/frontend/src/components/conversations/conversation-panel.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.test.tsx
@@ -23,6 +23,7 @@ import * as touchCapableModule from "@/hooks/use-touch-capable"
 import * as discussModule from "@/hooks/use-discuss-with-ariadne"
 import * as shareHandoffModule from "@/stores/share-handoff-store"
 import * as boardReplyComposerModule from "@/components/board/board-reply-composer"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import {
   requestConversationReplyOpen,
   resetConversationReplyOpenStoreCache,
@@ -131,6 +132,12 @@ beforeEach(() => {
   // The panel resolves its host stream type from the synced IDB row.
   vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue({ id: "stream_1", type: "channel" } as never)
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // BoardCard hosts the inline branch composer, whose queue hook needs the
+  // pending-messages provider — stub the hook so the harness stays lean.
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
   vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({
     addReaction: vi.fn(),
     removeReaction: vi.fn(),

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -25,8 +25,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { Skeleton } from "@/components/ui/skeleton"
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from "@/components/ui/empty"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
-import { buildBoardRows, BoardEventRowItem } from "@/components/board/board-row-item"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
+import { groupBranches, type BranchConversationView } from "@/lib/board/branch-grouping"
+import {
+  useConversationGraph,
+  useStreamStructuralIndex,
+  deriveBranchConversations,
+  collectBranchThreadStreamIds,
+  deriveBranchProvenance,
+} from "@/hooks/use-conversation-graph"
+import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
 import { cn } from "@/lib/utils"
@@ -43,7 +53,7 @@ import { useStreamName } from "@/hooks/use-stream-name"
 import { useConversationService, usePanel, parseConversationPanel, useSidebar } from "@/contexts"
 import { useStreamFromStore } from "@/stores/stream-store"
 import { consumeConversationReplyOpen, subscribeConversationReplyOpen } from "@/stores/conversation-reply-open-store"
-import { conversationKeys, useConversationBoardPost } from "@/hooks/use-conversations"
+import { conversationKeys, useConversationBoardPost, useSplitThread } from "@/hooks/use-conversations"
 import { useBoardCardMessages } from "@/hooks/use-board-card-messages"
 import { usePanelStreamSubscriptions } from "@/hooks/use-panel-stream-subscriptions"
 import { buildConversationLink } from "@/lib/stream-links"
@@ -96,11 +106,21 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
 
   // Keep the conversation's streams (root + threads) caught up + joined while the
   // panel is open, so the rail is live and offline-first. Its own SyncEngine slot,
-  // so it composes with the board feed rather than clobbering it.
-  const panelStreamIds = useMemo(
-    () => (post ? [...new Set([post.conversation.streamId, ...(post.streamIds ?? [])])] : []),
-    [post]
-  )
+  // so it composes with the board feed rather than clobbering it. The nested
+  // branch conversations' threads are folded in too — the panel renders their
+  // bodies inline, so they must sync like any other rendered stream.
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const panelStreamIds = useMemo(() => {
+    if (!post) return []
+    const branchIds = collectBranchThreadStreamIds({
+      conversationId: post.conversation.id,
+      memberMessageIds: post.conversation.messageIds,
+      index: structuralIndex,
+      graph: conversationGraph,
+    })
+    return [...new Set([post.conversation.streamId, ...(post.streamIds ?? []), ...branchIds])]
+  }, [post, structuralIndex, conversationGraph])
   usePanelStreamSubscriptions(panelStreamIds)
   // The panel's streams aren't in the URL (`?panel=conv:…`), so the SW's push
   // suppression can only know they're on screen if we register them here.
@@ -284,6 +304,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
+  const splitThread = useSplitThread(workspaceId)
   const { conversation } = post
   // Per-row read state + the mark-read/unread actions for this conversation's
   // rows (docs/sparse-read-overlay-design.md). The panel has no unread dot, so
@@ -302,6 +323,20 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const [searchParams] = useSearchParams()
   const highlightMessageId = searchParams.get("m")
 
+  // Shared graph + structural index, needed before the rail hook: the inline
+  // branch composer derives the branch thread streams (and pending sub-topic
+  // draft rails) the panel subscribes to as extra rails.
+  const conversationGraph = useConversationGraph(workspaceId)
+  const structuralIndex = useStreamStructuralIndex(workspaceId)
+  const inlineComposer = useInlineBranchComposer({
+    workspaceId,
+    conversationId: conversation.id,
+    memberMessageIds: conversation.messageIds,
+    index: structuralIndex,
+    graph: conversationGraph,
+  })
+  const { derivePendingBranches } = inlineComposer
+
   const {
     openingMessage,
     replies: railReplies,
@@ -309,7 +344,12 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     pendingReplies,
     source,
     events: railEvents,
-  } = useBoardCardMessages(post, hostStreamType)
+    messagesById,
+    taggedByConversation,
+  } = useBoardCardMessages(post, hostStreamType, {
+    branchStreamIds: inlineComposer.branchStreamIds,
+    extraDraftPanelIds: inlineComposer.extraDraftPanelIds,
+  })
 
   // Backfill the full window when the local rail is missing older replies (or the
   // stream isn't synced yet); the live rail shows immediately, this only fills the
@@ -355,7 +395,138 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     () => resolveBoardEventRows(railEvents, { conversationId: conversation.id, memberMessageIds }),
     [railEvents, conversation.id, memberMessageIds]
   )
-  const rows = buildBoardRows(all, eventRows)
+
+  // Per-thread-boundary grouping — same derivation as the board card (the panel
+  // is the always-expanded peer). Overflow rows link into the thread's own stream
+  // panel here rather than back to this conversation.
+  const { getPanelUrl } = usePanel()
+  const occupiedStreamIds = useMemo(() => {
+    const set = new Set<string>([conversation.streamId])
+    for (const message of all) if (message.streamId) set.add(message.streamId)
+    return set
+  }, [conversation.streamId, all])
+  // A nested branch's bodies resolve through the panel's merged rail — its server
+  // `messageIds` unioned with the rows tagged with its id (a just-sent branch
+  // reply rides the tag through its echo window). The panel is always expanded,
+  // so every locally-available branch message shows; only unsynced members count
+  // toward the "N more replies" link.
+  const resolveBranchMessages = useCallback(
+    (branchConversationId: string, branchMemberIds: string[]) => {
+      const rows: RenderableMessage[] = []
+      const seen = new Set<string>()
+      for (const id of branchMemberIds) {
+        const message = messagesById.get(id)
+        if (!message) continue
+        rows.push(message)
+        seen.add(id)
+      }
+      for (const tagged of taggedByConversation.get(branchConversationId) ?? []) {
+        if (!seen.has(tagged.id)) rows.push(tagged)
+      }
+      rows.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      const knownTotal = Math.max(branchMemberIds.length, rows.length)
+      return { messages: rows, hiddenCount: Math.max(0, knownTotal - rows.length) }
+    },
+    [messagesById, taggedByConversation]
+  )
+  const branchesByForkMessageId = useMemo(() => {
+    const branches = deriveBranchConversations({
+      conversationId: conversation.id,
+      memberMessageIds: conversation.messageIds,
+      index: structuralIndex,
+      graph: conversationGraph,
+      resolveMessages: resolveBranchMessages,
+      excludeThreadStreamIds: occupiedStreamIds,
+    })
+    const byFork = new Map<string, BranchConversationView[]>()
+    for (const branch of branches) {
+      const list = byFork.get(branch.forkMessageId)
+      if (list) list.push(branch)
+      else byFork.set(branch.forkMessageId, [branch])
+    }
+    // In-flight sub-topic sends render as synthetic pending branches until the
+    // graph takes over (one thread per fork, so a graph-covered fork wins).
+    for (const branch of derivePendingBranches(messagesById)) {
+      if (!byFork.has(branch.forkMessageId)) byFork.set(branch.forkMessageId, [branch])
+    }
+    return byFork
+  }, [
+    conversation.id,
+    conversation.messageIds,
+    structuralIndex,
+    conversationGraph,
+    resolveBranchMessages,
+    occupiedStreamIds,
+    derivePendingBranches,
+    messagesById,
+  ])
+  const provenance = useMemo(
+    () =>
+      deriveBranchProvenance({
+        conversationId: conversation.id,
+        anchorStreamId: conversation.streamId,
+        index: structuralIndex,
+        graph: conversationGraph,
+      }),
+    [conversation.id, conversation.streamId, structuralIndex, conversationGraph]
+  )
+  const rows = buildBranchedBoardRows(
+    groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
+    eventRows,
+    branchesByForkMessageId
+  )
+  const renderMessage = (message: RenderableMessage, continuation: boolean) => {
+    // Each row renders against its own stream so reactions and the permalink
+    // target where the message actually lives (one root, many streams); fall
+    // back to the anchor.
+    const rowStreamId = message.streamId ?? conversation.streamId
+    // Hide "New sub-topic" once a thread already exists under the message (a
+    // populated thread would mix membership — "Split this thread" is the gesture
+    // there, adjustment D).
+    const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    return (
+      <MessageItem
+        key={message.id}
+        workspaceId={workspaceId}
+        streamId={rowStreamId}
+        message={message}
+        authorName={getActorName(message.authorId, message.authorType)}
+        currentUserId={currentUserId}
+        continuation={continuation}
+        conversationId={conversation.id}
+        conversationRootStreamId={conversation.streamId}
+        isHighlighted={message.id === highlightMessageId}
+        surfaceClassName="bg-background"
+        onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
+      />
+    )
+  }
+  // A nested branch's rows are OUTSIDE this conversation: render-only (null read
+  // provider — no mark-read/unread here) and identified as the CHILD conversation
+  // so copy-link opens its panel. Same shape as the board card's.
+  const renderBranchMessage = (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => {
+    const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    return (
+      <ConversationReadProvider value={null}>
+        <MessageItem
+          workspaceId={workspaceId}
+          streamId={message.streamId ?? branch.threadStreamId}
+          message={message}
+          authorName={getActorName(message.authorId, message.authorType)}
+          currentUserId={currentUserId}
+          continuation={continuation}
+          conversationId={branch.conversationId}
+          conversationRootStreamId={branch.threadStreamId}
+          surfaceClassName="bg-background"
+          onNewSubtopic={
+            canBranch
+              ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
+              : undefined
+          }
+        />
+      </ConversationReadProvider>
+    )
+  }
   // The conversation's most-recently-active stream — the latest reply's own stream
   // (a thread under the root), so a continuation follows the conversation there
   // instead of re-interleaving the channel (board-view-design.md). Falls back to
@@ -388,31 +559,19 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
         <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
-          {rows.map((row) =>
-            row.kind === "message" ? (
-              <MessageItem
-                key={row.message.id}
-                workspaceId={workspaceId}
-                // Each row renders against its own stream so reactions and the
-                // permalink target where the message actually lives (one root, many
-                // streams); fall back to the anchor.
-                streamId={row.message.streamId ?? conversation.streamId}
-                message={row.message}
-                authorName={getActorName(row.message.authorId, row.message.authorType)}
-                currentUserId={currentUserId}
-                continuation={row.continuation}
-                conversationId={conversation.id}
-                conversationRootStreamId={conversation.streamId}
-                isHighlighted={row.message.id === highlightMessageId}
-                // Break out of the list's px-4 and pad content back so the actor
-                // accent fills to the panel edges (stream-view look), rows aligned.
-                surfaceClassName="bg-background px-4"
-                rowInsetClassName="-mx-4"
-              />
-            ) : (
-              <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
-            )
+          {provenance && (
+            <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
           )}
+          <BranchedBoardRows
+            rows={rows}
+            workspaceId={workspaceId}
+            renderMessage={renderMessage}
+            continueThreadTo={(streamId) => getPanelUrl(streamId)}
+            onSplitThread={(threadStreamId) => splitThread.mutate({ conversationId: conversation.id, threadStreamId })}
+            renderBranchMessage={renderBranchMessage}
+            renderBranchTail={inlineComposer.renderBranchTail}
+            renderAfterMessage={inlineComposer.renderAfterMessage}
+          />
           {loadingMore && <span className="mt-3 block text-xs text-muted-foreground">Loading messages…</span>}
           {backfillFailed && (
             <button

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -135,6 +135,12 @@ interface MessageItemProps {
    * on `surfaceClassName` so content stays aligned (board: `-mx-3 sm:-mx-4` +
    * `px-3 sm:px-4`; panel: `-mx-4` + `px-4`). Omit on the label page (no accent). */
   rowInsetClassName?: string
+  /** Open a thread under this message and mint its child conversation (the declared
+   * "New sub-topic" branch gesture). Passed already-guarded by the conversation
+   * surfaces — set only when no thread yet exists under the message (adjustment D)
+   * — so the action shows exactly where a fresh branch is valid; other surfaces
+   * leave it undefined and the action hides. */
+  onNewSubtopic?: () => void
 }
 
 /**
@@ -160,6 +166,7 @@ export function MessageItem({
   isHighlighted,
   surfaceClassName,
   rowInsetClassName,
+  onNewSubtopic,
 }: MessageItemProps) {
   const { formatTime, formatFull } = useFormattedDate()
   const { openUserProfile } = useUserProfile()
@@ -408,6 +415,7 @@ export function MessageItem({
       label: viewInStreamLabel(rowStream?.type),
     },
     onLabelMessage: () => setLabelPickerOpen(true),
+    onNewSubtopic,
     onMarkReadUpToHere:
       conversationRead && rowRead !== "read" ? () => conversationRead.markReadUpToHere(message.id) : undefined,
     onMarkUnread: conversationRead && rowRead !== "unread" ? () => conversationRead.markUnread(message.id) : undefined,

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -20,6 +20,7 @@ import {
   Tag,
   ArrowUpRight,
   PanelRight,
+  GitBranch,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -89,6 +90,16 @@ export interface MessageActionContext {
    * in the flat timeline with an instant provenance chip.
    */
   onReplyInConversation?: () => void
+  /**
+   * The declared branch gesture (board-view-design.md): open a real thread under
+   * this message and mint a child conversation for it (the first reply carries a
+   * `newSubtopic` directive; no reply = nothing created). Set ONLY by the
+   * conversation surfaces (board card / conversation panel), and only when no
+   * thread yet exists under the message — a populated thread would create mixed
+   * membership, so "Split this thread" is the gesture there instead (adjustment
+   * D). The plain timeline never sets it.
+   */
+  onNewSubtopic?: () => void
   /**
    * Share-to-root fast path: queue a pointer share into the top-level non-thread
    * ancestor (channel/dm/scratchpad) and navigate there. Always preferred over
@@ -339,6 +350,17 @@ export const messageActions: MessageAction[] = [
     groupId: "reply",
     when: (ctx) => !!ctx.onReplyInConversation,
     action: (ctx) => ctx.onReplyInConversation?.(),
+  },
+  {
+    // Declared branch: open a thread under this message and mint its child
+    // conversation. The conversation surfaces (board card / panel) set the handler,
+    // and only when no thread yet exists under the message (adjustment D) — the
+    // plain timeline and populated-thread rows leave it unset.
+    id: "new-subtopic",
+    label: "New sub-topic",
+    icon: GitBranch,
+    when: (ctx) => !!ctx.onNewSubtopic,
+    action: (ctx) => ctx.onNewSubtopic?.(),
   },
   {
     // In-stream → conversation panel (the mirror of "View in channel"). Only

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -79,6 +79,7 @@ export interface ConversationService {
   muteStream: typeof conversationsApi.muteStream
   unmuteStream: typeof conversationsApi.unmuteStream
   getBoardExclusions: typeof conversationsApi.getBoardExclusions
+  splitThread: typeof conversationsApi.splitThread
 }
 
 export interface ActivityService {

--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -5,6 +5,7 @@ import { createDraftPanelId } from "@/contexts/panel-context"
 import type { BoardViewPost } from "./use-stable-board-view"
 import {
   useBoardCardMessages,
+  useBoardRailsReady,
   useStableReplyWindow,
   __clearBoardRailRegistry,
   __boardRailRegistrySize,
@@ -882,5 +883,29 @@ describe("useStableReplyWindow", () => {
 
     rerender({ convId: "conv_2", replies: ["x1", "x2", "x3", "x4"].map(reply) })
     expect(ids(result.current)).toEqual(["x2", "x3", "x4"])
+  })
+})
+
+describe("useBoardRailsReady", () => {
+  it("is false until every rail's first IDB read lands, then true — the reveal gate", async () => {
+    await db.events.bulkPut([msgEvent("m1", "hello", 1, "stream_a"), msgEvent("m2", "there", 2, "stream_b")])
+
+    const { result } = renderHook(() => useBoardRailsReady(["stream_a", "stream_b"]))
+    // First snapshot precedes the rails' async first read.
+    expect(result.current).toBe(false)
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it("is true for an empty stream set (nothing to wait for)", () => {
+    const { result } = renderHook(() => useBoardRailsReady([]))
+    expect(result.current).toBe(true)
+  })
+
+  it("pre-warms the shared registry so a later card mount reads resolved rails", async () => {
+    await db.events.bulkPut([msgEvent("m1", "warm", 1, "stream_warm")])
+    const { result } = renderHook(() => useBoardRailsReady(["stream_warm"]))
+    await waitFor(() => expect(result.current).toBe(true))
+    // The registry entry the gate created is the same one a mounting card uses.
+    expect(__boardRailRegistrySize()).toBeGreaterThan(0)
   })
 })

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -392,6 +392,31 @@ function useChildThreadStreamIds(workspaceId: string, parentMessageIds: string[]
   return useSyncExternalStore(subscribe, getSnapshot)
 }
 
+/**
+ * Pre-warm the rails behind `streamIds` and report when every one has completed
+ * its first IDB read. The board page holds its first card paint on this (plus the
+ * conversation graph) so a card's first frame is its FINAL frame — bodies, branch
+ * groups, and event rows all present at once instead of resolving in over the
+ * next few hundred milliseconds (the refresh pop-in Kris rejected, 2026-07-05).
+ * Subscribing here creates the shared registry entries, so cards mounting after
+ * the reveal reuse already-resolved rails.
+ */
+export function useBoardRailsReady(streamIds: string[]): boolean {
+  const key = streamIds.join(",")
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubscribes = streamIds.map((id) => subscribeStreamRail(id, onChange))
+      return () => {
+        for (const unsubscribe of unsubscribes) unsubscribe()
+      }
+    },
+    // `key` captures the set; the closure over `streamIds` is consistent with it.
+    [key]
+  )
+  const getSnapshot = useCallback(() => streamIds.every((id) => railRegistry.get(id)?.rail.resolved ?? false), [key])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
 /** How many stream rails the registry currently holds — for tests, to prove a
  *  drained rail is actually torn down once its grace elapses (the leak half of
  *  the grace-teardown contract). */
@@ -437,11 +462,37 @@ export interface BoardCardMessages {
    *  `resolveBoardEventRows` to filter+group them to this conversation. Always the
    *  live rail's rows (empty on a cold projection open, filled once synced). */
   events: CachedEvent[]
+  /** The merged rail's renderable message rows by id — the card resolves a nested
+   *  branch conversation's own messages through this (its `messageIds` ∪ the rows
+   *  tagged with its id). Live off the same `db.events` rail. */
+  messagesById: Map<string, RenderableMessage>
+  /** Rail rows tagged by the conversation they attach to — a just-sent branch reply
+   *  shows in its branch through its echo window before the branch's server
+   *  `messageIds` lists it, the same union the card does for its own replies. */
+  taggedByConversation: Map<string, RenderableMessage[]>
+}
+
+/** Extra rails a board card subscribes to beyond its conversation's own streams:
+ *  the branch conversations it renders nested, and the draft-thread panels of any
+ *  in-flight "new sub-topic" gestures. Both are content-only (non-gating), so a
+ *  branch rail that's mid-load never drags the card back to its projection. */
+export interface BoardCardExtraRails {
+  /** Thread streams of the branch conversations the card renders (direct + nested).
+   *  Routed to EXTRA even though the suppression folds them into `post.streamIds`
+   *  for the board-page subscription, so they don't gate the parent card. */
+  branchStreamIds?: string[]
+  /** Draft-panel ids (`createDraftPanelId`) of open/pending inline "new sub-topic"
+   *  composers, so their optimistic message renders before the thread echo lands. */
+  extraDraftPanelIds?: string[]
 }
 
 const NO_PENDING: RenderableMessage[] = []
 
-type BoardCardView = BoardCardMessages & { nextRetained: RenderableMessage[] }
+// The memoized per-render derivation below; the rail's message maps are appended
+// at the return boundary (they come straight off the merged rail, not the view).
+type BoardCardView = Omit<BoardCardMessages, "messagesById" | "taggedByConversation"> & {
+  nextRetained: RenderableMessage[]
+}
 
 /**
  * A board card's messages, read OFFLINE-FIRST from the same `db.events` store the
@@ -456,10 +507,18 @@ type BoardCardView = BoardCardMessages & { nextRetained: RenderableMessage[] }
  * which catches them up + joins their rooms, so the fallback resolves to the live
  * rail once that sync lands — the projection just covers the cold-open window.
  */
-export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: string): BoardCardMessages {
+export function useBoardCardMessages(
+  post: BoardViewPost,
+  hostStreamType?: string,
+  extraRails?: BoardCardExtraRails
+): BoardCardMessages {
   const streamId = post.conversation.streamId
   const messageIds = post.conversation.messageIds
   const openingId = post.openingMessage?.id ?? null
+  const branchStreamIds = extraRails?.branchStreamIds ?? EMPTY_THREAD_IDS
+  const branchStreamKey = branchStreamIds.join(",")
+  const extraDraftPanelIds = extraRails?.extraDraftPanelIds ?? EMPTY_THREAD_IDS
+  const extraDraftPanelKey = extraDraftPanelIds.join(",")
 
   // Flat conversation: the opening is `messageIds[0]`, replies are the rest. A
   // thread's opening is the parent message (not a member), so every messageId is a
@@ -496,23 +555,32 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
   // never flips the card back to its projection). Keyed on stable primitives, not
   // the post.* objects (which a parent re-render would re-create, churning subs).
   const gatingStreamIds = useMemo(() => {
+    // Branch conversation streams the suppression folded into `post.streamIds` (for
+    // the board-page subscription) must NOT gate this card — they're a separate
+    // conversation the card only renders; route them to EXTRA below instead.
+    const branchSet = new Set(branchStreamIds)
     const set = new Set<string>([streamId])
-    for (const id of post.streamIds ?? []) set.add(id)
+    for (const id of post.streamIds ?? []) if (!branchSet.has(id)) set.add(id)
     if (openingStreamId) set.add(openingStreamId)
     for (const message of post.recentMessages) if (message.streamId) set.add(message.streamId)
     return [...set].sort()
-  }, [streamId, streamIdsKey, openingStreamId, recentStreamsKey])
+  }, [streamId, streamIdsKey, openingStreamId, recentStreamsKey, branchStreamKey])
   const gatingKey = gatingStreamIds.join(",")
   const extraStreamIds = useMemo(() => {
     const gating = new Set(gatingStreamIds)
     const set = new Set<string>()
     for (const id of childThreadIds) if (!gating.has(id)) set.add(id)
+    // The branch conversations the card renders nested, and any open/pending
+    // inline "new sub-topic" draft panels — content-only, so a mid-load branch
+    // rail never flips the parent card back to its projection.
+    for (const id of branchStreamIds) if (!gating.has(id)) set.add(id)
+    for (const id of extraDraftPanelIds) if (!gating.has(id)) set.add(id)
     if (threadable && messageIds.length <= 1 && openingId) {
       const panel = createDraftPanelId(streamId, openingId)
       if (!gating.has(panel)) set.add(panel)
     }
     return [...set].sort()
-  }, [childThreadKey, gatingKey, threadable, messageIdsKey, openingId, streamId])
+  }, [childThreadKey, gatingKey, threadable, messageIdsKey, openingId, streamId, branchStreamKey, extraDraftPanelKey])
 
   const rail = useMergedStreamRail(gatingStreamIds, extraStreamIds)
   const conversationId = post.conversation.id
@@ -676,7 +744,14 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     }
   }, [view, conversationId, replyIds])
 
-  return view
+  // Expose the merged rail's message maps so the card can resolve its nested
+  // branch conversations' bodies through the same rail (kept off the `view` memo
+  // above, whose branches build the card's OWN messages — the rail identity is
+  // stable per snapshot, so the branch derivation memoizes on it downstream).
+  return useMemo(
+    () => ({ ...view, messagesById: rail.messages, taggedByConversation: rail.taggedByConversation }),
+    [view, rail.messages, rail.taggedByConversation]
+  )
 }
 
 /**

--- a/apps/frontend/src/hooks/use-conversation-graph.test.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest"
+import { StreamTypes } from "@threa/types"
+import type { CachedBoardPost, CachedStream } from "@/db"
+import type { RenderableMessage } from "@/components/message/message-item"
+import {
+  deriveBranchConversations,
+  collectBranchThreadStreamIds,
+  branchParentConversationId,
+  type ConversationGraph,
+  type StreamStructuralIndex,
+} from "./use-conversation-graph"
+
+function stream(id: string, type: string, parentMessageId: string | null = null): CachedStream {
+  return {
+    id,
+    workspaceId: "ws_1",
+    type,
+    parentStreamId: null,
+    parentMessageId,
+    rootStreamId: type === StreamTypes.THREAD ? "root" : null,
+  } as CachedStream
+}
+
+function post(id: string, anchorStreamId: string, messageIds: string[], topicSummary: string | null): CachedBoardPost {
+  return {
+    id,
+    workspaceId: "ws_1",
+    conversation: { id, streamId: anchorStreamId, messageIds, topicSummary },
+    rootStreamId: "root",
+  } as unknown as CachedBoardPost
+}
+
+/** Build the two indices the pure helpers read, from plain fixtures. */
+function fixtures(streams: CachedStream[], posts: CachedBoardPost[]) {
+  const index: StreamStructuralIndex = {
+    streamsById: new Map(streams.map((s) => [s.id, s])),
+    threadsByParentMessageId: new Map(
+      streams.filter((s) => s.type === StreamTypes.THREAD && s.parentMessageId).map((s) => [s.parentMessageId!, s])
+    ),
+  }
+  const graph: ConversationGraph = {
+    conversationByAnchorStreamId: new Map(
+      posts
+        .filter((p) => p.conversation.streamId !== (p.rootStreamId ?? p.conversation.streamId))
+        .map((p) => [p.conversation.streamId, p])
+    ),
+    conversationIdByMemberMessageId: new Map(
+      posts.flatMap((p) => p.conversation.messageIds.map((m) => [m, p.id] as const))
+    ),
+    conversationById: new Map(posts.map((p) => [p.id, p])),
+  }
+  return { index, graph }
+}
+
+const resolveEmpty = () => ({ messages: [] as RenderableMessage[], hiddenCount: 0 })
+
+describe("deriveBranchConversations", () => {
+  // root conv (m1) → thread t1 anchors child (c1) → thread t2 anchors grandchild
+  // (g1) → thread t3 anchors great-grandchild (gg1).
+  const streams = [
+    stream("root", StreamTypes.CHANNEL),
+    stream("t1", StreamTypes.THREAD, "m1"),
+    stream("t2", StreamTypes.THREAD, "c1"),
+    stream("t3", StreamTypes.THREAD, "g1"),
+  ]
+  const posts = [
+    post("conv_root", "root", ["m1"], "Root topic"),
+    post("conv_child", "t1", ["c1"], "Child topic"),
+    post("conv_grand", "t2", ["g1"], "Grand topic"),
+    post("conv_great", "t3", ["gg1"], "Great topic"),
+  ]
+
+  it("discovers branches recursively with normalized depth, capping visible depth at 2", () => {
+    const { index, graph } = fixtures(streams, posts)
+    const branches = deriveBranchConversations({
+      conversationId: "conv_root",
+      memberMessageIds: ["m1"],
+      index,
+      graph,
+      resolveMessages: resolveEmpty,
+    })
+    expect(branches).toHaveLength(1)
+    const child = branches[0]
+    expect(child).toMatchObject({
+      conversationId: "conv_child",
+      threadStreamId: "t1",
+      forkMessageId: "m1",
+      title: "Child topic",
+      displayDepth: 1,
+      overflow: false,
+    })
+    const grand = child.children[0]
+    expect(grand).toMatchObject({ conversationId: "conv_grand", displayDepth: 2, forkMessageId: "c1" })
+    // Depth 2 is the visible floor: the great-grandchild does not nest — the
+    // grandchild flags overflow (its subtree continues in the panel) instead.
+    expect(grand.children).toEqual([])
+    expect(grand.overflow).toBe(true)
+  })
+
+  it("skips threads the parent conversation itself occupies (soft/spanning render inline)", () => {
+    const { index, graph } = fixtures(streams, posts)
+    const branches = deriveBranchConversations({
+      conversationId: "conv_root",
+      memberMessageIds: ["m1"],
+      index,
+      graph,
+      resolveMessages: resolveEmpty,
+      excludeThreadStreamIds: new Set(["t1"]),
+    })
+    expect(branches).toEqual([])
+  })
+
+  it("resolves branch bodies through the supplied resolver", () => {
+    const { index, graph } = fixtures(streams, posts)
+    const body = { id: "c1", streamId: "t1" } as RenderableMessage
+    const branches = deriveBranchConversations({
+      conversationId: "conv_root",
+      memberMessageIds: ["m1"],
+      index,
+      graph,
+      resolveMessages: (conversationId) =>
+        conversationId === "conv_child" ? { messages: [body], hiddenCount: 3 } : { messages: [], hiddenCount: 0 },
+    })
+    expect(branches[0].messages).toEqual([body])
+    expect(branches[0].hiddenCount).toBe(3)
+  })
+})
+
+describe("collectBranchThreadStreamIds", () => {
+  it("flattens every branch thread within the depth budget", () => {
+    const streams = [
+      stream("root", StreamTypes.CHANNEL),
+      stream("t1", StreamTypes.THREAD, "m1"),
+      stream("t2", StreamTypes.THREAD, "c1"),
+      stream("t3", StreamTypes.THREAD, "g1"),
+    ]
+    const posts = [
+      post("conv_root", "root", ["m1"], null),
+      post("conv_child", "t1", ["c1"], null),
+      post("conv_grand", "t2", ["g1"], null),
+      post("conv_great", "t3", ["gg1"], null),
+    ]
+    const { index, graph } = fixtures(streams, posts)
+    const ids = collectBranchThreadStreamIds({ conversationId: "conv_root", memberMessageIds: ["m1"], index, graph })
+    // t3 sits past the depth budget — its subtree renders behind the overflow
+    // link, so its rail isn't subscribed from this card.
+    expect(ids.sort()).toEqual(["t1", "t2"])
+  })
+})
+
+describe("branchParentConversationId", () => {
+  it("resolves the parent conversation a branch's anchor thread forks off", () => {
+    const streams = [stream("root", StreamTypes.CHANNEL), stream("t1", StreamTypes.THREAD, "m1")]
+    const posts = [post("conv_root", "root", ["m1"], null), post("conv_child", "t1", ["c1"], null)]
+    const { index, graph } = fixtures(streams, posts)
+    expect(branchParentConversationId("conv_child", index, graph)).toBe("conv_root")
+    // A root-anchored conversation is no branch.
+    expect(branchParentConversationId("conv_root", index, graph)).toBeNull()
+    // An empty parent never counts (mirrors the board's cardinality filter).
+    const emptied = posts.map((p) => (p.id === "conv_root" ? post("conv_root", "root", [], null) : p))
+    const f2 = fixtures(streams, emptied)
+    expect(branchParentConversationId("conv_child", f2.index, f2.graph)).toBeNull()
+  })
+})

--- a/apps/frontend/src/hooks/use-conversation-graph.ts
+++ b/apps/frontend/src/hooks/use-conversation-graph.ts
@@ -1,0 +1,348 @@
+import { useCallback, useSyncExternalStore } from "react"
+import { liveQuery, type Subscription } from "dexie"
+import { StreamTypes } from "@threa/types"
+import { db, type CachedBoardPost, type CachedStream } from "@/db"
+import { useWorkspaceStreamsRaw } from "@/stores/workspace-store"
+import { streamLabel } from "@/lib/streams"
+import { stripMarkdownToInline } from "@/lib/markdown/strip"
+import type { RenderableMessage } from "@/components/message/message-item"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
+
+/**
+ * The board's cross-conversation lookups, derived once per workspace from the
+ * cached conversations and shared across every card:
+ *
+ * - `conversationByAnchorStreamId` — the conversation anchored to a **thread**
+ *   stream. Only thread-anchored conversations are indexed (a channel/DM anchor
+ *   is shared by many conversations), so a parent card can resolve the child
+ *   conversation a fork thread hosts. `rootStreamId !== anchor` marks the thread
+ *   anchor (a top-level anchor is its own root).
+ * - `conversationIdByMemberMessageId` — the conversation each message is a primary
+ *   member of, so a child card can find the parent conversation its opener thread
+ *   forked from.
+ * - `conversationById` — resolve a looked-up id back to its post (topic/anchor).
+ */
+export interface ConversationGraph {
+  conversationByAnchorStreamId: Map<string, CachedBoardPost>
+  conversationIdByMemberMessageId: Map<string, string>
+  conversationById: Map<string, CachedBoardPost>
+}
+
+const EMPTY_GRAPH: ConversationGraph = {
+  conversationByAnchorStreamId: new Map(),
+  conversationIdByMemberMessageId: new Map(),
+  conversationById: new Map(),
+}
+
+export function buildConversationGraph(posts: CachedBoardPost[]): ConversationGraph {
+  return buildGraph(posts)
+}
+
+function buildGraph(posts: CachedBoardPost[]): ConversationGraph {
+  const conversationByAnchorStreamId = new Map<string, CachedBoardPost>()
+  const conversationIdByMemberMessageId = new Map<string, string>()
+  const conversationById = new Map<string, CachedBoardPost>()
+  for (const post of posts) {
+    conversationById.set(post.id, post)
+    const anchor = post.conversation.streamId
+    if (post.rootStreamId !== undefined && post.rootStreamId !== anchor) {
+      conversationByAnchorStreamId.set(anchor, post)
+    }
+    for (const messageId of post.conversation.messageIds ?? []) conversationIdByMemberMessageId.set(messageId, post.id)
+  }
+  return { conversationByAnchorStreamId, conversationIdByMemberMessageId, conversationById }
+}
+
+interface GraphEntry {
+  graph: ConversationGraph
+  /** False until the first IDB read emits — the board's reveal gate holds first
+   *  paint on it so branch nesting is present from the very first frame. */
+  resolved: boolean
+  listeners: Set<() => void>
+  subscription: Subscription
+  refCount: number
+}
+
+// INV-9 exception: one shared `db.conversations` liveQuery per workspace,
+// ref-counted across every board card. The board renders hundreds of cards over
+// hundreds of conversations; a per-card scan for "which conversation anchors this
+// thread / owns this message" would be O(cards × conversations). This collapses
+// it to one liveQuery per workspace whose derived index every card reads, torn
+// down when the last card unmounts (adjustment E). Mirrors `threadIndexRegistry`.
+const graphRegistry = new Map<string, GraphEntry>()
+
+function subscribeConversationGraph(workspaceId: string, listener: () => void): () => void {
+  let entry = graphRegistry.get(workspaceId)
+  if (!entry) {
+    const created: GraphEntry = {
+      graph: EMPTY_GRAPH,
+      resolved: false,
+      listeners: new Set(),
+      refCount: 0,
+      subscription: { unsubscribe() {} } as Subscription,
+    }
+    // Register BEFORE subscribing so `getSnapshot` observes the entry consistently;
+    // the callback re-reads the live entry so a late emission after teardown no-ops.
+    graphRegistry.set(workspaceId, created)
+    created.subscription = liveQuery(() =>
+      db.conversations.where("workspaceId").equals(workspaceId).toArray()
+    ).subscribe((posts) => {
+      const live = graphRegistry.get(workspaceId)
+      if (!live) return
+      live.graph = buildGraph(posts)
+      live.resolved = true
+      for (const notify of live.listeners) notify()
+    })
+    entry = created
+  }
+  entry.listeners.add(listener)
+  entry.refCount += 1
+  return () => {
+    const current = graphRegistry.get(workspaceId)
+    if (!current) return
+    current.listeners.delete(listener)
+    current.refCount -= 1
+    if (current.refCount <= 0) {
+      current.subscription.unsubscribe()
+      graphRegistry.delete(workspaceId)
+    }
+  }
+}
+
+/** The shared conversation graph for a workspace, live from `db.conversations`. */
+export function useConversationGraph(workspaceId: string): ConversationGraph {
+  const subscribe = useCallback(
+    (onChange: () => void) => subscribeConversationGraph(workspaceId, onChange),
+    [workspaceId]
+  )
+  const getSnapshot = useCallback(() => graphRegistry.get(workspaceId)?.graph ?? EMPTY_GRAPH, [workspaceId])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** Whether the shared graph's first IDB read has landed. Part of the board's
+ *  coordinated reveal: cards must not take their first paint against
+ *  `EMPTY_GRAPH`, or branch nesting pops in a frame later. */
+export function useConversationGraphReady(workspaceId: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => subscribeConversationGraph(workspaceId, onChange),
+    [workspaceId]
+  )
+  const getSnapshot = useCallback(() => graphRegistry.get(workspaceId)?.resolved ?? false, [workspaceId])
+  return useSyncExternalStore(subscribe, getSnapshot)
+}
+
+/** The board's structural stream index — parent pointers (for depth/branch
+ *  grouping) and threads keyed by their fork message (for stub discovery). */
+export interface StreamStructuralIndex {
+  streamsById: Map<string, CachedStream>
+  threadsByParentMessageId: Map<string, CachedStream>
+}
+
+// Cached by the raw streams array identity so every card shares one build; the
+// raw array reference is stable across cards until `db.streams` changes.
+const structuralIndexCache = new WeakMap<CachedStream[], StreamStructuralIndex>()
+
+function computeStructuralIndex(streams: CachedStream[]): StreamStructuralIndex {
+  const cached = structuralIndexCache.get(streams)
+  if (cached) return cached
+  const streamsById = new Map<string, CachedStream>()
+  const threadsByParentMessageId = new Map<string, CachedStream>()
+  for (const stream of streams) {
+    streamsById.set(stream.id, stream)
+    if (stream.type === StreamTypes.THREAD && stream.parentMessageId) {
+      threadsByParentMessageId.set(stream.parentMessageId, stream)
+    }
+  }
+  const index = { streamsById, threadsByParentMessageId }
+  structuralIndexCache.set(streams, index)
+  return index
+}
+
+export function useStreamStructuralIndex(workspaceId: string): StreamStructuralIndex {
+  const streams = useWorkspaceStreamsRaw(workspaceId)
+  return computeStructuralIndex(streams)
+}
+
+/**
+ * The branch relationship, resolved from the graph alone: the parent conversation
+ * a `conversationId`'s anchor thread forks off, or `null` when it isn't a branch
+ * (anchor isn't a thread, its fork message belongs to no conversation, or that
+ * conversation is empty/itself). The single walk primitive shared by the child
+ * card's "branched from" provenance, the parent card's nested discovery, and the
+ * board list's one-card-per-root suppression — so all three read the same rule.
+ */
+export function resolveParentConversationId(params: {
+  conversationId: string
+  anchorStreamId: string
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+}): string | null {
+  const { conversationId, anchorStreamId, index, graph } = params
+  const anchor = index.streamsById.get(anchorStreamId)
+  if (!anchor || anchor.type !== StreamTypes.THREAD || !anchor.parentMessageId) return null
+  const parentId = graph.conversationIdByMemberMessageId.get(anchor.parentMessageId)
+  if (!parentId || parentId === conversationId) return null
+  const parentPost = graph.conversationById.get(parentId)
+  if (!parentPost || parentPost.conversation.messageIds.length === 0) return null
+  return parentId
+}
+
+/** {@link resolveParentConversationId} keyed by id alone — the board list
+ *  suppression's transitive walk resolves ancestors it holds no post object for
+ *  (a middle parent filtered out of the current lens) straight off the graph. */
+export function branchParentConversationId(
+  conversationId: string,
+  index: StreamStructuralIndex,
+  graph: ConversationGraph
+): string | null {
+  const post = graph.conversationById.get(conversationId)
+  if (!post) return null
+  return resolveParentConversationId({ conversationId, anchorStreamId: post.conversation.streamId, index, graph })
+}
+
+/** Whether any of `memberMessageIds` opens a further non-empty branch conversation
+ *  — the depth-cap overflow signal (a grandchild that itself branches links out
+ *  instead of nesting a third level). */
+function hasDeeperBranch(
+  memberMessageIds: string[],
+  index: StreamStructuralIndex,
+  graph: ConversationGraph,
+  seenConversationIds: Set<string>
+): boolean {
+  for (const messageId of memberMessageIds) {
+    const thread = index.threadsByParentMessageId.get(messageId)
+    if (!thread) continue
+    const childPost = graph.conversationByAnchorStreamId.get(thread.id)
+    if (childPost && !seenConversationIds.has(childPost.id) && childPost.conversation.messageIds.length > 0) return true
+  }
+  return false
+}
+
+/**
+ * The branch conversations nested inside a parent card, discovered recursively
+ * from the stream graph (Kris dogfood ruling 2026-07-05, board-view-design.md):
+ * for each of the parent's member messages, the thread forking off it that
+ * anchors another non-empty conversation becomes a branch; that child's own
+ * member messages are walked for grandchildren, capped at `maxDepth` (deeper
+ * subtrees collapse to a `continue in panel` link via the `overflow` flag).
+ *
+ * Structure comes from the graph (server-known `messageIds`); message BODIES come
+ * from `resolveMessages`, which reads the parent card's merged rail (and slices to
+ * the collapsed window, returning `hiddenCount`). `seenConversationIds` guards
+ * against a cycle re-nesting a conversation already on the path.
+ */
+export function deriveBranchConversations(params: {
+  conversationId: string
+  memberMessageIds: string[]
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+  resolveMessages: (
+    conversationId: string,
+    memberMessageIds: string[]
+  ) => { messages: RenderableMessage[]; hiddenCount: number }
+  /** Threads the parent conversation itself occupies — those render inline
+   *  (soft/spanning nodes), never doubled as a branch group (mixed membership). */
+  excludeThreadStreamIds?: Set<string>
+  maxDepth?: number
+}): BranchConversationView[] {
+  const {
+    conversationId,
+    memberMessageIds,
+    index,
+    graph,
+    resolveMessages,
+    excludeThreadStreamIds,
+    maxDepth = 2,
+  } = params
+  const walk = (forkCandidateIds: string[], depth: number, seen: Set<string>): BranchConversationView[] => {
+    const out: BranchConversationView[] = []
+    const seenFork = new Set<string>()
+    for (const messageId of forkCandidateIds) {
+      if (seenFork.has(messageId)) continue
+      seenFork.add(messageId)
+      const thread = index.threadsByParentMessageId.get(messageId)
+      if (!thread || excludeThreadStreamIds?.has(thread.id)) continue
+      const childPost = graph.conversationByAnchorStreamId.get(thread.id)
+      if (!childPost || seen.has(childPost.id) || childPost.conversation.messageIds.length === 0) continue
+      const childConversationId = childPost.id
+      const nextSeen = new Set(seen).add(childConversationId)
+      const childMemberIds = childPost.conversation.messageIds
+      const { messages, hiddenCount } = resolveMessages(childConversationId, childMemberIds)
+      const title = stripMarkdownToInline(childPost.conversation.topicSummary ?? "") || streamLabel(thread, "generic")
+      const children = depth < maxDepth ? walk(childMemberIds, depth + 1, nextSeen) : []
+      const overflow = depth >= maxDepth && hasDeeperBranch(childMemberIds, index, graph, nextSeen)
+      out.push({
+        conversationId: childConversationId,
+        threadStreamId: thread.id,
+        forkMessageId: messageId,
+        title,
+        displayDepth: depth,
+        overflow,
+        messages,
+        hiddenCount,
+        children,
+      })
+    }
+    return out
+  }
+  return walk(memberMessageIds, 1, new Set([conversationId]))
+}
+
+/** Every branch thread stream a parent card renders, flattened from the graph
+ *  alone (no rail) so the card can subscribe to them ahead of resolving their
+ *  bodies. Mirrors {@link deriveBranchConversations}' walk. */
+export function collectBranchThreadStreamIds(params: {
+  conversationId: string
+  memberMessageIds: string[]
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+  maxDepth?: number
+}): string[] {
+  const { conversationId, memberMessageIds, index, graph, maxDepth = 2 } = params
+  const out = new Set<string>()
+  const walk = (forkCandidateIds: string[], depth: number, seen: Set<string>) => {
+    if (depth > maxDepth) return
+    const seenFork = new Set<string>()
+    for (const messageId of forkCandidateIds) {
+      if (seenFork.has(messageId)) continue
+      seenFork.add(messageId)
+      const thread = index.threadsByParentMessageId.get(messageId)
+      if (!thread) continue
+      const childPost = graph.conversationByAnchorStreamId.get(thread.id)
+      if (!childPost || seen.has(childPost.id) || childPost.conversation.messageIds.length === 0) continue
+      out.add(thread.id)
+      const nextSeen = new Set(seen).add(childPost.id)
+      if (depth < maxDepth) walk(childPost.conversation.messageIds, depth + 1, nextSeen)
+    }
+  }
+  walk(memberMessageIds, 1, new Set([conversationId]))
+  return [...out]
+}
+
+/**
+ * "Branched from …" provenance for a child card: present iff the conversation's
+ * opener stream is a thread whose fork message is a member of another non-empty
+ * conversation.
+ */
+export function deriveBranchProvenance(params: {
+  conversationId: string
+  anchorStreamId: string
+  index: StreamStructuralIndex
+  graph: ConversationGraph
+}): { parentConversationId: string; title: string } | null {
+  const parentId = resolveParentConversationId(params)
+  if (!parentId) return null
+  const parentPost = params.graph.conversationById.get(parentId)!
+  const parentAnchor = params.index.streamsById.get(parentPost.conversation.streamId)
+  const title =
+    stripMarkdownToInline(parentPost.conversation.topicSummary ?? "") ||
+    (parentAnchor ? streamLabel(parentAnchor, "generic") : "conversation")
+  return { parentConversationId: parentId, title }
+}
+
+/** Tear down every shared conversation-graph subscription — for tests, so a
+ *  module-level registry can't leak a liveQuery (or a snapshot) across cases. */
+export function __clearConversationGraphRegistry(): void {
+  for (const entry of graphRegistry.values()) entry.subscription.unsubscribe()
+  graphRegistry.clear()
+}

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { toast } from "sonner"
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   useConversationService,
@@ -7,7 +8,6 @@ import {
   useSocketReconnectCount,
   createDraftPanelId,
 } from "@/contexts"
-import { toast } from "sonner"
 import { db } from "@/db"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { seedBoardPosts, useBoardPost, mergeBoardConversation } from "@/stores/board-store"
@@ -786,6 +786,30 @@ export function useUnmuteStream(workspaceId: string) {
     onError: (_error, streamId) => {
       void putMuted(workspaceId, streamId)
       toast.error("Couldn't unmute the stream")
+    },
+  })
+}
+
+/**
+ * Split a soft thread out of its parent conversation into its own topic (the
+ * board seam gesture). The card visibly re-forms into a nested branch group, so
+ * no success toast (INV-63); the board feed is invalidated so the new
+ * conversation and the shrunken source re-project, and the
+ * `conversation:created`/`updated` sync events converge the card in place. A
+ * failure surfaces as an error toast — the gesture has no other on-screen signal.
+ */
+export function useSplitThread(workspaceId: string) {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ conversationId, threadStreamId }: { conversationId: string; threadStreamId: string }) =>
+      conversationService.splitThread(workspaceId, conversationId, threadStreamId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [...conversationKeys.all, "workspaceList", workspaceId] })
+    },
+    onError: () => {
+      toast.error("Couldn't split the thread. Try again.")
     },
   })
 }

--- a/apps/frontend/src/hooks/use-queue-draft-message.ts
+++ b/apps/frontend/src/hooks/use-queue-draft-message.ts
@@ -245,7 +245,10 @@ export function useQueueDraftMessage(workspaceId: string) {
  *  on the real `message_created` payload — so the sender's own flat-timeline
  *  provenance chip (Mechanism C) renders on the optimistic row and stays put when
  *  the echo swaps in. A `threadFromMessage` reply is an opener the timeline chip
- *  ignores, so it tags the board card (`conversationId`) only. */
+ *  ignores, so it tags the board card (`conversationId`) only. `newSubtopic` mints
+ *  its child conversation server-side, so the id is unknown here — the optimistic
+ *  reply renders in the new thread rail by `streamId` and the parent-card stub
+ *  lands once the `conversation:created` echo caches the child (untagged, default). */
 export function conversationTag(directive: ConversationDirective | undefined): {
   conversationId?: string
   declaredConversationId?: string

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { act, renderHook } from "@testing-library/react"
 import type { BoardLens, BoardScopeStreamType } from "@threa/types"
 import * as boardStoreModule from "@/stores/board-store"
+import * as graphModule from "./use-conversation-graph"
 import type { CachedBoardPost } from "@/db"
 import {
   reconcileStableView,
@@ -397,6 +398,91 @@ describe("useStableBoardView", () => {
     rerender({ filter: typesFilter(["dm"]) })
     expect(result.current.posts.map((p) => p.id)).toEqual(["d"])
     expect(result.current.newCount).toBe(0)
+  })
+
+  it("folds a branch conversation into its visible parent — one card, effective activity, folded streams", () => {
+    // parent (anchor "root", member m1) is forked by child (anchor thread "t1"
+    // off m1). The child is newer (900) than the unrelated "other" (500).
+    const base = post("parent", 300)
+    const parent = {
+      ...base,
+      streamIds: ["root"],
+      conversation: { ...base.conversation, streamId: "root", messageIds: ["m1"] },
+    } as CachedBoardPost
+    const childBase = post("child", 900)
+    const child = {
+      ...childBase,
+      streamIds: ["t1"],
+      conversation: { ...childBase.conversation, streamId: "t1", messageIds: ["c1"] },
+    } as CachedBoardPost
+    const other = post("other", 500)
+
+    const threadRow = { id: "t1", type: "thread", parentStreamId: "root", parentMessageId: "m1", rootStreamId: "root" }
+    vi.spyOn(graphModule, "useStreamStructuralIndex").mockReturnValue({
+      streamsById: new Map([["t1", threadRow]]),
+      threadsByParentMessageId: new Map([["m1", threadRow]]),
+    } as unknown as ReturnType<typeof graphModule.useStreamStructuralIndex>)
+    vi.spyOn(graphModule, "useConversationGraph").mockReturnValue({
+      conversationByAnchorStreamId: new Map([["t1", child]]),
+      conversationIdByMemberMessageId: new Map([
+        ["m1", "parent"],
+        ["c1", "child"],
+      ]),
+      conversationById: new Map([
+        ["parent", parent],
+        ["child", child],
+        ["other", other],
+      ]),
+    } as unknown as ReturnType<typeof graphModule.useConversationGraph>)
+
+    mockLive(feed(child, other, parent))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL))
+    // One card per root discussion: the child folds into the parent, whose
+    // effective activity (900) now outranks "other" (500).
+    expect(result.current.posts.map((p) => p.id)).toEqual(["parent", "other"])
+    expect(result.current.newCount).toBe(0)
+    // The rendered parent copy declares the folded child's streams (so the board
+    // page's subscriptions still cover them) without mutating the cached post.
+    expect(result.current.posts[0].streamIds).toEqual(expect.arrayContaining(["root", "t1"]))
+    expect(parent.streamIds).toEqual(["root"])
+    expect(parent._lastActivityMs).toBe(300)
+  })
+
+  it("keeps a branch standalone when its parent is filtered out of the view", () => {
+    const childBase = post("child", 900)
+    const child = {
+      ...childBase,
+      streamIds: ["t1"],
+      conversation: { ...childBase.conversation, streamId: "t1", messageIds: ["c1"] },
+    } as CachedBoardPost
+    const base = post("parent", 300)
+    const parent = {
+      ...base,
+      streamIds: ["root"],
+      conversation: { ...base.conversation, streamId: "root", messageIds: ["m1"] },
+    } as CachedBoardPost
+    const threadRow = { id: "t1", type: "thread", parentStreamId: "root", parentMessageId: "m1", rootStreamId: "root" }
+    vi.spyOn(graphModule, "useStreamStructuralIndex").mockReturnValue({
+      streamsById: new Map([["t1", threadRow]]),
+      threadsByParentMessageId: new Map([["m1", threadRow]]),
+    } as unknown as ReturnType<typeof graphModule.useStreamStructuralIndex>)
+    vi.spyOn(graphModule, "useConversationGraph").mockReturnValue({
+      conversationByAnchorStreamId: new Map([["t1", child]]),
+      conversationIdByMemberMessageId: new Map([
+        ["m1", "parent"],
+        ["c1", "child"],
+      ]),
+      conversationById: new Map([
+        ["parent", parent],
+        ["child", child],
+      ]),
+    } as unknown as ReturnType<typeof graphModule.useConversationGraph>)
+
+    // The live feed holds only the child (its parent didn't match the filters):
+    // never vanish content — the child stays a standalone card.
+    mockLive(feed(child))
+    const { result } = renderHook(() => useStableBoardView("ws_1", ALL))
+    expect(result.current.posts.map((p) => p.id)).toEqual(["child"])
   })
 
   it("resets the committed view when the scope changes, not when it is re-created equal", () => {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { matchesBoardLens, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useBoardPosts } from "@/stores/board-store"
+import { projectNestedBoardView } from "@/lib/board/nested-board-view"
+import {
+  buildConversationGraph,
+  useStreamStructuralIndex,
+  branchParentConversationId,
+} from "@/hooks/use-conversation-graph"
 import type { CachedBoardPost } from "@/db"
 
 /** How long `revealNext` stays armed after the viewer posts. Bounds the auto-
@@ -300,26 +306,43 @@ export function useStableBoardView(
     [hidden, muted, muteActive]
   )
 
-  // Filter the shared feed to the lens + scopes + exclusions. Recomputed when the
-  // feed or filter changes; `Date.now()` is sampled then (the staleness signal for
-  // `needs-resolution` only needs to be fresh at feed-change granularity, which
-  // is frequent on a live board).
+  // The branch relationship for one-card-per-root suppression (below) derives
+  // from the SAME posts array being filtered, not the shared graph registry: the
+  // registry is a second liveQuery over the same table, and racing it means the
+  // first commit can paint a child card standalone only to fold it away a beat
+  // later — a card vanishing on refresh. Building from `rawLive` makes
+  // suppression consistent with its input by construction; cards keep the
+  // registry hook (they mount without the board list) and both build the same
+  // index shape.
+  const graph = useMemo(() => (rawLive ? buildConversationGraph(rawLive) : null), [rawLive])
+  const index = useStreamStructuralIndex(workspaceId)
+  // Filter the shared feed to the lens + scopes + exclusions, then fold branch
+  // conversations into their parent's card (one card per root discussion — a child
+  // whose parent survives the same filters is suppressed and bumps the parent's
+  // effective activity; a child whose parent is filtered out stays standalone). The
+  // fold runs BEFORE reconcile, so the committed-view machinery only ever sees the
+  // projected list. Recomputed when the feed or filter changes; `Date.now()` is
+  // sampled then (the staleness signal for `needs-resolution` only needs to be
+  // fresh at feed-change granularity, which is frequent on a live board).
   const live = useMemo(
     () =>
-      rawLive === undefined
+      rawLive === undefined || graph === null
         ? undefined
-        : rawLive.filter(
-            (post) =>
-              matchesBoardLens(post, lens, Date.now()) &&
-              matchesScope(post, scope) &&
-              matchesTypeScope(post, types) &&
-              matchesExcludedStreams(post, excludeStreams) &&
-              matchesExcludedTypes(post, excludeTypes) &&
-              matchesLabelScope(post, labels) &&
-              matchesExcludedLabels(post, excludeLabels) &&
-              !isExcluded(post)
+        : projectNestedBoardView(
+            rawLive.filter(
+              (post) =>
+                matchesBoardLens(post, lens, Date.now()) &&
+                matchesScope(post, scope) &&
+                matchesTypeScope(post, types) &&
+                matchesExcludedStreams(post, excludeStreams) &&
+                matchesExcludedTypes(post, excludeTypes) &&
+                matchesLabelScope(post, labels) &&
+                matchesExcludedLabels(post, excludeLabels) &&
+                !isExcluded(post)
+            ),
+            (conversationId) => branchParentConversationId(conversationId, index, graph)
           ),
-    [rawLive, lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, isExcluded]
+    [rawLive, lens, scope, types, excludeStreams, excludeTypes, labels, excludeLabels, isExcluded, graph, index]
   )
   const [committed, setCommitted] = useState<CommittedView>(EMPTY_VIEW)
   const [buffered, setBuffered] = useState<string[]>([])

--- a/apps/frontend/src/lib/board/board-event-rows.ts
+++ b/apps/frontend/src/lib/board/board-event-rows.ts
@@ -11,9 +11,9 @@ import { getSessionId, getSessionSlotKey, getTriggerMessageId } from "@/componen
  * `bumps: false` contract in STREAM_ROW_SPEC).
  */
 export type BoardEventRow =
-  | { kind: "session"; key: string; sortMs: number; events: CachedEvent[] }
-  | { kind: "memo"; key: string; sortMs: number; event: CachedEvent }
-  | { kind: "followUp"; key: string; sortMs: number; event: CachedEvent; cancelled: boolean }
+  | { kind: "session"; key: string; sortMs: number; streamId: string; events: CachedEvent[] }
+  | { kind: "memo"; key: string; sortMs: number; streamId: string; event: CachedEvent }
+  | { kind: "followUp"; key: string; sortMs: number; streamId: string; event: CachedEvent; cancelled: boolean }
 
 export interface ResolveBoardEventRowsCtx {
   /** The conversation the card renders. */
@@ -72,13 +72,14 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
       const target = payload?.conversationId ?? payload?.sourceConversationId ?? null
       if (target !== ctx.conversationId) continue
       if (event.eventType === "memos:captured") {
-        rows.push({ kind: "memo", key: event.id, sortMs: timeMs(event), event })
+        rows.push({ kind: "memo", key: event.id, sortMs: timeMs(event), streamId: event.streamId, event })
       } else if (event.eventType === "agent:follow_up_scheduled") {
         const followUpId = (event.payload as { followUpId?: string })?.followUpId
         rows.push({
           kind: "followUp",
           key: event.id,
           sortMs: timeMs(event),
+          streamId: event.streamId,
           event,
           cancelled: followUpId ? cancelledFollowUpIds.has(followUpId) : false,
         })
@@ -104,7 +105,13 @@ export function resolveBoardEventRows(events: CachedEvent[], ctx: ResolveBoardEv
     if (!existing || startMs > existing.startMs) bySlot.set(slotKey, { events: ordered, startMs })
   }
   for (const [slotKey, slot] of bySlot) {
-    rows.push({ kind: "session", key: slotKey, sortMs: timeMs(slot.events[0]), events: slot.events })
+    rows.push({
+      kind: "session",
+      key: slotKey,
+      sortMs: timeMs(slot.events[0]),
+      streamId: slot.events[0].streamId,
+      events: slot.events,
+    })
   }
 
   rows.sort((a, b) => a.sortMs - b.sortMs)

--- a/apps/frontend/src/lib/board/branch-grouping.test.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest"
+import type { RenderableMessage } from "@/components/message/message-item"
+import { groupBranches, type BranchStreamNode, type BranchGrouping } from "./branch-grouping"
+import { buildBranchedBoardRows } from "@/components/board/board-row-item"
+
+function msg(id: string, streamId: string, minute: number, authorId = "u1"): RenderableMessage {
+  return {
+    id,
+    streamId,
+    authorId,
+    authorType: "user",
+    contentMarkdown: id,
+    reactions: {},
+    createdAt: `2026-07-04T10:${String(minute).padStart(2, "0")}:00Z`,
+  }
+}
+
+function stream(
+  parentStreamId: string | null,
+  rootStreamId: string | null,
+  parentMessageId: string | null
+): BranchStreamNode {
+  return { parentStreamId, rootStreamId, parentMessageId }
+}
+
+describe("groupBranches", () => {
+  it("renders a single-stream conversation flat", () => {
+    const streams = new Map([["root", stream(null, null, null)]])
+    const messages = [msg("m1", "root", 0), msg("m2", "root", 1)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "flat",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages,
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it("classifies convert-to-thread (root→thread) as soft: one downward seam, no indent", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      ["thread", stream("root", "root", "m2")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "root", 1), msg("m3", "thread", 2), msg("m4", "thread", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "soft",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(0, 2),
+          children: [],
+        },
+        {
+          streamId: "thread",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(2),
+          children: [],
+        },
+      ],
+      softSeam: { streamId: "thread", afterMessageId: "m2", direction: "down" },
+    })
+  })
+
+  it("classifies the Slack case (thread→root) as soft with an upward seam", () => {
+    const streams = new Map([
+      ["thread", stream("root", "root", "p0")],
+      ["root", stream(null, null, null)],
+    ])
+    const messages = [msg("m1", "thread", 0), msg("m2", "thread", 1), msg("m3", "root", 2), msg("m4", "root", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "thread" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "soft",
+      roots: [
+        {
+          streamId: "thread",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(0, 2),
+          children: [],
+        },
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: messages.slice(2),
+          children: [],
+        },
+      ],
+      softSeam: { streamId: "root", afterMessageId: "m2", direction: "up" },
+    })
+  })
+
+  it("classifies a non-monotonic two-stream bounce as spanning, not soft", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      ["thread", stream("root", "root", "m1")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "thread", 1), msg("m3", "root", 2)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[2]],
+          children: [
+            {
+              streamId: "thread",
+              depth: 1,
+              displayDepth: 1,
+              overflow: false,
+              forkMessageId: "m1",
+              messages: [messages[1]],
+              children: [],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("places a 3-stream spanning conversation as a nested tree at fork messages", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      ["T1", stream("R", "R", "r2")],
+      ["T2", stream("T1", "R", "t1a")],
+    ])
+    const messages = [
+      msg("r1", "R", 0),
+      msg("r2", "R", 1),
+      msg("t1a", "T1", 2),
+      msg("t1b", "T1", 3),
+      msg("t2a", "T2", 4),
+    ]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "R",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[1]],
+          children: [
+            {
+              streamId: "T1",
+              depth: 1,
+              displayDepth: 1,
+              overflow: false,
+              forkMessageId: "r2",
+              messages: [messages[2], messages[3]],
+              children: [
+                {
+                  streamId: "T2",
+                  depth: 2,
+                  displayDepth: 2,
+                  overflow: false,
+                  forkMessageId: "t1a",
+                  messages: [messages[4]],
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it("marks a subtree past depth 2 as overflow", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      ["T1", stream("R", "R", "r1")],
+      ["T2", stream("T1", "R", "t1a")],
+      ["T3", stream("T2", "R", "t2a")],
+    ])
+    const messages = [
+      msg("r1", "R", 0),
+      msg("t1a", "T1", 1),
+      msg("t2a", "T2", 2),
+      msg("t3a", "T3", 3),
+      msg("r2", "R", 4),
+    ]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    // Deep node T3 (relative depth 3) is capped at displayDepth 2 and flagged overflow.
+    const t1 = grouping.roots[0].children[0]
+    const t2 = t1.children[0]
+    const t3 = t2.children[0]
+    expect(t3).toEqual({
+      streamId: "T3",
+      depth: 3,
+      displayDepth: 2,
+      overflow: true,
+      forkMessageId: "t2a",
+      messages: [messages[3]],
+      children: [],
+    })
+    // The overflow node collapses to a single continue-thread row carrying its subtree count.
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    const overflow = rows.find((r) => r.kind === "continue-thread")
+    expect(overflow).toEqual({
+      kind: "continue-thread",
+      key: "continue:T3",
+      streamId: "T3",
+      hiddenCount: 1,
+      displayDepth: 2,
+    })
+  })
+
+  it("renders an unresolvable parent chain at the base level without crashing", () => {
+    const streams = new Map([
+      ["root", stream(null, null, null)],
+      // parentStreamId points at a stream absent from the cache.
+      ["orphan", stream("missing", "root", "x")],
+    ])
+    const messages = [msg("m1", "root", 0), msg("m2", "orphan", 1), msg("m3", "root", 2)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "root" } })
+    expect(grouping).toEqual<BranchGrouping>({
+      kind: "spanning",
+      roots: [
+        {
+          streamId: "root",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[0], messages[2]],
+          children: [],
+        },
+        {
+          streamId: "orphan",
+          depth: 0,
+          displayDepth: 0,
+          overflow: false,
+          forkMessageId: null,
+          messages: [messages[1]],
+          children: [],
+        },
+      ],
+    })
+  })
+
+  it("anchors a child group chronologically when its fork message isn't rendered", () => {
+    const streams = new Map([
+      ["R", stream(null, null, null)],
+      // T1 forks off r2, which is NOT among the rendered messages.
+      ["T1", stream("R", "R", "r2")],
+    ])
+    const messages = [msg("r1", "R", 0), msg("t1a", "T1", 2), msg("r3", "R", 3)]
+    const grouping = groupBranches(messages, { streams, conversation: { streamId: "R" } })
+    // T1 still attaches under R (its occupied ancestor) with its true fork id.
+    expect(grouping.roots[0].children[0]).toMatchObject({ streamId: "T1", forkMessageId: "r2", displayDepth: 1 })
+    // The builder anchors it by its first message's time: r1, then t1a, then r3.
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => (r.kind === "message" ? { id: r.message.id, depth: r.displayDepth } : r.kind))).toEqual([
+      { id: "r1", depth: 0 },
+      { id: "t1a", depth: 1 },
+      { id: "r3", depth: 0 },
+    ])
+  })
+})

--- a/apps/frontend/src/lib/board/branch-grouping.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.ts
@@ -1,0 +1,255 @@
+import type { RenderableMessage } from "@/components/message/message-item"
+
+/**
+ * The stream-graph fields grouping needs: the parent pointers that place a
+ * message's stream in the thread tree. `CachedStream` satisfies this
+ * structurally, so a card passes its cached streams straight through; tests pass
+ * plain objects.
+ */
+export interface BranchStreamNode {
+  parentStreamId: string | null
+  rootStreamId: string | null
+  /** The message this stream (a thread) forks off — its fork point in the parent stream. */
+  parentMessageId: string | null
+}
+
+/**
+ * One occupied stream's slot in a conversation's render tree. A `BranchNode`
+ * holds the conversation's own messages that live in `streamId` (chronological)
+ * and the child threads that fork off them.
+ */
+export interface BranchNode {
+  streamId: string
+  /** Parent-stream hops from `streamId` up to the conversation's effective root. */
+  depth: number
+  /** `min(depth - shallowest occupied depth, 2)` — the indent level; base renders at 0. */
+  displayDepth: number
+  /** `depth - shallowest occupied depth > 2`: collapse this subtree behind a "continue thread" row. */
+  overflow: boolean
+  /** The parent-stream message this node hangs off, or null for a base node / a
+   *  node whose fork point isn't rendered (then it anchors chronologically). */
+  forkMessageId: string | null
+  messages: RenderableMessage[]
+  children: BranchNode[]
+}
+
+/**
+ * How a card's already-displayed messages render across their streams:
+ *
+ * - `flat` — one occupied stream; render chronological, no indent.
+ * - `soft` — exactly two occupied streams crossed once (convert-to-thread, the
+ *   Slack thread→root case); render flat with a single "continued in …" seam,
+ *   no indent (the thread is transport, not a branch).
+ * - `spanning` — genuine back-and-forth across ≥2 boundaries; render Reddit-style
+ *   with each thread indented one level per boundary (capped at 2, deeper behind
+ *   an overflow row).
+ */
+export interface BranchGrouping {
+  kind: "flat" | "soft" | "spanning"
+  /** Base-level nodes (shallowest occupied depth), each carrying its subtree. */
+  roots: BranchNode[]
+  /** Present only for `soft`: the seam between the two runs. */
+  softSeam?: { streamId: string; afterMessageId: string | null; direction: "down" | "up" }
+}
+
+export interface BranchGroupingContext {
+  /** Every stream the conversation might occupy or walk through, by id. */
+  streams: Map<string, BranchStreamNode>
+  /** The conversation's anchor stream — its effective root terminates depth walks. */
+  conversation: { streamId: string }
+}
+
+function timeMs(message: RenderableMessage): number {
+  return new Date(message.createdAt).getTime()
+}
+
+const MAX_WALK = 64
+
+/**
+ * Group a conversation's rendered messages into its stream-boundary render tree.
+ * Pure: depends only on the messages (each carrying its own `streamId`), the
+ * stream graph, and the conversation's anchor. Never throws on an unresolvable
+ * parent chain — such a stream renders at the base level (see adjustment A).
+ */
+export function groupBranches(messages: RenderableMessage[], ctx: BranchGroupingContext): BranchGrouping {
+  const { streams, conversation } = ctx
+  const ordered = [...messages].sort((a, b) => timeMs(a) - timeMs(b))
+
+  // First-appearance order of the streams the conversation's messages occupy.
+  const occupied: string[] = []
+  const occupiedSet = new Set<string>()
+  for (const message of ordered) {
+    const streamId = message.streamId ?? conversation.streamId
+    if (!occupiedSet.has(streamId)) {
+      occupiedSet.add(streamId)
+      occupied.push(streamId)
+    }
+  }
+
+  const conversationRoot = streams.get(conversation.streamId)?.rootStreamId ?? conversation.streamId
+
+  const messagesByStream = new Map<string, RenderableMessage[]>()
+  for (const message of ordered) {
+    const streamId = message.streamId ?? conversation.streamId
+    const list = messagesByStream.get(streamId)
+    if (list) list.push(message)
+    else messagesByStream.set(streamId, [message])
+  }
+
+  const flatNode = (streamId: string): BranchNode => ({
+    streamId,
+    depth: 0,
+    displayDepth: 0,
+    overflow: false,
+    forkMessageId: null,
+    messages: messagesByStream.get(streamId) ?? [],
+    children: [],
+  })
+
+  if (occupied.length <= 1) {
+    return { kind: "flat", roots: [flatNode(occupied[0] ?? conversation.streamId)] }
+  }
+
+  // Number of stream boundaries the chronological sequence crosses.
+  let transitions = 0
+  for (let i = 1; i < ordered.length; i++) {
+    const prev = ordered[i - 1].streamId ?? conversation.streamId
+    const cur = ordered[i].streamId ?? conversation.streamId
+    if (prev !== cur) transitions++
+  }
+
+  if (occupied.length === 2 && transitions === 1) {
+    const firstStream = occupied[0]
+    let idx = ordered.findIndex((m) => (m.streamId ?? conversation.streamId) !== firstStream)
+    if (idx < 0) idx = ordered.length
+    const secondStream = (ordered[idx]?.streamId ?? conversation.streamId) as string
+    const run1 = ordered.slice(0, idx)
+    const run2 = ordered.slice(idx)
+    const dFirst = depthOf(firstStream, streams, conversationRoot)
+    const dSecond = depthOf(secondStream, streams, conversationRoot)
+    return {
+      kind: "soft",
+      roots: [
+        { ...flatNode(firstStream), messages: run1 },
+        { ...flatNode(secondStream), messages: run2 },
+      ],
+      softSeam: {
+        streamId: secondStream,
+        afterMessageId: run1.at(-1)?.id ?? null,
+        direction: dSecond >= dFirst ? "down" : "up",
+      },
+    }
+  }
+
+  // Spanning: place each occupied stream by its absolute depth, normalized so the
+  // shallowest occupied level renders at indent 0 (adjustment A).
+  const depths = new Map<string, number>()
+  for (const streamId of occupied) depths.set(streamId, depthOf(streamId, streams, conversationRoot))
+  let minOccupied = Infinity
+  for (const depth of depths.values()) if (depth < minOccupied) minOccupied = depth
+
+  const nodesByStream = new Map<string, BranchNode>()
+  for (const streamId of occupied) {
+    const depth = depths.get(streamId) ?? 0
+    const rel = depth - minOccupied
+    nodesByStream.set(streamId, {
+      streamId,
+      depth,
+      displayDepth: Math.min(rel, 2),
+      overflow: rel > 2,
+      forkMessageId: streams.get(streamId)?.parentMessageId ?? null,
+      messages: messagesByStream.get(streamId) ?? [],
+      children: [],
+    })
+  }
+
+  const roots: BranchNode[] = []
+  for (const streamId of occupied) {
+    if ((depths.get(streamId) ?? 0) !== minOccupied) continue
+    const node = nodesByStream.get(streamId)!
+    node.forkMessageId = null
+    roots.push(node)
+  }
+
+  for (const streamId of occupied) {
+    if ((depths.get(streamId) ?? 0) === minOccupied) continue
+    const node = nodesByStream.get(streamId)!
+    const ancestor = nearestOccupiedAncestor(streamId, streams, occupiedSet)
+    if (ancestor && nodesByStream.has(ancestor)) {
+      nodesByStream.get(ancestor)!.children.push(node)
+    } else {
+      // Fork point unrendered (no occupied ancestor): anchor chronologically at
+      // the base level, keeping its own indent.
+      node.forkMessageId = null
+      roots[0].children.push(node)
+    }
+  }
+
+  return { kind: "spanning", roots }
+}
+
+/** Parent-stream hops from `streamId` up to the conversation root. An unresolvable
+ *  chain (a stream not in cache, or a broken parent link) collapses to 0 — the
+ *  base level — never a throw (adjustment A). */
+function depthOf(streamId: string, streams: Map<string, BranchStreamNode>, conversationRoot: string): number {
+  let currentId = streamId
+  let depth = 0
+  for (let i = 0; i < MAX_WALK; i++) {
+    if (currentId === conversationRoot) return depth
+    const node = streams.get(currentId)
+    if (!node) return 0
+    if (node.parentStreamId == null) return depth
+    depth++
+    currentId = node.parentStreamId
+  }
+  return 0
+}
+
+/** The nearest ancestor stream (walking `parentStreamId`) that the conversation
+ *  also occupies, or null when none is occupied. */
+function nearestOccupiedAncestor(
+  streamId: string,
+  streams: Map<string, BranchStreamNode>,
+  occupied: Set<string>
+): string | null {
+  let currentId = streams.get(streamId)?.parentStreamId ?? null
+  for (let i = 0; i < MAX_WALK; i++) {
+    if (currentId == null) return null
+    if (occupied.has(currentId)) return currentId
+    const node = streams.get(currentId)
+    if (!node) return null
+    currentId = node.parentStreamId
+  }
+  return null
+}
+
+/**
+ * A branch conversation nested inside a parent card: the child conversation's own
+ * messages rendered under a "↳ topic" header at its fork point, recursively —
+ * grandchildren indent one level deeper, capped at 2; deeper collapses to a
+ * "continue in panel" link (Kris dogfood ruling 2026-07-05, board-view-design.md,
+ * replacing the old between-cards stub).
+ */
+export interface BranchConversationView {
+  conversationId: string
+  threadStreamId: string
+  /** The parent-conversation member message this branch forks off — its placement anchor. */
+  forkMessageId: string
+  title: string
+  /** Nesting level among branches: 1 for a direct child, 2 for a grandchild. */
+  displayDepth: number
+  /** This branch nests past the depth cap — render the panel link, not its subtree. */
+  overflow: boolean
+  /** The child conversation's own messages, resolved through the parent card's rail
+   *  (already sliced to the collapsed window when the card is collapsed). */
+  messages: RenderableMessage[]
+  /** Locally-available branch messages hidden by the collapsed window — surfaced as
+   *  an "N more replies" link into the child panel. 0 when nothing is hidden. */
+  hiddenCount: number
+  /** Nested grandchild branches (each `displayDepth + 1`). */
+  children: BranchConversationView[]
+  /** A just-sent inline sub-topic whose child conversation hasn't echoed yet:
+   *  `conversationId` is the synthetic draft-panel id, so the header doesn't link
+   *  and the tail offers no reply until the real conversation takes over. */
+  pending?: boolean
+}

--- a/apps/frontend/src/lib/board/branch-grouping.ts
+++ b/apps/frontend/src/lib/board/branch-grouping.ts
@@ -249,7 +249,9 @@ export interface BranchConversationView {
   /** Nested grandchild branches (each `displayDepth + 1`). */
   children: BranchConversationView[]
   /** A just-sent inline sub-topic whose child conversation hasn't echoed yet:
-   *  `conversationId` is the synthetic draft-panel id, so the header doesn't link
-   *  and the tail offers no reply until the real conversation takes over. */
+   *  `conversationId` is the synthetic draft-panel id, so the header doesn't
+   *  link. The tail still offers a reply — it queues through the idempotent
+   *  sub-topic path (find-or-create thread, mint-or-attach conversation), so a
+   *  slow or dropped echo never blocks continuing the branch. */
   pending?: boolean
 }

--- a/apps/frontend/src/lib/board/nested-board-view.test.ts
+++ b/apps/frontend/src/lib/board/nested-board-view.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest"
+import type { CachedBoardPost } from "@/db"
+import { projectNestedBoardView } from "./nested-board-view"
+
+function post(id: string, activityMs: number, streamIds: string[] = [`stream_${id}`]): CachedBoardPost {
+  return {
+    id,
+    workspaceId: "ws_1",
+    _lastActivityMs: activityMs,
+    _cachedAt: activityMs,
+    streamIds,
+    conversation: { id, streamId: streamIds[0], lastActivityAt: new Date(activityMs).toISOString() },
+    openingMessage: null,
+    recentMessages: [],
+    totalReplies: 0,
+  } as unknown as CachedBoardPost
+}
+
+/** Parent map → the graph-only resolver shape `projectNestedBoardView` consumes. */
+function parents(map: Record<string, string>): (id: string) => string | null {
+  return (id) => map[id] ?? null
+}
+
+describe("projectNestedBoardView", () => {
+  it("suppresses a child whose parent is present in the same list", () => {
+    const posts = [post("parent", 300), post("child", 200)]
+    const out = projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(out.map((p) => p.conversation.id)).toEqual(["parent"])
+  })
+
+  it("keeps a child standalone when its parent is filtered out / inaccessible", () => {
+    // "child"'s parent resolves to "parent", but "parent" isn't in the filtered list.
+    const posts = [post("child", 200)]
+    const out = projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(out.map((p) => p.conversation.id)).toEqual(["child"])
+  })
+
+  it("folds a grandchild transitively to the nearest present ancestor", () => {
+    // parent present, child present (suppressed), grandchild present → both fold into parent.
+    const posts = [post("parent", 300), post("child", 250), post("grandchild", 200)]
+    const out = projectNestedBoardView(posts, parents({ child: "parent", grandchild: "child" }))
+    expect(out.map((p) => p.conversation.id)).toEqual(["parent"])
+  })
+
+  it("folds a grandchild's activity and streams to the SURVIVOR, not its suppressed middle parent", () => {
+    // Full present chain A ← B ← C where C has the latest activity: B's card never
+    // renders, so C's bump and stream declarations must land on A — folding them
+    // into suppressed B would silently drop both.
+    const posts = [post("A", 300), post("B", 250), post("C", 400)]
+    const out = projectNestedBoardView(posts, parents({ B: "A", C: "B" }))
+    expect(
+      out.map((p) => ({ id: p.conversation.id, ms: p._lastActivityMs, streams: [...(p.streamIds ?? [])].sort() }))
+    ).toEqual([{ id: "A", ms: 400, streams: ["stream_A", "stream_B", "stream_C"] }])
+  })
+
+  it("folds a grandchild to the nearest VISIBLE ancestor when the middle parent is absent", () => {
+    // child (the middle) is filtered out; grandchild folds to parent (present), and
+    // child itself survives because its own parent is present.
+    const posts = [post("parent", 300), post("grandchild", 200)]
+    const out = projectNestedBoardView(posts, parents({ grandchild: "child", child: "parent" }))
+    // grandchild's nearest present ancestor is parent → suppressed; parent survives.
+    expect(out.map((p) => p.conversation.id)).toEqual(["parent"])
+  })
+
+  it("bumps a surviving parent to its folded child's later activity", () => {
+    const posts = [post("parent", 300), post("child", 900)]
+    const out = projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(out.map((p) => p.conversation.id)).toEqual(["parent"])
+    expect(out[0]._lastActivityMs).toBe(900)
+    expect(Date.parse(out[0].conversation.lastActivityAt)).toBe(900)
+  })
+
+  it("re-sorts a bumped parent above a sibling by effective activity", () => {
+    // "other" (500) sorts above "parent" (300) by own activity, but parent's child
+    // (900) bumps parent's effective activity above it.
+    const posts = [post("other", 500), post("parent", 300), post("child", 900)]
+    const out = projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(out.map((p) => p.conversation.id)).toEqual(["parent", "other"])
+  })
+
+  it("folds a suppressed child's streams into the surviving parent's declared set", () => {
+    const posts = [post("parent", 300, ["stream_parent"]), post("child", 200, ["thread_child", "thread_child_2"])]
+    const out = projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(new Set(out[0].streamIds)).toEqual(new Set(["stream_parent", "thread_child", "thread_child_2"]))
+  })
+
+  it("does not mutate the input posts", () => {
+    const posts = [post("parent", 300, ["stream_parent"]), post("child", 900, ["thread_child"])]
+    const parentBefore = { ...posts[0], conversation: { ...posts[0].conversation }, streamIds: [...posts[0].streamIds] }
+    projectNestedBoardView(posts, parents({ child: "parent" }))
+    expect(posts[0]._lastActivityMs).toBe(parentBefore._lastActivityMs)
+    expect(posts[0].conversation.lastActivityAt).toBe(parentBefore.conversation.lastActivityAt)
+    expect(posts[0].streamIds).toEqual(parentBefore.streamIds)
+  })
+
+  it("is a no-op when nothing has a branch parent", () => {
+    const posts = [post("a", 300), post("b", 200)]
+    const out = projectNestedBoardView(posts, () => null)
+    expect(out.map((p) => p.conversation.id)).toEqual(["a", "b"])
+  })
+
+  it("terminates on a cyclic parent chain (no infinite walk)", () => {
+    // The real resolver can't emit a cycle (thread hierarchy is a DAG, and it
+    // guards `parent === self`); the walk's cycle guard is purely defensive.
+    const posts = [post("a", 300), post("b", 200)]
+    const out = projectNestedBoardView(posts, parents({ a: "b", b: "a" }))
+    expect(Array.isArray(out)).toBe(true)
+  })
+})

--- a/apps/frontend/src/lib/board/nested-board-view.ts
+++ b/apps/frontend/src/lib/board/nested-board-view.ts
@@ -1,0 +1,115 @@
+import type { CachedBoardPost } from "@/db"
+
+/**
+ * Fold a lens/scope-filtered board feed into one card per root discussion
+ * (board-view-design.md § "Nested threads × conversations", corrected
+ * 2026-07-05). A conversation whose anchor thread forks off a member message of
+ * another conversation is a **branch** rendered inside that parent's card, so it
+ * is suppressed from the top-level list — but only when its parent is itself
+ * present in the same filtered list. A child whose parent is filtered out or
+ * inaccessible stays standalone: content never vanishes.
+ *
+ * Pure: the branch relationship is supplied as `parentIdOf` (the graph-only walk
+ * primitive `branchParentConversationId`), so this stays testable without hooks.
+ *
+ * Two folds happen alongside suppression, both on **shallow copies** — the cached
+ * IDB rows are never mutated:
+ *
+ *  - **Effective activity.** A surviving parent inherits the max `_lastActivityMs`
+ *    of the branches folding into it, so a branch reply bumps the parent card for
+ *    ordering (`reconcileStableView`/`postMs` read the copied `lastActivityAt`).
+ *  - **Declared streams.** A survivor's `streamIds` gains its folded children's
+ *    streams, so the board page's `useBoardStreamSubscriptions` (and the card's
+ *    visible-streams declaration) still catch up + join the suppressed branches'
+ *    thread rooms — otherwise a branch nobody joined would never sync.
+ *
+ * Suppression is transitive: a grandchild whose parent is also suppressed folds
+ * to the nearest **present** ancestor's card. Survivors are returned newest
+ * effective-activity first so the committed snapshot orders on the fold.
+ */
+export function projectNestedBoardView(
+  posts: CachedBoardPost[],
+  parentIdOf: (conversationId: string) => string | null
+): CachedBoardPost[] {
+  if (posts.length === 0) return posts
+  const present = new Set(posts.map((post) => post.conversation.id))
+
+  // The nearest ancestor present in the filtered list, walking branch parents.
+  // Cycle-guarded so a corrupt graph can't spin. `null` ⇒ this post survives.
+  const nearestPresentAncestor = (id: string): string | null => {
+    const seen = new Set<string>([id])
+    let current = parentIdOf(id)
+    while (current && !seen.has(current)) {
+      if (present.has(current)) return current
+      seen.add(current)
+      current = parentIdOf(current)
+    }
+    return null
+  }
+
+  // Two passes: suppression depends only on presence, but the fold target must
+  // be the nearest SURVIVING ancestor — in a present chain A ← B ← C, B folds
+  // into A and so must C (B's card never renders), or C's activity bump and
+  // stream declarations would fold into a suppressed post and be dropped.
+  const suppressed = new Set<string>()
+  for (const post of posts) {
+    if (nearestPresentAncestor(post.conversation.id)) suppressed.add(post.conversation.id)
+  }
+
+  const nearestSurvivingAncestor = (id: string): string | null => {
+    const seen = new Set<string>([id])
+    let current = parentIdOf(id)
+    while (current && !seen.has(current)) {
+      if (present.has(current) && !suppressed.has(current)) return current
+      seen.add(current)
+      current = parentIdOf(current)
+    }
+    return null
+  }
+
+  const effectiveMs = new Map<string, number>()
+  const foldedStreams = new Map<string, Set<string>>()
+  for (const post of posts) {
+    const id = post.conversation.id
+    if (!suppressed.has(id)) continue
+    const ancestor = nearestSurvivingAncestor(id)
+    if (!ancestor) continue
+    effectiveMs.set(ancestor, Math.max(effectiveMs.get(ancestor) ?? Number.NEGATIVE_INFINITY, post._lastActivityMs))
+    let streams = foldedStreams.get(ancestor)
+    if (!streams) {
+      streams = new Set<string>()
+      foldedStreams.set(ancestor, streams)
+    }
+    streams.add(post.conversation.streamId)
+    for (const streamId of post.streamIds ?? []) streams.add(streamId)
+  }
+
+  const survivors: CachedBoardPost[] = []
+  for (const post of posts) {
+    const id = post.conversation.id
+    if (suppressed.has(id)) continue
+    const bumpedMs = effectiveMs.get(id)
+    const folded = foldedStreams.get(id)
+    if (bumpedMs === undefined && !folded) {
+      survivors.push(post)
+      continue
+    }
+    const streamIds = folded ? [...new Set([...(post.streamIds ?? []), ...folded])] : post.streamIds
+    const eff = bumpedMs !== undefined && bumpedMs > post._lastActivityMs ? bumpedMs : post._lastActivityMs
+    survivors.push(
+      eff > post._lastActivityMs
+        ? {
+            ...post,
+            _lastActivityMs: eff,
+            streamIds,
+            conversation: { ...post.conversation, lastActivityAt: new Date(eff).toISOString() },
+          }
+        : { ...post, streamIds }
+    )
+  }
+
+  // Effective-activity desc; V8's stable sort keeps the input's (already
+  // activity-desc) order for ties, so only a bumped parent moves.
+  survivors.sort((a, b) => b._lastActivityMs - a._lastActivityMs)
+  return survivors
+}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -14,6 +14,7 @@ import * as messageReactionsModule from "@/hooks/use-message-reactions"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as userProfileModule from "@/components/user-profile"
 import * as contextsModule from "@/contexts"
+import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 
 const WORKSPACE_ID = "ws_1"
 
@@ -152,6 +153,12 @@ beforeEach(() => {
   // BoardCard reads the viewer id for reaction state; sourced from auth, which
   // isn't mounted in this harness.
   vi.spyOn(useWorkspacesModule, "useWorkspaceUserId").mockReturnValue("usr_me")
+  // BoardCard hosts the inline branch composer, whose queue hook needs the
+  // pending-messages provider — stub the hook so the harness stays lean.
+  vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
+    queueDraftMessage: vi.fn().mockResolvedValue({ clientId: "client_1" }),
+    currentUserId: "usr_me",
+  } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
   // Reactions reuse the timeline's <MessageReactions>, whose toggle hook reaches
   // for the SyncEngine. Stub the hook so the real component still renders.
   vi.spyOn(messageReactionsModule, "useMessageReactions").mockReturnValue({

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -29,6 +29,9 @@ import {
   useUnmuteStream,
 } from "@/hooks/use-conversations"
 import { useBoardHiddenConversations, useBoardMutedStreamIds } from "@/stores/board-exclusions-store"
+import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
+import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
+import { SKELETON_DELAY_MS } from "@/contexts/coordinated-loading-context"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
@@ -55,6 +58,12 @@ import {
 } from "@threa/types"
 
 const VALID_LENSES = new Set<string>(BOARD_LENSES)
+
+/** How many leading cards' rails the reveal gate pre-warms before first paint.
+ *  Covers the viewport with margin; cards past it mount against already-warm or
+ *  fast-resolving rails below the fold, where late resolution can't shift
+ *  anything the viewer sees. */
+const REVEAL_PREWARM_CARDS = 12
 
 /** Empty-state copy per lens — an empty Decisions view isn't "nothing on the board". */
 const LENS_EMPTY_COPY: Record<BoardLens, { title: string; body: string }> = {
@@ -335,6 +344,35 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // Keep the streams behind on-screen cards live + offline-first (threads and
   // public channels the viewer never joined aren't subscribed at bootstrap).
   useBoardStreamSubscriptions(posts)
+  // Coordinated reveal: hold the first card paint until the above-fold cards'
+  // rails AND the conversation graph have completed their first IDB read, so a
+  // card's first frame is its final frame — no skeleton→card swap, no branch
+  // replies or agent rows resolving in afterwards (content never shifts unless
+  // content actually changed — Kris's refresh ruling, 2026-07-05). Warm-device
+  // holds are one IDB round-trip; the skeleton appears only past the same delay
+  // the timeline uses, so the common path is blank-for-a-beat → complete board.
+  const prewarmStreamIds = useMemo(() => {
+    const set = new Set<string>()
+    for (const post of posts.slice(0, REVEAL_PREWARM_CARDS)) {
+      set.add(post.conversation.streamId)
+      for (const id of post.streamIds ?? []) set.add(id)
+    }
+    return [...set].sort()
+  }, [posts])
+  const railsReady = useBoardRailsReady(prewarmStreamIds)
+  const graphReady = useConversationGraphReady(workspaceId)
+  const revealReady = railsReady && graphReady
+  const holding = posts.length > 0 && !revealReady
+  const loading = isLoading || viewLoading || seedPending || holding
+  const [skeletonVisible, setSkeletonVisible] = useState(false)
+  useEffect(() => {
+    if (!loading) {
+      setSkeletonVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setSkeletonVisible(true), SKELETON_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [loading])
   const streams = useWorkspaceStreams(workspaceId)
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
@@ -405,10 +443,12 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   else if (isFetchNextPageError) loadMoreLabel = "Retry"
 
   // Prefer cached/live content: a transient refetch error never hides a feed we
-  // already have. Skeleton only before the first IDB read resolves AND nothing
-  // is cached; empty state only once IDB has resolved to genuinely nothing.
+  // already have. Cards render only once the reveal gate clears (rails + graph
+  // resolved) so the first paint is complete; the skeleton earns its slot only
+  // past SKELETON_DELAY_MS of genuine loading (cold device), never as a flash on
+  // a warm refresh. Empty state only once IDB has resolved to genuinely nothing.
   let content
-  if (posts.length > 0) {
+  if (posts.length > 0 && revealReady) {
     content = (
       <div className="flex flex-col">
         {sections.map((section) => (
@@ -448,8 +488,10 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         )}
       </div>
     )
-  } else if (isError) {
-    // A failed fetch must read as a failure, not as the empty state's upbeat copy.
+  } else if (isError && posts.length === 0) {
+    // A failed fetch must read as a failure, not as the empty state's upbeat
+    // copy — but cached content mid-reveal still outranks it (the hold above
+    // resolves in one IDB round-trip; erroring over a full cache would flash).
     content = (
       <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
         <AlertCircle className="h-8 w-8 text-destructive" />
@@ -460,8 +502,8 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         </Button>
       </div>
     )
-  } else if (isLoading || viewLoading || seedPending) {
-    content = (
+  } else if (loading) {
+    content = skeletonVisible ? (
       <div className="flex flex-col gap-3">
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i} className="rounded-xl border bg-card p-4">
@@ -476,7 +518,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
           </div>
         ))}
       </div>
-    )
+    ) : null
   } else {
     // A filtered-empty view is the FILTERS coming up empty, never the board
     // hiding things — so it always offers the one-tap way back to everything.

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -754,6 +754,16 @@ invisible and unnamed today):
   migrate-to-thread continuation, quote-reply spillover, convert-to-thread.
   Same conversation, same card. Renders as continuation — at most a subtle
   "moved to thread" seam, **no indent**, because topically nothing branched.
+
+  _Refined 2026-07-06 (Kris)._ Convert-to-thread gets **no seam at all**: when
+  the pre-boundary run is just the lone opener (the first reply to a lone post
+  files into a thread), the thread carries the whole conversation by design, so
+  it renders seamlessly forever — regardless of how large the thread grows.
+  The seam (and its "split into its own topic" heal) marks only a discussion
+  that ran flat in the channel/DM and then migrated into a thread
+  mid-conversation. The signal is the pre-boundary run (opener-only vs ≥2
+  messages), never thread size or author count.
+
 - **True thread** — the thread is a _sub-topic_. Own conversation in the data
   model, but **rendered nested inside the parent card** (corrected 2026-07-05,
   below): a branch group at the fork point — "↳ _GPU budget_" header plus the

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -754,11 +754,31 @@ invisible and unnamed today):
   migrate-to-thread continuation, quote-reply spillover, convert-to-thread.
   Same conversation, same card. Renders as continuation — at most a subtle
   "moved to thread" seam, **no indent**, because topically nothing branched.
-- **True thread** — the thread is a _sub-topic_. Own conversation, own card,
-  linked both ways: a **branch stub** at the fork point on the parent card
-  ("↳ _GPU budget_") and "branched from _Hardware refresh_" provenance on the
-  child. Nesting survives **between** cards instead of inside one — the
-  conversation-grain mirror of the message-grain provenance chip.
+- **True thread** — the thread is a _sub-topic_. Own conversation in the data
+  model, but **rendered nested inside the parent card** (corrected 2026-07-05,
+  below): a branch group at the fork point — "↳ _GPU budget_" header plus the
+  child's messages indented under it — not a separate card. "Branched from
+  _Hardware refresh_" provenance still renders on the child's own panel view.
+
+  _Corrected 2026-07-05 (Kris, dogfooding over tailscale)._ The first ship
+  rendered true threads **between** cards — child = own board card, parent gets
+  a "↳ stub" link. Verdict: "I tried creating a new subtopic which then opened
+  a thread which creates two separate cards in the board. Not what I expected.
+  I expected Facebook/Instagram-like nested comments effectively. Or like,
+  reddit style." The rule that replaces it: **one card per root discussion** —
+  a conversation whose anchor thread forks off another conversation's member
+  message is folded into that parent's card as an indented branch group
+  (recursively, same depth cap as spanning); it is suppressed from the
+  top-level board list **iff its parent card is itself visible in the same
+  view** (no access / filtered-out parent ⇒ the child stays standalone rather
+  than vanishing). A branch reply counts toward the parent card's effective
+  activity for ordering. The child conversation keeps existing in the data
+  model exactly as before — classification, memos, split, and the panel all
+  operate on it; only the board projection changed. The same session's second
+  ruling: **replying happens inline on the card** — a branch tail (and the
+  "new sub-topic" gesture itself) expands a composer in place; it must not
+  bounce into a thread/panel view (mobile especially).
+
 - **Spanning case** (one conversation genuinely across nested threads with
   back-and-forth in several) — Reddit-style but bounded: indent per **thread
   boundary** only (never per reply; Threa's tree is structural, not

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -343,17 +343,22 @@ export interface SyncHeartbeatPayload {
  * boundary-extractor infers the conversation (default). Present → the sender
  * declares it, and the send assigns it synchronously in the message's
  * transaction: `new` mints a fresh conversation seeded with the message;
- * `existing` attaches to `conversationId`; `threadFromMessage` mints the
- * conversation for this message (a thread's first reply) and retires the lone
- * `sourceConversationId` it threaded off, so the board shows one card — the
- * thread — instead of the source post plus the thread. The id is a sibling of
- * the discriminant (not folded into one field) so a missing/garbage id on
- * `existing`/`threadFromMessage` is a validation error, distinct from `new`.
+ * `existing` attaches to `conversationId`; `threadFromMessage` attaches this
+ * message (a thread's first reply) to the SAME `sourceConversationId` as a
+ * cross-stream member, so one conversation spans the root opener + the thread
+ * reply and the board card renders in place with no swap; `newSubtopic` mints a
+ * fresh child conversation anchored to the message's (thread) stream — the
+ * declared branch gesture from the board — attaching to the conversation already
+ * anchored there when two users branch the same message concurrently. The id is a
+ * sibling of the discriminant (not folded into one field) so a missing/garbage id
+ * on `existing`/`threadFromMessage` is a validation error, distinct from `new`
+ * and `newSubtopic`.
  */
 export type ConversationDirective =
   | { intent: "new" }
   | { intent: "existing"; conversationId: string }
   | { intent: "threadFromMessage"; sourceConversationId: string }
+  | { intent: "newSubtopic" }
 
 /**
  * JSON input format - used by rich clients sending ProseMirror JSON directly.

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -403,15 +403,18 @@ export const BOARD_LENS_MAX_COMPLETENESS = 4
 // records that the sender DECLARED the conversation at send time, so the
 // extractor must not re-cluster it: 'new' minted a fresh conversation seeded
 // with the message; 'existing' attached it to a caller-named conversation;
-// 'threadFromMessage' minted the thread's conversation seeded with this reply
-// and retired the lone source conversation it threaded off (board reply path).
-export const CONVERSATION_INTENTS = ["new", "existing", "threadFromMessage"] as const
+// 'threadFromMessage' attached this reply to the SAME source conversation as a
+// cross-stream member so one conversation spans root + thread (board reply path);
+// 'newSubtopic' minted a fresh child conversation anchored to the message's
+// thread stream (the board branch gesture).
+export const CONVERSATION_INTENTS = ["new", "existing", "threadFromMessage", "newSubtopic"] as const
 export type ConversationIntent = (typeof CONVERSATION_INTENTS)[number]
 
 export const ConversationIntents = {
   NEW: "new",
   EXISTING: "existing",
   THREAD_FROM_MESSAGE: "threadFromMessage",
+  NEW_SUBTOPIC: "newSubtopic",
 } as const satisfies Record<string, ConversationIntent>
 
 // Memo types (GAM)


### PR DESCRIPTION
Nested conversations on the board — **board-view-design.md** § "Nested threads × conversations", item 5 ("big enough for its own pass"). Shaped by two rounds of live dogfooding on 2026-07-05 (rulings recorded in the doc's "Corrected 2026-07-05" block). **Rebased onto current `origin/main` and retargeted to `main`.**

## Rebase note (why one commit)

The feature branch was six commits on an older main. Since then the parallel board stack merged: **#1179** (shared stream-row rendering — my branch's first commit was a duplicate of it), **#1193** (Mine lens), **#1194** (rename/resolve), **#1196** (hide/mute), **#1198** (saved views), all touching the exact files the pivot rewrote. A literal replay would resolve `board-card.tsx` / `use-stable-board-view.ts` / conversations `service`+`handlers` three-to-four times each and integrate a **superseded** stub design (later deleted by the pivot) against the new code. Instead this squashes to one integration commit off the new base, resolving each overlapping surface **once at its final state**. The design-evolution history lives in `docs/board-view-design.md` + the sections below.

## Problem

Three gaps the feature closes: (1) no declared way to *open* a sub-topic — the async classifier was the only path to a true thread; (2) the first design (child = its own card + a stub link) failed dogfooding — "I expected Facebook/Instagram like nested comments… reply inline instead of in a thread view"; (3) the board popped content in over ~4s on refresh (skeleton→cards swap, replies resolving late, agent rows splitting author runs) — IDB-cached content arriving late on a surface that must be offline-first.

## Solution

### 1. `newSubtopic` declared directive

`ConversationDirective` gains `{ intent: "newSubtopic" }` (types, `CONVERSATION_INTENTS`, Zod discriminated union). `conversation-assigner.ts` `NEW_SUBTOPIC` branch locks the thread stream row (`SELECT … FOR UPDATE`) then `findActiveByStream` find-or-mint — two users clicking the same message yield ONE conversation, the loser attaches (INV-20). Branch relationship stays graph-derived (thread `parentMessageId` ∈ parent conversation) — no new column; classifier-minted and gesture-minted children are renderer-identical.

### 2. Branches nest inside the parent card + inline reply (the pivot)

- **One card per root discussion:** `projectNestedBoardView` (pure) suppresses a conversation branched off another's member message iff a branch ancestor survives the same filtered view; folds target the nearest **surviving** ancestor (caught in self-review — folding to the nearest *present* ancestor dropped a grandchild's activity/streams into its suppressed middle parent; regression-tested). Runs inside `useStableBoardView` off the **same posts array it filters** (`buildConversationGraph(rawLive)`), not a second registry liveQuery — so a child can't paint standalone then fold away. Composed with main's exclusion + label filtering (`isExcluded`, `matchesExcludedStreams/Types/Labels`), not replacing it.
- **Nested rendering:** `deriveBranchConversations` walks the graph recursively (depth-capped at 2, "Continue this thread" overflow); threads the parent occupies stay inline. `BranchGroup` renders "↳ topic" + indented children, render-only (no auto-read, no unread-dot). Branch rails subscribe as **extra/non-gating** so a mid-load branch never flips the parent to its projection (#1188 discipline).
- **Inline composers:** `InlineComposerForm` (extracted from `BoardReplyComposer`) powers branch-tail replies (`{intent:"existing", conversationId}`) and "New sub-topic" (queues `streamCreation` + `{intent:"newSubtopic"}`; nothing exists until send; in-flight sub-topic renders as a synthetic pending branch until `conversation:created`).

### 3. Coordinated reveal — first paint is the final frame

The board holds first card paint until above-fold rails (`useBoardRailsReady`, first 12 posts' streams) AND the conversation graph finish their first IDB read, then paints once — bodies, branches, event rows in frame one. Warm refresh = one IDB round-trip hold. Skeletons only past `SKELETON_DELAY_MS` (the timeline's constant); a transient refetch error no longer outranks cached content mid-reveal.

### 4. Split this thread into its own topic

`POST /conversations/:id/split-thread {threadStreamId}` → `splitThreadIntoConversation`: source locked (`findByIdForUpdate`); thread validated (type / same effective root per INV-62 / fork message ∈ members — explicit 400 codes); move set = members in the thread **or its descendant threads** (`listSelfAndDescendantIds`, recursive CTE); rows locked in id order; fresh conversation minted anchored to the thread (**no copied title** — extractor fills it); memberships moved set-based; `conversation_feedback` per moved message; outbox `conversation:created`/`:updated`/`:message_reassigned` via `resolveConversationDelivery` — `reassignMessage`'s discipline end to end. Affordance on down-direction soft seams; the card re-forms into a nested branch as its own confirmation (no toast, INV-63).

### 5. Convert-to-thread continuations render seamlessly (follow-up `5f1f834`)

Kris ruling 2026-07-06: replying to a lone channel/DM board post files the reply into a thread by design (convert-to-thread, #1113) — the thread carries the whole conversation, so the board must not dress it in thread chrome. `buildBranchedBoardRows` now treats a down-seam whose pre-boundary run is just the opener as transport and emits both runs as one flat run: no "continued in …" seam, no split action, continuation flows across — regardless of how large the thread grows. The signal is the pre-boundary run (opener-only vs ≥2 messages), never thread size or author count — no threshold constant. A flat discussion that migrated into a thread mid-conversation keeps the seam + split heal; up-seams and nested branch groups are unchanged. Card and conversation panel share the flattener, so both surfaces fix together. Ruling recorded in `docs/board-view-design.md` § "Soft thread" (refined 2026-07-06).

## Key integration decisions (this rebase)

- **`board-event-rows.ts`** — kept main's session-slot dedup (collapses a re-run to the latest trace) AND added the branch-folding `streamId` on every row.
- **`board-card.tsx` / `conversation-panel.tsx`** — merged main's rename/resolve actions menu + hide/mute with the nested rendering + inline composer; kept main's edge-accent row styling on primary rows (branch rows stay plain — they're indented).
- **`service.ts` / `handlers.ts` / `use-conversations.ts`** — split-method collisions (both sides inserted a method at the same anchor); each got its own copy (`updateConversation` + `splitThreadIntoConversation`; the five exclusion hooks + `useSplitThread`).
- Took main's `supersededClientIds` (#1188, which the branch predated) throughout `use-board-card-messages.ts`; dropped the #1179 rendering duplicate (already on main).

## Test plan

- [x] Backend `bun test src/features/conversations src/features/messaging` — 204 pass
- [x] Frontend board logic + hooks (`board-event-rows`, `branch-grouping`, `nested-board-view`, `board-row-item`, `use-conversation-graph`, `use-board-card-messages`, `use-stable-board-view`) — 110 pass
- [x] Frontend component mounts (`board-card` + `.branches`/`.new-subtopic`/`.split`, `conversation-panel`, `board` page) — 53 pass
- [x] Monorepo `bun run typecheck` — 0 errors across all 14 packages
- [x] Split-thread batch SQL EXPLAIN-validated against live Postgres (unit suites are mock-based)
- [x] Follow-up `5f1f834`: board/panel/stable-view suites — 112 pass; monorepo lint + typecheck clean (pre-commit)
- [ ] Staging E2E on the per-PR env (staging label applied)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_