### PR TITLE
fix(conversations): restore extractor summary persistence lost in a squash-merge collision

### DIFF
--- a/apps/backend/src/features/conversations/repository.ts
+++ b/apps/backend/src/features/conversations/repository.ts
@@ -717,12 +717,13 @@ export const ConversationRepository = {
     db: Querier,
     workspaceId: string,
     id: string,
-    params: { completenessScore?: number; status?: ConversationStatus }
+    params: { completenessScore?: number; status?: ConversationStatus; summary?: string }
   ): Promise<void> {
     await db.query(sql`
       UPDATE conversations SET
         completeness_score = COALESCE(${params.completenessScore ?? null}, completeness_score),
         status = CASE WHEN status_locked_by_user THEN status ELSE COALESCE(${params.status ?? null}, status) END,
+        summary = COALESCE(${params.summary ?? null}, summary),
         updated_at = NOW()
       WHERE id = ${id} AND workspace_id = ${workspaceId}
     `)

--- a/apps/backend/src/features/conversations/service.test.ts
+++ b/apps/backend/src/features/conversations/service.test.ts
@@ -17,6 +17,7 @@ function fakeConversation(over: Partial<Conversation> = {}): Conversation {
     participantIds: [],
     secondaryMessageIds: [],
     topicSummary: "Topic",
+    summary: null,
     completenessScore: 3,
     confidence: 0.5,
     status: "resolved",

--- a/apps/backend/tests/integration/conversation-repository.test.ts
+++ b/apps/backend/tests/integration/conversation-repository.test.ts
@@ -687,6 +687,62 @@ describe("ConversationRepository", () => {
     })
   })
 
+  describe("applyExtractionUpdate", () => {
+    test("persists score, status, and summary; a user-locked status is never overridden", async () => {
+      const convId = conversationId()
+
+      await withTransaction(pool, async (client) => {
+        await ConversationRepository.insert(client, {
+          id: convId,
+          streamId: testStreamId,
+          workspaceId: testWorkspaceId,
+          completenessScore: 2,
+          status: ConversationStatuses.ACTIVE,
+        })
+      })
+
+      await withTransaction(pool, async (client) => {
+        await ConversationRepository.applyExtractionUpdate(client, testWorkspaceId, convId, {
+          completenessScore: 5,
+          status: ConversationStatuses.STALLED,
+          summary: "Rolling summary from the extractor",
+        })
+      })
+
+      const afterExtraction = await withTransaction(pool, async (client) =>
+        ConversationRepository.findById(client, convId)
+      )
+      expect(afterExtraction).toMatchObject({
+        completenessScore: 5,
+        status: ConversationStatuses.STALLED,
+        summary: "Rolling summary from the extractor",
+      })
+
+      // The user resolves the conversation (locking status); a later extraction
+      // pass may refine score/summary but must not reopen it.
+      await withTransaction(pool, async (client) => {
+        await ConversationRepository.update(client, testWorkspaceId, convId, {
+          status: ConversationStatuses.RESOLVED,
+          statusLockedByUser: true,
+        })
+        await ConversationRepository.applyExtractionUpdate(client, testWorkspaceId, convId, {
+          completenessScore: 7,
+          status: ConversationStatuses.ACTIVE,
+          summary: "Refined summary",
+        })
+      })
+
+      const afterLockedPass = await withTransaction(pool, async (client) =>
+        ConversationRepository.findById(client, convId)
+      )
+      expect(afterLockedPass).toMatchObject({
+        completenessScore: 7,
+        status: ConversationStatuses.RESOLVED,
+        summary: "Refined summary",
+      })
+    })
+  })
+
   describe("assignments + bumpActivity", () => {
     test("derives messageIds from assignments and bumpActivity updates lastActivityAt", async () => {
       const convId = conversationId()


### PR DESCRIPTION
## Problem

Backend `tsc` fails on `main`: `boundary-extraction-service.ts:506` passes `summary` to `ConversationRepository.applyExtractionUpdate`, whose params type (and SQL) have no such field, and the `fakeConversation` fixture in `service.test.ts` lacks the now-required `summary`. CI doesn't run backend typecheck (only enclave's), so main stayed green — but the repo-wide pre-commit hook blocks every local commit, and extractor-refreshed conversation summaries silently stopped persisting.

Squash-merge collision: #1187 wrote `summary` through the generic `ConversationRepository.update`. #1198 (branched before #1187 landed) swapped that call to its new `applyExtractionUpdate` — which adds the user-status-lock guard but predates the summary field. The merge stitched #1187's `summary: update.summary` argument onto a method that never accepted it.

## Solution

Restore #1187's behavior under #1198's guard: `applyExtractionUpdate` accepts `summary?: string` and writes `summary = COALESCE($summary, summary)` — same only-when-provided semantics as `completeness_score`. The fixture gains `summary: null`.

`applyExtractionUpdate` had no test coverage at all; the new integration test pins all three behaviors: score/status/summary persist, and a `status_locked_by_user` row keeps its user-set status through a later extraction pass while still taking the score/summary refinements.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/repository.ts` | `summary` param + COALESCE write on `applyExtractionUpdate` |
| `apps/backend/src/features/conversations/service.test.ts` | `summary: null` on the `fakeConversation` fixture |
| `apps/backend/tests/integration/conversation-repository.test.ts` | new `applyExtractionUpdate` describe: summary persistence + user status lock |

## Out of scope (deliberate)

CI not typechecking the backend (this broke main invisibly; the deploy workflow catches only frontend) — worth its own follow-up.

## Test plan

- [x] `bun run --cwd apps/backend typecheck` — clean (was 2 errors)
- [x] `bun test tests/integration/conversation-repository.test.ts` — 34 pass (1 new)
- [x] `bun test src/features/conversations/` — 81 pass

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785905719&installation_id=129946197&pr_number=1215&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1215&signature=ff5527d5e8caeda035213078f08e9f7906607df1c85dcdb956b3b01b8f9e6b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->