### PR TITLE
fix(board): never render a reply doubled across the optimistic/echo hand-off (deflakes main CI)

### DIFF
--- a/apps/frontend/src/hooks/use-board-card-messages.test.tsx
+++ b/apps/frontend/src/hooks/use-board-card-messages.test.tsx
@@ -522,7 +522,9 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
     await waitFor(() => expect(shownBodies(result.current)).toEqual(["my convert reply"]))
 
     // 3) Server echo (stream-sync swap): real event replaces the optimistic one in
-    //    one transaction, tag carried forward.
+    //    one transaction, tag carried forward. The echo names its optimistic twin
+    //    via clientMessageId — that's how handleMessageCreated finds the temp row,
+    //    and how the card suppresses a stale rail's leftover copy of it.
     await db.transaction("rw", db.events, async () => {
       await db.events.put({
         id: "msg_real_c",
@@ -536,6 +538,7 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
           contentMarkdown: "my convert reply",
           reactions: {},
           conversationId: "conv_1",
+          clientMessageId: "temp_c",
         },
         actorId: "usr_1",
         actorType: "user",
@@ -563,6 +566,73 @@ describe("useBoardCardMessages stability (no flicker, no hiding)", () => {
       expect(frame.source).toBe("events")
       expect(shownBodies(frame)).toEqual(["my convert reply"])
       expect(frame.openingMessage?.contentMarkdown).toBe("the opening")
+    }
+  })
+
+  it("never doubles a reply while its optimistic row and server echo are both visible", async () => {
+    // The deterministic form of a race the liveQuery rails can produce: the echo
+    // swap (put real + delete temp, one transaction) is atomic PER RAIL, but a
+    // card merges several independent rails — the draft-panel rail can still be
+    // on its pre-swap snapshot (temp row present) when the reply stream's rail
+    // already shows the echo. Model that window literally: both rows in IDB at
+    // once. The echo's clientMessageId names the temp row, so the card must
+    // render the reply exactly once throughout.
+    const PANEL = createDraftPanelId(STREAM, "m1")
+    await db.events.bulkPut([msgEvent("m1", "the opening", 1, STREAM)])
+    const lone = makePost({ messageIds: ["m1"], openingId: "m1", streamIds: [STREAM] })
+    const { frames, result } = renderRecorded(lone, "channel")
+    await waitFor(() => expect(result.current.source).toBe("events"))
+
+    await db.events.put({
+      id: "temp_d",
+      workspaceId: WS,
+      streamId: PANEL,
+      sequence: "1700000000003",
+      _sequenceNum: 1700000000003,
+      eventType: "message_created",
+      payload: { messageId: "temp_d", contentMarkdown: "my doubled reply", reactions: {}, conversationId: "conv_1" },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(3).toISOString(),
+      _cachedAt: 3,
+      _status: "pending",
+    } as CachedEvent)
+    await waitFor(() => expect(shownBodies(result.current)).toEqual(["my doubled reply"]))
+    const from = frames.length
+
+    // Echo lands on the anchor stream while the temp row still exists.
+    await db.events.put({
+      id: "msg_real_d",
+      workspaceId: WS,
+      streamId: STREAM,
+      sequence: "2",
+      _sequenceNum: 2,
+      eventType: "message_created",
+      payload: {
+        messageId: "msg_real_d",
+        contentMarkdown: "my doubled reply",
+        reactions: {},
+        conversationId: "conv_1",
+        clientMessageId: "temp_d",
+      },
+      actorId: "usr_1",
+      actorType: "user",
+      createdAt: new Date(4).toISOString(),
+      _cachedAt: 4,
+    } as CachedEvent)
+    await waitFor(() =>
+      expect([...result.current.replies, ...result.current.pendingReplies].map((m) => m.id)).toEqual(["msg_real_d"])
+    )
+
+    // The swap's delete finally lands; nothing on screen may move.
+    await db.events.delete("temp_d")
+    await waitFor(() =>
+      expect([...result.current.replies, ...result.current.pendingReplies].map((m) => m.id)).toEqual(["msg_real_d"])
+    )
+
+    for (const frame of frames.slice(from)) {
+      expect(frame.source).toBe("events")
+      expect(shownBodies(frame)).toEqual(["my doubled reply"])
     }
   })
 

--- a/apps/frontend/src/hooks/use-board-card-messages.ts
+++ b/apps/frontend/src/hooks/use-board-card-messages.ts
@@ -29,6 +29,12 @@ interface MessageCreatedPayloadShape {
   /** Set only on an optimistic board reply, naming the conversation it attaches
    *  to so a card can surface the pending row before the server echo lands. */
   conversationId?: string
+  /** On a server echo: the optimistic (client) id this message confirms. The
+   *  swap deletes that temp row, but a card merges several independent rails —
+   *  one can still hold a stale snapshot with the temp row while another already
+   *  shows the echo, doubling the reply for a frame. This is the precise link
+   *  that lets the card suppress the superseded copy. */
+  clientMessageId?: string
 }
 
 /** Project a `message_created` event row into the shared render shape the timeline
@@ -66,6 +72,12 @@ interface StreamRail {
    *  hand-off); once it's in `messageIds` the card dedups it. Only board replies
    *  carry the tag, so this stays proportional to the stream's reply count. */
   taggedByConversation: Map<string, RenderableMessage[]>
+  /** The optimistic (client) ids confirmed by a real row on this stream —
+   *  `payload.clientMessageId` of every synced message. A temp row with its id
+   *  here is superseded: it may linger in another rail's stale snapshot (or in
+   *  IDB until the swap's delete lands), and rendering it beside its confirmed
+   *  twin doubles the reply for a frame. */
+  supersededClientIds: Set<string>
   /** Spec-eligible non-message rows on this stream (agent sessions, memo captures,
    *  follow-up scheduled/cancelled), in read order — resolved to conversation rows
    *  by `resolveBoardEventRows`. Render-only: none is a member or bumps activity. */
@@ -78,6 +90,7 @@ const LOADING_RAIL: StreamRail = {
   messages: new Map(),
   seen: new Set(),
   taggedByConversation: new Map(),
+  supersededClientIds: new Set(),
   events: [],
   resolved: false,
 }
@@ -86,6 +99,7 @@ function buildRail(events: CachedEvent[]): StreamRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
+  const supersededClientIds = new Set<string>()
   const eventRows: CachedEvent[] = []
   for (const event of events) {
     // The rail reads message_created + the board's non-message row types; anything
@@ -96,6 +110,9 @@ function buildRail(events: CachedEvent[]): StreamRail {
     }
     const payload = (event.payload ?? {}) as MessageCreatedPayloadShape
     if (payload.messageId) seen.add(payload.messageId)
+    // Only a real (synced) row supersedes: the optimistic row itself carries no
+    // clientMessageId, so a pending row can never suppress anything.
+    if (payload.clientMessageId && !event._status) supersededClientIds.add(payload.clientMessageId)
     const message = eventToRenderable(event)
     if (!message) continue
     messages.set(message.id, message)
@@ -112,7 +129,7 @@ function buildRail(events: CachedEvent[]): StreamRail {
   for (const list of taggedByConversation.values()) {
     list.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
   }
-  return { messages, seen, taggedByConversation, events: eventRows, resolved: true }
+  return { messages, seen, taggedByConversation, supersededClientIds, events: eventRows, resolved: true }
 }
 
 interface StreamRailEntry {
@@ -216,6 +233,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   const messages = new Map<string, RenderableMessage>()
   const seen = new Set<string>()
   const taggedByConversation = new Map<string, RenderableMessage[]>()
+  const supersededClientIds = new Set<string>()
   const eventsById = new Map<string, CachedEvent>()
   // Resolved once every GATING rail has read — a still-loading discovered thread
   // doesn't count, so the card keeps its live view instead of dropping to the
@@ -229,6 +247,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
     }
     for (const [id, message] of rail.messages) messages.set(id, message)
     for (const id of rail.seen) seen.add(id)
+    for (const id of rail.supersededClientIds) supersededClientIds.add(id)
     for (const event of rail.events) eventsById.set(event.id, event)
     for (const [conversationId, list] of rail.taggedByConversation) {
       const existing = taggedByConversation.get(conversationId)
@@ -242,7 +261,7 @@ function mergeRails(rails: StreamRail[], gatingCount: number): MergedRail {
   const events = [...eventsById.values()].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
   )
-  return { messages, seen, taggedByConversation, events, resolved, allResolved }
+  return { messages, seen, taggedByConversation, supersededClientIds, events, resolved, allResolved }
 }
 
 /**
@@ -539,9 +558,15 @@ export function useBoardCardMessages(post: BoardViewPost, hostStreamType?: strin
     // `messageIds` doesn't list yet — the optimistic row, and the swapped real
     // row in the window before `conversation:updated` lands. Exclude ids already
     // in `replyIds` so a confirmed reply renders once (via `replies`), not twice.
+    // Exclude superseded optimistic rows too: the echo swap deletes the temp row,
+    // but a merged rail can pair one rail's fresh snapshot (echo present) with
+    // another's stale one (temp still there) — without this the reply renders
+    // doubled for that frame.
     const replyIdSet = new Set(replyIds)
     const tagged = rail.taggedByConversation.get(conversationId)
-    const unconfirmed = tagged ? tagged.filter((m) => !replyIdSet.has(m.id)) : NO_PENDING
+    const unconfirmed = tagged
+      ? tagged.filter((m) => !replyIdSet.has(m.id) && !rail.supersededClientIds.has(m.id))
+      : NO_PENDING
     const pendingReplies = unconfirmed.length > 0 ? unconfirmed : NO_PENDING
 
     // The server's count excludes `messageIds[0]` for a flat conversation even


### PR DESCRIPTION
## Problem

The "convert-to-thread hand-off" frame-recording test in `use-board-card-messages.test.tsx` fails ~1 in 3 runs with the reply doubled for one frame (`['my convert reply', 'my convert reply']`). It red-flagged main CI on #1211's merge commit and blocked a deploy until a re-run.

It's a real product race, not test noise. A board card merges several independent liveQuery rails (anchor stream, discovered threads, the optimistic draft panel). The echo swap in `handleMessageCreated` (put real event + delete temp row) is atomic **per rail**, but nothing synchronizes rails with each other: the draft-panel rail can still be on its pre-swap snapshot (temp row present) while the thread rail already shows the echo. For that frame the card's `pendingReplies` holds both the optimistic row and its confirmed twin — the viewer's reply renders twice.

## Solution

Use the linkage the wire already carries: the echo's payload names its optimistic twin via `clientMessageId` (that's how `handleMessageCreated` finds the temp row to delete).

- `buildRail` collects `payload.clientMessageId` of every synced (`_status === undefined`) message into `supersededClientIds`; `mergeRails` unions them.
- The card filters superseded ids out of the `unconfirmed`/`pendingReplies` derivation — a temp row whose confirmed twin is visible in ANY rail is dropped, regardless of which rail's snapshot it came from.
- The retained-pending bridge (which covers the opposite race, the zero-copy frame) is untouched; it inherits the filtered rows via `nextRetained`.

The existing hand-off test now models the echo faithfully (`clientMessageId: "temp_c"` on the real event — matching what `EventService.createMessage` stores). A new deterministic regression test models the race literally: both rows in IDB at once, then the delete landing, with exactly one copy required in every frame.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-board-card-messages.ts` | `supersededClientIds` on `StreamRail`/`mergeRails`; filter in the pending-replies derivation |
| `apps/frontend/src/hooks/use-board-card-messages.test.tsx` | `clientMessageId` on the hand-off echo; new deterministic no-double test |

## Test plan

- [x] `vitest run use-board-card-messages.test.tsx` — 29 pass; 20 consecutive runs green (previously ~1 in 3 red)
- [x] Board suites (`board-card`, `board-card-auto-read`, `use-stable-board-view`, `board.test`) — 87 pass
- [x] Frontend `tsc --noEmit` clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785905852&installation_id=129946197&pr_number=1216&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1216&signature=41a77c4152cec57168a0ce0b2e7b613eb7499c9d62b2834ebcf7b45d8ec5dd7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->