### PR TITLE
ci: typecheck all workspaces on PRs, not just the enclave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      # Typechecks every workspace, not just the enclave. PR CI historically
-      # skipped this, so backend/frontend type breaks only surfaced later in the
-      # Deploy Cloudflare build — after merge, on main. Running the full
-      # monorepo `tsc` here catches cross-workspace drift (e.g. squash-merge
-      # collisions) at PR time.
+      # Full monorepo tsc, not just the enclave: catches cross-workspace type
+      # drift (e.g. squash-merge collisions) at PR time, before it can reach the
+      # Deploy Cloudflare build — which is the only other place `tsc` runs.
       - name: Typecheck all workspaces
         run: bun run typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,31 @@ jobs:
       - name: Lint enclave
         run: bun run --cwd apps/enclave lint
 
-      - name: Typecheck enclave
-        run: bun run --cwd apps/enclave typecheck
-
       - name: Check Dockerfile workspace COPY lines
         run: bun run check:dockerfiles
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      # Typechecks every workspace, not just the enclave. PR CI historically
+      # skipped this, so backend/frontend type breaks only surfaced later in the
+      # Deploy Cloudflare build — after merge, on main. Running the full
+      # monorepo `tsc` here catches cross-workspace drift (e.g. squash-merge
+      # collisions) at PR time.
+      - name: Typecheck all workspaces
+        run: bun run typecheck
 
   test:
     name: Tests


### PR DESCRIPTION
## Problem

PR CI never typechecked most of the monorepo. The `lint` job ran `tsc` for **one** workspace — `apps/enclave` — and nothing else. The full root `typecheck` script (all 14 workspaces) ran only implicitly, inside the `bun run --cwd apps/frontend build` step of **Deploy Cloudflare**, which fires on `workflow_run` *after* a merge to `main`.

So backend and frontend type breaks passed PR CI green and first surfaced as a red deploy on `main`. Two recent incidents came through exactly this gap:

- **#1211** — #1203's `commandsApi.dispatch` test mock dropped the `event` field `DispatchCommandResponse` requires. Green PR CI, red deploy.
- **#1215** — a squash-merge collision (#1198's `applyExtractionUpdate` had no `summary` param; #1187's caller passed one) broke backend `tsc` on `main` with green PR CI.

## Solution

Add a dedicated **Typecheck** job to `ci.yml` that runs `bun run typecheck` — the existing root script covering all 14 workspaces (`packages/{types,prosemirror,crypto,backend-common,agent-runtime}` + `apps/{backend,control-plane,workspace-router,backoffice-router,frontend,backoffice,db-read-proxy,enclave,public-site}`). Cross-workspace type drift now fails at PR time.

Since `deploy-cloudflare.yml` gates every job on `github.event.workflow_run.conclusion == 'success'`, the deploy now also waits on typecheck — a break can no longer reach a deploy at all.

The old "Typecheck enclave" step in `lint` is removed; the enclave is covered by the full run, so keeping it would be duplicate work (INV-38).

Pure `tsc` — the job needs no Postgres/MinIO services, unlike `test`. Runs ~2min.

## Files changed

| File | Change |
| ---- | ------ |
| `.github/workflows/ci.yml` | New `typecheck` job runs `bun run typecheck` (all 14 workspaces); drop redundant "Typecheck enclave" step from `lint`. |

## Out of scope (deliberate)

- Not splitting typecheck into a per-workspace matrix. A single serial job is ~2min and simpler; revisit if it becomes a bottleneck.
- Not adding backend/frontend **tests** beyond what `test` already runs — this closes the *typecheck* gap only.

## Test plan

- [x] `bun run typecheck` on this tip — 0 errors across all 14 workspaces (~1m50s)
- [x] Pre-commit hook (full lint + typecheck + api-docs check) passed before the commit landed
- [x] `ci.yml` parses; jobs are `lint, typecheck, test, workos-permissions`; typecheck steps are Checkout / Setup Bun / Install / Typecheck all workspaces
- [ ] Job behavior on a *broken* type — not exercised here (this branch is green by construction); the mechanism is a plain `bun run typecheck`, which fails non-zero on any `tsc` error

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01W17PugXUo2SA4ZiF5a8AXo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785912875&installation_id=129946197&pr_number=1217&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1217&signature=bec1679cf996f67054a7afd1f2536daa9b8353e02054b2c3974295ccf0ae721a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->