### PR TITLE
feat(streams): brief settings editor UI (roadmap 4.3)

### DIFF
--- a/apps/backend/src/features/streams/brief-service.ts
+++ b/apps/backend/src/features/streams/brief-service.ts
@@ -1,16 +1,16 @@
 import type { Pool } from "pg"
+import { STREAM_BRIEF_MAX_CHARS } from "@threa/types"
 import { streamBriefId, streamBriefRevisionId } from "../../lib/id"
 import { withTransaction } from "../../db"
 import { HttpError } from "../../lib/errors"
 import { StreamBriefRepository, type BriefAuthorKind, type StreamBrief } from "./brief-repository"
 
 /**
- * The brief is a prompt insert, not a document store — every companion turn in
- * the stream carries it verbatim, so the cap keeps it from eating the context
- * budget. Enforced here (not only in the endpoint's Zod schema) so the agent
- * tool path (roadmap 4.2) hits the same wall.
+ * The cap is enforced here (not only in the endpoint's Zod schema) so the agent
+ * tool path (roadmap 4.2) hits the same wall. Re-exported so existing importers
+ * keep their `./brief-service` source; the value lives in `@threa/types` (INV-33).
  */
-export const STREAM_BRIEF_MAX_CHARS = 4000
+export { STREAM_BRIEF_MAX_CHARS }
 
 /**
  * Threads carry no brief of their own — a thread reads and writes its root

--- a/apps/frontend/src/api/index.ts
+++ b/apps/frontend/src/api/index.ts
@@ -60,3 +60,4 @@ export { e2eKeysApi, type E2eKeyResponse, type SetE2eKeyInput, type SetE2eKeyRes
 export { labelsApi, type CreateLabelInput, type UpdateLabelInput } from "./labels"
 export { draftsApi } from "./drafts"
 export { agentFollowUpsApi } from "./agent-follow-ups"
+export { streamBriefsApi, type StreamBrief } from "./stream-briefs"

--- a/apps/frontend/src/api/stream-briefs.ts
+++ b/apps/frontend/src/api/stream-briefs.ts
@@ -1,0 +1,41 @@
+import { api } from "./client"
+import type { AuthorType } from "@threa/types"
+
+/**
+ * A stream brief (roadmap 4.1) as it arrives on the wire — `Date` columns are
+ * ISO strings after JSON serialization. Threads carry no brief of their own;
+ * GET/PUT on a thread resolve the root's brief server-side.
+ */
+export interface StreamBrief {
+  id: string
+  workspaceId: string
+  streamId: string
+  content: string
+  version: number
+  updatedByKind: AuthorType
+  updatedById: string
+  createdAt: string
+  updatedAt: string
+}
+
+export const streamBriefsApi = {
+  async get(workspaceId: string, streamId: string): Promise<StreamBrief | null> {
+    const { brief } = await api.get<{ brief: StreamBrief | null }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/brief`
+    )
+    return brief
+  },
+
+  /**
+   * Full-replacement write with optimistic concurrency. `version` is what the
+   * client last read (0 when no brief existed). A concurrent write throws an
+   * `ApiError` with code `BRIEF_VERSION_CONFLICT` carrying `details.current`.
+   */
+  async put(workspaceId: string, streamId: string, input: { content: string; version: number }): Promise<StreamBrief> {
+    const { brief } = await api.put<{ brief: StreamBrief }>(
+      `/api/workspaces/${workspaceId}/streams/${streamId}/brief`,
+      input
+    )
+    return brief
+  },
+}

--- a/apps/frontend/src/components/stream-settings/brief-section.test.tsx
+++ b/apps/frontend/src/components/stream-settings/brief-section.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { StreamTypes, Visibilities, AuthorTypes, type Stream } from "@threa/types"
+import { streamBriefsApi, type StreamBrief } from "@/api"
+import { ApiError } from "@/api/client"
+import { BriefSection } from "./brief-section"
+
+afterEach(() => vi.restoreAllMocks())
+
+function channel(overrides: Partial<Stream> = {}): Stream {
+  return {
+    id: "stream_chan",
+    workspaceId: "ws_1",
+    type: StreamTypes.CHANNEL,
+    displayName: null,
+    slug: "general",
+    description: null,
+    visibility: Visibilities.PUBLIC,
+    parentStreamId: null,
+    parentMessageId: null,
+    rootStreamId: null,
+    companionMode: "off",
+    companionPersonaId: null,
+    createdBy: "usr_1",
+    createdAt: "2026-06-22T10:00:00Z",
+    updatedAt: "2026-06-22T10:00:00Z",
+    archivedAt: null,
+    ...overrides,
+  }
+}
+
+function brief(overrides: Partial<StreamBrief> = {}): StreamBrief {
+  return {
+    id: "sbrf_1",
+    workspaceId: "ws_1",
+    streamId: "stream_chan",
+    content: "Ship behind a flag.",
+    version: 3,
+    updatedByKind: AuthorTypes.USER,
+    updatedById: "usr_1",
+    createdAt: "2026-06-22T10:00:00Z",
+    updatedAt: "2026-06-22T10:00:00Z",
+    ...overrides,
+  }
+}
+
+function renderSection(stream: Stream = channel()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <BriefSection workspaceId="ws_1" stream={stream} />
+    </QueryClientProvider>
+  )
+}
+
+describe("BriefSection", () => {
+  it("renders the existing brief in a read view with an Edit affordance", async () => {
+    vi.spyOn(streamBriefsApi, "get").mockResolvedValue(brief({ content: "Ship behind a flag." }))
+    renderSection()
+
+    expect(await screen.findByText("Ship behind a flag.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument()
+  })
+
+  it("offers an empty state when no brief exists yet", async () => {
+    vi.spyOn(streamBriefsApi, "get").mockResolvedValue(null)
+    renderSection()
+
+    expect(await screen.findByRole("button", { name: "Add a brief" })).toBeInTheDocument()
+  })
+
+  it("saves an edit with the version the client read", async () => {
+    vi.spyOn(streamBriefsApi, "get").mockResolvedValue(brief({ content: "Old", version: 3 }))
+    const put = vi.spyOn(streamBriefsApi, "put").mockResolvedValue(brief({ content: "New", version: 4 }))
+    renderSection()
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit" }))
+    const textarea = screen.getByRole("textbox", { name: "Stream brief editor" })
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "New")
+    await userEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => expect(put).toHaveBeenCalledWith("ws_1", "stream_chan", { content: "New", version: 3 }))
+    // Success returns to the read view with the fresh content.
+    expect(await screen.findByText("New")).toBeInTheDocument()
+  })
+
+  it("surfaces a concurrent edit inline instead of overwriting silently (INV-63)", async () => {
+    vi.spyOn(streamBriefsApi, "get").mockResolvedValue(brief({ content: "Old", version: 3 }))
+    vi.spyOn(streamBriefsApi, "put").mockRejectedValue(
+      new ApiError(409, "BRIEF_VERSION_CONFLICT", "conflict", { current: brief({ content: "Theirs", version: 4 }) })
+    )
+    renderSection()
+
+    await userEvent.click(await screen.findByRole("button", { name: "Edit" }))
+    const textarea = screen.getByRole("textbox", { name: "Stream brief editor" })
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Mine")
+    await userEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText(/Someone else updated this brief/)).toBeInTheDocument()
+    // The editor stays open with the user's in-progress text — nothing lost.
+    expect(screen.getByRole("textbox", { name: "Stream brief editor" })).toHaveValue("Mine")
+  })
+})

--- a/apps/frontend/src/components/stream-settings/brief-section.tsx
+++ b/apps/frontend/src/components/stream-settings/brief-section.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { StreamTypes, STREAM_BRIEF_MAX_CHARS, type Stream } from "@threa/types"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { MarkdownContent } from "@/components/ui/markdown-content"
+import { ApiError } from "@/api/client"
+import type { StreamBrief } from "@/api"
+import { useStreamBrief, useUpdateStreamBrief } from "@/hooks/use-stream-brief"
+import { streamKeys } from "@/hooks/use-streams"
+import { formatRelativeTime } from "@/lib/dates"
+
+/**
+ * Read/correct a stream's brief from settings (roadmap 4.3). The brief is
+ * plain markdown (no `content_json` twin — 4.1), so this edits a textarea and
+ * renders the markdown for the view, rather than reusing the rich message
+ * editor. A concurrent edit surfaces inline (no toast, INV-63); saving again
+ * overwrites, or the editor can load the other version first.
+ */
+export function BriefSection({ workspaceId, stream }: { workspaceId: string; stream: Stream }) {
+  const queryClient = useQueryClient()
+  const { data: brief, isLoading } = useStreamBrief(workspaceId, stream.id)
+  const updateMutation = useUpdateStreamBrief(workspaceId, stream.id)
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState("")
+  const [hadConflict, setHadConflict] = useState(false)
+
+  const isThread = stream.type === StreamTypes.THREAD
+  const savedContent = brief?.content ?? ""
+  const baseVersion = brief?.version ?? 0
+
+  const startEditing = () => {
+    setDraft(savedContent)
+    setHadConflict(false)
+    setIsEditing(true)
+  }
+
+  const cancelEditing = () => {
+    setIsEditing(false)
+    setHadConflict(false)
+  }
+
+  const handleSave = () => {
+    const content = draft.trim()
+    if (content === savedContent.trim() || updateMutation.isPending) return
+    updateMutation.mutate(
+      { content, version: baseVersion },
+      {
+        onSuccess: () => {
+          setIsEditing(false)
+          setHadConflict(false)
+        },
+        onError: (error) => {
+          if (ApiError.isApiError(error) && error.code === "BRIEF_VERSION_CONFLICT") {
+            // Refresh the known row to the writer's version so the next save
+            // carries the current version (overwrites), and keep the editor
+            // open with the user's in-progress text — nothing is lost silently.
+            const current = (error.details?.current ?? null) as StreamBrief | null
+            if (current) {
+              queryClient.setQueryData<StreamBrief | null>(streamKeys.brief(workspaceId, stream.id), current)
+            }
+            setHadConflict(true)
+            return
+          }
+          toast.error(error instanceof Error ? error.message : "Failed to save brief")
+        },
+      }
+    )
+  }
+
+  let body: React.ReactNode
+  if (isLoading) {
+    body = <p className="text-xs text-muted-foreground">Loading brief…</p>
+  } else if (isEditing) {
+    body = (
+      <div className="space-y-2">
+        {hadConflict && (
+          <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+            Someone else updated this brief while you were editing. Save again to overwrite their version, or{" "}
+            <button
+              type="button"
+              className="font-medium underline underline-offset-2"
+              onClick={() => {
+                setDraft(savedContent)
+                setHadConflict(false)
+              }}
+            >
+              load their changes
+            </button>{" "}
+            to start from it.
+          </p>
+        )}
+        <Textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          maxLength={STREAM_BRIEF_MAX_CHARS}
+          placeholder="e.g. This channel tracks the Q3 launch. Decisions: ship behind a flag; owner is @sam. Prefer terse updates."
+          aria-label="Stream brief editor"
+          className="min-h-[160px] font-mono text-xs"
+        />
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-muted-foreground">
+            {draft.length}/{STREAM_BRIEF_MAX_CHARS}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={cancelEditing} disabled={updateMutation.isPending}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleSave}
+              disabled={draft.trim() === savedContent.trim() || updateMutation.isPending}
+            >
+              {updateMutation.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  } else if (brief && savedContent.trim()) {
+    body = (
+      <div className="space-y-2">
+        <div className="rounded-lg border border-input bg-card p-3">
+          <MarkdownContent content={savedContent} className="text-sm" />
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] text-muted-foreground">
+            Updated {formatRelativeTime(new Date(brief.updatedAt), undefined, undefined, { terse: true })}
+          </span>
+          <Button type="button" variant="outline" size="sm" onClick={startEditing}>
+            Edit
+          </Button>
+        </div>
+      </div>
+    )
+  } else {
+    body = (
+      <div className="rounded-lg border border-dashed border-input p-4 text-center">
+        <p className="text-xs text-muted-foreground">No brief yet.</p>
+        <Button type="button" variant="outline" size="sm" className="mt-2" onClick={startEditing}>
+          Add a brief
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label className="text-sm font-medium">Brief</Label>
+        <p className="text-xs text-muted-foreground">
+          A short standing context Ariadne reads on every turn in this {isThread ? "thread" : "stream"} — goals,
+          decisions, and preferences that outlive any one conversation.
+          {isThread ? " This brief is shared with the parent channel." : ""}
+        </p>
+      </div>
+
+      {body}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/stream-settings/companion-tab.tsx
+++ b/apps/frontend/src/components/stream-settings/companion-tab.tsx
@@ -13,6 +13,7 @@ import {
 } from "@threa/types"
 import { ToolPolicyPicker } from "./tool-policy-picker"
 import { ExternalAgentIndicator } from "./external-agent-indicator"
+import { BriefSection } from "./brief-section"
 
 interface CompanionTabProps {
   workspaceId: string
@@ -103,6 +104,10 @@ export function CompanionTab({
           e2e={isE2e}
         />
       )}
+
+      {/* Briefs are server-stored plaintext the enclave prompt never injects, so
+          they are unsupported on encrypted streams (roadmap §4.1 deviation). */}
+      {!isE2e && <BriefSection workspaceId={workspaceId} stream={stream} />}
     </div>
   )
 }

--- a/apps/frontend/src/hooks/use-stream-brief.ts
+++ b/apps/frontend/src/hooks/use-stream-brief.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { streamBriefsApi, type StreamBrief } from "@/api"
+import { streamKeys } from "./use-streams"
+
+/**
+ * Read a stream's brief (roadmap 4.3). `null` means no brief exists yet.
+ * Enabled only when a stream is addressed — the settings dialog mounts this,
+ * and the dialog itself only renders for stream members.
+ */
+export function useStreamBrief(workspaceId: string, streamId: string) {
+  return useQuery({
+    queryKey: streamKeys.brief(workspaceId, streamId),
+    queryFn: () => streamBriefsApi.get(workspaceId, streamId),
+    enabled: !!workspaceId && !!streamId,
+    staleTime: 30_000,
+  })
+}
+
+/**
+ * Full-replacement brief write. The caller passes the version it read; a
+ * concurrent edit surfaces as an `ApiError` (`BRIEF_VERSION_CONFLICT`) the
+ * caller handles inline (INV-63 — no toast). On success the fresh row lands in
+ * the brief cache so the view reflects the new version immediately.
+ */
+export function useUpdateStreamBrief(workspaceId: string, streamId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (input: { content: string; version: number }) => streamBriefsApi.put(workspaceId, streamId, input),
+    onSuccess: (brief) => {
+      queryClient.setQueryData<StreamBrief | null>(streamKeys.brief(workspaceId, streamId), brief)
+    },
+  })
+}

--- a/apps/frontend/src/hooks/use-streams.ts
+++ b/apps/frontend/src/hooks/use-streams.ts
@@ -30,6 +30,7 @@ export const streamKeys = {
   bootstrap: (workspaceId: string, streamId: string) =>
     [...streamKeys.all, "bootstrap", workspaceId, streamId] as const,
   events: (workspaceId: string, streamId: string) => [...streamKeys.all, "events", workspaceId, streamId] as const,
+  brief: (workspaceId: string, streamId: string) => [...streamKeys.all, "brief", workspaceId, streamId] as const,
 }
 
 export function useStreams(workspaceId: string, filters?: { type?: StreamType }) {

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -48,7 +48,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 3.3  | Conversation-anchored agent replies                   | ☑      | #1170 |
 | 4.1  | `stream_briefs` storage + endpoints + injection       | ☑      | #1214 |
 | 4.2  | `update_stream_brief` tool + timeline event           | ☐      |       |
-| 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2) | ☑      | #TBD  |
+| 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2) | ☑      | #1218 |
 | 4.4  | Brief correction eval                                 | ☐      |       |
 | 5.1  | `delegate_task` tool + delegation substrate + INV-64  | ☐      |       |
 | 5.2  | Delegation card UI                                    | ☐      |       |

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -32,39 +32,39 @@ Two concurrent efforts share primitives with this work; steps below reference th
 
 ## Status
 
-| Step | Deliverable                                          | Status | PR    |
-| ---- | ---------------------------------------------------- | ------ | ----- |
-| 1.1  | `schedule_follow_up` tool + follow-up infra          | ☑      | #1138 |
-| 1.2  | Follow-up turn invocation (context + prompt)         | ☑      | #1142 |
-| 1.3  | Follow-up visibility: timeline card + cancel         | ☑      | #1176 |
-| 1.4  | Configurable follow-up limits (workspace setting)    | ☐      |       |
-| 1.5  | Turn-purpose consolidation (invocation variants)     | ☑      | #1155 |
-| 1.6  | Follow-up admin tools (list/cancel/update)           | ☑      | #1159 |
-| 2.1  | Generalized session abort                            | ☑      | #1177 |
-| 2.2  | Stop/Redirect affordances on the activity card       | ☑      | #1190 |
-| 2.3  | Per-turn model resolution + first escalation rule    | ☑      | #1202 |
-| 3.1  | Persisted episode summaries                          | ☑      | #1162 |
-| 3.2  | Per-thread session concurrency                       | ☑      | #1167 |
-| 3.3  | Conversation-anchored agent replies                  | ☑      | #1170 |
-| 4.1  | `stream_briefs` storage + endpoints + injection      | ☑      | #1214 |
-| 4.2  | `update_stream_brief` tool + timeline event          | ☐      |       |
-| 4.3  | Brief UI: settings editor + timeline event           | ☐      |       |
-| 4.4  | Brief correction eval                                | ☐      |       |
-| 5.1  | `delegate_task` tool + delegation substrate + INV-64 | ☐      |       |
-| 5.2  | Delegation card UI                                   | ☐      |       |
-| 5.3  | Delegation public API (claim/status/complete)        | ☐      |       |
-| 5.4  | claude-code-remote delegation support                | ☐      |       |
-| 5.5  | `@threa/mcp` server                                  | ☐      |       |
-| 6.1  | Memo edit/archive endpoints + explorer UI            | ☐      |       |
-| 6.2  | `save_memo` tool                                     | ☐      |       |
-| 6.3  | Reflective capture at session completion             | ☐      |       |
-| 6.4  | `memoScope` (user/stream/workspace)                  | ☐      |       |
-| 6.5  | Retrieval feedback decay                             | ☐      |       |
-| 7.1  | Workspace persona CRUD API                           | ☐      |       |
-| 7.2  | Persona picker UI                                    | ☐      |       |
-| 8.1  | Ambient classifier on settled conversations          | ☐      |       |
-| 8.2  | "Ariadne noticed" card + budget + toggle             | ☐      |       |
-| 8.3  | Ambient precision eval                               | ☐      |       |
+| Step | Deliverable                                           | Status | PR    |
+| ---- | ----------------------------------------------------- | ------ | ----- |
+| 1.1  | `schedule_follow_up` tool + follow-up infra           | ☑      | #1138 |
+| 1.2  | Follow-up turn invocation (context + prompt)          | ☑      | #1142 |
+| 1.3  | Follow-up visibility: timeline card + cancel          | ☑      | #1176 |
+| 1.4  | Configurable follow-up limits (workspace setting)     | ☐      |       |
+| 1.5  | Turn-purpose consolidation (invocation variants)      | ☑      | #1155 |
+| 1.6  | Follow-up admin tools (list/cancel/update)            | ☑      | #1159 |
+| 2.1  | Generalized session abort                             | ☑      | #1177 |
+| 2.2  | Stop/Redirect affordances on the activity card        | ☑      | #1190 |
+| 2.3  | Per-turn model resolution + first escalation rule     | ☑      | #1202 |
+| 3.1  | Persisted episode summaries                           | ☑      | #1162 |
+| 3.2  | Per-thread session concurrency                        | ☑      | #1167 |
+| 3.3  | Conversation-anchored agent replies                   | ☑      | #1170 |
+| 4.1  | `stream_briefs` storage + endpoints + injection       | ☑      | #1214 |
+| 4.2  | `update_stream_brief` tool + timeline event           | ☐      |       |
+| 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2) | ☑      | #TBD  |
+| 4.4  | Brief correction eval                                 | ☐      |       |
+| 5.1  | `delegate_task` tool + delegation substrate + INV-64  | ☐      |       |
+| 5.2  | Delegation card UI                                    | ☐      |       |
+| 5.3  | Delegation public API (claim/status/complete)         | ☐      |       |
+| 5.4  | claude-code-remote delegation support                 | ☐      |       |
+| 5.5  | `@threa/mcp` server                                   | ☐      |       |
+| 6.1  | Memo edit/archive endpoints + explorer UI             | ☐      |       |
+| 6.2  | `save_memo` tool                                      | ☐      |       |
+| 6.3  | Reflective capture at session completion              | ☐      |       |
+| 6.4  | `memoScope` (user/stream/workspace)                   | ☐      |       |
+| 6.5  | Retrieval feedback decay                              | ☐      |       |
+| 7.1  | Workspace persona CRUD API                            | ☐      |       |
+| 7.2  | Persona picker UI                                     | ☐      |       |
+| 8.1  | Ambient classifier on settled conversations           | ☐      |       |
+| 8.2  | "Ariadne noticed" card + budget + toggle              | ☐      |       |
+| 8.3  | Ambient precision eval                                | ☐      |       |
 
 Suggested order: Phase 1 → 2 → 4 → 5, with 3/6/7 interleavable anytime and 8 strictly last (it depends on 1, 1.5, and 4). Pull **3.1 forward to right after Phase 1** — fired follow-up turns consume episode summaries (see 3.1), and until it lands the 1.2 prompt hint is compensating for their absence.
 
@@ -386,6 +386,16 @@ Tag's channel memory / Claude Code's CLAUDE.md: a persistent, human-auditable, c
 **Tests:** component tests for editor save/conflict and event rendering (INV-39: real components, observable behavior).
 
 **Done when:** a user can read, correct, and audit the brief entirely from the UI.
+
+**Deviations (shipped):**
+
+- **Shipped the settings editor; the timeline renderer moves to 4.2.** 4.3 landed ahead of 4.2 (in-app visibility was the priority), so the `stream:brief_updated` event it would render does not exist yet. Building a renderer for an event nothing emits is speculative (INV-36), so `brief-updated-event.tsx` + its `event-item.tsx` dispatch + deep-link ship in **4.2**, the step that introduces the event. 4.3's deliverable is the read/correct surface against 4.1's existing `GET/PUT` endpoints — a complete, observable user-facing surface on its own.
+- **Section lives inside the Companion tab, not a new tab.** `BriefSection` renders at the bottom of `companion-tab.tsx` ("AI instructions and behavior" — the brief _is_ standing AI instructions), matching the Shape's "adjacent to `companion-tab.tsx`". No new settings tab/registration. Hidden on E2E streams (the PUT rejects them — §4.1 `BRIEF_E2E_UNSUPPORTED`), so the editor never offers a write that 400s.
+- **Plain textarea + rendered-markdown view, not the rich editor.** The brief is markdown `TEXT` with no `content_json` twin (§4.1), so the editor is a `Textarea` (Shadcn, INV-14) and the view renders via `MarkdownContent` — unlike `description-section.tsx`, which round-trips ProseMirror JSON. If 4.3's editor ever goes rich-text, that's the §4.1 `content_json` follow-up.
+- **Conflict UX keeps the user's text.** A 409 refreshes the known row to the writer's version (cache write) and shows an inline amber banner (no toast, INV-63) while keeping the editor open with the in-progress draft — saving again overwrites at the fresh version, or "load their changes" seeds the editor from the other version. Nothing is lost silently.
+- **`STREAM_BRIEF_MAX_CHARS` moved to `@threa/types`** (from `brief-service.ts`) so the editor's char counter and the backend Zod cap share one source (INV-33); the service re-exports it so existing backend importers are untouched.
+- **Author attribution + full revision-history browser deferred.** The read view shows the current version's freshness (`Updated <relative>`); per-change authorship (who + reason + diff) is the 4.2 timeline event's job, and a revisions-list browser would need a new endpoint over `stream_brief_revisions` (not built speculatively, INV-36). "Audit" in v1 = the current version is visible and correctable; richer audit arrives with 4.2's event.
+- **New surfaces:** `api/stream-briefs.ts` (`streamBriefsApi` + `StreamBrief` wire type), `hooks/use-stream-brief.ts` (`useStreamBrief` query + `useUpdateStreamBrief` mutation, `streamKeys.brief`), `components/stream-settings/brief-section.tsx` (+ test). The brief is fetched on demand when settings open — it's not on the stream bootstrap envelope.
 
 ### 4.4 Brief correction eval
 

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -18,6 +18,14 @@ export const DM_PARTICIPANT_COUNT = 2
  */
 export const STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH = 10_000
 
+/**
+ * Hard cap on a stream brief's markdown (roadmap 4.1). The brief is a prompt
+ * insert carried verbatim into every companion turn, not a document store, so
+ * the cap keeps it from eating the context budget. Shared source of truth for
+ * the backend service/Zod schema and the settings-editor char counter (INV-33).
+ */
+export const STREAM_BRIEF_MAX_CHARS = 4000
+
 export const VISIBILITY_OPTIONS = ["public", "private"] as const
 export type Visibility = (typeof VISIBILITY_OPTIONS)[number]
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export {
   StreamTypes,
   DM_PARTICIPANT_COUNT,
   STREAM_DESCRIPTION_MAX_MARKDOWN_LENGTH,
+  STREAM_BRIEF_MAX_CHARS,
   // Visibility
   VISIBILITY_OPTIONS,
   type Visibility,


### PR DESCRIPTION
**Roadmap:** [Ariadne collaborator roadmap §4.3](docs/plans/ariadne-collaborator-roadmap.md) — builds on 4.1 (#1214).

## Problem

Step 4.1 (#1214) shipped durable, versioned per-stream briefs with `GET/PUT /api/workspaces/:wid/streams/:sid/brief` and prompt injection — but **human-editable via API only**. There was no in-app surface: a user could not read the brief that shapes every companion turn, correct it when it drifts, or even see that one exists. The brief was invisible standing context.

## Solution

A "Brief" section in stream settings, rendered inside the Companion tab (the brief _is_ standing AI instructions), backed by the existing 4.1 endpoints. Rendered-markdown view + edit-in-place textarea; a concurrent edit is surfaced inline, never silently clobbered.

### How it works

- **`BriefSection`** (`components/stream-settings/brief-section.tsx`) renders at the bottom of `companion-tab.tsx`. Four states via an if/else `body` (no nested ternary, INV-47): loading, editing, read view (`MarkdownContent`), and an empty "Add a brief" state.
- **Plain textarea, not the rich editor.** The brief is markdown `TEXT` with no `content_json` twin (4.1 decision), so editing uses a Shadcn `Textarea` (INV-14) with a `STREAM_BRIEF_MAX_CHARS` counter and `maxLength`, and the view renders through `MarkdownContent`. This is deliberately unlike `description-section.tsx`, which round-trips ProseMirror JSON.
- **Conflict UX keeps the user's text (INV-63).** Save sends `{ content, version }` with the version the client read. On a 409 (`BRIEF_VERSION_CONFLICT`), the handler writes the fresh row from `details.current` into the brief cache (so the next save carries the current version → overwrites) and shows an inline amber banner while keeping the editor open with the in-progress draft. "Load their changes" seeds the editor from the other version. No toast — the banner is the signal.
- **Data plumbing:** `api/stream-briefs.ts` (`streamBriefsApi.get/put` + `StreamBrief` wire type), `hooks/use-stream-brief.ts` (`useStreamBrief` query + `useUpdateStreamBrief` mutation, `streamKeys.brief`). The brief is fetched on demand when settings open — it is not on the stream bootstrap envelope.
- **Hidden on E2E streams.** The 4.1 PUT rejects encrypted streams (`BRIEF_E2E_UNSUPPORTED`), so the section is gated on `!isE2e` — the editor never offers a write that 400s.

### Key design decisions

**1. Timeline renderer moves to 4.2, not shipped here.** 4.3 landed ahead of 4.2 (in-app visibility was the priority). The `stream:brief_updated` timeline event does not exist yet — it's introduced by 4.2's agent-write tool. Building `brief-updated-event.tsx` for an event nothing emits would be speculative (INV-36), so the renderer + deep link ship with 4.2. 4.3's deliverable is the read/correct surface against 4.1's existing endpoints — complete and observable on its own.

**2. `STREAM_BRIEF_MAX_CHARS` moved to `@threa/types`.** The editor's char counter and the backend Zod cap must agree; duplicating `4000` in the frontend invites drift (INV-33). The constant now lives in `packages/types/src/constants.ts`; `brief-service.ts` re-exports it so existing backend importers (`brief-handlers.ts`, the streams barrel, the service test) are untouched.

**3. Author attribution + revision-history browser deferred.** The read view shows current-version freshness (`Updated <relative>`). Per-change authorship (who + reason + diff) is 4.2's timeline event; a revisions-list browser would need a new endpoint over `stream_brief_revisions` — not built speculatively (INV-36). "Audit" in v1 = the current version is visible and correctable.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/stream-settings/brief-section.tsx` | The brief read/edit UI |
| `apps/frontend/src/components/stream-settings/brief-section.test.tsx` | Component tests (render, save-with-version, conflict) |
| `apps/frontend/src/api/stream-briefs.ts` | `streamBriefsApi` + `StreamBrief` wire type |
| `apps/frontend/src/hooks/use-stream-brief.ts` | `useStreamBrief` query + `useUpdateStreamBrief` mutation |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | Add `STREAM_BRIEF_MAX_CHARS` (shared cap) |
| `packages/types/src/index.ts` | Re-export the constant |
| `apps/backend/src/features/streams/brief-service.ts` | Source the cap from `@threa/types`, re-export it |
| `apps/frontend/src/components/stream-settings/companion-tab.tsx` | Render `BriefSection` (non-E2E) |
| `apps/frontend/src/hooks/use-streams.ts` | Add `streamKeys.brief` |
| `apps/frontend/src/api/index.ts` | Export `streamBriefsApi` / `StreamBrief` |
| `docs/plans/ariadne-collaborator-roadmap.md` | Check 4.3; record deviations |

## Out of scope (deliberate)

- **`stream:brief_updated` timeline renderer + deep link** → 4.2 (introduces the event).
- **Agent-authored brief writes** → 4.2 (`update_stream_brief` tool).
- **Revision-history browser / per-change authorship** → follow-up; needs a `stream_brief_revisions` list endpoint.
- **E2E parity** — briefs remain unsupported on encrypted streams, consistent across the roadmap.

## Test plan

- [x] `bun run --cwd apps/frontend test src/components/stream-settings/brief-section.test.tsx` — 4 pass (render existing, empty state, save with read version, conflict shown inline + draft preserved)
- [x] `bun run --cwd apps/frontend test src/components/stream-settings/` — 37 pass (no regression)
- [x] Backend `bun test src/features/streams/brief-{service,handlers}.test.ts` — 13 pass (constant-source change)
- [x] `tsc --noEmit` clean across `packages/types`, `apps/backend`, `apps/frontend`
- [x] Full pre-commit (monorepo typecheck + lint + migrations + api-docs) green

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_016fK13bF2PHUfsMHv5Ys39p)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785940550&installation_id=129946197&pr_number=1218&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1218&signature=d121be5cb5e93dfb439c64d528397437d32a1efc4741f21701b302885df1f7b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->