### PR TITLE
fix(board): keep soft-thread seam window-independent + generic pending-branch reply chip

### DIFF
--- a/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/board-card.new-subtopic.test.tsx
@@ -325,7 +325,9 @@ describe("BoardCard — inline sub-topic + branch reply", () => {
     await screen.findByText("Pending sub-topic body.")
 
     await user.click(await screen.findByRole("button", { name: "Reply" }))
-    expect(await screen.findByText("Replying in New sub-topic")).toBeTruthy()
+    // The pending branch has no extracted topic yet, so the chip names the target
+    // generically rather than echoing the "New sub-topic" placeholder back.
+    expect(await screen.findByText("Replying in this sub-topic")).toBeTruthy()
     await user.click(screen.getByRole("button", { name: "Send inline" }))
 
     expect(queueDraftMessage).toHaveBeenLastCalledWith(

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -233,7 +233,8 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
     buildBranchedBoardRows(
       groupBranches(messages, { streams: structuralIndex.streamsById, conversation: { streamId } }),
       eventRows,
-      branchesByForkMessageId
+      branchesByForkMessageId,
+      openingMessage?.id
     )
   // A spanning-overflow row from a card opens the whole conversation in the panel.
   const continueThreadTo = () => getPanelUrl(createConversationPanelId(conversation.id))

--- a/apps/frontend/src/components/board/board-row-item.test.ts
+++ b/apps/frontend/src/components/board/board-row-item.test.ts
@@ -99,7 +99,7 @@ describe("buildBranchedBoardRows continuation", () => {
       streams,
       conversation: { streamId: "root" },
     })
-    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    const rows = buildBranchedBoardRows(grouping, [], new Map(), "a")
     expect(rows.map((r) => r.kind)).toEqual(["message", "message"])
     const reply = rows[1]
     expect(reply.kind === "message" && reply.continuation).toBe(true)
@@ -122,8 +122,42 @@ describe("buildBranchedBoardRows continuation", () => {
       ],
       { streams, conversation: { streamId: "root" } }
     )
-    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    const rows = buildBranchedBoardRows(grouping, [], new Map(), "a")
     expect(rows.map((r) => r.kind)).toEqual(["message", "message", "message", "message"])
+  })
+
+  it("keeps the seam when the pre-boundary run is a single reply that isn't the opener (collapsed window)", () => {
+    // A migrated flat discussion, collapsed so the flattener sees only a trailing
+    // reply-only window that happens to start with one channel reply. The single
+    // pre-boundary message is NOT the conversation opener, so this is the same
+    // migration the expanded card seams — not a convert-to-thread. The seam must
+    // survive the windowing (else it flickers between collapsed and expanded).
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "r2")],
+    ])
+    const grouping = groupBranches([msg("r2", "u1", 5, "root"), msg("t1", "u1", 6, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    // The real opener (`r1`) sits in the hidden middle, absent from the window.
+    const rows = buildBranchedBoardRows(grouping, [], new Map(), "r1")
+    expect(rows.map((r) => r.kind)).toEqual(["message", "seam", "message"])
+  })
+
+  it("without an opening id a lone down-crossing keeps its seam (no suppression hint)", () => {
+    // The suppression is opt-in via the opener id; a caller that can't vouch the
+    // run starts at the opener gets the conservative seam, never a dropped one.
+    const streams = new Map([
+      ["root", streamNode(null, null, null)],
+      ["thread", streamNode("root", "root", "a")],
+    ])
+    const grouping = groupBranches([msg("a", "u1", 0, "root"), msg("b", "u1", 1, "thread")], {
+      streams,
+      conversation: { streamId: "root" },
+    })
+    const rows = buildBranchedBoardRows(grouping, [], new Map())
+    expect(rows.map((r) => r.kind)).toEqual(["message", "seam", "message"])
   })
 
   it("an up-seam keeps its seam even when the first run is a single message", () => {

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -137,7 +137,8 @@ function branchAnchorMs(branch: BranchConversationView): number {
 export function buildBranchedBoardRows(
   grouping: BranchGrouping,
   eventRows: BoardEventRow[],
-  branchesByForkMessageId: Map<string, BranchConversationView[]>
+  branchesByForkMessageId: Map<string, BranchConversationView[]>,
+  openingMessageId?: string
 ): BoardRow[] {
   const firstMs = earliestMessageMs(grouping.roots)
   const renderedForkIds = new Set<string>()
@@ -244,10 +245,17 @@ export function buildBranchedBoardRows(
   // convert-to-thread signature (a first reply to a lone post files into a
   // thread): the thread IS the conversation, so no seam ever — not a size
   // threshold; the run stays opener-only however large the thread grows.
+  // The single pre-boundary message must be the conversation's actual opener:
+  // on a collapsed card the flattener sees a trailing reply-only window, so a
+  // migrated discussion whose window happens to start with one channel reply
+  // would otherwise misfire as "converted" here and drop the seam it shows once
+  // expanded. Matching the opener id keeps the classification window-independent.
   const convertedOpener =
     grouping.kind === "soft" &&
     grouping.softSeam?.direction === "down" &&
-    (grouping.roots[0]?.messages.length ?? 0) <= 1
+    grouping.roots[0]?.messages.length === 1 &&
+    openingMessageId != null &&
+    grouping.roots[0]?.messages[0]?.id === openingMessageId
 
   if (grouping.kind === "soft" && grouping.softSeam && !convertedOpener) {
     const [runA, runB] = grouping.roots

--- a/apps/frontend/src/components/board/use-inline-branch-composer.tsx
+++ b/apps/frontend/src/components/board/use-inline-branch-composer.tsx
@@ -237,7 +237,10 @@ export function useInlineBranchComposer(params: {
             memoAnchorStreamId={hostStreamId}
             draftKey={`board:branch-reply:${branch.conversationId}`}
             placeholder="Reply…"
-            contextChip={`Replying in ${branch.title}`}
+            // A pending branch's `title` is the "New sub-topic" placeholder (the
+            // real topic isn't extracted until the echo), so name the target
+            // generically rather than echoing the placeholder back.
+            contextChip={branch.pending ? "Replying in this sub-topic" : `Replying in ${branch.title}`}
             rejectE2e={E2E_REPLY_MESSAGE}
             onSubmit={(sendInput) => submitBranchReply(branch, sendInput)}
             onClose={closeComposer}

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -473,7 +473,8 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   const rows = buildBranchedBoardRows(
     groupBranches(all, { streams: structuralIndex.streamsById, conversation: { streamId: conversation.streamId } }),
     eventRows,
-    branchesByForkMessageId
+    branchesByForkMessageId,
+    openingMessage?.id
   )
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
     // Each row renders against its own stream so reactions and the permalink


### PR DESCRIPTION
Two dogfood follow-ups on the merged nested sub-topics work (#1213). No new
behavior — both tighten rough edges the merged code shipped.

## Problem

**1. Soft-thread seam flickered between collapsed and expanded.** The seam
suppression `convertedOpener` (`board-row-item.tsx`) keyed on the pre-boundary
run being a single message: `(grouping.roots[0]?.messages.length ?? 0) <= 1`.
That's the convert-to-thread signature (a first reply to a lone post files into
a thread → the thread carries the whole conversation → no seam). But the
classifier runs over whatever message list it's handed, and on a **collapsed**
card the non-contiguous path (`board-card.tsx:508`) feeds it
`branchRows(displayedReplies)` — the trailing reply window, opening rendered
separately. A genuinely *migrated* flat discussion (opener + channel replies →
thread), collapsed so the window straddles the boundary as
`[oneChannelReply, threadReply, …]`, has a single pre-boundary message that
tripped `convertedOpener` → the "continued in… / Split into its own topic" seam
was dropped. Expand the card and the run becomes `[opener, …channel replies]`
(≥2) → seam reappears. Same conversation, two different renders.

**2. Pending-branch reply chip echoed a placeholder.** A just-sent sub-topic
renders as a synthetic `pending` branch whose `title` is the literal
`"New sub-topic"` placeholder (`use-inline-branch-composer.tsx:141`) until the
`conversation:created` echo lands and the real topic is extracted. The
reply-target contextChip rendered `Replying in ${branch.title}` →
"Replying in New sub-topic", naming a placeholder instead of the target.

## Solution

**1.** `buildBranchedBoardRows` takes an `openingMessageId`; `convertedOpener`
now requires the lone pre-boundary message to *be* that opener, making the
classification independent of the render window:

```ts
grouping.roots[0]?.messages.length === 1 &&
openingMessageId != null &&
grouping.roots[0]?.messages[0]?.id === openingMessageId
```

Threaded from both surfaces (`board-card.tsx`, `conversation-panel.tsx`) as
`openingMessage?.id`. A windowed slice whose run doesn't start at the opener
keeps its seam; a true convert-to-thread (run *is* `[opener]`) stays seamless
however large the thread grows. Omitting the id falls back to the conservative
always-seam — suppression is opt-in via a vouched opener, never a dropped seam.

Why this is correct and not just a patch: a *true* convert-to-thread has all
replies in the thread, so a collapsed window over its replies is single-stream
→ `flat`, never `soft` — the seam never arises there. `soft` only surfaces in
the collapsed path for a genuinely migrated discussion, which is exactly the
case that must keep its seam. The opener-id check draws that line precisely, and
matches the design's own wording (`board-view-design.md` § Soft thread, refined
2026-07-06: "the signal is the pre-boundary run … never thread size or author
count").

**2.** Chip falls back to a generic label when the branch is pending:
`branch.pending ? "Replying in this sub-topic" : ` + `Replying in ${branch.title}`.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-row-item.tsx` | `buildBranchedBoardRows` gains `openingMessageId?`; `convertedOpener` requires the lone pre-boundary message to equal it |
| `apps/frontend/src/components/board/board-card.tsx` | `branchRows` closure passes `openingMessage?.id` (covers both contiguous + collapsed call sites) |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | passes `openingMessage?.id` to `buildBranchedBoardRows` |
| `apps/frontend/src/components/board/use-inline-branch-composer.tsx` | pending-branch reply chip → "Replying in this sub-topic" |
| `apps/frontend/src/components/board/board-row-item.test.ts` | +2 cases (windowed-straddle keeps seam; no-hint default keeps seam); converted-opener cases pass the opener id |
| `apps/frontend/src/components/board/board-card.new-subtopic.test.tsx` | pending-branch chip assertion updated to the generic copy |

## Out of scope (deliberate)

- The `groupBranches` classifier (`lib/board/branch-grouping.ts`) is untouched —
  the fix is entirely in the flattener's suppression check, so soft/spanning
  classification and the up-seam / nested-branch paths are unchanged.
- The convert-to-thread design rule itself (Kris, 2026-07-06) stands; this only
  makes its discriminator window-independent.

## Test plan

- [x] `board-row-item` / `board-card.branches` / `board-card.new-subtopic` / `board-card.split` / `branch-grouping` — 36 pass (was 34; +2 new)
- [x] `src/components/conversations/` — 18 pass
- [x] Frontend `tsc --noEmit` — 0 errors
- [x] Pre-commit gauntlet (all-workspace typecheck, `astro check`, OpenAPI `--check`) — clean
- [ ] No board Playwright e2e and no local Postgres in this container, so the collapsed-window straddle is covered by the deterministic `buildBranchedBoardRows` unit case rather than a browser run

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_013fUKXmWA26d4SUV78dh51a)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785941157&installation_id=129946197&pr_number=1219&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1219&signature=e37826af28130a30f3b19473c5e3b3a3100fc413bcb27bf4a4ca8a9bb7a2b74f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->