### PR TITLE
fix(board): deflake ⋯-menu action assertions with waitFor

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -271,7 +271,10 @@ describe("BoardCard conversation actions", () => {
     await user.click(await screen.findByRole("button", { name: "Conversation actions" }))
     await user.click(await screen.findByText("Mark resolved"))
 
-    expect(updateConversation).toHaveBeenCalledWith(WS, "conv_1", { status: "resolved" })
+    // The menu item's onClick fires the mutation on a microtask after the click
+    // resolves, so assert via waitFor — a bare synchronous expect races the
+    // dispatch and flakes under CI load (still asserting the exact call args).
+    await waitFor(() => expect(updateConversation).toHaveBeenCalledWith(WS, "conv_1", { status: "resolved" }))
   })
 
   it("hides the conversation from the board via the ⋯ menu", async () => {
@@ -282,6 +285,6 @@ describe("BoardCard conversation actions", () => {
     await user.click(await screen.findByRole("button", { name: "Conversation actions" }))
     await user.click(await screen.findByText("Hide from board"))
 
-    expect(hideConversation).toHaveBeenCalledWith(WS, "conv_1")
+    await waitFor(() => expect(hideConversation).toHaveBeenCalledWith(WS, "conv_1"))
   })
 })


### PR DESCRIPTION
## Problem

`board-card.test.tsx` flakes on the `⋯`-menu action cases. The "hides the conversation from the board via the ⋯ menu" test failed **three consecutive full-suite CI runs** on an unrelated PR (#1220) while passing **9/9 locally** in isolation — the classic signature of a test-timing race that only surfaces under CI scheduling load.

The two menu-action tests assert the mutation was called **synchronously** right after the click resolves:

```ts
await user.click(await screen.findByText("Hide from board"))
expect(hideConversation).toHaveBeenCalledWith(WS, "conv_1")   // races the dispatch
```

The menu item's `onClick` fires the mutation on a microtask after the click settles, so a bare synchronous `expect(...).toHaveBeenCalledWith(...)` can run before the call lands.

## Solution

Wrap both assertions (`updateConversation` line 274, `hideConversation` line 285) in `await waitFor(...)`:

```ts
await waitFor(() => expect(hideConversation).toHaveBeenCalledWith(WS, "conv_1"))
```

Same exact call args are asserted — this fixes the timing race, it does **not** loosen the check. The sibling "marks resolved" test uses the identical pattern and is fixed proactively (latent flake).

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-card.test.tsx` | Import `waitFor`; wrap the two `⋯`-menu action assertions in `await waitFor(...)` |

## Test plan

- [x] `bun run --cwd apps/frontend test src/components/board/board-card.test.tsx` — 9 pass
- [x] Pre-commit: full monorepo typecheck (14 workspaces), lint, migrations, api-docs check — green
- [ ] The flake is load-dependent (green locally regardless), so the real proof is CI staying green across runs — verified once this merges and #1220's Tests re-run passes.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HH1AhzsKBb98ohUYbu1dTa)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785951284&installation_id=129946197&pr_number=1221&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1221&signature=ee2ac0e589f7f419e6ba3b87d7fdddd2413b46658892c934b85b5d8a0f260237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->