### PR TITLE
feat(timeline): open captured memos in a preview dialog instead of navigating

### DIFF
--- a/apps/frontend/src/components/timeline/memo-captured-event.test.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { MemoryRouter } from "react-router-dom"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MemoCapturedEvent } from "./memo-captured-event"
 import type { MemosCapturedEventPayload, StreamEvent } from "@threa/types"
 
@@ -19,15 +21,19 @@ function createEvent(payload: MemosCapturedEventPayload): StreamEvent {
 }
 
 function renderEvent(payload: MemosCapturedEventPayload) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
-    <MemoryRouter>
-      <MemoCapturedEvent event={createEvent(payload)} workspaceId="ws_1" />
-    </MemoryRouter>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <MemoCapturedEvent event={createEvent(payload)} workspaceId="ws_1" />
+      </MemoryRouter>
+    </QueryClientProvider>
   )
 }
 
 describe("MemoCapturedEvent", () => {
-  it("renders each captured memo title as a link into the memory explorer", () => {
+  it("renders each captured memo title as a button that opens the memo preview in place", async () => {
+    const user = userEvent.setup()
     renderEvent({
       conversationId: "conv_1",
       memos: [
@@ -37,14 +43,16 @@ describe("MemoCapturedEvent", () => {
     })
 
     expect(screen.getByText(/Saved to memory:/)).toBeInTheDocument()
-    expect(screen.getByRole("link", { name: "Use prefixed ULIDs" })).toHaveAttribute(
-      "href",
-      "/w/ws_1/memory?memo=memo_1"
-    )
-    expect(screen.getByRole("link", { name: "Deploy via Railway" })).toHaveAttribute(
-      "href",
-      "/w/ws_1/memory?memo=memo_2"
-    )
+    // Titles are buttons (open the preview), not links away to the explorer.
+    expect(screen.queryByRole("link", { name: "Use prefixed ULIDs" })).toBeNull()
+    const trigger = screen.getByRole("button", { name: "Use prefixed ULIDs" })
+    expect(trigger).toHaveAttribute("aria-haspopup", "dialog")
+
+    await user.click(trigger)
+
+    // The preview dialog opens in place; its footer offers the explorer link.
+    const explorerLink = await waitFor(() => screen.getByRole("link", { name: /Open in memory/i }))
+    expect(explorerLink).toHaveAttribute("href", "/w/ws_1/memory?memo=memo_1")
   })
 
   it("renders nothing for an empty capture payload", () => {

--- a/apps/frontend/src/components/timeline/memo-captured-event.tsx
+++ b/apps/frontend/src/components/timeline/memo-captured-event.tsx
@@ -1,7 +1,8 @@
-import { Link } from "react-router-dom"
+import { useState } from "react"
 import { Sparkles } from "lucide-react"
 import type { MemosCapturedEventPayload, StreamEvent } from "@threa/types"
-import { memoDeepLink } from "@/lib/memo-url"
+import { cn } from "@/lib/utils"
+import { MemoPreviewDialog } from "@/components/memo/memo-preview-dialog"
 
 interface MemoCapturedEventProps {
   event: StreamEvent
@@ -13,11 +14,15 @@ interface MemoCapturedEventProps {
  * knowledge from this stream (INV-62). The event is appended when the memo
  * batch commits, which per-stream debouncing places just after the source
  * conversation, so the row reads as a small "Threa kept this" gift moment
- * rather than an out-of-place system log line. Each title deep-links to the
- * memory explorer (`?memo=` is the canonical memo deep-link, see memo-url.ts).
+ * rather than an out-of-place system log line. Each title opens the memo in an
+ * in-place preview (`MemoPreviewDialog`) — a modal on desktop, a drawer on
+ * mobile — rather than navigating away to the memory explorer, which was
+ * disruptive mid-conversation. The dialog footer still links through to the
+ * full explorer for anyone who wants it.
  */
 export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps) {
   const payload = event.payload as MemosCapturedEventPayload | undefined
+  const [openMemo, setOpenMemo] = useState<{ memoId: string; title: string } | null>(null)
   if (!payload?.memos?.length) return null
 
   return (
@@ -28,15 +33,29 @@ export function MemoCapturedEvent({ event, workspaceId }: MemoCapturedEventProps
         {payload.memos.map((memo, index) => (
           <span key={memo.memoId}>
             {index > 0 && ", "}
-            <Link
-              to={memoDeepLink(workspaceId, memo.memoId)}
-              className="font-medium text-foreground/80 underline-offset-2 hover:underline"
+            <button
+              type="button"
+              onClick={() => setOpenMemo({ memoId: memo.memoId, title: memo.title })}
+              aria-haspopup="dialog"
+              className={cn(
+                "font-medium text-foreground/80 underline-offset-2 hover:underline",
+                "rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              )}
             >
               {memo.title}
-            </Link>
+            </button>
           </span>
         ))}
       </p>
+      <MemoPreviewDialog
+        open={openMemo !== null}
+        onOpenChange={(open) => {
+          if (!open) setOpenMemo(null)
+        }}
+        workspaceId={workspaceId}
+        memoId={openMemo?.memoId ?? ""}
+        fallbackTitle={openMemo?.title ?? ""}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Problem

Clicking a memo title in the `memos:captured` timeline row navigated away to the memory explorer (`/w/:workspaceId/memory?memo=`). In the timeline and board views this is disruptive — a `<Link>` navigation tears the user out of the conversation they're reading to open a full-page explorer, just to glance at a memo that was captured in situ (INV-62).

Both views render this row through one shared component, `MemoCapturedEvent` (`apps/frontend/src/components/timeline/memo-captured-event.tsx`), used by `event-item.tsx` (timeline) and `board-row-item.tsx` (board), so the disruptive behavior was uniform across both.

## Solution

Open the memo in place instead of navigating. The titles now trigger `MemoPreviewDialog` — the existing responsive surface (centered modal on desktop, snap drawer on mobile) that reuses `MemoDetailContent`, so the rendered memo matches the explorer exactly. Its footer keeps the "Open in memory" link for anyone who still wants the full explorer.

No new component: `MemoPreviewDialog` already existed for inline memo embeds (`lib/markdown/memo-embed-block.tsx`); this wires the timeline/board rows to the same surface.

### How it works

- Each memo title becomes a `<button aria-haspopup="dialog">` (was a `<Link>`). Per INV-40, opening a dialog is an action, not navigation, so a button is correct.
- `MemoCapturedEvent` holds `openMemo: { memoId, title } | null` state; clicking a title sets it and opens the single `MemoPreviewDialog`, which fetches via `useMemoDetail` only while open and shares the `memoKeys.detail` cache with the embed card.
- The one shared component change covers both the timeline (stream page) and the board.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/memo-captured-event.tsx` | Titles open `MemoPreviewDialog` in place (button + dialog state) instead of `<Link>` navigation to the explorer. |
| `apps/frontend/src/components/timeline/memo-captured-event.test.tsx` | Assert the title is a dialog-opening button (not a link) and that opening it surfaces the preview with the explorer footer link; wrap in `QueryClientProvider` for `useMemoDetail`. |

## Test plan

- [x] `bun run test src/components/timeline/memo-captured-event.test.tsx` — 2 pass
- [x] `bun run test src/components/timeline/event-item.test.tsx` — 12 pass (mocks `MemoCapturedEvent`; unaffected)
- [x] `tsc --noEmit -p apps/frontend/tsconfig.json` clean; full monorepo lint + typecheck green via pre-commit hook

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01BiPit5BW4k9m513BgtPb2H)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785962709&installation_id=129946197&pr_number=1224&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1224&signature=355ee66b69c630584abae56a692e26d5a32f464f3f4cfd500e9c17d5dfb03f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->