### PR TITLE
feat(conversations): multi-select conversation split in the timeline

### DIFF
--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -82,6 +82,16 @@ const splitThreadSchema = z.object({
   threadStreamId: z.string().min(1),
 })
 
+// Batch reassignment of hand-picked messages to another conversation. A present
+// `targetConversationId` reassigns into that existing conversation; absent/null
+// mints a new one (the "split into its own topic" gesture). Capped at 100, like
+// the message-move flow, so a hand-built request can't splice an unbounded set.
+const reassignMessagesSchema = z.object({
+  streamId: z.string().min(1),
+  messageIds: z.array(z.string().min(1)).min(1).max(100),
+  targetConversationId: z.string().min(1).nullish(),
+})
+
 const markReadSchema = z.object({
   throughMessageId: z.string().min(1),
 })
@@ -281,6 +291,36 @@ export function createConversationHandlers({
       await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
 
       const result = await conversationService.reassignMessage({ workspaceId, conversationId, messageId, userId })
+      res.json(result)
+    },
+
+    /**
+     * User correction from the timeline conversation overlay: reassign a set of
+     * selected messages to another conversation — an existing one
+     * (`targetConversationId`) or a freshly minted one (absent → the split
+     * gesture). Access gates on the source stream (the messages' home, and the
+     * mint's anchor); the service pins an existing target to that same stream.
+     */
+    async reassignMessages(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { streamId, messageIds, targetConversationId } = validateRequest(reassignMessagesSchema, req.body)
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(streamId, workspaceId, userId)
+
+      const target = targetConversationId
+        ? { kind: "existing" as const, conversationId: targetConversationId }
+        : { kind: "new" as const }
+
+      const result = await conversationService.reassignMessagesToConversation({
+        workspaceId,
+        streamId,
+        messageIds,
+        target,
+        actorUserId: userId,
+      })
       res.json(result)
     },
 

--- a/apps/backend/src/features/conversations/service.reassign-messages.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign-messages.test.ts
@@ -71,6 +71,8 @@ interface Spies {
 function setup(options: {
   conversations: Record<string, Conversation>
   primaries: Record<string, string>
+  /** Membership returned by the authoritative (2nd) read, if it differs (a race). */
+  authoritativePrimaries?: Record<string, string>
   existingTargetId?: string
 }): Spies {
   const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
@@ -82,11 +84,21 @@ function setup(options: {
   spyOn(ConversationRepository, "findByIdForUpdate").mockImplementation(
     async (_c: unknown, _ws: string, id: string) => options.conversations[id] ?? null
   )
+  // Two calls happen: an unlocked peek, then the authoritative re-read once
+  // messages are pinned. `authoritativePrimaries`, when set, models a race by
+  // returning different membership on the second (authoritative) call.
+  let primariesCall = 0
   spyOn(ConversationRepository, "findPrimariesByMessageIds").mockImplementation(async (_c, _ws, ids: string[]) => {
+    primariesCall++
+    const table =
+      options.authoritativePrimaries && primariesCall >= 2 ? options.authoritativePrimaries : options.primaries
     const map = new Map<string, Conversation>()
     for (const id of ids) {
-      const convId = options.primaries[id]
+      const convId = table[id]
+      // A conversation the peek never saw isn't in `conversations`, so it's never
+      // locked — exactly the "raced into an un-pre-locked conversation" case.
       if (convId && options.conversations[convId]) map.set(id, options.conversations[convId])
+      else if (convId) map.set(id, makeConversation({ id: convId, streamId: "chan_1" }))
     }
     return map
   })
@@ -280,6 +292,25 @@ describe("ConversationService.reassignMessagesToConversation", () => {
     expect(spies.removePrimaryMessages).not.toHaveBeenCalled()
     expect(spies.outboxInsert).not.toHaveBeenCalled()
     expect(result.sourceConversations).toEqual([])
+  })
+
+  test("mints no orphan conversation when a new-target selection all races away", async () => {
+    // Peek sees m2 in conv_a; by the authoritative re-read a concurrent op has
+    // moved it into conv_raced, which was never peeked (so never locked).
+    const spies = setup({
+      conversations: { conv_a: makeConversation() },
+      primaries: { m2: "conv_a" },
+      authoritativePrimaries: { m2: "conv_raced" },
+    })
+
+    await expect(reassign(["m2"], { kind: "new" })).rejects.toMatchObject({
+      code: "NO_MESSAGES_TO_MOVE",
+      status: 409,
+    })
+    // The mint is deferred past the no-op check, so nothing was inserted.
+    expect(spies.insert).not.toHaveBeenCalled()
+    expect(spies.addPrimaryMessages).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
   })
 
   test("rejects a selection with a message from another stream (400)", async () => {

--- a/apps/backend/src/features/conversations/service.reassign-messages.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign-messages.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, spyOn, mock, test } from "bun:test"
+import type { PoolClient } from "pg"
+import { ConversationService } from "./service"
+import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationFeedbackRepository } from "./feedback-repository"
+import * as delivery from "./conversation-delivery"
+import { StreamRepository } from "../streams"
+import { MessageRepository, type Message } from "../messaging"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const ACTOR_ID = "usr_1"
+
+// Every message lives in chan_1; `m_foreign` is the cross-stream negative case.
+const MESSAGES: Record<string, { streamId: string; authorId: string; sequence: number }> = {
+  m1: { streamId: "chan_1", authorId: "usr_1", sequence: 1 },
+  m2: { streamId: "chan_1", authorId: "usr_2", sequence: 2 },
+  m3: { streamId: "chan_1", authorId: "usr_1", sequence: 3 },
+  m4: { streamId: "chan_1", authorId: "usr_2", sequence: 4 },
+  m_other: { streamId: "chan_1", authorId: "usr_3", sequence: 5 },
+  m_foreign: { streamId: "chan_2", authorId: "usr_1", sequence: 6 },
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_a",
+    streamId: "chan_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["m1", "m2", "m3", "m4"],
+    participantIds: ["usr_1", "usr_2"],
+    secondaryMessageIds: [],
+    topicSummary: "Fable",
+    summary: null,
+    completenessScore: 1,
+    confidence: 1,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function message(id: string): Message {
+  const base = MESSAGES[id]
+  return { id, streamId: base.streamId, authorId: base.authorId, sequence: base.sequence } as unknown as Message
+}
+
+function messageMap(ids: string[]): Map<string, Message> {
+  return new Map(ids.map((id) => [id, message(id)]))
+}
+
+interface Spies {
+  insert: ReturnType<typeof spyOn>
+  removePrimaryMessages: ReturnType<typeof spyOn>
+  addPrimaryMessages: ReturnType<typeof spyOn>
+  resolveIfEmpty: ReturnType<typeof spyOn>
+  reactivateIfInactive: ReturnType<typeof spyOn>
+  bumpActivityForIds: ReturnType<typeof spyOn>
+  feedbackInsertMany: ReturnType<typeof spyOn>
+  outboxInsert: ReturnType<typeof spyOn>
+}
+
+/**
+ * @param conversations Every conversation the batch touches, keyed by id. The
+ *   source(s) selected messages leave, plus any existing destination.
+ * @param primaries messageId → current primary conversation id.
+ */
+function setup(options: {
+  conversations: Record<string, Conversation>
+  primaries: Record<string, string>
+  existingTargetId?: string
+}): Spies {
+  const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
+  spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withTransaction)
+
+  spyOn(StreamRepository, "findById").mockResolvedValue({ id: "chan_1", type: "channel" } as never)
+
+  spyOn(ConversationRepository, "findByIdForUpdate").mockImplementation(
+    async (_c: unknown, _ws: string, id: string) => options.conversations[id] ?? null
+  )
+  spyOn(ConversationRepository, "findPrimariesByMessageIds").mockImplementation(async (_c, _ws, ids: string[]) => {
+    const map = new Map<string, Conversation>()
+    for (const id of ids) {
+      const convId = options.primaries[id]
+      if (convId && options.conversations[convId]) map.set(id, options.conversations[convId])
+    }
+    return map
+  })
+  // Post-write re-read: return the touched rows by id (membership doesn't need to
+  // reflect the writes for these assertions — we assert on the mutating calls).
+  spyOn(ConversationRepository, "findByIds").mockImplementation(async (_c, _ws, ids: string[]) =>
+    ids.map((id) => options.conversations[id]).filter((c): c is Conversation => c !== undefined)
+  )
+  spyOn(ConversationRepository, "findById").mockImplementation(
+    async (_c: unknown, id: string) => options.conversations[id] ?? null
+  )
+
+  const insert = spyOn(ConversationRepository, "insert").mockImplementation(async (_c, params) => {
+    const created = makeConversation({
+      id: params.id,
+      streamId: params.streamId,
+      topicSummary: null,
+      messageIds: [],
+      participantIds: [],
+    })
+    options.conversations[params.id] = created
+    return created
+  })
+
+  spyOn(MessageRepository, "findByIdsForUpdate").mockImplementation(async (_c, ids: string[]) =>
+    ids
+      .filter((id) => MESSAGES[id])
+      .map(message)
+      .sort((a, b) => (a as unknown as { sequence: number }).sequence - (b as unknown as { sequence: number }).sequence)
+  )
+  spyOn(MessageRepository, "findByIds").mockImplementation(async (_c, ids: string[]) =>
+    messageMap(ids.filter((id) => MESSAGES[id]))
+  )
+
+  spyOn(delivery, "resolveConversationDelivery").mockResolvedValue({
+    parentStreamId: "chan_1",
+    streamVisibility: "public",
+  })
+
+  return {
+    insert,
+    removePrimaryMessages: spyOn(ConversationRepository, "removePrimaryMessages").mockResolvedValue(undefined as never),
+    addPrimaryMessages: spyOn(ConversationRepository, "addPrimaryMessages").mockResolvedValue(undefined as never),
+    resolveIfEmpty: spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never),
+    reactivateIfInactive: spyOn(ConversationRepository, "reactivateIfInactive").mockResolvedValue(undefined as never),
+    bumpActivityForIds: spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never),
+    feedbackInsertMany: spyOn(ConversationFeedbackRepository, "insertMany").mockResolvedValue(undefined as never),
+    outboxInsert: spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never),
+  }
+}
+
+function service(): ConversationService {
+  return new ConversationService({} as never)
+}
+
+function reassign(messageIds: string[], target: { kind: "existing"; conversationId: string } | { kind: "new" }) {
+  return service().reassignMessagesToConversation({
+    workspaceId: WORKSPACE_ID,
+    streamId: "chan_1",
+    messageIds,
+    target,
+    actorUserId: ACTOR_ID,
+  })
+}
+
+type Event = { type: string; payload: Record<string, any> }
+function events(outboxInsert: ReturnType<typeof spyOn>): Event[] {
+  return outboxInsert.mock.calls.map((c: unknown[]) => ({
+    type: c[1] as string,
+    payload: c[2] as Record<string, any>,
+  }))
+}
+
+describe("ConversationService.reassignMessagesToConversation", () => {
+  afterEach(() => mock.restore())
+
+  test("splits selected messages into a freshly minted conversation", async () => {
+    const spies = setup({
+      conversations: { conv_a: makeConversation() },
+      primaries: { m2: "conv_a", m3: "conv_a" },
+    })
+
+    const result = await reassign(["m2", "m3"], { kind: "new" })
+
+    // Minted anchored to the stream, no copied title (fresh-mint precedent).
+    expect(spies.insert).toHaveBeenCalledTimes(1)
+    expect(spies.insert.mock.calls[0][1]).toMatchObject({ streamId: "chan_1", workspaceId: WORKSPACE_ID })
+    expect(spies.insert.mock.calls[0][1].topicSummary).toBeUndefined()
+    const newId = spies.insert.mock.calls[0][1].id as string
+
+    // Move set added to the new conversation, in sequence order, authors deduped.
+    expect(spies.addPrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      newId,
+      ["m2", "m3"],
+      ["usr_2", "usr_1"]
+    )
+    // Source loses exactly the moved ids; participants recomputed from the rest.
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_a",
+      ["m2", "m3"],
+      ["usr_1", "usr_2"]
+    )
+    expect(result.conversation.id).toBe(newId)
+    expect(result.sourceConversations.map((c) => c.id)).toEqual(["conv_a"])
+  })
+
+  test("reassigns selected messages into an existing conversation, unioning participants", async () => {
+    const target = makeConversation({
+      id: "conv_b",
+      topicSummary: "Roadmap",
+      messageIds: ["m_other"],
+      participantIds: ["usr_3"],
+    })
+    const spies = setup({
+      conversations: { conv_a: makeConversation(), conv_b: target },
+      primaries: { m2: "conv_a" },
+    })
+
+    await reassign(["m2"], { kind: "existing", conversationId: "conv_b" })
+
+    expect(spies.insert).not.toHaveBeenCalled()
+    // Existing member's author (usr_3) preserved alongside the arrival (usr_2).
+    expect(spies.addPrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_b",
+      ["m2"],
+      ["usr_3", "usr_2"]
+    )
+  })
+
+  test("writes one feedback row per moved message and per-message reassigned events", async () => {
+    const spies = setup({
+      conversations: { conv_a: makeConversation() },
+      primaries: { m2: "conv_a", m3: "conv_a" },
+    })
+
+    await reassign(["m2", "m3"], { kind: "new" })
+
+    const rows = spies.feedbackInsertMany.mock.calls[0][1] as Array<Record<string, unknown>>
+    expect(rows.map((r) => r.messageId)).toEqual(["m2", "m3"])
+    expect(rows.every((r) => r.fromConversationId === "conv_a" && r.userId === ACTOR_ID)).toBe(true)
+
+    const reassigned = events(spies.outboxInsert).filter((e) => e.type === "conversation:message_reassigned")
+    expect(reassigned.map((e) => e.payload.messageId)).toEqual(["m2", "m3"])
+    expect(events(spies.outboxInsert).some((e) => e.type === "conversation:created")).toBe(true)
+  })
+
+  test("handles a selection spanning two source conversations", async () => {
+    const convA = makeConversation({ id: "conv_a", messageIds: ["m1", "m2"], participantIds: ["usr_1", "usr_2"] })
+    const convB = makeConversation({ id: "conv_b", messageIds: ["m3", "m4"], participantIds: ["usr_1", "usr_2"] })
+    const spies = setup({
+      conversations: { conv_a: convA, conv_b: convB },
+      primaries: { m2: "conv_a", m3: "conv_b" },
+    })
+
+    const result = await reassign(["m2", "m3"], { kind: "new" })
+
+    // Each source loses only its own contributed id.
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_a",
+      ["m2"],
+      ["usr_1"]
+    )
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_b",
+      ["m3"],
+      ["usr_2"]
+    )
+    expect(result.sourceConversations.map((c) => c.id).sort()).toEqual(["conv_a", "conv_b"])
+  })
+
+  test("is a no-op when every selected message already lives in the destination", async () => {
+    const target = makeConversation({ id: "conv_b", messageIds: ["m2"], participantIds: ["usr_2"] })
+    const spies = setup({
+      conversations: { conv_b: target },
+      primaries: { m2: "conv_b" },
+    })
+
+    const result = await reassign(["m2"], { kind: "existing", conversationId: "conv_b" })
+
+    expect(spies.addPrimaryMessages).not.toHaveBeenCalled()
+    expect(spies.removePrimaryMessages).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+    expect(result.sourceConversations).toEqual([])
+  })
+
+  test("rejects a selection with a message from another stream (400)", async () => {
+    setup({ conversations: { conv_a: makeConversation() }, primaries: { m2: "conv_a" } })
+    await expect(reassign(["m2", "m_foreign"], { kind: "new" })).rejects.toMatchObject({
+      code: "MESSAGE_NOT_IN_STREAM",
+      status: 400,
+    })
+  })
+
+  test("rejects an existing target in a different stream (400)", async () => {
+    const target = makeConversation({ id: "conv_b", streamId: "chan_2" })
+    setup({ conversations: { conv_a: makeConversation(), conv_b: target }, primaries: { m2: "conv_a" } })
+    await expect(reassign(["m2"], { kind: "existing", conversationId: "conv_b" })).rejects.toMatchObject({
+      code: "CONVERSATION_NOT_IN_STREAM",
+      status: 400,
+    })
+  })
+
+  test("rejects when a selected message does not exist (404)", async () => {
+    setup({ conversations: { conv_a: makeConversation() }, primaries: {} })
+    await expect(reassign(["m2", "does_not_exist"], { kind: "new" })).rejects.toMatchObject({
+      code: "MESSAGE_NOT_FOUND",
+      status: 404,
+    })
+  })
+})

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -126,6 +126,30 @@ export interface SplitThreadResult {
   sourceConversation: ConversationWithStaleness
 }
 
+/** Where a batch reassignment lands: an existing conversation in the stream, or
+ *  a freshly minted one (the "split into its own topic" gesture). */
+export type ReassignMessagesTarget = { kind: "existing"; conversationId: string } | { kind: "new" }
+
+export interface ReassignMessagesParams {
+  workspaceId: string
+  /** The stream the selected messages live in — the anchor for a minted
+   *  conversation, and the stream every selected message must belong to. */
+  streamId: string
+  /** The messages to reassign (1..N). Deduped; order is re-derived from `sequence`. */
+  messageIds: string[]
+  /** Destination: an existing conversation in the stream, or a fresh mint. */
+  target: ReassignMessagesTarget
+  /** The correcting user — recorded with each moved message's feedback row. */
+  actorUserId: string
+}
+
+export interface ReassignMessagesResult {
+  /** The destination conversation (minted or existing) with final membership. */
+  conversation: ConversationWithStaleness
+  /** Every source conversation that lost members, with final membership. */
+  sourceConversations: ConversationWithStaleness[]
+}
+
 /**
  * Public interface for querying conversations.
  * Computes temporal staleness on read.
@@ -714,6 +738,242 @@ export class ConversationService {
         conversation: addStalenessFields(newConversation),
         sourceConversation: addStalenessFields(updatedSource),
       }
+    })
+  }
+
+  /**
+   * User correction from the timeline conversation overlay: reassign a hand-picked
+   * SET of messages to another conversation — an existing one, or a freshly minted
+   * one (the "these should be their own topic" split). The batch counterpart to
+   * {@link reassignMessage}; membership-only, like {@link splitThreadIntoConversation}
+   * — no message events move, so broadcast sequences and INV-61 contiguity are
+   * untouched (the messages stay in their stream).
+   *
+   * Concurrency: the message rows are locked first (INV-20) — the serialization
+   * point against a concurrent reassign/extraction of the same messages, as in
+   * {@link reassignMessage} — so `findPrimariesByMessageIds` is stable. Each touched
+   * source and an existing destination are then locked before their membership is
+   * read and their `participant_ids` recomputed, so a concurrent extraction can't
+   * clobber the arrays we SET. Locks are taken messages-then-conversations here;
+   * {@link splitThreadIntoConversation} takes them the other way, so two of these
+   * racing the same rows can deadlock — Postgres aborts one cleanly (no
+   * corruption), acceptable for a rare same-user correction. All member/feedback
+   * writes and the outbox events commit in one transaction (INV-6/7), delivered via
+   * the outbox (INV-4). A minted destination follows the fresh-mint precedent (no
+   * `topicSummary` — the extractor fills it), never copying a source title.
+   */
+  async reassignMessagesToConversation(params: ReassignMessagesParams): Promise<ReassignMessagesResult> {
+    const { workspaceId, streamId, messageIds, target, actorUserId } = params
+
+    return withTransaction(this.pool, async (client) => {
+      const uniqueIds = [...new Set(messageIds)]
+
+      // Lock the moving rows first (INV-20); `findByIdsForUpdate` returns them in
+      // `sequence` order — also the timeline order we preserve when appending to
+      // the destination.
+      const lockedMessages = await MessageRepository.findByIdsForUpdate(client, uniqueIds)
+      if (lockedMessages.length !== uniqueIds.length) {
+        throw new HttpError("Some selected messages were not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+      }
+      const messageById = new Map(lockedMessages.map((m) => [m.id, m]))
+      // A primary membership always lives in the message's own stream, and a mint
+      // anchors on `streamId`; so every selected message must be in this stream.
+      for (const message of lockedMessages) {
+        if (message.streamId !== streamId) {
+          throw new HttpError("All selected messages must belong to the same stream", {
+            status: 400,
+            code: "MESSAGE_NOT_IN_STREAM",
+          })
+        }
+      }
+      const orderedIds = lockedMessages.map((m) => m.id)
+
+      // Where each moving message currently lives (primary). Stable now that the
+      // message rows are locked — nothing can reassign them out from under us.
+      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
+
+      let destination: Conversation
+      if (target.kind === "existing") {
+        const existing = await ConversationRepository.findByIdForUpdate(client, workspaceId, target.conversationId)
+        if (!existing) {
+          throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+        }
+        if (existing.streamId !== streamId) {
+          throw new HttpError("Conversation is not in this stream", {
+            status: 400,
+            code: "CONVERSATION_NOT_IN_STREAM",
+          })
+        }
+        destination = existing
+      } else {
+        destination = await ConversationRepository.insert(client, {
+          id: generateConversationId(),
+          streamId,
+          workspaceId,
+          confidence: 1,
+          status: ConversationStatuses.ACTIVE,
+        })
+      }
+
+      // Skip messages already primary in the destination (a no-op reassign — e.g.
+      // re-running the same split).
+      const moveIds = orderedIds.filter((id) => primaries.get(id)?.id !== destination.id)
+      if (moveIds.length === 0) {
+        const fresh = await ConversationRepository.findById(client, destination.id)
+        if (!fresh) throw new Error(`Conversation ${destination.id} disappeared during reassignment`)
+        return { conversation: addStalenessFields(fresh), sourceConversations: [] }
+      }
+
+      // Group the move set by its current source (a selection can span more than
+      // one). Ids with no primary yet (extraction hasn't assigned them) carry no
+      // source — pure adds, recorded with a null `fromConversationId`.
+      const movedBySource = new Map<string, string[]>()
+      for (const id of moveIds) {
+        const sourceId = primaries.get(id)?.id
+        if (!sourceId) continue
+        const list = movedBySource.get(sourceId)
+        if (list) list.push(id)
+        else movedBySource.set(sourceId, [id])
+      }
+
+      // Lock each source row (INV-20), sorted for a deterministic order across
+      // concurrent batches, so its membership can be read and its participants
+      // recomputed without a concurrent extraction racing the write.
+      const sourceRows = new Map<string, Conversation>()
+      for (const sourceId of [...movedBySource.keys()].sort()) {
+        const row = await ConversationRepository.findByIdForUpdate(client, workspaceId, sourceId)
+        if (row) sourceRows.set(sourceId, row)
+      }
+
+      // Hydrate the authors of every message that stays in a source and every
+      // message already in the destination — needed to recompute the
+      // `participant_ids` we SET on the arrays below.
+      const authorLookupIds = new Set<string>(moveIds)
+      for (const row of sourceRows.values()) for (const id of row.messageIds) authorLookupIds.add(id)
+      for (const id of destination.messageIds) authorLookupIds.add(id)
+      const memberMessages = await MessageRepository.findByIds(client, [...authorLookupIds])
+
+      // Remove moved ids from each source, recomputing that source's remaining
+      // participants; resolve a source the move empties.
+      for (const [sourceId, movedFromSource] of movedBySource) {
+        const source = sourceRows.get(sourceId)
+        if (!source) continue
+        const movedSet = new Set(movedFromSource)
+        const remainingIds = source.messageIds.filter((id) => !movedSet.has(id))
+        await ConversationRepository.removePrimaryMessages(
+          client,
+          workspaceId,
+          sourceId,
+          movedFromSource,
+          distinctAuthors(remainingIds, memberMessages)
+        )
+        await ConversationRepository.resolveIfEmpty(client, workspaceId, sourceId)
+      }
+
+      // One feedback row per moved message (parity with the other correction
+      // paths), each recording its own source (or null) and stream (INV-56).
+      await ConversationFeedbackRepository.insertMany(
+        client,
+        moveIds.map((id) => ({
+          id: conversationFeedbackId(),
+          workspaceId,
+          streamId: messageById.get(id)!.streamId,
+          messageId: id,
+          fromConversationId: primaries.get(id)?.id ?? null,
+          toConversationId: destination.id,
+          userId: actorUserId,
+        }))
+      )
+
+      // Add the whole move set to the destination, recomputing its FULL participant
+      // list (existing members + arrivals) — `addPrimaryMessages` SETs participants,
+      // so an incomplete union would drop the existing ones.
+      await ConversationRepository.addPrimaryMessages(
+        client,
+        workspaceId,
+        destination.id,
+        moveIds,
+        distinctAuthors([...destination.messageIds, ...moveIds], memberMessages)
+      )
+      await ConversationRepository.reactivateIfInactive(client, workspaceId, destination.id)
+
+      const touchedIds = [destination.id, ...sourceRows.keys()]
+      await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
+
+      // Re-read every touched row post-write so the events carry final membership.
+      const finalById = new Map(
+        (await ConversationRepository.findByIds(client, workspaceId, touchedIds)).map((c) => [c.id, c])
+      )
+      const finalDestination = finalById.get(destination.id)
+      if (!finalDestination) {
+        throw new Error(`Conversation ${destination.id} disappeared during reassignment`)
+      }
+
+      // Every message, source, and destination shares one stream (guarded above),
+      // so one delivery resolution covers all of them (INV-62), as in
+      // {@link reassignMessage}.
+      const stream = await StreamRepository.findById(client, streamId)
+      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+
+      if (target.kind === "new") {
+        await OutboxRepository.insert(client, "conversation:created", {
+          workspaceId,
+          streamId: finalDestination.streamId,
+          conversationId: finalDestination.id,
+          conversation: addStalenessFields(finalDestination),
+          parentStreamId,
+          streamVisibility,
+        })
+      }
+
+      for (const id of touchedIds) {
+        // A minted destination is carried by the `conversation:created` above;
+        // emit `conversation:updated` for the existing rows only.
+        if (id === destination.id && target.kind === "new") continue
+        const conv = finalById.get(id)
+        if (!conv) continue
+        await OutboxRepository.insert(client, "conversation:updated", {
+          workspaceId,
+          streamId: conv.streamId,
+          conversationId: conv.id,
+          conversation: addStalenessFields(conv),
+          parentStreamId,
+          streamVisibility,
+        })
+      }
+
+      // Per-message move events route to each message's own stream (for the
+      // timeline membership map + extraction feedback), mirroring the other paths.
+      for (const id of moveIds) {
+        const fromConversationId = primaries.get(id)?.id ?? null
+        if (fromConversationId) {
+          await OutboxRepository.insert(client, "conversation:message_reassigned", {
+            workspaceId,
+            streamId: messageById.get(id)!.streamId,
+            messageId: id,
+            fromConversationId,
+            toConversationId: destination.id,
+            reason: "user_correction",
+          })
+        } else {
+          await OutboxRepository.insert(client, "conversation:message_assigned", {
+            workspaceId,
+            streamId: messageById.get(id)!.streamId,
+            parentStreamId,
+            messageId: id,
+            conversationId: destination.id,
+            isPrimary: true,
+            reason: "user_correction",
+          })
+        }
+      }
+
+      const sourceConversations = [...sourceRows.keys()]
+        .map((id) => finalById.get(id))
+        .filter((c): c is Conversation => c !== undefined)
+        .map(addStalenessFields)
+
+      return { conversation: addStalenessFields(finalDestination), sourceConversations }
     })
   }
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -760,10 +760,15 @@ export class ConversationService {
    * that could still cycle) — a message whose primary raced into an un-pre-locked
    * conversation is simply left where it is. Holding each source lock lets its
    * `participant_ids` be recomputed without a concurrent extraction clobbering the
-   * array. All member/feedback writes and the outbox events commit in one
-   * transaction (INV-6/7), delivered via the outbox (INV-4). A minted destination
-   * follows the fresh-mint precedent (no `topicSummary` — the extractor fills it),
-   * never copying a source title.
+   * array. (This total order is deadlock-free against itself and against
+   * {@link splitThreadIntoConversation}, also conversation-first. The singular
+   * {@link reassignMessage} takes locks the other way — message row first, then the
+   * conversation rows via its UPDATEs — the same pre-existing cross-order those two
+   * already have; a rare cross-path cycle there is transient, since `withTransaction`
+   * retries 40P01 with backoff.) All member/feedback writes and the outbox events
+   * commit in one transaction (INV-6/7), delivered via the outbox (INV-4). A minted
+   * destination follows the fresh-mint precedent (no `topicSummary` — the extractor
+   * fills it), never copying a source title.
    */
   async reassignMessagesToConversation(params: ReassignMessagesParams): Promise<ReassignMessagesResult> {
     const { workspaceId, streamId, messageIds, target, actorUserId } = params
@@ -831,7 +836,39 @@ export class ConversationService {
       }
       const orderedIds = lockedMessages.map((m) => m.id)
 
-      // Request validated — mint the destination now (no orphan on an early throw).
+      // Authoritative grouping, stable now the message rows are pinned. NO further
+      // conversation lock is taken here — a message already primary in the (existing)
+      // dest is a no-op, and one whose primary raced into a conversation we didn't
+      // pre-lock is left where it is (locking it now would be a conv lock after a
+      // message lock, the one ordering that could still cycle). Nothing is ever
+      // already primary in a not-yet-minted destination, so the "already there"
+      // exclusion only applies to an existing target.
+      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
+      const existingDestId = destination?.id ?? null
+      const moveIds = orderedIds.filter((id) => {
+        const currentId = primaries.get(id)?.id
+        if (existingDestId !== null && currentId === existingDestId) return false
+        return currentId == null || sourceRows.has(currentId)
+      })
+      if (moveIds.length === 0) {
+        if (destination) {
+          // Existing target: a legitimate no-op (everything already lives there).
+          const fresh = await ConversationRepository.findById(client, destination.id)
+          if (!fresh) throw new Error(`Conversation ${destination.id} disappeared during reassignment`)
+          return { conversation: addStalenessFields(fresh), sourceConversations: [] }
+        }
+        // New target with nothing left to move — every selected message was
+        // reassigned out from under us between the peek and the lock. The mint is
+        // deferred to exactly here, so we never created an orphan empty conversation
+        // (INV-57-adjacent: no dangling row); surface a conflict instead.
+        throw new HttpError("The selected messages are no longer available to move", {
+          status: 409,
+          code: "NO_MESSAGES_TO_MOVE",
+        })
+      }
+
+      // Something to move — mint the destination now for a new target (deferred to
+      // here so an all-raced-away selection above leaves no orphan row).
       if (!destination) {
         destination = await ConversationRepository.insert(client, {
           id: generateConversationId(),
@@ -843,23 +880,6 @@ export class ConversationService {
       }
       // Non-null past the mint; bind it so the closures below keep the narrowing.
       const dest = destination
-
-      // Authoritative grouping, stable now the message rows are pinned. NO further
-      // conversation lock is taken here — a message already primary in the dest is a
-      // no-op, and one whose primary raced into a conversation we didn't pre-lock is
-      // left where it is (locking it now would be a conv lock after a message lock,
-      // the one ordering that could still cycle).
-      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
-      const moveIds = orderedIds.filter((id) => {
-        const currentId = primaries.get(id)?.id
-        if (currentId === dest.id) return false
-        return currentId == null || sourceRows.has(currentId)
-      })
-      if (moveIds.length === 0) {
-        const fresh = await ConversationRepository.findById(client, dest.id)
-        if (!fresh) throw new Error(`Conversation ${dest.id} disappeared during reassignment`)
-        return { conversation: addStalenessFields(fresh), sourceConversations: [] }
-      }
 
       // Group the move set by its current source (a selection can span more than
       // one). Ids with no primary yet (extraction hasn't assigned them) carry no

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -749,18 +749,18 @@ export class ConversationService {
    * — no message events move, so broadcast sequences and INV-61 contiguity are
    * untouched (the messages stay in their stream).
    *
-   * Concurrency: the message rows are locked first (INV-20) — the serialization
-   * point against a concurrent reassign/extraction of the same messages, as in
-   * {@link reassignMessage} — so `findPrimariesByMessageIds` is stable. Each touched
-   * source and an existing destination are then locked before their membership is
-   * read and their `participant_ids` recomputed, so a concurrent extraction can't
-   * clobber the arrays we SET. Locks are taken messages-then-conversations here;
-   * {@link splitThreadIntoConversation} takes them the other way, so two of these
-   * racing the same rows can deadlock — Postgres aborts one cleanly (no
-   * corruption), acceptable for a rare same-user correction. All member/feedback
-   * writes and the outbox events commit in one transaction (INV-6/7), delivered via
-   * the outbox (INV-4). A minted destination follows the fresh-mint precedent (no
-   * `topicSummary` — the extractor fills it), never copying a source title.
+   * Concurrency (INV-20): conversation rows are locked BEFORE the message rows —
+   * the same order {@link splitThreadIntoConversation} uses — so two corrections
+   * racing the same conversation + messages can't form a lock cycle (no deadlock).
+   * The lock set is chosen from an unlocked peek at current membership, then the
+   * grouping is re-read authoritatively once the message rows are pinned; a source
+   * a message raced into between the two is late-locked (the messages are already
+   * held, so that can't loop). Holding each source lock lets its `participant_ids`
+   * be recomputed without a concurrent extraction clobbering the array. All
+   * member/feedback writes and the outbox events commit in one transaction
+   * (INV-6/7), delivered via the outbox (INV-4). A minted destination follows the
+   * fresh-mint precedent (no `topicSummary` — the extractor fills it), never
+   * copying a source title.
    */
   async reassignMessagesToConversation(params: ReassignMessagesParams): Promise<ReassignMessagesResult> {
     const { workspaceId, streamId, messageIds, target, actorUserId } = params
@@ -768,9 +768,43 @@ export class ConversationService {
     return withTransaction(this.pool, async (client) => {
       const uniqueIds = [...new Set(messageIds)]
 
-      // Lock the moving rows first (INV-20); `findByIdsForUpdate` returns them in
-      // `sequence` order — also the timeline order we preserve when appending to
-      // the destination.
+      // Conversation-before-message lock ordering (see the method doc). Sources
+      // are locked idempotently and in a deterministic order; `lockSource` skips
+      // the destination and anything already held.
+      const sourceRows = new Map<string, Conversation>()
+
+      // Unlocked peek: chooses the source lock set only. The authoritative
+      // grouping is re-read below once the messages are pinned.
+      const preReadPrimaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, uniqueIds)
+
+      // Lock the destination first: an existing target is locked now; a mint is
+      // deferred until after message validation so a bad request leaves no orphan.
+      let destination: Conversation | null = null
+      if (target.kind === "existing") {
+        const existing = await ConversationRepository.findByIdForUpdate(client, workspaceId, target.conversationId)
+        if (!existing) {
+          throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+        }
+        if (existing.streamId !== streamId) {
+          throw new HttpError("Conversation is not in this stream", {
+            status: 400,
+            code: "CONVERSATION_NOT_IN_STREAM",
+          })
+        }
+        destination = existing
+      }
+
+      const lockSource = async (id: string) => {
+        if (id === destination?.id || sourceRows.has(id)) return
+        const row = await ConversationRepository.findByIdForUpdate(client, workspaceId, id)
+        if (row) sourceRows.set(id, row)
+      }
+      for (const id of [...new Set([...preReadPrimaries.values()].map((c) => c.id))].sort()) {
+        await lockSource(id)
+      }
+
+      // Now lock the moving rows; `findByIdsForUpdate` returns them in `sequence`
+      // order — also the timeline order we preserve when appending to the dest.
       const lockedMessages = await MessageRepository.findByIdsForUpdate(client, uniqueIds)
       if (lockedMessages.length !== uniqueIds.length) {
         throw new HttpError("Some selected messages were not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
@@ -788,24 +822,8 @@ export class ConversationService {
       }
       const orderedIds = lockedMessages.map((m) => m.id)
 
-      // Where each moving message currently lives (primary). Stable now that the
-      // message rows are locked — nothing can reassign them out from under us.
-      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
-
-      let destination: Conversation
-      if (target.kind === "existing") {
-        const existing = await ConversationRepository.findByIdForUpdate(client, workspaceId, target.conversationId)
-        if (!existing) {
-          throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
-        }
-        if (existing.streamId !== streamId) {
-          throw new HttpError("Conversation is not in this stream", {
-            status: 400,
-            code: "CONVERSATION_NOT_IN_STREAM",
-          })
-        }
-        destination = existing
-      } else {
+      // Request validated — mint the destination now (no orphan on an early throw).
+      if (!destination) {
         destination = await ConversationRepository.insert(client, {
           id: generateConversationId(),
           streamId,
@@ -814,12 +832,23 @@ export class ConversationService {
           status: ConversationStatuses.ACTIVE,
         })
       }
+      // Non-null past the mint; bind it so the closures below keep the narrowing.
+      const dest = destination
+
+      // Authoritative grouping, stable now the message rows are pinned. A source a
+      // message raced into after the peek is late-locked here — the messages are
+      // already held, so this can't loop.
+      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
+      for (const id of orderedIds) {
+        const sourceId = primaries.get(id)?.id
+        if (sourceId) await lockSource(sourceId)
+      }
 
       // Skip messages already primary in the destination (a no-op reassign — e.g.
       // re-running the same split).
-      const moveIds = orderedIds.filter((id) => primaries.get(id)?.id !== destination.id)
+      const moveIds = orderedIds.filter((id) => primaries.get(id)?.id !== dest.id)
       if (moveIds.length === 0) {
-        const fresh = await ConversationRepository.findById(client, destination.id)
+        const fresh = await ConversationRepository.findById(client, dest.id)
         if (!fresh) throw new Error(`Conversation ${destination.id} disappeared during reassignment`)
         return { conversation: addStalenessFields(fresh), sourceConversations: [] }
       }
@@ -834,15 +863,6 @@ export class ConversationService {
         const list = movedBySource.get(sourceId)
         if (list) list.push(id)
         else movedBySource.set(sourceId, [id])
-      }
-
-      // Lock each source row (INV-20), sorted for a deterministic order across
-      // concurrent batches, so its membership can be read and its participants
-      // recomputed without a concurrent extraction racing the write.
-      const sourceRows = new Map<string, Conversation>()
-      for (const sourceId of [...movedBySource.keys()].sort()) {
-        const row = await ConversationRepository.findByIdForUpdate(client, workspaceId, sourceId)
-        if (row) sourceRows.set(sourceId, row)
       }
 
       // Hydrate the authors of every message that stays in a source and every
@@ -880,7 +900,7 @@ export class ConversationService {
           streamId: messageById.get(id)!.streamId,
           messageId: id,
           fromConversationId: primaries.get(id)?.id ?? null,
-          toConversationId: destination.id,
+          toConversationId: dest.id,
           userId: actorUserId,
         }))
       )

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -749,18 +749,21 @@ export class ConversationService {
    * — no message events move, so broadcast sequences and INV-61 contiguity are
    * untouched (the messages stay in their stream).
    *
-   * Concurrency (INV-20): conversation rows are locked BEFORE the message rows —
-   * the same order {@link splitThreadIntoConversation} uses — so two corrections
-   * racing the same conversation + messages can't form a lock cycle (no deadlock).
-   * The lock set is chosen from an unlocked peek at current membership, then the
-   * grouping is re-read authoritatively once the message rows are pinned; a source
-   * a message raced into between the two is late-locked (the messages are already
-   * held, so that can't loop). Holding each source lock lets its `participant_ids`
-   * be recomputed without a concurrent extraction clobbering the array. All
-   * member/feedback writes and the outbox events commit in one transaction
-   * (INV-6/7), delivered via the outbox (INV-4). A minted destination follows the
-   * fresh-mint precedent (no `topicSummary` — the extractor fills it), never
-   * copying a source title.
+   * Concurrency (INV-20): conversation rows are locked BEFORE the message rows,
+   * and EVERY one of them — an existing destination and all sources — in a single
+   * globally sorted order, so no two callers can take the same pair of rows in
+   * opposite orders (the AB-BA cycle a "destination first, then sources" order
+   * would allow when two calls target each other's conversations). The lock set is
+   * chosen from an unlocked peek at current membership; the grouping is re-read
+   * authoritatively once the messages are pinned, and no further conversation lock
+   * is ever taken after that (a conv lock after a message lock is the one ordering
+   * that could still cycle) — a message whose primary raced into an un-pre-locked
+   * conversation is simply left where it is. Holding each source lock lets its
+   * `participant_ids` be recomputed without a concurrent extraction clobbering the
+   * array. All member/feedback writes and the outbox events commit in one
+   * transaction (INV-6/7), delivered via the outbox (INV-4). A minted destination
+   * follows the fresh-mint precedent (no `topicSummary` — the extractor fills it),
+   * never copying a source title.
    */
   async reassignMessagesToConversation(params: ReassignMessagesParams): Promise<ReassignMessagesResult> {
     const { workspaceId, streamId, messageIds, target, actorUserId } = params
@@ -768,20 +771,29 @@ export class ConversationService {
     return withTransaction(this.pool, async (client) => {
       const uniqueIds = [...new Set(messageIds)]
 
-      // Conversation-before-message lock ordering (see the method doc). Sources
-      // are locked idempotently and in a deterministic order; `lockSource` skips
-      // the destination and anything already held.
-      const sourceRows = new Map<string, Conversation>()
-
-      // Unlocked peek: chooses the source lock set only. The authoritative
+      // Unlocked peek: chooses the conversation lock set only. The authoritative
       // grouping is re-read below once the messages are pinned.
       const preReadPrimaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, uniqueIds)
 
-      // Lock the destination first: an existing target is locked now; a mint is
-      // deferred until after message validation so a bad request leaves no orphan.
+      // Lock the destination + every source in ONE globally sorted order (see the
+      // method doc) — the destination is not special-cased first, so two calls
+      // targeting each other's conversations can't deadlock.
+      const existingDestinationId = target.kind === "existing" ? target.conversationId : null
+      const lockOrder = [
+        ...new Set([
+          ...(existingDestinationId ? [existingDestinationId] : []),
+          ...[...preReadPrimaries.values()].map((c) => c.id),
+        ]),
+      ].sort()
+      const lockedConversations = new Map<string, Conversation>()
+      for (const id of lockOrder) {
+        const row = await ConversationRepository.findByIdForUpdate(client, workspaceId, id)
+        if (row) lockedConversations.set(id, row)
+      }
+
       let destination: Conversation | null = null
-      if (target.kind === "existing") {
-        const existing = await ConversationRepository.findByIdForUpdate(client, workspaceId, target.conversationId)
+      if (existingDestinationId) {
+        const existing = lockedConversations.get(existingDestinationId)
         if (!existing) {
           throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
         }
@@ -794,13 +806,10 @@ export class ConversationService {
         destination = existing
       }
 
-      const lockSource = async (id: string) => {
-        if (id === destination?.id || sourceRows.has(id)) return
-        const row = await ConversationRepository.findByIdForUpdate(client, workspaceId, id)
-        if (row) sourceRows.set(id, row)
-      }
-      for (const id of [...new Set([...preReadPrimaries.values()].map((c) => c.id))].sort()) {
-        await lockSource(id)
+      // Sources = every locked conversation that isn't the destination.
+      const sourceRows = new Map<string, Conversation>()
+      for (const [id, row] of lockedConversations) {
+        if (id !== destination?.id) sourceRows.set(id, row)
       }
 
       // Now lock the moving rows; `findByIdsForUpdate` returns them in `sequence`
@@ -835,21 +844,20 @@ export class ConversationService {
       // Non-null past the mint; bind it so the closures below keep the narrowing.
       const dest = destination
 
-      // Authoritative grouping, stable now the message rows are pinned. A source a
-      // message raced into after the peek is late-locked here — the messages are
-      // already held, so this can't loop.
+      // Authoritative grouping, stable now the message rows are pinned. NO further
+      // conversation lock is taken here — a message already primary in the dest is a
+      // no-op, and one whose primary raced into a conversation we didn't pre-lock is
+      // left where it is (locking it now would be a conv lock after a message lock,
+      // the one ordering that could still cycle).
       const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, orderedIds)
-      for (const id of orderedIds) {
-        const sourceId = primaries.get(id)?.id
-        if (sourceId) await lockSource(sourceId)
-      }
-
-      // Skip messages already primary in the destination (a no-op reassign — e.g.
-      // re-running the same split).
-      const moveIds = orderedIds.filter((id) => primaries.get(id)?.id !== dest.id)
+      const moveIds = orderedIds.filter((id) => {
+        const currentId = primaries.get(id)?.id
+        if (currentId === dest.id) return false
+        return currentId == null || sourceRows.has(currentId)
+      })
       if (moveIds.length === 0) {
         const fresh = await ConversationRepository.findById(client, dest.id)
-        if (!fresh) throw new Error(`Conversation ${destination.id} disappeared during reassignment`)
+        if (!fresh) throw new Error(`Conversation ${dest.id} disappeared during reassignment`)
         return { conversation: addStalenessFields(fresh), sourceConversations: [] }
       }
 

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -535,6 +535,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     ...authed,
     conversation.splitThread
   )
+  app.post("/api/workspaces/:workspaceId/conversations/reassign-messages", ...authed, conversation.reassignMessages)
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/read", ...authed, conversation.markRead)
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/unread", ...authed, conversation.markUnread)
 

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -167,6 +167,21 @@ export const conversationsApi = {
   },
 
   /**
+   * User correction: reassign a set of selected messages to another conversation.
+   * A `targetConversationId` reassigns into that existing conversation; omit it to
+   * mint a new one (the split gesture). The backend applies every move in one
+   * transaction and records each as boundary-extraction feedback; the response
+   * carries the destination and every source that lost messages, so the overlay
+   * recolors immediately (the follow-up socket events are idempotent overwrites).
+   */
+  async reassignMessages(
+    workspaceId: string,
+    body: { streamId: string; messageIds: string[]; targetConversationId?: string | null }
+  ): Promise<{ conversation: ConversationWithStaleness; sourceConversations: ConversationWithStaleness[] }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/reassign-messages`, body)
+  },
+
+  /**
    * User edit of a conversation from the board card / panel: rename the topic
    * (`topicSummary`) and/or mark it resolved/reopened (`status`). At least one
    * field required; `status` is limited to `active`/`resolved`.

--- a/apps/frontend/src/components/thread/stream-panel.tsx
+++ b/apps/frontend/src/components/thread/stream-panel.tsx
@@ -241,7 +241,7 @@ export function StreamPanel({ workspaceId, onClose }: StreamPanelProps) {
 
   const handleSelectMessages = useCallback(() => {
     if (!panelId) return
-    dispatchStartBatchSelect(panelId)
+    dispatchStartBatchSelect(panelId, "moveToThread")
   }, [panelId])
 
   const panelMenuActions: SidebarActionItem[] = []

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState, type ReactNode } from "react"
-import { Check, ChevronUp, Layers, Loader2, X } from "lucide-react"
+import { Check, ChevronUp, Layers, Loader2, Plus, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import {
@@ -7,6 +7,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer"
@@ -262,61 +263,70 @@ export function ConversationOverlayRow({
           </span>
         )}
         {!selectionActive && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="Correct conversation for this message"
-              title="Correct conversation"
-              className={cn(
-                "reveal-actions absolute left-1 top-1/2 z-10 hidden h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full",
-                "border border-border/60 bg-popover shadow-sm sm:flex",
-                isPending && "opacity-100"
-              )}
-            >
-              {isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-              ) : (
-                <span
-                  aria-hidden
-                  className="h-2 w-2 rounded-full"
-                  style={{
-                    backgroundColor:
-                      colorIndex != null ? conversationColor(colorIndex) : "hsl(var(--muted-foreground) / 0.5)",
-                  }}
-                />
-              )}
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" side="right" className="w-64">
-            <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-              This message belongs to…
-            </DropdownMenuLabel>
-            {model.conversations.map((candidate) => {
-              const isCurrent = candidate.id === annotation.conversationId
-              const candidateColorIndex = model.colorIndexById.get(candidate.id) ?? 0
-              return (
-                <DropdownMenuItem
-                  key={candidate.id}
-                  disabled={isCurrent || isPending}
-                  onSelect={() => onReassignMessage(messageId, candidate.id)}
-                  className="gap-2"
-                >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Correct conversation for this message"
+                title="Correct conversation"
+                className={cn(
+                  "reveal-actions absolute left-1 top-1/2 z-10 hidden h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full",
+                  "border border-border/60 bg-popover shadow-sm sm:flex",
+                  isPending && "opacity-100"
+                )}
+              >
+                {isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                ) : (
                   <span
                     aria-hidden
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: conversationColor(candidateColorIndex) }}
+                    className="h-2 w-2 rounded-full"
+                    style={{
+                      backgroundColor:
+                        colorIndex != null ? conversationColor(colorIndex) : "hsl(var(--muted-foreground) / 0.5)",
+                    }}
                   />
-                  <span className="flex-1 truncate">{candidate.topicSummary || "Untitled conversation"}</span>
-                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                    {candidate.messageIds.length}
-                  </span>
-                  {isCurrent && <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
-                </DropdownMenuItem>
-              )
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                )}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="right" className="w-64">
+              <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                This message belongs to…
+              </DropdownMenuLabel>
+              {model.conversations.map((candidate) => {
+                const isCurrent = candidate.id === annotation.conversationId
+                const candidateColorIndex = model.colorIndexById.get(candidate.id) ?? 0
+                return (
+                  <DropdownMenuItem
+                    key={candidate.id}
+                    disabled={isCurrent || isPending}
+                    onSelect={() => onReassignMessage(messageId, candidate.id)}
+                    className="gap-2"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: conversationColor(candidateColorIndex) }}
+                    />
+                    <span className="flex-1 truncate">{candidate.topicSummary || "Untitled conversation"}</span>
+                    <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                      {candidate.messageIds.length}
+                    </span>
+                    {isCurrent && <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+                  </DropdownMenuItem>
+                )
+              })}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={isPending}
+                onSelect={() => onReassignMessage(messageId, null)}
+                className="gap-2"
+              >
+                <Plus className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">New conversation</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
     </div>
@@ -383,6 +393,22 @@ export function ConversationPickerDrawer({
               </button>
             )
           })}
+          <button
+            type="button"
+            disabled={isPending}
+            onClick={() => {
+              if (isPending) return
+              onOpenChange(false)
+              onReassignMessage(messageId, null)
+            }}
+            className={cn(
+              "mt-1 flex w-full items-center gap-3 rounded-lg border-t border-border/60 px-3 py-2.5 text-left text-sm transition-colors",
+              isPending ? "opacity-60" : "active:bg-muted/80"
+            )}
+          >
+            <Plus className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate">New conversation</span>
+          </button>
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -32,13 +32,14 @@ export function ConversationOverlayPanel({
   overlay,
   inViewConversations,
   onClose,
-  searchBarOpen = false,
+  topBarOpen = false,
 }: {
   overlay: ConversationOverlayContext
   inViewConversations: ConversationWithStaleness[]
   onClose: () => void
-  /** Stream search renders a full-width bar at the container top; drop below it. */
-  searchBarOpen?: boolean
+  /** A full-width strip (stream search, or the split-selection bar) occupies the
+   *  container top; drop the panel below it so it doesn't cover the bar's actions. */
+  topBarOpen?: boolean
 }) {
   const isMobile = useIsMobile()
   // Collapsed by default on mobile; the user's explicit choice wins once made.
@@ -49,7 +50,7 @@ export function ConversationOverlayPanel({
   return (
     <div
       data-testid="conversation-overlay-panel"
-      className={cn("absolute right-2 z-20 flex justify-end", !isMobile && (searchBarOpen ? "top-14" : "top-2"))}
+      className={cn("absolute right-2 z-20 flex justify-end", !isMobile && (topBarOpen ? "top-14" : "top-2"))}
       // --composer-height measures the floating pill itself; the pill also
       // floats above the container bottom and has the send-hint line under
       // it, so a plain +0.5rem (what Jump-to-latest uses, which sits flush

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -185,11 +185,15 @@ export function ConversationOverlayRow({
   overlay,
   annotation,
   messageId,
+  selectionActive = false,
   children,
 }: {
   overlay: ConversationOverlayContext
   annotation: ConversationRowAnnotation
   messageId: string
+  /** While a split selection is active the row is a selection toggle; the
+   *  single-message correction swatch is hidden so it can't intercept the tap. */
+  selectionActive?: boolean
   children: ReactNode
 }) {
   const { model, focusedConversationId, onReassignMessage, pendingMessageIds, observeRow } = overlay
@@ -257,6 +261,7 @@ export function ConversationOverlayRow({
             <span className="truncate">{conversation.topicSummary || "Untitled conversation"}</span>
           </span>
         )}
+        {!selectionActive && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -312,6 +317,7 @@ export function ConversationOverlayRow({
             })}
           </DropdownMenuContent>
         </DropdownMenu>
+        )}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-picker.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import type { ConversationWithStaleness } from "@threa/types"
+import { ConversationPickerDrawer } from "./conversation-overlay"
+import { buildConversationOverlayModel, type ConversationOverlayContext } from "./model"
+
+function makeConversation(overrides: Partial<ConversationWithStaleness>): ConversationWithStaleness {
+  return {
+    id: "conv_1",
+    streamId: "stream_123",
+    workspaceId: "ws_1",
+    messageIds: [],
+    participantIds: [],
+    secondaryMessageIds: [],
+    topicSummary: null,
+    summary: null,
+    completenessScore: 1,
+    confidence: 0.5,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: "2026-06-01T00:00:00.000Z",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    temporalStaleness: 0,
+    effectiveCompleteness: 1,
+    ...overrides,
+  }
+}
+
+function makeOverlay(onReassignMessage: ConversationOverlayContext["onReassignMessage"]): ConversationOverlayContext {
+  const conversations = [
+    makeConversation({ id: "conv_a", topicSummary: "Pizza", messageIds: ["msg_1"] }),
+    makeConversation({ id: "conv_b", topicSummary: "Deploys", messageIds: ["msg_2"] }),
+  ]
+  return {
+    model: buildConversationOverlayModel(conversations, "stream_123"),
+    focusedConversationId: null,
+    onToggleFocus: vi.fn(),
+    onReassignMessage,
+    pendingMessageIds: new Set(),
+    observeRow: () => () => {},
+  }
+}
+
+describe("ConversationPickerDrawer", () => {
+  it("reassigns to an existing conversation by id", () => {
+    const onReassignMessage = vi.fn<(messageId: string, toConversationId: string | null) => void>()
+    render(
+      <ConversationPickerDrawer
+        open
+        onOpenChange={vi.fn()}
+        overlay={makeOverlay(onReassignMessage)}
+        annotation={{ conversationId: "conv_a", blockStart: true }}
+        messageId="msg_1"
+      />
+    )
+    fireEvent.click(screen.getByText("Deploys"))
+    expect(onReassignMessage).toHaveBeenCalledWith("msg_1", "conv_b")
+  })
+
+  it("moves the message to a new conversation with a null target", () => {
+    const onReassignMessage = vi.fn<(messageId: string, toConversationId: string | null) => void>()
+    render(
+      <ConversationPickerDrawer
+        open
+        onOpenChange={vi.fn()}
+        overlay={makeOverlay(onReassignMessage)}
+        annotation={{ conversationId: "conv_a", blockStart: true }}
+        messageId="msg_1"
+      />
+    )
+    fireEvent.click(screen.getByText("New conversation"))
+    expect(onReassignMessage).toHaveBeenCalledWith("msg_1", null)
+  })
+})

--- a/apps/frontend/src/components/timeline/conversation-overlay/model.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/model.ts
@@ -120,8 +120,11 @@ export interface ConversationOverlayContext {
   /** Conversation being focused via the in-view panel; others dim. */
   focusedConversationId: string | null
   onToggleFocus: (conversationId: string) => void
-  /** User correction: move a message's primary membership. */
-  onReassignMessage: (messageId: string, toConversationId: string) => void
+  /**
+   * User correction: move a message's primary membership to an existing
+   * conversation, or to a freshly minted one when `toConversationId` is null.
+   */
+  onReassignMessage: (messageId: string, toConversationId: string | null) => void
   /**
    * messageIds with an in-flight correction, for pending affordance state.
    * A set rather than the latest mutation's variables: two rapid corrections

--- a/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-overlay.ts
+++ b/apps/frontend/src/components/timeline/conversation-overlay/use-conversation-overlay.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import type { ConversationWithStaleness } from "@threa/types"
-import { useConversations, useReassignConversationMessage } from "@/hooks/use-conversations"
+import {
+  useConversations,
+  useReassignConversationMessage,
+  useReassignMessagesToConversation,
+} from "@/hooks/use-conversations"
 import { buildConversationOverlayModel, type ConversationOverlayContext } from "./model"
 
 export interface ConversationOverlayState {
@@ -46,6 +50,10 @@ export function useConversationOverlay({
   const { conversations } = useConversations(workspaceId, streamId, { enabled })
   const [focusedConversationId, setFocusedConversationId] = useState<string | null>(null)
   const reassign = useReassignConversationMessage(workspaceId, streamId)
+  // "New conversation" reuses the bulk endpoint with a single id and a null
+  // target — the only path that mints a destination; the single-message
+  // endpoint moves to an existing conversation only.
+  const reassignToNew = useReassignMessagesToConversation(workspaceId, streamId)
 
   // Focus is ephemeral view state: drop it when the overlay closes or the
   // user navigates to another stream.
@@ -118,25 +126,36 @@ export function useConversationOverlay({
   // decorated rows' pending affordances.
   const [pendingMessageIds, setPendingMessageIds] = useState<ReadonlySet<string>>(() => new Set())
 
-  const { mutate } = reassign
+  const { mutate: mutateReassign } = reassign
+  const { mutate: mutateReassignToNew } = reassignToNew
   const onReassignMessage = useCallback(
-    (messageId: string, toConversationId: string) => {
+    (messageId: string, toConversationId: string | null) => {
       setPendingMessageIds((previous) => new Set(previous).add(messageId))
-      mutate(
+      const clearPending = () =>
+        setPendingMessageIds((previous) => {
+          const next = new Set(previous)
+          next.delete(messageId)
+          return next
+        })
+      if (toConversationId === null) {
+        mutateReassignToNew(
+          { messageIds: [messageId], targetConversationId: null },
+          {
+            onError: () => toast.error("Couldn't move the message to a new conversation"),
+            onSettled: clearPending,
+          }
+        )
+        return
+      }
+      mutateReassign(
         { messageId, toConversationId },
         {
           onError: () => toast.error("Couldn't move the message to that conversation"),
-          onSettled: () => {
-            setPendingMessageIds((previous) => {
-              const next = new Set(previous)
-              next.delete(messageId)
-              return next
-            })
-          },
+          onSettled: clearPending,
         }
       )
     },
-    [mutate]
+    [mutateReassign, mutateReassignToNew]
   )
 
   const context = useMemo(

--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -754,6 +754,7 @@ describe("timelineRowPropsEqual (memoized row comparator)", () => {
     const onToggleMessage = () => {}
     const batchWith = (selected: string[]) => ({
       enabled: true,
+      dragSelect: true,
       selectedMessageIds: new Set(selected),
       invalidTargetIds: new Set<string>(),
       hoveredTargetId: null,

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -54,6 +54,13 @@ interface EventListProps {
 export interface BatchTimelineState {
   /** Whether batch-selection mode is active. */
   enabled: boolean
+  /**
+   * Whether this batch uses the drag-onto-a-target gesture (move-to-thread). When
+   * false (split-conversation), rows must NOT get `touch-action: none` — the user
+   * scrolls the timeline by touch to reach far-apart messages, and selection is a
+   * plain tap toggle, so suppressing native pan would trap touch users.
+   */
+  dragSelect: boolean
   /** Message IDs currently selected for the batch operation. */
   selectedMessageIds: Set<string>
   /** Message IDs that are not valid drop targets during a drag. */

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -707,6 +707,10 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
           overlay={ctx.conversationOverlay}
           annotation={item.conversationRow}
           messageId={overlayMessageId}
+          // Split-select keeps the overlay mounted for its coloring, but the row
+          // is a selection toggle then — hide the single-message correction swatch
+          // so it can't steal the tap (it renders outside the row's `inert` slot).
+          selectionActive={ctx.batch?.enabled ?? false}
         >
           {eventNode}
         </ConversationOverlayRow>

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -15,6 +15,7 @@ import {
   Share2,
   CornerDownRight,
   Layers,
+  ListChecks,
   CheckCheck,
   CircleDot,
   Tag,
@@ -480,8 +481,8 @@ export const messageActions: MessageAction[] = [
     // messages, then reassign them to another conversation or split them into a
     // new one. Also overlay-gated (needs the conversation list to pick a target).
     id: "split-conversation",
-    label: "Select messages to move…",
-    icon: Layers,
+    label: "Move messages to conversation…",
+    icon: ListChecks,
     when: (ctx) => !!ctx.onSplitConversation,
     action: (ctx) => ctx.onSplitConversation?.(),
   },

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -161,6 +161,14 @@ export interface MessageActionContext {
    */
   onReassignConversation?: () => void
   /**
+   * Enter multi-select mode to reassign a SET of messages' conversation
+   * membership — into another conversation or a new one (the split gesture),
+   * seeded with this message. Set only while the conversation overlay is active
+   * (it supplies the target list). The batch counterpart to
+   * {@link onReassignConversation}.
+   */
+  onSplitConversation?: () => void
+  /**
    * Jump to where this message actually lives — its own stream timeline,
    * `?m=` highlighted. Set only on surfaces that render a message OUTSIDE its
    * home stream (the board card, the conversation panel, the label page), so
@@ -466,6 +474,16 @@ export const messageActions: MessageAction[] = [
     icon: Layers,
     when: (ctx) => !!ctx.onReassignConversation,
     action: (ctx) => ctx.onReassignConversation?.(),
+  },
+  {
+    // Multi-select counterpart of "Move to conversation…": select several
+    // messages, then reassign them to another conversation or split them into a
+    // new one. Also overlay-gated (needs the conversation list to pick a target).
+    id: "split-conversation",
+    label: "Select messages to move…",
+    icon: Layers,
+    when: (ctx) => !!ctx.onSplitConversation,
+    action: (ctx) => ctx.onSplitConversation?.(),
   },
   {
     // Destination-side discovery for messages that arrived via a move.

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -743,7 +743,10 @@ function MessageLayout({
             "before:content-[''] before:absolute before:-top-4 before:-bottom-4 before:left-0 before:right-0 before:bg-primary/[0.04] before:-z-10",
           isHighlighted && "animate-highlight-flash",
           isNew && !isHighlighted && "animate-new-message-fade",
-          batchEnabled && "cursor-pointer select-none touch-none",
+          batchEnabled && "cursor-pointer select-none",
+          // `touch-none` only for the drag-to-target gesture (move-to-thread);
+          // split mode is tap-only and must leave native touch scrolling intact.
+          batchEnabled && batch?.dragSelect && "touch-none",
           batchEnabled && isSelected && "bg-primary/[0.07] ring-1 ring-primary/45 ring-inset",
           batchEnabled && isInvalidTarget && "opacity-40 grayscale",
           batchEnabled && isHoveredTarget && "ring-2 ring-primary/60 ring-inset"

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -1213,7 +1213,15 @@ function SentMessageEvent({
       // and on archived streams to match the stream-header menu's gating.
       onMoveToThread:
         !batch?.enabled && !isThreadParentProp && !currentStream?.archivedAt
-          ? () => dispatchStartBatchSelect(streamId, payload.messageId)
+          ? () => dispatchStartBatchSelect(streamId, "moveToThread", payload.messageId)
+          : undefined,
+      // Multi-select entry into the conversation-split flow: reassign several
+      // messages' conversation membership at once. Only meaningful with the
+      // overlay on (it needs the conversation list to pick a target) and hidden
+      // during batch mode itself.
+      onSplitConversation:
+        conversationOverlayRow && !batch?.enabled && !currentStream?.archivedAt
+          ? () => dispatchStartBatchSelect(streamId, "splitConversation", payload.messageId)
           : undefined,
       // Destination-side discovery for moved messages. The drawer only
       // renders once the tombstone hydrates from IDB, so gate the menu

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -528,9 +528,11 @@ export function StreamContent({
   // correction swatch) — batch turns every row into a selection toggle, and the
   // overlay's swatch would compete for the same clicks. Split-conversation batch
   // mode KEEPS the overlay on: the coloring is what tells the user which topic
-  // each message currently belongs to while they pick what to move (the row is
-  // `inert` in batch mode, so the swatch can't compete anyway). The URL param is
-  // kept, so the overlay returns when move-to-thread batch mode ends.
+  // each message currently belongs to while they pick what to move. The overlay
+  // row hides its own correction swatch while a selection is active (the swatch
+  // renders outside the row's `inert` slot, so it needs its own gate — see
+  // `ConversationOverlayRow.selectionActive`). The URL param is kept, so the
+  // overlay returns when move-to-thread batch mode ends.
   const activeConversationOverlay = batchMode && batchIntent === "moveToThread" ? undefined : conversationOverlay
   const parentStreamId = stream?.parentStreamId
   const parentMessageId = stream?.parentMessageId

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useLayoutEffect, useCallback, useRef, useState } from "react"
 import { useLocation, useSearchParams } from "react-router-dom"
 import { Virtualizer, type VirtualizerHandle } from "virtua"
-import { MessageSquare, ArrowDown, ArrowUp, X, Move, Loader2, Check } from "lucide-react"
+import { MessageSquare, ArrowDown, ArrowUp, X, Move, Loader2, Check, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useQueryClient } from "@tanstack/react-query"
 import {
@@ -81,7 +81,15 @@ import { buildMessageConversationMap } from "./conversation-overlay/model"
 import type { ConversationOverlayContext } from "./conversation-overlay/model"
 import { MessageConversationProvider } from "./conversation-overlay/message-conversation-context"
 import { useConversationMembershipHeal } from "./conversation-overlay/use-conversation-membership-heal"
-import { useConversations } from "@/hooks/use-conversations"
+import { useConversations, useReassignMessagesToConversation } from "@/hooks/use-conversations"
+import { conversationColor } from "./conversation-overlay/model"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { MessageInput } from "./message-input"
 import { StreamDateHeader } from "./stream-date-header"
 import { JoinChannelBar } from "./join-channel-bar"
@@ -96,7 +104,7 @@ import { useStreamSearch } from "@/hooks/use-stream-search"
 import { useSearchHighlight } from "@/hooks/use-search-highlight"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { localStartOfDayMs } from "@/lib/dates"
-import { addStartBatchSelectListener } from "@/lib/batch-selection-events"
+import { addStartBatchSelectListener, type BatchSelectIntent } from "@/lib/batch-selection-events"
 import { addMarkReadUpToHereListener, addMarkUnreadListener } from "@/lib/mark-read-events"
 import { ReadFrontierContext, type ReadFrontier } from "./read-frontier-context"
 import { useReadMessageIds } from "@/hooks/use-unread-counts"
@@ -391,6 +399,10 @@ export function StreamContent({
   const user = useUser()
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [batchMode, setBatchMode] = useState(false)
+  // What the current batch selection is for. `moveToThread` (default) drags the
+  // selection onto a target message; `splitConversation` reassigns the selection's
+  // conversation membership via the footer target picker (no drag, no drop target).
+  const [batchIntent, setBatchIntent] = useState<BatchSelectIntent>("moveToThread")
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(() => new Set())
   const [hoveredBatchTargetId, setHoveredBatchTargetId] = useState<string | null>(null)
   const [dragGhost, setDragGhost] = useState<{ x: number; y: number } | null>(null)
@@ -512,11 +524,14 @@ export function StreamContent({
       { replace: true }
     )
   }, [setSearchParams])
-  // Batch-selection mode suspends the whole overlay (legend, rails, chips,
-  // correction swatch) — batch turns every row into a selection toggle, and
-  // the overlay's swatch would compete for the same clicks. The URL param is
-  // kept, so the overlay returns when batch mode ends.
-  const activeConversationOverlay = batchMode ? undefined : conversationOverlay
+  // Move-to-thread batch mode suspends the whole overlay (legend, rails, chips,
+  // correction swatch) — batch turns every row into a selection toggle, and the
+  // overlay's swatch would compete for the same clicks. Split-conversation batch
+  // mode KEEPS the overlay on: the coloring is what tells the user which topic
+  // each message currently belongs to while they pick what to move (the row is
+  // `inert` in batch mode, so the swatch can't compete anyway). The URL param is
+  // kept, so the overlay returns when move-to-thread batch mode ends.
+  const activeConversationOverlay = batchMode && batchIntent === "moveToThread" ? undefined : conversationOverlay
   const parentStreamId = stream?.parentStreamId
   const parentMessageId = stream?.parentMessageId
   const parentCachedEvents = useStreamEvents(parentStreamId ?? undefined)
@@ -774,8 +789,9 @@ export function StreamContent({
   )
 
   const startBatchSelect = useCallback(
-    (preselectedMessageId?: string) => {
+    (intent: BatchSelectIntent, preselectedMessageId?: string) => {
       setBatchMode(true)
+      setBatchIntent(intent)
       setSelectedMessageIds(preselectedMessageId ? new Set([preselectedMessageId]) : new Set())
       setHoveredBatchTargetId(null)
       setDragGhost(null)
@@ -820,7 +836,7 @@ export function StreamContent({
   useEffect(() => {
     return addStartBatchSelectListener((detail) => {
       if (detail.streamId !== streamId) return
-      startBatchSelect(detail.preselectedMessageId)
+      startBatchSelect(detail.intent, detail.preselectedMessageId)
     })
   }, [startBatchSelect, streamId])
 
@@ -899,6 +915,30 @@ export function StreamContent({
     setMoveAttempt(null)
   }, [isMoveConfirming])
 
+  // Split-conversation batch action: reassign the current selection to another
+  // conversation (`targetConversationId`) or a new one (null). Membership-only —
+  // no confirm dialog, unlike move-to-thread, since it's reversible by moving the
+  // messages back. Exits batch mode on success; the overlay recolors from cache.
+  const reassignMessages = useReassignMessagesToConversation(workspaceId, streamId)
+  const [isSplitting, setIsSplitting] = useState(false)
+  const runSplit = useCallback(
+    (targetConversationId: string | null) => {
+      const messageIds = Array.from(selectedMessageIds)
+      if (messageIds.length === 0 || isSplitting) return
+      setIsSplitting(true)
+      reassignMessages.mutate(
+        { messageIds, targetConversationId },
+        {
+          onSuccess: () => cancelBatchMode(),
+          onError: (error) =>
+            toast.error(error instanceof Error ? error.message : "Couldn't move the selected messages"),
+          onSettled: () => setIsSplitting(false),
+        }
+      )
+    },
+    [cancelBatchMode, isSplitting, reassignMessages, selectedMessageIds]
+  )
+
   // Phase derived from the single source of truth. Drives the inline status
   // row in the footer and the disabled/aria-busy state of the Move button.
   let movePhase: MovePhase
@@ -938,6 +978,9 @@ export function StreamContent({
           if (!pointer || pointer.id !== event.pointerId) return
           const distance = Math.hypot(event.clientX - pointer.x, event.clientY - pointer.y)
           if (!pointer.dragging && distance < 6) return
+          // Split mode has no drop target — dragging is meaningless, so never
+          // enter the drag branch; every gesture resolves as a tap toggle.
+          if (batchIntent === "splitConversation") return
           event.preventDefault()
           if (!pointer.dragging && !selectedMessageIds.has(pointer.messageId)) {
             setSelectedMessageIds((prev) => new Set(prev).add(pointer.messageId))
@@ -2013,7 +2056,20 @@ export function StreamContent({
                         onNavigate={handleSearchNavigate}
                       />
                     )}
-                    {batchMode && <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />}
+                    {batchMode &&
+                      (batchIntent === "splitConversation" ? (
+                        <SplitSelectionBar
+                          count={selectedMessageIds.size}
+                          conversations={conversationOverlay?.model.conversations ?? streamConversations}
+                          colorIndexById={conversationOverlay?.model.colorIndexById}
+                          busy={isSplitting}
+                          onMoveToExisting={runSplit}
+                          onCreateNew={() => runSplit(null)}
+                          onCancel={cancelBatchMode}
+                        />
+                      ) : (
+                        <BatchSelectionBar count={selectedMessageIds.size} onCancel={cancelBatchMode} />
+                      ))}
                     {activeConversationOverlay && (
                       <ConversationOverlayPanel
                         overlay={activeConversationOverlay}
@@ -2890,6 +2946,106 @@ function BatchSelectionBar({ count, onCancel }: { count: number; onCancel: () =>
       <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={onCancel} aria-label="Cancel selection">
         <X className="h-3.5 w-3.5" />
       </Button>
+    </div>
+  )
+}
+
+/**
+ * The split-conversation twin of {@link BatchSelectionBar}. Same flush-top strip,
+ * but instead of the drag-to-target hint it offers a target picker: reassign the
+ * selection into an existing conversation, or split it into a new one. No drag,
+ * no confirm dialog — membership moves are reversible.
+ */
+function SplitSelectionBar({
+  count,
+  conversations,
+  colorIndexById,
+  busy,
+  onMoveToExisting,
+  onCreateNew,
+  onCancel,
+}: {
+  count: number
+  conversations: ConversationWithStaleness[]
+  colorIndexById?: ReadonlyMap<string, number>
+  busy: boolean
+  onMoveToExisting: (conversationId: string) => void
+  onCreateNew: () => void
+  onCancel: () => void
+}) {
+  const disabled = count === 0 || busy
+
+  return (
+    <div
+      className={cn(
+        "absolute top-0 left-0 right-0 z-20",
+        "flex items-center gap-2 px-2 py-1.5 sm:px-4 sm:py-2",
+        "bg-background/95 backdrop-blur-sm border-b shadow-sm"
+      )}
+      style={{ userSelect: "none" }}
+    >
+      <div className="flex items-center gap-2 shrink-0">
+        <span
+          className={cn(
+            "inline-flex items-center justify-center h-6 min-w-6 px-1.5 rounded-full",
+            "text-xs font-medium tabular-nums tracking-tight transition-colors",
+            count > 0 ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground"
+          )}
+          aria-live="polite"
+        >
+          {count}
+        </span>
+        <span className="hidden sm:inline text-sm font-medium">
+          {count === 1 ? "message selected" : "messages selected"}
+        </span>
+      </div>
+
+      <div className="ml-auto flex items-center gap-1.5 shrink-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              className="h-7 gap-1.5"
+              disabled={disabled}
+              aria-label="Move selected messages to a conversation"
+            >
+              {busy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <Move className="h-3.5 w-3.5" aria-hidden />
+              )}
+              <span>Move to…</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="max-h-[50dvh] w-64 overflow-y-auto">
+            <DropdownMenuItem onSelect={() => onCreateNew()} className="gap-2">
+              <Plus className="h-4 w-4 shrink-0" aria-hidden />
+              <span>New conversation</span>
+            </DropdownMenuItem>
+            {conversations.length > 0 && <DropdownMenuSeparator />}
+            {conversations.map((conversation) => (
+              <DropdownMenuItem
+                key={conversation.id}
+                onSelect={() => onMoveToExisting(conversation.id)}
+                className="gap-2"
+              >
+                <span
+                  aria-hidden
+                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: conversationColor(colorIndexById?.get(conversation.id) ?? 0) }}
+                />
+                <span className="min-w-0 flex-1 truncate">{conversation.topicSummary || "Untitled conversation"}</span>
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {conversation.messageIds.length}
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onCancel} aria-label="Cancel selection">
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -848,12 +848,13 @@ export function StreamContent({
   const batchState = useMemo<BatchTimelineState | undefined>(
     () => ({
       enabled: batchMode,
+      dragSelect: batchIntent === "moveToThread",
       selectedMessageIds,
       invalidTargetIds: invalidBatchTargetIds,
       hoveredTargetId: hoveredBatchTargetId,
       onToggleMessage: toggleBatchMessage,
     }),
-    [batchMode, selectedMessageIds, invalidBatchTargetIds, hoveredBatchTargetId, toggleBatchMessage]
+    [batchMode, batchIntent, selectedMessageIds, invalidBatchTargetIds, hoveredBatchTargetId, toggleBatchMessage]
   )
 
   const findMessageIdFromPoint = useCallback((x: number, y: number) => {
@@ -953,7 +954,10 @@ export function StreamContent({
   const moveMessageCount = moveAttempt?.messageIds.length ?? 0
   const moveMessageCountLabel = `${moveMessageCount} selected message${moveMessageCount === 1 ? "" : "s"}`
 
-  const batchPointerHandlers = batchMode
+  // The drag-onto-a-target gesture belongs to move-to-thread only. Split mode
+  // attaches nothing here: each row toggles via its own `onClick`, so native
+  // touch scrolling stays intact (see BatchTimelineState.dragSelect).
+  const batchPointerHandlers = batchMode && batchIntent === "moveToThread"
     ? {
         onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
           const target = event.target as HTMLElement
@@ -978,9 +982,6 @@ export function StreamContent({
           if (!pointer || pointer.id !== event.pointerId) return
           const distance = Math.hypot(event.clientX - pointer.x, event.clientY - pointer.y)
           if (!pointer.dragging && distance < 6) return
-          // Split mode has no drop target — dragging is meaningless, so never
-          // enter the drag branch; every gesture resolves as a tap toggle.
-          if (batchIntent === "splitConversation") return
           event.preventDefault()
           if (!pointer.dragging && !selectedMessageIds.has(pointer.messageId)) {
             setSelectedMessageIds((prev) => new Set(prev).add(pointer.messageId))
@@ -2075,7 +2076,10 @@ export function StreamContent({
                         overlay={activeConversationOverlay}
                         inViewConversations={inViewConversations}
                         onClose={closeConversationOverlay}
-                        searchBarOpen={isSearchOpen}
+                        // Split mode keeps the overlay panel mounted while the
+                        // SplitSelectionBar occupies the flush-top strip; drop the
+                        // panel below it so it doesn't cover the bar's actions.
+                        topBarOpen={isSearchOpen || (batchMode && batchIntent === "splitConversation")}
                       />
                     )}
                     {isDraft && (
@@ -3042,7 +3046,18 @@ function SplitSelectionBar({
             ))}
           </DropdownMenuContent>
         </DropdownMenu>
-        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onCancel} aria-label="Cancel selection">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          // Disabled mid-request: the reassign can't be aborted (cancelBatchMode
+          // only resets local UI), and letting the bar vanish while the mutation
+          // still lands would silently reassign after an apparent cancel. Matches
+          // the move-to-thread dialog's Cancel guard.
+          disabled={busy}
+          onClick={onCancel}
+          aria-label="Cancel selection"
+        >
           <X className="h-3.5 w-3.5" />
         </Button>
       </div>

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -922,6 +922,12 @@ export function StreamContent({
   // conversation (`targetConversationId`) or a new one (null). Membership-only —
   // no confirm dialog, unlike move-to-thread, since it's reversible by moving the
   // messages back. Exits batch mode on success; the overlay recolors from cache.
+  //
+  // `streamId`, not `rootStreamId`: split is only reachable while the conversation
+  // overlay is active, which is CHANNEL/DM-only (`supportsConversationOverlay`) —
+  // never a thread — so `streamId` here IS the conversation root, matches the
+  // overlay's `useConversations` cache key, and is the stream the selected rows
+  // actually live in (the backend requires `message.streamId === streamId`).
   const reassignMessages = useReassignMessagesToConversation(workspaceId, streamId)
   const [isSplitting, setIsSplitting] = useState(false)
   const runSplit = useCallback(

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -73,6 +73,7 @@ export interface ConversationService {
   markRead: typeof conversationsApi.markRead
   markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
+  reassignMessages: typeof conversationsApi.reassignMessages
   updateConversation: typeof conversationsApi.updateConversation
   hideConversation: typeof conversationsApi.hideConversation
   unhideConversation: typeof conversationsApi.unhideConversation

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -633,6 +633,45 @@ export function useReassignConversationMessage(workspaceId: string, streamId: st
 }
 
 /**
+ * Batch counterpart of {@link useReassignConversationMessage}: reassign a set of
+ * selected messages to another conversation, or split them into a new one
+ * (`targetConversationId` omitted). The response carries the destination and
+ * every source that lost messages; they're written straight into the list cache
+ * so the overlay recolors immediately — a minted destination is appended if it
+ * isn't already present. The `conversation:*` socket events that follow are
+ * idempotent overwrites of the same rows.
+ */
+export function useReassignMessagesToConversation(workspaceId: string, streamId: string) {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      messageIds,
+      targetConversationId,
+    }: {
+      messageIds: string[]
+      targetConversationId?: string | null
+    }) => conversationService.reassignMessages(workspaceId, { streamId, messageIds, targetConversationId }),
+    onSuccess: ({ conversation, sourceConversations }) => {
+      const updatedById = new Map([conversation, ...sourceConversations].map((c) => [c.id, c]))
+      queryClient.setQueryData(
+        conversationKeys.list(workspaceId, streamId, {}),
+        (old: ConversationWithStaleness[] | undefined) => {
+          if (!old) return old
+          const merged = old.map((c) => updatedById.get(c.id) ?? c)
+          // A minted destination isn't in the list yet — append it.
+          return old.some((c) => c.id === conversation.id) ? merged : [...merged, conversation]
+        }
+      )
+      for (const id of [conversation.id, ...sourceConversations.map((c) => c.id)]) {
+        queryClient.invalidateQueries({ queryKey: conversationKeys.messages(id) })
+      }
+    },
+  })
+}
+
+/**
  * Rename a conversation's topic and/or mark it resolved/reopened from the board
  * card or conversation panel. Optimistic + self-reconciling: the change shows the
  * instant it's dispatched and settles on the HTTP response, no socket wait.

--- a/apps/frontend/src/lib/batch-selection-events.ts
+++ b/apps/frontend/src/lib/batch-selection-events.ts
@@ -1,21 +1,35 @@
 const START_BATCH_SELECT_EVENT = "threa:start-batch-select"
 
+/**
+ * What the batch selection is for:
+ * - `moveToThread` — the default: physically relocate the selected messages into
+ *   a thread (drag the selection onto a target message, confirm).
+ * - `splitConversation` — reassign the selected messages' conversation membership
+ *   to another conversation or a freshly minted one. Only meaningful while the
+ *   conversation overlay is on; tap to select, then pick a target.
+ */
+export type BatchSelectIntent = "moveToThread" | "splitConversation"
+
 interface BatchSelectEventDetail {
   streamId: string
+  intent: BatchSelectIntent
   /**
-   * When the move flow is launched from a per-message context menu, the
-   * single message acts as the initial selection so the user can either
-   * confirm immediately or extend the selection. Absent for the
-   * stream-level "Move messages…" entry, which starts with nothing
-   * selected.
+   * When the flow is launched from a per-message context menu, the single
+   * message acts as the initial selection so the user can either confirm
+   * immediately or extend the selection. Absent for the stream-level entry,
+   * which starts with nothing selected.
    */
   preselectedMessageId?: string
 }
 
-export function dispatchStartBatchSelect(streamId: string, preselectedMessageId?: string): void {
+export function dispatchStartBatchSelect(
+  streamId: string,
+  intent: BatchSelectIntent,
+  preselectedMessageId?: string
+): void {
   document.dispatchEvent(
     new CustomEvent<BatchSelectEventDetail>(START_BATCH_SELECT_EVENT, {
-      detail: { streamId, preselectedMessageId },
+      detail: { streamId, intent, preselectedMessageId },
     })
   )
 }

--- a/apps/frontend/src/pages/stream.tsx
+++ b/apps/frontend/src/pages/stream.tsx
@@ -317,7 +317,7 @@ export function StreamPage() {
   }
 
   const handleSelectMessages = () => {
-    dispatchStartBatchSelect(streamId)
+    dispatchStartBatchSelect(streamId, "moveToThread")
   }
 
   // System streams are read-only on the backend (e.g. activity/notification


### PR DESCRIPTION
## Problem

The timeline conversation overlay lets you correct one message's topic at a time — the per-message "Move to conversation…" action (`onReassignConversation` → `ConversationPickerDrawer` → `reassignMessage`, single message, existing conversation only). When a conversation has silently absorbed a run of messages that are really a separate topic (the recurring "everything got filed under *Fable*" case), there is no way to peel several of them off at once, and no way to send them to a **new** conversation. Multi-select already exists in the timeline but is wired solely to *move-to-thread* (physically relocating message events into a thread stream, drag-onto-target + confirm) — a different operation with different mechanics.

## Solution

Add a batch conversation reassignment: select N messages in the overlay, then move them into another conversation or split them into a freshly minted one. This is **membership-only** — it rewrites the `conversations` row arrays, exactly like `splitThreadIntoConversation`. No `stream_events` move, no `broadcast_sequence` allocation, so INV-61 timeline contiguity is untouched (the messages never leave their stream).

### How it works

**Backend** — `ConversationService.reassignMessagesToConversation` (`apps/backend/src/features/conversations/service.ts`), one `withTransaction`:

1. Lock the moving rows first via `MessageRepository.findByIdsForUpdate` — the serialization point against a concurrent reassign/extraction of the same messages (INV-20), and it returns them in `sequence` order (the order preserved when appending to the destination). Guard: every selected message must be in the request's `streamId` (`MESSAGE_NOT_IN_STREAM`); a missing id is `MESSAGE_NOT_FOUND`.
2. `findPrimariesByMessageIds` — stable now the rows are locked — resolves each message's current primary conversation.
3. Resolve the destination: `findByIdForUpdate` for an existing target (pinned to the same stream, `CONVERSATION_NOT_IN_STREAM`), or mint one with `ConversationRepository.insert` anchored on `streamId`, no `topicSummary` (fresh-mint precedent — the extractor fills the title, never a copied source title).
4. Drop messages already primary in the destination (no-op reassign — e.g. re-running the same split); early-return when nothing is left to move.
5. Group the move set by source (a selection may span more than one conversation). Lock each source row (sorted, deterministic order), recompute its remaining `participant_ids` from the survivors, `removePrimaryMessages`, then `resolveIfEmpty`.
6. One `conversation_feedback` row per moved message (`insertMany`), each recording its own source (or null) and stream — extractor ground truth, parity with the other correction paths.
7. `addPrimaryMessages` to the destination with the **union** of its existing members' authors and the arrivals (the array UPDATE SETs participants, so an incomplete union would drop existing ones), then `reactivateIfInactive`.
8. `bumpActivityForIds`, re-read the touched rows, and emit via the outbox (INV-4/6/7): `conversation:created` for a mint, `conversation:updated` for each existing touched row, and per moved message `conversation:message_reassigned` (had a source) or `conversation:message_assigned` (didn't). All touched rows share one stream, so one `resolveConversationDelivery` covers delivery (INV-62), as in `reassignMessage`.

`POST /api/workspaces/:workspaceId/conversations/reassign-messages` — `reassignMessages` handler, `reassignMessagesSchema` (Zod, INV-55): `streamId`, `messageIds` (1–100, matching the move-to-thread cap), optional `targetConversationId` (present → existing, absent/null → new). Access gates on the source stream via `validateStreamAccess`.

**Frontend**:

- `conversationsApi.reassignMessages` + `useReassignMessagesToConversation` — on success writes the returned destination + every source into the `conversationKeys.list` cache, appending a minted destination that isn't there yet, so the overlay recolors immediately; the follow-up `conversation:*` socket events are idempotent overwrites.
- `stream-content.tsx` gains a `batchIntent` (`"moveToThread" | "splitConversation"`) threaded through the batch-select event (`batch-selection-events.ts`). Split mode: keeps the conversation overlay **on** (its coloring is what tells you which topic each message currently belongs to; the row is `inert` in batch mode, so the correction swatch can't compete), disables drag-to-target (every gesture is a tap toggle), and renders `SplitSelectionBar` — a "Move to…" dropdown listing existing conversations (colored dot + title + count) plus "New conversation". No confirm dialog, unlike move-to-thread, since a membership move is reversible.
- Entry point: "Select messages to move…" message action (`onSplitConversation` in `message-actions.ts` / `message-event.tsx`), overlay-gated and hidden during batch mode, seeded with the clicked message. The existing single-message "Move to conversation…" and the drag-to-thread flow are unchanged.

### Key design decisions

**1. Membership reassignment, not a message move.** A conversation is a grouping over messages (`conversations.message_ids`), not a location, so a split only rewrites those arrays. Modeled on `splitThreadIntoConversation`, not the move-to-thread flow — the latter allocates fresh dense `broadcast_sequence` slots at the destination and declares `vacatedBroadcastSequences` on a `messages:moved` tombstone. None of that applies here because the messages stay put, so `computeTimelineHoles` never sees a gap.

**2. Lock messages first, then sources.** `reassignMessage` (the single-message sibling) uses the message-row lock as its serialization point; this batch path follows it, then locks each touched source before recomputing its participants so a concurrent extraction can't clobber the array. `splitThreadIntoConversation` takes the locks the other way (conversation-then-message), so two of these racing the exact same rows can deadlock — Postgres aborts one cleanly (no corruption), acceptable for a rare same-user correction. Documented on the method.

**3. Handle a multi-source selection.** Nothing stops a user selecting messages the extractor split across two conversations; the move set is grouped by current primary and each source is drained independently, rather than assuming one source.

**4. Split mode keeps the overlay on.** Move-to-thread batch mode suspends the overlay (its swatch competes for the tap); split mode needs the coloring to be legible while choosing, and the `inert` row already neutralizes the swatch — so the gating is now `batchMode && batchIntent === "moveToThread"`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/conversations/service.reassign-messages.test.ts` | Unit tests for the batch service method |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/service.ts` | `reassignMessagesToConversation` + `ReassignMessages{Target,Params,Result}` types |
| `apps/backend/src/features/conversations/handlers.ts` | `reassignMessages` handler + `reassignMessagesSchema` |
| `apps/backend/src/routes.ts` | `POST /conversations/reassign-messages` route |
| `apps/frontend/src/api/conversations.ts` | `reassignMessages` API client method |
| `apps/frontend/src/hooks/use-conversations.ts` | `useReassignMessagesToConversation` mutation hook |
| `apps/frontend/src/contexts/services-context.tsx` | Expose `reassignMessages` on `ConversationService` |
| `apps/frontend/src/lib/batch-selection-events.ts` | `BatchSelectIntent` on the start-batch-select event |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `batchIntent` state, split-mode gating, `runSplit`, `SplitSelectionBar` |
| `apps/frontend/src/components/timeline/message-event.tsx` | `onSplitConversation` wiring + intent on `onMoveToThread` |
| `apps/frontend/src/components/timeline/message-actions.ts` | `onSplitConversation` ctx + "Select messages to move…" item |
| `apps/frontend/src/pages/stream.tsx`, `apps/frontend/src/components/thread/stream-panel.tsx` | Pass `"moveToThread"` intent to existing `dispatchStartBatchSelect` callers |

## Out of scope (deliberate)

- **Auto-title.** A minted conversation is untitled and named by the boundary extractor, matching `splitThreadIntoConversation`. No title prompt (confirmed with the requester).
- **Empty-source shell.** Splitting a source's last members out leaves it auto-`resolveIfEmpty`'d — the same shell the single-message reassign already produces (dropped from the board feed via `cardinality(message_ids) > 0`; can linger in the overlay legend at 0 messages until re-clustered). Not changed here.
- **Brush/drag multi-select.** Selection is tap-to-toggle; no drag-across-rows range select (move-to-thread doesn't have it either).

## Test plan

- [x] `bun test apps/backend/src/features/conversations/` — 104 pass (8 new: mint, existing target with participant union, multi-source, no-op, and the cross-stream / wrong-stream-target / missing-message guards)
- [x] `bun test apps/backend/src/features/messaging/ apps/backend/src/features/conversations/` — 212 pass (shared `routes.ts` touched)
- [x] `bunx vitest run` over `src/components/timeline`, `src/components/board/board-card.split.test.tsx`, `src/components/conversations`, and the INV-63 toast guard — 440 pass
- [x] `tsc --noEmit` — backend and frontend clean
- [x] `eslint` on all changed files — clean
- [ ] No full-stack E2E — standing up Postgres + both apps wasn't practical in-session; coverage is unit/integration only, and the interaction reuses the existing batch-select machinery

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Let a user multi-select timeline messages in the conversation overlay and reassign them — to another conversation or a new one — in one action.

**What was built.** A membership-only batch reassign: backend service method + endpoint, frontend API client + hook, and a split-selection mode reusing the existing batch-select machinery with a target picker.

**Design decisions.** (1) Membership rewrite, not a message move — no broadcast-sequence / contiguity interaction (modeled on `splitThreadIntoConversation`). (2) Messages-first locking (serialization point), then per-source locks for race-safe participant recompute; deadlock vs `splitThreadIntoConversation` is possible but Postgres-safe. (3) Multi-source selections handled by grouping the move set by current primary. (4) Split mode keeps overlay coloring on; drag-to-target disabled.

**Schema changes.** None — reuses `conversations` / `conversation_feedback`.

**What's NOT included.** Title prompt (auto-titled), empty-source-shell cleanup, brush-select. See Out of scope.

**Status.** Complete; backend + frontend tests, typecheck, lint green. No live-DB E2E.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013qWZEqsTw8LeWeKdTBiyXu)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785963459&installation_id=129946197&pr_number=1225&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1225&signature=eff8631475e1c3e2cc6f12259f79b5c7da3d989672432a4ce66c164c5f0fd8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->