### PR TITLE
ci(evals): on-demand /eval slash command posts eval results to PRs

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -5,6 +5,178 @@ on:
     types: [created]
 
 jobs:
+  eval:
+    name: Run AI evals
+    # PR comments starting with `/eval` only. startsWith tolerates the trailing
+    # whitespace/newline GitHub appends to comment bodies.
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/eval')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Serialise eval requests per PR. Do NOT cancel in-progress — an eval spends
+    # real money on model calls, so let a running one finish rather than kill it.
+    concurrency:
+      group: eval-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_USER: threa
+          POSTGRES_PASSWORD: threa
+          POSTGRES_DB: threa
+        ports:
+          - 5454:5432
+        options: >-
+          --health-cmd "pg_isready -U threa -d threa"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Check write permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            if (!['write', 'admin'].includes(data.permission)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: `⛔ @${context.payload.comment.user.login} — you need write access to run evals.`,
+              });
+              core.setFailed('Insufficient permissions');
+            }
+
+      - name: Resolve PR head
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            // The job checks out and runs the PR head with the OPENROUTER secret
+            // in scope. Refuse fork PRs — running fork code with secrets is a
+            // token-exfiltration vector. Internal branches (claude/*) are fine.
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: '⛔ `/eval` runs the PR head with repo secrets, so it is limited to branches in this repository — not forks.',
+              });
+              core.setFailed('Refusing to run eval on a fork PR');
+              return;
+            }
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('ref', pr.head.ref);
+
+      - name: Acknowledge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      # Check out the PR's head so evals run against the code under review, not
+      # the default branch. Only write-access users reach this point.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Validate the command into a safe argv (allowlisted flags, charset-checked
+      # values). continue-on-error so a bad command posts a helpful reply rather
+      # than a bare red X.
+      - name: Parse command
+        id: parse
+        continue-on-error: true
+        env:
+          EVAL_COMMAND: ${{ github.event.comment.body }}
+        run: |
+          cd apps/backend
+          bun run evals/slash/parse-args.ts > /tmp/eval_args 2> /tmp/eval_error
+
+      - name: Report invalid command
+        if: steps.parse.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const err = (fs.readFileSync('/tmp/eval_error', 'utf8') || 'Invalid command.').trim();
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `⛔ **Eval command rejected:** ${err}\n\n` +
+                'Usage: `/eval [-s <suite>] [-c <case,ids>] [-m <model,ids>] [-r <runs>] [-t <temp>] [--min-pass-rate <n>]`\n' +
+                'Suites: `boundary-extraction` (default), `memo-classifier`, `memorizer`, `stream-naming`, `multimodal-vision`, `companion`.',
+            });
+            core.setFailed('Invalid /eval command');
+
+      # Run the eval. set +e captures the exit code (non-zero = a case missed its
+      # pass-rate threshold) without failing the step, so the report still posts.
+      - name: Run evals
+        id: run
+        if: steps.parse.outcome == 'success'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+        run: |
+          cd apps/backend
+          ARGS=$(cat /tmp/eval_args)
+          set +e
+          # ARGS is charset-validated (no spaces/quotes/globs) — safe to word-split.
+          bun run evals/run.ts $ARGS --no-langfuse --json /tmp/eval_results.json
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+
+      - name: Format report
+        if: steps.parse.outcome == 'success'
+        env:
+          EVAL_RESULTS_JSON: /tmp/eval_results.json
+          EVAL_SHA: ${{ steps.pr.outputs.sha }}
+          EVAL_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVAL_EXIT_CODE: ${{ steps.run.outputs.exit_code }}
+        run: |
+          cd apps/backend
+          EVAL_COMMAND="/eval $(cat /tmp/eval_args)" bun run evals/slash/format-report.ts > /tmp/eval_comment.md
+
+      - name: Post report
+        if: steps.parse.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/eval_comment.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });
+
   staging-reset-db:
     name: Reset PR staging database
     # Only run when the comment is on a PR (not a plain issue) and matches the command.

--- a/apps/backend/evals/README.md
+++ b/apps/backend/evals/README.md
@@ -38,6 +38,24 @@ bun run eval -- --config evals/example-config.yaml
 | `memo-classifier`     | Knowledge-worthiness classification |
 | `memorizer`           | Memo generation from messages       |
 
+## Run from a PR comment (`/eval`)
+
+Comment `/eval` on any PR to run a suite against that PR's code and get the
+results posted back as a comment (an at-a-glance table + per-case `<details>`,
+in the code-review report style). Requires write access. The `Slash Commands`
+workflow spins up postgres+pgvector, runs the eval, and posts the report.
+
+```
+/eval                                             # boundary-extraction, production config
+/eval -s memo-classifier -r 6 --min-pass-rate 0.8 # 6 runs, per-case pass rates
+/eval -m openrouter:openai/gpt-5.4-mini,openrouter:openai/gpt-5.4-nano  # compare models
+```
+
+Accepted flags mirror the CLI: `-s/--suite`, `-c/--case`, `-m/--model` (≤4),
+`-r/--runs` (≤12), `-p/--parallel` (≤8), `-t/--temperature`, `--min-pass-rate`.
+Values are allowlist-validated (`evals/slash/parse-args.ts`) — Langfuse is off
+and cost/latency are capped. Needs the `OPENROUTER_API_KEY` repo secret.
+
 ## Variance: tune against tallies, not single runs
 
 The components under test are stochastic even at low temperature — borderline

--- a/apps/backend/evals/slash/format-report.test.ts
+++ b/apps/backend/evals/slash/format-report.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test"
+import { formatReport, EVAL_REPORT_MARKER, type EvalReport, type FormatMeta } from "./format-report"
+
+const meta: FormatMeta = {
+  command: "/eval -s boundary-extraction -r 6",
+  sha: "abcdef1234567890",
+  runUrl: "https://github.com/o/r/actions/runs/1",
+  exitCode: 0,
+  hasResults: true,
+}
+
+function report(overrides: Partial<EvalReport["suites"][0]["permutations"][0]> = {}): EvalReport {
+  return {
+    suites: [
+      {
+        suiteName: "boundary-extraction",
+        permutations: [
+          {
+            model: "openrouter:openai/gpt-5.4-mini",
+            temperature: 0.2,
+            runs: 6,
+            executedModels: { "openrouter:openai/gpt-5.4-mini": 228 },
+            usage: { inputTokens: 1000, outputTokens: 500, totalCost: 0.0421 },
+            totalDurationMs: 42000,
+            runEvaluations: [{ name: "accuracy", score: 0.95, passed: true, details: null }],
+            cases: [
+              { caseId: "green-1", caseName: "g", passes: 6, runs: 6, passRate: 1, lastFailure: null },
+              {
+                caseId: "flaky-1",
+                caseName: "f",
+                passes: 4,
+                runs: 6,
+                passRate: 4 / 6,
+                lastFailure: [{ name: "conversation-decision", details: "Expected existing but got new" }],
+              },
+            ],
+            ...overrides,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe("formatReport", () => {
+  it("leads with the marker so runs can be identified/superseded", () => {
+    expect(formatReport(report(), meta).startsWith(EVAL_REPORT_MARKER)).toBe(true)
+  })
+
+  it("shows a green verdict, the command, the short SHA, and the summary row", () => {
+    const md = formatReport(report(), meta)
+    expect(md).toContain("✅ **All cases cleared their pass-rate threshold.**")
+    expect(md).toContain("`/eval -s boundary-extraction -r 6`")
+    expect(md).toContain("`abcdef1`")
+    expect(md).toContain("| boundary-extraction | `openai/gpt-5.4-mini` |")
+    expect(md).toContain("$0.0421")
+  })
+
+  it("renders a failing verdict counting red and flaky cases", () => {
+    const md = formatReport(report(), { ...meta, exitCode: 1 })
+    expect(md).toContain("❌ **1 case(s) below threshold** (0 red, 1 flaky).")
+  })
+
+  it("lists the flaky case with its pass rate and last failure in the details block", () => {
+    const md = formatReport(report(), meta)
+    expect(md).toContain("🟡 `flaky-1`")
+    expect(md).toContain("4/6")
+    expect(md).toContain("conversation-decision: Expected existing but got new")
+  })
+
+  it("escapes pipe characters in failure text so the table survives", () => {
+    const md = formatReport(
+      report({
+        cases: [
+          {
+            caseId: "red-1",
+            caseName: "r",
+            passes: 0,
+            runs: 6,
+            passRate: 0,
+            lastFailure: [{ name: "x", details: "got a | b | c" }],
+          },
+        ],
+      }),
+      meta
+    )
+    expect(md).toContain("got a \\| b \\| c")
+    expect(md).toContain("🔴 `red-1`")
+  })
+
+  it("emits a crash notice when no results were produced", () => {
+    const md = formatReport(null, { ...meta, exitCode: 1, hasResults: false })
+    expect(md).toContain("💥")
+    expect(md).toContain("crashed before producing results")
+    expect(md).toContain(meta.runUrl)
+  })
+})

--- a/apps/backend/evals/slash/format-report.ts
+++ b/apps/backend/evals/slash/format-report.ts
@@ -1,0 +1,187 @@
+/**
+ * Render an eval `--json` report into a GitHub-comment markdown overview, in
+ * the same at-a-glance style the code-review skill uses: a marker line, a
+ * verdict header, a summary table, per-permutation `<details>`, and a footer.
+ *
+ * Pure formatting — no I/O except the CLI wrapper at the bottom.
+ */
+
+export interface EvalCaseResult {
+  caseId: string
+  caseName: string
+  passes: number
+  runs: number
+  passRate: number
+  lastFailure: { name: string; details?: string | null }[] | null
+}
+
+export interface EvalPermutation {
+  model: string
+  temperature: number | null
+  runs: number
+  executedModels: Record<string, number>
+  usage: { inputTokens: number; outputTokens: number; totalCost: number } | null
+  totalDurationMs: number
+  runEvaluations: { name: string; score: number; passed: boolean; details: string | null }[]
+  cases: EvalCaseResult[]
+}
+
+export interface EvalReport {
+  suites: { suiteName: string; permutations: EvalPermutation[] }[]
+}
+
+export interface FormatMeta {
+  command: string
+  sha: string
+  runUrl: string
+  /** Eval CLI exit code: 0 = every case cleared its threshold, non-zero otherwise. */
+  exitCode: number
+  /** True when the results JSON was produced (distinguishes threshold-fail from a crash). */
+  hasResults: boolean
+}
+
+export const EVAL_REPORT_MARKER = "<!-- eval-report -->"
+
+const shortModel = (m: string) => m.replace(/^openrouter:/, "")
+
+function fmtDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const s = ms / 1000
+  if (s < 60) return `${s.toFixed(1)}s`
+  const m = Math.floor(s / 60)
+  return `${m}m${Math.round(s - m * 60)}s`
+}
+
+function cell(text: string): string {
+  // Keep table cells single-line and pipe-safe.
+  return text.replace(/\r?\n/g, " ").replace(/\|/g, "\\|").trim()
+}
+
+function truncate(text: string, max = 140): string {
+  return text.length > max ? text.slice(0, max - 1) + "…" : text
+}
+
+function caseStatus(c: EvalCaseResult): "green" | "flaky" | "red" {
+  if (c.passRate >= 1) return "green"
+  if (c.passRate <= 0) return "red"
+  return "flaky"
+}
+
+function failureSummary(c: EvalCaseResult): string {
+  if (!c.lastFailure || c.lastFailure.length === 0) return ""
+  return c.lastFailure.map((f) => (f.details ? `${f.name}: ${f.details}` : f.name)).join("; ")
+}
+
+function permutationRow(suiteName: string, p: EvalPermutation): string {
+  const green = p.cases.filter((c) => caseStatus(c) === "green").length
+  const flaky = p.cases.filter((c) => caseStatus(c) === "flaky").length
+  const red = p.cases.filter((c) => caseStatus(c) === "red").length
+  const runEvals =
+    p.runEvaluations.map((e) => `${e.passed ? "✅" : "❌"} ${e.name} ${e.score.toFixed(2)}`).join("<br>") || "—"
+  const casesCell = `${green}/${p.cases.length}` + (flaky ? ` · ${flaky} flaky` : "") + (red ? ` · ${red} red` : "")
+  const cost = p.usage ? `$${p.usage.totalCost.toFixed(4)}` : "—"
+  return `| ${cell(suiteName)} | \`${cell(shortModel(p.model))}\` | ${casesCell} | ${runEvals} | ${cost} | ${fmtDuration(p.totalDurationMs)} |`
+}
+
+function permutationDetails(suiteName: string, p: EvalPermutation): string {
+  const emoji = { green: "🟢", flaky: "🟡", red: "🔴" } as const
+  // Order: red first, then flaky, then green — problems surface at the top.
+  const rank = { red: 0, flaky: 1, green: 2 } as const
+  const rows = [...p.cases]
+    .sort((a, b) => rank[caseStatus(a)] - rank[caseStatus(b)])
+    .map((c) => {
+      const st = caseStatus(c)
+      const failure = st === "green" ? "" : cell(truncate(failureSummary(c)))
+      return `| ${emoji[st]} \`${cell(c.caseId)}\` | ${c.passes}/${c.runs} | ${failure} |`
+    })
+    .join("\n")
+
+  const executed =
+    Object.entries(p.executedModels)
+      .map(([m, n]) => `\`${shortModel(m)}\` (${n})`)
+      .join(", ") || "—"
+
+  const belowThreshold = p.cases.filter((c) => caseStatus(c) !== "green").length
+  const summary = `${suiteName} · ${shortModel(p.model)} — ${belowThreshold ? `${belowThreshold} case(s) below threshold` : "all green"}`
+
+  return [
+    `<details><summary>${cell(summary)}</summary>`,
+    "",
+    `| Case | Pass rate | Last failure |`,
+    `| --- | --- | --- |`,
+    rows,
+    "",
+    `Executed models: ${executed}`,
+    "</details>",
+  ].join("\n")
+}
+
+export function formatReport(report: EvalReport | null, meta: FormatMeta): string {
+  const lines: string[] = [EVAL_REPORT_MARKER, "### 🧪 Eval report"]
+
+  if (!report || !meta.hasResults) {
+    lines.push(
+      "",
+      `💥 **The eval run crashed before producing results.** [View run logs](${meta.runUrl}).`,
+      "",
+      `**Command:** \`${meta.command}\` · **Commit:** \`${meta.sha.slice(0, 7)}\``,
+      "",
+      "🤖 eval-runner"
+    )
+    return lines.join("\n")
+  }
+
+  const perms = report.suites.flatMap((s) => s.permutations.map((p) => ({ suiteName: s.suiteName, p })))
+  const flaky = perms.reduce((n, { p }) => n + p.cases.filter((c) => caseStatus(c) === "flaky").length, 0)
+  const red = perms.reduce((n, { p }) => n + p.cases.filter((c) => caseStatus(c) === "red").length, 0)
+  const totalCost = perms.reduce((sum, { p }) => sum + (p.usage?.totalCost ?? 0), 0)
+
+  const verdict =
+    meta.exitCode === 0
+      ? "✅ **All cases cleared their pass-rate threshold.**"
+      : `❌ **${red + flaky} case(s) below threshold** (${red} red, ${flaky} flaky).`
+
+  lines.push(
+    "",
+    verdict,
+    "",
+    `**Command:** \`${meta.command}\` · **Commit:** \`${meta.sha.slice(0, 7)}\` · [run log](${meta.runUrl})`,
+    "",
+    `| Suite | Model | Cases | Run evals | Cost | Time |`,
+    `| --- | --- | --- | --- | --- | --- |`,
+    ...perms.map(({ suiteName, p }) => permutationRow(suiteName, p)),
+    "",
+    ...perms.map(({ suiteName, p }) => permutationDetails(suiteName, p)),
+    "",
+    `Total cost: $${totalCost.toFixed(4)}`,
+    "",
+    "🤖 eval-runner"
+  )
+  return lines.join("\n")
+}
+
+if (import.meta.main) {
+  const path = process.env.EVAL_RESULTS_JSON
+  const meta: FormatMeta = {
+    command: process.env.EVAL_COMMAND ?? "/eval",
+    sha: process.env.EVAL_SHA ?? "",
+    runUrl: process.env.EVAL_RUN_URL ?? "",
+    // `||` (not `??`) so an empty string from a step that died early defaults
+    // to failure rather than parsing as 0 and showing a false green.
+    exitCode: Number(process.env.EVAL_EXIT_CODE || "1"),
+    hasResults: false,
+  }
+  let report: EvalReport | null = null
+  if (path) {
+    const file = Bun.file(path)
+    if (await file.exists()) {
+      try {
+        report = (await file.json()) as EvalReport
+        meta.hasResults = true
+      } catch {
+        report = null
+      }
+    }
+  }
+  process.stdout.write(formatReport(report, meta))
+}

--- a/apps/backend/evals/slash/parse-args.test.ts
+++ b/apps/backend/evals/slash/parse-args.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test"
+import { parseEvalCommand, EvalCommandError, DEFAULT_SUITE } from "./parse-args"
+
+describe("parseEvalCommand", () => {
+  it("defaults to the boundary-extraction suite when none is named", () => {
+    expect(parseEvalCommand("/eval")).toEqual({
+      args: ["-s", DEFAULT_SUITE],
+      echo: `/eval -s ${DEFAULT_SUITE}`,
+    })
+  })
+
+  it("passes through all supported flags in canonical order", () => {
+    const parsed = parseEvalCommand(
+      "/eval -s memo-classifier -c a-1,b_2 -m openrouter:openai/gpt-5.4-mini -r 6 -p 4 -t 0.2 --min-pass-rate 0.8"
+    )
+    expect(parsed.args).toEqual([
+      "-s",
+      "memo-classifier",
+      "-c",
+      "a-1,b_2",
+      "-m",
+      "openrouter:openai/gpt-5.4-mini",
+      "-r",
+      "6",
+      "-p",
+      "4",
+      "-t",
+      "0.2",
+      "--min-pass-rate",
+      "0.8",
+    ])
+  })
+
+  it("accepts long-form flags and ignores lines after the first", () => {
+    const parsed = parseEvalCommand("/eval --suite stream-naming --runs 3\nplease and thanks")
+    expect(parsed.args).toEqual(["-s", "stream-naming", "-r", "3"])
+  })
+
+  it("normalizes a comma-separated model list within the cap", () => {
+    const parsed = parseEvalCommand("/eval -m openrouter:openai/gpt-5.4-mini,openrouter:openai/gpt-5.4-nano")
+    expect(parsed.args).toEqual([
+      "-s",
+      DEFAULT_SUITE,
+      "-m",
+      "openrouter:openai/gpt-5.4-mini,openrouter:openai/gpt-5.4-nano",
+    ])
+  })
+
+  it("rejects a list with spaces after commas (whitespace truncates it)", () => {
+    expect(() => parseEvalCommand("/eval -m openrouter:a/b, openrouter:c/d")).toThrow(/no spaces/)
+  })
+
+  it("rejects a body that does not start with /eval", () => {
+    expect(() => parseEvalCommand("/evaluate now")).toThrow(EvalCommandError)
+    expect(() => parseEvalCommand("hello")).toThrow(EvalCommandError)
+  })
+
+  it("rejects an unknown suite", () => {
+    expect(() => parseEvalCommand("/eval -s not-a-suite")).toThrow(/Unknown suite/)
+  })
+
+  it("rejects an unknown flag rather than silently dropping it", () => {
+    expect(() => parseEvalCommand("/eval --danger rm")).toThrow(/Unknown argument/)
+  })
+
+  it("rejects shell-injection characters in values", () => {
+    expect(() => parseEvalCommand("/eval -c a;rm-rf")).toThrow(EvalCommandError)
+    expect(() => parseEvalCommand("/eval -m evil$(whoami)")).toThrow(EvalCommandError)
+    expect(() => parseEvalCommand("/eval -c `id`")).toThrow(EvalCommandError)
+  })
+
+  it("enforces the model-count cap", () => {
+    expect(() => parseEvalCommand("/eval -m a:b,c:d,e:f,g:h,i:j")).toThrow(/At most/)
+  })
+
+  it("enforces numeric bounds", () => {
+    expect(() => parseEvalCommand("/eval -r 99")).toThrow(/between 1 and 12/)
+    expect(() => parseEvalCommand("/eval -r 0")).toThrow(/between 1 and 12/)
+    expect(() => parseEvalCommand("/eval -p 100")).toThrow(/between 1 and 8/)
+    expect(() => parseEvalCommand("/eval -t 2")).toThrow(/between 0.0 and 1.0/)
+    expect(() => parseEvalCommand("/eval --min-pass-rate 5")).toThrow(/between 0.0 and 1.0/)
+  })
+
+  it("rejects a flag with a missing value", () => {
+    expect(() => parseEvalCommand("/eval -s")).toThrow(/requires a value/)
+    expect(() => parseEvalCommand("/eval -s -r 3")).toThrow(/requires a value/)
+  })
+})

--- a/apps/backend/evals/slash/parse-args.ts
+++ b/apps/backend/evals/slash/parse-args.ts
@@ -1,0 +1,174 @@
+/**
+ * Parse and validate a `/eval` slash-command comment into a safe argv for the
+ * eval CLI (`evals/run.ts`).
+ *
+ * Security: the comment body is attacker-influenced (anyone who can comment on
+ * a PR). The GitHub workflow gates execution on write-permission, but this
+ * parser is the second line of defence: it allowlists flags and character-
+ * validates every value, so a crafted comment can never inject shell tokens or
+ * unknown flags into the command line. Unknown tokens are a hard error, never
+ * silently dropped (INV-11).
+ */
+
+/** Suite names accepted by `-s` — kept in sync with `run.ts` `allSuites`. */
+export const EVAL_SUITES = [
+  "companion",
+  "stream-naming",
+  "boundary-extraction",
+  "multimodal-vision",
+  "memo-classifier",
+  "memorizer",
+] as const
+
+/** Default suite when the command names none — the cheap, high-signal one. */
+export const DEFAULT_SUITE = "boundary-extraction"
+
+/** Bounds that cap cost/latency of an on-demand run. */
+export const MAX_RUNS = 12
+export const MAX_MODELS = 4
+export const MAX_PARALLEL = 8
+
+const CASE_ID = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+// Model ids look like `openrouter:openai/gpt-5.4-mini`.
+const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/
+
+export interface ParsedEvalCommand {
+  /** Sanitized argv to pass after `bun run eval --` (excludes infra flags). */
+  args: string[]
+  /** Normalized single-line command echoed back to the user. */
+  echo: string
+}
+
+export class EvalCommandError extends Error {}
+
+function intInRange(raw: string, flag: string, min: number, max: number): string {
+  if (!/^\d+$/.test(raw)) throw new EvalCommandError(`\`${flag}\` expects an integer, got \`${raw}\`.`)
+  const n = Number(raw)
+  if (n < min || n > max) throw new EvalCommandError(`\`${flag}\` must be between ${min} and ${max}, got ${n}.`)
+  return String(n)
+}
+
+/**
+ * Split a comma-separated list value. Because the whole command is tokenized on
+ * whitespace first, a space inside the list (`a, b`) would silently truncate it
+ * — so an empty segment is a hard error pointing the user at the no-space form.
+ */
+function splitList(raw: string, label: string): string[] {
+  const parts = raw.split(",")
+  if (parts.some((p) => p === "")) {
+    throw new EvalCommandError(`${label} list must be comma-separated with no spaces (got \`${raw}\`).`)
+  }
+  return parts
+}
+
+function unitFloat(raw: string, flag: string): string {
+  if (!/^(0(\.\d+)?|1(\.0+)?)$/.test(raw)) {
+    throw new EvalCommandError(`\`${flag}\` must be a number between 0.0 and 1.0, got \`${raw}\`.`)
+  }
+  return raw
+}
+
+/**
+ * Parse the first line of a `/eval …` comment. Throws `EvalCommandError` with a
+ * user-facing message on anything invalid.
+ */
+export function parseEvalCommand(body: string): ParsedEvalCommand {
+  const firstLine = (body ?? "").trim().split("\n")[0]?.trim() ?? ""
+  const withoutPrefix = firstLine.replace(/^\/eval\b/, "")
+  if (withoutPrefix === firstLine) {
+    throw new EvalCommandError("Command must start with `/eval`.")
+  }
+
+  const tokens = withoutPrefix.split(/\s+/).filter(Boolean)
+
+  let suite: string | undefined
+  let cases: string | undefined
+  let models: string | undefined
+  let runs: string | undefined
+  let parallel: string | undefined
+  let temperature: string | undefined
+  let minPassRate: string | undefined
+
+  const takeValue = (flag: string, i: number): string => {
+    const v = tokens[i + 1]
+    if (v === undefined || v.startsWith("-")) throw new EvalCommandError(`\`${flag}\` requires a value.`)
+    return v
+  }
+
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]
+    switch (t) {
+      case "-s":
+      case "--suite": {
+        const v = takeValue(t, i++)
+        if (!(EVAL_SUITES as readonly string[]).includes(v)) {
+          throw new EvalCommandError(`Unknown suite \`${v}\`. Valid: ${EVAL_SUITES.join(", ")}.`)
+        }
+        suite = v
+        break
+      }
+      case "-c":
+      case "--case": {
+        const ids = splitList(takeValue(t, i++), "Case")
+        for (const id of ids) {
+          if (!CASE_ID.test(id)) throw new EvalCommandError(`Invalid case id \`${id}\`.`)
+        }
+        cases = ids.join(",")
+        break
+      }
+      case "-m":
+      case "--model": {
+        const ids = splitList(takeValue(t, i++), "Model")
+        if (ids.length > MAX_MODELS) {
+          throw new EvalCommandError(`At most ${MAX_MODELS} models can be compared at once (got ${ids.length}).`)
+        }
+        for (const id of ids) {
+          if (!MODEL_ID.test(id)) throw new EvalCommandError(`Invalid model id \`${id}\`.`)
+        }
+        models = ids.join(",")
+        break
+      }
+      case "-r":
+      case "--runs":
+        runs = intInRange(takeValue(t, i++), t, 1, MAX_RUNS)
+        break
+      case "-p":
+      case "--parallel":
+        parallel = intInRange(takeValue(t, i++), t, 1, MAX_PARALLEL)
+        break
+      case "-t":
+      case "--temperature":
+        temperature = unitFloat(takeValue(t, i++), t)
+        break
+      case "--min-pass-rate":
+        minPassRate = unitFloat(takeValue(t, i++), t)
+        break
+      default:
+        throw new EvalCommandError(`Unknown argument \`${t}\`. Supported: -s -c -m -r -p -t --min-pass-rate.`)
+    }
+  }
+
+  const args: string[] = []
+  args.push("-s", suite ?? DEFAULT_SUITE)
+  if (cases) args.push("-c", cases)
+  if (models) args.push("-m", models)
+  if (runs) args.push("-r", runs)
+  if (parallel) args.push("-p", parallel)
+  if (temperature) args.push("-t", temperature)
+  if (minPassRate) args.push("--min-pass-rate", minPassRate)
+
+  return { args, echo: `/eval ${args.join(" ")}`.trim() }
+}
+
+// CLI entry: `bun run evals/slash/parse-args.ts` reads $EVAL_COMMAND, prints the
+// sanitized args space-separated to stdout (safe: every token is charset-
+// validated). On invalid input, prints the reason to stderr and exits 1.
+if (import.meta.main) {
+  try {
+    const parsed = parseEvalCommand(process.env.EVAL_COMMAND ?? "")
+    process.stdout.write(parsed.args.join(" "))
+  } catch (error) {
+    process.stderr.write(error instanceof EvalCommandError ? error.message : String(error))
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Summary

Comment `/eval` on a PR to run an eval suite against **that PR's code** and get the results posted back as a comment — in the code-review skill's at-a-glance style (verdict header, summary table, per-permutation `<details>` with per-case pass rates and last failures). Targeted args mirror the eval CLI.

Motivation: the eval suites (`boundary-extraction`, `memo-classifier`, …) need a real DB + genuine model access to run, which isn't available when tuning prompts locally. This makes running them a one-line PR comment.

## Usage

```
/eval                                             # boundary-extraction, production config
/eval -s memo-classifier -r 6 --min-pass-rate 0.8 # 6 runs, per-case pass rates
/eval -m openrouter:openai/gpt-5.4-mini,openrouter:openai/gpt-5.4-nano  # compare models
```

Flags: `-s/--suite`, `-c/--case`, `-m/--model` (≤4), `-r/--runs` (≤12), `-p/--parallel` (≤8), `-t/--temperature`, `--min-pass-rate`.

## What changed

- **`.github/workflows/slash-commands.yml`** — new `eval` job on `issue_comment`. Spins up `pgvector/pgvector:pg17` (same service config as `ci.yml`), installs, parses the command, runs `evals/run.ts` with `--no-langfuse --json`, and posts the formatted report. Per-PR concurrency with **no** `cancel-in-progress` (a run spends real money on model calls); 30-min timeout.
- **`apps/backend/evals/slash/parse-args.ts`** — allowlist parser turning the comment into a safe argv. Validated flags only, charset-checked values, model/run/parallel caps, `boundary-extraction` default. Unknown tokens are a hard error (INV-11), never silently dropped.
- **`apps/backend/evals/slash/format-report.ts`** — pure formatter: `--json` report → markdown (marker + verdict + summary table + `<details>` per permutation). Distinguishes a below-threshold run (JSON present, exit 1) from a crash (no JSON).
- **Tests** — `parse-args.test.ts` (security-focused: injection chars, unknown flags, bounds, missing values, caps) and `format-report.test.ts` (verdict states, flaky/red rendering, pipe-escaping, crash notice). 18 cases.
- **`apps/backend/evals/README.md`** — a "Run from a PR comment" section.

## Design decisions

- **Runs the PR head, not the base** — you want to eval the proposed change. That means the checked-out code runs with the `OPENROUTER_API_KEY` secret in scope, so the job is gated on **write access** *and* **refuses fork PRs** (a fork could exfiltrate the secret). Internal `claude/*` branches — the actual use case — are unaffected.
- **Parsing/formatting live in tested TS, not YAML** — the security-critical arg validation and the report rendering are unit-tested modules; the workflow just wires them together.
- **Cost guards** — Langfuse off, `boundary-extraction` default (not "all suites"), model/run caps, no cancel-in-progress so a paid run isn't wasted.

## Requires

- `OPENROUTER_API_KEY` repo secret (already used in prod). `TAVILY_API_KEY` optional — only the `companion` suite's web-search tool needs it.

## Verification

- `parse-args` + `format-report` unit tests pass (18/18); backend `tsc` clean; eslint clean; workflow YAML validates. Both CLIs smoke-tested end-to-end (valid parse, rejected-injection, formatted report from a synthetic `--json`).
- Not verifiable in-sandbox: the live workflow run (needs the Actions runner, the pgvector service, and repo secrets). The postgres service config is copied verbatim from the passing `ci.yml` test job, so the DB-bootstrap path is CI-proven; the first real `/eval` comment exercises it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjuhUrjzq7aRsLhJ9DcqZA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964688&installation_id=129946197&pr_number=1227&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1227&signature=7fa30598df312b843e7f6b03da910c6b9df08ae95b65b6ca5f00966acf0b3f93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->