### PR TITLE
fix(conversations): stop entity-magnet clumping in boundary classifier

### DIFF
--- a/apps/backend/evals/suites/boundary-extraction/cases.ts
+++ b/apps/backend/evals/suites/boundary-extraction/cases.ts
@@ -1488,6 +1488,133 @@ Any ideas what's causing this?`,
     },
   },
 
+  // ── Entity-magnet resistance ─────────────────────────────────────────────
+  // The reported prod failure: several distinct conversations that all mention
+  // the model "Fable" (peripherally) collapsed into one conversation titled
+  // "Fable". A shared named entity is a subject, not a topic — a different
+  // question about the same name is a new conversation, and a fresh topic about
+  // a recurring name must be titled by its aspect, not the bare name.
+
+  {
+    id: "entity-magnet-distinct-aspect-001",
+    name: "Entity magnet: a different question about the same model opens a new conversation",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown: "Btw, hur bra är Fable på svenska egentligen? Funderar på att köra den för kundmejlen",
+      },
+      activeConversations: [
+        {
+          id: "conv_fable_pris",
+          topicSummary: "Fable-priser",
+          summary:
+            "Jämför Fable:s token-priser mot GPT för batch-jobb; output billigare, input dyrare. Öppen fråga exakt hur mycket dyrare input är.",
+          messageCount: 9,
+          lastMessagePreview: "ja input-priset är det enda som skaver",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 3,
+          contextMessageIds: ["msg_fpris_001", "msg_fpris_002"],
+        },
+      ],
+      recentMessages: [
+        {
+          id: "msg_fpris_001",
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "output-priset är typ halva GPT:s iallafall",
+          minutesAgo: 5,
+        },
+        {
+          id: "msg_fpris_002",
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "ja input-priset är det enda som skaver",
+          minutesAgo: 3,
+        },
+      ],
+      streamType: "dm",
+      category: "merge-resistance",
+    },
+    expectedOutput: {
+      // Same entity (Fable), different aspect (Swedish quality for support email)
+      // → a new conversation, and no collateral merge of the pricing thread.
+      expectNewConversation: true,
+      topicContains: ["svenska", "kundmejl", "kvalitet", "ton"],
+      expectNoReassignments: true,
+      minConfidence: 0.5,
+    },
+  },
+
+  {
+    id: "entity-magnet-name-aspect-001",
+    name: "Entity magnet: fresh topic about a recurring model is named by its aspect, not the bare name",
+    input: {
+      newMessage: {
+        authorId: "user_kris",
+        authorType: "user",
+        contentMarkdown:
+          "Fable verkar ha extremt lång kontext nu, typ 2M tokens. Undrar hur bra recall den har på riktigt",
+      },
+      activeConversations: [],
+      streamType: "dm",
+      category: "new-topic",
+    },
+    expectedOutput: {
+      expectNewConversation: true,
+      // Title must carry the aspect (context/recall), not just "Fable".
+      topicContains: ["kontext", "context", "recall", "token"],
+      minConfidence: 0.6,
+    },
+  },
+
+  {
+    id: "entity-magnet-same-aspect-continues-001",
+    name: "Entity continuity: a message advancing the same aspect stays in the conversation",
+    input: {
+      newMessage: {
+        authorId: "user_pierre",
+        authorType: "user",
+        contentMarkdown: "kollade nyss, input ligger på 3x GPT faktiskt, inte 2x",
+      },
+      activeConversations: [
+        {
+          id: "conv_fable_pris",
+          topicSummary: "Fable-priser",
+          summary:
+            "Jämför Fable:s token-priser mot GPT för batch-jobb; output billigare, input dyrare — exakt hur mycket dyrare är en öppen fråga.",
+          messageCount: 9,
+          lastMessagePreview: "input-priset är det enda som skaver",
+          participantIds: ["user_kris", "user_pierre"],
+          completenessScore: 5,
+          lastActivityMinutesAgo: 2,
+        },
+      ],
+      recentMessages: [
+        {
+          authorId: "user_kris",
+          authorType: "user",
+          contentMarkdown: "output-priset är typ halva GPT:s",
+          minutesAgo: 4,
+        },
+        {
+          authorId: "user_pierre",
+          authorType: "user",
+          contentMarkdown: "input-priset är det enda som skaver",
+          minutesAgo: 2,
+        },
+      ],
+      streamType: "dm",
+      category: "continue-existing",
+    },
+    expectedOutput: {
+      // Directly advances the same open pricing question → continues, no split.
+      expectConversationId: "conv_fable_pris",
+      minConfidence: 0.6,
+    },
+  },
+
   {
     id: "resolution-settled-plan-sv-001",
     name: "Resolution: agreed plan marks the conversation settled (Swedish)",

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -49,6 +49,9 @@ Messages carry an age like "(5m ago)" or "(2d ago)" and conversations carry "las
 ## Conversation summaries
 Conversations may carry a "covers:" summary of what has actually been discussed in them. Judge continuity against the summary, not just the title: continue a conversation only when the new message advances something the summary (or its recent messages) actually covers. A summary that already spans several loosely-related subjects is evidence the conversation has been over-extended — do NOT use its breadth as a reason to attach yet another subject; prefer a new conversation and let reassignment split things later.
 
+## A shared name is not a shared topic
+A person, product, model, project, or place named in the message is a SUBJECT the conversation is about — not the conversation itself. Two messages that both mention the same name are not the same conversation on that basis alone. "Fable is cheaper than GPT now", "does Fable handle Swedish well?", and "Fable is down again" are three separate conversations that merely share the word "Fable". Continue a conversation only when the new message advances the SAME question or aspect its summary and recent messages are actually about; a different question about the same recurring name OPENS A NEW conversation. This is the entity-magnet trap: a conversation whose title is a bare recurring name silently absorbs every later mention of that name, exactly like a catch-all label — resist it the same way you resist a busy live blob swallowing a focused topic.
+
 ## Choosing a conversation
 Decide in this order:
 
@@ -72,7 +75,7 @@ A message can belong to more than one conversation. If this new message clearly 
 If this new message reveals that one or more of the *Recent Messages* or messages from the *Active Conversations* was placed in the wrong conversation, move them. Each move needs a one-line reason. You can ONLY move messages whose IDs appear in this prompt — never any other. Examples of when to reassign:
 - The new message reveals the prior 1-2 messages were the start of a different topic (sandwich case).
 - The new message reopens a conversation that was prematurely marked resolved.
-- The new message shows two adjacent conversations are actually the same specific topic — move the smaller one into the larger. Same participants, same session, or "both are casual chat" is NOT the same topic: never fold a focused conversation into a broader or busier one, and never merge to tidy up. When in doubt, do not merge.
+- The new message shows two adjacent conversations are actually the same specific topic — move the smaller one into the larger. Same participants, same session, both naming the same person/product/model/project, or "both are casual chat" is NOT the same topic: never fold a focused conversation into a broader or busier one, and never merge to tidy up. When in doubt, do not merge.
 
 Reassignment is *the* mechanism for fixing classification mistakes, and it works in both directions — it is how conversations settle as more context arrives:
 - MERGE: the new message shows two threads are really one topic, or that an earlier message belongs with the current exchange — move it in.
@@ -94,6 +97,7 @@ Use it whenever the new message gives you evidence the prior placement was wrong
 When you set newConversationTopic, write a short title of 2-5 words that names the topic itself. Never exceed 5 words.
 - Lead with the subject. Do NOT add framing like "Discussion about", "Chat about", "Conversation regarding", "Thoughts on", "Questions about", and do NOT describe the tone ("Casual chat", "Quick question", "Banter about"). That a conversation discusses something is already implied — name the thing, not the act of discussing it.
 - Never use a vague catch-all label as a title: "General chat", "Reaction message", "Random", "Misc", "Off-topic", and the like name nothing and become a magnet that wrongly absorbs later messages. Always name the concrete subject the messages are actually about; if a short opener has no subject of its own, name what it is reacting to.
+- Name the specific aspect, not a bare recurring name. When the topic is one facet of a person, product, model, or project that comes up repeatedly, put the facet in the title ("Fable-priser", "Fable på svenska"), never the bare name alone — a lone recurring proper noun is a magnet that wrongly absorbs every later mention of it, the same failure as a catch-all label.
 - Do NOT state which language the conversation is in (never write "in Swedish", "auf Deutsch", etc.); that label is noise next to the conversation.
 - Write the title in the dominant language of the conversation, not English by default. If the participants are talking in Swedish, the title is in Swedish; if in Japanese, in Japanese. When the messages mix languages, follow the language the topic is actually discussed in and reuse the participants' own phrasing.
 - Keep names, products, technical terms, and other proper nouns exactly as they appear in the conversation. Never translate, localize, or re-spell them — carry the participants' own words into the title verbatim.


### PR DESCRIPTION
## Summary

Distinct conversations that all mention a recurring named entity (the reported case: the model **"Fable"**, peripheral to each) were collapsing into one conversation titled with the bare name. Two failure modes compounded:

1. A shared proper noun read as **topic continuity** — Fable came up in three different conversations (pricing, Swedish quality, "is it down"), so the classifier treated them as one.
2. The first got titled the bare word **"Fable"**, which then acted as a **magnet** absorbing every later mention. The existing guard only blocked generic catch-alls ("General chat"); a real name slipped through.

This is prompt-only tuning of the boundary classifier — no model or code-path change.

## What changed

`apps/backend/src/features/conversations/boundary-extraction/config.ts` (co-located config, INV-44):

- **New principle "A shared name is not a shared topic"** — a named person/product/model/project/place is a *subject*, not the conversation. Continue only when the message advances the *same question/aspect*; a different question about the same recurring name opens a new conversation.
- **Merge-resistance caution extended** — "sharing a named entity is not the same topic" now sits alongside same-session / same-participants / both-casual-chat.
- **Naming rule** — title the specific aspect ("Fable-priser", "Fable på svenska"), never the bare recurring name, which becomes a magnet like a catch-all label.

`apps/backend/evals/suites/boundary-extraction/cases.ts` — three `entity-magnet-*` cases:

- `entity-magnet-distinct-aspect-001` — a different question about the same model opens a new conversation (no collateral merge).
- `entity-magnet-name-aspect-001` — a fresh topic about a recurring name is titled by its aspect, not the bare name.
- `entity-magnet-same-aspect-continues-001` — a same-aspect follow-up still continues (guards against over-splitting).

## Verification

- Boundary-extraction unit tests pass; backend `tsc` clean.
- Ran the production extractor against a live model: the three new cases pass repeatedly, and titles came out aspect-named ("Fable på svenska", "Fable kontextlängd").
- Full existing suite: **no regression** vs the pre-tuning prompt (equal within model-proxy noise).
- The in-sandbox validation could only reach an older proxy model (real OpenRouter doesn't host the future-dated `gpt-5.4-mini`). **Comment `/eval -s boundary-extraction -r 6` on this PR** to validate against the actual production model.

## Note

This tunes *future* classification only — conversations already merged under "Fable" won't retroactively split (reassignment only fixes placements while messages are still in the recent window). Cleaning up the existing blob is a separate backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjuhUrjzq7aRsLhJ9DcqZA)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785991936&installation_id=129946197&pr_number=1228&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1228&signature=e47d1565da8ac01048b2f3c62e36da5c559db356ab0e1a28735c5af29526ccc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->