### PR TITLE
fix(memos): judge memo-worthiness by durability + agency, not topic

### DIFF
--- a/apps/backend/evals/fixtures/memo.ts
+++ b/apps/backend/evals/fixtures/memo.ts
@@ -8,6 +8,7 @@ import { ulid } from "ulid"
 import type { Memo } from "../../src/features/memos"
 import type { Conversation } from "../../src/features/conversations"
 import { MemoStatuses, MemoTypes, ConversationStatuses } from "@threa/types"
+import { formatRelativeDate } from "../../src/lib/temporal"
 import type { EvalClassifierMessage } from "../suites/memo-classifier/types"
 
 function escapeXml(text: string): string {
@@ -15,15 +16,18 @@ function escapeXml(text: string): string {
 }
 
 /**
- * Render messages exactly as MessageFormatter.formatMessages does in
- * production (the classifier counts messages by splitting on "<message"), but
- * from eval fixtures instead of DB rows.
+ * Render messages exactly as MessageFormatter.formatMessages does in production
+ * with `{ includeIds: true, relativeTo: now }` (the classifier counts messages by
+ * splitting on "<message"), but from eval fixtures instead of DB rows. Keep the
+ * attribute shape — including the relative `age` — in step with
+ * MessageFormatter.formatSingleMessage so evals exercise the real prompt (INV-45).
  */
 export function formatEvalMessages(messages: EvalClassifierMessage[], now: Date): string {
   const rendered = messages.map((m, i) => {
     const id = m.id ?? `msg_${ulid()}`
     const createdAt = new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000)
-    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
+    const age = escapeXml(formatRelativeDate(createdAt, now))
+    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}" age="${age}">${escapeXml(m.contentMarkdown)}</message>`
   })
   return `<messages>\n${rendered.join("\n")}\n</messages>`
 }

--- a/apps/backend/evals/fixtures/memo.ts
+++ b/apps/backend/evals/fixtures/memo.ts
@@ -8,28 +8,28 @@ import { ulid } from "ulid"
 import type { Memo } from "../../src/features/memos"
 import type { Conversation } from "../../src/features/conversations"
 import { MemoStatuses, MemoTypes, ConversationStatuses } from "@threa/types"
-import { formatRelativeDate } from "../../src/lib/temporal"
+import { renderMessagesXml } from "../../src/lib/ai/message-formatter"
 import type { EvalClassifierMessage } from "../suites/memo-classifier/types"
 
-function escapeXml(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
-}
-
 /**
- * Render messages exactly as MessageFormatter.formatMessages does in production
- * with `{ includeIds: true, relativeTo: now }` (the classifier counts messages by
- * splitting on "<message"), but from eval fixtures instead of DB rows. Keep the
- * attribute shape — including the relative `age` — in step with
- * MessageFormatter.formatSingleMessage so evals exercise the real prompt (INV-45).
+ * Render eval-fixture messages through the SAME production renderer the memo
+ * pipeline uses (`{ includeIds: true, relativeTo: now }`), so evals can't test a
+ * prompt that has drifted from production (INV-45). The fixtures already carry
+ * resolved author names, so no DB `Querier` is needed — only production's
+ * DB-bound name resolution is skipped, never the wire-format rendering itself.
  */
 export function formatEvalMessages(messages: EvalClassifierMessage[], now: Date): string {
-  const rendered = messages.map((m, i) => {
-    const id = m.id ?? `msg_${ulid()}`
-    const createdAt = new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000)
-    const age = escapeXml(formatRelativeDate(createdAt, now))
-    return `<message id="${id}" authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXml(m.authorName)}" createdAt="${createdAt.toISOString()}" age="${age}">${escapeXml(m.contentMarkdown)}</message>`
-  })
-  return `<messages>\n${rendered.join("\n")}\n</messages>`
+  return renderMessagesXml(
+    messages.map((m, i) => ({
+      id: m.id ?? `msg_${ulid()}`,
+      authorType: m.authorType,
+      authorId: m.authorId,
+      authorName: m.authorName,
+      contentMarkdown: m.contentMarkdown,
+      createdAt: new Date(now.getTime() - (m.minutesAgo ?? (messages.length - i) * 2) * 60_000),
+    })),
+    { includeIds: true, relativeTo: now }
+  )
 }
 
 export function toConversation(input: { topicSummary: string | null; participantIds: string[] }): Conversation {

--- a/apps/backend/evals/suites/memo-classifier/cases.ts
+++ b/apps/backend/evals/suites/memo-classifier/cases.ts
@@ -92,6 +92,58 @@ export const memoClassifierCases: EvalCase<MemoClassifierInput, MemoClassifierEx
   },
 
   {
+    id: "transient-status-not-worthy-001",
+    name: "Transient: an ephemeral 'it's broken right now' status is not durable knowledge",
+    input: {
+      topicSummary: "View run",
+      category: "transient",
+      messages: [
+        { ...KRIS, contentMarkdown: "btw view run är trasig just nu, bara vitt", minutesAgo: 12 },
+        { ...PIERRE, contentMarkdown: "ah, throwar den något i konsolen?", minutesAgo: 10 },
+        { ...KRIS, contentMarkdown: "orkar inte kika nu, får ta det sen", minutesAgo: 8 },
+        { ...PIERRE, contentMarkdown: "ok", minutesAgo: 7 },
+      ],
+    },
+    // Passing status of a feature, unresolved and stale within the hour: nothing
+    // durable was produced (no cause, no fix, no decision). Not the topic's fault
+    // — a *fix* for the same bug would be worthy; a bare "it's broken now" is not.
+    expectedOutput: { expectKnowledgeWorthy: false },
+  },
+
+  {
+    id: "tool-behavior-learning-001",
+    name: "Agency: a validated tool-behavior learning that changes how they work IS knowledge (topic-neutral)",
+    input: {
+      topicSummary: "Agentens tolkning av vaga svar",
+      category: "knowledge",
+      messages: [
+        {
+          ...KRIS,
+          contentMarkdown:
+            "märkte en grej med agenten: säger jag inte tydligt nej så tolkar den vaga svar som go-ahead",
+          minutesAgo: 30,
+        },
+        { ...PIERRE, contentMarkdown: "på riktigt? reproducerbart?", minutesAgo: 27 },
+        {
+          ...KRIS,
+          contentMarkdown:
+            "ja, konsekvent över flera turns. Så nu skriver jag alltid ett explicit stopp när jag är osäker",
+          minutesAgo: 22,
+        },
+        {
+          ...PIERRE,
+          contentMarkdown: "bra fynd, då lägger vi in en explicit-nej-regel i våra prompts",
+          minutesAgo: 18,
+        },
+      ],
+    },
+    // Same subject family as model-release-chatter (an AI model's behavior), but
+    // this is participant-discovered, validated, and it changed their practice —
+    // durable knowledge. The verdict must turn on agency, not on the topic.
+    expectedOutput: { expectKnowledgeWorthy: true },
+  },
+
+  {
     id: "procedure-setup-001",
     name: "Knowledge: a working setup with the how is worth keeping",
     input: {

--- a/apps/backend/evals/suites/memo-classifier/types.ts
+++ b/apps/backend/evals/suites/memo-classifier/types.ts
@@ -26,7 +26,7 @@ export interface MemoClassifierInput {
   messages: EvalClassifierMessage[]
   /** Active memos already sourced from this conversation (revision path). */
   existingMemos?: EvalExistingMemo[]
-  category?: "chatter" | "news-reactions" | "logistics" | "knowledge" | "mixed" | "revision"
+  category?: "chatter" | "news-reactions" | "logistics" | "knowledge" | "mixed" | "revision" | "transient"
 }
 
 export interface MemoClassifierOutput {

--- a/apps/backend/evals/suites/memorizer/cases.ts
+++ b/apps/backend/evals/suites/memorizer/cases.ts
@@ -63,6 +63,51 @@ export const memorizerCases: EvalCase<MemorizerInput, MemorizerExpected>[] = [
   },
 
   {
+    id: "transient-status-yields-nothing-001",
+    name: "Selectivity: an ephemeral 'broken right now' status produces no memo",
+    input: {
+      category: "transient",
+      messages: [
+        { ...KRIS, contentMarkdown: "btw view run är trasig just nu, bara vitt", minutesAgo: 12 },
+        { ...PIERRE, contentMarkdown: "ah, throwar den något?", minutesAgo: 10 },
+        { ...KRIS, contentMarkdown: "orkar inte kika nu, tar det sen", minutesAgo: 8 },
+        { ...PIERRE, contentMarkdown: "ok", minutesAgo: 7 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 0,
+    },
+  },
+
+  {
+    id: "tool-behavior-learning-captured-001",
+    name: "Extraction: a validated tool-behavior learning that changed their practice is captured",
+    input: {
+      category: "extraction",
+      messages: [
+        {
+          ...KRIS,
+          contentMarkdown:
+            "märkte en grej med agenten: säger jag inte tydligt nej så tolkar den vaga svar som go-ahead",
+          minutesAgo: 30,
+        },
+        { ...PIERRE, contentMarkdown: "reproducerbart?", minutesAgo: 27 },
+        {
+          ...KRIS,
+          contentMarkdown: "ja, konsekvent. Så nu skriver jag alltid ett explicit stopp när jag är osäker",
+          minutesAgo: 22,
+        },
+        { ...PIERRE, contentMarkdown: "bra fynd, vi lägger in en explicit-nej-regel i prompten", minutesAgo: 18 },
+      ],
+    },
+    expectedOutput: {
+      maxMemos: 2,
+      minMemos: 1,
+      mustCoverAny: [["go-ahead", "vaga", "tolkar", "explicit", "stopp", "nej"]],
+    },
+  },
+
+  {
     id: "revision-all-covered-001",
     name: "Revision: rephrased already-captured facts yield an empty set",
     input: {

--- a/apps/backend/evals/suites/memorizer/types.ts
+++ b/apps/backend/evals/suites/memorizer/types.ts
@@ -10,7 +10,7 @@ export interface MemorizerInput {
   memoryContext?: string[]
   /** Existing memos for this conversation — presence selects the revision path. */
   existingMemos?: EvalExistingMemo[]
-  category?: "extraction" | "revision" | "selectivity"
+  category?: "extraction" | "revision" | "selectivity" | "transient"
 }
 
 export interface MemorizerOutputMemo {

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -203,22 +203,26 @@ export type MemoSetOutput = z.infer<typeof memoSetSchema>
 
 export const CLASSIFIER_CONVERSATION_SYSTEM_PROMPT = `You are a knowledge classifier for a team chat application. You identify conversations that contain valuable knowledge worth preserving in organizational memory.
 
+Two tests decide it. Both turn on what the participants PRODUCED, never on the subject — any topic can pass or fail:
+- DURABILITY: would the core still be true and useful in six months? A decision, a worked-out procedure, a validated finding lasts. A passing state ("X is broken right now", "the deploy is green") is true for an hour and worthless after — not durable.
+- AGENCY: did the participants produce this themselves — decide it, work it out, validate it through their own experience — or just voice a reaction to something outside their control that set no direction? Producing knowledge passes; reacting does not.
+
 Knowledge-worthy conversations:
 - Document decisions with context and rationale
 - Capture procedures or processes that were worked out
-- Record learnings from debugging, incidents, or experiments
-- Establish context about why things are the way they are
+- Record learnings the participants discovered or validated themselves (from debugging, incidents, experiments, or observing a tool they build with behave a certain way)
+- Establish durable context about WHY things are the way they are
 - Contain reference information that will be useful later
 
 NOT knowledge-worthy:
 - Pure social chat or banter
-- Brief status exchanges
-- Reactions to news, product releases, or announcements — impressions, hot takes, and opinions about third-party events that set no direction for the participants' own work ("the new model looks disappointing", "did you see the leak?") are commentary, not knowledge
+- Transient status: a bare "it's broken / it works / it's slow right now" with no cause, fix, or decision — the state is stale within the hour, so nothing durable was produced (the FIX for that same bug WOULD be worthy — judge by what was produced, not the subject)
+- Reactions to news, product releases, or announcements — hot takes and impressions about things outside the participants' control that set no direction for their own work ("the new model looks disappointing", "did you see the leak?") fail the agency test. This is topic-neutral: the SAME subject becomes worthy the moment the participants turn it into something they produced — a validated learning about how a tool behaves, or a decision to adopt or drop it.
 - Personal small talk: travel plans, whereabouts, moods, weekend logistics
 - Conversations where important information is in external links only
 - Incomplete discussions that trail off without resolution
 
-A conversation is not knowledge-worthy just because it is long or touches technical subjects. Judge what would actually be recalled in six months: if the durable core is "they chatted about X", there is no memo.
+A conversation is not knowledge-worthy just because it is long or touches technical subjects. Judge what would actually be recalled in six months: if the durable core is "they chatted about X", there is no memo. Message tags carry a relative \`age\` (e.g. \`age="3 days ago"\`) — use it to gauge durability: a passing state described days ago has almost certainly gone stale, while a decision or validated learning stays durable regardless of age.
 
 Separately, flag containsActionItems true when someone committed to do something or was directly asked to (a task, to-do, or follow-up). This is independent of knowledge-worthiness: "send me the deck by Friday" has an action item but no durable knowledge, while a recorded decision may have knowledge but no open task.
 
@@ -249,12 +253,21 @@ How to write memos:
 1. ONE TOPIC PER MEMO. If a conversation settles two unrelated things (e.g. a deployment decision and a hiring update), produce two separate memos. Never blend topics into a single memo.
 2. EXTRACT, DON'T SUMMARIZE. Capture the durable conclusion — the decision, the answer, the fact, the procedure that was worked out — not a play-by-play of the discussion. A memo is what someone would want to recall in six months, never a transcript of who said what.
 3. BE TERSE. An abstract is a few sentences at most. If it reads like a recap of the conversation, rewrite it down to the bare conclusion.
-4. OMIT THE FORGETTABLE. Greetings, status pings, back-and-forth, and unresolved tangents produce no memo. Opinions, hot takes, gossip, and reactions to news or third-party products are NEVER memos, no matter how strongly worded or how long the exchange — commentary about the world is not knowledge the participants produced. Recasting the commentary as a fact about the participants ("they dislike X", "they found Y impressive") does not rescue it: sentiment toward external things is still commentary, memo-worthy only when it fixes a concrete choice with consequences (a tool adopted, a vendor rejected for a project). Likewise, facts about the outside world picked up from news, links, or hearsay are re-findable and go stale — no memo unless the participants acted on them. A "learning" is something the participants discovered, validated, or decided themselves. Returning very few memos — none at all when the conversation is commentary — is correct and expected.
+4. OMIT THE FORGETTABLE. Two topic-neutral tests decide whether something is worth a memo — apply them to the subject, never blanket-ban the subject itself:
+   - DURABLE? Greetings, status pings, back-and-forth, and unresolved tangents produce no memo. A transient state — "it's broken / it works / it's slow right now" with no cause, fix, or decision — is stale within the hour, so no memo (the FIX for that same bug IS a memo; capture what was produced, not the passing state).
+   - PRODUCED BY THEM? Opinions, hot takes, gossip, and reactions to news or third-party products are not memos on their own — commentary about the world is not knowledge the participants produced. Recasting it as a fact about the participants ("they dislike X", "they found Y impressive") does not rescue it. But this is NOT a ban on the topic: the moment the participants turn that same subject into something they produced — a decision to adopt or drop it, or a learning they validated themselves about how a tool they build with behaves — it IS a memo. A "learning" is something the participants discovered, validated, or decided themselves. Returning very few memos — none at all when the conversation is pure commentary or transient status — is correct and expected.
 {{MEMO_LANGUAGE_RULE}}
 6. BE FACTUAL. State the knowledge directly. No meta-commentary like "this memo captures..." or "the team discussed...".
 7. Use consistent vocabulary with prior memos when the same concept reappears.
 8. RESOLVE PRONOUNS when possible - If you can determine who "he/she/they" refers to from the conversation, use their actual name. If unclear (e.g., conversation continues from offline), leave the pronoun. When in doubt, preserve the original wording.
-9. ANCHOR DATES when possible - Convert relative dates ("yesterday", "next week") to actual dates using today's date: {{CURRENT_DATE}}. If ambiguous, leave as-is.
+9. ANCHOR DATES when possible - Convert relative dates ("yesterday", "next week") to actual dates using today's date: {{CURRENT_DATE}}. Message tags also carry a relative \`age\` (e.g. \`age="3 days ago"\`) — use it to anchor dates and to judge durability: a passing state from days ago has gone stale, while a decision or validated learning stays durable regardless of age. If ambiguous, leave as-is.
+
+CHOOSING knowledgeType — pick the tightest fit; if nothing fits, the memo probably should not exist:
+- decision: a choice the participants committed to, with its rationale.
+- procedure: a sequence they worked out that reliably achieves something.
+- learning: something they discovered or validated themselves.
+- reference: a stable, look-it-up fact worth pinning (an id, a value, a name).
+- context: durable "why it is this way" background that outlives the moment. Reach for it LAST, not as a catch-all — a transient status, a passing reaction, or an event that fits none of the other types is not context, it is not a memo.
 
 Output ONLY valid JSON matching the schema.`
 

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -172,12 +172,17 @@ export class MemoService implements MemoServiceLike {
       // includeIds: the memorizer and suggestion collector must cite source
       // message ids; without ids in the prompt the model can't reference them and
       // every memo falls back to the whole conversation (mis-attribution).
+      // Anchor relative ages to one "now" for the whole batch so the classifier
+      // and memorizer can weigh durability (live vs. stale content) without
+      // reasoning over absolute timestamps.
+      const now = new Date()
       const formattedConversations = new Map<string, string>()
       for (const [convId, msgs] of conversationMessages) {
         const messagesArray = Array.from(msgs.values()).filter((m): m is Message => m !== null)
         if (messagesArray.length > 0) {
           const formatted = await this.messageFormatter.formatMessages(client, workspaceId, messagesArray, {
             includeIds: true,
+            relativeTo: now,
           })
           formattedConversations.set(convId, formatted)
         }

--- a/apps/backend/src/lib/ai/message-formatter.test.ts
+++ b/apps/backend/src/lib/ai/message-formatter.test.ts
@@ -250,6 +250,34 @@ describe("MessageFormatter", () => {
     expect(result).toContain('<message id="msg_1" authorType="user"')
   })
 
+  test("omits the age attribute by default", async () => {
+    const messages = [createMessage({ id: "msg_1", authorId: "usr_123", authorType: "user", contentMarkdown: "Hi" })]
+    mockFindUsersByIds.mockResolvedValue([{ id: "usr_123", name: "Alice" }])
+
+    const result = await formatter.formatMessages(mockClient, "ws_test", messages)
+
+    expect(result).not.toContain("age=")
+  })
+
+  test("renders a relative age when relativeTo is set (durability anchoring for the memo pipeline)", async () => {
+    const messages = [
+      createMessage({
+        id: "msg_1",
+        authorId: "usr_123",
+        authorType: "user",
+        contentMarkdown: "Hi",
+        createdAt: new Date("2024-01-01T10:00:00Z"),
+      }),
+    ]
+    mockFindUsersByIds.mockResolvedValue([{ id: "usr_123", name: "Alice" }])
+
+    const result = await formatter.formatMessages(mockClient, "ws_test", messages, {
+      relativeTo: new Date("2024-01-03T10:00:00Z"),
+    })
+
+    expect(result).toContain('age="2 days ago"')
+  })
+
   describe("formatMessagesInline", () => {
     test("should return empty string for empty message list", async () => {
       const result = await formatter.formatMessagesInline(mockClient, "ws_test", [])

--- a/apps/backend/src/lib/ai/message-formatter.ts
+++ b/apps/backend/src/lib/ai/message-formatter.ts
@@ -4,6 +4,7 @@ import type { AttachmentWithExtraction } from "../../features/attachments"
 import { UserRepository } from "../../features/workspaces"
 import { PersonaRepository } from "../../features/agents"
 import { escapeXmlAttr } from "../xml"
+import { formatRelativeDate } from "../temporal"
 
 function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
@@ -24,6 +25,11 @@ export class MessageFormatter {
    *   a model asked to cite source messages (memorizer, suggestion collector) has
    *   real ids to return. Off by default — callers that don't cite stay unchanged.
    *
+   * @param options.relativeTo - Anchor date for a human-readable `age` attribute
+   *   (e.g. `age="2 days ago"`). Absolute `createdAt` requires the model to reason
+   *   about elapsed time; a relative age lets it judge durability directly (is the
+   *   captured state still live, or a stale one-off?). Off by default.
+   *
    * @example
    * const formatted = await messageFormatter.formatMessages(client, workspaceId, messages)
    * // <messages>
@@ -32,21 +38,23 @@ export class MessageFormatter {
    * // </messages>
    *
    * @example
-   * // With ids (memorizer / suggestion collector)
-   * const formatted = await messageFormatter.formatMessages(client, ws, messages, { includeIds: true })
-   * // <message id="msg_123" authorType="user" authorId="user_123" authorName="Alice" createdAt="...">Hello!</message>
+   * // With ids + relative age (memorizer / classifier)
+   * const formatted = await messageFormatter.formatMessages(client, ws, messages, { includeIds: true, relativeTo: new Date() })
+   * // <message id="msg_123" authorType="user" authorId="user_123" authorName="Alice" createdAt="..." age="2 days ago">Hello!</message>
    */
   async formatMessages(
     client: Querier,
     workspaceId: string,
     messages: Message[],
-    options?: { includeIds?: boolean }
+    options?: { includeIds?: boolean; relativeTo?: Date }
   ): Promise<string> {
     if (messages.length === 0) return "<messages></messages>"
 
     const nameById = await this.resolveAuthorNames(client, workspaceId, messages)
 
-    const formatted = messages.map((m) => this.formatSingleMessage(m, nameById, options?.includeIds ?? false))
+    const formatted = messages.map((m) =>
+      this.formatSingleMessage(m, nameById, options?.includeIds ?? false, options?.relativeTo)
+    )
 
     return `<messages>\n${formatted.join("\n")}\n</messages>`
   }
@@ -80,10 +88,19 @@ export class MessageFormatter {
     return nameById
   }
 
-  private formatSingleMessage(m: Message, nameById: Map<string, string>, includeIds: boolean): string {
+  private formatSingleMessage(
+    m: Message,
+    nameById: Map<string, string>,
+    includeIds: boolean,
+    relativeTo?: Date
+  ): string {
     const authorName = nameById.get(m.authorId) ?? "Unknown"
     const idAttr = includeIds ? `id="${m.id}" ` : ""
-    return `<message ${idAttr}authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(authorName)}" createdAt="${m.createdAt.toISOString()}">${escapeXml(m.contentMarkdown)}</message>`
+    // Keep this attribute shape in sync with the eval fixture renderer
+    // (apps/backend/evals/fixtures/memo.ts formatEvalMessages) so evals exercise
+    // the same prompt the classifier/memorizer see in production (INV-45).
+    const ageAttr = relativeTo ? ` age="${escapeXmlAttr(formatRelativeDate(m.createdAt, relativeTo))}"` : ""
+    return `<message ${idAttr}authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(authorName)}" createdAt="${m.createdAt.toISOString()}"${ageAttr}>${escapeXml(m.contentMarkdown)}</message>`
   }
 
   /**

--- a/apps/backend/src/lib/ai/message-formatter.ts
+++ b/apps/backend/src/lib/ai/message-formatter.ts
@@ -10,6 +10,42 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
+/** Author name already resolved; the pure renderer never touches the database. */
+export interface RenderableMessage {
+  id: string
+  authorType: string
+  authorId: string
+  authorName: string
+  contentMarkdown: string
+  createdAt: Date
+}
+
+export interface RenderMessageOptions {
+  /** Emit an `id` attribute so a model asked to cite sources has real ids. */
+  includeIds?: boolean
+  /** Anchor date for a relative `age` attribute (e.g. `age="2 days ago"`). */
+  relativeTo?: Date
+}
+
+/**
+ * The single source of truth for the `<messages>` prompt wire format. Both the
+ * production `MessageFormatter` (after it resolves author names from the DB) and
+ * the eval fixtures (which supply names directly) render through here, so the
+ * prompt the model sees in evals can't drift from production (INV-35/37, INV-45).
+ */
+export function renderMessagesXml(messages: RenderableMessage[], options?: RenderMessageOptions): string {
+  if (messages.length === 0) return "<messages></messages>"
+  return `<messages>\n${messages.map((m) => renderMessageXml(m, options)).join("\n")}\n</messages>`
+}
+
+function renderMessageXml(m: RenderableMessage, options?: RenderMessageOptions): string {
+  const idAttr = options?.includeIds ? `id="${escapeXmlAttr(m.id)}" ` : ""
+  const ageAttr = options?.relativeTo
+    ? ` age="${escapeXmlAttr(formatRelativeDate(m.createdAt, options.relativeTo))}"`
+    : ""
+  return `<message ${idAttr}authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(m.authorName)}" createdAt="${m.createdAt.toISOString()}"${ageAttr}>${escapeXml(m.contentMarkdown)}</message>`
+}
+
 /**
  * Formats messages for use in AI prompts with author names resolved from the database.
  *
@@ -46,17 +82,23 @@ export class MessageFormatter {
     client: Querier,
     workspaceId: string,
     messages: Message[],
-    options?: { includeIds?: boolean; relativeTo?: Date }
+    options?: RenderMessageOptions
   ): Promise<string> {
     if (messages.length === 0) return "<messages></messages>"
 
     const nameById = await this.resolveAuthorNames(client, workspaceId, messages)
 
-    const formatted = messages.map((m) =>
-      this.formatSingleMessage(m, nameById, options?.includeIds ?? false, options?.relativeTo)
+    return renderMessagesXml(
+      messages.map((m) => ({
+        id: m.id,
+        authorType: m.authorType,
+        authorId: m.authorId,
+        authorName: nameById.get(m.authorId) ?? "Unknown",
+        contentMarkdown: m.contentMarkdown,
+        createdAt: m.createdAt,
+      })),
+      options
     )
-
-    return `<messages>\n${formatted.join("\n")}\n</messages>`
   }
 
   /** Batch-resolves author names in at most 2 queries (users + personas). */
@@ -88,20 +130,6 @@ export class MessageFormatter {
     return nameById
   }
 
-  private formatSingleMessage(
-    m: Message,
-    nameById: Map<string, string>,
-    includeIds: boolean,
-    relativeTo?: Date
-  ): string {
-    const authorName = nameById.get(m.authorId) ?? "Unknown"
-    const idAttr = includeIds ? `id="${m.id}" ` : ""
-    // Keep this attribute shape in sync with the eval fixture renderer
-    // (apps/backend/evals/fixtures/memo.ts formatEvalMessages) so evals exercise
-    // the same prompt the classifier/memorizer see in production (INV-45).
-    const ageAttr = relativeTo ? ` age="${escapeXmlAttr(formatRelativeDate(m.createdAt, relativeTo))}"` : ""
-    return `<message ${idAttr}authorType="${m.authorType}" authorId="${m.authorId}" authorName="${escapeXmlAttr(authorName)}" createdAt="${m.createdAt.toISOString()}"${ageAttr}>${escapeXml(m.contentMarkdown)}</message>`
-  }
 
   /**
    * Format messages in a simple inline format for prompts.


### PR DESCRIPTION
## Problem

Memo generation between two DM participants had been producing mostly junk: of 155 active memos in one production DM, 111 were `context`/`learning`, and a large share were things the prompts *already* claimed to exclude — transient status ("View run är trasig", "mirror fungerar nu") that is false within the hour, and reactions/opinions about AI models ("4.7 känns inte särskilt speciell"). Two distinct issues sat behind the "weird memos" report; this PR addresses the ongoing one (the quality of what gets captured). The one-time July-5 wave of memos sourced from months-old messages was diagnosed separately as a deploy-race that has self-healed (the staleness-sweep guard in `accumulator-outbox-handler.ts:47` is now universally deployed) — out of scope here.

The instinct to fix this by forbidding topics (e.g. "model talk is not knowledge") is wrong: between two people who *build* with a model, "Fable interprets unclear answers as a green light" is a genuine validated learning. Relevance is not a property of the subject.

## Solution

Move the worthiness test from *topic* to *intent*, on two topic-neutral axes, and give the classifier the temporal context it needs to apply one of them.

### How it works

- **Durability + agency, in the prompts** (`memos/config.ts`). The classifier and memorizer now judge on two axes that turn on what the participants *produced*, never on the subject:
  - **Durability** — would the core still be true/useful in six months? A decision, a worked-out procedure, a validated finding lasts; a passing state ("it's broken right now") is stale within the hour.
  - **Agency** — did they produce it (decide, work out, validate) or just react to something outside their control? Reactions fail; the *same subject* passes the moment it becomes a decision or a validated learning. Stated explicitly as topic-neutral in both prompts so "model talk" isn't blanket-banned.
- **Transient status** is named as a non-memo in both prompts, with the counter-example inline (the *fix* for that same bug is worthy — judge what was produced, not the subject).
- **`context` sharpened** — it was undefined to the model and had become the catch-all absorbing transient state. The memorizer prompt now defines it as durable "why it is this way" background, to be reached for **last**.
- **Temporal grounding as a signal, not a cutoff** — the memo message rendering gains a relative `age` attribute (e.g. `age="3 days ago"`) via `formatRelativeDate` (`lib/temporal.ts:211`, already used by the researcher agent). `MemoService.processBatch` passes one `now` per batch so both the classifier and memorizer can weigh whether captured state is still live. The classifier previously got *no* "now" reference at all. This is deliberately not a recency gate — a conversation resumed after a vacation still memoizes.

### Key design decisions

**1. Topic-neutral intent test, not a topic blocklist** — per the reviewing user's ruling: forbidding subjects (model talk, news) is over-indexing on one workspace's noise. A validated learning about a tool you build with is real knowledge; the discriminator is durability + agency. Also avoids the language/keyword-heuristic trap (INV-54).

**2. Temporal as guidance, not a hard cutoff** — production data showed no continuous old-message drift to gate against (every memo outside the July-5 deploy-race was created within ~14 days of its source). A hard recency floor would wrongly drop conversations that legitimately resume after a vacation/long weekend. So the age is an input the model weighs, not a filter.

**3. One renderer for production and evals (no duplication)** — `renderMessagesXml` in `message-formatter.ts` is the single source of truth for the `<messages>` wire format. Production `MessageFormatter.formatMessages` resolves author names from the DB then renders through it; the eval fixtures already have names and render through the same function. Only the DB-bound name resolution is skipped in evals — never the rendering — so the prompt evals exercise can't drift from production (INV-35/37, INV-45).

### Design evolution (reviewer feedback)

The first version had `formatEvalMessages` hand-duplicate the `<message>` wire format, and the new `age` attribute was added to *both* renderers with a "keep in sync" comment. A reviewer flagged this as embedding application code in the test instead of testing it — the two would drift. Fixed by extracting `renderMessagesXml` (decision 3 above); the duplicate renderer and the fixture's separate `escapeXml` are gone, and the eval now escapes content/attributes exactly as production does.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/memos/config.ts` | Classifier + memorizer prompts reframed to durability/agency; transient-status excluded; `context` sharpened; `age` attribute explained |
| `apps/backend/src/lib/ai/message-formatter.ts` | Extract `renderMessagesXml` (shared wire-format renderer) + `relativeTo` → `age` attribute; `formatMessages` renders through it; drop private `formatSingleMessage` |
| `apps/backend/src/features/memos/service.ts` | `processBatch` passes one `relativeTo: now` per batch into the pre-format |
| `apps/backend/src/lib/ai/message-formatter.test.ts` | +2 tests: age omitted by default, rendered when `relativeTo` set |
| `apps/backend/evals/fixtures/memo.ts` | `formatEvalMessages` now calls the shared `renderMessagesXml` (was a hand-rolled copy); dead `escapeXml` removed (INV-45) |
| `apps/backend/evals/suites/memo-classifier/{cases,types}.ts` | `transient-status-not-worthy-001`, `tool-behavior-learning-001` (worthy model-talk contrast); `transient` category |
| `apps/backend/evals/suites/memorizer/{cases,types}.ts` | `transient-status-yields-nothing-001`, `tool-behavior-learning-captured-001`; `transient` category |

## Out of scope (deliberate)

- **The July-5 deploy-race pollution** (39 memos from stale March/April messages, one DM). Self-healed root cause; cleanup is a separate data write the user opted to defer.
- **No pipeline/schema change.** The `age` attribute is additive; the message-count split on `<message` is unaffected. Memo dedup/supersession/queueing untouched.

## Test plan

- [x] `bun test src/lib/ai/message-formatter` — 24 pass (incl. 2 new age tests; all pass unchanged after the `renderMessagesXml` extraction)
- [x] `bun test src/features/memos` — 54 pass
- [x] `bunx tsc --noEmit -p apps/backend/tsconfig.json` (incl. `evals/**`) — clean
- [ ] Eval suites **blocked in CI** — the `/eval` workflow crashes at startup because the `OPENROUTER_API_KEY` Actions secret (slash-commands.yml:145) is unset. Not a code failure. Once the secret is added, run `/eval -s memo-classifier` and `/eval -s memorizer`; success criterion: `garbage-leak-rate` / `over-capture-rate` stay at 0 on the new transient cases, and the knowledge cases (`tool-behavior-learning-*`, `procedure-setup-001`, `decision-measured-001`) pass.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_