### PR TITLE
fix(board): thread Stop + in-place Redirect onto the running-session card

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -22,6 +22,8 @@ import * as userProfileModule from "@/components/user-profile"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
+import * as inlineComposerModule from "@/components/board/board-inline-composer"
+import { spyOnExport } from "@/test/spy"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -282,6 +284,43 @@ describe("BoardCard agent activity", () => {
     expect(await screen.findByText("Interrupted, retrying…")).toBeTruthy()
     expect(screen.queryByText("Session failed")).toBeNull()
     expect(await screen.findByText(/2 steps/)).toBeTruthy()
+  })
+
+  it("shows Stop + Redirect on a running session, and Redirect opens the card composer in place", async () => {
+    const user = userEvent.setup()
+    // A running session's row mounts the live progress rail (useAgentActivity),
+    // which reads the socket — give it a fake one.
+    const { socket } = fakeSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    // Prevent the real editor mounting when Redirect opens the composer — the
+    // wiring under test is Redirect → open card composer, not editor mechanics.
+    spyOnExport(inlineComposerModule, "InlineComposerForm").mockReturnValue(((props: { placeholder: string }) => (
+      <div data-testid="reply-composer-open">{props.placeholder}</div>
+    )) as never)
+
+    // A running session (started, no terminal event) triggered by the card's
+    // opening message: the board card must expose the same Stop/Redirect pair the
+    // timeline card does.
+    await db.events.bulkPut([
+      sessionEvent("agent_session:started", 30, {
+        sessionId: "sess_run",
+        triggerMessageId: "m_open",
+        personaName: "Ariadne",
+      }),
+    ])
+    mountCard()
+
+    expect(await screen.findByRole("button", { name: "Stop" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Redirect" })).toBeTruthy()
+    // Composer starts collapsed to its resting affordance.
+    expect(screen.queryByTestId("reply-composer-open")).toBeNull()
+
+    await user.click(screen.getByRole("button", { name: "Redirect" }))
+
+    // Redirect opened the card's own composer in place (no navigation) and the
+    // fold-in hint confirms the running session will absorb the next message.
+    expect(await screen.findByTestId("reply-composer-open")).toBeTruthy()
+    expect(screen.getByText("Ariadne will fold your message into the current work")).toBeTruthy()
   })
 
   it("does NOT render a session whose invoking message is not a conversation member", async () => {

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -77,6 +77,12 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   const conversationService = useConversationService()
   const { openPanel, getPanelUrl } = usePanel()
   const [expanded, setExpanded] = useState(false)
+  // A running session's Redirect bumps this nonce to expand + focus the card's
+  // reply composer in place (its editor is collapsed until opened, so there's no
+  // DOM zone to walk to). A counter, not a boolean, so a repeat Redirect re-opens
+  // it after a manual collapse.
+  const [openReplySignal, setOpenReplySignal] = useState(0)
+  const openReplyComposer = useCallback(() => setOpenReplySignal((n) => n + 1), [])
   // Scopes text-selection quoting to this card so a selection routes into this
   // card's composer, not a sibling card's provider.
   const cardRef = useRef<HTMLDivElement>(null)
@@ -584,6 +590,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                     renderBranchMessage={renderBranchMessage}
                     renderBranchTail={inlineComposer.renderBranchTail}
                     renderAfterMessage={inlineComposer.renderAfterMessage}
+                    onRedirectSession={openReplyComposer}
                   />
                 ) : (
                   <>
@@ -625,6 +632,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                       renderBranchMessage={renderBranchMessage}
                       renderBranchTail={inlineComposer.renderBranchTail}
                       renderAfterMessage={inlineComposer.renderAfterMessage}
+                      onRedirectSession={openReplyComposer}
                     />
                   </>
                 )}
@@ -634,6 +642,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                 workspaceId={workspaceId}
                 post={post}
                 hostStreamType={streamType}
+                openReplySignal={openReplySignal}
                 // The conversation's most-recently-active stream — the latest displayed
                 // reply's own stream (a thread under the root), INCLUDING the viewer's own
                 // pending reply and any expand-backfilled rows, so a continuation follows

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -1,4 +1,5 @@
 import type { StreamEvent } from "@threa/types"
+import { useAbortSession } from "@/hooks"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
 import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
@@ -309,12 +310,25 @@ export function buildBranchedBoardRows(
  * and action wiring), so this only handles the event kinds. A `CachedEvent` is a
  * structural superset of `StreamEvent`, so the rail rows pass straight through.
  */
-export function BoardEventRowItem({ row, workspaceId }: { row: BoardEventRow; workspaceId: string }) {
+export function BoardEventRowItem({
+  row,
+  workspaceId,
+  onRedirectSession,
+}: {
+  row: BoardEventRow
+  workspaceId: string
+  /** Open + focus the card's reply composer for a running session's Redirect. */
+  onRedirectSession?: () => void
+}) {
   switch (row.kind) {
     case "session":
       return (
         <div className="px-3 sm:px-4">
-          <BoardAgentSessionRow events={row.events as StreamEvent[]} workspaceId={workspaceId} />
+          <BoardAgentSessionRow
+            events={row.events as StreamEvent[]}
+            workspaceId={workspaceId}
+            onRedirectSession={onRedirectSession}
+          />
         </div>
       )
     case "memo":
@@ -347,14 +361,31 @@ const SESSION_TERMINAL_EVENT_TYPES = new Set<string>([
  * the many past-trace rows a board carries, and confines a progress-tick re-render
  * to this leaf instead of the whole card.
  */
-function BoardAgentSessionRow({ events, workspaceId }: { events: StreamEvent[]; workspaceId: string }) {
+function BoardAgentSessionRow({
+  events,
+  workspaceId,
+  onRedirectSession,
+}: {
+  events: StreamEvent[]
+  workspaceId: string
+  onRedirectSession?: () => void
+}) {
   const running = !events.some((event) => SESSION_TERMINAL_EVENT_TYPES.has(event.eventType))
   if (!running) return <AgentSessionEvent events={events} />
-  return <BoardRunningSessionRow events={events} workspaceId={workspaceId} />
+  return <BoardRunningSessionRow events={events} workspaceId={workspaceId} onRedirectSession={onRedirectSession} />
 }
 
-function BoardRunningSessionRow({ events, workspaceId }: { events: StreamEvent[]; workspaceId: string }) {
+function BoardRunningSessionRow({
+  events,
+  workspaceId,
+  onRedirectSession,
+}: {
+  events: StreamEvent[]
+  workspaceId: string
+  onRedirectSession?: () => void
+}) {
   const socket = useSocket()
+  const abortSession = useAbortSession(socket)
   const userId = useWorkspaceUserId(workspaceId)
   const activity = useAgentActivity(events, socket, workspaceId, userId)
   const sessionId = events.reduce<string | null>((found, event) => found ?? getSessionId(event), null)
@@ -375,6 +406,8 @@ function BoardRunningSessionRow({ events, workspaceId }: { events: StreamEvent[]
       events={events}
       liveCounts={live ? { stepCount: live.stepCount, messageCount: live.messageCount } : undefined}
       liveSubstep={live?.substep ?? null}
+      onStopSession={(sessionId) => abortSession({ sessionId, workspaceId })}
+      onRedirect={onRedirectSession}
     />
   )
 }

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -231,6 +231,8 @@ interface BranchedBoardRowsProps {
   renderBranchTail?: (branch: BranchConversationView) => ReactNode
   /** The inline "new sub-topic" composer slot rendered under a message row. */
   renderAfterMessage?: (messageId: string) => ReactNode
+  /** Open + focus the surface's reply composer for a running session's Redirect. */
+  onRedirectSession?: () => void
 }
 
 function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNode {
@@ -242,6 +244,7 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
     renderBranchTail,
     renderAfterMessage,
     onSplitThread,
+    onRedirectSession,
   } = props
   switch (row.kind) {
     case "message":
@@ -252,7 +255,14 @@ function renderRowContent(row: BoardRow, props: BranchedBoardRowsProps): ReactNo
         </Fragment>
       )
     case "event":
-      return <BoardEventRowItem key={row.key} row={row.row} workspaceId={workspaceId} />
+      return (
+        <BoardEventRowItem
+          key={row.key}
+          row={row.row}
+          workspaceId={workspaceId}
+          onRedirectSession={onRedirectSession}
+        />
+      )
     case "seam":
       return (
         <ThreadSeamRow

--- a/apps/frontend/src/components/timeline/agent-session-event.test.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.test.tsx
@@ -261,6 +261,21 @@ describe("AgentSessionEvent", () => {
       expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
     })
 
+    it("Redirect calls onRedirect (board card) instead of walking the DOM, and shows the hint", () => {
+      const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
+      const onRedirect = vi.fn()
+
+      // No [data-editor-zone] in the tree — the board card has none; the surface
+      // owns opening + focusing its own composer via onRedirect.
+      renderEvent(<AgentSessionEvent events={runningEvents} onStopSession={vi.fn()} onRedirect={onRedirect} />)
+
+      fireEvent.click(screen.getByRole("button", { name: "Redirect" }))
+
+      expect(onRedirect).toHaveBeenCalledTimes(1)
+      expect(focusAtEnd).not.toHaveBeenCalled()
+      expect(screen.getByText("Ariadne will fold your message into the current work")).toBeInTheDocument()
+    })
+
     it("Redirect shows no hint when the surface has no composer", () => {
       const focusAtEnd = vi.spyOn(hooksModule, "focusAtEnd").mockImplementation(() => undefined)
 

--- a/apps/frontend/src/components/timeline/agent-session-event.tsx
+++ b/apps/frontend/src/components/timeline/agent-session-event.tsx
@@ -32,6 +32,13 @@ interface AgentSessionEventProps {
   liveSubstep?: string | null
   /** Click handler for the Stop button, rendered while the session is running. */
   onStopSession?: (sessionId: string) => void
+  /**
+   * Redirect override for surfaces whose composer isn't in the DOM to walk to
+   * (the board card, whose reply composer is collapsed until opened): open and
+   * focus that composer. When absent, Redirect walks to the nearest
+   * `[data-editor-zone]` editor instead (timeline, thread panel).
+   */
+  onRedirect?: () => void
 }
 
 type SessionStatus = "running" | "retrying" | "completed" | "failed" | "deleted"
@@ -287,6 +294,7 @@ export function AgentSessionEvent({
   liveCounts,
   liveSubstep,
   onStopSession,
+  onRedirect,
 }: AgentSessionEventProps) {
   const { getTraceUrl } = useTrace()
   const { status, sessionId, startedPayload, completedPayload, failedPayload, interruptedPayload, deletedPayload } =
@@ -315,15 +323,19 @@ export function AgentSessionEvent({
 
   // Redirect needs no backend call: the runtime already folds mid-run messages
   // into the running session (NewMessageAwareness → reconsidering). The button
-  // just pulls the cursor into this surface's composer and hints at what
-  // typing will do.
+  // just pulls the cursor into a composer and hints at what typing will do.
   const handleRedirect = (e: React.MouseEvent<HTMLButtonElement>) => {
-    // No composer on this surface (non-member public channel, archived or
-    // locked stream) — bail before the hint, or it promises a fold-in that
-    // can't happen.
-    const editor = findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
-    if (!editor) return
-    focusAtEnd(editor)
+    if (onRedirect) {
+      // The surface owns opening + focusing its composer (board card).
+      onRedirect()
+    } else {
+      // No composer on this surface (non-member public channel, archived or
+      // locked stream) — bail before the hint, or it promises a fold-in that
+      // can't happen.
+      const editor = findVisibleZoneEditor(e.currentTarget.closest<HTMLElement>("[data-editor-zone]"))
+      if (!editor) return
+      focusAtEnd(editor)
+    }
     if (redirectHintTimer.current !== null) window.clearTimeout(redirectHintTimer.current)
     setRedirectHintVisible(true)
     redirectHintTimer.current = window.setTimeout(() => setRedirectHintVisible(false), REDIRECT_HINT_MS)


### PR DESCRIPTION
## Problem

The board's running-session trace card was inert. `board-row-item.tsx` rendered `<AgentSessionEvent events={row.events} />` with no `onStopSession` and no redirect wiring, so on the board (and the conversation panel, which shares the same row component):

- **Stop was hidden.** `AgentSessionEvent` gates the Stop button on `onStopSession && …` — with the prop absent, it never rendered.
- **Redirect was a no-op.** Its handler walks `closest("[data-editor-zone]")` for a composer to focus; the board card has no `data-editor-zone`, so `findVisibleZoneEditor` returned null and the click did nothing.

The timeline card gets both because `event-list.tsx` / `stream-content.tsx` build `handleStopSession` from `useAbortSession(useSocket())` and thread it in, and the main/thread views wrap their composer in `data-editor-zone`. The board never did — so "jump in and steer" (roadmap 2.2, #1190) worked in the timeline but not on the board.

## Solution

Thread the same Stop path the timeline uses into the board's shared row component, and give `AgentSessionEvent` a redirect override for surfaces whose composer is lazily mounted (the board card's reply composer is collapsed to a resting affordance until opened, so there is no editor in the DOM to walk to).

### How it works

1. **Stop** — `BoardEventRowItem` (`board-row-item.tsx`) now sources `useAbortSession(useSocket())` and passes `onStopSession={(sessionId) => abortSession({ sessionId, workspaceId })}` into `AgentSessionEvent`. `useSocket()` reads a default-`null` context, so no provider is required in tests; `useAbortSession(null)` no-ops. This fixes the board **and** the conversation panel — both route session rows through `BoardEventRowItem` and both previously lacked Stop.
2. **Redirect override** — `AgentSessionEvent` gains an optional `onRedirect?: () => void`. When present, `handleRedirect` calls it (the surface owns opening + focusing its composer) instead of the DOM walk; when absent, the existing `[data-editor-zone]` walk runs unchanged (timeline, thread panel). Either branch shows the same "fold your message into the current work" hint for `REDIRECT_HINT_MS` (5s).
3. **Board card opens in place** — `board-card.tsx` holds an `openReplySignal` nonce and passes `onRedirectSession={() => setOpenReplySignal(n => n + 1)}` through `BranchedBoardRows` → `BoardEventRowItem` → `AgentSessionEvent.onRedirect`. The bump drives `BoardReplyComposer`'s existing `openReplySignal` prop, which expands the resting affordance into the live composer and focuses it (`InlineComposerForm` defaults `autoFocus`). The running session then absorbs the next message via the runtime's existing `NewMessageAwareness` fold-in — no backend call.

## Key design decisions

**1. Redirect opens the card composer in place, not navigate-away.** Chosen by the user (a-vs-b call). The board card already has a `BoardReplyComposer`; the fix is to open+focus it via the `openReplySignal` primitive already used by the conversation panel, so "fold into current work" stays literally true without yanking the user out of the board overview. Navigating to the stream/thread was the alternative — simpler and always-works, but breaks the in-place steer.

**2. `onRedirect` override rather than forcing a `data-editor-zone` onto the board card.** The card's composer is collapsed until tapped, so even with a `data-editor-zone` wrapper `findVisibleZoneEditor` would find no mounted editor. The override lets the surface open its own composer; the DOM-walk default is kept for timeline/thread where the composer is always mounted.

**3. Stop wired in the shared `BoardEventRowItem`, so the conversation panel gets it too.** One wiring site fixes both board surfaces (INV-35). The panel keeps its existing `data-editor-zone="panel"` DOM-walk Redirect (works when its composer is open) — no `onRedirectSession` threaded there, no regression.

Both actions stay buttons with `stopPropagation` inside the card's trace `<Link>` (INV-40); the running card's right slot already reserves their footprint (INV-21); no `toast.success` anywhere (INV-63).

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/agent-session-event.tsx` | Add optional `onRedirect`; `handleRedirect` uses it when present, else the `[data-editor-zone]` walk |
| `apps/frontend/src/components/board/board-row-item.tsx` | `BoardEventRowItem` sources `useAbortSession(useSocket())`, threads `onStopSession` + `onRedirect` into the session row; accepts `onRedirectSession` |
| `apps/frontend/src/components/board/branch-rows.tsx` | Thread `onRedirectSession` through `BranchedBoardRowsProps` to the event row |
| `apps/frontend/src/components/board/board-card.tsx` | `openReplySignal` nonce + `openReplyComposer`; wire to both `BranchedBoardRows` and `BoardReplyComposer` |
| `apps/frontend/src/components/timeline/agent-session-event.test.tsx` | New: Redirect calls `onRedirect` (board) instead of walking the DOM, still shows the hint |
| `apps/frontend/src/components/board/board-card.test.tsx` | New: running-session card shows Stop + Redirect; Redirect opens the card composer in place (stubs `InlineComposerForm`) |

## Out of scope (deliberate)

- **Conversation panel Redirect is unchanged** — it keeps the DOM-walk against its `data-editor-zone="panel"` (works when its composer is open). Only Stop was newly threaded there. Making the panel also open-on-Redirect would mean threading its existing `openReplySignal` setter down; not needed for the board ask.
- **Live counts / substep on board session cards** — the board still renders `AgentSessionEvent` without `liveCounts`/`liveSubstep` (unchanged); this PR is Stop/Redirect only.

## Test plan

- [x] `bun run --cwd apps/frontend typecheck` — clean (`tsc --noEmit`)
- [x] `agent-session-event.test.tsx` — 9 pass (1 new: `onRedirect` path)
- [x] `board-card.test.tsx` — 13 pass (1 new: running-session Stop/Redirect + open-in-place)
- [x] `src/components/board/`, `conversation-panel.test.tsx`, `src/components/trace/`, `event-list.test.tsx` — 116 pass together, no regressions
- [x] `eslint` on all six changed files — clean
- [x] Full pre-commit monorepo typecheck (14 workspaces) + lint + api-docs `--check` — passed; no `openapi.json` change (frontend-only)
- [ ] `/code-review` loop to 7/7 — running now (per request); findings will be pushed to this branch and noted here

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0132xdweS3K2DQt8PkcMP1Uo)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785998221&installation_id=129946197&pr_number=1231&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1231&signature=ffc8e123e52ed74c1b1b6b31b43ac3e5c4fafcefd1ac9b447a4c386a7536c720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->