### PR TITLE
feat(composer): preview uploaded images before send

### DIFF
--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from "react"
+import { useState, type ComponentType, type KeyboardEvent, type ReactNode } from "react"
 import { Link } from "react-router-dom"
 import { X } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
@@ -19,11 +19,25 @@ export interface AttachmentPillProps {
   secondary?: ReactNode
   status?: AttachmentPillStatus
   tooltip?: ReactNode
+  /**
+   * Small preview image shown in the leading slot in place of `icon` (e.g. an
+   * image attachment's thumbnail). Falls back to `icon` if it fails to load —
+   * the E2E-locked case, where the deterministic content URL serves ciphertext.
+   */
+  thumbnailSrc?: string
   /** When provided renders a small × button at the trailing edge. */
   onRemove?: () => void
+  /**
+   * Makes the pill activate (open a preview) on click / Enter / Space. The pill
+   * becomes a `role="button"` so a nested `onRemove` button can still live
+   * inside it — a real `<button>` can't nest another button.
+   */
+  onActivate?: () => void
   /** Internal route — turns the pill into a `<Link>`. */
   href?: string
   removeLabel?: string
+  /** Accessible name for the activate affordance (defaults to `label`). */
+  activateLabel?: string
   labelMaxWidth?: string
   className?: string
 }
@@ -46,6 +60,30 @@ const SECONDARY_TONE: Record<AttachmentPillStatus, string> = {
   error: "text-destructive/80",
 }
 
+function PillLeading({
+  icon: Icon,
+  thumbnailSrc,
+  spin,
+}: {
+  icon: ComponentType<{ className?: string }>
+  thumbnailSrc?: string
+  spin: boolean
+}) {
+  const [failed, setFailed] = useState(false)
+  if (thumbnailSrc && !failed) {
+    return (
+      <img
+        src={thumbnailSrc}
+        alt=""
+        draggable={false}
+        onError={() => setFailed(true)}
+        className="h-5 w-5 shrink-0 rounded object-cover"
+      />
+    )
+  }
+  return <Icon className={cn("h-3.5 w-3.5 shrink-0", spin && "animate-spin")} />
+}
+
 /**
  * Canonical pill primitive used by the composer attachment row and the
  * timeline message context-ref badge. Keeps file uploads and context refs
@@ -53,14 +91,17 @@ const SECONDARY_TONE: Record<AttachmentPillStatus, string> = {
  * remove + link affordances.
  */
 export function AttachmentPill({
-  icon: Icon,
+  icon,
   label,
   secondary,
   status = "default",
   tooltip,
+  thumbnailSrc,
   onRemove,
+  onActivate,
   href,
   removeLabel,
+  activateLabel,
   labelMaxWidth = "max-w-[160px]",
   className,
 }: AttachmentPillProps) {
@@ -72,7 +113,7 @@ export function AttachmentPill({
 
   const inner = (
     <>
-      <Icon className={cn("h-3.5 w-3.5 shrink-0", status === "pending" && "animate-spin")} />
+      <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={status === "pending" && !thumbnailSrc} />
       <span className={cn("truncate", labelMaxWidth)}>{label}</span>
       {secondary != null && <span className={SECONDARY_TONE[status]}>{secondary}</span>}
       {onRemove && (
@@ -95,16 +136,47 @@ export function AttachmentPill({
     </>
   )
 
-  const pill = href ? (
-    <Link
-      to={href}
-      className={cn(baseStyles, statusStyles, "cursor-pointer hover:brightness-110 transition-[filter]", className)}
-    >
-      {inner}
-    </Link>
-  ) : (
-    <div className={cn(baseStyles, statusStyles, className)}>{inner}</div>
-  )
+  let pill: ReactNode
+  if (href) {
+    pill = (
+      <Link
+        to={href}
+        className={cn(baseStyles, statusStyles, "cursor-pointer hover:brightness-110 transition-[filter]", className)}
+      >
+        {inner}
+      </Link>
+    )
+  } else if (onActivate) {
+    // role=button (not a real <button>) so the nested remove <button> is valid —
+    // buttons can't nest. The keydown guard keeps the nested button's own
+    // Enter/Space activation from also firing this activate.
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.target !== event.currentTarget) return
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault()
+        onActivate()
+      }
+    }
+    pill = (
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={activateLabel ?? label}
+        onClick={onActivate}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          baseStyles,
+          statusStyles,
+          "cursor-pointer hover:brightness-110 transition-[filter] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+          className
+        )}
+      >
+        {inner}
+      </div>
+    )
+  } else {
+    pill = <div className={cn(baseStyles, statusStyles, className)}>{inner}</div>
+  }
 
   if (!tooltip) return pill
 

--- a/apps/frontend/src/components/composer/attachment-pill.tsx
+++ b/apps/frontend/src/components/composer/attachment-pill.tsx
@@ -25,6 +25,12 @@ export interface AttachmentPillProps {
    * the E2E-locked case, where the deterministic content URL serves ciphertext.
    */
   thumbnailSrc?: string
+  /**
+   * Spin the leading icon. Defaults to the `pending` status; pass explicitly for
+   * a loading state the status enum doesn't capture (an E2E image decrypting
+   * while its status is already `uploaded`).
+   */
+  spinning?: boolean
   /** When provided renders a small × button at the trailing edge. */
   onRemove?: () => void
   /**
@@ -60,6 +66,9 @@ const SECONDARY_TONE: Record<AttachmentPillStatus, string> = {
   error: "text-destructive/80",
 }
 
+// Fixed 20px slot so swapping the thumbnail (20px) for the icon (14px) — on an
+// onError fallback or an E2E decrypt landing — never changes the chip's width
+// and shifts its neighbours in the flex row (INV-21).
 function PillLeading({
   icon: Icon,
   thumbnailSrc,
@@ -70,18 +79,21 @@ function PillLeading({
   spin: boolean
 }) {
   const [failed, setFailed] = useState(false)
-  if (thumbnailSrc && !failed) {
-    return (
-      <img
-        src={thumbnailSrc}
-        alt=""
-        draggable={false}
-        onError={() => setFailed(true)}
-        className="h-5 w-5 shrink-0 rounded object-cover"
-      />
-    )
-  }
-  return <Icon className={cn("h-3.5 w-3.5 shrink-0", spin && "animate-spin")} />
+  return (
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+      {thumbnailSrc && !failed ? (
+        <img
+          src={thumbnailSrc}
+          alt=""
+          draggable={false}
+          onError={() => setFailed(true)}
+          className="h-5 w-5 rounded object-cover"
+        />
+      ) : (
+        <Icon className={cn("h-3.5 w-3.5", spin && "animate-spin")} />
+      )}
+    </span>
+  )
 }
 
 /**
@@ -97,6 +109,7 @@ export function AttachmentPill({
   status = "default",
   tooltip,
   thumbnailSrc,
+  spinning,
   onRemove,
   onActivate,
   href,
@@ -113,7 +126,7 @@ export function AttachmentPill({
 
   const inner = (
     <>
-      <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={status === "pending" && !thumbnailSrc} />
+      <PillLeading icon={icon} thumbnailSrc={thumbnailSrc} spin={spinning ?? status === "pending"} />
       <span className={cn("truncate", labelMaxWidth)}>{label}</span>
       {secondary != null && <span className={SECONDARY_TONE[status]}>{secondary}</span>}
       {onRemove && (
@@ -125,7 +138,10 @@ export function AttachmentPill({
             onRemove()
           }}
           className={cn(
-            "ml-0.5 rounded-full p-0.5 opacity-60 hover:opacity-100 transition-opacity",
+            // p-1 (not p-0.5) enlarges the touch target: the chip itself is now
+            // tappable (opens the preview), so a near-miss on the × shouldn't
+            // land on the chip and open the lightbox instead of removing.
+            "ml-0.5 rounded-full p-1 opacity-60 hover:opacity-100 transition-opacity",
             STATUS_REMOVE_HOVER[status]
           )}
           aria-label={removeLabel ?? "Remove"}

--- a/apps/frontend/src/components/composer/message-composer.tsx
+++ b/apps/frontend/src/components/composer/message-composer.tsx
@@ -856,6 +856,7 @@ export function MessageComposer({
                     <PendingAttachments
                       attachments={pendingAttachments}
                       onRemove={onRemoveAttachment}
+                      workspaceId={workspaceId}
                       beforePills={
                         contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
                           <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />
@@ -1037,6 +1038,7 @@ export function MessageComposer({
         <PendingAttachments
           attachments={pendingAttachments}
           onRemove={onRemoveAttachment}
+          workspaceId={workspaceId}
           beforePills={
             contextRefs && contextRefs.length > 0 && streamId && workspaceId ? (
               <ContextRefStrip workspaceId={workspaceId} streamId={streamId} draftRefs={contextRefs} />

--- a/apps/frontend/src/components/gallery/pending-gallery-id.ts
+++ b/apps/frontend/src/components/gallery/pending-gallery-id.ts
@@ -1,0 +1,15 @@
+// A composer preview image is a locally-picked file that hasn't been sent yet.
+// Its bytes live only in a local object URL (and for E2E streams the server
+// holds nothing but ciphertext), so the attachment download API can't serve it.
+// The gallery keys item identity on `attachmentId`, so a preview image carries
+// this sentinel instead (mirrors the Giphy / link-preview sentinels). Download
+// branches on it and is suppressed; render + copy work straight from the url.
+const PENDING_GALLERY_PREFIX = "pending:"
+
+export function pendingGalleryId(key: string): string {
+  return `${PENDING_GALLERY_PREFIX}${key}`
+}
+
+export function isPendingGalleryId(id: string): boolean {
+  return id.startsWith(PENDING_GALLERY_PREFIX)
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -31,6 +31,7 @@ import { triggerDownload } from "@/lib/image-utils"
 import { ZoomableImage, type ZoomableImageHandle } from "@/components/gallery/zoomable-image"
 import { isGiphyGalleryId } from "@/components/gallery/giphy-gallery-id"
 import { isLinkPreviewGalleryId } from "@/components/gallery/link-preview-gallery-id"
+import { isPendingGalleryId } from "@/components/gallery/pending-gallery-id"
 import { buildEmbedPlaybackSrc } from "@/components/gallery/video-embed"
 import type { VideoPreviewProvider } from "@threa/types"
 import { ZoomControls } from "@/components/gallery/zoom-controls"
@@ -657,7 +658,11 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
   // serve them, and copy fetches the bytes so a site without CORS would only
   // toast an error — hide both, leaving view/zoom (which need no fetch).
   const isLinkPreviewImage = current ? isLinkPreviewGalleryId(current.attachmentId) : false
-  const canDownload = !isGiphy && !isLinkPreviewImage
+  // Composer preview images have no server-servable bytes (local object URL /
+  // E2E ciphertext), so the download API can't fetch them; copy still works
+  // straight from the object URL.
+  const isPending = current ? isPendingGalleryId(current.attachmentId) : false
+  const canDownload = !isGiphy && !isLinkPreviewImage && !isPending
   const canCopy =
     !isLinkPreviewImage &&
     (current?.type === "image" || current?.type === "markdown" || current?.type === "html" || current?.type === "text")

--- a/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
+++ b/apps/frontend/src/components/scheduled/scheduled-edit-dialog.tsx
@@ -282,6 +282,7 @@ export function ScheduledEditDialog({ workspaceId, scheduled, onClose }: Schedul
             <PendingAttachments
               attachments={attachmentsHook.pendingAttachments}
               onRemove={attachmentsHook.removeAttachment}
+              workspaceId={workspaceId}
             />
           </div>
         ) : null

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { PendingAttachments } from "./pending-attachments"
+import type { PendingAttachment } from "@/hooks/use-attachments"
+
+function imageAttachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
+  return {
+    id: "attach_img",
+    filename: "screenshot.png",
+    mimeType: "image/png",
+    sizeBytes: 2048,
+    status: "uploaded",
+    previewUrl: "blob:preview-1",
+    ...overrides,
+  }
+}
+
+describe("PendingAttachments", () => {
+  it("renders an image upload as a preview thumbnail", () => {
+    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+
+    const preview = screen.getByRole("button", { name: "Preview screenshot.png" })
+    expect(preview).toBeInTheDocument()
+    // Both the tile and the hover-card render the object URL.
+    expect(screen.getAllByAltText("screenshot.png")[0]).toHaveAttribute("src", "blob:preview-1")
+  })
+
+  it("falls back to a labeled pill for non-image files", () => {
+    const file: PendingAttachment = {
+      id: "attach_doc",
+      filename: "notes.txt",
+      mimeType: "text/plain",
+      sizeBytes: 1024,
+      status: "uploaded",
+    }
+    render(<PendingAttachments attachments={[file]} onRemove={vi.fn()} workspaceId="ws_1" />)
+
+    expect(screen.getByText("notes.txt")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Preview / })).not.toBeInTheDocument()
+  })
+
+  it("opens the lightbox when the thumbnail is clicked", () => {
+    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Preview screenshot.png" }))
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  it("removes an image via its remove control without opening the lightbox", () => {
+    const onRemove = vi.fn()
+    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={onRemove} workspaceId="ws_1" />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove screenshot.png" }))
+    expect(onRemove).toHaveBeenCalledWith("attach_img")
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("previews an image that is still uploading (no remove control yet)", () => {
+    render(
+      <PendingAttachments
+        attachments={[imageAttachment({ status: "uploading" })]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Preview screenshot.png" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Remove screenshot.png" })).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -16,16 +16,18 @@ function imageAttachment(overrides: Partial<PendingAttachment> = {}): PendingAtt
 }
 
 describe("PendingAttachments", () => {
-  it("renders an image upload as a preview thumbnail", () => {
-    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+  it("renders an image upload as a chip with a preview thumbnail", () => {
+    const { container } = render(
+      <PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />
+    )
 
-    const preview = screen.getByRole("button", { name: "Preview screenshot.png" })
-    expect(preview).toBeInTheDocument()
-    // Both the tile and the hover-card render the object URL.
-    expect(screen.getAllByAltText("screenshot.png")[0]).toHaveAttribute("src", "blob:preview-1")
+    // Filename stays visible as chip text; the leading slot shows the thumbnail.
+    expect(screen.getByText("screenshot.png")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Preview screenshot.png" })).toBeInTheDocument()
+    expect(container.querySelector('img[src="blob:preview-1"]')).toBeTruthy()
   })
 
-  it("falls back to a labeled pill for non-image files", () => {
+  it("falls back to a plain chip (no preview) for non-image files", () => {
     const file: PendingAttachment = {
       id: "attach_doc",
       filename: "notes.txt",
@@ -39,7 +41,7 @@ describe("PendingAttachments", () => {
     expect(screen.queryByRole("button", { name: /^Preview / })).not.toBeInTheDocument()
   })
 
-  it("opens the lightbox when the thumbnail is clicked", () => {
+  it("opens the lightbox when the image chip is activated", () => {
     render(<PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -56,7 +58,7 @@ describe("PendingAttachments", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
-  it("previews an image that is still uploading (no remove control yet)", () => {
+  it("shows the preview while an image is still uploading (no remove control yet)", () => {
     render(
       <PendingAttachments
         attachments={[imageAttachment({ status: "uploading" })]}

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -43,22 +43,34 @@ function PendingImageThumbnail({
 }) {
   const isUploading = attachment.status === "uploading"
   const isError = attachment.status === "error"
+  // Mirror the pill's generic-error fallback so an image that fails upload
+  // surfaces the same explanation the pill would, rather than a bare icon.
+  const isGenericError =
+    isError &&
+    (attachment.error === "Internal server error" || attachment.error === "Upload failed" || !attachment.error)
+  let errorText: string | undefined
+  if (isError) {
+    errorText = isGenericError ? "We couldn't upload this file. Please remove it and try again." : attachment.error
+  }
 
   const tile = (
     <div
       role="button"
       tabIndex={0}
-      aria-label={`Preview ${attachment.filename}`}
-      title={isError ? attachment.error : undefined}
+      aria-label={isError ? `${attachment.filename} — upload failed` : `Preview ${attachment.filename}`}
+      title={errorText}
       onClick={onOpen}
       onKeyDown={(e) => {
+        // Only the tile itself opens the lightbox — a keydown bubbling up from
+        // the nested remove button must not preventDefault its own activation.
+        if (e.target !== e.currentTarget) return
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault()
           onOpen()
         }
       }}
       className={cn(
-        "group/thumb relative h-12 w-12 shrink-0 cursor-pointer overflow-hidden rounded-md border bg-muted/30 transition-colors",
+        "relative h-12 w-12 shrink-0 cursor-pointer overflow-hidden rounded-md border bg-muted/30 transition-colors",
         "hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
         isError && "border-destructive"
       )}
@@ -80,6 +92,9 @@ function PendingImageThumbnail({
         </div>
       )}
       {!isUploading && (
+        // Always visible (not hover-revealed): touch has no hover, and the
+        // lightbox has no remove control, so a hidden × would strand a phone
+        // user with no way to drop a mis-picked image. Matches the pill.
         <button
           type="button"
           aria-label={`Remove ${attachment.filename}`}
@@ -88,7 +103,7 @@ function PendingImageThumbnail({
             e.stopPropagation()
             onRemove(attachment.id)
           }}
-          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground/70 opacity-0 transition-opacity hover:text-foreground group-hover/thumb:opacity-100 focus-visible:opacity-100"
+          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-1 text-foreground/70 opacity-80 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:opacity-100"
         >
           <X className="h-3 w-3" />
         </button>
@@ -106,6 +121,7 @@ function PendingImageThumbnail({
           draggable={false}
           className="max-h-64 max-w-full rounded object-contain"
         />
+        {errorText && <p className="px-1 pt-1 pb-0.5 text-xs text-destructive">{errorText}</p>}
       </HoverCardContent>
     </HoverCard>
   )
@@ -165,7 +181,7 @@ export function PendingAttachments({ attachments, onRemove, beforePills, workspa
           if (hasImagePreview(attachment)) {
             return (
               <PendingImageThumbnail
-                key={attachment.id}
+                key={attachment.previewUrl}
                 attachment={attachment}
                 onRemove={onRemove}
                 onOpen={() => setOpenPreviewUrl(attachment.previewUrl)}

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,12 +1,13 @@
-import { useMemo, useState, type ReactNode } from "react"
-import { Loader2, FileText, Image as ImageIcon, File as FileIcon, AlertCircle, X } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
+import { Loader2, FileText, Image as ImageIcon, File as FileIcon, AlertCircle } from "lucide-react"
 import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer/attachment-pill"
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
+import { useDecryptedAttachment } from "@/hooks/use-decrypted-attachment"
+import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { attachmentContentUrl } from "@/api"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { formatFileSize } from "@/lib/file-size"
-import { cn } from "@/lib/utils"
 
 function getFileIcon(mimeType: string): typeof FileIcon {
   if (mimeType.startsWith("image/")) return ImageIcon
@@ -20,111 +21,113 @@ const STATUS_MAP: Record<PendingAttachment["status"], AttachmentPillStatus> = {
   error: "error",
 }
 
-/** An image attachment with local bytes we can preview inline. */
-function hasImagePreview(a: PendingAttachment): a is PendingAttachment & { previewUrl: string } {
-  return a.mimeType.startsWith("image/") && !!a.previewUrl
+function isImageAttachment(a: PendingAttachment): boolean {
+  return a.mimeType.startsWith("image/")
 }
 
-/**
- * Composer image preview: a small tile showing the actual image so users can
- * see what they attached before sending. Hovering enlarges it (desktop);
- * clicking/tapping opens the shared media lightbox. The preview is available
- * immediately — even while the upload is still in flight — because it reads the
- * local object URL, not the server copy.
- */
-function PendingImageThumbnail({
-  attachment,
-  onRemove,
-  onOpen,
-}: {
-  attachment: PendingAttachment & { previewUrl: string }
+/** Stable identity across the temp→server id flip: the object URL never changes. */
+function attachmentKey(a: PendingAttachment): string {
+  return a.previewUrl ?? a.id
+}
+
+// The preview source for an image without a decrypt step: local bytes win;
+// otherwise the deterministic non-E2E content URL (thumbnail variant for the
+// chip, full for the lightbox). Returns null for non-images and for E2E images
+// (a ref is present → resolved via decrypt in E2eImageChip instead). Restore
+// fires only after a draft decrypts, so a present ref means "E2E, unlocked";
+// its absence here means non-E2E, where the content URL is a real image.
+function staticImageSrc(a: PendingAttachment, workspaceId: string): { thumb: string; full: string } | null {
+  if (a.previewUrl) return { thumb: a.previewUrl, full: a.previewUrl }
+  if (!isImageAttachment(a) || getAttachmentRef(a.id)) return null
+  return {
+    thumb: attachmentContentUrl(workspaceId, a.id, { variant: "thumbnail" }),
+    full: attachmentContentUrl(workspaceId, a.id),
+  }
+}
+
+interface ChipViewProps {
+  attachment: PendingAttachment
+  /** Leading-slot preview image; falls back to the type icon when absent/failed. */
+  thumbnailSrc?: string
+  /** Full-resolution URL for the lightbox, or null when not previewable. */
+  fullSrc: string | null
+  /** True while an E2E image's bytes are still decrypting. */
+  decrypting?: boolean
   onRemove: (id: string) => void
-  onOpen: () => void
-}) {
+  onOpen: (key: string) => void
+  onResolveSrc: (key: string, src: string | null) => void
+}
+
+function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onOpen, onResolveSrc }: ChipViewProps) {
+  const key = attachmentKey(attachment)
+
+  // Publish the full-res URL so the parent can build the lightbox item list.
+  useEffect(() => {
+    onResolveSrc(key, fullSrc)
+  }, [key, fullSrc, onResolveSrc])
+  useEffect(() => () => onResolveSrc(key, null), [key, onResolveSrc])
+
+  const status = STATUS_MAP[attachment.status]
   const isUploading = attachment.status === "uploading"
   const isError = attachment.status === "error"
-  // Mirror the pill's generic-error fallback so an image that fails upload
-  // surfaces the same explanation the pill would, rather than a bare icon.
+
   const isGenericError =
     isError &&
     (attachment.error === "Internal server error" || attachment.error === "Upload failed" || !attachment.error)
-  let errorText: string | undefined
-  if (isError) {
-    errorText = isGenericError ? "We couldn't upload this file. Please remove it and try again." : attachment.error
-  }
+  let tooltip: string | undefined
+  if (isGenericError) tooltip = "We couldn't upload this file. Please remove it and try again."
+  else if (isError) tooltip = attachment.error
 
-  const tile = (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-label={isError ? `${attachment.filename} — upload failed` : `Preview ${attachment.filename}`}
-      title={errorText}
-      onClick={onOpen}
-      onKeyDown={(e) => {
-        // Only the tile itself opens the lightbox — a keydown bubbling up from
-        // the nested remove button must not preventDefault its own activation.
-        if (e.target !== e.currentTarget) return
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          onOpen()
-        }
-      }}
-      className={cn(
-        "relative h-12 w-12 shrink-0 cursor-pointer overflow-hidden rounded-md border bg-muted/30 transition-colors",
-        "hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
-        isError && "border-destructive"
-      )}
-    >
-      <img
-        src={attachment.previewUrl}
-        alt={attachment.filename}
-        draggable={false}
-        className={cn("h-full w-full object-cover", (isUploading || isError) && "opacity-40")}
-      />
-      {isUploading && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <Loader2 className="h-4 w-4 animate-spin text-foreground/70" />
-        </div>
-      )}
-      {isError && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <AlertCircle className="h-4 w-4 text-destructive" />
-        </div>
-      )}
-      {!isUploading && (
-        // Always visible (not hover-revealed): touch has no hover, and the
-        // lightbox has no remove control, so a hidden × would strand a phone
-        // user with no way to drop a mis-picked image. Matches the pill.
-        <button
-          type="button"
-          aria-label={`Remove ${attachment.filename}`}
-          onClick={(e) => {
-            e.preventDefault()
-            e.stopPropagation()
-            onRemove(attachment.id)
-          }}
-          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-1 text-foreground/70 opacity-80 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:opacity-100"
-        >
-          <X className="h-3 w-3" />
-        </button>
-      )}
-    </div>
-  )
+  let Icon = getFileIcon(attachment.mimeType)
+  if (isUploading || decrypting) Icon = Loader2
+  else if (isError) Icon = AlertCircle
+
+  const canPreview = !!fullSrc && !isError
 
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
-      <HoverCardTrigger asChild>{tile}</HoverCardTrigger>
-      <HoverCardContent side="top" className="w-auto max-w-xs p-1">
-        <img
-          src={attachment.previewUrl}
-          alt={attachment.filename}
-          draggable={false}
-          className="max-h-64 max-w-full rounded object-contain"
-        />
-        {errorText && <p className="px-1 pt-1 pb-0.5 text-xs text-destructive">{errorText}</p>}
-      </HoverCardContent>
-    </HoverCard>
+    <AttachmentPill
+      icon={Icon}
+      thumbnailSrc={thumbnailSrc}
+      label={attachment.filename}
+      secondary={isError ? "Failed" : formatFileSize(attachment.sizeBytes)}
+      status={status}
+      tooltip={tooltip}
+      onRemove={isUploading ? undefined : () => onRemove(attachment.id)}
+      removeLabel={`Remove ${attachment.filename}`}
+      onActivate={canPreview ? () => onOpen(key) : undefined}
+      activateLabel={`Preview ${attachment.filename}`}
+      labelMaxWidth="max-w-[120px]"
+    />
   )
+}
+
+/** Chip whose preview needs no decrypt: local object URL, non-E2E thumbnail, or icon. */
+function StaticChip(props: {
+  attachment: PendingAttachment
+  workspaceId: string
+  onRemove: (id: string) => void
+  onOpen: (key: string) => void
+  onResolveSrc: (key: string, src: string | null) => void
+}) {
+  const src = staticImageSrc(props.attachment, props.workspaceId)
+  return <ChipView {...props} thumbnailSrc={src?.thumb} fullSrc={src?.full ?? null} />
+}
+
+/** Chip for an E2E image: decrypts the bytes in memory (no server thumbnail exists). */
+function E2eImageChip({
+  attachmentRef,
+  ...props
+}: {
+  attachment: PendingAttachment
+  attachmentRef: AttachmentRef
+  workspaceId: string
+  onRemove: (id: string) => void
+  onOpen: (key: string) => void
+  onResolveSrc: (key: string, src: string | null) => void
+}) {
+  const decrypted = useDecryptedAttachment(props.workspaceId, attachmentRef)
+  const url = decrypted.status === "ready" ? decrypted.url : null
+  return <ChipView {...props} thumbnailSrc={url ?? undefined} fullSrc={url} decrypting={decrypted.status === "pending"} />
 }
 
 interface PendingAttachmentsProps {
@@ -137,84 +140,72 @@ interface PendingAttachmentsProps {
    * to this message," not two stacked rows.
    */
   beforePills?: ReactNode
-  /** Enables the lightbox download affordance; download is gated for previews regardless. */
+  /** Anchors the lightbox; download stays gated for previews regardless. */
   workspaceId?: string
 }
 
 /**
- * Composer attachment row: image uploads render as preview thumbnails
- * (hover to enlarge, click/tap to open the lightbox), everything else as a
- * labeled `<AttachmentPill>` — alongside any caller-provided `beforePills`
- * (typically context-ref chips) inside a single `flex flex-wrap` container.
- *
- * Renders nothing when both lists are empty.
+ * Composer attachment row: every attachment renders as one uniform chip
+ * (filename + size + remove ×). Image chips show a preview thumbnail in the
+ * leading slot — from local bytes, the non-E2E server thumbnail, or an in-memory
+ * E2E decrypt — and tap/click to open the shared lightbox; other types keep
+ * their type icon. Renders nothing when both lists are empty.
  */
 export function PendingAttachments({ attachments, onRemove, beforePills, workspaceId }: PendingAttachmentsProps) {
-  // Track the open preview by object URL, not attachment id: the id flips from a
-  // temp id to the server id when an upload completes, but the object URL is
-  // stable, so an open lightbox survives its own upload finishing.
-  const [openPreviewUrl, setOpenPreviewUrl] = useState<string | null>(null)
+  const ws = workspaceId ?? ""
+  // Open lightbox tracked by the stable attachment key, not the id (which flips
+  // temp→server on upload completion), so an open preview survives its upload.
+  const [openKey, setOpenKey] = useState<string | null>(null)
+  // Full-res URL per image chip, published by each chip (a chip owns the E2E
+  // decrypt / object-URL lifecycle), so the lightbox item list has every source.
+  const [srcByKey, setSrcByKey] = useState<Map<string, string>>(new Map())
 
-  const imageAttachments = useMemo(() => attachments.filter(hasImagePreview), [attachments])
+  const onResolveSrc = useCallback((key: string, src: string | null) => {
+    setSrcByKey((prev) => {
+      if ((prev.get(key) ?? null) === src) return prev
+      const next = new Map(prev)
+      if (src) next.set(key, src)
+      else next.delete(key)
+      return next
+    })
+  }, [])
+
+  const imageAttachments = useMemo(() => attachments.filter(isImageAttachment), [attachments])
 
   const galleryItems = useMemo<GalleryItem[]>(
     () =>
-      imageAttachments.map((a) => ({
-        type: "image" as const,
-        url: a.previewUrl,
-        thumbnailUrl: a.previewUrl,
-        filename: a.filename,
-        attachmentId: pendingGalleryId(a.previewUrl),
-      })),
-    [imageAttachments]
+      imageAttachments
+        .map((a): GalleryItem | null => {
+          const key = attachmentKey(a)
+          const url = srcByKey.get(key)
+          if (!url) return null
+          return {
+            type: "image",
+            url,
+            thumbnailUrl: url,
+            filename: a.filename,
+            attachmentId: pendingGalleryId(key),
+          }
+        })
+        .filter((item): item is GalleryItem => item !== null),
+    [imageAttachments, srcByKey]
   )
 
   if (attachments.length === 0 && !beforePills) return null
 
-  const galleryIndex = openPreviewUrl ? imageAttachments.findIndex((a) => a.previewUrl === openPreviewUrl) : -1
+  const galleryIndex = openKey ? galleryItems.findIndex((g) => g.attachmentId === pendingGalleryId(openKey)) : -1
 
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 mb-3 max-h-[120px] overflow-y-auto">
         {beforePills}
         {attachments.map((attachment) => {
-          if (hasImagePreview(attachment)) {
-            return (
-              <PendingImageThumbnail
-                key={attachment.previewUrl}
-                attachment={attachment}
-                onRemove={onRemove}
-                onOpen={() => setOpenPreviewUrl(attachment.previewUrl)}
-              />
-            )
-          }
-
-          const status = STATUS_MAP[attachment.status]
-          const isUploading = attachment.status === "uploading"
-          const isError = attachment.status === "error"
-          let Icon = getFileIcon(attachment.mimeType)
-          if (isUploading) Icon = Loader2
-          else if (isError) Icon = AlertCircle
-
-          const isGenericError =
-            isError &&
-            (attachment.error === "Internal server error" || attachment.error === "Upload failed" || !attachment.error)
-          let tooltip: string | undefined
-          if (isGenericError) tooltip = "We couldn't upload this file. Please remove it and try again."
-          else if (isError) tooltip = attachment.error
-
-          return (
-            <AttachmentPill
-              key={attachment.id}
-              icon={Icon}
-              label={attachment.filename}
-              secondary={isError ? "Failed" : formatFileSize(attachment.sizeBytes)}
-              status={status}
-              tooltip={tooltip}
-              onRemove={isUploading ? undefined : () => onRemove(attachment.id)}
-              removeLabel={`Remove ${attachment.filename}`}
-              labelMaxWidth="max-w-[120px]"
-            />
+          const ref = !attachment.previewUrl && isImageAttachment(attachment) ? getAttachmentRef(attachment.id) : undefined
+          const shared = { attachment, workspaceId: ws, onRemove, onOpen: setOpenKey, onResolveSrc }
+          return ref ? (
+            <E2eImageChip key={attachmentKey(attachment)} attachmentRef={ref} {...shared} />
+          ) : (
+            <StaticChip key={attachmentKey(attachment)} {...shared} />
           )
         })}
       </div>
@@ -222,10 +213,10 @@ export function PendingAttachments({ attachments, onRemove, beforePills, workspa
       {galleryItems.length > 0 && (
         <MediaGallery
           isOpen={galleryIndex !== -1}
-          onClose={() => setOpenPreviewUrl(null)}
+          onClose={() => setOpenKey(null)}
           items={galleryItems}
           initialIndex={Math.max(0, galleryIndex)}
-          workspaceId={workspaceId ?? ""}
+          workspaceId={ws}
         />
       )}
     </>

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,8 +1,12 @@
-import type { ReactNode } from "react"
-import { Loader2, FileText, Image as ImageIcon, File as FileIcon, AlertCircle } from "lucide-react"
+import { useMemo, useState, type ReactNode } from "react"
+import { Loader2, FileText, Image as ImageIcon, File as FileIcon, AlertCircle, X } from "lucide-react"
 import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer/attachment-pill"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
+import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
+import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { formatFileSize } from "@/lib/file-size"
+import { cn } from "@/lib/utils"
 
 function getFileIcon(mimeType: string): typeof FileIcon {
   if (mimeType.startsWith("image/")) return ImageIcon
@@ -16,6 +20,97 @@ const STATUS_MAP: Record<PendingAttachment["status"], AttachmentPillStatus> = {
   error: "error",
 }
 
+/** An image attachment with local bytes we can preview inline. */
+function hasImagePreview(a: PendingAttachment): a is PendingAttachment & { previewUrl: string } {
+  return a.mimeType.startsWith("image/") && !!a.previewUrl
+}
+
+/**
+ * Composer image preview: a small tile showing the actual image so users can
+ * see what they attached before sending. Hovering enlarges it (desktop);
+ * clicking/tapping opens the shared media lightbox. The preview is available
+ * immediately — even while the upload is still in flight — because it reads the
+ * local object URL, not the server copy.
+ */
+function PendingImageThumbnail({
+  attachment,
+  onRemove,
+  onOpen,
+}: {
+  attachment: PendingAttachment & { previewUrl: string }
+  onRemove: (id: string) => void
+  onOpen: () => void
+}) {
+  const isUploading = attachment.status === "uploading"
+  const isError = attachment.status === "error"
+
+  const tile = (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`Preview ${attachment.filename}`}
+      title={isError ? attachment.error : undefined}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onOpen()
+        }
+      }}
+      className={cn(
+        "group/thumb relative h-12 w-12 shrink-0 cursor-pointer overflow-hidden rounded-md border bg-muted/30 transition-colors",
+        "hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+        isError && "border-destructive"
+      )}
+    >
+      <img
+        src={attachment.previewUrl}
+        alt={attachment.filename}
+        draggable={false}
+        className={cn("h-full w-full object-cover", (isUploading || isError) && "opacity-40")}
+      />
+      {isUploading && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <Loader2 className="h-4 w-4 animate-spin text-foreground/70" />
+        </div>
+      )}
+      {isError && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <AlertCircle className="h-4 w-4 text-destructive" />
+        </div>
+      )}
+      {!isUploading && (
+        <button
+          type="button"
+          aria-label={`Remove ${attachment.filename}`}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            onRemove(attachment.id)
+          }}
+          className="absolute right-0.5 top-0.5 rounded-full bg-background/80 p-0.5 text-foreground/70 opacity-0 transition-opacity hover:text-foreground group-hover/thumb:opacity-100 focus-visible:opacity-100"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  )
+
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>{tile}</HoverCardTrigger>
+      <HoverCardContent side="top" className="w-auto max-w-xs p-1">
+        <img
+          src={attachment.previewUrl}
+          alt={attachment.filename}
+          draggable={false}
+          className="max-h-64 max-w-full rounded object-contain"
+        />
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
 interface PendingAttachmentsProps {
   attachments: PendingAttachment[]
   onRemove: (id: string) => void
@@ -26,52 +121,97 @@ interface PendingAttachmentsProps {
    * to this message," not two stacked rows.
    */
   beforePills?: ReactNode
+  /** Enables the lightbox download affordance; download is gated for previews regardless. */
+  workspaceId?: string
 }
 
 /**
- * Composer attachment row: renders pending file uploads alongside any
- * caller-provided `beforePills` (typically context-ref chips) inside a
- * single `flex flex-wrap` container. Uses the shared `<AttachmentPill>`
- * primitive so files + context-refs share visuals (rounded-lg border,
- * primary accent, dashed-border pending state).
+ * Composer attachment row: image uploads render as preview thumbnails
+ * (hover to enlarge, click/tap to open the lightbox), everything else as a
+ * labeled `<AttachmentPill>` — alongside any caller-provided `beforePills`
+ * (typically context-ref chips) inside a single `flex flex-wrap` container.
  *
  * Renders nothing when both lists are empty.
  */
-export function PendingAttachments({ attachments, onRemove, beforePills }: PendingAttachmentsProps) {
+export function PendingAttachments({ attachments, onRemove, beforePills, workspaceId }: PendingAttachmentsProps) {
+  // Track the open preview by object URL, not attachment id: the id flips from a
+  // temp id to the server id when an upload completes, but the object URL is
+  // stable, so an open lightbox survives its own upload finishing.
+  const [openPreviewUrl, setOpenPreviewUrl] = useState<string | null>(null)
+
+  const imageAttachments = useMemo(() => attachments.filter(hasImagePreview), [attachments])
+
+  const galleryItems = useMemo<GalleryItem[]>(
+    () =>
+      imageAttachments.map((a) => ({
+        type: "image" as const,
+        url: a.previewUrl,
+        thumbnailUrl: a.previewUrl,
+        filename: a.filename,
+        attachmentId: pendingGalleryId(a.previewUrl),
+      })),
+    [imageAttachments]
+  )
+
   if (attachments.length === 0 && !beforePills) return null
 
+  const galleryIndex = openPreviewUrl ? imageAttachments.findIndex((a) => a.previewUrl === openPreviewUrl) : -1
+
   return (
-    <div className="flex flex-wrap gap-2 mb-3 max-h-[120px] overflow-y-auto">
-      {beforePills}
-      {attachments.map((attachment) => {
-        const status = STATUS_MAP[attachment.status]
-        const isUploading = attachment.status === "uploading"
-        const isError = attachment.status === "error"
-        let Icon = getFileIcon(attachment.mimeType)
-        if (isUploading) Icon = Loader2
-        else if (isError) Icon = AlertCircle
+    <>
+      <div className="flex flex-wrap items-center gap-2 mb-3 max-h-[120px] overflow-y-auto">
+        {beforePills}
+        {attachments.map((attachment) => {
+          if (hasImagePreview(attachment)) {
+            return (
+              <PendingImageThumbnail
+                key={attachment.id}
+                attachment={attachment}
+                onRemove={onRemove}
+                onOpen={() => setOpenPreviewUrl(attachment.previewUrl)}
+              />
+            )
+          }
 
-        const isGenericError =
-          isError &&
-          (attachment.error === "Internal server error" || attachment.error === "Upload failed" || !attachment.error)
-        let tooltip: string | undefined
-        if (isGenericError) tooltip = "We couldn't upload this file. Please remove it and try again."
-        else if (isError) tooltip = attachment.error
+          const status = STATUS_MAP[attachment.status]
+          const isUploading = attachment.status === "uploading"
+          const isError = attachment.status === "error"
+          let Icon = getFileIcon(attachment.mimeType)
+          if (isUploading) Icon = Loader2
+          else if (isError) Icon = AlertCircle
 
-        return (
-          <AttachmentPill
-            key={attachment.id}
-            icon={Icon}
-            label={attachment.filename}
-            secondary={isError ? "Failed" : formatFileSize(attachment.sizeBytes)}
-            status={status}
-            tooltip={tooltip}
-            onRemove={isUploading ? undefined : () => onRemove(attachment.id)}
-            removeLabel={`Remove ${attachment.filename}`}
-            labelMaxWidth="max-w-[120px]"
-          />
-        )
-      })}
-    </div>
+          const isGenericError =
+            isError &&
+            (attachment.error === "Internal server error" || attachment.error === "Upload failed" || !attachment.error)
+          let tooltip: string | undefined
+          if (isGenericError) tooltip = "We couldn't upload this file. Please remove it and try again."
+          else if (isError) tooltip = attachment.error
+
+          return (
+            <AttachmentPill
+              key={attachment.id}
+              icon={Icon}
+              label={attachment.filename}
+              secondary={isError ? "Failed" : formatFileSize(attachment.sizeBytes)}
+              status={status}
+              tooltip={tooltip}
+              onRemove={isUploading ? undefined : () => onRemove(attachment.id)}
+              removeLabel={`Remove ${attachment.filename}`}
+              labelMaxWidth="max-w-[120px]"
+            />
+          )
+        })}
+      </div>
+
+      {galleryItems.length > 0 && (
+        <MediaGallery
+          isOpen={galleryIndex !== -1}
+          onClose={() => setOpenPreviewUrl(null)}
+          items={galleryItems}
+          initialIndex={Math.max(0, galleryIndex)}
+          workspaceId={workspaceId ?? ""}
+        />
+      )}
+    </>
   )
 }

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -88,6 +88,7 @@ function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onO
     <AttachmentPill
       icon={Icon}
       thumbnailSrc={thumbnailSrc}
+      spinning={isUploading || decrypting}
       label={attachment.filename}
       secondary={isError ? "Failed" : formatFileSize(attachment.sizeBytes)}
       status={status}

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -36,9 +36,9 @@ function attachmentKey(a: PendingAttachment): string {
 // (a ref is present → resolved via decrypt in E2eImageChip instead). Restore
 // fires only after a draft decrypts, so a present ref means "E2E, unlocked";
 // its absence here means non-E2E, where the content URL is a real image.
-function staticImageSrc(a: PendingAttachment, workspaceId: string): { thumb: string; full: string } | null {
+function staticImageSrc(a: PendingAttachment, workspaceId: string | undefined): { thumb: string; full: string } | null {
   if (a.previewUrl) return { thumb: a.previewUrl, full: a.previewUrl }
-  if (!isImageAttachment(a) || getAttachmentRef(a.id)) return null
+  if (!isImageAttachment(a) || !workspaceId || getAttachmentRef(a.id)) return null
   return {
     thumb: attachmentContentUrl(workspaceId, a.id, { variant: "thumbnail" }),
     full: attachmentContentUrl(workspaceId, a.id),
@@ -104,7 +104,7 @@ function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onO
 /** Chip whose preview needs no decrypt: local object URL, non-E2E thumbnail, or icon. */
 function StaticChip(props: {
   attachment: PendingAttachment
-  workspaceId: string
+  workspaceId: string | undefined
   onRemove: (id: string) => void
   onOpen: (key: string) => void
   onResolveSrc: (key: string, src: string | null) => void
@@ -140,7 +140,13 @@ interface PendingAttachmentsProps {
    * to this message," not two stacked rows.
    */
   beforePills?: ReactNode
-  /** Anchors the lightbox; download stays gated for previews regardless. */
+  /**
+   * Anchors every preview source (non-E2E server thumbnail, E2E decrypt,
+   * lightbox). Optional because the composer's own `workspaceId` is; every URL
+   * path is guarded on its presence so a missing value yields an icon, never a
+   * malformed `/api/workspaces//…` request (INV-11) — local previews and remove
+   * still work without it.
+   */
   workspaceId?: string
 }
 
@@ -152,7 +158,6 @@ interface PendingAttachmentsProps {
  * their type icon. Renders nothing when both lists are empty.
  */
 export function PendingAttachments({ attachments, onRemove, beforePills, workspaceId }: PendingAttachmentsProps) {
-  const ws = workspaceId ?? ""
   // Open lightbox tracked by the stable attachment key, not the id (which flips
   // temp→server on upload completion), so an open preview survives its upload.
   const [openKey, setOpenKey] = useState<string | null>(null)
@@ -200,23 +205,27 @@ export function PendingAttachments({ attachments, onRemove, beforePills, workspa
       <div className="flex flex-wrap items-center gap-2 mb-3 max-h-[120px] overflow-y-auto">
         {beforePills}
         {attachments.map((attachment) => {
-          const ref = !attachment.previewUrl && isImageAttachment(attachment) ? getAttachmentRef(attachment.id) : undefined
-          const shared = { attachment, workspaceId: ws, onRemove, onOpen: setOpenKey, onResolveSrc }
-          return ref ? (
-            <E2eImageChip key={attachmentKey(attachment)} attachmentRef={ref} {...shared} />
+          const key = attachmentKey(attachment)
+          const ref =
+            workspaceId && !attachment.previewUrl && isImageAttachment(attachment)
+              ? getAttachmentRef(attachment.id)
+              : undefined
+          const shared = { attachment, onRemove, onOpen: setOpenKey, onResolveSrc }
+          return ref && workspaceId ? (
+            <E2eImageChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />
           ) : (
-            <StaticChip key={attachmentKey(attachment)} {...shared} />
+            <StaticChip key={key} workspaceId={workspaceId} {...shared} />
           )
         })}
       </div>
 
-      {galleryItems.length > 0 && (
+      {workspaceId && galleryItems.length > 0 && (
         <MediaGallery
           isOpen={galleryIndex !== -1}
           onClose={() => setOpenKey(null)}
           items={galleryItems}
           initialIndex={Math.max(0, galleryIndex)}
-          workspaceId={ws}
+          workspaceId={workspaceId}
         />
       )}
     </>

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -302,10 +302,24 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
 
   const restore = useCallback(
     (attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>) => {
-      for (const a of pendingAttachmentsRef.current) revokePreviewUrl(a.previewUrl)
+      // Carry over the local object URL for any attachment already in memory: a
+      // draft re-hydrate (the debounced save that lands mid-session, or a
+      // stash/restore pointer move) round-trips through this path, and without
+      // the carry-over the fresh-upload preview would collapse to an icon the
+      // instant the draft persisted. Preview persistence across an actual reload
+      // is the reader's job (server thumbnail / E2E decrypt) — there are no local
+      // bytes to carry then.
+      const priorPreviewById = new Map(
+        pendingAttachmentsRef.current.filter((a) => a.previewUrl).map((a) => [a.id, a.previewUrl])
+      )
+      const restoredIds = new Set(attachments.map((a) => a.id))
+      for (const a of pendingAttachmentsRef.current) {
+        if (a.previewUrl && !restoredIds.has(a.id)) revokePreviewUrl(a.previewUrl)
+      }
       const restoredAttachments = attachments.map((a) => ({
         ...a,
         status: "uploaded" as const,
+        previewUrl: priorPreviewById.get(a.id),
       }))
       pendingAttachmentsRef.current = restoredAttachments
       setPendingAttachments(restoredAttachments)

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -1,10 +1,35 @@
-import { useState, useCallback, useRef, type ChangeEvent, type RefObject } from "react"
+import { useState, useCallback, useEffect, useRef, type ChangeEvent, type RefObject } from "react"
 import { attachmentsApi } from "@/api"
 import { encryptAttachmentBytes, rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
 
 /** The placeholder name/mime the server forces for E2E ciphertext uploads. */
 const E2E_CIPHERTEXT_FILENAME = "encrypted"
 const E2E_CIPHERTEXT_MIME = "application/octet-stream"
+
+/**
+ * Object URL for the local bytes of a picked/pasted image, so the composer can
+ * preview the actual image before send. Reading from the local File means the
+ * preview is available immediately (even mid-upload) and works for E2E streams
+ * where the server only ever holds ciphertext. Best-effort: environments
+ * without object-URL support (jsdom) get `undefined` and fall back to a pill.
+ */
+function createImagePreviewUrl(file: File): string | undefined {
+  if (!file.type.startsWith("image/")) return undefined
+  try {
+    return URL.createObjectURL(file)
+  } catch {
+    return undefined
+  }
+}
+
+function revokePreviewUrl(url: string | undefined): void {
+  if (!url) return
+  try {
+    URL.revokeObjectURL(url)
+  } catch {
+    // no-op — see createImagePreviewUrl
+  }
+}
 
 interface UploadOptions {
   /**
@@ -30,6 +55,12 @@ export interface PendingAttachment {
   sizeBytes: number
   status: "uploading" | "uploaded" | "error"
   error?: string
+  /**
+   * Local object URL for image files, for the in-composer preview
+   * (thumbnail + lightbox). Undefined for non-images and for restored drafts,
+   * which carry no local bytes. Revoked on remove/clear/unmount.
+   */
+  previewUrl?: string
 }
 
 export interface UploadResult {
@@ -130,6 +161,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
 
       for (const file of files) {
         const tempId = `temp_${Date.now()}_${Math.random().toString(36).slice(2)}`
+        const previewUrl = createImagePreviewUrl(file)
 
         updatePendingAttachments((prev) => [
           ...prev,
@@ -139,6 +171,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
             mimeType: file.type || "application/octet-stream",
             sizeBytes: file.size,
             status: "uploading",
+            previewUrl,
           },
         ])
 
@@ -146,7 +179,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
           const facts = await uploadOne(file)
 
           updatePendingAttachments((prev) =>
-            prev.map((a) => (a.id === tempId ? { ...facts, status: "uploaded" as const } : a))
+            prev.map((a) => (a.id === tempId ? { ...facts, status: "uploaded" as const, previewUrl } : a))
           )
         } catch (err) {
           updatePendingAttachments((prev) =>
@@ -184,12 +217,14 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
         setImageCount(assignedImageIndex)
       }
 
+      const previewUrl = createImagePreviewUrl(file)
       const pendingAttachment: PendingAttachment = {
         id: tempId,
         filename: file.name,
         mimeType: file.type || "application/octet-stream",
         sizeBytes: file.size,
         status: "uploading",
+        previewUrl,
       }
 
       updatePendingAttachments((prev) => [...prev, pendingAttachment])
@@ -200,6 +235,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
         const uploadedAttachment: PendingAttachment = {
           ...facts,
           status: "uploaded",
+          previewUrl,
         }
 
         updatePendingAttachments((prev) => prev.map((a) => (a.id === tempId ? uploadedAttachment : a)))
@@ -233,6 +269,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
       const attachment = pendingAttachmentsRef.current.find((a) => a.id === attachmentId)
       if (!attachment) return
 
+      revokePreviewUrl(attachment.previewUrl)
       updatePendingAttachments((prev) => prev.filter((a) => a.id !== attachmentId))
 
       if (attachment.status === "uploaded" && !attachmentId.startsWith("temp_")) {
@@ -247,14 +284,25 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
   )
 
   const clear = useCallback(() => {
+    for (const a of pendingAttachmentsRef.current) revokePreviewUrl(a.previewUrl)
     pendingAttachmentsRef.current = []
     setPendingAttachments([])
     setImageCount(0)
     imageCountRef.current = 0
   }, [])
 
+  // Backstop for previews still live when the composer unmounts (navigating away
+  // with a draft mid-upload) — the happy path revokes via clear() on send.
+  useEffect(
+    () => () => {
+      for (const a of pendingAttachmentsRef.current) revokePreviewUrl(a.previewUrl)
+    },
+    []
+  )
+
   const restore = useCallback(
     (attachments: Array<{ id: string; filename: string; mimeType: string; sizeBytes: number }>) => {
+      for (const a of pendingAttachmentsRef.current) revokePreviewUrl(a.previewUrl)
       const restoredAttachments = attachments.map((a) => ({
         ...a,
         status: "uploaded" as const,

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -259,8 +259,9 @@ test.describe("Drafts Page", () => {
       editor.dispatchEvent(pasteEvent)
     }, Array.from(imageBuffer))
 
-    // Wait for upload
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 10000 })
+    // Wait for upload — the composer renders pending images as preview thumbnails
+    // (filename in the accessible name, not visible text).
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 10000 })
 
     // Wait for draft to be saved. The first debounce fires during upload (saving
     // attachments: []), so waitForDraftSaved returns immediately (link already highlighted).

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -259,8 +259,8 @@ test.describe("Drafts Page", () => {
       editor.dispatchEvent(pasteEvent)
     }, Array.from(imageBuffer))
 
-    // Wait for upload — the composer renders pending images as preview thumbnails
-    // (filename in the accessible name, not visible text).
+    // Wait for upload — the pending image renders as a chip whose visible label
+    // is the filename.
     await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 10000 })
 
     // Wait for draft to be saved. The first debounce fires during upload (saving

--- a/tests/browser/drafts-modal.spec.ts
+++ b/tests/browser/drafts-modal.spec.ts
@@ -261,7 +261,7 @@ test.describe("Drafts Page", () => {
 
     // Wait for upload — the composer renders pending images as preview thumbnails
     // (filename in the accessible name, not visible text).
-    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 10000 })
 
     // Wait for draft to be saved. The first debounce fires during upload (saving
     // attachments: []), so waitForDraftSaved returns immediately (link already highlighted).

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -72,7 +72,7 @@ test.describe("Inline File Uploads", () => {
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
 
     // Verify attachment chip shows the renamed filename (pasted-image-1.png)
-    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
   })
 
   test("should insert [filename] reference when pasting a non-image file", async ({ page }) => {
@@ -135,7 +135,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for first upload and verify filename
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
 
     // Paste second image
     await page.evaluate(async (imageData) => {
@@ -160,7 +160,7 @@ test.describe("Inline File Uploads", () => {
 
     // Should have two references with sequential naming
     await expect(editor.locator("span[data-type='attachment-reference']")).toHaveCount(2, { timeout: 10000 })
-    await expect(page.getByRole("button", { name: "Preview pasted-image-2.png" })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText("pasted-image-2.png")).toBeVisible({ timeout: 5000 })
   })
 
   test("should open lightbox when clicking image link in sent message", async ({ page }) => {
@@ -191,7 +191,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Check out this image: ")
@@ -247,7 +247,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Hover test: ")

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -203,7 +203,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait until attachment metadata is hydrated in the rendered message.
     // Inline link click depends on attachment context, which can lag briefly in CI.
-    const attachmentPill = page.locator("[role='button']:has(img[alt='pasted-image-1.png'])")
+    const attachmentPill = page.getByRole("button", { name: "pasted-image-1.png", exact: true })
     await expect(attachmentPill).toBeVisible({ timeout: 10000 })
 
     // Ensure the attachment image has loaded (src attribute is set and not a blob placeholder).
@@ -258,7 +258,7 @@ test.describe("Inline File Uploads", () => {
     await expect(imageLink).toBeVisible({ timeout: 10000 })
 
     // Find the attachment pill (the image button with the filename)
-    const attachmentPill = page.locator("[role='button']:has(img[alt='pasted-image-1.png'])")
+    const attachmentPill = page.getByRole("button", { name: "pasted-image-1.png", exact: true })
     await expect(attachmentPill).toBeVisible({ timeout: 5000 })
 
     // Before hover: pill should NOT be highlighted

--- a/tests/browser/inline-file-upload.spec.ts
+++ b/tests/browser/inline-file-upload.spec.ts
@@ -72,7 +72,7 @@ test.describe("Inline File Uploads", () => {
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
 
     // Verify attachment chip shows the renamed filename (pasted-image-1.png)
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
   })
 
   test("should insert [filename] reference when pasting a non-image file", async ({ page }) => {
@@ -135,7 +135,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for first upload and verify filename
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Paste second image
     await page.evaluate(async (imageData) => {
@@ -160,7 +160,7 @@ test.describe("Inline File Uploads", () => {
 
     // Should have two references with sequential naming
     await expect(editor.locator("span[data-type='attachment-reference']")).toHaveCount(2, { timeout: 10000 })
-    await expect(page.getByText("pasted-image-2.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-2.png" })).toBeVisible({ timeout: 5000 })
   })
 
   test("should open lightbox when clicking image link in sent message", async ({ page }) => {
@@ -191,7 +191,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Check out this image: ")
@@ -247,7 +247,7 @@ test.describe("Inline File Uploads", () => {
 
     // Wait for upload to complete (reference visible AND filename chip appears)
     await expect(editor.locator("span[data-type='attachment-reference']")).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText("pasted-image-1.png")).toBeVisible({ timeout: 5000 })
+    await expect(page.getByRole("button", { name: "Preview pasted-image-1.png" })).toBeVisible({ timeout: 5000 })
 
     // Type some text and send the message
     await editor.type("Hover test: ")


### PR DESCRIPTION
## Problem

Image uploads in the composer rendered as labeled pills — an icon plus filename plus size (`PendingAttachments` → `AttachmentPill`). You couldn't see *what* you attached until the message was sent and `AttachmentList` rendered the real thumbnails. For pasted screenshots or a batch of similar files that's a real gap: nothing distinguishes `Screenshot 2026-07-07.png` from `Screenshot 2026-07-07 (1).png` until it's too late to catch a mistake.

## Solution

Give image uploads a real preview in the composer, reusing the existing lightbox. Each image upload now renders a thumbnail of the actual bytes; **hover** enlarges it (desktop), **click/tap** opens the shared `MediaGallery` lightbox. Non-image files keep the pill.

The preview reads a **local object URL** created from the picked/pasted `File`, not the server copy — so it appears immediately (even while the upload is still in flight) and works for E2E streams where the server only ever holds ciphertext.

### How it works

1. **`useAttachments` captures `previewUrl`.** Both upload entry points (`handleFileSelect`, `uploadFile`) call `createImagePreviewUrl(file)` — `URL.createObjectURL` for `image/*`, guarded so environments without object-URL support (jsdom) fall back to `undefined`. The URL is preserved across the `uploading → uploaded` state transition and revoked on `removeAttachment`, `clear`, `restore`, and an unmount effect.
2. **`PendingAttachments` renders previews.** Images with a `previewUrl` render as 48px `PendingImageThumbnail` tiles (uploading spinner / error overlay, hover-card enlarge, in-place `×` remove); everything else falls through to the existing `AttachmentPill`. It mounts one local `MediaGallery` built from the image previews.
3. **Gallery identity is keyed by object URL, not attachment id.** A pending attachment's `id` flips from a `temp_…` id to the server id when its upload completes; the object URL is stable, so tracking the open preview by `previewUrl` keeps an open lightbox anchored across its own upload finishing.
4. **Download is gated for previews.** New `pending-gallery-id` sentinel (mirrors the existing `giphy:` / `link-preview:` sentinels) marks preview items; `image-gallery.tsx` suppresses the download affordance for them (no server-servable bytes — local URL / E2E ciphertext). Copy still works, straight from the object URL via `copyImage`.

### Key design decisions

**1. Local object URL, not a server thumbnail URL.** The preview must work before the upload finishes and inside E2E streams (server holds ciphertext only), so the source is the local `File`. This is also why download is gated rather than wired to the attachment API — for E2E it would fetch ciphertext.

**2. Track the open lightbox by `previewUrl`, not `id`.** The id is not stable (temp → server), the object URL is. Keying gallery state on the URL is what lets you open a preview mid-upload and have it stay open when the upload lands.

**3. Reuse `MediaGallery` rather than a bespoke viewer.** Same lightbox users already know from sent messages (zoom, swipe, arrow-nav), and it already had the `giphy` / `link-preview` sentinel pattern for "synthetic items with no downloadable attachment" — the pending sentinel slots straight in.

**4. Thumbnails only when we hold local bytes.** Restored drafts carry no `File`, so they keep the pill. No attempt to reconstruct previews for restored/E2E-restored attachments — out of scope, and risky.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/gallery/pending-gallery-id.ts` | `pending:` sentinel gallery id (mirrors giphy / link-preview) so the lightbox can gate download for not-yet-sent previews |
| `apps/frontend/src/components/timeline/pending-attachments.test.tsx` | Behavior tests: thumbnail render, pill fallback, click-opens-lightbox, remove, mid-upload preview |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-attachments.ts` | Add `previewUrl` to `PendingAttachment`; create object URL for images on upload; revoke on remove/clear/restore/unmount |
| `apps/frontend/src/components/timeline/pending-attachments.tsx` | Render image previews as thumbnail tiles (hover enlarge + click-to-open), mount local `MediaGallery`; keep pills for non-images |
| `apps/frontend/src/components/image-gallery.tsx` | Gate `canDownload` off for `pending:` sentinel items |
| `apps/frontend/src/components/composer/message-composer.tsx` | Thread `workspaceId` into both `PendingAttachments` mounts |

## Out of scope (deliberate)

- **Restored-draft previews.** A restored draft references an already-uploaded attachment with no local `File`; those keep the pill rather than reconstructing a thumbnail (would need a decrypt/URL path for E2E). Not attempted here.
- **Video/PDF previews in the composer.** Only `image/*` gets a tile; other types keep the pill. The lightbox already supports them, but the composer-side thumbnail is images-only for now.

## Test plan

- [x] `apps/frontend` `pending-attachments.test.tsx` + `use-attachments.test.ts` + `message-composer.test.tsx` — 41 pass
- [x] `image-gallery.reopen` + `attachment-list` (×2) + `message-input` suites — 56 pass (download-gating change caused no regression)
- [x] `tsc --noEmit` across the frontend — clean
- [x] `eslint` on all changed files — clean
- [ ] Not driven in a live browser — no workspace-auth harness available in this session; verified at the component-integration level (lightbox open asserted via the rendered dialog)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGPYgUwstwzqaJCYVFZmTq)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786006029&installation_id=129946197&pr_number=1232&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1232&signature=51382705caeca9412b3aef4f0d0d21372b6691754d0daab137445fe49eb214a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->