### PR TITLE
fix(board): subscribe running agent sessions to the live progress rail

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import type { Socket } from "socket.io-client"
 import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardPostMessage } from "@threa/types"
@@ -106,6 +107,23 @@ function sessionEvent(
   }
 }
 
+/** A socket that records its listeners so a test can fire an ephemeral event
+ *  (`agent_session:progress`) the way the backend's trace-emitter does. */
+function fakeSocket() {
+  const handlers = new Map<string, (payload: unknown) => void>()
+  const socket = {
+    on: (event: string, handler: (payload: unknown) => void) => {
+      handlers.set(event, handler)
+      return socket
+    },
+    off: (event: string) => {
+      handlers.delete(event)
+      return socket
+    },
+  } as unknown as Socket
+  return { socket, handlers }
+}
+
 const readValue = { state: () => "ungated" as const, markReadUpToHere: vi.fn(), markUnread: vi.fn() }
 
 beforeEach(async () => {
@@ -202,6 +220,42 @@ describe("BoardCard agent activity", () => {
     ])
     mountCard()
     expect(await screen.findByText("Session complete")).toBeTruthy()
+  })
+
+  it("live-updates a running session's step count from agent_session:progress", async () => {
+    // A session started from the card's opening message but not yet terminal: its
+    // events carry no counts, so the card rides the same ephemeral progress rail
+    // the timeline does (useAgentActivity). Without it the card sat at "0 steps"
+    // for the whole run.
+    const { socket, handlers } = fakeSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    await db.events.bulkPut([
+      sessionEvent("agent_session:started", 30, {
+        sessionId: "sess_C",
+        triggerMessageId: "m_open",
+        personaName: "Ariadne",
+        stepCount: 0,
+        messageCount: 0,
+      }),
+    ])
+    mountCard()
+
+    expect(await screen.findByText(/0 steps/)).toBeTruthy()
+
+    act(() => {
+      handlers.get("agent_session:progress")?.({
+        workspaceId: WS,
+        streamId: STREAM,
+        sessionId: "sess_C",
+        triggerMessageId: "m_open",
+        personaName: "Ariadne",
+        stepCount: 3,
+        messageCount: 1,
+        currentStepType: "tool_call",
+      })
+    })
+
+    expect(await screen.findByText(/3 steps/)).toBeTruthy()
   })
 
   it("does NOT render a session whose invoking message is not a conversation member", async () => {

--- a/apps/frontend/src/components/board/board-row-item.tsx
+++ b/apps/frontend/src/components/board/board-row-item.tsx
@@ -3,6 +3,10 @@ import { isContinuation, type RenderableMessage } from "@/components/message/mes
 import { AgentSessionEvent } from "@/components/timeline/agent-session-event"
 import { MemoCapturedEvent } from "@/components/timeline/memo-captured-event"
 import { FollowUpScheduledEvent } from "@/components/timeline/follow-up-event"
+import { getSessionId } from "@/components/timeline/session-grouping"
+import { useSocket } from "@/contexts"
+import { useWorkspaceUserId } from "@/hooks/use-workspaces"
+import { useAgentActivity, type MessageAgentActivity } from "@/hooks/use-agent-activity"
 import type { BoardEventRow } from "@/lib/board/board-event-rows"
 import type { BranchGrouping, BranchNode, BranchConversationView } from "@/lib/board/branch-grouping"
 
@@ -310,7 +314,7 @@ export function BoardEventRowItem({ row, workspaceId }: { row: BoardEventRow; wo
     case "session":
       return (
         <div className="px-3 sm:px-4">
-          <AgentSessionEvent events={row.events as StreamEvent[]} />
+          <BoardAgentSessionRow events={row.events as StreamEvent[]} workspaceId={workspaceId} />
         </div>
       )
     case "memo":
@@ -324,4 +328,53 @@ export function BoardEventRowItem({ row, workspaceId }: { row: BoardEventRow; wo
         />
       )
   }
+}
+
+const SESSION_TERMINAL_EVENT_TYPES = new Set<string>([
+  "agent_session:completed",
+  "agent_session:failed",
+  "agent_session:deleted",
+])
+
+/**
+ * An agent-session row on a board card / conversation panel. A terminal session
+ * carries its final step + message counts in its own payload, so it renders the
+ * shared card straight. A still-running session has no counts in its events — they
+ * arrive as ephemeral `agent_session:progress` socket ticks — so it delegates to
+ * {@link BoardRunningSessionRow}, which mounts the same live rail the timeline runs
+ * (`useAgentActivity`, event-list.tsx). Without that subscription the card sits at
+ * "0 steps" until the terminal event lands. Splitting keeps the subscription off
+ * the many past-trace rows a board carries, and confines a progress-tick re-render
+ * to this leaf instead of the whole card.
+ */
+function BoardAgentSessionRow({ events, workspaceId }: { events: StreamEvent[]; workspaceId: string }) {
+  const running = !events.some((event) => SESSION_TERMINAL_EVENT_TYPES.has(event.eventType))
+  if (!running) return <AgentSessionEvent events={events} />
+  return <BoardRunningSessionRow events={events} workspaceId={workspaceId} />
+}
+
+function BoardRunningSessionRow({ events, workspaceId }: { events: StreamEvent[]; workspaceId: string }) {
+  const socket = useSocket()
+  const userId = useWorkspaceUserId(workspaceId)
+  const activity = useAgentActivity(events, socket, workspaceId, userId)
+  const sessionId = events.reduce<string | null>((found, event) => found ?? getSessionId(event), null)
+  // `useAgentActivity` keys by trigger message and also carries socket-only
+  // sessions from other rows on the shared socket, so match this row's session by
+  // id — the same lookup event-list.tsx does off the activity map.
+  let live: MessageAgentActivity | undefined
+  if (sessionId != null) {
+    for (const entry of activity.values()) {
+      if (entry.sessionId === sessionId) {
+        live = entry
+        break
+      }
+    }
+  }
+  return (
+    <AgentSessionEvent
+      events={events}
+      liveCounts={live ? { stepCount: live.stepCount, messageCount: live.messageCount } : undefined}
+      liveSubstep={live?.substep ?? null}
+    />
+  )
 }


### PR DESCRIPTION
## Problem

An agent session on a board card (and in the conversation panel) sat at **"0 steps"** for its entire run, then jumped straight to the final count when it finished. The timeline never had this bug.

Two things were missing on the board:

- `BoardEventRowItem` (`apps/frontend/src/components/board/board-row-item.tsx`) rendered `AgentSessionEvent` with **no `liveCounts`** prop. Its running branch reads `liveCounts?.stepCount ?? 0` (`agent-session-event.tsx:184`), so absent the prop it renders `0`.
- Nothing on the board listened to the ephemeral `agent_session:progress` socket events. That subscription lives in exactly one hook — `useAgentActivity` — which was mounted only by the timeline's `StreamContent` (`stream-content.tsx:635`).

So the card only updated when the persisted terminal event (`agent_session:completed`, carrying the final `stepCount`) landed on the rail via the SyncEngine.

## Solution

Put the board session row on the same rail the timeline uses, localized to `board-row-item.tsx` — so the conversation panel, which renders session rows through the same `BoardEventRowItem`, gets the fix for free.

- A **terminal** session carries its final step/message counts in its own payload → renders `AgentSessionEvent` directly, as before.
- A **running** session delegates to a new `BoardRunningSessionRow`, which mounts `useAgentActivity(events, socket, workspaceId, userId)` — the timeline's progress subscription — and threads `stepCount` / `messageCount` / `substep` into the shared card, matched by session id.

No new subscription surface was needed: the backend emits `agent_session:progress` to the **stream room** (`trace-emitter.ts:116-120`), and the board already joins each card's stream room via `useBoardStreamSubscriptions` → `setBoardStreamIds`. The board was in the room the whole time; it just wasn't listening for that event.

### Key design decisions

**1. Split running vs. terminal into two components.** `BoardAgentSessionRow` branches on whether any of the row's events is terminal (`agent_session:completed`/`failed`/`deleted`) and only then mounts the subscribing child. Two reasons: the socket subscription mounts **only while a session runs**, so a board full of past traces holds no idle listeners; and a progress tick re-renders only the leaf row, not the whole (heavy) `BoardCard`.

**2. Match by session id, not trigger message.** `useAgentActivity` keys its output map by `triggerMessageId` and also carries socket-only sessions from other rows on the shared socket. The row looks up its own session by `sessionId` (derived from its events via `getSessionId`) — the same lookup `event-list.tsx:963` does. Keying by trigger would mis-associate rows.

**3. Reuse the timeline hook verbatim.** `useAgentActivity` already handles both the events-bootstrap source (the started event on the rail) and the live socket source, so the board needed no new logic — only to mount it and pass the props through.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-row-item.tsx` | Session row now routes through `BoardAgentSessionRow`; running sessions subscribe via `BoardRunningSessionRow` (`useAgentActivity`) and pass `liveCounts`/`liveSubstep` to `AgentSessionEvent`. |
| `apps/frontend/src/components/board/board-card.test.tsx` | New test: a running session's card live-updates from `0 steps` → `3 steps` on an `agent_session:progress` tick, plus a `fakeSocket` helper. |

## Out of scope (deliberate)

- **No Stop button on board session cards.** The timeline passes `onStopSession`; the board still doesn't. This PR fixes the live step counter (the reported bug) only — the running board card shows the same Redirect affordance it already did, no new Stop wiring.

## Test plan

- [x] `apps/frontend` — `board-card.test.tsx` 13 pass (incl. the new live-count test); full board suites (`src/components/board/`, `src/lib/board/board-event-rows.test.ts`) 67 pass
- [x] `apps/frontend` `tsc --noEmit` clean (whole-workspace typecheck via pre-commit hook, all workspaces green)
- [x] `eslint` clean on both changed files

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9Y7Eb2prHDHppe29fuzWZ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786006331&installation_id=129946197&pr_number=1233&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1233&signature=bbdb7ff0b0ae0c3a4d0e9385cd90dcca23f24bd273aaf876319d3e1b58701b39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->