### PR TITLE
feat(conversations): AI-proposed conversation split

### DIFF
--- a/apps/backend/src/features/conversations/boundary-extraction-service.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction-service.ts
@@ -14,7 +14,9 @@ import type {
   MessageAssignment,
   Reassignment,
   ReplyTarget,
+  SplitProposal,
 } from "./boundary-extraction/types"
+import { HttpError } from "../../lib/errors"
 import { collectQuoteReplyMessageIds } from "@threa/prosemirror"
 import { addStalenessFields } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
@@ -42,6 +44,49 @@ export class BoundaryExtractionService {
     private pool: Pool,
     private extractor: BoundaryExtractor
   ) {}
+
+  /**
+   * On-demand, read-only: ask the clustering model how an existing conversation
+   * should be split into smaller topics. Loads the conversation's messages,
+   * runs {@link BoundaryExtractor.splitConversation}, and returns the proposal —
+   * NO writes. The caller renders it for confirmation, then applies the confirmed
+   * groups via {@link ConversationService.applySplit}. A single returned group
+   * means the model judged the conversation focused (no split suggested).
+   */
+  async proposeSplit(conversationId: string, workspaceId: string): Promise<SplitProposal & { conversationId: string }> {
+    const { conversation, stream, messages } = await withClient(this.pool, async (client) => {
+      const conversation = await ConversationRepository.findById(client, conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return { conversation: null, stream: null, messages: [] as Message[] }
+      }
+      const stream = await StreamRepository.findById(client, conversation.streamId)
+      const messagesMap = await MessageRepository.findByIds(client, conversation.messageIds)
+      // Preserve the conversation's stored (chronological) order.
+      const messages = conversation.messageIds
+        .map((id) => messagesMap.get(id))
+        .filter((m): m is Message => m !== undefined)
+      return { conversation, stream, messages }
+    })
+
+    if (!conversation || !stream) {
+      throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+    }
+
+    const proposal = await this.extractor.splitConversation({
+      conversationId: conversation.id,
+      topicSummary: conversation.topicSummary,
+      summary: conversation.summary,
+      messages,
+      streamType: stream.type,
+      workspaceId,
+    })
+
+    logger.info(
+      { conversationId: conversation.id, groupCount: proposal.groups.length, messageCount: messages.length },
+      "Conversation split proposed"
+    )
+    return { conversationId: conversation.id, ...proposal }
+  }
 
   /**
    * Three-phase pattern (INV-41) so the AI call holds no DB connection:

--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -104,6 +104,71 @@ When you set newConversationTopic, write a short title of 2-5 words that names t
 
 Respond with ONLY the JSON object. No explanation, no markdown code blocks.`
 
+// --- On-demand conversation split (agent-proposed) -------------------------
+// Re-cluster the messages of ONE existing conversation into ≥1 topic group, in
+// a single batch call. Reuses the boundary model/temperature above (the tuned
+// clustering model) but a batch-shaped prompt: the incremental extractor sees
+// one new message against candidates, this sees a whole conversation at once.
+// The result is a PROPOSAL — the user confirms before anything is written.
+
+export const CONVERSATION_SPLIT_SYSTEM_PROMPT = `You are a conversation boundary analyst. You are given the full message history of ONE conversation that may have drifted across several distinct topics, and you regroup its messages into the smaller conversations they should have been. You output ONLY valid JSON matching the required schema. No explanations, no markdown, no prose - just the JSON object.`
+
+export const CONVERSATION_SPLIT_PROMPT = `Below is the complete message history of a single conversation, in chronological order. It may have grown to cover several distinct topics that each deserve their own conversation. Partition the messages into the smallest number of coherent topic groups that each stand on their own.
+
+## Conversation
+Current title: {{TITLE}}
+{{SUMMARY}}
+
+## Messages
+{{MESSAGES}}
+
+## How to group
+- **One group per distinct topic.** A group is a set of messages that advance the SAME question or aspect — a back-and-forth exchange, both participants' turns included. Keep an exchange whole: never split one live exchange so one side's turns land in a different group than the other's.
+- **A shared name is not a shared topic.** A person, product, model, project, or place named across messages is a SUBJECT, not a topic. "Fable is cheaper now", "does Fable handle Swedish?", and "Fable is down again" are three groups that merely share the word "Fable". Group by the specific question being advanced, not by the recurring name.
+- **Session gaps are evidence.** Messages carry an age. A gap of hours, an afternoon, overnight, or a weekend between turns usually marks a new topic even between the same people — prefer a new group across a large gap unless the later message explicitly resumes the earlier one's specific subject.
+- **Do not over-split.** A brief reaction, agreement, or follow-up ("samma här", "haha", "100%", "sounds good") belongs in the exchange it answers, not its own group. Only cut where the subject genuinely changes.
+- **Do not force a split.** If the whole conversation really is one topic, return a SINGLE group containing every message. Returning one group means "no split needed" and is a valid, common answer.
+- **Every message goes in exactly one group.** Assign each message id to one and only one group; do not drop any and do not repeat any.
+
+## Naming each group
+Write a 2-5 word title naming the topic itself. Never exceed 5 words.
+- Lead with the subject. No framing ("Discussion about", "Chat about", "Thoughts on") and no tone labels ("Casual chat", "Quick question").
+- Never a vague catch-all ("General chat", "Reaction", "Misc", "Off-topic") — name the concrete subject the messages are about.
+- Name the specific aspect, not a bare recurring name: "Fable-priser", "Fable på svenska", never "Fable" alone.
+- Do NOT state the language ("in Swedish"). Write the title in the conversation's own dominant language, keeping names, products, and technical terms exactly as they appear.
+
+## Output Requirements
+- groups: Array of {title, summary, messageIds}. At least one group. Order groups from the most central/largest topic to the most peripheral.
+  - title: 2-5 word topic title (see above).
+  - summary: one sentence stating what the group is about, in the conversation's own language.
+  - messageIds: the ids of the messages in this group, taken verbatim from the Messages list.
+- confidence: 0.0 to 1.0 confidence in this grouping overall.
+- reasoning: one brief sentence on why you split (or didn't).
+
+Respond with ONLY the JSON object. No explanation, no markdown code blocks.`
+
+export const conversationSplitResponseSchema = z.object({
+  groups: z
+    .array(
+      z
+        .object({
+          title: z.string().describe("2-5 word topic title in the conversation's own language, proper nouns verbatim"),
+          summary: z.string().nullable().describe("One-sentence summary of what this group is about, or null"),
+          messageIds: z
+            .array(z.string())
+            .min(1)
+            .describe("Ids of the messages in this group, verbatim from the prompt"),
+        })
+        .strict()
+    )
+    .min(1)
+    .describe("≥1 topic group; a single group means no split is needed. Order most-central topic first"),
+  confidence: z.number().min(0).max(1).describe("Overall confidence in this grouping (0.0 to 1.0)"),
+  reasoning: z.string().nullable().describe("One-sentence rationale for the split (or for leaving it whole)"),
+})
+
+export type ConversationSplitResponse = z.infer<typeof conversationSplitResponseSchema>
+
 export const messageAssignmentSchema = z
   .object({
     conversationId: z.string().nullable().describe("Existing conversation ID, or null to create a new one"),

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -752,6 +752,97 @@ describe("LLMBoundaryExtractor", () => {
   })
 })
 
+describe("LLMBoundaryExtractor.splitConversation", () => {
+  let extractor: LLMBoundaryExtractor
+
+  beforeEach(() => {
+    mockGenerateObject.mockReset()
+    extractor = new LLMBoundaryExtractor(mockAI as AI, mockConfigResolver)
+  })
+
+  function splitContext(ids: string[]) {
+    return {
+      conversationId: "conv_split",
+      topicSummary: "Fable",
+      summary: null,
+      messages: ids.map((id, i) =>
+        createMockMessage({ id, contentMarkdown: `msg ${id}`, createdAt: new Date(1_700_000_000_000 + i * 60_000) })
+      ),
+      streamType: "channel",
+      workspaceId: "wsp_test123",
+    }
+  }
+
+  test("returns a single group without an AI call for a short conversation", async () => {
+    const result = await extractor.splitConversation(splitContext(["m1", "m2", "m3"]))
+    expect(mockGenerateObject).not.toHaveBeenCalled()
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].messageIds).toEqual(["m1", "m2", "m3"])
+  })
+
+  test("partitions the model's groups and orders them largest-first", async () => {
+    mockGenerateObject.mockResolvedValueOnce({
+      value: {
+        groups: [
+          { title: "Small", summary: null, messageIds: ["m1"] },
+          { title: "Big", summary: "the bulk", messageIds: ["m2", "m3", "m4"] },
+        ],
+        confidence: 0.8,
+        reasoning: "two topics",
+      },
+      response: { usage: {} },
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    })
+
+    const result = await extractor.splitConversation(splitContext(["m1", "m2", "m3", "m4"]))
+
+    expect(result.groups.map((g) => g.title)).toEqual(["Big", "Small"])
+    expect(result.groups[0].messageIds).toEqual(["m2", "m3", "m4"])
+    expect(result.groups[1].messageIds).toEqual(["m1"])
+  })
+
+  test("drops unknown ids, dedupes across groups, and sweeps unassigned into the largest group", async () => {
+    mockGenerateObject.mockResolvedValueOnce({
+      value: {
+        groups: [
+          { title: "A", summary: null, messageIds: ["m1", "m2", "ghost"] },
+          // m2 repeated (first group wins); m5 unknown; m3 legitimately in B.
+          { title: "B", summary: null, messageIds: ["m2", "m3", "m5"] },
+        ],
+        confidence: 0.7,
+        reasoning: null,
+      },
+      response: { usage: {} },
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    })
+
+    // m4 is never mentioned by the model → swept into the largest group.
+    const result = await extractor.splitConversation(splitContext(["m1", "m2", "m3", "m4"]))
+
+    const allAssigned = result.groups.flatMap((g) => g.messageIds).sort()
+    expect(allAssigned).toEqual(["m1", "m2", "m3", "m4"])
+    // No id appears twice; no unknown id survives.
+    expect(new Set(allAssigned).size).toBe(4)
+    // Largest group ("A": m1,m2 + swept m4) leads.
+    expect(result.groups[0].messageIds).toContain("m4")
+  })
+
+  test("degrades to a single group when the response is unparseable", async () => {
+    mockGenerateObject.mockRejectedValueOnce(
+      new NoObjectGeneratedError({
+        message: "bad",
+        text: "not json",
+        response: {} as never,
+        usage: {} as never,
+        finishReason: "stop",
+      })
+    )
+    const result = await extractor.splitConversation(splitContext(["m1", "m2", "m3", "m4"]))
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].messageIds).toEqual(["m1", "m2", "m3", "m4"])
+  })
+})
+
 describe("formatRelativeAge", () => {
   const reference = new Date("2026-07-01T12:00:00Z")
 

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.test.ts
@@ -780,6 +780,49 @@ describe("LLMBoundaryExtractor.splitConversation", () => {
     expect(result.groups[0].messageIds).toEqual(["m1", "m2", "m3"])
   })
 
+  test("handles an empty conversation without dereferencing a missing message", async () => {
+    // A resolved/emptied thread-split shell: no messages, no topic. Must not throw.
+    const result = await extractor.splitConversation({
+      conversationId: "conv_empty",
+      topicSummary: null,
+      summary: null,
+      messages: [],
+      streamType: "channel",
+      workspaceId: "wsp_test123",
+    })
+    expect(mockGenerateObject).not.toHaveBeenCalled()
+    expect(result.groups).toHaveLength(1)
+    expect(result.groups[0].messageIds).toEqual([])
+    expect(result.groups[0].title).toBe("Conversation")
+  })
+
+  test("bounds the prompt to the most recent messages for an oversized conversation", async () => {
+    const ids = Array.from({ length: 320 }, (_, i) => `m${i}`)
+    mockGenerateObject.mockResolvedValueOnce({
+      value: {
+        groups: [{ title: "Only topic", summary: null, messageIds: ["m319"] }],
+        confidence: 0.5,
+        reasoning: null,
+      },
+      response: { usage: {} },
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    })
+
+    const result = await extractor.splitConversation(splitContext(ids))
+
+    // The prompt (2nd message = the user turn) names only the last 300 ids —
+    // m19..m319, never m0.
+    const call = mockGenerateObject.mock.calls[0] as unknown as [{ messages: { content: string }[] }]
+    const userPrompt = call[0].messages[1].content
+    expect(userPrompt).toContain("[m319]")
+    expect(userPrompt).not.toContain("[m0]")
+    // Validation is scoped to that window, so the swept partition never references
+    // the dropped older ids.
+    const allIds = result.groups.flatMap((g) => g.messageIds)
+    expect(allIds).not.toContain("m0")
+    expect(allIds.length).toBe(300)
+  })
+
   test("partitions the model's groups and orders them largest-first", async () => {
     mockGenerateObject.mockResolvedValueOnce({
       value: {

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -32,6 +32,17 @@ import {
 /** Below this, a conversation is too short to split meaningfully — skip the AI call. */
 const MIN_MESSAGES_TO_SPLIT = 4
 
+/**
+ * Upper bound on the messages fed into one split prompt. A drifted conversation
+ * can in principle be large; without a cap the prompt is unbounded and can
+ * exceed what `applySplit` will accept on confirm (its 500-message ceiling),
+ * wasting the call. We consider the most recent window — older messages beyond
+ * it stay in the source conversation (the apply path only moves messages that
+ * land in a proposed group). Kept under the apply ceiling so a proposal always
+ * fits.
+ */
+const MAX_SPLIT_MESSAGES = 300
+
 function indent(text: string, prefix: string): string {
   return text
     .split("\n")
@@ -124,20 +135,33 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
   }
 
   async splitConversation(context: SplitContext): Promise<SplitProposal> {
-    const orderedIds = context.messages.map((m) => m.id)
-
-    // Too short to split — return the whole thing as one group without an AI
-    // call. `groups.length === 1` is the caller's "no split needed" signal.
+    // Too short (or empty) to split — return the whole thing as one group without
+    // an AI call. `groups.length === 1` is the caller's "no split needed" signal.
+    // An empty conversation (a resolved/emptied thread-split shell) lands here too.
     if (context.messages.length < MIN_MESSAGES_TO_SPLIT) {
       return {
-        groups: [{ title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: orderedIds }],
+        groups: [{ title: this.splitFallbackTitle(context), messageIds: context.messages.map((m) => m.id) }],
         confidence: 1.0,
         reasoning: "Conversation is too short to split.",
       }
     }
 
+    // Bound the prompt: consider only the most recent MAX_SPLIT_MESSAGES. Anything
+    // older stays in the source (apply only moves messages that land in a group),
+    // and the proposal always fits applySplit's ceiling.
+    const scoped =
+      context.messages.length > MAX_SPLIT_MESSAGES
+        ? { ...context, messages: context.messages.slice(-MAX_SPLIT_MESSAGES) }
+        : context
+    if (scoped !== context) {
+      logger.info(
+        { conversationId: context.conversationId, total: context.messages.length, considered: MAX_SPLIT_MESSAGES },
+        "Conversation exceeds the split window — splitting the most recent messages only"
+      )
+    }
+
     const config = await this.configResolver.resolve(COMPONENT_PATHS.BOUNDARY_EXTRACTION)
-    const prompt = this.buildSplitPrompt(context)
+    const prompt = this.buildSplitPrompt(scoped)
 
     try {
       const { value } = await this.ai.generateObject({
@@ -150,12 +174,12 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
         temperature: config.temperature,
         telemetry: {
           functionId: "conversation-split",
-          metadata: { streamType: context.streamType, messageCount: context.messages.length },
+          metadata: { streamType: scoped.streamType, messageCount: scoped.messages.length },
         },
-        context: { workspaceId: context.workspaceId, origin: "user" },
+        context: { workspaceId: scoped.workspaceId, origin: "user" },
       })
 
-      return this.validateSplit(value, context)
+      return this.validateSplit(value, scoped)
     } catch (error) {
       // Same narrow handling as extract(): an unparseable object degrades to "no
       // split" (INV-11 — not a silent fallback: logged, and only this error type;
@@ -166,15 +190,21 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
           "LLM returned unparseable split response, proposing no split"
         )
         return {
-          groups: [
-            { title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: orderedIds },
-          ],
+          groups: [{ title: this.splitFallbackTitle(scoped), messageIds: scoped.messages.map((m) => m.id) }],
           confidence: 0.0,
           reasoning: null,
         }
       }
       throw error
     }
+  }
+
+  /** Empty-safe title for a no-split proposal: the stored topic, else the first
+   *  message's opening, else a neutral label (an emptied conversation has neither). */
+  private splitFallbackTitle(context: SplitContext): string {
+    if (context.topicSummary) return context.topicSummary
+    const first = context.messages[0]
+    return first ? this.truncateAsTopic(first) : "Conversation"
   }
 
   private buildSplitPrompt(context: SplitContext): string {
@@ -215,9 +245,7 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
     // Nothing survived (all ids unknown) — treat as no split.
     if (groups.length === 0) {
       return {
-        groups: [
-          { title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: [...validIds] },
-        ],
+        groups: [{ title: this.splitFallbackTitle(context), messageIds: [...validIds] }],
         confidence: parsed.confidence,
         reasoning: parsed.reasoning,
       }

--- a/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/llm-extractor.ts
@@ -9,6 +9,9 @@ import type {
   ExtractionResult,
   MessageAssignment,
   Reassignment,
+  SplitContext,
+  SplitProposal,
+  SplitGroup,
 } from "./types"
 import type { Message } from "../../messaging"
 import { logger } from "../../../lib/logger"
@@ -19,8 +22,15 @@ import {
   BOUNDARY_EXTRACTION_PROMPT,
   NEW_MESSAGE_ATTACHMENT_CHARS,
   RECENT_ATTACHMENT_CHARS,
+  CONVERSATION_SPLIT_SYSTEM_PROMPT,
+  CONVERSATION_SPLIT_PROMPT,
+  conversationSplitResponseSchema,
   type ExtractionResponse,
+  type ConversationSplitResponse,
 } from "./config"
+
+/** Below this, a conversation is too short to split meaningfully — skip the AI call. */
+const MIN_MESSAGES_TO_SPLIT = 4
 
 function indent(text: string, prefix: string): string {
   return text
@@ -111,6 +121,123 @@ export class LLMBoundaryExtractor implements BoundaryExtractor {
       }
       throw error
     }
+  }
+
+  async splitConversation(context: SplitContext): Promise<SplitProposal> {
+    const orderedIds = context.messages.map((m) => m.id)
+
+    // Too short to split — return the whole thing as one group without an AI
+    // call. `groups.length === 1` is the caller's "no split needed" signal.
+    if (context.messages.length < MIN_MESSAGES_TO_SPLIT) {
+      return {
+        groups: [{ title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: orderedIds }],
+        confidence: 1.0,
+        reasoning: "Conversation is too short to split.",
+      }
+    }
+
+    const config = await this.configResolver.resolve(COMPONENT_PATHS.BOUNDARY_EXTRACTION)
+    const prompt = this.buildSplitPrompt(context)
+
+    try {
+      const { value } = await this.ai.generateObject({
+        model: config.modelId,
+        schema: conversationSplitResponseSchema,
+        messages: [
+          { role: "system", content: CONVERSATION_SPLIT_SYSTEM_PROMPT },
+          { role: "user", content: prompt },
+        ],
+        temperature: config.temperature,
+        telemetry: {
+          functionId: "conversation-split",
+          metadata: { streamType: context.streamType, messageCount: context.messages.length },
+        },
+        context: { workspaceId: context.workspaceId, origin: "user" },
+      })
+
+      return this.validateSplit(value, context)
+    } catch (error) {
+      // Same narrow handling as extract(): an unparseable object degrades to "no
+      // split" (INV-11 — not a silent fallback: logged, and only this error type;
+      // API/rate-limit errors still propagate for the request to surface).
+      if (error instanceof NoObjectGeneratedError) {
+        logger.warn(
+          { conversationId: context.conversationId, text: error.text?.slice(0, 200) },
+          "LLM returned unparseable split response, proposing no split"
+        )
+        return {
+          groups: [
+            { title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: orderedIds },
+          ],
+          confidence: 0.0,
+          reasoning: null,
+        }
+      }
+      throw error
+    }
+  }
+
+  private buildSplitPrompt(context: SplitContext): string {
+    const now = context.messages[context.messages.length - 1]?.createdAt ?? context.messages[0].createdAt
+    const messagesSection = context.messages
+      .map(
+        (m) =>
+          `[${m.id}] (${formatRelativeAge(m.createdAt, now)}) ${m.authorType}:${m.authorId.slice(-8)}: ${m.contentMarkdown.slice(0, 300)}${m.contentMarkdown.length > 300 ? "…" : ""}`
+      )
+      .join("\n")
+
+    return CONVERSATION_SPLIT_PROMPT.replace("{{TITLE}}", context.topicSummary ?? "No title yet")
+      .replace("{{SUMMARY}}", context.summary ? `Current summary: ${context.summary}` : "")
+      .replace("{{MESSAGES}}", messagesSection)
+  }
+
+  /**
+   * Coerce the raw response into a partition of the input messages: keep only
+   * known ids, drop duplicates (first group wins), and sweep any message the
+   * model left unassigned into the largest group so nothing is lost. Groups
+   * emptied by that filtering are dropped; groups are ordered largest-first so
+   * the caller keeps the most representative group as the source conversation.
+   */
+  private validateSplit(parsed: ConversationSplitResponse, context: SplitContext): SplitProposal {
+    const validIds = new Set(context.messages.map((m) => m.id))
+    const orderIndex = new Map(context.messages.map((m, i) => [m.id, i]))
+    const assigned = new Set<string>()
+
+    const groups: SplitGroup[] = []
+    for (const g of parsed.groups) {
+      const ids = g.messageIds.filter((id) => validIds.has(id) && !assigned.has(id))
+      for (const id of ids) assigned.add(id)
+      if (ids.length === 0) continue
+      ids.sort((a, b) => (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0))
+      groups.push({ title: g.title, summary: g.summary ?? undefined, messageIds: ids })
+    }
+
+    // Nothing survived (all ids unknown) — treat as no split.
+    if (groups.length === 0) {
+      return {
+        groups: [
+          { title: context.topicSummary ?? this.truncateAsTopic(context.messages[0]), messageIds: [...validIds] },
+        ],
+        confidence: parsed.confidence,
+        reasoning: parsed.reasoning,
+      }
+    }
+
+    // Order largest-first so the "kept" group (the caller keeps groups[0] in the
+    // source conversation) is the most representative — fewest messages move.
+    groups.sort((a, b) => b.messageIds.length - a.messageIds.length)
+
+    // Sweep any unassigned messages into the largest group so the partition is
+    // total (the apply path only moves messages that ARE in a group).
+    const leftover = context.messages.map((m) => m.id).filter((id) => !assigned.has(id))
+    if (leftover.length > 0) {
+      const target = groups[0]
+      target.messageIds = [...target.messageIds, ...leftover].sort(
+        (a, b) => (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0)
+      )
+    }
+
+    return { groups, confidence: parsed.confidence, reasoning: parsed.reasoning }
   }
 
   private buildPrompt(context: ExtractionContext): string {

--- a/apps/backend/src/features/conversations/boundary-extraction/stub-extractor.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/stub-extractor.ts
@@ -1,4 +1,4 @@
-import type { BoundaryExtractor, ExtractionContext, ExtractionResult } from "./types"
+import type { BoundaryExtractor, ExtractionContext, ExtractionResult, SplitContext, SplitProposal } from "./types"
 import { logger } from "../../../lib/logger"
 import { StreamTypes } from "@threa/types"
 
@@ -37,6 +37,32 @@ export class StubBoundaryExtractor implements BoundaryExtractor {
       assignments: [{ conversationId: null, isPrimary: true }],
       newConversationTopic: this.extractTopic(context.newMessage.contentMarkdown),
       confidence: 1.0,
+    }
+  }
+
+  /**
+   * Deterministic stand-in for the batch split: halve a conversation of ≥4
+   * messages into two groups, otherwise leave it whole (one group). No language
+   * judgement — just enough structure for the propose/apply flow to be tested.
+   */
+  async splitConversation(context: SplitContext): Promise<SplitProposal> {
+    logger.debug({ conversationId: context.conversationId }, "Using stub boundary extractor for split")
+    const ids = context.messages.map((m) => m.id)
+    if (ids.length < 4) {
+      return {
+        groups: [{ title: context.topicSummary ?? "Conversation", messageIds: ids }],
+        confidence: 1.0,
+        reasoning: "Too short to split (stub).",
+      }
+    }
+    const mid = Math.ceil(ids.length / 2)
+    return {
+      groups: [
+        { title: context.topicSummary ?? "First topic", messageIds: ids.slice(0, mid) },
+        { title: "Second topic", messageIds: ids.slice(mid) },
+      ],
+      confidence: 1.0,
+      reasoning: "Stub even split.",
     }
   }
 

--- a/apps/backend/src/features/conversations/boundary-extraction/types.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/types.ts
@@ -158,6 +158,47 @@ export interface ExtractionContext {
   workspaceId: string
 }
 
+/**
+ * One proposed topic group from an on-demand conversation split. `messageIds` is
+ * a subset of the source conversation's messages; across a proposal the groups
+ * partition the conversation (every message in exactly one group). `title`/`summary`
+ * are model-generated and shown to the user for confirmation before any write.
+ */
+export interface SplitGroup {
+  title: string
+  summary?: string
+  messageIds: string[]
+}
+
+/** Input for a batch split: the full message set of one existing conversation. */
+export interface SplitContext {
+  conversationId: string
+  topicSummary: string | null
+  summary: string | null
+  /** The conversation's messages, in chronological (timeline) order. */
+  messages: Message[]
+  streamType: string
+  /** Workspace ID for cost attribution (INV-19). */
+  workspaceId: string
+}
+
+/**
+ * A proposed split of one conversation. `groups` is ordered most-central-topic
+ * first and always partitions the input messages; a single group means the model
+ * judged the conversation focused enough to leave whole (no split).
+ */
+export interface SplitProposal {
+  groups: SplitGroup[]
+  confidence: number
+  reasoning: string | null
+}
+
 export interface BoundaryExtractor {
   extract(context: ExtractionContext): Promise<ExtractionResult>
+  /**
+   * Re-cluster an existing conversation's messages into ≥1 topic group. Read-only
+   * (returns a proposal; the caller applies it after user confirmation). Reuses the
+   * boundary clustering model — see {@link BoundaryExtractor.extract}.
+   */
+  splitConversation(context: SplitContext): Promise<SplitProposal>
 }

--- a/apps/backend/src/features/conversations/handlers.test.ts
+++ b/apps/backend/src/features/conversations/handlers.test.ts
@@ -63,6 +63,11 @@ describe("Conversation Handlers", () => {
       updateConversation: mockUpdateConversation,
       splitThreadIntoConversation: mockSplitThread,
     } as never,
+    boundaryExtractionService: {
+      proposeSplit: mock(() =>
+        Promise.resolve({ conversationId: "conv_1", groups: [], confidence: 1, reasoning: null })
+      ),
+    } as never,
     boardExclusionService: {
       hideConversation: mockHideConversation,
       unhideConversation: mockUnhideConversation,

--- a/apps/backend/src/features/conversations/handlers.ts
+++ b/apps/backend/src/features/conversations/handlers.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import type { Request, Response } from "express"
 import type { ConversationService } from "./service"
+import type { BoundaryExtractionService } from "./boundary-extraction-service"
 import type { BoardExclusionService } from "./board-exclusion-service"
 import type { StreamService } from "../streams"
 import type { FeatureFlagService } from "../feature-flags"
@@ -100,6 +101,39 @@ const reassignMessagesSchema = z.object({
   targetConversationId: z.string().min(1).nullish(),
 })
 
+const proposeSplitParamsSchema = z.object({
+  conversationId: z.string().min(1),
+})
+
+// Apply a user-confirmed AI split: ≥2 groups partitioning the conversation's
+// messages. `groups[0]` is kept in the source (re-titled); the rest are minted.
+// Every message id appears in exactly one group; total capped like the move flow.
+const applySplitParamsSchema = z.object({
+  conversationId: z.string().min(1),
+})
+const applySplitSchema = z
+  .object({
+    groups: z
+      .array(
+        z.object({
+          title: z.string().trim().min(1).max(MAX_CONVERSATION_TOPIC_LENGTH),
+          summary: z.string().trim().min(1).optional(),
+          messageIds: z.array(z.string().min(1)).min(1),
+        })
+      )
+      .min(2)
+      .max(50),
+  })
+  .superRefine((body, ctx) => {
+    const all = body.groups.flatMap((g) => g.messageIds)
+    if (all.length > 500) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "groups name at most 500 messages in total" })
+    }
+    if (new Set(all).size !== all.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "each message may appear in only one group" })
+    }
+  })
+
 const markReadSchema = z.object({
   throughMessageId: z.string().min(1),
 })
@@ -128,6 +162,7 @@ const muteStreamParamsSchema = z.object({ streamId: z.string().min(1) })
 
 interface Dependencies {
   conversationService: ConversationService
+  boundaryExtractionService: BoundaryExtractionService
   boardExclusionService: BoardExclusionService
   streamService: StreamService
   featureFlagService: FeatureFlagService
@@ -135,6 +170,7 @@ interface Dependencies {
 
 export function createConversationHandlers({
   conversationService,
+  boundaryExtractionService,
   boardExclusionService,
   streamService,
   featureFlagService,
@@ -328,6 +364,62 @@ export function createConversationHandlers({
         streamId,
         messageIds,
         target,
+        actorUserId: userId,
+      })
+      res.json(result)
+    },
+
+    /**
+     * Ask the clustering model how a conversation should be split into smaller
+     * topics. Read-only — returns a proposal the client renders for confirmation;
+     * nothing is written until {@link applySplit}. A single-group proposal means
+     * "no split suggested". Access gates on the conversation's root stream (INV-62).
+     */
+    async proposeSplit(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { conversationId } = validateRequest(proposeSplitParamsSchema, req.params)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const proposal = await boundaryExtractionService.proposeSplit(conversationId, workspaceId)
+      res.json(proposal)
+    },
+
+    /**
+     * Apply a user-confirmed split proposal: keep the first group in the source
+     * conversation (re-titled) and mint the rest as new titled conversations. The
+     * source stream is derived from the conversation itself (the mint anchor), so
+     * the body carries only the confirmed groups. Access gates on the conversation's
+     * root stream (INV-62), like {@link reassignMessage}.
+     */
+    async applySplit(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+
+      const { conversationId } = validateRequest(applySplitParamsSchema, req.params)
+      const { groups } = validateRequest(applySplitSchema, req.body)
+
+      const conversation = await conversationService.getById(conversationId)
+      if (!conversation || conversation.workspaceId !== workspaceId) {
+        return res.status(404).json({ error: "Conversation not found" })
+      }
+
+      // validateStreamAccess handles public visibility + thread root membership
+      await streamService.validateStreamAccess(conversation.streamId, workspaceId, userId)
+
+      const result = await conversationService.applySplit({
+        workspaceId,
+        streamId: conversation.streamId,
+        conversationId,
+        groups,
         actorUserId: userId,
       })
       res.json(result)

--- a/apps/backend/src/features/conversations/index.ts
+++ b/apps/backend/src/features/conversations/index.ts
@@ -22,6 +22,9 @@ export type {
   MessageAssignment,
   Reassignment,
   ReplyTarget,
+  SplitContext,
+  SplitProposal,
+  SplitGroup,
 } from "./boundary-extraction/types"
 export {
   BOUNDARY_EXTRACTION_MODEL_ID,
@@ -29,8 +32,11 @@ export {
   BOUNDARY_EXTRACTION_SYSTEM_PROMPT,
   BOUNDARY_EXTRACTION_PROMPT,
   extractionResponseSchema,
+  CONVERSATION_SPLIT_SYSTEM_PROMPT,
+  CONVERSATION_SPLIT_PROMPT,
+  conversationSplitResponseSchema,
 } from "./boundary-extraction/config"
-export type { ExtractionResponse } from "./boundary-extraction/config"
+export type { ExtractionResponse, ConversationSplitResponse } from "./boundary-extraction/config"
 
 export { BoundaryExtractionHandler } from "./boundary-extraction-outbox-handler"
 export type { BoundaryExtractionHandlerConfig } from "./boundary-extraction-outbox-handler"

--- a/apps/backend/src/features/conversations/service.apply-split.test.ts
+++ b/apps/backend/src/features/conversations/service.apply-split.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, spyOn, mock, test } from "bun:test"
+import type { PoolClient } from "pg"
+import { ConversationService, type ApplySplitGroup } from "./service"
+import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationFeedbackRepository } from "./feedback-repository"
+import * as delivery from "./conversation-delivery"
+import { StreamRepository } from "../streams"
+import { MessageRepository, type Message } from "../messaging"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const ACTOR_ID = "usr_1"
+
+// The conversation under split lives in chan_1; `m_foreign` is the cross-stream case.
+const MESSAGES: Record<string, { streamId: string; authorId: string; sequence: number }> = {
+  m1: { streamId: "chan_1", authorId: "usr_1", sequence: 1 },
+  m2: { streamId: "chan_1", authorId: "usr_2", sequence: 2 },
+  m3: { streamId: "chan_1", authorId: "usr_1", sequence: 3 },
+  m4: { streamId: "chan_1", authorId: "usr_2", sequence: 4 },
+  m_foreign: { streamId: "chan_2", authorId: "usr_1", sequence: 5 },
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_a",
+    streamId: "chan_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["m1", "m2", "m3", "m4"],
+    participantIds: ["usr_1", "usr_2"],
+    secondaryMessageIds: [],
+    topicSummary: "Fable",
+    summary: null,
+    completenessScore: 1,
+    confidence: 1,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+function message(id: string): Message {
+  const base = MESSAGES[id]
+  return { id, streamId: base.streamId, authorId: base.authorId, sequence: base.sequence } as unknown as Message
+}
+
+interface Spies {
+  insert: ReturnType<typeof spyOn>
+  update: ReturnType<typeof spyOn>
+  removePrimaryMessages: ReturnType<typeof spyOn>
+  addPrimaryMessages: ReturnType<typeof spyOn>
+  resolveIfEmpty: ReturnType<typeof spyOn>
+  bumpActivityForIds: ReturnType<typeof spyOn>
+  feedbackInsertMany: ReturnType<typeof spyOn>
+  outboxInsert: ReturnType<typeof spyOn>
+}
+
+/**
+ * @param source The conversation being split (its `messageIds` are the members).
+ * @param primaries messageId → current primary conversation id (authoritative membership).
+ */
+function setup(options: { source: Conversation; primaries: Record<string, string> }): Spies {
+  const created: Record<string, Conversation> = { [options.source.id]: options.source }
+  const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
+  spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withTransaction)
+
+  spyOn(StreamRepository, "findById").mockResolvedValue({ id: "chan_1", type: "channel" } as never)
+
+  spyOn(ConversationRepository, "findByIdForUpdate").mockImplementation(
+    async (_c: unknown, _ws: string, id: string) => created[id] ?? null
+  )
+  spyOn(ConversationRepository, "findPrimariesByMessageIds").mockImplementation(async (_c, _ws, ids: string[]) => {
+    const map = new Map<string, Conversation>()
+    for (const id of ids) {
+      const convId = options.primaries[id]
+      if (convId) map.set(id, created[convId] ?? makeConversation({ id: convId }))
+    }
+    return map
+  })
+  spyOn(ConversationRepository, "findByIds").mockImplementation(async (_c, _ws, ids: string[]) =>
+    ids.map((id) => created[id]).filter((c): c is Conversation => c !== undefined)
+  )
+
+  const insert = spyOn(ConversationRepository, "insert").mockImplementation(async (_c, params) => {
+    const conv = makeConversation({
+      id: params.id,
+      streamId: params.streamId,
+      topicSummary: params.topicSummary ?? null,
+      summary: params.summary ?? null,
+      messageIds: [],
+      participantIds: [],
+    })
+    created[params.id] = conv
+    return conv
+  })
+
+  spyOn(MessageRepository, "findByIdsForUpdate").mockImplementation(async (_c, ids: string[]) =>
+    ids
+      .filter((id) => MESSAGES[id])
+      .map(message)
+      .sort((a, b) => (a as unknown as { sequence: number }).sequence - (b as unknown as { sequence: number }).sequence)
+  )
+  spyOn(MessageRepository, "findByIds").mockImplementation(
+    async (_c, ids: string[]) => new Map(ids.filter((id) => MESSAGES[id]).map((id) => [id, message(id)]))
+  )
+
+  spyOn(delivery, "resolveConversationDelivery").mockResolvedValue({
+    parentStreamId: "chan_1",
+    streamVisibility: "public",
+  })
+
+  return {
+    insert,
+    update: spyOn(ConversationRepository, "update").mockResolvedValue(null as never),
+    removePrimaryMessages: spyOn(ConversationRepository, "removePrimaryMessages").mockResolvedValue(undefined as never),
+    addPrimaryMessages: spyOn(ConversationRepository, "addPrimaryMessages").mockResolvedValue(undefined as never),
+    resolveIfEmpty: spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never),
+    bumpActivityForIds: spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never),
+    feedbackInsertMany: spyOn(ConversationFeedbackRepository, "insertMany").mockResolvedValue(undefined as never),
+    outboxInsert: spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never),
+  }
+}
+
+function applySplit(conversationId: string, groups: ApplySplitGroup[]) {
+  return new ConversationService({} as never).applySplit({
+    workspaceId: WORKSPACE_ID,
+    streamId: "chan_1",
+    conversationId,
+    groups,
+    actorUserId: ACTOR_ID,
+  })
+}
+
+type Event = { type: string; payload: Record<string, any> }
+function events(outboxInsert: ReturnType<typeof spyOn>): Event[] {
+  return outboxInsert.mock.calls.map((c: unknown[]) => ({ type: c[1] as string, payload: c[2] as Record<string, any> }))
+}
+
+describe("ConversationService.applySplit", () => {
+  afterEach(() => mock.restore())
+
+  test("keeps the first group in the source (re-titled) and mints the rest", async () => {
+    const spies = setup({
+      source: makeConversation(),
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_a", m4: "conv_a" },
+    })
+
+    const result = await applySplit("conv_a", [
+      { title: "Fable pricing", messageIds: ["m1", "m2"] },
+      { title: "Fable på svenska", summary: "Om Fable och svenska", messageIds: ["m3", "m4"] },
+    ])
+
+    // Source re-titled to the kept (first) group; only the moved ids are stripped.
+    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", {
+      topicSummary: "Fable pricing",
+      summary: undefined,
+    })
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_a",
+      ["m3", "m4"],
+      ["usr_1", "usr_2"]
+    )
+
+    // One mint, titled, carrying the second group's messages.
+    expect(spies.insert).toHaveBeenCalledTimes(1)
+    expect(spies.insert.mock.calls[0][1]).toMatchObject({
+      streamId: "chan_1",
+      topicSummary: "Fable på svenska",
+      summary: "Om Fable och svenska",
+    })
+    const mintedId = spies.insert.mock.calls[0][1].id as string
+    expect(spies.addPrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      mintedId,
+      ["m3", "m4"],
+      ["usr_1", "usr_2"]
+    )
+
+    expect(result.conversation.id).toBe("conv_a")
+    expect(result.newConversations.map((c) => c.id)).toEqual([mintedId])
+  })
+
+  test("writes one feedback row per moved message and the expected outbox events", async () => {
+    const spies = setup({
+      source: makeConversation(),
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_a", m4: "conv_a" },
+    })
+
+    await applySplit("conv_a", [
+      { title: "Keep", messageIds: ["m1", "m2"] },
+      { title: "A", messageIds: ["m3"] },
+      { title: "B", messageIds: ["m4"] },
+    ])
+
+    // Only moved messages get feedback rows, each recording the source it left.
+    const rows = spies.feedbackInsertMany.mock.calls[0][1] as Array<Record<string, unknown>>
+    expect(rows.map((r) => r.messageId).sort()).toEqual(["m3", "m4"])
+    expect(rows.every((r) => r.fromConversationId === "conv_a" && r.userId === ACTOR_ID)).toBe(true)
+
+    const evs = events(spies.outboxInsert)
+    // Two mints → two conversation:created; one conversation:updated for the source.
+    expect(evs.filter((e) => e.type === "conversation:created")).toHaveLength(2)
+    expect(evs.filter((e) => e.type === "conversation:updated").map((e) => e.payload.conversationId)).toEqual([
+      "conv_a",
+    ])
+    expect(
+      evs
+        .filter((e) => e.type === "conversation:message_reassigned")
+        .map((e) => e.payload.messageId)
+        .sort()
+    ).toEqual(["m3", "m4"])
+  })
+
+  test("skips a message that raced out of the source between propose and apply", async () => {
+    const spies = setup({
+      source: makeConversation({ messageIds: ["m1", "m2", "m3"] }),
+      // m4 was proposed to move but now lives elsewhere; m3 is still in the source.
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_a", m4: "conv_raced" },
+    })
+
+    await applySplit("conv_a", [
+      { title: "Keep", messageIds: ["m1", "m2"] },
+      { title: "Moved", messageIds: ["m3", "m4"] },
+    ])
+
+    // Only m3 actually moves; m4 is left where it now lives.
+    expect(spies.addPrimaryMessages.mock.calls[0][3]).toEqual(["m3"])
+    expect(spies.removePrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      "conv_a",
+      ["m3"],
+      ["usr_1", "usr_2"]
+    )
+  })
+
+  test("rejects with 409 when every moved message raced away", async () => {
+    const spies = setup({
+      source: makeConversation({ messageIds: ["m1", "m2"] }),
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_raced" },
+    })
+
+    await expect(
+      applySplit("conv_a", [
+        { title: "Keep", messageIds: ["m1", "m2"] },
+        { title: "Gone", messageIds: ["m3"] },
+      ])
+    ).rejects.toMatchObject({ code: "NO_MESSAGES_TO_MOVE", status: 409 })
+    expect(spies.insert).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+
+  test("rejects a group message from another stream (400)", async () => {
+    setup({
+      source: makeConversation({ messageIds: ["m1", "m2", "m_foreign"] }),
+      primaries: { m1: "conv_a", m2: "conv_a", m_foreign: "conv_a" },
+    })
+    await expect(
+      applySplit("conv_a", [
+        { title: "Keep", messageIds: ["m1"] },
+        { title: "Foreign", messageIds: ["m2", "m_foreign"] },
+      ])
+    ).rejects.toMatchObject({ code: "MESSAGE_NOT_IN_STREAM", status: 400 })
+  })
+})

--- a/apps/backend/src/features/conversations/service.apply-split.test.ts
+++ b/apps/backend/src/features/conversations/service.apply-split.test.ts
@@ -218,6 +218,50 @@ describe("ConversationService.applySplit", () => {
     ).toEqual(["m3", "m4"])
   })
 
+  test("re-titles the source when the split covered the whole conversation", async () => {
+    const spies = setup({
+      source: makeConversation(),
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_a", m4: "conv_a" },
+    })
+
+    await applySplit("conv_a", [
+      { title: "Kept", messageIds: ["m1", "m2"] },
+      { title: "Moved", messageIds: ["m3", "m4"] },
+    ])
+
+    expect(spies.update).toHaveBeenCalledWith(expect.anything(), WORKSPACE_ID, "conv_a", {
+      topicSummary: "Kept",
+      summary: undefined,
+    })
+  })
+
+  test("leaves the source title untouched when un-analyzed messages remain", async () => {
+    // m4 stays in the source but isn't in any proposed group (older than the split
+    // window / arrived after the proposal) — the kept group's title would misdescribe
+    // it, so the source keeps its existing title.
+    const spies = setup({
+      source: makeConversation({ messageIds: ["m1", "m2", "m3", "m4"] }),
+      primaries: { m1: "conv_a", m2: "conv_a", m3: "conv_a", m4: "conv_a" },
+    })
+
+    await applySplit("conv_a", [
+      { title: "Kept", messageIds: ["m1", "m2"] },
+      { title: "Moved", messageIds: ["m3"] },
+    ])
+
+    // m3 still moves out into a new conversation…
+    expect(spies.insert).toHaveBeenCalledTimes(1)
+    expect(spies.addPrimaryMessages).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKSPACE_ID,
+      expect.any(String),
+      ["m3"],
+      ["usr_1"]
+    )
+    // …but the source is NOT re-titled (m4 was never analyzed).
+    expect(spies.update).not.toHaveBeenCalled()
+  })
+
   test("skips a message that raced out of the source between propose and apply", async () => {
     const spies = setup({
       source: makeConversation({ messageIds: ["m1", "m2", "m3"] }),

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -13,6 +13,7 @@ import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
 import { conversationFeedbackId, conversationId as generateConversationId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
+import { logger } from "../../lib/logger"
 import {
   ConversationStatuses,
   StreamTypes,
@@ -153,6 +154,35 @@ export interface ReassignMessagesResult {
   conversation: ConversationWithStaleness
   /** Every source conversation that lost members, with final membership. */
   sourceConversations: ConversationWithStaleness[]
+}
+
+/** One confirmed topic group from an AI split proposal (see {@link ConversationService.applySplit}). */
+export interface ApplySplitGroup {
+  /** Model-proposed (user-confirmable) title for the group. */
+  title: string
+  summary?: string
+  /** Messages assigned to this group — a subset of the source conversation. */
+  messageIds: string[]
+}
+
+export interface ApplySplitParams {
+  workspaceId: string
+  /** The stream the source conversation and every message live in. */
+  streamId: string
+  /** The conversation being split. */
+  conversationId: string
+  /** ≥2 groups partitioning the split messages; `groups[0]` is kept in the source
+   *  conversation (re-titled), the rest are minted as new conversations. */
+  groups: ApplySplitGroup[]
+  /** The splitting user — recorded with each moved message's feedback row. */
+  actorUserId: string
+}
+
+export interface ApplySplitResult {
+  /** The source conversation, re-titled to the kept group, with final membership. */
+  conversation: ConversationWithStaleness
+  /** The freshly minted conversations, one per moved group, in group order. */
+  newConversations: ConversationWithStaleness[]
 }
 
 /**
@@ -1032,6 +1062,204 @@ export class ConversationService {
         .map(addStalenessFields)
 
       return { conversation: addStalenessFields(finalDestination), sourceConversations }
+    })
+  }
+
+  /**
+   * Apply a user-confirmed AI split proposal: partition ONE conversation's
+   * messages into the confirmed groups. `groups[0]` stays in the source
+   * conversation (re-titled to its group); every later group is minted as a new
+   * titled conversation and its messages moved in. Membership-only, like
+   * {@link reassignMessagesToConversation} — no message events move, so broadcast
+   * sequences and INV-61 contiguity are untouched.
+   *
+   * Concurrency (INV-20): the source conversation is locked BEFORE the message
+   * rows (conversation-first, matching {@link reassignMessagesToConversation} and
+   * {@link splitThreadIntoConversation}); the destinations are fresh mints with no
+   * pre-existing row to contend for, so the single source lock is the whole
+   * conversation lock set and the order is trivially deadlock-free. Membership is
+   * re-read authoritatively once the rows are pinned: a message that raced OUT of
+   * the source between propose and apply is simply skipped, never yanked from
+   * wherever it now lives. All member/feedback writes and outbox events commit in
+   * one transaction (INV-6/7), delivered via the outbox (INV-4).
+   */
+  async applySplit(params: ApplySplitParams): Promise<ApplySplitResult> {
+    const { workspaceId, streamId, conversationId, groups, actorUserId } = params
+
+    return withTransaction(this.pool, async (client) => {
+      const source = await ConversationRepository.findByIdForUpdate(client, workspaceId, conversationId)
+      if (!source) {
+        throw new HttpError("Conversation not found", { status: 404, code: "CONVERSATION_NOT_FOUND" })
+      }
+      if (source.streamId !== streamId) {
+        throw new HttpError("Conversation is not in this stream", {
+          status: 400,
+          code: "CONVERSATION_NOT_IN_STREAM",
+        })
+      }
+
+      const allIds = [...new Set(groups.flatMap((g) => g.messageIds))]
+      const lockedMessages = await MessageRepository.findByIdsForUpdate(client, allIds)
+      if (lockedMessages.length !== allIds.length) {
+        throw new HttpError("Some selected messages were not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
+      }
+      const messageById = new Map(lockedMessages.map((m) => [m.id, m]))
+      for (const message of lockedMessages) {
+        if (message.streamId !== streamId) {
+          throw new HttpError("All selected messages must belong to the same stream", {
+            status: 400,
+            code: "MESSAGE_NOT_IN_STREAM",
+          })
+        }
+      }
+
+      // Authoritative membership now the rows are pinned: only messages still
+      // primary in the source are moved; movers that raced out are skipped.
+      const primaries = await ConversationRepository.findPrimariesByMessageIds(client, workspaceId, allIds)
+      const inSource = new Set(allIds.filter((id) => primaries.get(id)?.id === source.id))
+
+      // groups[0] stays in the source; later groups mint. Filter each moved group
+      // to messages still in the source and drop groups left empty.
+      const [keepGroup, ...restGroups] = groups
+      const moveGroups = restGroups
+        .map((g) => ({ ...g, messageIds: g.messageIds.filter((id) => inSource.has(id)) }))
+        .filter((g) => g.messageIds.length > 0)
+
+      if (moveGroups.length === 0) {
+        // Every message that would have moved raced out from under us (or the
+        // split collapsed to one group). Nothing to do — surface a conflict rather
+        // than silently re-titling the source to a stale proposal.
+        throw new HttpError("The selected messages are no longer available to split", {
+          status: 409,
+          code: "NO_MESSAGES_TO_MOVE",
+        })
+      }
+
+      const movingIds = moveGroups.flatMap((g) => g.messageIds)
+      const movingSet = new Set(movingIds)
+      const remainingSourceIds = source.messageIds.filter((id) => !movingSet.has(id))
+
+      // Authors for the participant recompute: everything staying in the source
+      // plus every moved message (each mint SETs its own participant list).
+      const authorLookupIds = new Set<string>([...source.messageIds, ...movingIds])
+      const memberMessages = await MessageRepository.findByIds(client, [...authorLookupIds])
+
+      // Strip movers from the source, recompute its remaining participants, and
+      // re-title it to the kept group; resolve it if the split emptied it.
+      await ConversationRepository.removePrimaryMessages(
+        client,
+        workspaceId,
+        source.id,
+        movingIds,
+        distinctAuthors(remainingSourceIds, memberMessages)
+      )
+      await ConversationRepository.update(client, workspaceId, source.id, {
+        topicSummary: keepGroup.title,
+        summary: keepGroup.summary,
+      })
+      await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
+
+      // Mint one titled conversation per moved group, tracking where each id lands
+      // for the feedback rows.
+      const movedTo = new Map<string, string>()
+      const mintedIds: string[] = []
+      for (const g of moveGroups) {
+        const minted = await ConversationRepository.insert(client, {
+          id: generateConversationId(),
+          streamId,
+          workspaceId,
+          topicSummary: g.title,
+          summary: g.summary,
+          confidence: 1,
+          status: ConversationStatuses.ACTIVE,
+        })
+        await ConversationRepository.addPrimaryMessages(
+          client,
+          workspaceId,
+          minted.id,
+          g.messageIds,
+          distinctAuthors(g.messageIds, memberMessages)
+        )
+        mintedIds.push(minted.id)
+        for (const id of g.messageIds) movedTo.set(id, minted.id)
+      }
+
+      // One feedback row per moved message (parity with the other correction paths).
+      await ConversationFeedbackRepository.insertMany(
+        client,
+        movingIds.map((id) => ({
+          id: conversationFeedbackId(),
+          workspaceId,
+          streamId: messageById.get(id)!.streamId,
+          messageId: id,
+          fromConversationId: source.id,
+          toConversationId: movedTo.get(id)!,
+          userId: actorUserId,
+        }))
+      )
+
+      const touchedIds = [source.id, ...mintedIds]
+      await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
+
+      // Re-read every touched row post-write so the events carry final membership.
+      const finalById = new Map(
+        (await ConversationRepository.findByIds(client, workspaceId, touchedIds)).map((c) => [c.id, c])
+      )
+      const finalSource = finalById.get(source.id)
+      if (!finalSource) {
+        throw new Error(`Conversation ${source.id} disappeared during split`)
+      }
+
+      // Everything shares one stream (guarded above), so one delivery resolution
+      // covers every event (INV-62), as in {@link reassignMessagesToConversation}.
+      const stream = await StreamRepository.findById(client, streamId)
+      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+
+      for (const mintedId of mintedIds) {
+        const minted = finalById.get(mintedId)
+        if (!minted) continue
+        await OutboxRepository.insert(client, "conversation:created", {
+          workspaceId,
+          streamId: minted.streamId,
+          conversationId: minted.id,
+          conversation: addStalenessFields(minted),
+          parentStreamId,
+          streamVisibility,
+        })
+      }
+
+      await OutboxRepository.insert(client, "conversation:updated", {
+        workspaceId,
+        streamId: finalSource.streamId,
+        conversationId: finalSource.id,
+        conversation: addStalenessFields(finalSource),
+        parentStreamId,
+        streamVisibility,
+      })
+
+      // Per-message move events route to each message's own stream (for the
+      // timeline membership map + extraction feedback), mirroring the other paths.
+      for (const id of movingIds) {
+        await OutboxRepository.insert(client, "conversation:message_reassigned", {
+          workspaceId,
+          streamId: messageById.get(id)!.streamId,
+          messageId: id,
+          fromConversationId: source.id,
+          toConversationId: movedTo.get(id)!,
+          reason: "user_correction",
+        })
+      }
+
+      const newConversations = mintedIds
+        .map((id) => finalById.get(id))
+        .filter((c): c is Conversation => c !== undefined)
+        .map(addStalenessFields)
+
+      logger.info(
+        { conversationId: source.id, movedGroups: moveGroups.length, movedMessages: movingIds.length },
+        "Conversation split applied"
+      )
+      return { conversation: addStalenessFields(finalSource), newConversations }
     })
   }
 

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -1139,13 +1139,23 @@ export class ConversationService {
       const movingSet = new Set(movingIds)
       const remainingSourceIds = source.messageIds.filter((id) => !movingSet.has(id))
 
+      // Re-title the source to the kept group ONLY when the proposal accounted for
+      // the whole source. A proposal can cover a subset — the split window caps how
+      // many messages the model sees (see MAX_SPLIT_MESSAGES), or a message arrived
+      // after the proposal — leaving un-analyzed messages in the source; the kept
+      // group's title describes only the analyzed slice, so it would misdescribe the
+      // remainder. In that case keep the source's existing title.
+      const analyzedIds = new Set(groups.flatMap((g) => g.messageIds))
+      const sourceFullyAnalyzed = source.messageIds.every((id) => analyzedIds.has(id))
+
       // Authors for the participant recompute: everything staying in the source
       // plus every moved message (each mint SETs its own participant list).
       const authorLookupIds = new Set<string>([...source.messageIds, ...movingIds])
       const memberMessages = await MessageRepository.findByIds(client, [...authorLookupIds])
 
       // Strip movers from the source, recompute its remaining participants, and
-      // re-title it to the kept group; resolve it if the split emptied it.
+      // (when the whole source was analyzed) re-title it to the kept group; resolve
+      // it if the split emptied it.
       await ConversationRepository.removePrimaryMessages(
         client,
         workspaceId,
@@ -1153,10 +1163,12 @@ export class ConversationService {
         movingIds,
         distinctAuthors(remainingSourceIds, memberMessages)
       )
-      await ConversationRepository.update(client, workspaceId, source.id, {
-        topicSummary: keepGroup.title,
-        summary: keepGroup.summary,
-      })
+      if (sourceFullyAnalyzed) {
+        await ConversationRepository.update(client, workspaceId, source.id, {
+          topicSummary: keepGroup.title,
+          summary: keepGroup.summary,
+        })
+      }
       await ConversationRepository.resolveIfEmpty(client, workspaceId, source.id)
 
       // Mint one titled conversation per moved group, tracking where each id lands

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -21,7 +21,7 @@ import { createAttachmentHandlers } from "./features/attachments"
 import { createSearchHandlers } from "./features/search"
 import { createMemoHandlers } from "./features/memos"
 import { createEmojiHandlers } from "./features/emoji"
-import { createConversationHandlers, BoardExclusionService } from "./features/conversations"
+import { createConversationHandlers, BoardExclusionService, BoundaryExtractionService } from "./features/conversations"
 import { CommandAvailabilityService, createCommandHandlers } from "./features/commands"
 import { createUserPreferencesHandlers } from "./features/user-preferences"
 import { createWorkspaceSettingsHandlers } from "./features/workspace-settings"
@@ -113,6 +113,7 @@ interface Dependencies {
   searchService: SearchService
   memoExplorerService: MemoExplorerService
   conversationService: ConversationService
+  boundaryExtractionService: BoundaryExtractionService
   userPreferencesService: UserPreferencesService
   workspaceSettingsService: WorkspaceSettingsService
   featureFlagService: FeatureFlagService
@@ -173,6 +174,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     searchService,
     memoExplorerService,
     conversationService,
+    boundaryExtractionService,
     userPreferencesService,
     workspaceSettingsService,
     featureFlagService,
@@ -279,6 +281,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const boardExclusionService = new BoardExclusionService(pool)
   const conversation = createConversationHandlers({
     conversationService,
+    boundaryExtractionService,
     boardExclusionService,
     streamService,
     featureFlagService,
@@ -536,6 +539,12 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     conversation.splitThread
   )
   app.post("/api/workspaces/:workspaceId/conversations/reassign-messages", ...authed, conversation.reassignMessages)
+  app.post(
+    "/api/workspaces/:workspaceId/conversations/:conversationId/split-proposal",
+    ...authed,
+    conversation.proposeSplit
+  )
+  app.post("/api/workspaces/:workspaceId/conversations/:conversationId/split", ...authed, conversation.applySplit)
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/read", ...authed, conversation.markRead)
   app.post("/api/workspaces/:workspaceId/conversations/:conversationId/unread", ...authed, conversation.markUnread)
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -638,6 +638,14 @@ export async function startServer(): Promise<ServerInstance> {
   // so both transports persist through the identical path (INV-13).
   const botRuntimeWriteOps = createBotRuntimeWriteOps({ pool, io, botRuntimeService, botChannelService })
 
+  // Constructed here (not at the worker registration below) so the HTTP routes can
+  // reach it for the on-demand conversation-split endpoints; the boundary-extract
+  // worker reuses the same instance (INV-13).
+  const boundaryExtractor = config.useStubBoundaryExtraction
+    ? new StubBoundaryExtractor()
+    : new LLMBoundaryExtractor(ai, configResolver)
+  const boundaryExtractionService = new BoundaryExtractionService(pool, boundaryExtractor)
+
   registerRoutes(app, {
     pool,
     io,
@@ -650,6 +658,7 @@ export async function startServer(): Promise<ServerInstance> {
     searchService,
     memoExplorerService,
     conversationService,
+    boundaryExtractionService,
     userPreferencesService,
     workspaceSettingsService,
     featureFlagService,
@@ -905,10 +914,6 @@ export async function startServer(): Promise<ServerInstance> {
     fairness: QueueFairness.NONE,
   })
 
-  const boundaryExtractor = config.useStubBoundaryExtraction
-    ? new StubBoundaryExtractor()
-    : new LLMBoundaryExtractor(ai, configResolver)
-  const boundaryExtractionService = new BoundaryExtractionService(pool, boundaryExtractor)
   const boundaryExtractionWorker = createBoundaryExtractionWorker({ service: boundaryExtractionService })
   jobQueue.registerHandler(JobQueues.BOUNDARY_EXTRACT, boundaryExtractionWorker, {
     tier: QueueTiers.LIGHT,

--- a/apps/frontend/src/api/conversations.ts
+++ b/apps/frontend/src/api/conversations.ts
@@ -15,6 +15,29 @@ export interface ListConversationsParams {
   limit?: number
 }
 
+/** One proposed topic group from an AI split (see {@link conversationsApi.proposeSplit}). */
+export interface SplitGroup {
+  title: string
+  summary?: string | null
+  messageIds: string[]
+}
+
+/** A proposed split of one conversation. `groups` is ordered most-central-first
+ *  and partitions the conversation; a single group means "no split suggested". */
+export interface SplitProposal {
+  conversationId: string
+  groups: SplitGroup[]
+  confidence: number
+  reasoning: string | null
+}
+
+/** A confirmed group sent back to apply the split. */
+export interface SplitGroupInput {
+  title: string
+  summary?: string
+  messageIds: string[]
+}
+
 export interface ListWorkspaceConversationsParams extends ListConversationsParams {
   /** Structural lens to filter the feed by (`all` = no narrowing; omitted on the wire). */
   lens?: BoardLens
@@ -183,6 +206,30 @@ export const conversationsApi = {
     body: { streamId: string; messageIds: string[]; targetConversationId?: string | null }
   ): Promise<{ conversation: ConversationWithStaleness; sourceConversations: ConversationWithStaleness[] }> {
     return api.post(`/api/workspaces/${workspaceId}/conversations/reassign-messages`, body)
+  },
+
+  /**
+   * Ask the clustering model how a conversation should be split into smaller
+   * topics. Read-only — returns a proposal for the user to confirm. A single-group
+   * proposal means the model judged the conversation focused (no split suggested).
+   */
+  async proposeSplit(workspaceId: string, conversationId: string): Promise<SplitProposal> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/split-proposal`)
+  },
+
+  /**
+   * Apply a user-confirmed split: `groups[0]` stays in the source conversation
+   * (re-titled), the rest are minted as new titled conversations. The response
+   * carries the re-titled source and every minted conversation, so the caches
+   * recolor immediately (the follow-up `conversation:*` socket events are
+   * idempotent overwrites).
+   */
+  async applySplit(
+    workspaceId: string,
+    conversationId: string,
+    groups: SplitGroupInput[]
+  ): Promise<{ conversation: ConversationWithStaleness; newConversations: ConversationWithStaleness[] }> {
+    return api.post(`/api/workspaces/${workspaceId}/conversations/${conversationId}/split`, { groups })
   },
 
   /**

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -528,6 +528,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
               <ConversationActionsMenu
                 workspaceId={workspaceId}
                 conversationId={conversation.id}
+                streamId={conversation.streamId}
                 topicSummary={conversation.topicSummary}
                 status={conversation.status}
                 triggerClassName="shrink-0"

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { CircleCheck, Eye, EyeOff, EllipsisVertical, Pencil, RotateCcw } from "lucide-react"
+import { CircleCheck, Eye, EyeOff, EllipsisVertical, Pencil, RotateCcw, Sparkles } from "lucide-react"
 import { ConversationStatuses, MAX_CONVERSATION_TOPIC_LENGTH } from "@threa/types"
 import { Button } from "@/components/ui/button"
 import {
@@ -20,10 +20,14 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { cn } from "@/lib/utils"
 import { useUpdateConversation, useHideConversation, useUnhideConversation } from "@/hooks/use-conversations"
+import { ConversationSplitDialog } from "./conversation-split-dialog"
 
 interface ConversationActionsMenuProps {
   workspaceId: string
   conversationId: string
+  /** The conversation's stream — the anchor for the AI-split mint. Omit to hide
+   *  the "Split with AI" item (surfaces without a resolved stream id). */
+  streamId?: string
   /** Current topic — prefilled into the rename dialog; null renders as empty. */
   topicSummary: string | null
   /** Current status — selects the resolve vs. reopen item. */
@@ -45,12 +49,14 @@ interface ConversationActionsMenuProps {
 export function ConversationActionsMenu({
   workspaceId,
   conversationId,
+  streamId,
   topicSummary,
   status,
   isHidden = false,
   triggerClassName,
 }: ConversationActionsMenuProps) {
   const [renameOpen, setRenameOpen] = useState(false)
+  const [splitOpen, setSplitOpen] = useState(false)
   const update = useUpdateConversation(workspaceId)
   const hide = useHideConversation(workspaceId)
   const unhide = useUnhideConversation(workspaceId)
@@ -92,6 +98,18 @@ export function ConversationActionsMenu({
             {resolved ? <RotateCcw className="h-4 w-4" /> : <CircleCheck className="h-4 w-4" />}
             {resolved ? "Reopen" : "Mark resolved"}
           </DropdownMenuItem>
+          {streamId && (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                // Defer past the menu close so focus returns to the trigger first.
+                event.preventDefault()
+                setSplitOpen(true)
+              }}
+            >
+              <Sparkles className="h-4 w-4" />
+              Split with AI…
+            </DropdownMenuItem>
+          )}
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => (isHidden ? unhide.mutate(conversationId) : hide.mutate(conversationId))}>
             {isHidden ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
@@ -105,6 +123,15 @@ export function ConversationActionsMenu({
         initialTopic={topicSummary ?? ""}
         onSave={(next) => update.mutate({ conversationId, topicSummary: next })}
       />
+      {streamId && (
+        <ConversationSplitDialog
+          workspaceId={workspaceId}
+          streamId={streamId}
+          conversationId={splitOpen ? conversationId : null}
+          open={splitOpen}
+          onOpenChange={setSplitOpen}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
+++ b/apps/frontend/src/components/conversations/conversation-actions-menu.tsx
@@ -55,6 +55,7 @@ export function ConversationActionsMenu({
   isHidden = false,
   triggerClassName,
 }: ConversationActionsMenuProps) {
+  const [menuOpen, setMenuOpen] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
   const [splitOpen, setSplitOpen] = useState(false)
   const update = useUpdateConversation(workspaceId)
@@ -64,7 +65,7 @@ export function ConversationActionsMenu({
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"
@@ -78,9 +79,12 @@ export function ConversationActionsMenu({
         <DropdownMenuContent align="end">
           <DropdownMenuItem
             onSelect={(event) => {
-              // Defer the dialog until the menu has closed so Radix returns focus
-              // to the trigger before the dialog claims it.
+              // Close the menu explicitly and open the dialog. `preventDefault`
+              // stops Radix's own select-close (which returns focus to the
+              // trigger and can race the dialog); we drive the close via state so
+              // the menu can't linger open behind a dialog that doesn't steal focus.
               event.preventDefault()
+              setMenuOpen(false)
               setRenameOpen(true)
             }}
           >
@@ -101,8 +105,8 @@ export function ConversationActionsMenu({
           {streamId && (
             <DropdownMenuItem
               onSelect={(event) => {
-                // Defer past the menu close so focus returns to the trigger first.
                 event.preventDefault()
+                setMenuOpen(false)
                 setSplitOpen(true)
               }}
             >

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -256,6 +256,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
           <ConversationActionsMenu
             workspaceId={workspaceId}
             conversationId={post.conversation.id}
+            streamId={post.conversation.streamId}
             topicSummary={post.conversation.topicSummary}
             status={post.conversation.status}
             isHidden={hiddenConversations.has(post.conversation.id)}

--- a/apps/frontend/src/components/conversations/conversation-split-dialog.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-split-dialog.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ServicesProvider } from "@/contexts"
+import { ConversationSplitDialog } from "./conversation-split-dialog"
+import type { SplitProposal } from "@/api/conversations"
+
+function proposal(overrides: Partial<SplitProposal> = {}): SplitProposal {
+  return {
+    conversationId: "conv_1",
+    groups: [
+      { title: "Fable pricing", summary: "Cost of Fable", messageIds: ["m1", "m2", "m3"] },
+      { title: "Fable på svenska", summary: "Swedish support", messageIds: ["m4"] },
+    ],
+    confidence: 0.9,
+    reasoning: "two topics",
+    ...overrides,
+  }
+}
+
+function renderDialog(
+  services: { proposeSplit: ReturnType<typeof vi.fn>; applySplit: ReturnType<typeof vi.fn> },
+  onOpenChange = vi.fn()
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ServicesProvider services={{ conversations: services as never }}>
+        <ConversationSplitDialog
+          workspaceId="ws_1"
+          streamId="stream_1"
+          conversationId="conv_1"
+          open
+          onOpenChange={onOpenChange}
+        />
+      </ServicesProvider>
+    </QueryClientProvider>
+  )
+  return { onOpenChange }
+}
+
+describe("ConversationSplitDialog", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders the proposed groups and applies the confirmed split", async () => {
+    const applySplit = vi.fn().mockResolvedValue({ conversation: {}, newConversations: [] })
+    const proposeSplit = vi.fn().mockResolvedValue(proposal())
+    const { onOpenChange } = renderDialog({ proposeSplit, applySplit })
+
+    // Both proposed groups shown, first marked as staying, second as new.
+    expect(await screen.findByText("Fable pricing")).toBeInTheDocument()
+    expect(screen.getByText("Fable på svenska")).toBeInTheDocument()
+    expect(screen.getByText("Stays here")).toBeInTheDocument()
+    expect(screen.getByText("New conversation")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: /Split into 2 conversations/ }))
+
+    await waitFor(() =>
+      expect(applySplit).toHaveBeenCalledWith("ws_1", "conv_1", [
+        { title: "Fable pricing", summary: "Cost of Fable", messageIds: ["m1", "m2", "m3"] },
+        { title: "Fable på svenska", summary: "Swedish support", messageIds: ["m4"] },
+      ])
+    )
+    // Success is silent — the dialog just closes.
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+  })
+
+  it("shows a no-split message and no confirm button for a single-group proposal", async () => {
+    const applySplit = vi.fn()
+    const proposeSplit = vi
+      .fn()
+      .mockResolvedValue(proposal({ groups: [{ title: "One topic", summary: null, messageIds: ["m1", "m2"] }] }))
+    renderDialog({ proposeSplit, applySplit })
+
+    expect(await screen.findByText(/no split suggested/i)).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Split into/ })).not.toBeInTheDocument()
+    expect(applySplit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/components/conversations/conversation-split-dialog.test.tsx
+++ b/apps/frontend/src/components/conversations/conversation-split-dialog.test.tsx
@@ -48,10 +48,10 @@ describe("ConversationSplitDialog", () => {
     const proposeSplit = vi.fn().mockResolvedValue(proposal())
     const { onOpenChange } = renderDialog({ proposeSplit, applySplit })
 
-    // Both proposed groups shown, first marked as staying, second as new.
+    // Both proposed groups shown, first kept in this conversation, second new.
     expect(await screen.findByText("Fable pricing")).toBeInTheDocument()
     expect(screen.getByText("Fable på svenska")).toBeInTheDocument()
-    expect(screen.getByText("Stays here")).toBeInTheDocument()
+    expect(screen.getByText("This conversation")).toBeInTheDocument()
     expect(screen.getByText("New conversation")).toBeInTheDocument()
 
     await userEvent.click(screen.getByRole("button", { name: /Split into 2 conversations/ }))

--- a/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
+++ b/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
@@ -53,6 +53,15 @@ export function ConversationSplitDialog({
   const proposal = propose.data
   const canSplit = !!proposal && proposal.groups.length >= 2
 
+  // Don't let Escape / backdrop / the close button dismiss the dialog while the
+  // split is being written — success is silent (INV-63), so a mid-apply dismissal
+  // would leave the user with no correlation between their action and the board
+  // rearranging. The confirm's own onSuccess closes it directly once settled.
+  const handleOpenChange = (next: boolean) => {
+    if (!next && apply.isPending) return
+    onOpenChange(next)
+  }
+
   const onConfirm = () => {
     if (!proposal || !conversationId || !canSplit) return
     apply.mutate(
@@ -92,27 +101,34 @@ export function ConversationSplitDialog({
     body = <p className="py-8 text-sm text-muted-foreground">This conversation looks focused — no split suggested.</p>
   } else {
     body = (
-      <ul className="flex flex-col gap-2 py-1">
-        {proposal!.groups.map((group, index) => (
-          <li key={index} className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5">
-            <div className="flex items-center justify-between gap-2">
-              <span className="min-w-0 flex-1 truncate text-sm font-medium">{group.title}</span>
-              <span className="shrink-0 rounded-full bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
-                {index === 0 ? "Stays here" : "New conversation"}
-              </span>
-            </div>
-            {group.summary ? <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{group.summary}</p> : null}
-            <p className="mt-1 text-[11px] tabular-nums text-muted-foreground">
-              {group.messageIds.length} {group.messageIds.length === 1 ? "message" : "messages"}
-            </p>
-          </li>
-        ))}
-      </ul>
+      <div className="flex flex-col gap-2 py-1">
+        <p className="text-xs text-muted-foreground">
+          The first group stays in this conversation — it takes on that title. The rest become new conversations.
+        </p>
+        <ul className="flex flex-col gap-2">
+          {proposal!.groups.map((group, index) => (
+            <li key={index} className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5">
+              <div className="flex items-center justify-between gap-2">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium">{group.title}</span>
+                <span className="shrink-0 rounded-full bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                  {index === 0 ? "This conversation" : "New conversation"}
+                </span>
+              </div>
+              {group.summary ? (
+                <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{group.summary}</p>
+              ) : null}
+              <p className="mt-1 text-[11px] tabular-nums text-muted-foreground">
+                {group.messageIds.length} {group.messageIds.length === 1 ? "message" : "messages"}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
     )
   }
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange} disableSnapPoints>
       <ResponsiveDialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-lg" desktopClassName="pt-6">
         <ResponsiveDialogHeader className="px-4 pb-3 sm:px-6">
           <ResponsiveDialogTitle className="flex items-center gap-2">
@@ -127,7 +143,7 @@ export function ConversationSplitDialog({
         <ResponsiveDialogBody className="min-h-24 py-2">{body}</ResponsiveDialogBody>
 
         <ResponsiveDialogFooter className="gap-2 px-4 pb-4 pt-3 sm:px-6">
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={apply.isPending}>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={apply.isPending}>
             {canSplit ? "Cancel" : "Close"}
           </Button>
           {canSplit ? (

--- a/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
+++ b/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
@@ -1,0 +1,143 @@
+import { useEffect, type ReactNode } from "react"
+import { toast } from "sonner"
+import { Loader2, Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+  ResponsiveDialogDescription,
+  ResponsiveDialogBody,
+  ResponsiveDialogFooter,
+} from "@/components/ui/responsive-dialog"
+import { useProposeSplit, useApplySplit } from "@/hooks/use-conversations"
+
+/**
+ * "Split with AI": ask the clustering model how a conversation should be broken
+ * into smaller topics, show the proposed groups, and apply them on confirmation.
+ * Read-only until the user confirms — {@link useProposeSplit} writes nothing; the
+ * confirm calls {@link useApplySplit}, which keeps the first (largest) group in
+ * this conversation and mints the rest. Success is silent (INV-63): the overlay
+ * and board recolor from the mutation's cache write, so the dialog just closes.
+ */
+export function ConversationSplitDialog({
+  workspaceId,
+  streamId,
+  conversationId,
+  open,
+  onOpenChange,
+}: {
+  workspaceId: string
+  streamId: string
+  conversationId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const propose = useProposeSplit(workspaceId)
+  const apply = useApplySplit(workspaceId, streamId)
+  const { mutate: mutatePropose, reset: resetPropose } = propose
+  const { reset: resetApply } = apply
+
+  // Fetch a fresh proposal each time the dialog opens for a conversation; clear
+  // both mutations when it closes so a reopen never flashes the prior result.
+  useEffect(() => {
+    if (open && conversationId) {
+      mutatePropose(conversationId)
+    } else if (!open) {
+      resetPropose()
+      resetApply()
+    }
+  }, [open, conversationId, mutatePropose, resetPropose, resetApply])
+
+  const proposal = propose.data
+  const canSplit = !!proposal && proposal.groups.length >= 2
+
+  const onConfirm = () => {
+    if (!proposal || !conversationId || !canSplit) return
+    apply.mutate(
+      {
+        conversationId,
+        groups: proposal.groups.map((g) => ({
+          title: g.title,
+          summary: g.summary ?? undefined,
+          messageIds: g.messageIds,
+        })),
+      },
+      {
+        onSuccess: () => onOpenChange(false),
+        onError: () => toast.error("Couldn't split the conversation"),
+      }
+    )
+  }
+
+  let body: ReactNode
+  if (propose.isPending) {
+    body = (
+      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground" role="status">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        Analyzing the conversation…
+      </div>
+    )
+  } else if (propose.isError) {
+    body = (
+      <div className="flex flex-col items-start gap-3 py-6 text-sm">
+        <p className="text-muted-foreground">Couldn&apos;t analyze this conversation.</p>
+        <Button variant="outline" size="sm" onClick={() => conversationId && mutatePropose(conversationId)}>
+          Try again
+        </Button>
+      </div>
+    )
+  } else if (!canSplit) {
+    body = <p className="py-8 text-sm text-muted-foreground">This conversation looks focused — no split suggested.</p>
+  } else {
+    body = (
+      <ul className="flex flex-col gap-2 py-1">
+        {proposal!.groups.map((group, index) => (
+          <li key={index} className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5">
+            <div className="flex items-center justify-between gap-2">
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">{group.title}</span>
+              <span className="shrink-0 rounded-full bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                {index === 0 ? "Stays here" : "New conversation"}
+              </span>
+            </div>
+            {group.summary ? <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{group.summary}</p> : null}
+            <p className="mt-1 text-[11px] tabular-nums text-muted-foreground">
+              {group.messageIds.length} {group.messageIds.length === 1 ? "message" : "messages"}
+            </p>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange} disableSnapPoints>
+      <ResponsiveDialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-lg" desktopClassName="pt-6">
+        <ResponsiveDialogHeader className="px-4 pb-3 sm:px-6">
+          <ResponsiveDialogTitle className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-muted-foreground" aria-hidden />
+            Split with AI
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Let the model regroup this conversation into smaller topics. Nothing changes until you confirm.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <ResponsiveDialogBody className="min-h-24 py-2">{body}</ResponsiveDialogBody>
+
+        <ResponsiveDialogFooter className="gap-2 px-4 pb-4 pt-3 sm:px-6">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={apply.isPending}>
+            {canSplit ? "Cancel" : "Close"}
+          </Button>
+          {canSplit ? (
+            <Button onClick={onConfirm} disabled={apply.isPending}>
+              {apply.isPending ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden /> : null}
+              Split into {proposal!.groups.length} conversations
+            </Button>
+          ) : null}
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
+++ b/apps/frontend/src/components/conversations/conversation-split-dialog.tsx
@@ -83,14 +83,14 @@ export function ConversationSplitDialog({
   let body: ReactNode
   if (propose.isPending) {
     body = (
-      <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground" role="status">
+      <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground" role="status">
         <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
         Analyzing the conversation…
       </div>
     )
   } else if (propose.isError) {
     body = (
-      <div className="flex flex-col items-start gap-3 py-6 text-sm">
+      <div className="flex flex-col items-start gap-3 py-2 text-sm">
         <p className="text-muted-foreground">Couldn&apos;t analyze this conversation.</p>
         <Button variant="outline" size="sm" onClick={() => conversationId && mutatePropose(conversationId)}>
           Try again
@@ -98,14 +98,14 @@ export function ConversationSplitDialog({
       </div>
     )
   } else if (!canSplit) {
-    body = <p className="py-8 text-sm text-muted-foreground">This conversation looks focused — no split suggested.</p>
+    body = <p className="py-4 text-sm text-muted-foreground">This conversation looks focused — no split suggested.</p>
   } else {
     body = (
-      <div className="flex flex-col gap-2 py-1">
+      <div className="flex flex-col gap-3">
         <p className="text-xs text-muted-foreground">
           The first group stays in this conversation — it takes on that title. The rest become new conversations.
         </p>
-        <ul className="flex flex-col gap-2">
+        <ul className="-mx-1 flex max-h-[45vh] flex-col gap-2 overflow-y-auto px-1 scrollbar-thin">
           {proposal!.groups.map((group, index) => (
             <li key={index} className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5">
               <div className="flex items-center justify-between gap-2">
@@ -129,8 +129,8 @@ export function ConversationSplitDialog({
 
   return (
     <ResponsiveDialog open={open} onOpenChange={handleOpenChange} disableSnapPoints>
-      <ResponsiveDialogContent className="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-lg" desktopClassName="pt-6">
-        <ResponsiveDialogHeader className="px-4 pb-3 sm:px-6">
+      <ResponsiveDialogContent>
+        <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="flex items-center gap-2">
             <Sparkles className="h-4 w-4 text-muted-foreground" aria-hidden />
             Split with AI
@@ -140,9 +140,9 @@ export function ConversationSplitDialog({
           </ResponsiveDialogDescription>
         </ResponsiveDialogHeader>
 
-        <ResponsiveDialogBody className="min-h-24 py-2">{body}</ResponsiveDialogBody>
+        <ResponsiveDialogBody>{body}</ResponsiveDialogBody>
 
-        <ResponsiveDialogFooter className="gap-2 px-4 pb-4 pt-3 sm:px-6">
+        <ResponsiveDialogFooter>
           <Button variant="ghost" onClick={() => handleOpenChange(false)} disabled={apply.isPending}>
             {canSplit ? "Cancel" : "Close"}
           </Button>

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -154,7 +154,12 @@ export function ConversationOverlayPanel({
                       onClick={() => setSplitConversationId(conversation.id)}
                       title="Split with AI"
                       aria-label="Split this conversation with AI"
-                      className="ml-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/row:opacity-100"
+                      className={cn(
+                        "ml-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-opacity hover:bg-background hover:text-foreground focus-visible:opacity-100",
+                        // Touch has no hover to reveal it — keep it visible; on
+                        // desktop it stays a quiet hover/focus affordance.
+                        isMobile ? "opacity-100" : "opacity-0 group-hover/row:opacity-100"
+                      )}
                     >
                       <Sparkles className="h-3.5 w-3.5" aria-hidden />
                     </button>

--- a/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
+++ b/apps/frontend/src/components/timeline/conversation-overlay/conversation-overlay.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, type ReactNode } from "react"
-import { Check, ChevronUp, Layers, Loader2, Plus, X } from "lucide-react"
+import { Check, ChevronUp, Layers, Loader2, Plus, Sparkles, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { ConversationSplitDialog } from "@/components/conversations/conversation-split-dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,11 +32,15 @@ import { ConversationOverlayRowProvider } from "./row-context"
  */
 export function ConversationOverlayPanel({
   overlay,
+  workspaceId,
+  streamId,
   inViewConversations,
   onClose,
   topBarOpen = false,
 }: {
   overlay: ConversationOverlayContext
+  workspaceId: string
+  streamId: string
   inViewConversations: ConversationWithStaleness[]
   onClose: () => void
   /** A full-width strip (stream search, or the split-selection bar) occupies the
@@ -46,6 +51,8 @@ export function ConversationOverlayPanel({
   // Collapsed by default on mobile; the user's explicit choice wins once made.
   const [userCollapsed, setUserCollapsed] = useState<boolean | null>(null)
   const collapsed = userCollapsed ?? isMobile
+  // Which conversation the AI-split dialog is open for (null = closed).
+  const [splitConversationId, setSplitConversationId] = useState<string | null>(null)
   const { model, focusedConversationId, onToggleFocus } = overlay
 
   return (
@@ -112,37 +119,61 @@ export function ConversationOverlayPanel({
                 const colorIndex = model.colorIndexById.get(conversation.id) ?? 0
                 const isFocused = focusedConversationId === conversation.id
                 return (
-                  <button
+                  <div
                     key={conversation.id}
-                    type="button"
-                    onClick={() => onToggleFocus(conversation.id)}
-                    aria-pressed={isFocused}
-                    title={conversation.topicSummary ?? undefined}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent",
-                      isFocused && "font-medium",
+                      "group/row flex w-full items-center rounded-md pr-1 transition-colors hover:bg-accent",
                       focusedConversationId != null && !isFocused && "opacity-50"
                     )}
                     style={isFocused ? { backgroundColor: conversationColor(colorIndex, 0.12) } : undefined}
                   >
-                    <span
-                      aria-hidden
-                      className="h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: conversationColor(colorIndex) }}
-                    />
-                    <span className="min-w-0 flex-1 truncate">
-                      {conversation.topicSummary || "Untitled conversation"}
-                    </span>
-                    <span className="shrink-0 tabular-nums text-muted-foreground">
-                      {conversation.messageIds.length}
-                    </span>
-                  </button>
+                    <button
+                      type="button"
+                      onClick={() => onToggleFocus(conversation.id)}
+                      aria-pressed={isFocused}
+                      title={conversation.topicSummary ?? undefined}
+                      className={cn(
+                        "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
+                        isFocused && "font-medium"
+                      )}
+                    >
+                      <span
+                        aria-hidden
+                        className="h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: conversationColor(colorIndex) }}
+                      />
+                      <span className="min-w-0 flex-1 truncate">
+                        {conversation.topicSummary || "Untitled conversation"}
+                      </span>
+                      <span className="shrink-0 tabular-nums text-muted-foreground">
+                        {conversation.messageIds.length}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setSplitConversationId(conversation.id)}
+                      title="Split with AI"
+                      aria-label="Split this conversation with AI"
+                      className="ml-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover/row:opacity-100"
+                    >
+                      <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                    </button>
+                  </div>
                 )
               })
             )}
           </div>
         </div>
       )}
+      <ConversationSplitDialog
+        workspaceId={workspaceId}
+        streamId={streamId}
+        conversationId={splitConversationId}
+        open={splitConversationId !== null}
+        onOpenChange={(open) => {
+          if (!open) setSplitConversationId(null)
+        }}
+      />
     </div>
   )
 }

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -965,97 +965,98 @@ export function StreamContent({
   // The drag-onto-a-target gesture belongs to move-to-thread only. Split mode
   // attaches nothing here: each row toggles via its own `onClick`, so native
   // touch scrolling stays intact (see BatchTimelineState.dragSelect).
-  const batchPointerHandlers = batchMode && batchIntent === "moveToThread"
-    ? {
-        onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
-          const target = event.target as HTMLElement
-          if (target.closest("[data-batch-control]")) return
-          const messageId = target.closest<HTMLElement>("[data-message-id]")?.dataset.messageId
-          if (!messageId) return
-          event.preventDefault()
-          batchPointerRef.current = {
-            id: event.pointerId,
-            messageId,
-            x: event.clientX,
-            y: event.clientY,
-            dragging: false,
-            wasSelected: selectedMessageIds.has(messageId),
-          }
-          if (!selectedMessageIds.has(messageId)) {
-            setSelectedMessageIds((prev) => new Set(prev).add(messageId))
-          }
-        },
-        onPointerMove: (event: React.PointerEvent<HTMLElement>) => {
-          const pointer = batchPointerRef.current
-          if (!pointer || pointer.id !== event.pointerId) return
-          const distance = Math.hypot(event.clientX - pointer.x, event.clientY - pointer.y)
-          if (!pointer.dragging && distance < 6) return
-          event.preventDefault()
-          if (!pointer.dragging && !selectedMessageIds.has(pointer.messageId)) {
-            setSelectedMessageIds((prev) => new Set(prev).add(pointer.messageId))
-          }
-          pointer.dragging = true
-          setDragGhost({ x: event.clientX, y: event.clientY })
-          const targetId = findMessageIdFromPoint(event.clientX, event.clientY)
-          const validTargetId = isValidBatchTarget(targetId) ? targetId : null
-          setHoveredBatchTargetId((previous) => {
-            if (previous !== validTargetId && validTargetId && "vibrate" in navigator) {
-              navigator.vibrate?.(10)
+  const batchPointerHandlers =
+    batchMode && batchIntent === "moveToThread"
+      ? {
+          onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+            const target = event.target as HTMLElement
+            if (target.closest("[data-batch-control]")) return
+            const messageId = target.closest<HTMLElement>("[data-message-id]")?.dataset.messageId
+            if (!messageId) return
+            event.preventDefault()
+            batchPointerRef.current = {
+              id: event.pointerId,
+              messageId,
+              x: event.clientX,
+              y: event.clientY,
+              dragging: false,
+              wasSelected: selectedMessageIds.has(messageId),
             }
-            return validTargetId
-          })
-        },
-        onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
-          const pointer = batchPointerRef.current
-          if (!pointer || pointer.id !== event.pointerId) return
-          event.preventDefault()
-          suppressNextBatchClickRef.current = true
-          if (suppressNextBatchClickTimerRef.current !== null) {
-            window.clearTimeout(suppressNextBatchClickTimerRef.current)
-          }
-          suppressNextBatchClickTimerRef.current = window.setTimeout(() => {
-            suppressNextBatchClickRef.current = false
-            suppressNextBatchClickTimerRef.current = null
-          }, 350)
-          const targetId = hoveredBatchTargetId
-          const wasDragging = pointer.dragging
-          batchPointerRef.current = null
-          setDragGhost(null)
-          setHoveredBatchTargetId(null)
-          if (!wasDragging) {
-            setSelectedMessageIds((prev) => {
-              const next = new Set(prev)
-              if (pointer.wasSelected) {
-                next.delete(pointer.messageId)
-              } else {
-                next.add(pointer.messageId)
+            if (!selectedMessageIds.has(messageId)) {
+              setSelectedMessageIds((prev) => new Set(prev).add(messageId))
+            }
+          },
+          onPointerMove: (event: React.PointerEvent<HTMLElement>) => {
+            const pointer = batchPointerRef.current
+            if (!pointer || pointer.id !== event.pointerId) return
+            const distance = Math.hypot(event.clientX - pointer.x, event.clientY - pointer.y)
+            if (!pointer.dragging && distance < 6) return
+            event.preventDefault()
+            if (!pointer.dragging && !selectedMessageIds.has(pointer.messageId)) {
+              setSelectedMessageIds((prev) => new Set(prev).add(pointer.messageId))
+            }
+            pointer.dragging = true
+            setDragGhost({ x: event.clientX, y: event.clientY })
+            const targetId = findMessageIdFromPoint(event.clientX, event.clientY)
+            const validTargetId = isValidBatchTarget(targetId) ? targetId : null
+            setHoveredBatchTargetId((previous) => {
+              if (previous !== validTargetId && validTargetId && "vibrate" in navigator) {
+                navigator.vibrate?.(10)
               }
-              return next
+              return validTargetId
             })
-            return
-          }
-          if (wasDragging && targetId && isValidBatchTarget(targetId)) {
-            void dropBatchOnTarget(targetId)
-          }
-        },
-        onPointerCancel: () => {
-          batchPointerRef.current = null
-          setDragGhost(null)
-          setHoveredBatchTargetId(null)
-          suppressNextBatchClickRef.current = false
-          if (suppressNextBatchClickTimerRef.current !== null) {
-            window.clearTimeout(suppressNextBatchClickTimerRef.current)
-            suppressNextBatchClickTimerRef.current = null
-          }
-        },
-        onClickCapture: (event: React.MouseEvent<HTMLElement>) => {
-          if (!suppressNextBatchClickRef.current) return
-          suppressNextBatchClickRef.current = false
-          event.preventDefault()
-          event.stopPropagation()
-        },
-      }
-    : {}
+          },
+          onPointerUp: (event: React.PointerEvent<HTMLElement>) => {
+            const pointer = batchPointerRef.current
+            if (!pointer || pointer.id !== event.pointerId) return
+            event.preventDefault()
+            suppressNextBatchClickRef.current = true
+            if (suppressNextBatchClickTimerRef.current !== null) {
+              window.clearTimeout(suppressNextBatchClickTimerRef.current)
+            }
+            suppressNextBatchClickTimerRef.current = window.setTimeout(() => {
+              suppressNextBatchClickRef.current = false
+              suppressNextBatchClickTimerRef.current = null
+            }, 350)
+            const targetId = hoveredBatchTargetId
+            const wasDragging = pointer.dragging
+            batchPointerRef.current = null
+            setDragGhost(null)
+            setHoveredBatchTargetId(null)
+            if (!wasDragging) {
+              setSelectedMessageIds((prev) => {
+                const next = new Set(prev)
+                if (pointer.wasSelected) {
+                  next.delete(pointer.messageId)
+                } else {
+                  next.add(pointer.messageId)
+                }
+                return next
+              })
+              return
+            }
+            if (wasDragging && targetId && isValidBatchTarget(targetId)) {
+              void dropBatchOnTarget(targetId)
+            }
+          },
+          onPointerCancel: () => {
+            batchPointerRef.current = null
+            setDragGhost(null)
+            setHoveredBatchTargetId(null)
+            suppressNextBatchClickRef.current = false
+            if (suppressNextBatchClickTimerRef.current !== null) {
+              window.clearTimeout(suppressNextBatchClickTimerRef.current)
+              suppressNextBatchClickTimerRef.current = null
+            }
+          },
+          onClickCapture: (event: React.MouseEvent<HTMLElement>) => {
+            if (!suppressNextBatchClickRef.current) return
+            suppressNextBatchClickRef.current = false
+            event.preventDefault()
+            event.stopPropagation()
+          },
+        }
+      : {}
 
   // For drafts with pending events, compute timeline items from those events. Drafts
   // are a single-author transcript already, but running the same pipeline keeps the
@@ -2082,6 +2083,8 @@ export function StreamContent({
                     {activeConversationOverlay && (
                       <ConversationOverlayPanel
                         overlay={activeConversationOverlay}
+                        workspaceId={workspaceId}
+                        streamId={streamId}
                         inViewConversations={inViewConversations}
                         onClose={closeConversationOverlay}
                         // Split mode keeps the overlay panel mounted while the

--- a/apps/frontend/src/contexts/services-context.tsx
+++ b/apps/frontend/src/contexts/services-context.tsx
@@ -74,6 +74,8 @@ export interface ConversationService {
   markUnread: typeof conversationsApi.markUnread
   reassignMessage: typeof conversationsApi.reassignMessage
   reassignMessages: typeof conversationsApi.reassignMessages
+  proposeSplit: typeof conversationsApi.proposeSplit
+  applySplit: typeof conversationsApi.applySplit
   updateConversation: typeof conversationsApi.updateConversation
   hideConversation: typeof conversationsApi.hideConversation
   unhideConversation: typeof conversationsApi.unhideConversation

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -17,6 +17,7 @@ import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
+import type { SplitGroupInput } from "@/api/conversations"
 import { StreamTypes } from "@threa/types"
 import type {
   BoardLens,
@@ -669,6 +670,51 @@ export function useReassignMessagesToConversation(workspaceId: string, streamId:
         }
       )
       for (const id of [conversation.id, ...sourceConversations.map((c) => c.id)]) {
+        queryClient.invalidateQueries({ queryKey: conversationKeys.messages(id) })
+      }
+    },
+  })
+}
+
+/**
+ * Ask the clustering model how a conversation should be split. Read-only — the
+ * mutation returns the proposal and writes nothing; the caller renders it for
+ * confirmation and applies it via {@link useApplySplit}.
+ */
+export function useProposeSplit(workspaceId: string) {
+  const conversationService = useConversationService()
+  return useMutation({
+    mutationFn: (conversationId: string) => conversationService.proposeSplit(workspaceId, conversationId),
+  })
+}
+
+/**
+ * Apply a confirmed split proposal. Mirrors {@link useReassignMessagesToConversation}'s
+ * cache handling: the re-titled source and every minted conversation are written
+ * straight into the list cache (minted ones appended) so the board/overlay recolor
+ * immediately; the `conversation:*` socket events that follow are idempotent
+ * overwrites of the same rows. Messages for touched conversations are invalidated.
+ */
+export function useApplySplit(workspaceId: string, streamId: string) {
+  const conversationService = useConversationService()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ conversationId, groups }: { conversationId: string; groups: SplitGroupInput[] }) =>
+      conversationService.applySplit(workspaceId, conversationId, groups),
+    onSuccess: ({ conversation, newConversations }) => {
+      const updatedById = new Map([conversation, ...newConversations].map((c) => [c.id, c]))
+      queryClient.setQueryData(
+        conversationKeys.list(workspaceId, streamId, {}),
+        (old: ConversationWithStaleness[] | undefined) => {
+          if (!old) return old
+          const merged = old.map((c) => updatedById.get(c.id) ?? c)
+          // Minted conversations aren't in the list yet — append the new ones.
+          const present = new Set(old.map((c) => c.id))
+          return [...merged, ...newConversations.filter((c) => !present.has(c.id))]
+        }
+      )
+      for (const id of [conversation.id, ...newConversations.map((c) => c.id)]) {
         queryClient.invalidateQueries({ queryKey: conversationKeys.messages(id) })
       }
     },


### PR DESCRIPTION
## Problem

#1225 shipped manual conversation split: select timeline messages, move them into another conversation or a fresh one. It's hand-matching — the user decides every boundary. A drifted "blob" conversation (one that grew across several topics) still has to be untangled message by message.

The boundary extractor already knows how to cluster messages into conversations, but only *incrementally* — `BoundaryExtractionService.processMessage` classifies one new message at a time against the active conversations. There was no way to point that intelligence at an existing conversation and ask "how should this have been split?"

## Solution

An on-demand "Split with AI": select a conversation, the clustering model proposes how to break it into smaller topics, the user confirms, and the split applies. Propose-then-confirm — nothing is written until the user accepts. Reuses the tuned boundary model via a new *batch* entry point rather than the per-message path, and applies the result through membership rewrites only (no `stream_events` move), so INV-61 contiguity is untouched — the messages never leave their stream.

### How it works

**Propose (read-only).** `POST /api/workspaces/:workspaceId/conversations/:conversationId/split-proposal` → `BoundaryExtractionService.proposeSplit` loads the conversation's messages in stored order and calls the new `LLMBoundaryExtractor.splitConversation`. That method reuses the `BOUNDARY_EXTRACTION` model id + temperature (`config.modelId`/`config.temperature`) with a batch-shaped prompt (`CONVERSATION_SPLIT_PROMPT`/`CONVERSATION_SPLIT_SYSTEM_PROMPT` in `config.ts`) carrying the same clustering rules the incremental prompt uses — session gaps, the entity-magnet trap, the naming rules. `validateSplit` coerces the raw response into a real partition of the input: drops unknown ids, dedupes across groups (first group wins), sweeps any unassigned message into the largest group, and orders groups largest-first. Conversations under `MIN_MESSAGES_TO_SPLIT` (4) short-circuit to a single group with no AI call; an unparseable response degrades to a single group (INV-11 — logged, only `NoObjectGeneratedError`, API/rate-limit errors still propagate). A single-group proposal is the "no split suggested" signal.

**Apply (atomic).** `POST /api/workspaces/:workspaceId/conversations/:conversationId/split` → `ConversationService.applySplit`, one `withTransaction`. Locks the source conversation (`findByIdForUpdate`) then the message rows (`findByIdsForUpdate`) — conversation-before-message, matching `reassignMessagesToConversation`/`splitThreadIntoConversation`; the destinations are fresh mints with no pre-existing row to contend for, so the single source lock is the whole conversation lock set and the order is trivially deadlock-free. Re-reads authoritative membership once the rows are pinned: `groups[0]` stays in the source (re-titled to its group via `ConversationRepository.update`), each later group is minted as a titled conversation (`insert` with `topicSummary`/`summary`) and its still-in-source messages moved in. One `conversation_feedback` row per moved message; `conversation:created` per mint, `conversation:updated` for the source, `conversation:message_reassigned` per moved message, all in-transaction (INV-4/6/7). A message that raced out of the source between propose and apply is skipped, not yanked from wherever it now lives; if every mover raced away it 409s (`NO_MESSAGES_TO_MOVE`).

**Access.** Both handlers gate on the conversation's root stream via `streamService.validateStreamAccess` (INV-62). Apply derives the stream from the conversation server-side — the body carries only the confirmed groups, so a client can't retarget the mint anchor.

**Frontend.** `conversationsApi.proposeSplit`/`applySplit` + `useProposeSplit`/`useApplySplit`; the apply hook writes the re-titled source and minted conversations into the per-stream `conversationKeys.list` cache and appends the mints, mirroring `useReassignMessagesToConversation`. `ConversationSplitDialog` proposes on open, previews each group (title, summary, count, "Stays here" / "New conversation"), and applies on confirm — silent success (INV-63, the overlay/board recolor from the cache write), `toast.error` on failure only. Two entry points: the conversation overlay panel (per-conversation Sparkles button) and the board-card / conversation-panel `ConversationActionsMenu` ("Split with AI…"), which now takes an optional `streamId`.

### Key design decisions

**1. Atomic multi-group apply, not N reassign calls.** The handover suggested composing the existing `reassignMessagesToConversation` per group. That path is non-atomic (a partial split can strand messages), fires N transactions + N extraction churns, and mints untitled conversations (its fresh-mint precedent deliberately drops the title) — so the model's good titles would be lost until some later message re-titled them, which for a resolved split may be never. `applySplit` does the whole partition in one transaction and carries the titles. It reuses the same repository membership helpers (`removePrimaryMessages`/`addPrimaryMessages`/`resolveIfEmpty`/`bumpActivityForIds`), so it's new orchestration, not new data access. Correctness over scope (CLAUDE.md precedence #1).

**2. Reuse the extractor class, not a separate agent.** Per the scoping decision, `splitConversation` is a method on `LLMBoundaryExtractor` sharing the AI wrapper, model config, `formatRelativeAge`, and the clustering prose — a batch entry point, not a parallel implementation. Model + temperature come from the `BOUNDARY_EXTRACTION` component config so an eval override follows; the system/user prompts are split-specific (the boundary prompt is new-message-centric and wouldn't fit a whole-conversation input).

**3. Keep the largest group in the source.** `validateSplit` orders groups largest-first and `applySplit` keeps `groups[0]`, so the fewest messages move, the fewest feedback rows are written, and the source conversation stays the most representative of its original identity (board position, read-state). The source is re-titled to that group.

**4. Propose is read-only; the user confirms.** Per the scoping decision. The propose endpoint writes nothing — it's a pure AI read that returns a proposal. Apply is a separate, explicit action. This makes the AI cost visible on demand and the whole operation reversible-by-not-confirming.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/conversations/service.apply-split.test.ts` | `applySplit` unit tests — keep-largest/mint-rest, feedback + events, race-skip, 409, cross-stream 400 |
| `apps/frontend/src/components/conversations/conversation-split-dialog.tsx` | Propose→preview→confirm dialog, shared by both entry points |
| `apps/frontend/src/components/conversations/conversation-split-dialog.test.tsx` | Dialog propose/apply/no-split flow |

## Modified files

| File | Change |
| ---- | ------ |
| `boundary-extraction/config.ts` | `CONVERSATION_SPLIT_SYSTEM_PROMPT`, `CONVERSATION_SPLIT_PROMPT`, `conversationSplitResponseSchema` (reuse model/temperature) |
| `boundary-extraction/types.ts` | `SplitContext`/`SplitProposal`/`SplitGroup`; `splitConversation` on `BoundaryExtractor` |
| `boundary-extraction/llm-extractor.ts` | `splitConversation` + `buildSplitPrompt` + `validateSplit`; `MIN_MESSAGES_TO_SPLIT` |
| `boundary-extraction/stub-extractor.ts` | Deterministic stub split (halve ≥4 messages, else one group) |
| `boundary-extraction/llm-extractor.test.ts` | Split partition / order / dedupe-sweep / degrade tests |
| `boundary-extraction-service.ts` | `proposeSplit` (read-only) |
| `service.ts` | `applySplit` + `ApplySplitParams`/`ApplySplitGroup`/`ApplySplitResult` |
| `handlers.ts` | `proposeSplit`/`applySplit` handlers + Zod schemas (`groups` 2–50, ≤500 msgs, one group each) |
| `handlers.test.ts` | Mock `boundaryExtractionService` in the handler deps |
| `index.ts` | Export split types + config symbols |
| `routes.ts` | Register both routes; thread `boundaryExtractionService` into handler deps |
| `server.ts` | Hoist `boundaryExtractor`/`boundaryExtractionService` construction above `registerRoutes` (worker reuses the same instance) |
| `api/conversations.ts` | `proposeSplit`/`applySplit` + `SplitProposal`/`SplitGroup`/`SplitGroupInput` types |
| `hooks/use-conversations.ts` | `useProposeSplit`/`useApplySplit` |
| `contexts/services-context.tsx` | Add the two methods to `ConversationService` |
| `conversation-actions-menu.tsx` | Optional `streamId` + "Split with AI…" item + dialog |
| `conversation-panel.tsx`, `board/board-card.tsx` | Pass `streamId` to the actions menu |
| `conversation-overlay/conversation-overlay.tsx` | Per-conversation Sparkles trigger + dialog; row wrapper restructured (button-in-button avoided) |
| `timeline/stream-content.tsx` | Thread `workspaceId`/`streamId` into `ConversationOverlayPanel` (2 lines). **The rest of this file's diff is a prettier reflow of an existing ternary from lint-staged — no functional change.** |

## Out of scope (deliberate)

- **Board optimistic update.** `useApplySplit` writes the per-stream `conversationKeys.list` cache (right for the overlay). The board reads its own workspace feed / IDB, so minted conversations appear there via the `conversation:*` socket echo, not the optimistic write — same limitation `useReassignMessagesToConversation` already has. Not patched here; flag if wanted.
- **No preview of message *contents*.** The dialog previews per-group title + summary + count, not the individual message snippets. Titles/summaries are model-generated and enough to confirm; showing snippets would need a fetch.
- **No drag-to-adjust.** The user confirms or cancels the whole proposal; they can't move a message between proposed groups before applying.
- **No feature flag.** The endpoints are ungated like `reassign-messages`; the entry points inherit the surfaces' existing gates (`convOverlay=on`, `board-view`).

## Test plan

- [x] Backend `bun test src/features/conversations/` — 116 pass (incl. new `service.apply-split.test.ts` 5, split cases in `llm-extractor.test.ts`)
- [x] Frontend `vitest run src/components/conversations/ src/components/timeline/conversation-overlay/` — 42 pass (incl. new `conversation-split-dialog.test.tsx` 2)
- [x] `tsc --noEmit` across all workspaces + `tsc -p tsconfig.tests.json` — clean (via pre-commit hook)
- [x] ESLint + prettier + migration/dockerfile/api-doc checks — clean (pre-commit hook)
- [ ] Not exercised against a live LLM — `splitConversation` is covered via the stub extractor and the mocked-AI extractor test, like the incremental boundary path; the prompt itself isn't eval-gated in this PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwF8zTbWnfadMq23TCHdia)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786026536&installation_id=129946197&pr_number=1235&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1235&signature=fed06b3a6560007b7a44878fea6332b1ed212e48397cdcf4fbdae17908e820d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->