### PR TITLE
feat(composer): preview uploaded videos, PDFs, and docs before send

### DIFF
--- a/apps/frontend/src/components/gallery/upload-preview.test.ts
+++ b/apps/frontend/src/components/gallery/upload-preview.test.ts
@@ -52,6 +52,11 @@ describe("uploadGalleryType", () => {
   it("treats a .ts file as text, not an mp2t video", () => {
     expect(uploadGalleryType({ mimeType: "video/mp2t", filename: "module.ts" })).toBe("text")
   })
+
+  it("normalizes mixed-case and parameterized image mimes (server-restored records)", () => {
+    expect(uploadGalleryType({ mimeType: "Image/PNG", filename: "shot.png" })).toBe("image")
+    expect(uploadGalleryType({ mimeType: "image/png; charset=binary", filename: "shot.png" })).toBe("image")
+  })
 })
 
 describe("buildPendingGalleryItem", () => {

--- a/apps/frontend/src/components/gallery/upload-preview.test.ts
+++ b/apps/frontend/src/components/gallery/upload-preview.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import type { GalleryItem } from "@/components/image-gallery"
+import { buildPendingGalleryItem, uploadGalleryType } from "./upload-preview"
+import { isPendingGalleryId } from "./pending-gallery-id"
+
+// One representative uploaded file per gallery type — keyed on GalleryItem["type"]
+// so adding a new gallery type is a COMPILE error here until someone decides
+// whether an uploaded file previews as it (a fixture) or can never be one (null).
+// This is the drift guard: the composer's previewable set can't fall behind the
+// gallery's renderable set without failing this file.
+const FIXTURE_BY_TYPE: Record<GalleryItem["type"], { mimeType: string; filename: string } | null> = {
+  image: { mimeType: "image/png", filename: "shot.png" },
+  video: { mimeType: "video/mp4", filename: "clip.mp4" },
+  // Link-preview iframe — no attachment bytes, so it can never come from an upload.
+  "video-embed": null,
+  pdf: { mimeType: "application/pdf", filename: "report.pdf" },
+  markdown: { mimeType: "text/markdown", filename: "notes.md" },
+  html: { mimeType: "text/html", filename: "page.html" },
+  text: { mimeType: "text/plain", filename: "log.txt" },
+}
+
+const ALL_TYPES = Object.keys(FIXTURE_BY_TYPE) as GalleryItem["type"][]
+
+describe("uploadGalleryType", () => {
+  for (const type of ALL_TYPES) {
+    const fixture = FIXTURE_BY_TYPE[type]
+    if (fixture) {
+      it(`classifies a ${type} upload`, () => {
+        expect(uploadGalleryType(fixture)).toBe(type)
+      })
+    } else {
+      it(`never produces ${type} from an upload`, () => {
+        const producible = ALL_TYPES.map((t) => FIXTURE_BY_TYPE[t])
+          .filter((f): f is NonNullable<typeof f> => f !== null)
+          .map((f) => uploadGalleryType(f))
+        expect(producible).not.toContain(type)
+      })
+    }
+  }
+
+  it("returns null for non-previewable files", () => {
+    expect(uploadGalleryType({ mimeType: "application/zip", filename: "archive.zip" })).toBeNull()
+    expect(uploadGalleryType({ mimeType: "application/octet-stream", filename: "data.bin" })).toBeNull()
+  })
+
+  it("classifies by extension when the mime is octet-stream", () => {
+    expect(uploadGalleryType({ mimeType: "application/octet-stream", filename: "clip.mov" })).toBe("video")
+    expect(uploadGalleryType({ mimeType: "application/octet-stream", filename: "report.pdf" })).toBe("pdf")
+    expect(uploadGalleryType({ mimeType: "application/octet-stream", filename: "index.ts" })).toBe("text")
+  })
+
+  it("treats a .ts file as text, not an mp2t video", () => {
+    expect(uploadGalleryType({ mimeType: "video/mp2t", filename: "module.ts" })).toBe("text")
+  })
+})
+
+describe("buildPendingGalleryItem", () => {
+  it("builds an image item that self-thumbnails, tagged with the pending sentinel", () => {
+    const item = buildPendingGalleryItem("image", "blob:x", "shot.png", "blob:x")
+    expect(item).toMatchObject({ type: "image", url: "blob:x", thumbnailUrl: "blob:x", filename: "shot.png" })
+    expect(isPendingGalleryId(item.attachmentId)).toBe(true)
+  })
+
+  it("builds a video item with an empty poster (no client-side thumbnail pre-send)", () => {
+    const item = buildPendingGalleryItem("video", "blob:v", "clip.mp4", "blob:v")
+    expect(item).toMatchObject({ type: "video", url: "blob:v", thumbnailUrl: "", filename: "clip.mp4" })
+  })
+
+  it("builds document items without a thumbnail field", () => {
+    for (const type of ["pdf", "markdown", "html", "text"] as const) {
+      const item = buildPendingGalleryItem(type, "blob:d", `f.${type}`, "blob:d")
+      expect(item).toMatchObject({ type, url: "blob:d", filename: `f.${type}` })
+      expect("thumbnailUrl" in item).toBe(false)
+    }
+  })
+})

--- a/apps/frontend/src/components/gallery/upload-preview.ts
+++ b/apps/frontend/src/components/gallery/upload-preview.ts
@@ -1,0 +1,66 @@
+import type { GalleryItem } from "@/components/image-gallery"
+import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
+import { galleryDocType } from "@/components/stream-context/stream-gallery-items"
+import { isImageAttachment, isVideoAttachment } from "@/lib/attachment-kind"
+
+/**
+ * The gallery item types an *uploaded file* can produce. Every `GalleryItem`
+ * type except `video-embed`, which is a third-party link-preview iframe with no
+ * attachment bytes — it can never originate from a file the user picks/pastes.
+ *
+ * Written as `Exclude<…>` (not a hand-listed union) so adding a new
+ * `GalleryItem["type"]` automatically widens this and forces {@link
+ * buildPendingGalleryItem}'s exhaustive switch to handle it — the composer's
+ * previewable set can't silently drift behind the gallery's.
+ */
+export type UploadGalleryType = Exclude<GalleryItem["type"], "video-embed">
+
+/**
+ * Single source of truth for "does an uploaded file preview in the composer, and
+ * as which gallery type." Reuses the canonical `is*Attachment` / `galleryDocType`
+ * classifiers that the timeline attachment list already uses, so a file previews
+ * in the composer exactly when it would render in the timeline/board gallery.
+ *
+ * Returns `null` for non-previewable files (a `.zip`, an unknown binary) — those
+ * keep a plain, non-tappable chip.
+ */
+export function uploadGalleryType(a: { mimeType: string; filename: string }): UploadGalleryType | null {
+  if (isImageAttachment(a)) return "image"
+  if (isVideoAttachment(a)) return "video"
+  return galleryDocType(a)
+}
+
+/**
+ * Build the `MediaGallery` item for a pending (pre-send) attachment. The
+ * exhaustive `switch` is the compile-time drift guard: a new `UploadGalleryType`
+ * that isn't handled here fails to type-check.
+ *
+ * `url` is the preview source — a local `blob:` object URL (live compose), a
+ * presigned server URL, or an E2E-decrypted object URL — and doubles as the
+ * image thumbnail (images self-thumbnail; video falls back to a Play glyph;
+ * documents render an icon). The `pending:` sentinel id gates the gallery's
+ * download affordance off (no server-servable bytes for a local object URL).
+ */
+export function buildPendingGalleryItem(
+  type: UploadGalleryType,
+  url: string,
+  filename: string,
+  key: string
+): GalleryItem {
+  const attachmentId = pendingGalleryId(key)
+  switch (type) {
+    case "image":
+      return { type, url, thumbnailUrl: url, filename, attachmentId }
+    case "video":
+      return { type, url, thumbnailUrl: "", filename, attachmentId }
+    case "pdf":
+    case "markdown":
+    case "html":
+    case "text":
+      return { type, url, filename, attachmentId }
+    default: {
+      const _exhaustive: never = type
+      throw new Error(`Unhandled pending gallery type: ${String(_exhaustive)}`)
+    }
+  }
+}

--- a/apps/frontend/src/components/image-gallery.tsx
+++ b/apps/frontend/src/components/image-gallery.tsx
@@ -880,7 +880,7 @@ export function MediaGallery({ isOpen, onClose, items, initialIndex, workspaceId
           {currentIndex + 1} / {items.length}
         </span>
       )}
-      {current?.type === "video" ? (
+      {current?.type === "video" && canDownload ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="icon" className="h-10 w-10 text-white hover:bg-white/20 rounded-full">

--- a/apps/frontend/src/components/timeline/pending-attachments.test.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import { PendingAttachments } from "./pending-attachments"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 
-function imageAttachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
+function attachment(overrides: Partial<PendingAttachment> = {}): PendingAttachment {
   return {
     id: "attach_img",
     filename: "screenshot.png",
@@ -18,7 +18,7 @@ function imageAttachment(overrides: Partial<PendingAttachment> = {}): PendingAtt
 describe("PendingAttachments", () => {
   it("renders an image upload as a chip with a preview thumbnail", () => {
     const { container } = render(
-      <PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />
+      <PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />
     )
 
     // Filename stays visible as chip text; the leading slot shows the thumbnail.
@@ -27,22 +27,85 @@ describe("PendingAttachments", () => {
     expect(container.querySelector('img[src="blob:preview-1"]')).toBeTruthy()
   })
 
-  it("falls back to a plain chip (no preview) for non-image files", () => {
+  it("makes a pdf upload previewable from local bytes", () => {
+    render(
+      <PendingAttachments
+        attachments={[
+          attachment({ id: "attach_pdf", filename: "report.pdf", mimeType: "application/pdf", previewUrl: "blob:pdf" }),
+        ]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+      />
+    )
+
+    expect(screen.getByText("report.pdf")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Preview report.pdf" })).toBeInTheDocument()
+  })
+
+  it("makes a text upload previewable from local bytes", () => {
+    render(
+      <PendingAttachments
+        attachments={[
+          attachment({ id: "attach_txt", filename: "notes.txt", mimeType: "text/plain", previewUrl: "blob:txt" }),
+        ]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Preview notes.txt" })).toBeInTheDocument()
+  })
+
+  it("opens the lightbox when a video chip is activated", () => {
+    render(
+      <PendingAttachments
+        attachments={[
+          attachment({ id: "attach_vid", filename: "clip.mp4", mimeType: "video/mp4", previewUrl: "blob:vid" }),
+        ]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+      />
+    )
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Preview clip.mp4" }))
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  it("keeps a plain, non-previewable chip for an unsupported file type", () => {
+    render(
+      <PendingAttachments
+        attachments={[
+          attachment({ id: "attach_zip", filename: "archive.zip", mimeType: "application/zip", previewUrl: undefined }),
+        ]}
+        onRemove={vi.fn()}
+        workspaceId="ws_1"
+      />
+    )
+
+    expect(screen.getByText("archive.zip")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Preview / })).not.toBeInTheDocument()
+  })
+
+  it("shows a non-image doc without local bytes as a plain chip (reloaded draft)", () => {
+    // No previewUrl and no decrypt ref: the server bytes sit behind a presign the
+    // static path doesn't reach, so a reloaded non-image draft attachment falls
+    // back to a type icon rather than a broken preview.
     const file: PendingAttachment = {
       id: "attach_doc",
-      filename: "notes.txt",
-      mimeType: "text/plain",
+      filename: "spec.pdf",
+      mimeType: "application/pdf",
       sizeBytes: 1024,
       status: "uploaded",
     }
     render(<PendingAttachments attachments={[file]} onRemove={vi.fn()} workspaceId="ws_1" />)
 
-    expect(screen.getByText("notes.txt")).toBeInTheDocument()
+    expect(screen.getByText("spec.pdf")).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /^Preview / })).not.toBeInTheDocument()
   })
 
   it("opens the lightbox when the image chip is activated", () => {
-    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
+    render(<PendingAttachments attachments={[attachment()]} onRemove={vi.fn()} workspaceId="ws_1" />)
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Preview screenshot.png" }))
@@ -51,7 +114,7 @@ describe("PendingAttachments", () => {
 
   it("removes an image via its remove control without opening the lightbox", () => {
     const onRemove = vi.fn()
-    render(<PendingAttachments attachments={[imageAttachment()]} onRemove={onRemove} workspaceId="ws_1" />)
+    render(<PendingAttachments attachments={[attachment()]} onRemove={onRemove} workspaceId="ws_1" />)
 
     fireEvent.click(screen.getByRole("button", { name: "Remove screenshot.png" }))
     expect(onRemove).toHaveBeenCalledWith("attach_img")
@@ -60,11 +123,7 @@ describe("PendingAttachments", () => {
 
   it("shows the preview while an image is still uploading (no remove control yet)", () => {
     render(
-      <PendingAttachments
-        attachments={[imageAttachment({ status: "uploading" })]}
-        onRemove={vi.fn()}
-        workspaceId="ws_1"
-      />
+      <PendingAttachments attachments={[attachment({ status: "uploading" })]} onRemove={vi.fn()} workspaceId="ws_1" />
     )
 
     expect(screen.getByRole("button", { name: "Preview screenshot.png" })).toBeInTheDocument()

--- a/apps/frontend/src/components/timeline/pending-attachments.tsx
+++ b/apps/frontend/src/components/timeline/pending-attachments.tsx
@@ -1,18 +1,33 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
-import { Loader2, FileText, Image as ImageIcon, File as FileIcon, AlertCircle } from "lucide-react"
+import { Loader2, FileText, Image as ImageIcon, File as FileIcon, Film, Globe, AlertCircle } from "lucide-react"
 import { AttachmentPill, type AttachmentPillStatus } from "@/components/composer/attachment-pill"
 import { MediaGallery, type GalleryItem } from "@/components/image-gallery"
 import { pendingGalleryId } from "@/components/gallery/pending-gallery-id"
+import { buildPendingGalleryItem, uploadGalleryType, type UploadGalleryType } from "@/components/gallery/upload-preview"
 import { useDecryptedAttachment } from "@/hooks/use-decrypted-attachment"
 import { getAttachmentRef, type AttachmentRef } from "@/lib/crypto/attachment-crypto"
 import { attachmentContentUrl } from "@/api"
 import type { PendingAttachment } from "@/hooks/use-attachments"
 import { formatFileSize } from "@/lib/file-size"
 
-function getFileIcon(mimeType: string): typeof FileIcon {
-  if (mimeType.startsWith("image/")) return ImageIcon
-  if (mimeType.startsWith("text/") || mimeType === "application/pdf") return FileText
-  return FileIcon
+// Leading-slot icon for a previewable type, matching the gallery's own glyphs
+// (Globe for html, FileText for docs, Film for video). Non-previewable files
+// (type null — a zip, an unknown binary) fall back to the generic file icon.
+function iconForType(type: UploadGalleryType | null): typeof FileIcon {
+  switch (type) {
+    case "image":
+      return ImageIcon
+    case "video":
+      return Film
+    case "pdf":
+    case "markdown":
+    case "text":
+      return FileText
+    case "html":
+      return Globe
+    default:
+      return FileIcon
+  }
 }
 
 const STATUS_MAP: Record<PendingAttachment["status"], AttachmentPillStatus> = {
@@ -21,24 +36,28 @@ const STATUS_MAP: Record<PendingAttachment["status"], AttachmentPillStatus> = {
   error: "error",
 }
 
-function isImageAttachment(a: PendingAttachment): boolean {
-  return a.mimeType.startsWith("image/")
-}
-
 /** Stable identity across the temp→server id flip: the object URL never changes. */
 function attachmentKey(a: PendingAttachment): string {
   return a.previewUrl ?? a.id
 }
 
-// The preview source for an image without a decrypt step: local bytes win;
-// otherwise the deterministic non-E2E content URL (thumbnail variant for the
-// chip, full for the lightbox). Returns null for non-images and for E2E images
-// (a ref is present → resolved via decrypt in E2eImageChip instead). Restore
-// fires only after a draft decrypts, so a present ref means "E2E, unlocked";
-// its absence here means non-E2E, where the content URL is a real image.
-function staticImageSrc(a: PendingAttachment, workspaceId: string | undefined): { thumb: string; full: string } | null {
-  if (a.previewUrl) return { thumb: a.previewUrl, full: a.previewUrl }
-  if (!isImageAttachment(a) || !workspaceId || getAttachmentRef(a.id)) return null
+// Preview source for a chip that needs no decrypt: local bytes win for every
+// previewable type (image/video/pdf/markdown/html/text) and double as the image
+// thumbnail; otherwise a non-E2E image resolves to its deterministic content URL
+// (thumbnail variant for the chip, full for the lightbox). Returns null for
+// non-previewable files and for anything with no local bytes but a decryptable
+// ref (routed to E2eChip). A present ref means "E2E, unlocked"; its absence here
+// means non-E2E, where the content URL is real image bytes. Non-image types with
+// no local bytes (a reloaded draft) have no static source — their server bytes
+// sit behind a presign/decrypt this path doesn't reach, so they show a type icon
+// until re-picked.
+function staticSrc(
+  a: PendingAttachment,
+  type: UploadGalleryType | null,
+  workspaceId: string | undefined
+): { thumb?: string; full: string } | null {
+  if (a.previewUrl) return { thumb: type === "image" ? a.previewUrl : undefined, full: a.previewUrl }
+  if (type !== "image" || !workspaceId || getAttachmentRef(a.id)) return null
   return {
     thumb: attachmentContentUrl(workspaceId, a.id, { variant: "thumbnail" }),
     full: attachmentContentUrl(workspaceId, a.id),
@@ -47,18 +66,29 @@ function staticImageSrc(a: PendingAttachment, workspaceId: string | undefined): 
 
 interface ChipViewProps {
   attachment: PendingAttachment
+  /** Which gallery type this file previews as (drives the icon), or null. */
+  galleryType: UploadGalleryType | null
   /** Leading-slot preview image; falls back to the type icon when absent/failed. */
   thumbnailSrc?: string
   /** Full-resolution URL for the lightbox, or null when not previewable. */
   fullSrc: string | null
-  /** True while an E2E image's bytes are still decrypting. */
+  /** True while an E2E file's bytes are still decrypting. */
   decrypting?: boolean
   onRemove: (id: string) => void
   onOpen: (key: string) => void
   onResolveSrc: (key: string, src: string | null) => void
 }
 
-function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onOpen, onResolveSrc }: ChipViewProps) {
+function ChipView({
+  attachment,
+  galleryType,
+  thumbnailSrc,
+  fullSrc,
+  decrypting,
+  onRemove,
+  onOpen,
+  onResolveSrc,
+}: ChipViewProps) {
   const key = attachmentKey(attachment)
 
   // Publish the full-res URL so the parent can build the lightbox item list.
@@ -78,7 +108,7 @@ function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onO
   if (isGenericError) tooltip = "We couldn't upload this file. Please remove it and try again."
   else if (isError) tooltip = attachment.error
 
-  let Icon = getFileIcon(attachment.mimeType)
+  let Icon = iconForType(galleryType)
   if (isUploading || decrypting) Icon = Loader2
   else if (isError) Icon = AlertCircle
 
@@ -102,7 +132,7 @@ function ChipView({ attachment, thumbnailSrc, fullSrc, decrypting, onRemove, onO
   )
 }
 
-/** Chip whose preview needs no decrypt: local object URL, non-E2E thumbnail, or icon. */
+/** Chip whose preview needs no decrypt: local object URL, non-E2E image thumbnail, or icon. */
 function StaticChip(props: {
   attachment: PendingAttachment
   workspaceId: string | undefined
@@ -110,12 +140,13 @@ function StaticChip(props: {
   onOpen: (key: string) => void
   onResolveSrc: (key: string, src: string | null) => void
 }) {
-  const src = staticImageSrc(props.attachment, props.workspaceId)
-  return <ChipView {...props} thumbnailSrc={src?.thumb} fullSrc={src?.full ?? null} />
+  const type = uploadGalleryType(props.attachment)
+  const src = staticSrc(props.attachment, type, props.workspaceId)
+  return <ChipView {...props} galleryType={type} thumbnailSrc={src?.thumb} fullSrc={src?.full ?? null} />
 }
 
-/** Chip for an E2E image: decrypts the bytes in memory (no server thumbnail exists). */
-function E2eImageChip({
+/** Chip for an E2E file: decrypts the bytes in memory (no server thumbnail exists). */
+function E2eChip({
   attachmentRef,
   ...props
 }: {
@@ -126,9 +157,18 @@ function E2eImageChip({
   onOpen: (key: string) => void
   onResolveSrc: (key: string, src: string | null) => void
 }) {
+  const type = uploadGalleryType(props.attachment)
   const decrypted = useDecryptedAttachment(props.workspaceId, attachmentRef)
   const url = decrypted.status === "ready" ? decrypted.url : null
-  return <ChipView {...props} thumbnailSrc={url ?? undefined} fullSrc={url} decrypting={decrypted.status === "pending"} />
+  return (
+    <ChipView
+      {...props}
+      galleryType={type}
+      thumbnailSrc={type === "image" ? (url ?? undefined) : undefined}
+      fullSrc={url}
+      decrypting={decrypted.status === "pending"}
+    />
+  )
 }
 
 interface PendingAttachmentsProps {
@@ -153,17 +193,19 @@ interface PendingAttachmentsProps {
 
 /**
  * Composer attachment row: every attachment renders as one uniform chip
- * (filename + size + remove ×). Image chips show a preview thumbnail in the
- * leading slot — from local bytes, the non-E2E server thumbnail, or an in-memory
- * E2E decrypt — and tap/click to open the shared lightbox; other types keep
- * their type icon. Renders nothing when both lists are empty.
+ * (filename + size + remove ×). Previewable files (image/video/pdf/markdown/
+ * html/text — decided by the same {@link uploadGalleryType} the timeline uses)
+ * tap/click to open the shared lightbox; images also show a preview thumbnail in
+ * the leading slot (from local bytes, the non-E2E server thumbnail, or an
+ * in-memory E2E decrypt). Non-previewable files keep a plain type-icon chip.
+ * Renders nothing when both lists are empty.
  */
 export function PendingAttachments({ attachments, onRemove, beforePills, workspaceId }: PendingAttachmentsProps) {
   // Open lightbox tracked by the stable attachment key, not the id (which flips
   // temp→server on upload completion), so an open preview survives its upload.
   const [openKey, setOpenKey] = useState<string | null>(null)
-  // Full-res URL per image chip, published by each chip (a chip owns the E2E
-  // decrypt / object-URL lifecycle), so the lightbox item list has every source.
+  // Preview URL per previewable chip, published by each chip (a chip owns the
+  // E2E decrypt / object-URL lifecycle), so the lightbox item list has every source.
   const [srcByKey, setSrcByKey] = useState<Map<string, string>>(new Map())
 
   const onResolveSrc = useCallback((key: string, src: string | null) => {
@@ -176,25 +218,19 @@ export function PendingAttachments({ attachments, onRemove, beforePills, workspa
     })
   }, [])
 
-  const imageAttachments = useMemo(() => attachments.filter(isImageAttachment), [attachments])
-
   const galleryItems = useMemo<GalleryItem[]>(
     () =>
-      imageAttachments
+      attachments
         .map((a): GalleryItem | null => {
+          const type = uploadGalleryType(a)
+          if (!type) return null
           const key = attachmentKey(a)
           const url = srcByKey.get(key)
           if (!url) return null
-          return {
-            type: "image",
-            url,
-            thumbnailUrl: url,
-            filename: a.filename,
-            attachmentId: pendingGalleryId(key),
-          }
+          return buildPendingGalleryItem(type, url, a.filename, key)
         })
         .filter((item): item is GalleryItem => item !== null),
-    [imageAttachments, srcByKey]
+    [attachments, srcByKey]
   )
 
   if (attachments.length === 0 && !beforePills) return null
@@ -208,12 +244,12 @@ export function PendingAttachments({ attachments, onRemove, beforePills, workspa
         {attachments.map((attachment) => {
           const key = attachmentKey(attachment)
           const ref =
-            workspaceId && !attachment.previewUrl && isImageAttachment(attachment)
+            workspaceId && !attachment.previewUrl && uploadGalleryType(attachment) != null
               ? getAttachmentRef(attachment.id)
               : undefined
           const shared = { attachment, onRemove, onOpen: setOpenKey, onResolveSrc }
           return ref && workspaceId ? (
-            <E2eImageChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />
+            <E2eChip key={key} attachmentRef={ref} workspaceId={workspaceId} {...shared} />
           ) : (
             <StaticChip key={key} workspaceId={workspaceId} {...shared} />
           )

--- a/apps/frontend/src/hooks/use-attachments.ts
+++ b/apps/frontend/src/hooks/use-attachments.ts
@@ -1,20 +1,23 @@
 import { useState, useCallback, useEffect, useRef, type ChangeEvent, type RefObject } from "react"
 import { attachmentsApi } from "@/api"
 import { encryptAttachmentBytes, rememberAttachmentRef } from "@/lib/crypto/attachment-crypto"
+import { uploadGalleryType } from "@/components/gallery/upload-preview"
 
 /** The placeholder name/mime the server forces for E2E ciphertext uploads. */
 const E2E_CIPHERTEXT_FILENAME = "encrypted"
 const E2E_CIPHERTEXT_MIME = "application/octet-stream"
 
 /**
- * Object URL for the local bytes of a picked/pasted image, so the composer can
- * preview the actual image before send. Reading from the local File means the
- * preview is available immediately (even mid-upload) and works for E2E streams
- * where the server only ever holds ciphertext. Best-effort: environments
- * without object-URL support (jsdom) get `undefined` and fall back to a pill.
+ * Object URL for the local bytes of a picked/pasted file the gallery can preview
+ * (image, video, pdf, markdown, html, text — decided by the same
+ * {@link uploadGalleryType} the timeline uses), so the composer can preview the
+ * actual file before send. Reading from the local File means the preview is
+ * available immediately (even mid-upload) and works for E2E streams where the
+ * server only ever holds ciphertext. Best-effort: environments without
+ * object-URL support (jsdom) get `undefined` and fall back to a plain chip.
  */
-function createImagePreviewUrl(file: File): string | undefined {
-  if (!file.type.startsWith("image/")) return undefined
+function createPreviewUrl(file: File): string | undefined {
+  if (!uploadGalleryType({ mimeType: file.type, filename: file.name })) return undefined
   try {
     return URL.createObjectURL(file)
   } catch {
@@ -27,7 +30,7 @@ function revokePreviewUrl(url: string | undefined): void {
   try {
     URL.revokeObjectURL(url)
   } catch {
-    // no-op — see createImagePreviewUrl
+    // no-op — see createPreviewUrl
   }
 }
 
@@ -56,9 +59,10 @@ export interface PendingAttachment {
   status: "uploading" | "uploaded" | "error"
   error?: string
   /**
-   * Local object URL for image files, for the in-composer preview
-   * (thumbnail + lightbox). Undefined for non-images and for restored drafts,
-   * which carry no local bytes. Revoked on remove/clear/unmount.
+   * Local object URL for previewable files (image/video/pdf/markdown/html/text),
+   * for the in-composer preview (thumbnail + lightbox). Undefined for
+   * non-previewable files and for restored drafts, which carry no local bytes.
+   * Revoked on remove/clear/unmount.
    */
   previewUrl?: string
 }
@@ -161,7 +165,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
 
       for (const file of files) {
         const tempId = `temp_${Date.now()}_${Math.random().toString(36).slice(2)}`
-        const previewUrl = createImagePreviewUrl(file)
+        const previewUrl = createPreviewUrl(file)
 
         updatePendingAttachments((prev) => [
           ...prev,
@@ -217,7 +221,7 @@ export function useAttachments(workspaceId: string, options?: UploadOptions): Us
         setImageCount(assignedImageIndex)
       }
 
-      const previewUrl = createImagePreviewUrl(file)
+      const previewUrl = createPreviewUrl(file)
       const pendingAttachment: PendingAttachment = {
         id: tempId,
         filename: file.name,

--- a/apps/frontend/src/lib/attachment-kind.ts
+++ b/apps/frontend/src/lib/attachment-kind.ts
@@ -8,6 +8,35 @@ interface AttachmentTypeShape {
   filename: string
 }
 
+export function isImageAttachment(a: AttachmentTypeShape): boolean {
+  return a.mimeType.startsWith("image/")
+}
+
+// Video extensions we can play from raw bytes in a <video> element. Excludes the
+// ambiguous `.ts` — browsers map it to `video/mp2t`, but in this product a `.ts`
+// upload is far more often a TypeScript source file, so we let the text viewer
+// claim it (see the mp2t guard below).
+const VIDEO_EXTENSIONS = /\.(mp4|m4v|mov|webm|mkv|avi|ogv|mpe?g|3gp|wmv|flv)$/i
+
+/**
+ * Video attachments the gallery plays in a `<video>` element. Detection is by
+ * `video/*` mime with an extension fallback for files uploaded as
+ * `application/octet-stream`. Unlike the timeline (which keys off the backend's
+ * `processingStatus`), a freshly-picked file in the composer has no server
+ * processing state yet, so classification is mime/extension-only here.
+ *
+ * `video/mp2t` is deliberately not treated as video: it's the mime browsers hand
+ * to a `.ts` file, which is almost always TypeScript source in this codebase —
+ * letting it fall through to the text viewer beats rendering a text file's bytes
+ * as a broken `<video>`.
+ */
+export function isVideoAttachment(a: AttachmentTypeShape): boolean {
+  const mime = a.mimeType.split(";")[0].trim().toLowerCase()
+  if (mime === "video/mp2t") return false
+  if (mime.startsWith("video/")) return true
+  return VIDEO_EXTENSIONS.test(a.filename)
+}
+
 export function isMarkdownAttachment(a: AttachmentTypeShape): boolean {
   if (a.mimeType.startsWith("text/markdown") || a.mimeType === "text/x-markdown") return true
   return /\.(md|mdx|markdown)$/i.test(a.filename)

--- a/apps/frontend/src/lib/attachment-kind.ts
+++ b/apps/frontend/src/lib/attachment-kind.ts
@@ -9,7 +9,7 @@ interface AttachmentTypeShape {
 }
 
 export function isImageAttachment(a: AttachmentTypeShape): boolean {
-  return a.mimeType.startsWith("image/")
+  return a.mimeType.split(";")[0].trim().toLowerCase().startsWith("image/")
 }
 
 // Video extensions we can play from raw bytes in a <video> element. Excludes the


### PR DESCRIPTION
## Problem

PR #1232 gave the composer a pre-send preview for uploaded **images** — a thumbnail chip that opens the shared `MediaGallery` lightbox. Every other file type the timeline/board gallery already renders — video, PDF, markdown, HTML, plain text — still showed an inert chip in the composer: you couldn't check what you were about to send without sending it first.

Two gaps to close:
1. **Coverage** — a `report.pdf` or `clip.mp4` in the composer should open the same preview a user gets clicking it in the timeline (`AttachmentList` → `MediaGallery`).
2. **Drift** — the composer's "what's previewable" set was hand-rolled (`isImageAttachment`) and independent of the gallery's renderable set. Adding a new gallery type later would silently leave the composer behind. The ask was explicit: *"make sure it can't drift here in the future."*

## Solution

One classifier decides "does an uploaded file preview, and as which gallery type," reusing the exact `is*Attachment` / `galleryDocType` helpers the timeline already uses — so the composer previews precisely the gallery's renderable set. Drift is closed at compile time (an exhaustive `switch` + an `Exclude`-derived type) and again by a guard test keyed on `GalleryItem["type"]`.

### How it works

- **`uploadGalleryType(a)`** (new `apps/frontend/src/components/gallery/upload-preview.ts`) → `image | video | pdf | markdown | html | text | null`. It calls `isImageAttachment` → `isVideoAttachment` → `galleryDocType(a)` — the same canonical classifiers `AttachmentList` uses. `null` means non-previewable (a `.zip`), which keeps a plain, non-tappable chip.
- **Live-compose preview from local bytes.** `createImagePreviewUrl` → `createPreviewUrl` in `use-attachments.ts` now mints a `blob:` object URL for any previewable type (was image-only), gated on `uploadGalleryType`. Because it's the local file's plaintext bytes, this covers **all types, E2E and non-E2E, with no server round-trip** — the object URL feeds `<video>`, the PDF iframe, and the text/markdown/html viewers directly. The URL is carried over in `restore()` and revoked on remove/clear/unmount exactly as before.
- **Chip rendering** (`pending-attachments.tsx`). Every previewable chip taps/clicks to open `MediaGallery` (`role="button"`, `activateLabel="Preview <file>"`); images also render the mini-thumbnail in the fixed 20px leading slot, other types show a type icon matching the gallery's own glyphs (`Film` video, `FileText` doc, `Globe` html). `E2eImageChip` → `E2eChip` now decrypts any type in-memory for E2E reload. `staticSrc` resolves local bytes → non-E2E image content URL → `null`.
- **`buildPendingGalleryItem(type, url, filename, key)`** builds the `GalleryItem` through an exhaustive `switch` and tags it with the `pending:` sentinel id so the gallery gates download off (no server-servable bytes for a local object URL; copy still works).
- **Gallery video-download gate** (`image-gallery.tsx`). The video download dropdown condition became `current?.type === "video" && canDownload`. A pending video (local object URL, `pending:` id) has `canDownload === false`, so it no longer offers a download that would call `attachmentsApi.getDownloadUrl` with a non-servable sentinel id. Real timeline videos are unaffected (`canDownload` is true for them).

### Key design decisions

**1. Three drift guards, two of them compile-time.** `UploadGalleryType = Exclude<GalleryItem["type"], "video-embed">` + the exhaustive `switch` in `buildPendingGalleryItem` means adding a new `GalleryItem["type"]` fails to type-check until the composer handles it. The guard test `upload-preview.test.ts` keys a fixture map on `Record<GalleryItem["type"], …>`, so a new type also fails the test until someone adds a fixture and a decision. `video-embed` is the one deliberate exclusion — a link-preview iframe with no attachment bytes, so it can never originate from an upload.

**2. Non-E2E reload of video/docs deferred, on purpose.** Live compose (local bytes) covers every type; E2E reload previews via the decrypt path. The one gap is a **non-image draft attachment that survived a page reload on a non-E2E stream** — it falls back to a type icon instead of previewing. Closing it means a presigned server fetch, but the static path can't distinguish an E2E-ref-absent attachment from a non-E2E one, and feeding ciphertext to the PDF/text viewers renders readable garbage (an `<img>` degrades via `onError`; `PdfViewer`/`TextViewer` don't). Threading an `e2eEnabled` flag through the shared `MessageComposer` (~6 call sites) would close it safely — deferred as a follow-up rather than shipped half-safe. This is strictly better than before, where these types had no composer preview at all.

**3. Video classified by mime/extension, not `processingStatus`.** `AttachmentList` keys video off the backend's `processingStatus`, which a freshly-picked file doesn't have yet, so `isVideoAttachment` is mime/extension-based. `video/mp2t` deliberately falls through to the text viewer — browsers hand that mime to a `.ts` file, which is almost always TypeScript source here, so rendering it as a broken `<video>` would be the wrong default.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/gallery/upload-preview.ts` | `uploadGalleryType` classifier, `UploadGalleryType`, and the exhaustive `buildPendingGalleryItem` — the composer's single source of truth for previewability |
| `apps/frontend/src/components/gallery/upload-preview.test.ts` | Drift guard: fixture map keyed on `GalleryItem["type"]` + `buildPendingGalleryItem` shape assertions |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/pending-attachments.tsx` | Generalized chips to all previewable types; `staticSrc`/`iconForType`; `E2eImageChip`→`E2eChip`; gallery items via `buildPendingGalleryItem`; removed image-only `isImageAttachment`/`staticImageSrc`/`getFileIcon` dead branch |
| `apps/frontend/src/lib/attachment-kind.ts` | New canonical `isImageAttachment` / `isVideoAttachment` (with the `video/mp2t`→text guard) |
| `apps/frontend/src/hooks/use-attachments.ts` | `createImagePreviewUrl`→`createPreviewUrl` widened to all previewable types via `uploadGalleryType`; docstrings |
| `apps/frontend/src/components/image-gallery.tsx` | Video-download dropdown gated behind `canDownload` (suppresses it for pending videos) |
| `apps/frontend/src/components/timeline/pending-attachments.test.tsx` | Added pdf/video/text preview cases + non-previewable + reloaded-doc fallback |

## Out of scope (deliberate)

- **Non-E2E reload preview for video/docs** — deferred (see design decision 2). Falls back to a type-icon chip.
- **New browser E2E specs** — the executed unit tests cover the observable behavior; I didn't add Playwright specs I can't run in this session (CLAUDE.md: never ship unexecuted tests). Existing E2E specs are unaffected — their sent-message pill selectors (`"<filename>"`, exact) stay distinct from composer chips (`"Preview <filename>"`).

## Test plan

- [x] `bunx vitest run` — changed-behavior + regression suites (`upload-preview`, `pending-attachments`, `attachment-kind`, `use-attachments`, `attachment-list` (+ data-router), `use-draft-composer`, `message-composer`, `scheduled/*`, gallery dir, `attachment-context`): **136 pass across 10 files**
- [x] New coverage: `pending-attachments.test.tsx` gains pdf/video/text preview + non-previewable + reloaded-doc fallback cases (9 total); `upload-preview.test.ts` is the drift guard
- [x] `bun run typecheck` (frontend `tsc --noEmit`) clean
- [x] `bunx eslint` on all changed files clean
- [x] Pre-PR review (4 Sonnet agents — spec+design, correctness+data-flow, UX, mobile): no findings ≥80. One sub-threshold UX note (75) — reload parity for non-image drafts — is the deliberate deferral in design decision 2, and a live tappable chip already carries `cursor-pointer`/hover/focus affordances a non-tappable one lacks.
- [ ] No live app/browser drive in this session — behavior verified via the executed unit/integration tests, not a manual end-to-end run

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn7PRJRsnJd3MaSA3peZi8)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786051566&installation_id=129946197&pr_number=1238&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1238&signature=eaf79976aac0d2af636adfbde35293de7d6c237afd7050190236625d48c222ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->