### PR TITLE
fix(board): steady the N-more expand + float the "N new" pill

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
+import type { RefObject } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
+import type { VirtualizerHandle } from "virtua"
 import {
   Hash,
   FileEdit,
@@ -41,6 +43,7 @@ import { useBoardCardCollapse } from "@/hooks/use-board-card-collapse"
 import { conversationKeys, useSplitThread } from "@/hooks/use-conversations"
 import { useBoardCardMessages, useStableReplyWindow } from "@/hooks/use-board-card-messages"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
+import { useBoardCardRevealAnchor } from "@/hooks/use-board-card-reveal-anchor"
 import type { BoardViewPost } from "@/hooks/use-stable-board-view"
 
 interface BoardCardProps {
@@ -50,6 +53,12 @@ interface BoardCardProps {
   contextLabel: string
   /** Resolved stream type, selecting the context glyph. */
   streamType: string | undefined
+  /** The board's owned scroll viewport — lets a middle-gap expand hold the newest
+   *  replies still instead of shoving them down (`useBoardCardRevealAnchor`).
+   *  Absent when the card renders outside the virtualized board (tests). */
+  scrollerRef?: RefObject<HTMLDivElement | null>
+  /** virtua's imperative handle for the board feed, paired with `scrollerRef`. */
+  listRef?: RefObject<VirtualizerHandle | null>
 }
 
 const TYPE_GLYPH: Record<string, LucideIcon> = {
@@ -70,7 +79,7 @@ const BRANCH_PREVIEW_CAP = 2
  * conversation (no reply indentation); a collapsed "N more messages" gap fills
  * in on click. The stream it lives in is the header locator, not a topic line.
  */
-export function BoardCard({ workspaceId, post, contextLabel, streamType }: BoardCardProps) {
+export function BoardCard({ workspaceId, post, contextLabel, streamType, scrollerRef, listRef }: BoardCardProps) {
   const { conversation } = post
   const { getActorName } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
@@ -86,6 +95,10 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
   // Scopes text-selection quoting to this card so a selection routes into this
   // card's composer, not a sibling card's provider.
   const cardRef = useRef<HTMLDivElement>(null)
+  // Revealing the hidden middle ("N more messages") grows this card from OLDER
+  // content above the trailing replies; hold the card bottom fixed so the newest
+  // replies the reader is on don't jump (the board's `shift`, see the hook).
+  const beginReveal = useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef })
 
   // Shared graph + structural index, needed BEFORE the rail hook: the inline
   // branch composer derives the branch thread streams (and any pending
@@ -601,7 +614,10 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType }: Board
                     {!expanded && hiddenCount > 0 && (
                       <button
                         type="button"
-                        onClick={() => setExpanded(true)}
+                        onClick={() => {
+                          beginReveal()
+                          setExpanded(true)
+                        }}
                         className="mt-3 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
                       >
                         <ChevronDown className="h-3.5 w-3.5" />

--- a/apps/frontend/src/components/board/board-feed-list.tsx
+++ b/apps/frontend/src/components/board/board-feed-list.tsx
@@ -1,4 +1,4 @@
-import { Virtualizer } from "virtua"
+import { Virtualizer, type VirtualizerHandle } from "virtua"
 import type { ReactNode, RefObject } from "react"
 
 /**
@@ -16,6 +16,9 @@ import type { ReactNode, RefObject } from "react"
 export interface BoardFeedListProps {
   /** The scroller the board owns; virtua reads native scroll metrics off it. */
   scrollRef: RefObject<HTMLDivElement | null>
+  /** virtua's imperative handle, so a card can hold its scroll position across a
+   *  middle-gap expand via `scrollBy` (`useBoardCardRevealAnchor`). */
+  listRef?: RefObject<VirtualizerHandle | null>
   /** Height (px) of the composer sitting above the rows in the same scroller, so
    *  virtua's item offsets stay aligned. */
   startMargin: number
@@ -27,9 +30,9 @@ export interface BoardFeedListProps {
 // stays modest — raise only after profiling on a low-end device.
 const BUFFER_SIZE_PX = 800
 
-export function BoardFeedList({ scrollRef, startMargin, children }: BoardFeedListProps) {
+export function BoardFeedList({ scrollRef, listRef, startMargin, children }: BoardFeedListProps) {
   return (
-    <Virtualizer scrollRef={scrollRef} startMargin={startMargin} bufferSize={BUFFER_SIZE_PX}>
+    <Virtualizer ref={listRef} scrollRef={scrollRef} startMargin={startMargin} bufferSize={BUFFER_SIZE_PX}>
       {children}
     </Virtualizer>
   )

--- a/apps/frontend/src/components/board/board-new-posts-pill.tsx
+++ b/apps/frontend/src/components/board/board-new-posts-pill.tsx
@@ -1,0 +1,62 @@
+import { useRef } from "react"
+import { ArrowUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface BoardNewPostsPillProps {
+  /** Number of buffered new posts. */
+  count: number
+  /** Scroll to the top and commit the buffered order. */
+  onReveal: () => void
+  /**
+   * The board's owned scroll viewport. The pill is an overlay SIBLING of the
+   * scroller (not a descendant, or it would scroll away), so a wheel/touch landing
+   * on its `pointer-events-auto` button would otherwise be trapped and not scroll
+   * the feed. Forward it — same guard the stream date pill makes.
+   */
+  scrollerRef: React.RefObject<HTMLElement | null>
+}
+
+/**
+ * Floating "N new" pill, templated on the stream date pill (`StreamDateHeader`):
+ * a muted rounded chip floating over the TOP of the feed (`absolute`, pointer
+ * events only on the control) so buffered new posts never shove the composer/feed
+ * down — the old in-flow banner grew the column and nudged everything below it.
+ * A touch more prominent than a date label (primary accent) since it is an
+ * action, not a passive marker; clicking scrolls to the top and commits the
+ * buffered order. Never shifts feed layout (INV-21).
+ */
+export function BoardNewPostsPill({ count, onReveal, scrollerRef }: BoardNewPostsPillProps) {
+  // Touch-drag start Y so a touch scroll begun on the pill still scrolls the feed
+  // (the touch equivalent of onWheel); a tap doesn't move, so it never scrolls.
+  const touchStartY = useRef<number | null>(null)
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2">
+      <button
+        type="button"
+        onClick={onReveal}
+        aria-label={`Show ${count} new ${count === 1 ? "post" : "posts"}`}
+        onWheel={(e) => scrollerRef.current?.scrollBy({ top: e.deltaY })}
+        onTouchStart={(e) => {
+          touchStartY.current = e.touches[0]?.clientY ?? null
+        }}
+        onTouchMove={(e) => {
+          if (touchStartY.current == null) return
+          const y = e.touches[0]?.clientY ?? touchStartY.current
+          scrollerRef.current?.scrollBy({ top: touchStartY.current - y })
+          touchStartY.current = y
+        }}
+        onTouchEnd={() => {
+          touchStartY.current = null
+        }}
+        className={cn(
+          "pointer-events-auto inline-flex items-center gap-1 rounded-full border px-3 py-1.5",
+          "bg-background/95 text-xs font-medium text-primary shadow-sm backdrop-blur",
+          "transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        )}
+      >
+        <ArrowUp className="-ml-0.5 h-3 w-3" aria-hidden />
+        {count} new
+      </button>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/board/board-new-posts-pill.tsx
+++ b/apps/frontend/src/components/board/board-new-posts-pill.tsx
@@ -1,6 +1,6 @@
-import { useRef } from "react"
 import { ArrowUp } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { useForwardScroll } from "@/hooks/use-forward-scroll"
 
 interface BoardNewPostsPillProps {
   /** Number of buffered new posts. */
@@ -11,7 +11,7 @@ interface BoardNewPostsPillProps {
    * The board's owned scroll viewport. The pill is an overlay SIBLING of the
    * scroller (not a descendant, or it would scroll away), so a wheel/touch landing
    * on its `pointer-events-auto` button would otherwise be trapped and not scroll
-   * the feed. Forward it — same guard the stream date pill makes.
+   * the feed — `useForwardScroll` forwards it, same as the stream date pill.
    */
   scrollerRef: React.RefObject<HTMLElement | null>
 }
@@ -21,33 +21,19 @@ interface BoardNewPostsPillProps {
  * a muted rounded chip floating over the TOP of the feed (`absolute`, pointer
  * events only on the control) so buffered new posts never shove the composer/feed
  * down — the old in-flow banner grew the column and nudged everything below it.
- * A touch more prominent than a date label (primary accent) since it is an
- * action, not a passive marker; clicking scrolls to the top and commits the
- * buffered order. Never shifts feed layout (INV-21).
+ * A touch more prominent than a passive date label (primary accent) since it is
+ * an action, not a marker; clicking scrolls to the top and commits the buffered
+ * order. Never shifts feed layout (INV-21).
  */
 export function BoardNewPostsPill({ count, onReveal, scrollerRef }: BoardNewPostsPillProps) {
-  // Touch-drag start Y so a touch scroll begun on the pill still scrolls the feed
-  // (the touch equivalent of onWheel); a tap doesn't move, so it never scrolls.
-  const touchStartY = useRef<number | null>(null)
+  const forwardScroll = useForwardScroll(scrollerRef)
   return (
     <div className="pointer-events-none absolute left-1/2 top-2 z-20 -translate-x-1/2">
       <button
         type="button"
         onClick={onReveal}
         aria-label={`Show ${count} new ${count === 1 ? "post" : "posts"}`}
-        onWheel={(e) => scrollerRef.current?.scrollBy({ top: e.deltaY })}
-        onTouchStart={(e) => {
-          touchStartY.current = e.touches[0]?.clientY ?? null
-        }}
-        onTouchMove={(e) => {
-          if (touchStartY.current == null) return
-          const y = e.touches[0]?.clientY ?? touchStartY.current
-          scrollerRef.current?.scrollBy({ top: touchStartY.current - y })
-          touchStartY.current = y
-        }}
-        onTouchEnd={() => {
-          touchStartY.current = null
-        }}
+        {...forwardScroll}
         className={cn(
           "pointer-events-auto inline-flex items-center gap-1 rounded-full border px-3 py-1.5",
           "bg-background/95 text-xs font-medium text-primary shadow-sm backdrop-blur",

--- a/apps/frontend/src/components/timeline/stream-date-header.tsx
+++ b/apps/frontend/src/components/timeline/stream-date-header.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react"
+import { useState } from "react"
 import { CalendarDays, ChevronDown, ChevronLeft } from "lucide-react"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
 import { formatDayDivider, getPastDatePresets } from "@/lib/dates"
+import { useForwardScroll } from "@/hooks/use-forward-scroll"
 import { cn } from "@/lib/utils"
 
 interface StreamDateHeaderProps {
@@ -30,11 +31,9 @@ interface StreamDateHeaderProps {
 export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRef }: StreamDateHeaderProps) {
   const [open, setOpen] = useState(false)
   const [showCalendar, setShowCalendar] = useState(false)
-  // Touch-drag start Y for forwarding a touch scroll begun on the pill to the
-  // scroller (the touch equivalent of onWheel — a touch starting on the
-  // pointer-events-auto button would otherwise be trapped and not scroll the
-  // timeline on mobile). A tap doesn't move, so it never scrolls.
-  const touchStartY = useRef<number | null>(null)
+  // Forward a wheel/touch scroll begun on the pill to the timeline scroller —
+  // gated off while the jump popover is open so it scrolls its own list.
+  const forwardScroll = useForwardScroll(scrollerRef, !open)
 
   if (dayStartMs == null) return null
   const label = formatDayDivider(new Date(dayStartMs))
@@ -66,24 +65,10 @@ export function StreamDateHeader({ dayStartMs, visible, onJumpToDate, scrollerRe
             // Drop out of the tab order while faded out — otherwise keyboard
             // focus lands on an invisible control with a focus ring.
             tabIndex={visible ? undefined : -1}
-            // Forward wheel to the scroller (see scrollerRef doc): without this,
-            // wheeling over the pill leaves the timeline stuck. Skipped while the
-            // jump menu is open so the popover handles its own scroll.
-            onWheel={(e) => {
-              if (!open) scrollerRef?.current?.scrollBy({ top: e.deltaY })
-            }}
-            onTouchStart={(e) => {
-              touchStartY.current = open ? null : (e.touches[0]?.clientY ?? null)
-            }}
-            onTouchMove={(e) => {
-              if (touchStartY.current == null) return
-              const y = e.touches[0]?.clientY ?? touchStartY.current
-              scrollerRef?.current?.scrollBy({ top: touchStartY.current - y })
-              touchStartY.current = y
-            }}
-            onTouchEnd={() => {
-              touchStartY.current = null
-            }}
+            // Forward wheel/touch to the scroller (see scrollerRef doc): without
+            // this, a gesture over the pill leaves the timeline stuck. Gated off
+            // while the jump menu is open so the popover handles its own scroll.
+            {...forwardScroll}
             className={cn(
               // A faded-out pill must not capture clicks or wheel — drop pointer
               // events so they reach the scroller beneath it.

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -76,4 +76,26 @@ describe("useBoardCardRevealAnchor", () => {
     roCallback?.()
     expect(scrollBy).not.toHaveBeenCalled()
   })
+
+  it("keeps holding when a keystroke bubbles from the in-scroller composer", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    const editor = document.createElement("textarea")
+    scroller.appendChild(editor)
+    beginReveal()
+    // A key typed into the composer bubbles to the scroller's keydown listener;
+    // it must NOT disarm the hold, or the backfill correction is dropped.
+    editor.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).toHaveBeenCalledWith(332)
+  })
+
+  it("stops holding on a keydown that is not typing (keyboard scroll)", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal()
+    scroller.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true }))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { VirtualizerHandle } from "virtua"
+import { useBoardCardRevealAnchor } from "./use-board-card-reveal-anchor"
+
+// The hook reacts to card resizes via a ResizeObserver and defers its correction a
+// frame; drive both deterministically. jsdom has no layout, so element rects are
+// stubbed to model the card growing when its middle fills.
+let roCallback: (() => void) | null = null
+class FakeResizeObserver {
+  constructor(cb: () => void) {
+    roCallback = cb
+  }
+  observe() {}
+  disconnect() {}
+}
+
+function setRect(el: HTMLElement, top: number, bottom: number) {
+  el.getBoundingClientRect = () =>
+    ({ top, bottom, left: 0, right: 0, width: 0, height: bottom - top, x: 0, y: top, toJSON: () => ({}) }) as DOMRect
+}
+
+function setup() {
+  const card = document.createElement("div")
+  const scroller = document.createElement("div")
+  setRect(scroller, 0, 720)
+  setRect(card, 100, 300) // card bottom sits at viewport-Y 300 (scroller top is 0)
+  const scrollBy = vi.fn()
+  const listRef = { current: { scrollBy } as unknown as VirtualizerHandle }
+  const { result } = renderHook(() =>
+    useBoardCardRevealAnchor({ cardRef: { current: card }, scrollerRef: { current: scroller }, listRef })
+  )
+  return { card, scroller, scrollBy, beginReveal: result.current }
+}
+
+describe("useBoardCardRevealAnchor", () => {
+  let originalRO: typeof ResizeObserver | undefined
+  beforeEach(() => {
+    vi.useFakeTimers()
+    roCallback = null
+    originalRO = globalThis.ResizeObserver
+    globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+  })
+  afterEach(() => {
+    globalThis.ResizeObserver = originalRO as typeof ResizeObserver
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("holds the card bottom fixed when the middle fills above the trailing replies", () => {
+    const { card, scrollBy, beginReveal } = setup()
+    beginReveal() // captures the anchor at the card bottom (300)
+    setRect(card, 100, 632) // 332px of older middle inserted above the trailing
+    roCallback?.()
+    // Correct by exactly how far the bottom moved, through virtua's own scrollBy, so
+    // the newest replies stay at the same viewport-Y.
+    expect(scrollBy).toHaveBeenCalledWith(332)
+  })
+
+  it("leaves scroll alone when no reveal is armed, so a live append still pushes normally", () => {
+    const { card, scrollBy } = setup()
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("stops holding once the reader scrolls, rather than fighting the gesture", () => {
+    const { card, scroller, scrollBy, beginReveal } = setup()
+    beginReveal()
+    scroller.dispatchEvent(new Event("wheel"))
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts
@@ -98,4 +98,25 @@ describe("useBoardCardRevealAnchor", () => {
     roCallback?.()
     expect(scrollBy).not.toHaveBeenCalled()
   })
+
+  it("closes the window after the post-resize settle gap", () => {
+    const { card, scrollBy, beginReveal } = setup()
+    beginReveal()
+    setRect(card, 100, 632)
+    roCallback?.() // corrects (arms the settle timer)
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(400) // REVEAL_SETTLE_MS elapses → close
+    setRect(card, 100, 700)
+    roCallback?.() // disarmed → no further correction
+    expect(scrollBy).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes the window at the hard cap even if no resize ever settles it", () => {
+    const { card, scrollBy, beginReveal } = setup()
+    beginReveal()
+    vi.advanceTimersByTime(2500) // REVEAL_MAX_MS elapses → close
+    setRect(card, 100, 632)
+    roCallback?.()
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef } from "react"
+import type { RefObject } from "react"
+import type { VirtualizerHandle } from "virtua"
+
+/** No-resize quiet gap after which the reveal window closes on its own. Long
+ *  enough to span the sync expand and its async server backfill; short enough that
+ *  a live reply landing after it pushes the view normally again. */
+const REVEAL_SETTLE_MS = 400
+/** Hard cap so a stalled backfill can't leave the window armed forever. */
+const REVEAL_MAX_MS = 2500
+
+interface Options {
+  cardRef: RefObject<HTMLDivElement | null>
+  /** The board's owned scroll viewport. Absent off the board page (tests, jsdom). */
+  scrollerRef?: RefObject<HTMLDivElement | null>
+  /** virtua's imperative handle for the board feed. Absent off the board page. */
+  listRef?: RefObject<VirtualizerHandle | null>
+}
+
+/**
+ * Holds a board card's bottom edge at a fixed viewport position while OLDER
+ * content fills in above it — the "N more messages" middle-gap expand and its
+ * async server backfill. Without this the fill shoves the trailing (newest)
+ * replies the reader is looking at down the page: a card is a single virtua item,
+ * and virtua anchors per-ITEM, so it cannot hold a position INSIDE one growing
+ * item; the board scroller also runs `overflow-anchor: none`, so the browser won't
+ * compensate either. The timeline gets this for free — each message is its own
+ * item, so an older page is a list-level prepend its `shift` maintains from the
+ * end. The board analog: measure how far the card bottom moved on each resize
+ * during the reveal and undo it through virtua's own `scrollBy`, so the newest
+ * replies stay put and the older middle appears above them (INV-61, the board's
+ * "don't move shit on me").
+ *
+ * Scoped to a reveal WINDOW opened by the returned `beginReveal()` — a live reply
+ * appended BELOW the trailing must still push the view, so compensation runs only
+ * from the expand gesture until growth settles, and a user scroll closes it at
+ * once rather than fighting a deliberate gesture. `scrollBy` goes through virtua's
+ * own machinery (a raw `scrollTop` write is re-asserted away by virtua's per-item
+ * resize handling — the library tug-of-war the owned-scroller design avoids).
+ */
+export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Options): () => void {
+  // Target viewport-Y of the card's bottom edge while the window is armed; null
+  // when disarmed (the RO correction and gesture-close both key off this).
+  const anchorRef = useRef<number | null>(null)
+  const settleTimerRef = useRef(0)
+  const maxTimerRef = useRef(0)
+  const detachGestureRef = useRef<(() => void) | null>(null)
+
+  const measure = useCallback(() => {
+    const card = cardRef.current
+    const scroller = scrollerRef?.current
+    if (!card || !scroller) return null
+    return card.getBoundingClientRect().bottom - scroller.getBoundingClientRect().top
+  }, [cardRef, scrollerRef])
+
+  const close = useCallback(() => {
+    anchorRef.current = null
+    if (settleTimerRef.current) {
+      clearTimeout(settleTimerRef.current)
+      settleTimerRef.current = 0
+    }
+    if (maxTimerRef.current) {
+      clearTimeout(maxTimerRef.current)
+      maxTimerRef.current = 0
+    }
+    detachGestureRef.current?.()
+    detachGestureRef.current = null
+  }, [])
+
+  const beginReveal = useCallback(() => {
+    const scroller = scrollerRef?.current
+    if (!scroller || !listRef?.current) return
+    const anchor = measure()
+    if (anchor === null) return
+    anchorRef.current = anchor
+    if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
+    maxTimerRef.current = window.setTimeout(close, REVEAL_MAX_MS)
+    // A deliberate scroll means the reader took over — stop holding immediately.
+    detachGestureRef.current?.()
+    const onGesture = () => close()
+    scroller.addEventListener("wheel", onGesture, { passive: true })
+    scroller.addEventListener("touchmove", onGesture, { passive: true })
+    scroller.addEventListener("keydown", onGesture)
+    detachGestureRef.current = () => {
+      scroller.removeEventListener("wheel", onGesture)
+      scroller.removeEventListener("touchmove", onGesture)
+      scroller.removeEventListener("keydown", onGesture)
+    }
+  }, [measure, scrollerRef, listRef, close])
+
+  // Correct on every card resize while armed, re-arming the settle timer so the
+  // window spans the expand + its backfill, then closes once growth stops.
+  useEffect(() => {
+    const card = cardRef.current
+    if (!card || typeof ResizeObserver === "undefined") return
+    let raf = 0
+    const observer = new ResizeObserver(() => {
+      if (anchorRef.current === null) return
+      cancelAnimationFrame(raf)
+      // Correct after virtua's own resize re-measure lands (next frame) so the two
+      // adjustments don't stack into a double shift.
+      raf = requestAnimationFrame(() => {
+        const target = anchorRef.current
+        if (target === null) return
+        const after = measure()
+        if (after === null) return
+        const delta = after - target
+        if (Math.abs(delta) > 0.5) listRef?.current?.scrollBy(delta)
+      })
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current)
+      settleTimerRef.current = window.setTimeout(close, REVEAL_SETTLE_MS)
+    })
+    observer.observe(card)
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(raf)
+    }
+  }, [cardRef, measure, listRef, close])
+
+  useEffect(() => () => close(), [close])
+
+  return beginReveal
+}

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -9,6 +9,16 @@ const REVEAL_SETTLE_MS = 400
 /** Hard cap so a stalled backfill can't leave the window armed forever. */
 const REVEAL_MAX_MS = 2500
 
+/** A keydown counts as "the reader scrolled" only when it can move the scroller —
+ *  not when it's typing. The board composer renders inside the SAME scroller, so
+ *  its keystrokes bubble to the keydown listener; without this gate a space typed
+ *  into the composer mid-backfill would close the window and drop the correction. */
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null
+  if (!el) return false
+  return el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT"
+}
+
 interface Options {
   cardRef: RefObject<HTMLDivElement | null>
   /** The board's owned scroll viewport. Absent off the board page (tests, jsdom). */
@@ -76,15 +86,20 @@ export function useBoardCardRevealAnchor({ cardRef, scrollerRef, listRef }: Opti
     if (maxTimerRef.current) clearTimeout(maxTimerRef.current)
     maxTimerRef.current = window.setTimeout(close, REVEAL_MAX_MS)
     // A deliberate scroll means the reader took over — stop holding immediately.
+    // keydown is gated to non-editable targets so typing in the in-scroller
+    // composer (whose keystrokes bubble here) doesn't disarm the hold.
     detachGestureRef.current?.()
     const onGesture = () => close()
+    const onKeyGesture = (e: KeyboardEvent) => {
+      if (!isEditableTarget(e.target)) close()
+    }
     scroller.addEventListener("wheel", onGesture, { passive: true })
     scroller.addEventListener("touchmove", onGesture, { passive: true })
-    scroller.addEventListener("keydown", onGesture)
+    scroller.addEventListener("keydown", onKeyGesture)
     detachGestureRef.current = () => {
       scroller.removeEventListener("wheel", onGesture)
       scroller.removeEventListener("touchmove", onGesture)
-      scroller.removeEventListener("keydown", onGesture)
+      scroller.removeEventListener("keydown", onKeyGesture)
     }
   }, [measure, scrollerRef, listRef, close])
 

--- a/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
+++ b/apps/frontend/src/hooks/use-board-card-reveal-anchor.ts
@@ -14,9 +14,13 @@ const REVEAL_MAX_MS = 2500
  *  its keystrokes bubble to the keydown listener; without this gate a space typed
  *  into the composer mid-backfill would close the window and drop the correction. */
 function isEditableTarget(target: EventTarget | null): boolean {
-  const el = target as HTMLElement | null
-  if (!el) return false
-  return el.isContentEditable || el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.tagName === "SELECT"
+  if (!(target instanceof HTMLElement)) return false
+  return (
+    target.isContentEditable ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  )
 }
 
 interface Options {

--- a/apps/frontend/src/hooks/use-forward-scroll.test.ts
+++ b/apps/frontend/src/hooks/use-forward-scroll.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { TouchEvent, WheelEvent } from "react"
+import { useForwardScroll } from "./use-forward-scroll"
+
+function setup(enabled = true) {
+  const scrollBy = vi.fn()
+  const scrollerRef = { current: { scrollBy } as unknown as HTMLElement }
+  const { result } = renderHook(() => useForwardScroll(scrollerRef, enabled))
+  return { scrollBy, handlers: result.current }
+}
+
+const wheel = (deltaY: number) => ({ deltaY }) as unknown as WheelEvent
+const touch = (clientY: number) => ({ touches: [{ clientY }] }) as unknown as TouchEvent
+
+describe("useForwardScroll", () => {
+  it("forwards a wheel delta to the scroller when enabled", () => {
+    const { scrollBy, handlers } = setup()
+    handlers.onWheel(wheel(40))
+    expect(scrollBy).toHaveBeenCalledWith({ top: 40 })
+  })
+
+  it("does not forward a wheel when disabled", () => {
+    const { scrollBy, handlers } = setup(false)
+    handlers.onWheel(wheel(40))
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("forwards a touch drag as scroll delta and resets on end", () => {
+    const { scrollBy, handlers } = setup()
+    handlers.onTouchStart(touch(100))
+    handlers.onTouchMove(touch(70)) // finger up 30 → scroll down 30
+    expect(scrollBy).toHaveBeenLastCalledWith({ top: 30 })
+    handlers.onTouchMove(touch(55)) // up another 15
+    expect(scrollBy).toHaveBeenLastCalledWith({ top: 15 })
+    handlers.onTouchEnd()
+    scrollBy.mockClear()
+    handlers.onTouchMove(touch(10)) // no active drag → no-op
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it("ignores a touch drag when disabled", () => {
+    const { scrollBy, handlers } = setup(false)
+    handlers.onTouchStart(touch(100))
+    handlers.onTouchMove(touch(70))
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/frontend/src/hooks/use-forward-scroll.ts
+++ b/apps/frontend/src/hooks/use-forward-scroll.ts
@@ -1,0 +1,36 @@
+import { useRef, type RefObject, type TouchEvent, type WheelEvent } from "react"
+
+/**
+ * Wheel/touch handlers that forward a scroll gesture landing on an overlay
+ * control to a scroller it floats over. A pill positioned `absolute` as a sibling
+ * of the scroller (the stream date pill, the board "N new" pill) is not a
+ * descendant of it, so a wheel/touch caught by the pill's `pointer-events-auto`
+ * button would otherwise be trapped and never scroll the content beneath. Spread
+ * the returned handlers onto the control.
+ *
+ * `enabled` gates forwarding off while the control owns the gesture itself (e.g.
+ * the date pill's jump popover is open and scrolls its own list).
+ */
+export function useForwardScroll(scrollerRef: RefObject<HTMLElement | null> | undefined, enabled = true) {
+  // Touch-drag start Y so a touch scroll begun on the control still scrolls the
+  // scroller (the touch equivalent of onWheel); a tap doesn't move, so it never
+  // scrolls.
+  const touchStartY = useRef<number | null>(null)
+  return {
+    onWheel: (e: WheelEvent) => {
+      if (enabled) scrollerRef?.current?.scrollBy({ top: e.deltaY })
+    },
+    onTouchStart: (e: TouchEvent) => {
+      touchStartY.current = enabled ? (e.touches[0]?.clientY ?? null) : null
+    },
+    onTouchMove: (e: TouchEvent) => {
+      if (touchStartY.current == null) return
+      const y = e.touches[0]?.clientY ?? touchStartY.current
+      scrollerRef?.current?.scrollBy({ top: touchStartY.current - y })
+      touchStartY.current = y
+    },
+    onTouchEnd: () => {
+      touchStartY.current = null
+    },
+  }
+}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import type { VirtualizerHandle } from "virtua"
-import { AlertCircle, ArrowLeft, ArrowUp, LayoutGrid } from "lucide-react"
+import { AlertCircle, ArrowLeft, LayoutGrid } from "lucide-react"
 import { Link, Navigate, useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -34,6 +34,7 @@ import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
 import { SKELETON_DELAY_MS } from "@/contexts/coordinated-loading-context"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardFeedList } from "@/components/board/board-feed-list"
+import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
 import {
@@ -651,26 +652,12 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       <span className="sr-only" role="status" aria-live="polite">
         {newCount > 0 ? `${newCount} new ${newCount === 1 ? "post" : "posts"} available` : ""}
       </span>
-      {/* The "N new" pill: a non-scrolling row ABOVE the scroller, not an overlay
-          inside it — so it never overlaps the composer and never clips (an overlay
-          anchored to the composer's height slides off-screen once the composer
-          expands to mobile full-screen). Trade-off: appearing (newCount 0→1)
-          shrinks the scroller, nudging the composer + feed down once until it's
-          dismissed. Clicking scrolls to the top and commits the buffered order. */}
-      {newCount > 0 && (
-        <div className="flex shrink-0 justify-center px-2 pb-1 pt-2">
-          <Button
-            size="sm"
-            onClick={revealNew}
-            aria-label={`Show ${newCount} new ${newCount === 1 ? "post" : "posts"}`}
-            className="min-h-11 gap-1.5 rounded-full px-4 shadow-md"
-          >
-            <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
-            {newCount} new
-          </Button>
-        </div>
-      )}
-      <div className="flex-1 overflow-hidden">
+      {/* The "N new" pill floats over the top of the feed (see BoardNewPostsPill),
+          so buffered posts never shove the composer/feed down the way the old
+          in-flow banner did. Anchored to the viewport top (fixed `top-2`), not the
+          composer's height, so a mobile-expanded composer can't clip it. */}
+      <div className="relative flex-1 overflow-hidden">
+        {newCount > 0 && <BoardNewPostsPill count={newCount} onReveal={revealNew} scrollerRef={scrollerRef} />}
         {/* Owned scroller (a plain overflow div, like the timeline): virtua drives
             it via `scrollRef`, so scroll decisions read native metrics with no
             library tug-of-war. `overflowAnchor: none` keeps the browser's own

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import type { VirtualizerHandle } from "virtua"
 import { AlertCircle, ArrowLeft, ArrowUp, LayoutGrid } from "lucide-react"
 import { Link, Navigate, useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -396,6 +397,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   // virtua then maintains scroll position across item measurement and above-fold
   // reflow, which is what the hand-rolled `useBoardScrollAnchor` used to do.
   const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const listRef = useRef<VirtualizerHandle | null>(null)
   const registerScroller = useCallback((node: HTMLDivElement | null) => {
     scrollerRef.current = node
   }, [])
@@ -545,7 +547,14 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
         const { contextLabel, streamType } = labelsFor(row.post.conversation)
         return (
           <div key={row.key} className="pb-3">
-            <BoardCard workspaceId={workspaceId} post={row.post} contextLabel={contextLabel} streamType={streamType} />
+            <BoardCard
+              workspaceId={workspaceId}
+              post={row.post}
+              contextLabel={contextLabel}
+              streamType={streamType}
+              scrollerRef={scrollerRef}
+              listRef={listRef}
+            />
           </div>
         )
       }),
@@ -682,7 +691,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
               <BoardComposer workspaceId={workspaceId} onPosted={handlePosted} />
             </div>
             {showFeed ? (
-              <BoardFeedList scrollRef={scrollerRef} startMargin={startMargin}>
+              <BoardFeedList scrollRef={scrollerRef} listRef={listRef} startMargin={startMargin}>
                 {renderedRows}
               </BoardFeedList>
             ) : (


### PR DESCRIPTION
## Problem

Two board scroll-stability annoyances that survived the `virtua` virtualization (#1234), both "content the reader is looking at moves under them":

1. **Per-card "N more messages" reads as a prepend.** A board card is a mini-timeline (oldest reply at the card top, newest at the bottom) with the middle collapsed behind an "N more messages" link. Tapping it fills the middle with older replies — and shoves the *newest* replies (what an activity-sorted card foregrounds) down the page. The card is a **single `virtua` item**, and `virtua` anchors per-item, so it cannot hold a position *inside* one growing item; the board scroller also runs `overflow-anchor: none`, so the browser won't compensate either. The timeline gets this for free — each message is its own item, so an older page is a list-level prepend its `shift` prop maintains from the end.

2. **The "N new" pill was a call-to-action banner that shoved the whole feed down.** It sat in-flow between the filter bar and the scroller as a full-width gold button, so `newCount` 0→1 grew the column and nudged the composer + feed down once (the score-50 note carried out of #1234's review). Too loud, and positioned *above* the board rather than part of it.

## Solution

Two targeted fixes, each borrowing the timeline's own mechanism.

### How it works

**1. `useBoardCardRevealAnchor` — the board analog of `virtua`'s `shift`.** On the "N more" tap it opens a reveal *window* and holds the card's bottom edge at a fixed viewport-Y: it measures how far that edge moved on each resize and undoes it through `virtua`'s own imperative `scrollBy` (a raw `scrollTop` write is re-asserted away by `virtua`'s per-item resize handling — the library tug-of-war the owned-scroller design avoids). So the newest replies stay put and the older middle fills in above them. The window spans the sync expand **and** its async server backfill (the `getBoardMessages` fetch that lands even older replies), re-arming a settle timer on each resize, and closes on a user scroll so it never fights a deliberate gesture. `virtua`'s imperative handle (`VirtualizerHandle`) is threaded `board.tsx` → `BoardFeedList` → `Virtualizer`; the card gets the scroller + handle refs to run the correction.

**2. `BoardNewPostsPill` — templated on the stream date pill (`StreamDateHeader`).** A muted rounded chip floating over the top of the feed (`absolute top-2`, `pointer-events` only on the control), so buffered posts never shift layout (INV-21). A touch more prominent than a passive date label — primary-accent text — since it's an action; wheel/touch over it forward to the scroller like the date pill. Anchored to the viewport top (fixed `top-2`), not the composer's height, so a mobile-expanded composer can't clip it — the regression the earlier `top: startMargin` overlay attempt hit in #1234's review.

### Key design decisions

**1. Correct through `virtua.scrollBy`, not a raw `scrollTop` write.** Verified in a standalone Chromium harness: a `scrollHeight`-delta + `scrollTop +=` correction reads `grew: 0` (the scroller's `scrollHeight` is a `virtua`-controlled spacer that lags the real DOM resize by a frame) and gets re-asserted away. Routing the correction through the imperative handle lands the anchor at **0px** shift vs **332px** unfixed.

**2. Anchor the card *bottom* (hold the newest), not the card top.** Holding the top is the current behaviour — it shoves the newest down, which is the bug. Holding the bottom keeps the newest replies (the activity-relevant part) still and lets older content fill above, matching the timeline's reverse-scroll "maintain from the end" (INV-61, "don't move shit on me").

**3. Scoped to a reveal window, closed on gesture.** A live reply appended *below* the trailing must still push the view normally, so the compensation runs only from the expand tap until growth settles (`REVEAL_SETTLE_MS` 400ms, hard cap `REVEAL_MAX_MS` 2500ms), and a user wheel/touch/key closes it at once rather than fighting the scroll.

**4. Pill floats, not banner.** The in-flow banner was rejected for shoving the feed; the fixed-`top-2` overlay is the timeline's proven pattern. It grazes the composer's top edge (the composer lives at the top of the board), the same tradeoff as the date pill floating over messages — accepted, and far quieter than the gold CTA.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-board-card-reveal-anchor.ts` | Holds a card's bottom edge fixed across a middle-gap expand + backfill, via `virtua.scrollBy`; scoped to a reveal window, closed on user scroll |
| `apps/frontend/src/hooks/use-board-card-reveal-anchor.test.ts` | Hook behaviour: corrects by the resize delta when armed, no-ops when disarmed, stops on a scroll gesture |
| `apps/frontend/src/components/board/board-new-posts-pill.tsx` | Floating muted "N new" pill (date-pill template) that never shifts feed layout |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/board.tsx` | Thread a `VirtualizerHandle` ref to the feed + cards; replace the in-flow "N new" banner with the floating `BoardNewPostsPill` in a `relative` scroller wrapper; drop the now-unused `ArrowUp` pill markup |
| `apps/frontend/src/components/board/board-card.tsx` | Optional `scrollerRef`/`listRef` props; call `useBoardCardRevealAnchor().beginReveal()` on the "N more messages" tap |
| `apps/frontend/src/components/board/board-feed-list.tsx` | Accept and forward an optional `listRef` to `Virtualizer` |

## Out of scope (deliberate)

- **Feed-level "Load more" (older *conversations*)** — unchanged; it correctly appends older pages below the last card.
- **Bug 12 ("load-more control's stacking vs the sticky header")** — turned out to be the "N new" pill on inspection, which this PR fixes; no separate sticky-header stacking change was needed.
- **No `shift` on the board `Virtualizer`** — still omitted (#1234's decision); the per-card reveal is a sub-item correction, not a list-level prepend.

## Test plan

- [x] `apps/frontend` — `use-board-card-reveal-anchor.test.ts` (3 pass: corrects when armed, no-op disarmed, stops on gesture)
- [x] `apps/frontend` — `board.test.tsx` (15 pass) + `board-card.test.tsx` (13 pass) unchanged and green after the added props / pill swap
- [x] Full pre-commit gate on both commits: prettier + all-app eslint + `tsc --noEmit` across all 14 workspaces + dockerfile/migration checks + OpenAPI `--check` — clean
- [x] **Browser-verified against real `virtua`** in a standalone Chromium harness exercising the shipping hook: trailing-reply viewport shift **0px** with the fix vs **332px** without; the floating pill positioning mocked and eyeballed
- [ ] Not driven against the live authed board in-session (no auth/data harness) — verified via the standalone `virtua` harness + unit tests instead; staging (`staging` label) is for the visual pass

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_