### PR TITLE
fix(conversations): anchor completeness scale in boundary classifier prompt

### DIFF
--- a/apps/backend/src/features/conversations/boundary-extraction/config.ts
+++ b/apps/backend/src/features/conversations/boundary-extraction/config.ts
@@ -89,6 +89,7 @@ Use it whenever the new message gives you evidence the prior placement was wrong
 - newConversationSummary: One sentence stating what the new conversation is about, in the conversation's own language. Required whenever newConversationTopic is set.
 - reassignments: Array of {messageId, toConversationId, reason, confidence}. messageId must be from this prompt. toConversationId=null means "move into the new conversation being created this turn" (only valid if assignments includes a conversationId=null primary).
 - completenessUpdates: Array of {conversationId, score (1-7), status, summary} for conversations whose completeness, status, or content moved on.
+  - score (1-7) measures how settled the conversation is: 1-2 = just opened, no substance yet; 3-5 = active exchange, the question or task still open; 6-7 = reached an explicit conclusion — the problem confirmed solved, the question answered, or a plan agreed. An explicit resolution ("that fixed it", "works now, thanks", "låter som en plan") scores 6 or 7, not 5; pair it with status "resolved".
   - status must be one of: "active", "stalled", "resolved"
   - summary: a refreshed "covers:" summary for the conversation — max ~40 words, plain prose in the conversation's own language, stating what has been discussed and where it landed. Include it whenever the conversation gained content this pass (at minimum for the conversation the new message joined); pass null to keep the stored summary.
 - confidence: 0.0 to 1.0 confidence in this classification overall.

--- a/docs/plans/cosmic-orbiting-seal.md
+++ b/docs/plans/cosmic-orbiting-seal.md
@@ -1,0 +1,103 @@
+# Harden the residual flaky boundary-extraction eval cases
+
+## Context
+
+The `/eval` on-demand runner now works end-to-end in CI (PR #1227; the
+`OPENROUTER_API_KEY` Actions secret is set — a real run on PR #1237 posted a
+report: `gpt-5.4-mini`, 228 executions, $0.69, 7m42s). That was the first at-scale
+measurement of the boundary-extraction suite against the production model. Its
+6-run sample flagged six cases below the strict per-case `--min-pass-rate 0.8`
+gate, but 6 runs at `temperature 0.2` is too noisy to trust per-case.
+
+A reliable **10-run in-sandbox baseline** (full suite, tuned HEAD) reframed the
+problem. Aggregate gates were already healthy — accuracy **0.966**,
+decision-accuracy **0.984**, average-confidence **0.965** — and only **one** case
+was meaningfully broken:
+
+| Case                                    | 10-run baseline | Note                                   |
+| --------------------------------------- | --------------- | -------------------------------------- |
+| `resolution-explicit-001`               | **5/10**        | the real outlier                       |
+| `live-pivot-mid-blob-001`               | 7/10            | hardest live-pivot (72-msg stale blob) |
+| `live-pivot-btw-001`                    | 8/10            | at the line                            |
+| `reply-quote-continues-quoted-conv-001` | 9/10            | noise                                  |
+| `live-pivot-mid-blob-sum-001`           | 9/10            | noise                                  |
+| `entity-magnet-distinct-aspect-001`     | 9/10            | noise                                  |
+| all others (32)                         | 10/10           | —                                      |
+
+The CI 6-run flakes (`live-pivot-new-subject-001` at 4/6, `entity-magnet-distinct`
+at 4/6) were sampling noise — both are 9–10/10 over 10 runs.
+
+## Root cause of the one real failure
+
+`resolution-explicit-001` is **not** a boundary-decision failure. On the message
+"Perfect, that fixed it! The deployment is now working. Thanks everyone!", the
+model correctly sets `status: "resolved"` but scores completeness **5** when the
+case expects `minScore: 6` (evaluator: `"Score 5 below expected min 6"`).
+
+The gap: the 1–7 completeness scale is defined **only** in a zod `.describe()`
+(`config.ts:146`), never in the prompt body — `## Output Requirements` (line 91)
+just says `score (1-7)`. With no anchor, the model hedges on borderline
+resolutions. Diagnostic contrast: `resolution-settled-plan-sv-001` (also
+`minScore: 6`) passes 10/10, while `resolution-explicit-001` reaches ≥6 only half
+the time — same assertion, no rubric.
+
+## What was done
+
+**One targeted, additive change** — a completeness rubric in the prompt body
+(`BOUNDARY_EXTRACTION_PROMPT`, `## Output Requirements`,
+`apps/backend/src/features/conversations/boundary-extraction/config.ts`):
+
+> - score (1-7) measures how settled the conversation is: 1-2 = just opened, no
+>   substance yet; 3-5 = active exchange, the question or task still open; 6-7 =
+>   reached an explicit conclusion — the problem confirmed solved, the question
+>   answered, or a plan agreed. An explicit resolution ("that fixed it", "works
+>   now, thanks", "låter som en plan") scores 6 or 7, not 5; pair it with status
+>   "resolved".
+
+Shared by prod and evals per INV-44. No code-path, schema, model, or temperature
+change.
+
+### Deliberately NOT changed
+
+The live-pivot and entity-magnet sections were left untouched. Over 10 runs they
+sit at 7–10/10, and the prompt **already** addresses them explicitly — line 63 is
+the subject-change test and line 64's show-and-tell rule literally quotes
+`"detta känns fint"`, the exact opening of the `live-pivot-new-subject` message.
+These are at the model's reliability ceiling on genuinely ambiguous inputs (a
+short excited one-liner into a 30-min-stale 72-message blob). Adding more prose
+there is low-value and risks regressing the 32 green cases that depend on the same
+shared logic (`continuity-short-ack`, `live-reaction-continues` — both 10/10).
+
+## Result (validation)
+
+Full-suite `-r 10`, in-sandbox, before → after the rubric:
+
+- `resolution-explicit-001`: **5/10 → 10/10** ✅
+- `resolution-settled-plan-sv-001`: 10/10 → 10/10 (other completeness case — no regression)
+- Aggregate accuracy: 0.966 → **0.979**; decision-accuracy 0.984 → 0.984
+- Live-pivot family nudged up (`btw` 8→9, `mid-blob` 7→8)
+- Every case now clears `--min-pass-rate 0.8` (lowest is `live-pivot-mid-blob-001`
+  at 8/10); no previously-passing case dropped.
+
+## Verification harness (in-sandbox)
+
+Bun 1.3.11's `fetch` can't complete TLS through the agent proxy's CONNECT tunnel,
+but `curl` can. To run evals in this sandbox:
+
+- Local Postgres 16 + pgvector on `:5454`, role `threa/threa`, cluster under
+  `/var/lib/postgresql/evaldata` (docker is unprivileged here).
+- Preload a curl-backed `fetch` shim so `generateObject` reaches OpenRouter:
+  `bun --preload <shim> evals/run.ts -s boundary-extraction -r 10 --min-pass-rate 0.8 --no-langfuse`.
+- `OPENROUTER_API_KEY` is present in the sandbox env.
+
+CI confirmation: comment `/eval -s boundary-extraction -r 10 --min-pass-rate 0.8`
+on the PR to re-measure against the canonical runner (CI has direct egress; no shim
+needed there).
+
+## Out of scope
+
+- No temperature/model change (`mini`/`0.2` are deliberate, `config.ts:6-13`).
+- No new eval cases (INV-36).
+- The curl-fetch shim is a sandbox-only workaround, not checked in.
+- Existing production "Fable"/blob merges are historical; tuning only affects
+  future classification — a backfill is a separate task.


### PR DESCRIPTION
## Problem

The boundary classifier's completeness score (1–7) is asserted by two eval cases but was **undefined in the prompt body** — the scale lived only in a zod `.describe()` (`config.ts:146`). With no anchor, `gpt-5.4-mini` hedged on borderline resolutions.

Surfaced by the first at-scale `/eval` run against the production model (the on-demand runner from #1227, now that the `OPENROUTER_API_KEY` Actions secret is set). A reliable 10-run in-sandbox baseline showed the suite healthy in aggregate (accuracy 0.966, decision-accuracy 0.984) with exactly one genuinely-broken case:

- `resolution-explicit-001` — on "Perfect, that fixed it! The deployment is now working. Thanks everyone!", the model correctly sets `status: "resolved"` but scores completeness **5** when the case expects `minScore: 6`. Pass rate **5/10**.

Diagnostic tell: `resolution-settled-plan-sv-001` (same `minScore: 6`) already passes 10/10 — same assertion, no rubric. The other CI-flagged cases (live-pivot family, entity-magnet) were 6-run sampling noise; over 10 runs they sit at 7–10/10.

## Solution

Add a completeness rubric to `## Output Requirements` in `BOUNDARY_EXTRACTION_PROMPT` (`apps/backend/src/features/conversations/boundary-extraction/config.ts`), anchoring the 1–7 scale in the prompt body:

> score (1-7) measures how settled the conversation is: 1-2 = just opened, no substance yet; 3-5 = active exchange, the question or task still open; 6-7 = reached an explicit conclusion — the problem confirmed solved, the question answered, or a plan agreed. An explicit resolution ("that fixed it", "works now, thanks", "låter som en plan") scores 6 or 7, not 5; pair it with status "resolved".

Prompt-only. No code-path, schema, model, or temperature change. Shared by prod and evals per INV-44.

### Deliberately left alone

The live-pivot and entity-magnet sections. Over 10 runs they're 7–10/10, and the prompt already addresses them explicitly (line 64's show-and-tell rule literally quotes `"detta känns fint"`, the exact opening of the `live-pivot-new-subject` message). They're at the model's ceiling on genuinely ambiguous inputs; adding prose there risks regressing the 32 green cases that share the same live-session logic (`continuity-short-ack`, `live-reaction-continues` — both 10/10) for marginal gain.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/boundary-extraction/config.ts` | +1 line: completeness-score rubric in the prompt's `## Output Requirements` |
| `docs/plans/cosmic-orbiting-seal.md` | Investigation + validation record |

## Test plan

Full boundary-extraction suite, `-r 10`, in-sandbox against `openrouter:openai/gpt-5.4-mini` (local pg16+pgvector; Bun-fetch-through-proxy worked around with a curl-backed `fetch` shim), before → after:

- [x] `resolution-explicit-001`: **5/10 → 10/10**
- [x] `resolution-settled-plan-sv-001`: 10/10 → 10/10 (other completeness case — no regression)
- [x] Aggregate accuracy 0.966 → **0.979**; decision-accuracy flat 0.984
- [x] Every case clears `--min-pass-rate 0.8` (lowest `live-pivot-mid-blob-001` at 8/10); no previously-passing case dropped
- [x] `bun run --cwd apps/backend typecheck` — clean
- [x] Pre-commit hook (full-repo lint + typecheck + api-docs check) — passed
- [ ] CI `/eval` confirmation against the canonical runner — posting `/eval -s boundary-extraction -r 10 --min-pass-rate 0.8` on this PR now

## Out of scope

- No temperature/model change (`mini`/`0.2` deliberate, `config.ts:6-13`).
- No new eval cases (INV-36).
- The live-pivot-mid-blob case at 8/10 is at the model's ceiling — not chased.
- Existing production "Fable"/blob merges are historical; tuning only affects future classification — backfill is a separate task.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4JrndRHeisRYydXir8VVq)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786102881&installation_id=129946197&pr_number=1241&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1241&signature=b641db769bbe3ad74b41cd25f73c505e2281f425567c74dd4de0bd5dc3da690c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->