### PR TITLE
feat(board): per-user default lens (boardDefaultLens preference)

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -26,3 +26,17 @@ describe("updatePreferencesSchema voiceSteeringWords", () => {
     expect(updatePreferencesSchema.parse({}).voiceSteeringWords).toBeUndefined()
   })
 })
+
+describe("updatePreferencesSchema boardDefaultLens", () => {
+  it("accepts a known lens", () => {
+    expect(updatePreferencesSchema.parse({ boardDefaultLens: "mine" }).boardDefaultLens).toBe("mine")
+  })
+
+  it("rejects an unknown lens", () => {
+    expect(updatePreferencesSchema.safeParse({ boardDefaultLens: "everything" }).success).toBe(false)
+  })
+
+  it("treats the field as optional", () => {
+    expect(updatePreferencesSchema.parse({}).boardDefaultLens).toBeUndefined()
+  })
+})

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -23,6 +23,7 @@ import {
   MESSAGE_COLLAPSE_THRESHOLD_MAX,
   BOARD_CARD_COLLAPSE_THRESHOLD_MIN,
   BOARD_CARD_COLLAPSE_THRESHOLD_MAX,
+  BOARD_LENSES,
 } from "@threa/types"
 import { workScheduleSchema, statusPresetsSchema } from "../../lib/schemas"
 import { validateRequest } from "../../lib/validation"
@@ -64,6 +65,7 @@ const updatePreferencesSchema = z.object({
     .min(BOARD_CARD_COLLAPSE_THRESHOLD_MIN)
     .max(BOARD_CARD_COLLAPSE_THRESHOLD_MAX)
     .optional(),
+  boardDefaultLens: z.enum(BOARD_LENSES).optional(),
   // Model id like "elevenlabs:scribe-v2-realtime". Validated against the model
   // registry server-side when a session opens; this layer only bounds length.
   voiceTranscriptionModel: z.string().max(100).nullable().optional(),

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -75,6 +75,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "blockquoteCollapseThreshold",
     "messageCollapseThreshold",
     "boardCardCollapseThreshold",
+    "boardDefaultLens",
     "voiceTranscriptionModel",
     "voicePolishLevel",
     "voiceSteeringWords",

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -93,10 +93,12 @@ const TYPE_LABELS: Record<BoardScopeStreamType, string> = {
   system: "System",
 }
 
-/** The lens's URL (INV-59): the default lens is the bare `/board`, others a segment.
- *  `search` rides along so switching lens keeps the scope (and an open panel). */
-function lensHref(workspaceId: string, lens: BoardLens, search: string): string {
-  const base = lens === DEFAULT_BOARD_LENS ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${lens}`
+/** The lens's URL (INV-59): the viewer's home lens rests at the bare `/board`,
+ *  every other lens takes a segment (so `all` gets `/board/all` when it isn't
+ *  home). `search` rides along so switching lens keeps the scope (and an open
+ *  panel). */
+function lensHref(workspaceId: string, lens: BoardLens, search: string, homeLens: BoardLens): string {
+  const base = lens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${lens}`
   return `${base}${search}`
 }
 
@@ -109,6 +111,9 @@ type FilterIcon = ComponentType<{ className?: string }>
 interface BoardFilterBarProps {
   workspaceId: string
   lens: BoardLens
+  /** The viewer's home lens (bare `/board`) — decides which lens is segment-less
+   *  and where "Clear filters" returns (the All surfacing baseline). */
+  homeLens: BoardLens
   /** Included scope stream ids (root streams), in URL order. */
   scopeStreamIds: string[]
   /** Excluded stream ids (anchor-or-root veto), in URL order. */
@@ -159,6 +164,7 @@ interface BoardFilterBarProps {
 export function BoardFilterBar({
   workspaceId,
   lens,
+  homeLens,
   scopeStreamIds,
   excludeStreamIds,
   onStreamFilterChange,
@@ -213,6 +219,7 @@ export function BoardFilterBar({
       <BoardLensMenu
         workspaceId={workspaceId}
         lens={lens}
+        homeLens={homeLens}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         scopeStreamTypes={scopeStreamTypes}
@@ -345,7 +352,7 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          to={`/w/${workspaceId}/board${clearedSearch}`}
+          to={lensHref(workspaceId, DEFAULT_BOARD_LENS, clearedSearch, homeLens)}
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters
@@ -474,6 +481,7 @@ function ExcludeToggle({ excluded, onToggle, subject }: { excluded: boolean; onT
 function BoardLensMenu({
   workspaceId,
   lens,
+  homeLens,
   scopeStreamIds,
   excludeStreamIds,
   scopeStreamTypes,
@@ -483,6 +491,7 @@ function BoardLensMenu({
 }: {
   workspaceId: string
   lens: BoardLens
+  homeLens: BoardLens
   scopeStreamIds: string[]
   excludeStreamIds: string[]
   scopeStreamTypes: BoardScopeStreamType[]
@@ -505,7 +514,7 @@ function BoardLensMenu({
           return (
             <Link
               key={value}
-              to={lensHref(workspaceId, value, search)}
+              to={lensHref(workspaceId, value, search, homeLens)}
               onClick={() => setOpen(false)}
               aria-current={selected ? "true" : undefined}
               className={cn(
@@ -526,6 +535,7 @@ function BoardLensMenu({
       <BoardSavedViews
         workspaceId={workspaceId}
         lens={lens}
+        homeLens={homeLens}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         scopeStreamTypes={scopeStreamTypes}

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -24,7 +24,8 @@ import {
 } from "@/stores/workspace-store"
 import type { CachedLabel } from "@/hooks/use-labels"
 import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
-import { BoardSavedViews } from "@/components/board/board-saved-views"
+import { BoardSavedViews, isViewActive, type BoardViewSelection } from "@/components/board/board-saved-views"
+import { useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { cn } from "@/lib/utils"
@@ -455,13 +456,28 @@ function BoardLensMenu({
   const current = BOARD_LENS_DEFS[lens]
   const CurrentIcon = current.icon
 
+  // A saved view IS the selection when the live lens + every filter axis match
+  // it, so it — not its base lens — is what reads as active. Resolved once here
+  // so the lens list and the saved-view list can't both mark a row.
+  const { data: views } = useBoardViews(workspaceId)
+  const selection: BoardViewSelection = {
+    lens,
+    scopeStreamIds,
+    scopeStreamTypes,
+    scopeLabelIds,
+    excludeStreamIds,
+    excludeStreamTypes,
+    excludeLabelIds,
+  }
+  const activeViewId = views?.find((view) => isViewActive(view, selection))?.id ?? null
+
   const content = (
     <>
       <nav aria-label="Board lens" className="py-1">
         {BOARD_LENSES.map((value) => {
           const def = BOARD_LENS_DEFS[value]
           const Icon = def.icon
-          const selected = value === lens
+          const selected = value === lens && activeViewId === null
           return (
             <Link
               key={value}
@@ -487,6 +503,7 @@ function BoardLensMenu({
         workspaceId={workspaceId}
         lens={lens}
         homeLens={homeLens}
+        activeViewId={activeViewId}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         scopeStreamTypes={scopeStreamTypes}

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -1,27 +1,9 @@
 import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
-import {
-  Archive,
-  Ban,
-  Bell,
-  BellOff,
-  BookMarked,
-  Check,
-  ChevronDown,
-  CircleDashed,
-  Hash,
-  Layers,
-  LayoutGrid,
-  Tag,
-  User,
-  X,
-  Zap,
-} from "lucide-react"
-import type { LucideIcon } from "lucide-react"
+import { Archive, Ban, Bell, BellOff, Check, ChevronDown, Hash, Layers, Tag, X } from "lucide-react"
 import {
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
-  DEFAULT_BOARD_LENS,
   MAX_BOARD_SCOPE_STREAMS,
   MAX_BOARD_SCOPE_LABELS,
   type BoardLens,
@@ -44,42 +26,8 @@ import type { CachedLabel } from "@/hooks/use-labels"
 import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
 import { BoardSavedViews } from "@/components/board/board-saved-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
+import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { cn } from "@/lib/utils"
-
-export interface BoardLensDef {
-  value: BoardLens
-  label: string
-  /** One-line answer to "what does this show?" — rendered under the label in the picker. */
-  description: string
-  icon: LucideIcon
-}
-
-/**
- * Display metadata per lens. The board page reuses labels for empty-state copy;
- * order of rendering follows `BOARD_LENSES`.
- */
-export const BOARD_LENS_DEFS: Record<BoardLens, BoardLensDef> = {
-  all: { value: "all", label: "All", description: "Everything, newest activity first", icon: LayoutGrid },
-  active: { value: "active", label: "Active", description: "Still in motion — not stalled or resolved", icon: Zap },
-  "needs-resolution": {
-    value: "needs-resolution",
-    label: "Needs resolution",
-    description: "Stalled or gone quiet while unresolved",
-    icon: CircleDashed,
-  },
-  decisions: {
-    value: "decisions",
-    label: "Decisions",
-    description: "Settled — captured as a memo",
-    icon: BookMarked,
-  },
-  mine: {
-    value: "mine",
-    label: "Mine",
-    description: "Conversations you're in or mentioned in",
-    icon: User,
-  },
-}
 
 /** Stream types offered in the pickers: the board's root-stream grains (shared
  *  with the backend validator). */
@@ -191,8 +139,11 @@ export function BoardFilterBar({
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
   const labelById = useMemo(() => new Map(myLabels.map((l) => [l.id, l])), [myLabels])
 
+  // The viewer's home lens is their baseline, so being on it (with no scope
+  // narrowing) is NOT "filtered" — otherwise a non-All home shows a permanent
+  // "Clear filters" affordance on its own untouched landing view.
   const isFiltered =
-    lens !== DEFAULT_BOARD_LENS ||
+    lens !== homeLens ||
     scopeStreamIds.length > 0 ||
     excludeStreamIds.length > 0 ||
     scopeStreamTypes.length > 0 ||
@@ -352,7 +303,7 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          to={lensHref(workspaceId, DEFAULT_BOARD_LENS, clearedSearch, homeLens)}
+          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens)}
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters
@@ -549,7 +500,7 @@ function BoardLensMenu({
 
   const trigger = (
     <Button
-      variant={lens === DEFAULT_BOARD_LENS ? "outline" : "secondary"}
+      variant={lens === homeLens ? "outline" : "secondary"}
       size="sm"
       className="h-7 shrink-0 gap-1.5 rounded-full px-2.5 text-xs font-normal"
       aria-label={`Board lens: ${current.label}`}

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -30,6 +30,7 @@ function mount(boardViews: Record<string, unknown>, props: Partial<Parameters<ty
           <BoardSavedViews
             workspaceId="ws_1"
             lens="mine"
+            homeLens="all"
             scopeStreamIds={["stream_1"]}
             scopeStreamTypes={[]}
             scopeLabelIds={[]}
@@ -49,16 +50,24 @@ afterEach(() => vi.restoreAllMocks())
 
 describe("savedViewHref", () => {
   it("expands a saved view into its canonical board URL", () => {
-    const href = savedViewHref("ws_1", view({ scopeStreamIds: ["s1", "s2"], scopeStreamTypes: ["channel"] }))
+    const href = savedViewHref("ws_1", view({ scopeStreamIds: ["s1", "s2"], scopeStreamTypes: ["channel"] }), "all")
     const url = new URL(href, "http://x")
     expect(url.pathname).toBe("/w/ws_1/board/mine")
     expect(url.searchParams.get("in")).toBe("s1,s2")
     expect(url.searchParams.get("is")).toBe("channel")
   })
 
-  it("uses the bare board path for the All lens with no scope", () => {
-    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }))).toBe(
+  it("uses the bare board path for the home lens with no scope", () => {
+    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }), "all")).toBe(
       "/w/ws_1/board"
+    )
+  })
+
+  it("segments the All lens when the viewer's home lens is something else", () => {
+    // Home is Active, so bare `/board` is Active; a saved All view must address
+    // its own `/board/all` segment to reproduce, not collapse to the home.
+    expect(savedViewHref("ws_1", view({ baseLens: "all", scopeStreamIds: [], scopeStreamTypes: [] }), "active")).toBe(
+      "/w/ws_1/board/all"
     )
   })
 
@@ -72,7 +81,8 @@ describe("savedViewHref", () => {
         excludeStreamIds: ["s9"],
         excludeStreamTypes: ["system"],
         excludeLabelIds: ["label_b"],
-      })
+      }),
+      "all"
     )
     const url = new URL(href, "http://x")
     expect(url.pathname).toBe("/w/ws_1/board")

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -31,6 +31,7 @@ function mount(boardViews: Record<string, unknown>, props: Partial<Parameters<ty
             workspaceId="ws_1"
             lens="mine"
             homeLens="all"
+            activeViewId={null}
             scopeStreamIds={["stream_1"]}
             scopeStreamTypes={[]}
             scopeLabelIds={[]}

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardView } from "@threa/types"
 import { ServicesProvider } from "@/contexts"
-import { BoardSavedViews, savedViewHref } from "./board-saved-views"
+import { BoardSavedViews, savedViewHref, isViewActive, type BoardViewSelection } from "./board-saved-views"
 
 const view = (over: Partial<BoardView> = {}): BoardView => ({
   id: "boardview_1",
@@ -47,6 +47,32 @@ function mount(boardViews: Record<string, unknown>, props: Partial<Parameters<ty
 }
 
 afterEach(() => vi.restoreAllMocks())
+
+describe("isViewActive", () => {
+  const selection = (over: Partial<BoardViewSelection> = {}): BoardViewSelection => ({
+    lens: "mine",
+    scopeStreamIds: ["stream_1"],
+    scopeStreamTypes: [],
+    scopeLabelIds: [],
+    excludeStreamIds: [],
+    excludeStreamTypes: [],
+    excludeLabelIds: [],
+    ...over,
+  })
+
+  it("matches when the lens and every filter axis agree, order-independent", () => {
+    expect(isViewActive(view({ scopeStreamIds: ["a", "b"] }), selection({ scopeStreamIds: ["b", "a"] }))).toBe(true)
+  })
+
+  it("is inactive when the lens differs", () => {
+    expect(isViewActive(view(), selection({ lens: "all" }))).toBe(false)
+  })
+
+  it("is inactive when a filter axis differs", () => {
+    expect(isViewActive(view(), selection({ scopeStreamIds: ["stream_2"] }))).toBe(false)
+    expect(isViewActive(view(), selection({ excludeStreamTypes: ["system"] }))).toBe(false)
+  })
+})
 
 describe("savedViewHref", () => {
   it("expands a saved view into its canonical board URL", () => {

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -105,6 +105,9 @@ interface BoardSavedViewsProps {
   lens: BoardLens
   /** The viewer's home lens — the segment-less one when addressing a saved view. */
   homeLens: BoardLens
+  /** The saved view whose lens + filters match the live board, or `null`. Owned by
+   *  the lens menu so the lens list and this list never both mark a row. */
+  activeViewId: string | null
   scopeStreamIds: string[]
   scopeStreamTypes: BoardScopeStreamType[]
   scopeLabelIds: string[]
@@ -126,6 +129,7 @@ export function BoardSavedViews({
   workspaceId,
   lens,
   homeLens,
+  activeViewId,
   scopeStreamIds,
   scopeStreamTypes,
   scopeLabelIds,
@@ -153,16 +157,6 @@ export function BoardSavedViews({
     excludeStreamTypes.length > 0 ||
     excludeLabelIds.length > 0
 
-  const selection: BoardViewSelection = {
-    lens,
-    scopeStreamIds,
-    scopeStreamTypes,
-    scopeLabelIds,
-    excludeStreamIds,
-    excludeStreamTypes,
-    excludeLabelIds,
-  }
-
   const submit = (name: string) => {
     if (editing?.id) update.mutate({ id: editing.id, input: { name } })
     else
@@ -187,12 +181,12 @@ export function BoardSavedViews({
             Saved views
           </p>
           {views?.map((view) => {
-            const active = isViewActive(view, selection)
+            const active = view.id === activeViewId
             return (
               <div
                 key={view.id}
                 className={cn(
-                  "group mx-1 flex items-center rounded-item pr-1 transition-colors hover:bg-muted",
+                  "group mx-1 flex items-start gap-1 rounded-item px-2.5 py-2 transition-colors hover:bg-muted",
                   active && "bg-muted/60"
                 )}
               >
@@ -200,31 +194,38 @@ export function BoardSavedViews({
                   to={savedViewHref(workspaceId, view, homeLens)}
                   onClick={onNavigate}
                   aria-current={active ? "true" : undefined}
-                  className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2"
+                  className="flex min-w-0 flex-1 items-start gap-2.5"
                 >
                   <Bookmark className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-sm font-medium">{view.name}</span>
                     <span className="block truncate text-xs text-muted-foreground">{summarize(view)}</span>
                   </span>
-                  {active && <Check className="mt-0.5 h-4 w-4 shrink-0" />}
                 </Link>
-                <button
-                  type="button"
-                  onClick={() => setEditing({ id: view.id, name: view.name })}
-                  aria-label={`Rename ${view.name}`}
-                  className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => remove.mutate(view.id)}
-                  aria-label={`Delete ${view.name}`}
-                  className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive focus:opacity-100 group-hover:opacity-100"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
+                {/* Right slot: the active check sits at the row's right edge (same
+                    column as the lens list's check) and fades to the rename/delete
+                    actions on hover/focus — one indicator, never both. */}
+                <div className="relative flex shrink-0 items-start">
+                  <button
+                    type="button"
+                    onClick={() => setEditing({ id: view.id, name: view.name })}
+                    aria-label={`Rename ${view.name}`}
+                    className="rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove.mutate(view.id)}
+                    aria-label={`Delete ${view.name}`}
+                    className="rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                  {active && (
+                    <Check className="pointer-events-none absolute right-0 top-1 h-4 w-4 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0" />
+                  )}
+                </div>
               </div>
             )
           })}

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -107,10 +107,10 @@ export function BoardSavedViews({
   // `null` closed; `{ id: null }` = save-current; `{ id }` = rename that view.
   const [editing, setEditing] = useState<{ id: string | null; name: string } | null>(null)
 
-  // Only offer "save current view" when there's actually a filter to bookmark —
-  // the plain All home is nothing worth saving.
+  // Only offer "save current view" when there's actually a narrowing to bookmark
+  // — the viewer's plain home lens is nothing worth saving.
   const isFiltered =
-    lens !== DEFAULT_BOARD_LENS ||
+    lens !== homeLens ||
     scopeStreamIds.length > 0 ||
     scopeStreamTypes.length > 0 ||
     scopeLabelIds.length > 0 ||

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
-import { Bookmark, Pencil, Plus, Trash2 } from "lucide-react"
+import { Bookmark, Check, Pencil, Plus, Trash2 } from "lucide-react"
 import {
   DEFAULT_BOARD_LENS,
   MAX_BOARD_VIEW_NAME_LENGTH,
@@ -18,6 +18,7 @@ import {
   ResponsiveDialogHeader,
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
+import { cn } from "@/lib/utils"
 import { useBoardViews, useSaveBoardView, useUpdateBoardView, useDeleteBoardView } from "@/hooks/use-board-views"
 import {
   BOARD_SCOPE_PARAM,
@@ -42,6 +43,40 @@ export function savedViewHref(workspaceId: string, view: BoardView, homeLens: Bo
   if (view.excludeLabelIds.length > 0) params.set(BOARD_EXCLUDE_LABEL_PARAM, view.excludeLabelIds.join(","))
   const qs = params.toString()
   return qs ? `${base}?${qs}` : base
+}
+
+/** The board's live view — lens plus every filter axis — matched against a saved
+ *  view to mark which one you're currently looking at. */
+export interface BoardViewSelection {
+  lens: BoardLens
+  scopeStreamIds: string[]
+  scopeStreamTypes: BoardScopeStreamType[]
+  scopeLabelIds: string[]
+  excludeStreamIds: string[]
+  excludeStreamTypes: BoardScopeStreamType[]
+  excludeLabelIds: string[]
+}
+
+/** Order-independent membership equality — URL params carry no stable order, so
+ *  `?in=a,b` and `?in=b,a` are the same selection. */
+function sameMembers(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false
+  const set = new Set(a)
+  return b.every((x) => set.has(x))
+}
+
+/** A saved view is active when the live lens and every filter axis match what it
+ *  bookmarked. Archived is not part of a saved view, so it doesn't participate. */
+export function isViewActive(view: BoardView, selection: BoardViewSelection): boolean {
+  return (
+    view.baseLens === selection.lens &&
+    sameMembers(view.scopeStreamIds, selection.scopeStreamIds) &&
+    sameMembers(view.scopeStreamTypes, selection.scopeStreamTypes) &&
+    sameMembers(view.scopeLabelIds, selection.scopeLabelIds) &&
+    sameMembers(view.excludeStreamIds, selection.excludeStreamIds) &&
+    sameMembers(view.excludeStreamTypes, selection.excludeStreamTypes) &&
+    sameMembers(view.excludeLabelIds, selection.excludeLabelIds)
+  )
 }
 
 /** Count phrase: `3 streams`, `1 label`. */
@@ -118,6 +153,16 @@ export function BoardSavedViews({
     excludeStreamTypes.length > 0 ||
     excludeLabelIds.length > 0
 
+  const selection: BoardViewSelection = {
+    lens,
+    scopeStreamIds,
+    scopeStreamTypes,
+    scopeLabelIds,
+    excludeStreamIds,
+    excludeStreamTypes,
+    excludeLabelIds,
+  }
+
   const submit = (name: string) => {
     if (editing?.id) update.mutate({ id: editing.id, input: { name } })
     else
@@ -141,40 +186,48 @@ export function BoardSavedViews({
           <p className="px-3 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             Saved views
           </p>
-          {views?.map((view) => (
-            <div
-              key={view.id}
-              className="group mx-1 flex items-center rounded-item pr-1 transition-colors hover:bg-muted"
-            >
-              <Link
-                to={savedViewHref(workspaceId, view, homeLens)}
-                onClick={onNavigate}
-                className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2"
+          {views?.map((view) => {
+            const active = isViewActive(view, selection)
+            return (
+              <div
+                key={view.id}
+                className={cn(
+                  "group mx-1 flex items-center rounded-item pr-1 transition-colors hover:bg-muted",
+                  active && "bg-muted/60"
+                )}
               >
-                <Bookmark className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium">{view.name}</span>
-                  <span className="block truncate text-xs text-muted-foreground">{summarize(view)}</span>
-                </span>
-              </Link>
-              <button
-                type="button"
-                onClick={() => setEditing({ id: view.id, name: view.name })}
-                aria-label={`Rename ${view.name}`}
-                className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
-              >
-                <Pencil className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                onClick={() => remove.mutate(view.id)}
-                aria-label={`Delete ${view.name}`}
-                className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive focus:opacity-100 group-hover:opacity-100"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          ))}
+                <Link
+                  to={savedViewHref(workspaceId, view, homeLens)}
+                  onClick={onNavigate}
+                  aria-current={active ? "true" : undefined}
+                  className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2"
+                >
+                  <Bookmark className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium">{view.name}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{summarize(view)}</span>
+                  </span>
+                  {active && <Check className="mt-0.5 h-4 w-4 shrink-0" />}
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => setEditing({ id: view.id, name: view.name })}
+                  aria-label={`Rename ${view.name}`}
+                  className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 group-hover:opacity-100"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove.mutate(view.id)}
+                  aria-label={`Delete ${view.name}`}
+                  className="shrink-0 rounded p-1 text-muted-foreground/60 opacity-0 transition-opacity hover:text-destructive focus:opacity-100 group-hover:opacity-100"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )
+          })}
           {isFiltered && (
             <button
               type="button"

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -28,10 +28,11 @@ import {
   BOARD_EXCLUDE_LABEL_PARAM,
 } from "@/components/board/board-filter-params"
 
-/** Expand a saved view into the canonical board URL it bookmarks (INV-59). */
-export function savedViewHref(workspaceId: string, view: BoardView): string {
-  const base =
-    view.baseLens === DEFAULT_BOARD_LENS ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${view.baseLens}`
+/** Expand a saved view into the canonical board URL it bookmarks (INV-59). The
+ *  viewer's home lens is the segment-less one, so a saved All view addresses
+ *  `/board/all` for anyone whose home is another lens. */
+export function savedViewHref(workspaceId: string, view: BoardView, homeLens: BoardLens): string {
+  const base = view.baseLens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${view.baseLens}`
   const params = new URLSearchParams()
   if (view.scopeStreamIds.length > 0) params.set(BOARD_SCOPE_PARAM, view.scopeStreamIds.join(","))
   if (view.scopeStreamTypes.length > 0) params.set(BOARD_TYPE_PARAM, view.scopeStreamTypes.join(","))
@@ -67,6 +68,8 @@ interface BoardSavedViewsProps {
   workspaceId: string
   /** The board's live filter state — captured when saving "the current view". */
   lens: BoardLens
+  /** The viewer's home lens — the segment-less one when addressing a saved view. */
+  homeLens: BoardLens
   scopeStreamIds: string[]
   scopeStreamTypes: BoardScopeStreamType[]
   scopeLabelIds: string[]
@@ -87,6 +90,7 @@ interface BoardSavedViewsProps {
 export function BoardSavedViews({
   workspaceId,
   lens,
+  homeLens,
   scopeStreamIds,
   scopeStreamTypes,
   scopeLabelIds,
@@ -143,7 +147,7 @@ export function BoardSavedViews({
               className="group mx-1 flex items-center rounded-item pr-1 transition-colors hover:bg-muted"
             >
               <Link
-                to={savedViewHref(workspaceId, view)}
+                to={savedViewHref(workspaceId, view, homeLens)}
                 onClick={onNavigate}
                 className="flex min-w-0 flex-1 items-start gap-2.5 px-2.5 py-2"
               >

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -20,9 +20,12 @@ import {
   BOARD_CARD_COLLAPSE_THRESHOLD_MIN,
   BOARD_CARD_COLLAPSE_THRESHOLD_MAX,
   DEFAULT_BOARD_CARD_COLLAPSE_THRESHOLD,
+  BOARD_LENSES,
+  DEFAULT_BOARD_LENS,
   type Theme,
   type MessageDisplay,
   type LabelRemoveOnMove,
+  type BoardLens,
 } from "@threa/types"
 
 const THEME_LABELS: Record<Theme, string> = {
@@ -53,6 +56,22 @@ const LABEL_REMOVE_DESCRIPTIONS: Record<LabelRemoveOnMove, string> = {
   never: "Leave labels alone — a moved stream keeps every label it had",
 }
 
+const BOARD_LENS_LABELS: Record<BoardLens, string> = {
+  all: "All",
+  active: "Active",
+  "needs-resolution": "Needs resolution",
+  decisions: "Decisions",
+  mine: "Mine",
+}
+
+const BOARD_LENS_DESCRIPTIONS: Record<BoardLens, string> = {
+  all: "Everything, newest activity first",
+  active: "Still in motion — not stalled or resolved",
+  "needs-resolution": "Stalled or gone quiet while unresolved",
+  decisions: "Settled — captured as a memo",
+  mine: "Conversations you're in or mentioned in",
+}
+
 export function AppearanceSettings() {
   const { preferences, updatePreference } = usePreferences()
 
@@ -63,6 +82,7 @@ export function AppearanceSettings() {
   const blockquoteThreshold = preferences?.blockquoteCollapseThreshold ?? DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD
   const messageThreshold = preferences?.messageCollapseThreshold ?? DEFAULT_MESSAGE_COLLAPSE_THRESHOLD
   const boardCardThreshold = preferences?.boardCardCollapseThreshold ?? DEFAULT_BOARD_CARD_COLLAPSE_THRESHOLD
+  const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
 
   // Local input state so users can type freely without each keystroke
   // hitting the preferences mutation. We commit on blur / Enter only.
@@ -349,6 +369,34 @@ export function AppearanceSettings() {
             className="w-24"
           />
         </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Board home</h3>
+          <p className="text-sm text-muted-foreground">
+            The lens the board opens on. Every lens still has its own view — this only picks where you land
+          </p>
+        </div>
+        <RadioGroup
+          value={boardDefaultLens}
+          onValueChange={(value) => updatePreference("boardDefaultLens", value as BoardLens)}
+          className="space-y-3"
+        >
+          {BOARD_LENSES.map((option) => (
+            <div key={option} className="flex items-start space-x-3">
+              <RadioGroupItem value={option} id={`board-lens-${option}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`board-lens-${option}`} className="cursor-pointer">
+                  {BOARD_LENS_LABELS[option]}
+                </Label>
+                <p className="text-sm text-muted-foreground">{BOARD_LENS_DESCRIPTIONS[option]}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
       </section>
 
       <Separator />

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
+import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
   THEME_OPTIONS,
   MESSAGE_DISPLAY_OPTIONS,
@@ -54,22 +55,6 @@ const LABEL_REMOVE_DESCRIPTIONS: Record<LabelRemoveOnMove, string> = {
   ask: "Prompt when you drag a labeled stream into a custom section or another label",
   always: "Drop the label it was sitting under whenever you move it elsewhere",
   never: "Leave labels alone — a moved stream keeps every label it had",
-}
-
-const BOARD_LENS_LABELS: Record<BoardLens, string> = {
-  all: "All",
-  active: "Active",
-  "needs-resolution": "Needs resolution",
-  decisions: "Decisions",
-  mine: "Mine",
-}
-
-const BOARD_LENS_DESCRIPTIONS: Record<BoardLens, string> = {
-  all: "Everything, newest activity first",
-  active: "Still in motion — not stalled or resolved",
-  "needs-resolution": "Stalled or gone quiet while unresolved",
-  decisions: "Settled — captured as a memo",
-  mine: "Conversations you're in or mentioned in",
 }
 
 export function AppearanceSettings() {
@@ -390,9 +375,9 @@ export function AppearanceSettings() {
               <RadioGroupItem value={option} id={`board-lens-${option}`} className="mt-1" />
               <div className="grid gap-1">
                 <Label htmlFor={`board-lens-${option}`} className="cursor-pointer">
-                  {BOARD_LENS_LABELS[option]}
+                  {BOARD_LENS_DEFS[option].label}
                 </Label>
-                <p className="text-sm text-muted-foreground">{BOARD_LENS_DESCRIPTIONS[option]}</p>
+                <p className="text-sm text-muted-foreground">{BOARD_LENS_DEFS[option].description}</p>
               </div>
             </div>
           ))}

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -83,6 +83,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       blockquoteCollapseThreshold: 6,
       messageCollapseThreshold: 16,
       boardCardCollapseThreshold: 600,
+      boardDefaultLens: "all",
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
       voiceSteeringWords: [],

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -92,6 +92,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       blockquoteCollapseThreshold: 6,
       messageCollapseThreshold: 16,
       boardCardCollapseThreshold: 600,
+      boardDefaultLens: "all",
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
       voiceSteeringWords: [],

--- a/apps/frontend/src/lib/board/lens-defs.ts
+++ b/apps/frontend/src/lib/board/lens-defs.ts
@@ -1,0 +1,39 @@
+import type { LucideIcon } from "lucide-react"
+import { BookMarked, CircleDashed, LayoutGrid, User, Zap } from "lucide-react"
+import { type BoardLens } from "@threa/types"
+
+export interface BoardLensDef {
+  value: BoardLens
+  label: string
+  /** One-line answer to "what does this show?" — rendered under the label in the picker. */
+  description: string
+  icon: LucideIcon
+}
+
+/**
+ * Display metadata per lens (label, one-line description, glyph). The single
+ * source for lens copy (INV-33) — the board lens picker and the settings
+ * "Board home" control both read from here. Order follows `BOARD_LENSES`.
+ */
+export const BOARD_LENS_DEFS: Record<BoardLens, BoardLensDef> = {
+  all: { value: "all", label: "All", description: "Everything, newest activity first", icon: LayoutGrid },
+  active: { value: "active", label: "Active", description: "Still in motion — not stalled or resolved", icon: Zap },
+  "needs-resolution": {
+    value: "needs-resolution",
+    label: "Needs resolution",
+    description: "Stalled or gone quiet while unresolved",
+    icon: CircleDashed,
+  },
+  decisions: {
+    value: "decisions",
+    label: "Decisions",
+    description: "Settled — captured as a memo",
+    icon: BookMarked,
+  },
+  mine: {
+    value: "mine",
+    label: "Mine",
+    description: "Conversations you're in or mentioned in",
+    icon: User,
+  },
+}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -234,6 +234,30 @@ describe("BoardPage", () => {
     expect(screen.queryByText("Someone else's topic.")).toBeNull()
   })
 
+  it("shows no 'Clear filters' on the plain home lens (home is the baseline)", async () => {
+    // With a Mine home, the plain `/board` (lens=mine, no scope filters) is the
+    // viewer's untouched baseline — no filtered-state affordance.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "mine" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
+    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board` })
+    await screen.findByText("My own topic.")
+    expect(screen.queryByText("Clear filters")).toBeNull()
+  })
+
+  it("shows 'Clear filters' once the lens is narrowed off the home lens", async () => {
+    // Home is Mine; `/board/all` is a different lens, i.e. a narrowing away from
+    // the baseline, so the clear-to-home affordance reappears.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "mine" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
+    mountBoard([mine], { entry: `/w/${WORKSPACE_ID}/board/all` })
+    await screen.findByText("My own topic.")
+    expect(screen.getByText("Clear filters")).toBeTruthy()
+  })
+
   it("offers an inline reply affordance on each post", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     await screen.findByText("Rotate the tokens before Friday.")

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -187,6 +187,11 @@ beforeEach(() => {
   vi.spyOn(contextsModule, "usePreferences").mockReturnValue({
     preferences: { timezone: "UTC", locale: "en-US" },
   } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+  // BoardPage resolves the home lens (bare `/board`) from the preferences
+  // context; default to All so existing cases keep their unsegmented meaning.
+  vi.spyOn(contextsModule, "usePreferencesOptional").mockReturnValue({
+    preferences: { boardDefaultLens: "all" },
+  } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
 })
 
 afterEach(() => vi.restoreAllMocks())
@@ -209,6 +214,21 @@ describe("BoardPage", () => {
     const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
     const notMine = { ...makePost({ id: "conv_other" }, { contentMarkdown: "Someone else's topic." }), isMine: false }
     mountBoard([mine, notMine], { entry: `/w/${WORKSPACE_ID}/board/mine` })
+
+    expect(await screen.findByText("My own topic.")).toBeTruthy()
+    expect(screen.queryByText("Someone else's topic.")).toBeNull()
+  })
+
+  it("lands the bare `/board` on the viewer's home-lens preference", async () => {
+    // boardDefaultLens picks which lens bare `/board` resolves to; here Mine, so
+    // the unsegmented URL filters down to the viewer's own conversations without
+    // a `/board/mine` segment.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "mine" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    const mine = { ...makePost({ id: "conv_mine" }, { contentMarkdown: "My own topic." }), isMine: true }
+    const notMine = { ...makePost({ id: "conv_other" }, { contentMarkdown: "Someone else's topic." }), isMine: false }
+    mountBoard([mine, notMine], { entry: `/w/${WORKSPACE_ID}/board` })
 
     expect(await screen.findByText("My own topic.")).toBeTruthy()
     expect(screen.queryByText("Someone else's topic.")).toBeNull()

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ThreadPanelSlot } from "@/components/layout"
 import { PanelHost } from "@/components/layout/panel-host"
 import { SidebarToggle } from "@/components/layout/sidebar-toggle"
-import { usePanel, useSidebar } from "@/contexts"
+import { usePanel, usePreferencesOptional, useSidebar } from "@/contexts"
 import { usePanelLayout } from "@/hooks"
 import { useFeatureFlagWhenKnown } from "@/hooks/use-feature-flags"
 import { resolveStreamName } from "@/lib/streams"
@@ -145,27 +145,28 @@ function groupByRecency(posts: BoardViewPost[], activityById: Map<string, number
  * The board: a cross-stream feed of posts (each conversation surfaced as a
  * message-led post) ordered by recent activity, grouped into recency sections.
  *
- * Route is `/w/:workspaceId/board/:lens?` — bare `/board` is **All**, the
- * default home: everything, always, never hidden behind a filter. The lens
- * segments (`/board/active`, `/board/needs-resolution`, `/board/decisions`)
- * are optional narrowings picked from the filter bar
+ * Route is `/w/:workspaceId/board/:lens?`. Bare `/board` rests on the viewer's
+ * **home lens** — the `boardDefaultLens` preference, `all` for everyone who
+ * hasn't changed it (everything, newest activity first, nothing hidden). The
+ * other lenses (`/board/active`, `/board/needs-resolution`, `/board/decisions`,
+ * `/board/mine`) are optional narrowings picked from the filter bar
  * (board-view-design.md § "Lenses"); the stream scope rides `?in=`. Refreshes,
- * back/forward, and shared links land on the same view (INV-59). `all`
- * canonicalises to the unsegmented URL (keeping the query string) so there
- * aren't two URLs for the default; an unknown segment redirects to it.
+ * back/forward, and shared links land on the same view (INV-59). Whichever lens
+ * is home canonicalises to the unsegmented URL (keeping the query string) so
+ * there aren't two URLs for it — so `all` takes the `/board/all` segment for a
+ * viewer whose home is some other lens. An unknown segment redirects to home.
  */
 export function BoardPage() {
   const { workspaceId, lens: lensParam } = useParams<{ workspaceId: string; lens?: string }>()
   const location = useLocation()
+  const preferences = usePreferencesOptional()
+  const homeLens = preferences?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
   if (!workspaceId) return null
-  if (lensParam === DEFAULT_BOARD_LENS) {
+  if (lensParam === homeLens || (lensParam !== undefined && !VALID_LENSES.has(lensParam))) {
     return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
   }
-  if (lensParam !== undefined && !VALID_LENSES.has(lensParam)) {
-    return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
-  }
-  const lens: BoardLens = (lensParam as BoardLens | undefined) ?? DEFAULT_BOARD_LENS
-  return <BoardPageGate workspaceId={workspaceId} lens={lens} />
+  const lens: BoardLens = (lensParam as BoardLens | undefined) ?? homeLens
+  return <BoardPageGate workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
 }
 
 /**
@@ -175,14 +176,22 @@ export function BoardPage() {
  * refreshes on /board before the bootstrap cache is populated. The backend
  * endpoint 404s without the flag too, so this is the UX half of the gate.
  */
-function BoardPageGate({ workspaceId, lens }: { workspaceId: string; lens: BoardLens }) {
+function BoardPageGate({ workspaceId, lens, homeLens }: { workspaceId: string; lens: BoardLens; homeLens: BoardLens }) {
   const boardFlag = useFeatureFlagWhenKnown(workspaceId, "board-view")
   if (boardFlag === null) return null
   if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
-  return <BoardPageInner workspaceId={workspaceId} lens={lens} />
+  return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
 }
 
-function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: BoardLens }) {
+function BoardPageInner({
+  workspaceId,
+  lens,
+  homeLens,
+}: {
+  workspaceId: string
+  lens: BoardLens
+  homeLens: BoardLens
+}) {
   const { isMobile } = useSidebar()
   const { isPanelOpen, closePanel } = usePanel()
   // The board's filters live in the URL (INV-59) — six params, three dimensions
@@ -439,9 +448,15 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
   }
 
   const navigate = useNavigate()
-  // Every route back to the unfiltered home keeps the non-filter query state
-  // (an open `?panel=` must survive clearing filters).
-  const boardHome = { pathname: `/w/${workspaceId}/board`, search: boardHomeSearch(searchParams.toString()) }
+  // The surfacing baseline is **All**, not the home lens: a fresh post is no
+  // Decision (and needn't be Active), so only the widest lens guarantees the
+  // author's own card appears (design § "your own action always surfaces"). All
+  // rests at bare `/board` unless the viewer's home is another lens, in which
+  // case All takes the `/board/all` segment. The non-filter query state (an open
+  // `?panel=`) rides along so it survives clearing filters.
+  const allPathname =
+    homeLens === DEFAULT_BOARD_LENS ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${DEFAULT_BOARD_LENS}`
+  const boardHome = { pathname: allPathname, search: boardHomeSearch(searchParams.toString()) }
   const hasFilterParams =
     scopeStreamIds.length > 0 ||
     scopeStreamTypes.length > 0 ||
@@ -635,6 +650,7 @@ function BoardPageInner({ workspaceId, lens }: { workspaceId: string; lens: Boar
       <BoardFilterBar
         workspaceId={workspaceId}
         lens={lens}
+        homeLens={homeLens}
         scopeStreamIds={scopeStreamIds}
         excludeStreamIds={excludeStreamIds}
         onStreamFilterChange={setStreamFilter}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -63,6 +63,12 @@ import {
 
 const VALID_LENSES = new Set<string>(BOARD_LENSES)
 
+/** Lenses that always contain the viewer's own fresh post: `all` (everything)
+ *  and `mine` (a self-authored conversation is `isMine`). The status/memo lenses
+ *  gate on classification a brand-new post may not have yet, so posting from
+ *  those routes back to All so the author's card always surfaces. */
+const SELF_POST_VISIBLE_LENSES = new Set<BoardLens>(["all", "mine"])
+
 /** How many leading cards' rails the reveal gate pre-warms before first paint.
  *  Covers the viewport with margin; cards past it mount against already-warm or
  *  fast-resolving rails below the fold, where late resolution can't shift
@@ -465,11 +471,14 @@ function BoardPageInner({
     scopeLabelIds.length > 0 ||
     excludeLabelIds.length > 0
   const handlePosted = () => {
-    // The viewer's own post must ALWAYS surface — but a filtered view might not
-    // match it (a fresh post is no Decision). Posting from a filtered board
-    // returns to the All home first; the reveal arm survives the view reset, so
-    // the authored card shows up top instead of hiding behind a filter.
-    if (lens !== DEFAULT_BOARD_LENS || hasFilterParams) {
+    // The viewer's own post must ALWAYS surface. It already shows where the
+    // current view can contain it — an unfiltered `all`/`mine` lens — so stay
+    // put there (a `mine` home shouldn't bounce the author off their own home).
+    // Any other view (a status/memo lens, or an active scope filter) might not
+    // match the fresh post, so return to the All baseline; the reveal arm
+    // survives the view reset and floats the authored card to the top.
+    const currentViewSurfacesOwnPost = SELF_POST_VISIBLE_LENSES.has(lens) && !hasFilterParams
+    if (!currentViewSurfacesOwnPost) {
       navigate(boardHome)
     }
     revealNext()

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -180,9 +180,13 @@ right, so split the dials in two:
 > `boardDefaultLens` preference — **All** for everyone who hasn't changed it. It
 > only moves the landing: every lens keeps its own URL (the home lens is the
 > segment-less one, so **All** takes `/board/all` for a viewer who homes
-> elsewhere), and **All** stays the surfacing baseline a fresh post returns to
-> (a brand-new post is no Decision and needn't be Active, so only the widest lens
-> guarantees the author sees their own card).
+> elsewhere), and the home lens is the viewer's baseline for filtered-state chrome
+> (no "Clear filters" on the plain home; "Clear filters" returns to it). The
+> surfacing rule ("your own action always surfaces") still routes a fresh post to
+> **All** — the only lens that always contains it — _unless_ the current view
+> already does: an unfiltered `all` or `mine` (a self-authored post is `isMine`).
+> A status/memo lens (`active`/`needs-resolution`/`decisions`) can't be trusted to
+> match a brand-new post, so posting from one still returns to All.
 
 - **All** (default) — everything, `lastActivityAt` desc. The resurfacing wall.
 - **Active** — `status = active`: still in motion, not stalled or resolved.

--- a/docs/board-view-design.md
+++ b/docs/board-view-design.md
@@ -176,6 +176,14 @@ right, so split the dials in two:
 
 **Structural lenses (same signal for everyone):**
 
+> **Per-user home lens (shipped):** which lens the bare `/board` opens on is the
+> `boardDefaultLens` preference — **All** for everyone who hasn't changed it. It
+> only moves the landing: every lens keeps its own URL (the home lens is the
+> segment-less one, so **All** takes `/board/all` for a viewer who homes
+> elsewhere), and **All** stays the surfacing baseline a fresh post returns to
+> (a brand-new post is no Decision and needn't be Active, so only the widest lens
+> guarantees the author sees their own card).
+
 - **All** (default) — everything, `lastActivityAt` desc. The resurfacing wall.
 - **Active** — `status = active`: still in motion, not stalled or resolved.
 - **Needs resolution** — `status = stalled`, or high `temporalStaleness` with

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -1,5 +1,6 @@
 import type { WorkSchedule } from "./work-schedule"
 import type { StatusPreset } from "./user-status"
+import { DEFAULT_BOARD_LENS, type BoardLens } from "./constants"
 
 // Workspace-scoped preferences that sync across devices.
 
@@ -275,6 +276,12 @@ export interface UserPreferences {
    */
   boardCardCollapseThreshold: number
   /**
+   * The lens the board lands on when the URL names no lens segment (bare
+   * `/board`). Defaults to `all`. This only picks the home; every lens still has
+   * its own URL, and `all` stays the surfacing baseline a fresh post returns to.
+   */
+  boardDefaultLens: BoardLens
+  /**
    * Preferred voice dictation model id (e.g. "elevenlabs:scribe-v2-realtime",
    * "deepgram:nova-3"). When null, the backend falls back to the configured
    * default. The string is validated server-side against the model registry.
@@ -338,6 +345,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
   messageCollapseThreshold: DEFAULT_MESSAGE_COLLAPSE_THRESHOLD,
   boardCardCollapseThreshold: DEFAULT_BOARD_CARD_COLLAPSE_THRESHOLD,
+  boardDefaultLens: DEFAULT_BOARD_LENS,
   voiceTranscriptionModel: null,
   voicePolishLevel: "opinionated",
   voiceSteeringWords: [],
@@ -368,6 +376,7 @@ export interface UpdateUserPreferencesInput {
   blockquoteCollapseThreshold?: number
   messageCollapseThreshold?: number
   boardCardCollapseThreshold?: number
+  boardDefaultLens?: BoardLens
   voiceTranscriptionModel?: string | null
   voicePolishLevel?: VoicePolishLevel
   voiceSteeringWords?: string[]


### PR DESCRIPTION
## Problem

Bare `/board` always opened on **All**. A user who lives in one lens — Active, or Mine — had to re-narrow on every visit; there was no way to make the board land where they actually work. `DEFAULT_BOARD_LENS` was a compile-time constant baked into routing, `lensHref`, and `savedViewHref`.

## Solution

Add a per-user `boardDefaultLens` preference (default **All**) that picks which lens bare `/board` rests on. The subtlety: when the home lens was hardcoded to All, one constant played two roles — the **home** (what the segment-less URL renders, and the viewer's baseline) and the **All surfacing baseline** (the widest lens a fresh post is guaranteed to appear in). Making home configurable splits them, threaded separately.

### How it works

- `BoardPage` (`apps/frontend/src/pages/board.tsx`) reads `homeLens` from `usePreferencesOptional()`, falling back to `DEFAULT_BOARD_LENS`. Bare `/board` renders `homeLens`; the home lens canonicalises to the segment-less URL (`lensParam === homeLens` redirects to bare `/board`); an unknown segment redirects to home.
- Because the home lens owns the bare URL, **All takes an explicit `/board/all` segment** for any viewer who homes elsewhere. `lensHref` and `savedViewHref` key the segment-less form off `homeLens`, so every lens keeps a canonical, shareable URL (INV-59).
- **Home is the viewer's baseline for filtered-state chrome.** The lens-menu trigger variant and both `isFiltered` predicates (filter bar + saved views) compare against `homeLens`, so a non-All home shows no permanent "Clear filters" / filled trigger on its own untouched landing; "Clear filters" returns to home.
- **The surfacing baseline is All, but posting only routes there when needed.** `handlePosted` stays put when the current view already contains a fresh self-post — an unfiltered `all`/`mine` (a self-authored conversation is `isMine`) — and returns to the All view (`/board/all` when home isn't All) only from a status/memo lens or a scoped view, where the post might not match.
- Preference plumbing follows the existing key-value override store — **no migration.** Backend validates with `z.enum(BOARD_LENSES)` and lists `boardDefaultLens` in `simpleKeys`; `mergeOverrides` already applies any key onto `DEFAULT_USER_PREFERENCES`.
- Settings exposes a "Board home" radio group in appearance settings. Lens copy comes from the shared `BOARD_LENS_DEFS` (INV-33), extracted to `apps/frontend/src/lib/board/lens-defs.ts` so the picker and the setting can't drift.

### Also in this PR — active saved-view indicator

Surfaced while dogfooding: saved views had **no active-state indicator** — opening one navigated to its lens+filters, but the picker only checkmarked the *base lens*, so a saved view never showed as selected. `isViewActive` (in `board-saved-views.tsx`) matches the board's live lens + every filter axis against each saved view (order-independent — URL params carry no order) and checkmarks/tints the one you're viewing, mirroring the lens list's selected styling. Pre-existing gap (saved views shipped in #1198); folded in here since it's the same surface. Archived isn't part of a saved view, so it doesn't participate in the match.

### Key design decisions

**1. Bare `/board` renders the home lens; All gets `/board/all` when it isn't home.** Every lens has one canonical URL; the home lens is the segment-less one. Keeps shared-link determinism (INV-59).

**2. Home is the chrome/clear baseline; All is the surfacing net.** "Clear filters" and filtered-state chrome key to `homeLens` (the user's declared default), so their home never reads as "filtered". Surfacing targets All — but only when the current view can't already show the post (`all`/`mine`, unfiltered), so a `mine` home doesn't bounce on every post.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/board/lens-defs.ts` | `BOARD_LENS_DEFS` (+ `BoardLensDef`) — single source of lens copy, read by the board picker and the settings control (INV-33) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/preferences.ts` | `boardDefaultLens: BoardLens` on the type / defaults / update input |
| `apps/backend/src/features/user-preferences/handlers.ts` · `service.ts` | `z.enum(BOARD_LENSES)` on the update schema + `simpleKeys` entry |
| `apps/frontend/src/pages/board.tsx` | Resolve `homeLens`; home-aware routing/canonicalisation; `SELF_POST_VISIBLE_LENSES` gates `handlePosted` |
| `apps/frontend/src/components/board/board-filter-bar.tsx` | `lensHref`/trigger/`isFiltered`/"Clear filters" key off `homeLens`; consume `BOARD_LENS_DEFS` |
| `apps/frontend/src/components/board/board-saved-views.tsx` | `savedViewHref(…, homeLens)`; home-aware `isFiltered`; `isViewActive` active-view indicator |
| `apps/frontend/src/components/settings/appearance-settings.tsx` | "Board home" radio group reading `BOARD_LENS_DEFS` |
| `docs/board-view-design.md` | Home lens / surfacing rule note under § "Lenses" |

## Out of scope (deliberate)

- **Saved-view-as-default** — making a full saved view (lens + filters) the default landing needs a new preference shape (view id + fallback when deleted); a distinct follow-up. This PR's preference stores only a lens.
- Item 5 (mobile composer) and move-to-sub-conversation remain the next board follow-ups; both flagged ask-before-building.

## Test plan

- [x] Backend `bun test src/features/user-preferences` — 11 pass
- [x] Frontend `board.test` — 18 pass (bare `/board` lands on the home lens; no "Clear filters" on the plain home; reappears once narrowed off home)
- [x] Frontend `board-saved-views` — 10 pass (home-aware `savedViewHref`; `isViewActive` match/mismatch)
- [x] Frontend `board-filter` / `appearance` / `use-streams` / `use-unread-counts` / `quick-links` — pass
- [x] `tsc --noEmit` + eslint clean; full pre-commit gate (all-app tsc + astro check + api-docs `--check`) passed on every commit
- [ ] No live Postgres in this env — the preference write is exercised via mock-based handler/service unit tests, not an integration round-trip. Staging click-through: set a non-All home, confirm bare `/board` lands there, "All" / "Clear filters" reach `/board/all` / home, posting from `mine` home doesn't bounce, and the open saved view shows its checkmark.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_