### PR TITLE
fix(backend): make DB pool pre-warm non-fatal so PR backends stop crash-looping

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -254,8 +254,21 @@ export async function startServer(): Promise<ServerInstance> {
   const configuredWarm = process.env.DATABASE_WARM_POOL_COUNT
   const warmCount = Math.min(configuredWarm ? Number(configuredWarm) : 15, Number(process.env.DATABASE_POOL_MAX) || 30)
   logger.info({ warmCount }, "Pre-warming connection pool...")
-  await warmPool(pools.main, warmCount)
-  logger.info("Connection pool pre-warmed")
+  // Best-effort: pre-warming is a cold-start optimization, never a boot gate. On
+  // a shared-DB PR deploy the server can be at its connection cap, and warmPool
+  // holds `warmCount` connections at once — the first demand for multiple slots,
+  // so it's where a saturated server first bites. Letting it throw here escapes
+  // the top-level `await startServer()` as an unhandledRejection and the process
+  // exits before it ever binds a port; the supervisor restarts it and every
+  // restart re-storms connect(), so the pool never drains and the backend
+  // crash-loops without serving. Boot regardless; the pool fills lazily and a
+  // healthy, listening instance lets the storm subside.
+  try {
+    await warmPool(pools.main, warmCount)
+    logger.info("Connection pool pre-warmed")
+  } catch (err) {
+    logger.warn({ err, warmCount }, "Connection pool pre-warm failed — continuing; pool will fill on demand")
+  }
 
   const workosOrgService = config.useStubAuth ? new StubWorkosOrgService() : new WorkosOrgServiceImpl(config.workos)
   const storage = createS3Storage(config.s3)


### PR DESCRIPTION
## Problem

Staging PR-preview backends were crash-looping at boot and never serving a single request. `startServer()` runs as a top-level `await` in `apps/backend/src/index.ts:10`. Inside it, `warmPool(pools.main, warmCount)` (`apps/backend/src/server.ts:257`) is the first code to hold several DB connections at once. Against the connection-saturated shared staging Postgres it hit pg-pool's `connectionTimeoutMillis` (10000ms in `DEFAULT_POOL_CONFIG`, `packages/backend-common/src/db/index.ts:35`) and threw `timeout exceeded when trying to connect`.

That rejection escaped the top-level await as an unhandledRejection — and the `process.on("unhandledRejection", …)` handler in `index.ts` is registered *after* the `await startServer()`, so it never caught it. The process exited before binding a port, the supervisor restarted it, and every restart re-stormed `connect()` — so the shared pool never drained and the backend crash-looped without ever listening.

Railway logs from one shared DB confirm the shape: over ~4h, **45 boot attempts**, migrations completing every time (single sequential connection), but **42 pre-warm timeouts** and **0 "Server listening"** — across **3 backend services / 7 deployments**, all dying at the identical `warmPool` chokepoint.

#1237 fixed the deploy *job* (psql retries, the Microsoft-apt flake, smaller per-instance pools) so CI goes green — but it never made *boot* survive a saturated server. The failure moved from a red deploy everyone notices to a green deploy with a silently crash-looping preview, which is the regression this fixes.

## Solution

Wrap the pre-warm in try/catch. Pre-warming is a cold-start optimization (avoiding a thundering-herd cold pool when workers start), never a boot gate — so on failure, log a warning and keep booting. The server then binds its port and serves even if warm-up couldn't grab connections; the pool fills lazily on demand, and a healthy, listening instance lets the supervisor stop restarting it so the connection storm subsides.

```ts
try {
  await warmPool(pools.main, warmCount)
  logger.info("Connection pool pre-warmed")
} catch (err) {
  logger.warn({ err, warmCount }, "Connection pool pre-warm failed — continuing; pool will fill on demand")
}
```

`runMigrations(pool)` at `server.ts:244` already proves basic DB connectivity before this block, so the catch only masks the specific saturation race it targets — a permanent auth/network failure still fails earlier and uncaught. `warmPool` releases any partially-acquired clients in its own `finally` (`packages/backend-common/src/db/index.ts`), so the new catch path leaks no connections.

Not a silent fallback (INV-11): the failure is logged loudly at `warn`, and no default value is substituted — the code just skips an optimization. `DATABASE_WARM_POOL_COUNT` remains the operator knob (staging PR backends set it to `2`; `"0"` disables warm-up entirely), now purely a cold-start-latency setting that can no longer wedge boot.

## Out of scope (deliberate)

The root pressure — the shared staging Postgres sitting at its connection cap as PR environments accumulate — is operational, not fixable from app code here. This change stops the crash-loop and breaks the self-reinforcing storm; if enough previews stay live, individual queries can still hit the 10s timeout. Follow-up worth considering: raise `max_connections` on the shared server, or tighten PR-env teardown. Not touched in this PR.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/server.ts` | Wrap `warmPool` pre-warm in try/catch so a connection-timeout during warm-up logs a warning and continues instead of crashing boot. |

## Test plan

- [x] `bun run --filter '@threa/backend' typecheck` — clean (exit 0)
- [x] Full pre-commit hook on commit — all-workspace lint + typecheck, `check:migrations` (193 clean), `check:dockerfiles`, astro check — all pass
- [x] Pre-PR review (1 combined Sonnet reviewer, backend-only diff): correctness, data-flow, CLAUDE.md (INV-11/25/34/36/38), design, security — **no findings ≥80**
- [ ] No boot-time integration harness for `startServer()` against a saturated pool, so the crash-loop path isn't exercised by an automated test — verified by reading the top-level-await → unhandledRejection crash path in `index.ts` and confirming the catch keeps boot proceeding to `server.listen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015mJtJ8xdhqGiq1jECVshtq)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786106099&installation_id=129946197&pr_number=1243&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1243&signature=d028217ad2ff15d2f045dff31d74a482fd1ab406decb8b5b3141ee41d15edbad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->