### PR TITLE
perf(board): seed saved lenses from the workspace bootstrap payload

### DIFF
--- a/apps/backend/src/features/workspaces/handlers.ts
+++ b/apps/backend/src/features/workspaces/handlers.ts
@@ -7,6 +7,7 @@ import type { WorkspaceSettingsService } from "../workspace-settings"
 import type { FeatureFlagService } from "../feature-flags"
 import type { PlatformAdminService } from "../platform-admin"
 import type { SidebarConfigService } from "../sidebar-config"
+import type { BoardViewService } from "../board-views"
 import type { InvitationService } from "../invitations"
 import type { WorkspaceIntegrationService } from "../workspace-integrations"
 import type { ActivityService } from "../activity"
@@ -62,6 +63,7 @@ interface Dependencies {
   featureFlagService: FeatureFlagService
   platformAdminService: PlatformAdminService
   sidebarConfigService: SidebarConfigService
+  boardViewService: BoardViewService
   invitationService: InvitationService
   workspaceIntegrationService: WorkspaceIntegrationService
   activityService?: ActivityService
@@ -81,6 +83,7 @@ export function createWorkspaceHandlers({
   featureFlagService,
   platformAdminService,
   sidebarConfigService,
+  boardViewService,
   invitationService,
   workspaceIntegrationService,
   activityService,
@@ -162,6 +165,7 @@ export function createWorkspaceHandlers({
         featureFlags,
         viewerIsPlatformAdmin,
         sidebarConfig,
+        boardViews,
         dmPeers,
         labels,
         labelAssignments,
@@ -178,6 +182,7 @@ export function createWorkspaceHandlers({
         featureFlagService.getFlags(workspaceId, userId),
         platformAdminService.hasAccess(workspaceId, req.user!.workosUserId),
         sidebarConfigService.getConfig(workspaceId, userId),
+        boardViewService.list(workspaceId, userId),
         streamService.listDmPeers(workspaceId, userId),
         labelService.listForActor(workspaceId, userId),
         labelAssignmentService.listForViewer(workspaceId, { type: LabelActorTypes.USER, id: userId }),
@@ -296,6 +301,7 @@ export function createWorkspaceHandlers({
           workspaceSettings,
           featureFlags,
           sidebarConfig,
+          boardViews,
           labels,
           labelAssignments,
           invitations,

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -238,6 +238,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const authHandlers = createAuthHandlers()
   const avatarUpload = createAvatarUploadMiddleware()
   const commandAvailabilityService = new CommandAvailabilityService({ pool, commandRegistry })
+  const boardViewService = new BoardViewService(pool)
   const workspace = createWorkspaceHandlers({
     workspaceService,
     streamService,
@@ -246,6 +247,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
     featureFlagService,
     platformAdminService,
     sidebarConfigService,
+    boardViewService,
     invitationService,
     workspaceIntegrationService,
     activityService,
@@ -290,7 +292,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
   const preferences = createUserPreferencesHandlers({ userPreferencesService })
   const workspaceSettings = createWorkspaceSettingsHandlers({ workspaceSettingsService })
   const sidebarConfig = createSidebarConfigHandlers({ sidebarConfigService })
-  const boardView = createBoardViewHandlers({ boardViewService: new BoardViewService(pool), featureFlagService })
+  const boardView = createBoardViewHandlers({ boardViewService, featureFlagService })
   const userE2eKeys = createUserE2eKeysHandlers({ userE2eKeysService })
   const aiUsage = createAIUsageHandlers({ pool })
   const debug = createDebugHandlers({ pool, poolMonitor })

--- a/apps/frontend/src/contexts/index.ts
+++ b/apps/frontend/src/contexts/index.ts
@@ -17,6 +17,7 @@ export {
   type StreamService,
   type MessageService,
   type ConversationService,
+  type BoardViewService,
   type ActivityService,
   type SavedService,
   type SavedSuggestionsService,

--- a/apps/frontend/src/hooks/use-board-views.test.tsx
+++ b/apps/frontend/src/hooks/use-board-views.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { createElement, type ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { BoardView, WorkspaceBootstrap } from "@threa/types"
+import { ServicesProvider, type BoardViewService } from "@/contexts"
+import { workspaceKeys } from "./use-workspaces"
+import { useBoardViews } from "./use-board-views"
+
+const mockList = vi.fn<BoardViewService["list"]>()
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(ServicesProvider, {
+        services: { boardViews: { list: mockList } as unknown as BoardViewService } as never,
+        children,
+      })
+    )
+  }
+}
+
+const view = (over: Partial<BoardView> = {}): BoardView => ({
+  id: "boardview_1",
+  name: "Design work",
+  baseLens: "mine",
+  scopeStreamIds: [],
+  scopeStreamTypes: [],
+  scopeLabelIds: [],
+  excludeStreamIds: [],
+  excludeStreamTypes: [],
+  excludeLabelIds: [],
+  sortOrder: 0,
+  ...over,
+})
+
+function seedBootstrap(queryClient: QueryClient, boardViews: BoardView[] | undefined) {
+  queryClient.setQueryData(workspaceKeys.bootstrap("ws_1"), { boardViews } as Partial<WorkspaceBootstrap>)
+}
+
+beforeEach(() => {
+  mockList.mockReset()
+})
+
+describe("useBoardViews", () => {
+  it("paints the saved lenses from the bootstrap payload without an on-mount fetch", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const seeded = [view(), view({ id: "boardview_2", name: "Mine" })]
+    seedBootstrap(queryClient, seeded)
+
+    const { result } = renderHook(() => useBoardViews("ws_1"), { wrapper: wrapper(queryClient) })
+
+    expect(result.current.data).toEqual(seeded)
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it("falls through to the fetch when the bootstrap snapshot lacks the field", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    seedBootstrap(queryClient, undefined)
+    const fetched = [view({ id: "boardview_fetched" })]
+    mockList.mockResolvedValue(fetched)
+
+    const { result } = renderHook(() => useBoardViews("ws_1"), { wrapper: wrapper(queryClient) })
+
+    await waitFor(() => expect(result.current.data).toEqual(fetched))
+    expect(mockList).toHaveBeenCalledWith("ws_1")
+  })
+})

--- a/apps/frontend/src/hooks/use-board-views.test.tsx
+++ b/apps/frontend/src/hooks/use-board-views.test.tsx
@@ -54,6 +54,10 @@ describe("useBoardViews", () => {
 
     expect(result.current.data).toEqual(seeded)
     expect(mockList).not.toHaveBeenCalled()
+    // The seed inherits the bootstrap's fetch time, not the query's mount time,
+    // so the staleTime window counts from the real fetch (guards INV-53).
+    const bootstrapUpdatedAt = queryClient.getQueryState(workspaceKeys.bootstrap("ws_1"))?.dataUpdatedAt
+    expect(result.current.dataUpdatedAt).toBe(bootstrapUpdatedAt)
   })
 
   it("falls through to the fetch when the bootstrap snapshot lacks the field", async () => {

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -19,7 +19,12 @@ export const boardViewKeys = {
  * saved lenses so the picker paints populated instead of flashing empty for the
  * on-mount fetch. `initialData` only primes an empty cache entry, so a save/
  * update/delete invalidation still refetches; an older bootstrap snapshot lacking
- * the field falls through to the fetch.
+ * the field falls through to the fetch. `initialDataUpdatedAt` inherits the
+ * bootstrap's actual fetch time (not the seeded query's mount time), so the 60s
+ * `staleTime` counts from when the data was really fetched — otherwise a board
+ * opened long after login would read fresh-at-mount and `refetchOnReconnect`
+ * (which only fires when stale) couldn't close the multi-device gap (INV-53).
+ * Mirrors `useStreamContextBag`.
  */
 export function useBoardViews(workspaceId: string) {
   const boardViews = useBoardViewService()
@@ -28,6 +33,7 @@ export function useBoardViews(workspaceId: string) {
     queryKey: boardViewKeys.list(workspaceId),
     queryFn: () => boardViews.list(workspaceId),
     initialData: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.boardViews,
+    initialDataUpdatedAt: () => queryClient.getQueryState(workspaceKeys.bootstrap(workspaceId))?.dataUpdatedAt,
     staleTime: 60_000,
     refetchOnReconnect: true,
   })

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
+import type { WorkspaceBootstrap } from "@threa/types"
 import { useBoardViewService } from "@/contexts"
+import { workspaceKeys } from "@/hooks/use-workspaces"
 import type { SaveBoardViewInput, UpdateBoardViewInput } from "@/api"
 
 export const boardViewKeys = {
@@ -12,12 +14,20 @@ export const boardViewKeys = {
  * per-viewer config, so it rides React-Query with cache invalidation (the
  * sidebar_configs house style), not the IDB sync engine. `refetchOnReconnect`
  * closes the multi-device gap (INV-53).
+ *
+ * Seeds from the workspace bootstrap payload (`boardViews`), which carries the
+ * saved lenses so the picker paints populated instead of flashing empty for the
+ * on-mount fetch. `initialData` only primes an empty cache entry, so a save/
+ * update/delete invalidation still refetches; an older bootstrap snapshot lacking
+ * the field falls through to the fetch.
  */
 export function useBoardViews(workspaceId: string) {
   const boardViews = useBoardViewService()
+  const queryClient = useQueryClient()
   return useQuery({
     queryKey: boardViewKeys.list(workspaceId),
     queryFn: () => boardViews.list(workspaceId),
+    initialData: () => queryClient.getQueryData<WorkspaceBootstrap>(workspaceKeys.bootstrap(workspaceId))?.boardViews,
     staleTime: 60_000,
     refetchOnReconnect: true,
   })

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -35,6 +35,7 @@ import type {
   WorkspaceInvitation,
   Persona,
   Bot,
+  BoardView,
 } from "./domain"
 import type { UserPreferences } from "./preferences"
 import type { WorkspaceSettings } from "./workspace-settings"
@@ -1405,6 +1406,13 @@ export interface WorkspaceBootstrap {
   userPreferences: UserPreferences
   /** Viewer's persisted sidebar layout for this workspace (defaults to the Smart preset). */
   sidebarConfig: SidebarConfig
+  /**
+   * Viewer's saved board lenses, so the lens picker paints populated instead of
+   * fetching on board mount (board-view-design.md § "Lenses"). Seeds the
+   * `board-views` React-Query cache. Optional: snapshots cached before the field
+   * shipped lack it (absent → the board falls back to its own fetch).
+   */
+  boardViews?: BoardView[]
   /** The viewer's own labels (every label is private to its creator). */
   labels: Label[]
   /**


### PR DESCRIPTION
## Problem

The board lens / saved-views picker rode `useBoardViews` — a `useQuery` that fetched the viewer's saved lenses on board mount (`apps/frontend/src/hooks/use-board-views.ts`). So the picker flashed empty for ~1s on every first board open while that request resolved, even though every other low-frequency per-viewer config the board needs (`sidebarConfig`) already arrives in the workspace bootstrap the user has already waited for.

## Solution

Fold the viewer's saved board views into the workspace bootstrap payload — the same shape `sidebarConfig` already uses — and seed the `board-views` React-Query cache from it via `initialData`. The picker paints populated with no extra round-trip; the separate on-mount fetch is gone for the common case.

### How it works

- `WorkspaceBootstrap.boardViews?: BoardView[]` (`packages/types/src/api.ts`). Optional: a bootstrap snapshot cached in IDB/React-Query before this field shipped lacks it, and must degrade to the old fetch rather than render an empty picker.
- The bootstrap handler assembles it via `boardViewService.list(workspaceId, userId)` in the existing `Promise.all`, inserted right after the `sidebarConfig` pair so the destructure stays aligned, and returns it in `data` (`apps/backend/src/features/workspaces/handlers.ts`). The service already scopes the query to `(workspace_id, user_id)`.
- `routes.ts` hoists `const boardViewService = new BoardViewService(pool)` and shares the one instance between the workspace handlers and the board-view handlers (previously the board-view handlers constructed their own inline) — INV-13, construct long-lived collaborators once.
- `useBoardViews` seeds from the bootstrap query cache via `initialData`, paired with `initialDataUpdatedAt` reading the bootstrap query state's `dataUpdatedAt` (see the review note below). `initialData` only primes an empty cache entry, so a `useSaveBoardView` / `useUpdateBoardView` / `useDeleteBoardView` invalidation still refetches, and `refetchOnReconnect: true` still closes the multi-device gap (INV-53). When the getter returns `undefined` (bootstrap not yet cached, or an old snapshot), the query falls through to its normal `queryFn` fetch.
- `apps/frontend/src/contexts/index.ts` re-exports the `BoardViewService` type (like its sibling service types) so the hook's new test can import it.

## Files changed

| File | Change |
| ---- | ------ |
| `packages/types/src/api.ts` | `boardViews?: BoardView[]` on `WorkspaceBootstrap` (+ `BoardView` import) |
| `apps/backend/src/features/workspaces/handlers.ts` | Assemble `boardViews` in the bootstrap `Promise.all` + response; add `boardViewService` dep |
| `apps/backend/src/routes.ts` | Hoist `BoardViewService`, share it between workspace + board-view handlers |
| `apps/frontend/src/hooks/use-board-views.ts` | Seed `useBoardViews` from the bootstrap cache via `initialData` + `initialDataUpdatedAt` |
| `apps/frontend/src/contexts/index.ts` | Re-export the `BoardViewService` type |
| `apps/frontend/src/hooks/use-board-views.test.tsx` | New — seeds from bootstrap (inheriting its `dataUpdatedAt`) without fetching; falls through when the field is absent |

## Out of scope (deliberate)

- No change to the board-view REST endpoints, service query, or repository — the list is reused as-is, only surfaced earlier.
- Old cached bootstrap snapshots keep working via the fetch fallback; no migration or cache-version bump.

## Test plan

- [x] `apps/frontend` — `use-board-views.test.tsx` (2 pass: seeds from bootstrap with no `list` call and inherits the bootstrap's `dataUpdatedAt`; falls through to fetch when the snapshot lacks the field)
- [x] `apps/frontend` — `board-saved-views.test.tsx` (6 pass) + `board.test.tsx` (15 pass) unchanged and green
- [x] Full pre-commit gate on both commits: prettier + all-workspace eslint + `tsc --noEmit` across all 14 workspaces + dockerfile/migration checks — clean
- [ ] Backend `board-views` handler test is a live-Postgres integration test (ECONNREFUSED in this sandbox); untouched by this change (the service/repo are reused unchanged), so covered by the existing suite in CI rather than re-run here
- [ ] Not driven against a live authed board in-session (no auth/data harness); the seeding path is exercised by the new unit tests instead

## Pre-PR review (`/code-review`, 3 sonnet reviewers: spec+design, correctness+data-flow, UX)

1 finding fixed, 0 dismissed. The UX lens (corroborated by the spec lens as a sub-threshold note) caught that the `initialData` seed omitted `initialDataUpdatedAt`, so React-Query stamped it fresh at query-mount time instead of the bootstrap's real fetch time — a board opened long after login would extend the 60s `staleTime` from the wrong origin and defeat `refetchOnReconnect` (which only refetches when stale), undermining the INV-53 multi-device claim in the hook's own docstring. Fixed in the second commit by pairing `initialData` with `initialDataUpdatedAt: () => queryClient.getQueryState(...)?.dataUpdatedAt`, mirroring `useStreamContextBag`. No correctness, data-flow, security, or CLAUDE.md findings; destructure alignment in the bootstrap `Promise.all` and workspace+user scoping of the surfaced list both confirmed clean.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01386yumEnFXyhtskvskVaWC)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786108919&installation_id=129946197&pr_number=1244&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1244&signature=156d9e7b9f38cc3370960fa32ee22f480e27ba1adb627643aebafd77e80359fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->