### PR TITLE
fix(board): align conversation-view row padding with the timeline

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -24,6 +24,7 @@ import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as inlineComposerModule from "@/components/board/board-inline-composer"
 import { spyOnExport } from "@/test/spy"
+import { MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 
 const WS = "ws_1"
 const STREAM = "stream_1"
@@ -475,6 +476,34 @@ describe("BoardCard collapse", () => {
       expect(screen.queryByText("Opening body.")).toBeNull()
     } finally {
       restore()
+    }
+  })
+})
+
+describe("BoardCard row layout", () => {
+  beforeEach(() => {
+    vi.spyOn(conversationReadModule, "useConversationReadController").mockReturnValue({
+      value: readValue,
+      hasUnread: () => false,
+      markReadSilently: () => Promise.resolve(),
+      setExplicitUnreadListener: () => {},
+      getReadTruth: () => ({ lastReadSequence: null, readMessageIds: [] }),
+    })
+  })
+
+  // The board row must carry the same vertical rhythm as the timeline
+  // (MessageEvent), applied to the *accent* row so a persona/bot tint band stays
+  // contiguous across a group — not on the outer wrapper as a margin, which
+  // reintroduces the between-block gaps this alignment removed (INV-35).
+  it("applies the shared message-row padding to the accent row, not the wrapper", async () => {
+    mountCard()
+    const wrapper = (await screen.findByText("Opening body.")).closest("[data-message-row]")
+    expect(wrapper).toBeTruthy()
+    expect(wrapper!.className).not.toMatch(/(^|\s)mt-/)
+    const accent = wrapper!.querySelector(".reveal-host")
+    expect(accent).toBeTruthy()
+    for (const cls of MESSAGE_ROW_HEAD_PADDING.split(" ")) {
+      expect(accent!.className).toContain(cls)
     }
   })
 })

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -589,7 +589,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
 
           {!bodyCollapsed && (
             <>
-              <div ref={bodyRef} className="mt-3 [&>*:first-child]:mt-0">
+              <div ref={bodyRef}>
                 {provenance && (
                   <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
                 )}

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -187,9 +187,12 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
 export function BranchProvenanceRow({ conversationId, title }: { conversationId: string; title: string }) {
   const { getPanelUrl } = usePanel()
   return (
+    // Leads the card/panel message list; carries its own top gap (like the
+    // sibling ContinueThreadRow) since the rows below self-space via their
+    // internal padding and the container no longer adds a leading margin.
     <Link
       to={getPanelUrl(createConversationPanelId(conversationId))}
-      className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
     >
       <GitBranch className="h-3.5 w-3.5 shrink-0" />
       <span className="truncate">Branched from {title}</span>

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -498,7 +498,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         conversationId={conversation.id}
         conversationRootStreamId={conversation.streamId}
         isHighlighted={message.id === highlightMessageId}
-        surfaceClassName="bg-background"
+        // Break the row out of the list's px-4 and re-pad it, so an actor accent
+        // fills to the panel edges (the stream-view look) with content aligned —
+        // matching the board card and timeline.
+        surfaceClassName="bg-background px-4"
+        rowInsetClassName="-mx-4"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
       />
     )
@@ -560,7 +564,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       <QuoteReplyProvider>
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
-        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-3 [&>*:first-child]:mt-0">
+        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 pb-3">
           {provenance && (
             <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
           )}

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -11,6 +11,7 @@ import {
 } from "@threa/types"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
+import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 import { RelativeTime } from "@/components/relative-time"
 import { MarkdownContent, AttachmentProvider } from "@/components/ui/markdown-content"
 import { CollapsibleBody, useMessageCollapseThreshold } from "@/lib/markdown/collapsible-body"
@@ -635,7 +636,7 @@ export function MessageItem({
         data-author-id={message.authorId}
         data-actor-type={message.authorType}
         className={cn(
-          "relative mt-0.5 scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
+          "relative scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
           rowInsetClassName
         )}
         {...touchHandlers}
@@ -644,6 +645,7 @@ export function MessageItem({
         <div
           className={cn(
             "group reveal-host relative flex gap-3",
+            MESSAGE_ROW_CONTINUATION_PADDING,
             surfaceClassName,
             theme.rowAccent,
             longPress.isPressed && "opacity-70 transition-opacity",
@@ -687,7 +689,7 @@ export function MessageItem({
       data-author-id={message.authorId}
       data-actor-type={message.authorType}
       className={cn(
-        "relative mt-3 scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
+        "relative scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
         rowInsetClassName
       )}
       {...touchHandlers}
@@ -696,6 +698,7 @@ export function MessageItem({
       <div
         className={cn(
           "group reveal-host relative flex items-start gap-3",
+          MESSAGE_ROW_HEAD_PADDING,
           surfaceClassName,
           theme.rowAccent,
           longPress.isPressed && "opacity-70 transition-opacity",

--- a/apps/frontend/src/components/message/message-row-layout.ts
+++ b/apps/frontend/src/components/message/message-row-layout.ts
@@ -1,0 +1,16 @@
+/**
+ * Vertical rhythm for a message row, shared by every surface that renders a
+ * message: the stream timeline (`MessageEvent`) and the board card /
+ * conversation panel (`MessageItem`). Both apply it to the *accent* row (the
+ * element carrying `theme.rowAccent`) so a persona/bot tint band stays
+ * contiguous across a grouped run instead of breaking into separated blocks
+ * (INV-35) — the drift these constants exist to prevent.
+ *
+ * Heads keep a generous top pad to separate author groups, but a tight bottom
+ * pad so the gap from the head body to the first continuation body matches the
+ * cont-to-cont gap (4px). Group separation is carried by the next head's `pt-3`
+ * (2px + 12px = 14px between groups), consistent regardless of whether the
+ * previous group ended with a head or a continuation.
+ */
+export const MESSAGE_ROW_HEAD_PADDING = "pt-3 pb-0.5"
+export const MESSAGE_ROW_CONTINUATION_PADDING = "py-0.5"

--- a/apps/frontend/src/components/timeline/message-event.tsx
+++ b/apps/frontend/src/components/timeline/message-event.tsx
@@ -17,6 +17,7 @@ import { MessageContextBadge } from "@/components/composer"
 import { RelativeTime } from "@/components/relative-time"
 import { ActorAvatar } from "@/components/actor-avatar"
 import { actorRowTheme } from "@/components/message/actor-row-theme"
+import { MESSAGE_ROW_CONTINUATION_PADDING, MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 import { usePendingMessages, usePanel, createDraftPanelId, createConversationPanelId, useTrace } from "@/contexts"
 import { useUserProfile } from "@/components/user-profile"
 import { useDeleteMessage } from "@/hooks/use-delete-message"
@@ -664,14 +665,7 @@ function MessageLayout({
   // accessible name; heads already have a visible author label.
   const rowAriaLabel = renderAsContinuation ? `Message from ${actorName}` : undefined
   const rowDataGroupContinuation = renderAsContinuation ? "true" : undefined
-  // Heads keep a generous top pad to separate groups visually, but a tight
-  // bottom pad so the gap from the head body to the first continuation body
-  // matches the cont-to-cont gap (4px). Without this, heads with a follow-up
-  // continuation got 12px+2px = 14px below them and the first message in a
-  // group felt detached. Group separation is preserved by the next head's
-  // pt-3 (2px + 12px = 14px between groups, consistent regardless of whether
-  // the previous group ended with a head or a continuation).
-  const rowVerticalPadding = renderAsContinuation ? "py-0.5" : "pt-3 pb-0.5"
+  const rowVerticalPadding = renderAsContinuation ? MESSAGE_ROW_CONTINUATION_PADDING : MESSAGE_ROW_HEAD_PADDING
   const isSelected = batch?.selectedMessageIds.has(payload.messageId) ?? false
   const isInvalidTarget = batch?.invalidTargetIds.has(payload.messageId) ?? false
   const isHoveredTarget = batch?.hoveredTargetId === payload.messageId

--- a/apps/frontend/src/pages/label-detail.tsx
+++ b/apps/frontend/src/pages/label-detail.tsx
@@ -364,10 +364,11 @@ function MessagesSection({
   return (
     <div className="divide-y overflow-hidden rounded-xl border bg-card">
       {messages.map((message) => (
-        // Each labeled message is standalone, so zero the item's leading margin
-        // (which spaces stacked messages in a board card) and let the cell
-        // padding own the rhythm. The origin stream rides in the item's header.
-        <div key={message.id} className="px-4 py-3 [&>*]:mt-0">
+        // Each labeled message is standalone, so zero the row's internal
+        // vertical padding (which spaces stacked messages in a board card /
+        // timeline) via `surfaceClassName` and let the cell's own `py-3` own the
+        // rhythm. The origin stream rides in the item's header.
+        <div key={message.id} className="px-4 py-3">
           <MessageItem
             workspaceId={workspaceId}
             streamId={message.streamId}
@@ -375,6 +376,7 @@ function MessagesSection({
             authorName={getActorName(message.authorId, message.authorType)}
             currentUserId={currentUserId}
             streamLabel={resolveMessageStream(message.streamId)}
+            surfaceClassName="py-0"
           />
         </div>
       ))}


### PR DESCRIPTION
## Problem

Board cards and the conversation panel render messages through `MessageItem`; the stream timeline renders through `MessageEvent`. The two carried a message row's **vertical rhythm differently**:

- `MessageEvent` pads its *accent* row internally (`rowVerticalPadding = pt-3 pb-0.5` head / `py-0.5` continuation), so a persona/bot tint band (`theme.rowAccent`) stays **contiguous** across a grouped run.
- `MessageItem` put the spacing on the **outer wrapper** as a margin (`mt-3` head / `mt-0.5` continuation). The accent tint therefore broke into **separated tiles** with transparent gaps, and the group rhythm was 12/2px instead of the timeline's 14/4px.

The conversation panel also never broke its rows out to the surface edge, so a persona/bot accent **stripe** sat 16px in rather than flush like on the board card and timeline.

This is board-workstream **item 10** (conversation-view padding ≠ timeline) from `docs/board-timeline-drift-audit.md` — FE-only, no merge of `MessageItem`/`MessageEvent` (§7 scope guard forbids that; only the shared padding is unified).

## Solution

Extract the timeline's vertical-rhythm strings to one module both components consume, then move `MessageItem`'s spacing from the outer margin onto the accent row so the tint band is contiguous — and give the panel rows the same full-bleed inset the board and timeline already use.

### How it works

- **New `message-row-layout.ts`** exports `MESSAGE_ROW_HEAD_PADDING` (`pt-3 pb-0.5`) and `MESSAGE_ROW_CONTINUATION_PADDING` (`py-0.5`). `MessageEvent` (was an inline `rowVerticalPadding` ternary) and `MessageItem` both import them, so the two surfaces can't drift (INV-33/INV-35).
- **`MessageItem`** drops the outer `mt-3`/`mt-0.5` and applies the shared padding to the inner `.reveal-host` accent row (both head and continuation branches) → contiguous accent band, 14/4 rhythm identical to the timeline.
- **Containers** drop the now-redundant top margin / first-child reset: board `bodyRef` (`mt-3 [&>*:first-child]:mt-0` → none), panel list (`px-4 py-3 [&>*:first-child]:mt-0` → `px-4 pb-3`). The first row's own `pt-3` supplies the header→first-message gap, unchanged at 20px (board) / 12px (panel).
- **Conversation-panel primary rows** gain `rowInsetClassName="-mx-4"` + `surfaceClassName="bg-background px-4"`, so a persona/bot accent stripe reaches the panel edge (the `-mx-4` exactly cancels the list's `px-4`, no horizontal overflow — same box model the board card already ships). Nested branch rows stay inset, matching the board.

### Design evolution (self-review)

A 4-reviewer pre-PR pass (`/code-review`) caught two regressions from moving the rhythm off the outer margin, fixed in `59d4f97`:

1. **Leading `BranchProvenanceRow`.** When a card/panel is itself a branched sub-topic, `BranchProvenanceRow` — not a message row — leads the list. It carried no top spacing and relied on the container's now-removed top margin, so "Branched from …" jammed against the header (~0px). Fixed by giving it its own `mt-3`, matching the sibling `ContinueThreadRow`.
2. **Label-detail page.** `label-detail.tsx` (untouched by the first commit) wraps each `MessageItem` in a `px-4 py-3` bordered cell and used `[&>*]:mt-0` to zero the row's *outer* margin so the cell owned the rhythm. The rhythm now lives as internal accent-row padding the direct-child selector can't reach — every labeled row gained ~12px top (asymmetric 24/14). Fixed by passing `surfaceClassName="py-0"`, which tailwind-merge orders after the padding constant in `cn(...)` and so zeroes the internal padding, restoring the cell's symmetric `py-3`.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/message/message-row-layout.ts` | Shared message-row vertical-rhythm constants, consumed by `MessageEvent` and `MessageItem` (INV-33/35) |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/message/message-item.tsx` | Apply the shared padding to the accent row; drop the outer `mt-3`/`mt-0.5` |
| `apps/frontend/src/components/timeline/message-event.tsx` | Consume the shared constants instead of an inline `rowVerticalPadding` string |
| `apps/frontend/src/components/board/board-card.tsx` | `bodyRef` drops its redundant top margin / first-child reset |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Primary rows full-bleed (`-mx-4` + `px-4`); list drops top pad / first-child reset |
| `apps/frontend/src/components/board/branch-rows.tsx` | `BranchProvenanceRow` carries its own `mt-3` leading gap (review fix) |
| `apps/frontend/src/pages/label-detail.tsx` | Pass `surfaceClassName="py-0"` so the standalone label cell owns the rhythm (review fix) |
| `apps/frontend/src/components/board/board-card.test.tsx` | Guard test: the board row carries the shared padding on the accent element, not the wrapper |

## Out of scope (deliberate)

- **No merge of `MessageItem` / `MessageEvent`.** The drift audit §7 forbids it (independent action contexts, real theming drift). Only the vertical-rhythm constants are unified.
- **Nested branch rows stay inset**, not full-bleed — matching the board's existing treatment of branch replies.
- No collision with in-flight #1242 (item 6), which touches `board.tsx`/`board-filter-bar`/`board-saved-views`; this touches the row/render layer only.

## Test plan

- [x] Guard test added; `board-card.test.tsx` + `board-card.branches.test.tsx` + `conversation-panel.test.tsx` + `label-detail.test.tsx` — 46 pass
- [x] `timeline/` + `message/` suites — 461 pass (constant swap is byte-identical, no timeline regression)
- [x] `tsc --noEmit` (frontend) clean; eslint clean on all changed files
- [x] Full pre-commit gate (prettier + all-app eslint + 14-workspace `tsc`) green on both commits
- [x] Pre-PR review — 4 sonnet reviewers (spec+design, correctness+data-flow, UX, mobile): 2 findings, both fixed in `59d4f97`; mobile confirmed the `-mx-4` box model is overflow-safe
- [ ] Not rendered in a live browser — verified via jsdom component mounts + box-model reasoning against the timeline's shipped approach, not a visual screenshot

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013m3ooJZWyNXwWZjP6udXub)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786115875&installation_id=129946197&pr_number=1245&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1245&signature=94cecb2baa09927f82a9b77fd28465be5c45bbada816d244fd45a8698d2709ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->