### PR TITLE
fix(board): empty-state CTA on non-All home; DRY the filtered predicate

### DIFF
--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -28,6 +28,7 @@ import { BoardSavedViews, isViewActive, type BoardViewSelection } from "@/compon
 import { useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
+import { isBoardFiltered } from "@/lib/board/filter-state"
 import { cn } from "@/lib/utils"
 
 /** Stream types offered in the pickers: the board's root-stream grains (shared
@@ -143,14 +144,15 @@ export function BoardFilterBar({
   // The viewer's home lens is their baseline, so being on it (with no scope
   // narrowing) is NOT "filtered" — otherwise a non-All home shows a permanent
   // "Clear filters" affordance on its own untouched landing view.
-  const isFiltered =
-    lens !== homeLens ||
-    scopeStreamIds.length > 0 ||
-    excludeStreamIds.length > 0 ||
-    scopeStreamTypes.length > 0 ||
-    excludeStreamTypes.length > 0 ||
-    scopeLabelIds.length > 0 ||
-    excludeLabelIds.length > 0
+  const isFiltered = isBoardFiltered(homeLens, {
+    lens,
+    scopeStreamIds,
+    scopeStreamTypes,
+    scopeLabelIds,
+    excludeStreamIds,
+    excludeStreamTypes,
+    excludeLabelIds,
+  })
   const clearedSearch = useMemo(() => boardHomeSearch(location.search), [location.search])
 
   const labelFor = (streamId: string) =>

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -28,6 +28,9 @@ import {
   BOARD_EXCLUDE_TYPE_PARAM,
   BOARD_EXCLUDE_LABEL_PARAM,
 } from "@/components/board/board-filter-params"
+import { isBoardFiltered, type BoardViewSelection } from "@/lib/board/filter-state"
+
+export type { BoardViewSelection }
 
 /** Expand a saved view into the canonical board URL it bookmarks (INV-59). The
  *  viewer's home lens is the segment-less one, so a saved All view addresses
@@ -43,18 +46,6 @@ export function savedViewHref(workspaceId: string, view: BoardView, homeLens: Bo
   if (view.excludeLabelIds.length > 0) params.set(BOARD_EXCLUDE_LABEL_PARAM, view.excludeLabelIds.join(","))
   const qs = params.toString()
   return qs ? `${base}?${qs}` : base
-}
-
-/** The board's live view — lens plus every filter axis — matched against a saved
- *  view to mark which one you're currently looking at. */
-export interface BoardViewSelection {
-  lens: BoardLens
-  scopeStreamIds: string[]
-  scopeStreamTypes: BoardScopeStreamType[]
-  scopeLabelIds: string[]
-  excludeStreamIds: string[]
-  excludeStreamTypes: BoardScopeStreamType[]
-  excludeLabelIds: string[]
 }
 
 /** Order-independent membership equality — URL params carry no stable order, so
@@ -148,14 +139,15 @@ export function BoardSavedViews({
 
   // Only offer "save current view" when there's actually a narrowing to bookmark
   // — the viewer's plain home lens is nothing worth saving.
-  const isFiltered =
-    lens !== homeLens ||
-    scopeStreamIds.length > 0 ||
-    scopeStreamTypes.length > 0 ||
-    scopeLabelIds.length > 0 ||
-    excludeStreamIds.length > 0 ||
-    excludeStreamTypes.length > 0 ||
-    excludeLabelIds.length > 0
+  const isFiltered = isBoardFiltered(homeLens, {
+    lens,
+    scopeStreamIds,
+    scopeStreamTypes,
+    scopeLabelIds,
+    excludeStreamIds,
+    excludeStreamTypes,
+    excludeLabelIds,
+  })
 
   const submit = (name: string) => {
     if (editing?.id) update.mutate({ id: editing.id, input: { name } })

--- a/apps/frontend/src/lib/board/filter-state.ts
+++ b/apps/frontend/src/lib/board/filter-state.ts
@@ -1,0 +1,32 @@
+import type { BoardLens, BoardScopeStreamType } from "@threa/types"
+
+/** The board's live view — lens plus every filter axis — matched against a saved
+ *  view to mark which one you're currently looking at, and against the viewer's
+ *  home lens to decide whether the board is narrowed. */
+export interface BoardViewSelection {
+  lens: BoardLens
+  scopeStreamIds: string[]
+  scopeStreamTypes: BoardScopeStreamType[]
+  scopeLabelIds: string[]
+  excludeStreamIds: string[]
+  excludeStreamTypes: BoardScopeStreamType[]
+  excludeLabelIds: string[]
+}
+
+/** Is the board showing something narrower than the viewer's home? True when the
+ *  live lens differs from home or any include/exclude axis is populated. The home
+ *  lens is the baseline, so resting on it with no scope is NOT filtered — this
+ *  gates the "Clear filters" chrome, the "Save current view" affordance, and the
+ *  empty-state "Show everything" CTA, all of which must stay hidden on the plain
+ *  landing view of a non-All home. */
+export function isBoardFiltered(homeLens: BoardLens, selection: BoardViewSelection): boolean {
+  return (
+    selection.lens !== homeLens ||
+    selection.scopeStreamIds.length > 0 ||
+    selection.scopeStreamTypes.length > 0 ||
+    selection.scopeLabelIds.length > 0 ||
+    selection.excludeStreamIds.length > 0 ||
+    selection.excludeStreamTypes.length > 0 ||
+    selection.excludeLabelIds.length > 0
+  )
+}

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -258,6 +258,28 @@ describe("BoardPage", () => {
     expect(screen.getByText("Clear filters")).toBeTruthy()
   })
 
+  it("shows the empty state without a 'Show everything' CTA on the plain home lens", async () => {
+    // Empty `/board` with a Mine home is the baseline coming up empty, not a
+    // filtered view — the lens empty copy shows, but the "Show everything" CTA
+    // (which reads as "you've narrowed something") must not.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "mine" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board` })
+    expect(await screen.findByText("Nothing here for you yet")).toBeTruthy()
+    expect(screen.queryByText("Show everything")).toBeNull()
+  })
+
+  it("shows 'Show everything' on an empty view narrowed off the home lens", async () => {
+    // Home is Mine; empty `/board/all` is a narrowing away from baseline, so the
+    // empty state offers the one-tap way back home.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "mine" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    mountBoard([], { entry: `/w/${WORKSPACE_ID}/board/all` })
+    expect(await screen.findByText("Show everything")).toBeTruthy()
+  })
+
   it("offers an inline reply affordance on each post", async () => {
     mountBoard([makePost({}, { contentMarkdown: "Rotate the tokens before Friday." })])
     await screen.findByText("Rotate the tokens before Friday.")

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -37,6 +37,7 @@ import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
+import { isBoardFiltered } from "@/lib/board/filter-state"
 import {
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
@@ -624,8 +625,19 @@ function BoardPageInner({
     } else {
       // A filtered-empty view is the FILTERS coming up empty, never the board
       // hiding things — so it always offers the one-tap way back to everything.
+      // Filtered is measured against the viewer's home lens, so a non-All home's
+      // own empty landing view shows the empty copy without a "Show everything"
+      // CTA (it's already at baseline).
       const scoped = hasFilterParams
-      const isFiltered = lens !== DEFAULT_BOARD_LENS || scoped
+      const isFiltered = isBoardFiltered(homeLens, {
+        lens,
+        scopeStreamIds,
+        scopeStreamTypes,
+        scopeLabelIds,
+        excludeStreamIds,
+        excludeStreamTypes,
+        excludeLabelIds,
+      })
       const copy = scoped ? SCOPED_EMPTY_COPY : LENS_EMPTY_COPY[lens]
       stateContent = (
         <div className="flex flex-col items-center justify-center gap-2 px-6 py-16 text-center">


### PR DESCRIPTION
## Problem

When per-user `boardDefaultLens` shipped (#1242), "filtered" became relative to the viewer's **home lens**, not the global `DEFAULT_BOARD_LENS`. Three sites decide whether the board is filtered, but one was missed: the empty-state CTA in `apps/frontend/src/pages/board.tsx`.

```ts
const isFiltered = lens !== DEFAULT_BOARD_LENS || scoped
```

A Mine-home user landing on their own empty `/board` (lens `mine`, no scope filters) is at baseline, yet `mine !== DEFAULT_BOARD_LENS` made `isFiltered` true — so the empty state showed a **"Show everything"** CTA that reads as "you've narrowed something down." The empty *copy* was already correct (keyed on `scoped`); only the CTA was wrong. Flagged by CodeRabbit post-merge on #1242.

The three predicates were also drifting by construction — three hand-inlined copies of the same lens-plus-six-axes check (`board-filter-bar.tsx`, `board-saved-views.tsx`, `board.tsx`), which is exactly what let one fall out of sync.

## Solution

Extract the predicate once and use it at all three sites so it can't drift again.

### How it works

- New `apps/frontend/src/lib/board/filter-state.ts` exports `isBoardFiltered(homeLens, selection)` and the `BoardViewSelection` type (moved here from `board-saved-views.tsx`). The predicate is `selection.lens !== homeLens || <any include/exclude axis non-empty>` — home lens is the baseline, so resting on it with no scope is not filtered.
- `board.tsx` empty state now calls `isBoardFiltered(homeLens, { lens, ...six axes })` instead of `lens !== DEFAULT_BOARD_LENS || scoped`. This fixes the CTA. The empty *copy* still keys off `scoped` (`hasFilterParams`) as before — a lens-empty view and a filter-empty view read differently.
- `board-filter-bar.tsx` (the "Clear filters" chrome) and `board-saved-views.tsx` (the "Save current view" affordance) call the same helper in place of their inline predicates.
- `board-saved-views.tsx` re-exports `BoardViewSelection` so existing importers (`board-filter-bar.tsx`, the saved-views test) are untouched.

### Key design decisions

**Shared `lib/board` module over inlining a fourth copy** — the drift is the root cause, so the fix is one authority, not a fourth correct copy. `lib/board/` already houses pure board logic (`lens-defs.ts`, `branch-grouping.ts`); a pure predicate belongs there, not in the saved-views component module that `board.tsx` would otherwise have to import a component file from.

**Copy stays keyed on `scoped`, only the CTA moves to `isBoardFiltered`** — a Mine-home empty landing is genuinely empty (show the lens copy), not a filter miss (show "Nothing matches the filters"). The bug was only ever the CTA gate, so that's the only line that changed behavior.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/board/filter-state.ts` | `isBoardFiltered(homeLens, selection)` + `BoardViewSelection`, the single home-aware filtered predicate |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/pages/board.tsx` | Empty-state CTA gate uses `isBoardFiltered(homeLens, …)` (the fix); import added |
| `apps/frontend/src/components/board/board-filter-bar.tsx` | "Clear filters" `isFiltered` uses the shared helper |
| `apps/frontend/src/components/board/board-saved-views.tsx` | "Save current view" `isFiltered` uses the shared helper; `BoardViewSelection` moved to lib and re-exported |
| `apps/frontend/src/pages/board.test.tsx` | Two regressions (below) |

## Test plan

- [x] `bun run --cwd apps/frontend test board.test board-saved-views` — 30 pass (2 new)
  - Mine-home empty `/board` → shows "Nothing here for you yet", no "Show everything" CTA
  - Mine-home empty `/board/all` (narrowed off home) → "Show everything" still shown
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] `bunx eslint` over the 5 touched files — clean
- [x] Full pre-commit gate (prettier + all-app lint + all-package `tsc` + astro check + api-docs `--check`) passed on commit

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQgcLBKmCUaD58vGpRGixt)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786118724&installation_id=129946197&pr_number=1247&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1247&signature=c2f0333859c0470454abc9d191fda456838a1762a1d58a525adcbe16b427e9e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->