### PR TITLE
feat(board): slot authored posts optimistically, keyed by the real conversation id

### DIFF
--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -56,8 +56,8 @@ describe("conversationAssigner — threadFromMessage", () => {
     mock.restore()
   })
 
-  async function thread(sourceConversationId: string, reply = makeReply()): Promise<void> {
-    await conversationAssigner.assignInTransaction(CLIENT, {
+  async function thread(sourceConversationId: string, reply = makeReply()): Promise<string> {
+    return conversationAssigner.assignInTransaction(CLIENT, {
       workspaceId: WORKSPACE_ID,
       message: reply,
       directive: { intent: "threadFromMessage", sourceConversationId },
@@ -67,7 +67,8 @@ describe("conversationAssigner — threadFromMessage", () => {
   test("attaches the reply to the SAME source conversation — one conversation, no mint", async () => {
     findByIdForUpdate.mockResolvedValue(makeSource())
 
-    await thread("conv_src")
+    // Returns the joined source id so the caller can surface it on the send.
+    expect(await thread("conv_src")).toBe("conv_src")
 
     // The reply joins the source as a cross-stream member; nothing is minted.
     expect(insert).not.toHaveBeenCalled()
@@ -91,11 +92,13 @@ describe("conversationAssigner — threadFromMessage", () => {
   test("falls back to minting a conversation when the source is missing/foreign (reply never orphaned)", async () => {
     findByIdForUpdate.mockResolvedValue(null)
 
-    await thread("conv_gone")
+    const returned = await thread("conv_gone")
 
-    // No source to attach to → mint a fresh conversation in the thread stream.
+    // No source to attach to → mint a fresh conversation in the thread stream,
+    // and return that minted id (never orphaned, never the missing source id).
     expect(insert).toHaveBeenCalledTimes(1)
     expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
+    expect(returned).toBe(insert.mock.calls[0][1].id as string)
     expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({ created: true })
   })
 
@@ -143,8 +146,8 @@ describe("conversationAssigner — newSubtopic (declared branch, stream-locked m
     mock.restore()
   })
 
-  async function newSubtopic(reply = makeReply("thr_1")): Promise<void> {
-    await conversationAssigner.assignInTransaction(LOCK_CLIENT, {
+  async function newSubtopic(reply = makeReply("thr_1")): Promise<string> {
+    return conversationAssigner.assignInTransaction(LOCK_CLIENT, {
       workspaceId: WORKSPACE_ID,
       message: reply,
       directive: { intent: "newSubtopic" },
@@ -154,7 +157,7 @@ describe("conversationAssigner — newSubtopic (declared branch, stream-locked m
   test("mints a fresh conversation anchored to the thread stream when none is active there", async () => {
     findActiveByStream.mockResolvedValue([])
 
-    await newSubtopic()
+    const returned = await newSubtopic()
 
     // Locks the thread stream row before deciding (INV-20), then mints anchored to
     // the thread — the branch relationship (thr_1.parentMessageId ∈ the parent
@@ -164,6 +167,7 @@ describe("conversationAssigner — newSubtopic (declared branch, stream-locked m
     expect(insert.mock.calls[0][1]).toMatchObject({ streamId: "thr_1", workspaceId: WORKSPACE_ID })
     // The mint generates its own id; the reply joins that same conversation.
     const mintedId = insert.mock.calls[0][1].id as string
+    expect(returned).toBe(mintedId)
     expect(addPrimaryMessage).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, mintedId, "msg_reply", "usr_1")
     expect(bumpActivityForIds).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, [mintedId])
     expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
@@ -192,7 +196,7 @@ describe("conversationAssigner — newSubtopic (declared branch, stream-locked m
     // stream lock + findActiveByStream and attaches instead of minting again.
     findActiveByStream.mockResolvedValue([{ id: "conv_sub", streamId: "thr_1" } as unknown as Conversation])
 
-    await newSubtopic()
+    expect(await newSubtopic()).toBe("conv_sub")
 
     expect(insert).not.toHaveBeenCalled()
     expect(addPrimaryMessage).toHaveBeenCalledWith(LOCK_CLIENT, WORKSPACE_ID, "conv_sub", "msg_reply", "usr_1")
@@ -225,9 +229,9 @@ describe("conversationAssigner — existing (same-root guard)", () => {
     mock.restore()
   })
 
-  async function existing(target: Conversation, reply: Message): Promise<void> {
+  async function existing(target: Conversation, reply: Message): Promise<string> {
     findByIdForUpdate.mockResolvedValue(target)
-    await conversationAssigner.assignInTransaction(CLIENT, {
+    return conversationAssigner.assignInTransaction(CLIENT, {
       workspaceId: WORKSPACE_ID,
       message: reply,
       directive: { intent: "existing", conversationId: target.id },
@@ -235,7 +239,7 @@ describe("conversationAssigner — existing (same-root guard)", () => {
   }
 
   test("attaches a same-stream reply", async () => {
-    await existing(makeSource({ id: "conv_a", streamId: "chan_1" }), makeReply("chan_1"))
+    expect(await existing(makeSource({ id: "conv_a", streamId: "chan_1" }), makeReply("chan_1"))).toBe("conv_a")
     expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_a", "msg_reply", "usr_1")
   })
 

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -39,21 +39,17 @@ import { HttpError } from "../../lib/errors"
 export const conversationAssigner: ConversationAssigner = {
   async assignInTransaction(client, { workspaceId, message, directive }) {
     if (directive.intent === ConversationIntents.THREAD_FROM_MESSAGE) {
-      if (await attachThreadReplyToSource(client, workspaceId, message, directive.sourceConversationId)) {
-        return
-      }
-      await mintConversationForMessage(client, workspaceId, message)
-      return
+      const sourceId = await attachThreadReplyToSource(client, workspaceId, message, directive.sourceConversationId)
+      if (sourceId) return sourceId
+      return mintConversationForMessage(client, workspaceId, message)
     }
 
     if (directive.intent === ConversationIntents.NEW_SUBTOPIC) {
-      await mintOrAttachSubtopicConversation(client, workspaceId, message)
-      return
+      return mintOrAttachSubtopicConversation(client, workspaceId, message)
     }
 
     if (directive.intent === ConversationIntents.NEW) {
-      await mintConversationForMessage(client, workspaceId, message)
-      return
+      return mintConversationForMessage(client, workspaceId, message)
     }
 
     // `existing`. Workspace-scoped + row-locked (INV-8, INV-20): a stale/foreign
@@ -90,11 +86,13 @@ export const conversationAssigner: ConversationAssigner = {
       created: false,
       reason: "declared",
     })
+    return target.id
   },
 }
 
-/** Mint a fresh conversation in the message's stream, seeded with the message. */
-async function mintConversationForMessage(client: PoolClient, workspaceId: string, message: Message): Promise<void> {
+/** Mint a fresh conversation in the message's stream, seeded with the message.
+ *  Returns the minted id. */
+async function mintConversationForMessage(client: PoolClient, workspaceId: string, message: Message): Promise<string> {
   const newId = conversationId()
   await ConversationRepository.insert(client, {
     id: newId,
@@ -112,6 +110,7 @@ async function mintConversationForMessage(client: PoolClient, workspaceId: strin
     created: true,
     reason: "declared",
   })
+  return newId
 }
 
 /**
@@ -127,12 +126,11 @@ async function mintOrAttachSubtopicConversation(
   client: PoolClient,
   workspaceId: string,
   message: Message
-): Promise<void> {
+): Promise<string> {
   await client.query(sql`SELECT id FROM streams WHERE id = ${message.streamId} FOR UPDATE`)
   const active = (await ConversationRepository.findActiveByStream(client, message.streamId))[0]
   if (!active) {
-    await mintConversationForMessage(client, workspaceId, message)
-    return
+    return mintConversationForMessage(client, workspaceId, message)
   }
   await ConversationRepository.addPrimaryMessage(client, workspaceId, active.id, message.id, message.authorId)
   await ConversationRepository.bumpActivityForIds(client, workspaceId, [active.id])
@@ -143,6 +141,7 @@ async function mintOrAttachSubtopicConversation(
     created: false,
     reason: "declared",
   })
+  return active.id
 }
 
 /**
@@ -155,15 +154,16 @@ async function mintOrAttachSubtopicConversation(
  * The reply's stream must be a thread whose parent message belongs to the source
  * conversation, the source must be anchored at that parent stream (the root), and
  * the actor must be able to reach it (INV-62). Any mismatch
- * (foreign/non-member/no-access/race) returns false so the caller mints a fresh
- * conversation instead — the reply is never left without a primary.
+ * (foreign/non-member/no-access/race) returns null so the caller mints a fresh
+ * conversation instead — the reply is never left without a primary. On success
+ * returns the source conversation's id.
  */
 async function attachThreadReplyToSource(
   client: PoolClient,
   workspaceId: string,
   message: Message,
   sourceConversationId: string
-): Promise<boolean> {
+): Promise<string | null> {
   const thread = await StreamRepository.findById(client, message.streamId)
   const source = await ConversationRepository.findByIdForUpdate(client, workspaceId, sourceConversationId)
   if (
@@ -174,7 +174,7 @@ async function attachThreadReplyToSource(
     !source.messageIds.includes(thread.parentMessageId) ||
     !(await checkStreamAccess(client, source.streamId, workspaceId, message.authorId))
   ) {
-    return false
+    return null
   }
   await ConversationRepository.addPrimaryMessage(client, workspaceId, source.id, message.id, message.authorId)
   await ConversationRepository.reactivateIfInactive(client, workspaceId, source.id)
@@ -186,7 +186,7 @@ async function attachThreadReplyToSource(
     created: false,
     reason: "declared",
   })
-  return true
+  return source.id
 }
 
 /**

--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -871,7 +871,7 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
     contentMarkdown: "hello",
   }
 
-  const assignInTransaction = mock(async () => {})
+  const assignInTransaction = mock(async () => "conv_assigned")
   const conversationAssigner = { assignInTransaction }
 
   beforeEach(() => {
@@ -958,6 +958,19 @@ describe("EventService.createMessage conversation declaration (Mechanism C)", ()
     const eventPayload = (StreamEventRepository.insert as any).mock.calls[0][1].payload
     expect(eventPayload).not.toHaveProperty("declaredConversationId")
     expect(assignInTransaction).not.toHaveBeenCalled()
+  })
+
+  it("surfaces the assigner's conversation id from createMessageReturningConversation for an optimistic board card", async () => {
+    const service = new EventService({} as any, conversationAssigner)
+
+    const declared = await service.createMessageReturningConversation({
+      ...baseParams,
+      conversation: { intent: ConversationIntents.NEW },
+    })
+    expect(declared.conversationId).toBe("conv_assigned")
+
+    const undeclared = await service.createMessageReturningConversation({ ...baseParams })
+    expect(undeclared.conversationId).toBeUndefined()
   })
 })
 

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -380,10 +380,14 @@ function assertE2eContentMatch(params: {
  * row + its outbox events). Invoked only when a send declares a directive.
  */
 export interface ConversationAssigner {
+  /** Assigns the message to its declared conversation and returns that
+   *  conversation's id — minted (a `new` post) or joined (`existing`,
+   *  `threadFromMessage`, `newSubtopic`) — so the caller can surface it on the
+   *  send response for an optimistic board card. */
   assignInTransaction(
     client: PoolClient,
     params: { workspaceId: string; message: Message; directive: ConversationDirective }
-  ): Promise<void>
+  ): Promise<string>
 }
 
 export class EventService {
@@ -444,21 +448,42 @@ export class EventService {
   }
 
   async createMessage(params: CreateMessageParams): Promise<Message> {
+    return (await this.createMessageReturningConversation(params)).message
+  }
+
+  /**
+   * Same send as {@link createMessage}, but also returns the id of the
+   * conversation a declared directive assigned the message to (minted for `new`,
+   * joined for `existing`/`threadFromMessage`/`newSubtopic`) — `undefined` when
+   * no directive was declared. The board composer surfaces it on the send
+   * response so it can write an optimistic board card keyed by the real
+   * conversation id (no temp-id swap), reconciled by the `conversation:*` echo.
+   */
+  async createMessageReturningConversation(
+    params: CreateMessageParams
+  ): Promise<{ message: Message; conversationId?: string }> {
     try {
       return await this._createMessageTxn(params)
     } catch (error) {
       // Concurrent duplicate: the txn rolled back (no orphaned stream_events/outbox),
       // and we return the already-committed message from the winning transaction.
-      if (error instanceof DuplicateMessageError) return error.existingMessage
+      // No conversation id — the winner already surfaced its own; the loser's
+      // optimistic card would double the winner's, so leave it to the echo/refetch.
+      if (error instanceof DuplicateMessageError) return { message: error.existingMessage }
       throw error
     }
   }
 
-  async createMessageInTransaction(client: PoolClient, params: CreateMessageParams): Promise<Message> {
-    // Fast path for sequential retries: return the existing message without writes.
+  async createMessageInTransaction(
+    client: PoolClient,
+    params: CreateMessageParams
+  ): Promise<{ message: Message; conversationId?: string }> {
+    // Fast path for sequential retries: return the existing message without
+    // writes. No conversation id — the first send already surfaced it; a retry
+    // reconciles through the echo/refetch, not a fresh optimistic card.
     if (params.clientMessageId) {
       const existing = await MessageRepository.findByClientMessageId(client, params.streamId, params.clientMessageId)
-      if (existing) return existing
+      if (existing) return { message: existing }
     }
     // The enclave seals its E2E reply with the message AAD bound to a
     // server-minted id, so the caller can pass that same id here to keep the
@@ -736,22 +761,24 @@ export class EventService {
     // transaction (so the board sees it the instant the send returns and the
     // async extractor leaves it locked). The assigner is injected to keep
     // messaging decoupled from conversation internals; fail loud (INV-11) if a
-    // directive arrives without one wired rather than silently dropping it.
+    // directive arrives without one wired rather than silently dropping it. Its
+    // returned id rides the send response for an optimistic board card.
+    let conversationId: string | undefined
     if (params.conversation) {
       if (!this.conversationAssigner) {
         throw new Error("Message declares a conversation but no ConversationAssigner is configured")
       }
-      await this.conversationAssigner.assignInTransaction(client, {
+      conversationId = await this.conversationAssigner.assignInTransaction(client, {
         workspaceId: params.workspaceId,
         message,
         directive: params.conversation,
       })
     }
 
-    return message
+    return { message, conversationId }
   }
 
-  private async _createMessageTxn(params: CreateMessageParams): Promise<Message> {
+  private async _createMessageTxn(params: CreateMessageParams): Promise<{ message: Message; conversationId?: string }> {
     return withTransaction(this.pool, (client) => this.createMessageInTransaction(client, params))
   }
 

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -396,7 +396,10 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
       const inlineRefIds = collectAttachmentReferenceIds(contentJson)
       const attachmentIds = [...new Set([...explicitAttachmentIds, ...inlineRefIds])]
 
-      const message = await eventService.createMessage({
+      // `conversationId` is the id the declared directive assigned the message to
+      // (a fresh mint for a board `new` post) — surfaced so the board composer can
+      // slot an optimistic card keyed by the real id, reconciled by the echo.
+      const { message, conversationId } = await eventService.createMessageReturningConversation({
         workspaceId,
         streamId,
         authorId: userId,
@@ -410,7 +413,7 @@ export function createMessageHandlers({ pool, eventService, streamService, comma
         confirmedPrivacyWarning: data.confirmedPrivacyWarning,
       })
 
-      res.status(201).json({ message: serializeMessage(message) })
+      res.status(201).json({ message: serializeMessage(message), ...(conversationId && { conversationId }) })
     },
 
     async update(req: Request, res: Response) {

--- a/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
+++ b/apps/backend/src/features/public-api/complete-invocation-floor.test.ts
@@ -82,7 +82,7 @@ function arrangeCompletion(params: { existingSteps: unknown[]; manifest?: unknow
     createdAt: new Date("2026-06-11T09:00:04.000Z"),
   }
   const createMessageInTransaction = mock((_client: unknown, _params: Record<string, unknown>) =>
-    Promise.resolve(message)
+    Promise.resolve({ message })
   )
   const eventService = {
     createMessageInTransaction,

--- a/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
+++ b/apps/backend/src/features/public-api/e2e-stream-gate.test.ts
@@ -150,17 +150,19 @@ describe("public API E2E-stream plaintext gate", () => {
       fn({})) as never)
     const createMessageInTransaction = mock((_client: unknown, params: Record<string, unknown>) =>
       Promise.resolve({
-        id: params.id,
-        streamId: "stream_1",
-        sequence: 1n,
-        authorId: "bot_1",
-        authorType: "bot",
-        contentJson: { type: "doc", content: [] },
-        contentMarkdown: params.contentMarkdown,
-        reactions: {},
-        metadata: {},
-        editedAt: null,
-        createdAt: new Date(),
+        message: {
+          id: params.id,
+          streamId: "stream_1",
+          sequence: 1n,
+          authorId: "bot_1",
+          authorType: "bot",
+          contentJson: { type: "doc", content: [] },
+          contentMarkdown: params.contentMarkdown,
+          reactions: {},
+          metadata: {},
+          editedAt: null,
+          createdAt: new Date(),
+        },
       })
     )
     const botRuntimeService = {

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1401,24 +1401,26 @@ export function createPublicApiHandlers({
       const { message, sessionFinalized } = await withTransaction(pool, async (client) => {
         const reply = data.reply
         const message = reply
-          ? await eventService.createMessageInTransaction(client, {
-              id: reply.messageId,
-              workspaceId: stream.workspaceId,
-              streamId: session.streamId,
-              sessionId: session.id,
-              authorId: bot.id,
-              authorType: AuthorTypes.BOT,
-              contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
-              contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
-              ciphertext: Buffer.from(reply.ciphertext, "base64"),
-              envelope: reply.envelope,
-              e2eVersion: 2,
-              // Restrict the bot's reach to this scratchpad and dedupe a redelivered
-              // completion (one reply per invocation), mirroring the enclave reply.
-              accessibleStreamIds: [session.streamId],
-              clientMessageId: `bot-invocation:${session.id}`,
-              ...(reply.attachmentIds && reply.attachmentIds.length > 0 && { attachmentIds: reply.attachmentIds }),
-            })
+          ? (
+              await eventService.createMessageInTransaction(client, {
+                id: reply.messageId,
+                workspaceId: stream.workspaceId,
+                streamId: session.streamId,
+                sessionId: session.id,
+                authorId: bot.id,
+                authorType: AuthorTypes.BOT,
+                contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
+                contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+                ciphertext: Buffer.from(reply.ciphertext, "base64"),
+                envelope: reply.envelope,
+                e2eVersion: 2,
+                // Restrict the bot's reach to this scratchpad and dedupe a redelivered
+                // completion (one reply per invocation), mirroring the enclave reply.
+                accessibleStreamIds: [session.streamId],
+                clientMessageId: `bot-invocation:${session.id}`,
+                ...(reply.attachmentIds && reply.attachmentIds.length > 0 && { attachmentIds: reply.attachmentIds }),
+              })
+            ).message
           : null
 
         // Flip the claim atomically (INV-20): the `status = 'claimed'` predicate
@@ -1535,33 +1537,37 @@ export function createPublicApiHandlers({
               { status: 400, code: "E2E_WRONG_KEY_GENERATION" }
             )
           }
-          message = await eventService.createMessageInTransaction(client, {
-            id: data.sealedReply.messageId,
-            workspaceId: req.workspaceId!,
-            streamId: claim.responseStreamId,
-            authorId: bot.id,
-            authorType: AuthorTypes.BOT,
-            contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
-            contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
-            ciphertext: Buffer.from(data.sealedReply.ciphertext, "base64"),
-            envelope: data.sealedReply.envelope,
-            e2eVersion: 2,
-            accessibleStreamIds: [claim.responseStreamId],
-            clientMessageId: `bot-invocation:${claim.id}`,
-          })
+          message = (
+            await eventService.createMessageInTransaction(client, {
+              id: data.sealedReply.messageId,
+              workspaceId: req.workspaceId!,
+              streamId: claim.responseStreamId,
+              authorId: bot.id,
+              authorType: AuthorTypes.BOT,
+              contentJson: E2E_PLACEHOLDER_CONTENT_JSON,
+              contentMarkdown: E2E_PLACEHOLDER_CONTENT_MARKDOWN,
+              ciphertext: Buffer.from(data.sealedReply.ciphertext, "base64"),
+              envelope: data.sealedReply.envelope,
+              e2eVersion: 2,
+              accessibleStreamIds: [claim.responseStreamId],
+              clientMessageId: `bot-invocation:${claim.id}`,
+            })
+          ).message
         } else if (contentMarkdown) {
-          message = await eventService.createMessageInTransaction(client, {
-            workspaceId: req.workspaceId!,
-            streamId: claim.responseStreamId,
-            authorId: bot.id,
-            authorType: AuthorTypes.BOT,
-            contentJson: contentJson!,
-            contentMarkdown,
-            attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
-            clientMessageId: `bot-invocation:${claim.id}`,
-            sources: data.sources,
-            metadata: data.metadata,
-          })
+          message = (
+            await eventService.createMessageInTransaction(client, {
+              workspaceId: req.workspaceId!,
+              streamId: claim.responseStreamId,
+              authorId: bot.id,
+              authorType: AuthorTypes.BOT,
+              contentJson: contentJson!,
+              contentMarkdown,
+              attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+              clientMessageId: `bot-invocation:${claim.id}`,
+              sources: data.sources,
+              metadata: data.metadata,
+            })
+          ).message
         }
         const completed = await botRuntimeService.completeInvocationInTransaction(client, {
           workspaceId: req.workspaceId!,

--- a/apps/backend/src/features/public-api/sealed-complete.test.ts
+++ b/apps/backend/src/features/public-api/sealed-complete.test.ts
@@ -92,8 +92,7 @@ function arrange(
   const insertOutbox = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
 
   const createMessageInTransaction = mock(async (_client: unknown, params: { id: string }) => ({
-    id: params.id,
-    streamId: session.streamId,
+    message: { id: params.id, streamId: session.streamId },
   }))
   const getLatestSequence = mock(async () => 5n)
   const completeInvocationInTransaction = mock(async (_db: unknown, _params: unknown) =>

--- a/apps/backend/tests/integration/access-control.test.ts
+++ b/apps/backend/tests/integration/access-control.test.ts
@@ -1017,7 +1017,7 @@ describe("Access Control", () => {
         await withTransaction(pool, async (client) => {
           // The explorer search requires message_id IS NOT NULL; create a
           // message in the stream and point the attachment at it.
-          const message = await eventService.createMessageInTransaction(client, {
+          const { message } = await eventService.createMessageInTransaction(client, {
             workspaceId: wsId,
             streamId: streamIdValue,
             authorId: ownerId,

--- a/apps/frontend/src/api/messages.ts
+++ b/apps/frontend/src/api/messages.ts
@@ -18,12 +18,21 @@ export const messageKeys = {
 }
 
 export const messagesApi = {
-  async create(workspaceId: string, streamId: string, data: CreateMessageInput): Promise<Message> {
-    const res = await api.post<{ message: Message }>(`/api/workspaces/${workspaceId}/messages`, {
+  /**
+   * Send a message. Returns the created `message` and — when the send declared a
+   * conversation directive (a board post's `intent: "new"`) — the `conversationId`
+   * the backend assigned it synchronously, so the board composer can slot an
+   * optimistic card keyed by the real id (reconciled by the `conversation:*` echo).
+   */
+  async create(
+    workspaceId: string,
+    streamId: string,
+    data: CreateMessageInput
+  ): Promise<{ message: Message; conversationId?: string }> {
+    return api.post<{ message: Message; conversationId?: string }>(`/api/workspaces/${workspaceId}/messages`, {
       ...data,
       streamId,
     })
-    return res.message
   },
 
   async createDm(workspaceId: string, dmUserId: string, data: CreateDmMessageInput): Promise<Message> {

--- a/apps/frontend/src/components/board/board-composer.tsx
+++ b/apps/frontend/src/components/board/board-composer.tsx
@@ -159,7 +159,8 @@ function BoardComposerForm({
     const pendingAttachments = composer.getPendingAttachmentsSnapshot()
     const liveContent = editorContent ?? composer.content
     const normalizedContent = materializePendingAttachmentReferences(liveContent, pendingAttachments)
-    const attachmentIds = extractUploadedAttachments(normalizedContent).map((a) => a.id)
+    const uploadedAttachments = extractUploadedAttachments(normalizedContent)
+    const attachmentIds = uploadedAttachments.map((a) => a.id)
 
     composer.setIsSending(true)
     try {
@@ -167,6 +168,8 @@ function BoardComposerForm({
         target,
         contentJson: normalizedContent,
         attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+        // Full summaries so the optimistic board card renders thumbnails at once.
+        attachments: uploadedAttachments.length > 0 ? uploadedAttachments : undefined,
       })
       composer.setContent(EMPTY_DOC)
       await composer.resolveDraft()

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -8,6 +8,8 @@ import * as contextsModule from "@/contexts"
 import * as syncEngineModule from "@/sync/sync-engine"
 import * as draftScratchpadsModule from "./use-draft-scratchpads"
 import * as queueDraftModule from "./use-queue-draft-message"
+import * as boardStoreModule from "@/stores/board-store"
+import * as workspaceStoreModule from "@/stores/workspace-store"
 import { SocketEventGate } from "@/sync/socket-event-gate"
 import {
   useConversations,
@@ -258,8 +260,8 @@ describe("useCreateBoardPost", () => {
     vi.restoreAllMocks()
   })
 
-  function mockBoardDeps() {
-    const create = vi.fn().mockResolvedValue({})
+  function mockBoardDeps(createResult: unknown = {}) {
+    const create = vi.fn().mockResolvedValue(createResult)
     vi.spyOn(contextsModule, "useMessageService").mockReturnValue({
       create,
     } as unknown as contextsModule.MessageService)
@@ -272,11 +274,13 @@ describe("useCreateBoardPost", () => {
       queueDraftMessage,
       currentUserId: "user_1",
     } as unknown as ReturnType<typeof queueDraftModule.useQueueDraftMessage>)
-    return { create, createScratchpad, queueDraftMessage }
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([])
+    const putOptimistic = vi.spyOn(boardStoreModule, "putOptimisticBoardPost").mockResolvedValue(undefined)
+    return { create, createScratchpad, queueDraftMessage, putOptimistic }
   }
 
   it("posts to an existing stream as a new-conversation message with an idempotency key (no scratchpad created)", async () => {
-    const { create, createScratchpad, queueDraftMessage } = mockBoardDeps()
+    const { create, createScratchpad, queueDraftMessage, putOptimistic } = mockBoardDeps()
 
     const { queryClient, wrapper } = createWrapper()
     const invalidate = vi.spyOn(queryClient, "invalidateQueries")
@@ -304,6 +308,41 @@ describe("useCreateBoardPost", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [...conversationKeys.all, "workspaceList", WORKSPACE_ID],
     })
+    // No conversation id on the response (nothing to key an optimistic card by).
+    expect(putOptimistic).not.toHaveBeenCalled()
+  })
+
+  it("slots an optimistic card keyed by the conversation id the send returns", async () => {
+    const { putOptimistic } = mockBoardDeps({
+      message: { id: "msg_1", createdAt: "2026-06-22T12:00:00.000Z" },
+      conversationId: "conv_new",
+    })
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      { id: STREAM_ID, type: "channel", rootStreamId: null },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useCreateBoardPost(WORKSPACE_ID), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        target: { type: "stream", streamId: STREAM_ID },
+        contentJson: { type: "doc", content: [] },
+      })
+    })
+
+    expect(putOptimistic).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      expect.objectContaining({
+        conversationId: "conv_new",
+        messageId: "msg_1",
+        streamId: STREAM_ID,
+        authorId: "user_1",
+        rootStreamId: STREAM_ID,
+        rootStreamType: "channel",
+        createdAt: "2026-06-22T12:00:00.000Z",
+      })
+    )
   })
 
   it("creates a draft scratchpad and queues the first message via the promote-on-send queue (no eager server stream)", async () => {

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -345,6 +345,32 @@ describe("useCreateBoardPost", () => {
     )
   })
 
+  it("does not fail the send when the optimistic cache write throws (message already committed server-side)", async () => {
+    const { putOptimistic } = mockBoardDeps({
+      message: { id: "msg_1", createdAt: "2026-06-22T12:00:00.000Z" },
+      conversationId: "conv_new",
+    })
+    putOptimistic.mockRejectedValue(new Error("IDB quota exceeded"))
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
+      { id: STREAM_ID, type: "channel", rootStreamId: null },
+    ] as unknown as ReturnType<typeof workspaceStoreModule.useWorkspaceStreams>)
+
+    const { wrapper } = createWrapper()
+    const { result } = renderHook(() => useCreateBoardPost(WORKSPACE_ID), { wrapper })
+
+    // The mutation resolves despite the cache-write failure — no false send error
+    // that would prompt a duplicate resend.
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          target: { type: "stream", streamId: STREAM_ID },
+          contentJson: { type: "doc", content: [] },
+        })
+      ).resolves.toBeUndefined()
+    })
+    expect(putOptimistic).toHaveBeenCalled()
+  })
+
   it("creates a draft scratchpad and queues the first message via the promote-on-send queue (no eager server stream)", async () => {
     const { create, createScratchpad, queueDraftMessage } = mockBoardDeps()
 

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -314,7 +314,12 @@ describe("useCreateBoardPost", () => {
 
   it("slots an optimistic card keyed by the conversation id the send returns", async () => {
     const { putOptimistic } = mockBoardDeps({
-      message: { id: "msg_1", createdAt: "2026-06-22T12:00:00.000Z" },
+      message: {
+        id: "msg_1",
+        createdAt: "2026-06-22T12:00:00.000Z",
+        // Server-resolved markdown (mentions → ids, INV-64), not the client input.
+        contentMarkdown: "hey [@ana](user:usr_ana)",
+      },
       conversationId: "conv_new",
     })
     vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([
@@ -341,6 +346,7 @@ describe("useCreateBoardPost", () => {
         rootStreamId: STREAM_ID,
         rootStreamType: "channel",
         createdAt: "2026-06-22T12:00:00.000Z",
+        contentMarkdown: "hey [@ana](user:usr_ana)",
       })
     )
   })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -44,6 +44,9 @@ export interface CreateBoardPostInput {
   target: BoardPostTarget
   contentJson: JSONContent
   attachmentIds?: string[]
+  /** Full attachment summaries (not just ids) so the optimistic card renders
+   *  thumbnails immediately instead of popping them in on refetch. */
+  attachments?: AttachmentSummary[]
 }
 
 /** Shared stable empty list so a disabled/loading query returns one identity. */
@@ -250,11 +253,11 @@ export function useCreateBoardPost(workspaceId: string) {
   const streams = useWorkspaceStreams(workspaceId)
 
   return useMutation({
-    mutationFn: async ({ target, contentJson, attachmentIds }: CreateBoardPostInput) => {
+    mutationFn: async ({ target, contentJson, attachmentIds, attachments }: CreateBoardPostInput) => {
       if (target.type === "newScratchpad") {
         const draftId = await createScratchpad(target.companionMode)
         await queueDraftMessage(
-          { contentJson, attachmentIds },
+          { contentJson, attachmentIds, attachments },
           {
             workspaceId,
             streamId: draftId,
@@ -283,18 +286,25 @@ export function useCreateBoardPost(workspaceId: string) {
       // id the backend minted synchronously — so it's on screen as the composer
       // clears, not after the echo + board-head refetch. Reconciled in place by
       // both (same id, `_status` cleared). A channel/DM is its own effective root.
+      // Best-effort: the message is already committed server-side, so a local IDB
+      // write failure must not fail the send (which would risk a duplicate resend).
       const stream = streams.find((s) => s.id === target.streamId)
       if (conversationId && currentUserId && stream) {
-        await putOptimisticBoardPost(workspaceId, {
-          conversationId,
-          messageId: message.id,
-          streamId: target.streamId,
-          authorId: currentUserId,
-          contentMarkdown: serializeToMarkdown(contentJson),
-          rootStreamId: stream.rootStreamId ?? stream.id,
-          rootStreamType: stream.type as BoardScopeStreamType,
-          createdAt: message.createdAt,
-        })
+        try {
+          await putOptimisticBoardPost(workspaceId, {
+            conversationId,
+            messageId: message.id,
+            streamId: target.streamId,
+            authorId: currentUserId,
+            contentMarkdown: serializeToMarkdown(contentJson),
+            rootStreamId: stream.rootStreamId ?? stream.id,
+            rootStreamType: stream.type as BoardScopeStreamType,
+            createdAt: message.createdAt,
+            attachments,
+          })
+        } catch (err) {
+          console.error("Failed to seed optimistic board post", err)
+        }
       }
     },
     onSuccess: () => {

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -260,6 +260,12 @@ export function useCreateBoardPost(workspaceId: string) {
             streamId: draftId,
             streamCreation: { type: StreamTypes.SCRATCHPAD, companionMode: target.companionMode },
             draftId,
+            // Declare the fresh conversation so the promote-on-send backend mints
+            // it synchronously (and returns its id) instead of leaving it to the
+            // async extractor — the queue drain seeds the board card off that id
+            // the moment the scratchpad materializes. `intent: "new"` because an
+            // authored post is always a new topic boundary.
+            conversation: { intent: "new" },
           }
         )
         return

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -9,8 +9,10 @@ import {
   createDraftPanelId,
 } from "@/contexts"
 import { db } from "@/db"
+import { useWorkspaceStreams } from "@/stores/workspace-store"
+import { serializeToMarkdown } from "@threa/prosemirror"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
-import { seedBoardPosts, useBoardPost, mergeBoardConversation } from "@/stores/board-store"
+import { seedBoardPosts, useBoardPost, mergeBoardConversation, putOptimisticBoardPost } from "@/stores/board-store"
 import { seedBoardExclusions, putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
 import type { BoardViewPost } from "./use-stable-board-view"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
@@ -243,8 +245,9 @@ export function useWorkspaceConversations(
 export function useCreateBoardPost(workspaceId: string) {
   const messageService = useMessageService()
   const { createScratchpad } = useDraftScratchpads(workspaceId)
-  const { queueDraftMessage } = useQueueDraftMessage(workspaceId)
+  const { queueDraftMessage, currentUserId } = useQueueDraftMessage(workspaceId)
   const queryClient = useQueryClient()
+  const streams = useWorkspaceStreams(workspaceId)
 
   return useMutation({
     mutationFn: async ({ target, contentJson, attachmentIds }: CreateBoardPostInput) => {
@@ -262,13 +265,31 @@ export function useCreateBoardPost(workspaceId: string) {
         return
       }
 
-      await messageService.create(workspaceId, target.streamId, {
+      const { message, conversationId } = await messageService.create(workspaceId, target.streamId, {
         streamId: target.streamId,
         contentJson,
         attachmentIds,
         clientMessageId: generateClientId(),
         conversation: { intent: "new" },
       })
+
+      // Slot the card the instant the send returns, keyed by the real conversation
+      // id the backend minted synchronously — so it's on screen as the composer
+      // clears, not after the echo + board-head refetch. Reconciled in place by
+      // both (same id, `_status` cleared). A channel/DM is its own effective root.
+      const stream = streams.find((s) => s.id === target.streamId)
+      if (conversationId && currentUserId && stream) {
+        await putOptimisticBoardPost(workspaceId, {
+          conversationId,
+          messageId: message.id,
+          streamId: target.streamId,
+          authorId: currentUserId,
+          contentMarkdown: serializeToMarkdown(contentJson),
+          rootStreamId: stream.rootStreamId ?? stream.id,
+          rootStreamType: stream.type as BoardScopeStreamType,
+          createdAt: message.createdAt,
+        })
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...conversationKeys.all, "workspaceList", workspaceId] })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -10,7 +10,6 @@ import {
 } from "@/contexts"
 import { db } from "@/db"
 import { useWorkspaceStreams } from "@/stores/workspace-store"
-import { serializeToMarkdown } from "@threa/prosemirror"
 import { useOptionalSyncEngine } from "@/sync/sync-engine"
 import { seedBoardPosts, useBoardPost, mergeBoardConversation, putOptimisticBoardPost } from "@/stores/board-store"
 import { seedBoardExclusions, putHidden, deleteHidden, putMuted, deleteMuted } from "@/stores/board-exclusions-store"
@@ -296,7 +295,10 @@ export function useCreateBoardPost(workspaceId: string) {
             messageId: message.id,
             streamId: target.streamId,
             authorId: currentUserId,
-            contentMarkdown: serializeToMarkdown(contentJson),
+            // Server-resolved markdown (mentions → ids, INV-64), not a client
+            // re-serialize that could show a bare `@slug` until reconcile — matches
+            // the drain path.
+            contentMarkdown: message.contentMarkdown,
             rootStreamId: stream.rootStreamId ?? stream.id,
             rootStreamType: stream.type as BoardScopeStreamType,
             createdAt: message.createdAt,

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -8,6 +8,7 @@ import * as prosemirrorModule from "@threa/prosemirror"
 import * as draftPromotionsModule from "@/lib/draft-promotions"
 import * as streamSyncModule from "@/sync/stream-sync"
 import * as draftStoreModule from "@/stores/draft-store"
+import * as boardStoreModule from "@/stores/board-store"
 import * as useDraftMessageModule from "./use-draft-message"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
@@ -122,13 +123,15 @@ describe("useMessageQueue", () => {
       mockEventsUpdate(...args)) as unknown as typeof dbModule.db.events.update)
 
     vi.spyOn(dbModule.db.streams, "put").mockResolvedValue(undefined as never)
+    vi.spyOn(dbModule.db.streams, "delete").mockResolvedValue(undefined as never)
     vi.spyOn(dbModule.db.draftScratchpads, "delete").mockResolvedValue(undefined as never)
 
-    vi.spyOn(dbModule.db, "transaction").mockImplementation(((
-      _mode: string,
-      _tables: unknown,
-      fn: () => Promise<void>
-    ) => fn()) as unknown as typeof dbModule.db.transaction)
+    // db.transaction is called with a variable table list (2- and 3-table forms);
+    // invoke the LAST arg (the callback) regardless of how many tables precede it.
+    vi.spyOn(dbModule.db, "transaction").mockImplementation(((...args: unknown[]) => {
+      const fn = args[args.length - 1] as () => Promise<void>
+      return fn()
+    }) as unknown as typeof dbModule.db.transaction)
 
     vi.spyOn(dbModule, "sequenceToNum").mockImplementation((seq: string) => Number(seq))
 
@@ -397,5 +400,81 @@ describe("useMessageQueue", () => {
       attachmentIds: ["attach_1", "attach_2"],
       clientMessageId: "temp_attach",
     })
+  })
+
+  it("seeds an optimistic board card once a new-scratchpad post's send returns its conversation id", async () => {
+    // A promoted scratchpad send: streamId is already the real stream, and the
+    // send declares the fresh conversation (`intent: "new"`) so the backend mints
+    // and returns it. (Promotion itself is covered by its own tests.)
+    const realStream = { id: "stream_real", type: "scratchpad", rootStreamId: null }
+    vi.spyOn(dbModule.db.streams, "get").mockResolvedValue(realStream as never)
+    mockCreate.mockResolvedValue({
+      message: {
+        id: "msg_1",
+        authorId: "usr_1",
+        contentMarkdown: "first note",
+        streamId: "stream_real",
+        createdAt: "2026-07-08T12:00:00.000Z",
+      },
+      conversationId: "conv_new",
+    })
+    const putOptimistic = vi.spyOn(boardStoreModule, "putOptimisticBoardPost").mockResolvedValue(undefined)
+
+    mockPendingMessages = [
+      {
+        clientId: "temp_scratch",
+        workspaceId: "ws_1",
+        streamId: "stream_real",
+        content: "first note",
+        contentFormat: "markdown",
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "first note" }] }] },
+        createdAt: 1000,
+        retryCount: 0,
+        conversation: { intent: "new" },
+      } as unknown as MockPendingMessage,
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    // The card is seeded from the response, keyed by the real conversation +
+    // stream ids, so it lands the moment the scratchpad materializes.
+    expect(putOptimistic).toHaveBeenCalledWith(
+      "ws_1",
+      expect.objectContaining({
+        conversationId: "conv_new",
+        messageId: "msg_1",
+        streamId: "stream_real",
+        authorId: "usr_1",
+        contentMarkdown: "first note",
+        rootStreamId: "stream_real",
+        rootStreamType: "scratchpad",
+      })
+    )
+  })
+
+  it("does not seed a board card for an ordinary send that declared no new conversation", async () => {
+    const putOptimistic = vi.spyOn(boardStoreModule, "putOptimisticBoardPost").mockResolvedValue(undefined)
+    mockPendingMessages = [
+      {
+        clientId: "temp_plain",
+        workspaceId: "ws_1",
+        streamId: "stream_1",
+        content: "Hello",
+        contentFormat: "markdown",
+        contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Hello" }] }] },
+        createdAt: 1000,
+        retryCount: 0,
+      },
+    ]
+
+    renderHook(() => useMessageQueue(), { wrapper: createWrapper() })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    expect(putOptimistic).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -12,7 +12,13 @@ import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
 import { StreamTypes, ShareErrorCodes, draftStreamScope } from "@threa/types"
 import type { PendingMessage } from "@/db"
-import type { BoardScopeStreamType, CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
+import type {
+  AttachmentSummary,
+  BoardScopeStreamType,
+  CreateStreamInput,
+  Stream,
+  StreamWithPreview,
+} from "@threa/types"
 import { ApiError } from "@/api/client"
 import { surfacePrivacyBlockToast } from "@/lib/share-privacy-toast"
 
@@ -256,19 +262,31 @@ export function useMessageQueue(): void {
           // `conversation:created` echo + board-head refetch. Reconciled in place by
           // both (same id, `_status` cleared). `existing`/`threadFromMessage` replies
           // also return an id, but their card already exists so the write no-ops.
+          // Best-effort: the send already succeeded, so a local IDB failure must not
+          // drop the iteration into the retry/failed path for a delivered message.
           if (conversationId && next.conversation?.intent === "new") {
-            const stream = await db.streams.get(next.streamId)
-            if (stream) {
-              await putOptimisticBoardPost(next.workspaceId, {
-                conversationId,
-                messageId: message.id,
-                streamId: next.streamId,
-                authorId: message.authorId,
-                contentMarkdown: message.contentMarkdown,
-                rootStreamId: stream.rootStreamId ?? stream.id,
-                rootStreamType: stream.type as BoardScopeStreamType,
-                createdAt: message.createdAt,
-              })
+            try {
+              const stream = await db.streams.get(next.streamId)
+              if (stream) {
+                // The optimistic event carries the attachment summaries (the send
+                // response doesn't), so the card renders thumbnails immediately.
+                const optimisticEvent = await db.events.get(next.clientId)
+                const attachments = (optimisticEvent?.payload as { attachments?: AttachmentSummary[] } | undefined)
+                  ?.attachments
+                await putOptimisticBoardPost(next.workspaceId, {
+                  conversationId,
+                  messageId: message.id,
+                  streamId: next.streamId,
+                  authorId: message.authorId,
+                  contentMarkdown: message.contentMarkdown,
+                  rootStreamId: stream.rootStreamId ?? stream.id,
+                  rootStreamType: stream.type as BoardScopeStreamType,
+                  createdAt: message.createdAt,
+                  attachments,
+                })
+              }
+            } catch (err) {
+              console.error("Failed to seed optimistic board post from queue drain", err)
             }
           }
         }

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -7,11 +7,12 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { emitDraftPromoted } from "@/lib/draft-promotions"
 import { setParentThreadId } from "@/sync/stream-sync"
 import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
+import { putOptimisticBoardPost } from "@/stores/board-store"
 import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
 import { StreamTypes, ShareErrorCodes, draftStreamScope } from "@threa/types"
 import type { PendingMessage } from "@/db"
-import type { CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
+import type { BoardScopeStreamType, CreateStreamInput, Stream, StreamWithPreview } from "@threa/types"
 import { ApiError } from "@/api/client"
 import { surfacePrivacyBlockToast } from "@/lib/share-privacy-toast"
 
@@ -236,7 +237,7 @@ export function useMessageQueue(): void {
           })
         } else {
           const contentJson = next.contentJson ?? parseMarkdown(next.content)
-          await messageService.create(next.workspaceId, next.streamId, {
+          const { message, conversationId } = await messageService.create(next.workspaceId, next.streamId, {
             streamId: next.streamId,
             contentJson,
             attachmentIds: next.attachmentIds,
@@ -247,6 +248,29 @@ export function useMessageQueue(): void {
             // the async extractor; omitted on ordinary sends.
             conversation: next.conversation,
           })
+
+          // A board post to a NEW scratchpad minted a fresh conversation on send
+          // (`intent: "new"`). Seed its board card from the response — keyed by the
+          // real conversation + (post-promotion) stream ids — so it appears the
+          // moment the scratchpad materializes rather than after the async
+          // `conversation:created` echo + board-head refetch. Reconciled in place by
+          // both (same id, `_status` cleared). `existing`/`threadFromMessage` replies
+          // also return an id, but their card already exists so the write no-ops.
+          if (conversationId && next.conversation?.intent === "new") {
+            const stream = await db.streams.get(next.streamId)
+            if (stream) {
+              await putOptimisticBoardPost(next.workspaceId, {
+                conversationId,
+                messageId: message.id,
+                streamId: next.streamId,
+                authorId: message.authorId,
+                contentMarkdown: message.contentMarkdown,
+                rootStreamId: stream.rootStreamId ?? stream.id,
+                rootStreamType: stream.type as BoardScopeStreamType,
+                createdAt: message.createdAt,
+              })
+            }
+          }
         }
 
         await db.pendingMessages.delete(next.clientId)

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -55,6 +55,11 @@ function post(id: string, activityMs: number): CachedBoardPost {
   } as unknown as CachedBoardPost
 }
 
+/** The viewer's own optimistic post — `_status: "pending"`, as `putOptimisticBoardPost` writes it. */
+function pendingPost(id: string, activityMs: number): CachedBoardPost {
+  return { ...post(id, activityMs), _status: "pending" } as unknown as CachedBoardPost
+}
+
 /** A post carrying the fields `matchesBoardLens` reads, for cross-lens tests. */
 function lensPost(
   id: string,
@@ -177,46 +182,40 @@ describe("useStableBoardView", () => {
     expect(result.current.newCount).toBe(0)
   })
 
-  it("auto-reveals on the next arrival when revealNext is armed (the viewer's own post)", () => {
+  it("reveals the viewer's own pending post at top the moment it lands", () => {
     mockLive(feed(post("a", 300)))
     const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
-    act(() => result.current.revealNext())
-    act(() => mockLive(feed(post("mine", 600), post("a", 300))))
+    act(() => mockLive(feed(pendingPost("mine", 600), post("a", 300))))
     rerender()
     expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
     expect(result.current.newCount).toBe(0)
   })
 
-  it("reveals a post that already buffered before revealNext armed (the optimistic write landed first)", () => {
+  it("reveals a pending post that materializes arbitrarily later (a queued scratchpad send), no arm window", () => {
     mockLive(feed(post("a", 300)))
     const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
-    // The optimistic IDB write lands and buffers BEFORE the send resolves and arms.
-    act(() => mockLive(feed(post("mine", 600), post("a", 300))))
+    // An unrelated arrival buffers first; then, much later (past any old 8s arm),
+    // the viewer's own scratchpad card finally lands from the drain.
+    act(() => mockLive(feed(post("other", 500), post("a", 300))))
     rerender()
     expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
     expect(result.current.newCount).toBe(1)
-    // Arming now flushes the already-buffered card instead of stranding it.
-    act(() => result.current.revealNext())
+    act(() => mockLive(feed(pendingPost("mine", 900), post("other", 500), post("a", 300))))
+    rerender()
+    // The own card reveals at top; the unrelated arrival stays behind the pill.
     expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
-    expect(result.current.newCount).toBe(0)
+    expect(result.current.newCount).toBe(1)
   })
 
-  it("disarms revealNext after its window, so a later unrelated arrival buffers", () => {
-    vi.useFakeTimers()
-    try {
-      mockLive(feed(post("a", 300)))
-      const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
-      act(() => result.current.revealNext())
-      // Nothing arrived within the window; the arm expires.
-      act(() => vi.advanceTimersByTime(8001))
-      act(() => mockLive(feed(post("late", 600), post("a", 300))))
-      rerender()
-      // The stale arm did not fire — the late arrival waits behind the pill.
-      expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
-      expect(result.current.newCount).toBe(1)
-    } finally {
-      vi.useRealTimers()
-    }
+  it("reveals ONLY the viewer's own pending card, leaving other users' arrivals buffered", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
+    // Two unrelated new conversations accumulate, then the viewer posts.
+    act(() => mockLive(feed(pendingPost("mine", 900), post("x", 700), post("y", 600), post("a", 300))))
+    rerender()
+    // Posting doesn't flush x/y — they stay behind the pill; only "mine" surfaces.
+    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
+    expect(result.current.newCount).toBe(2)
   })
 
   it("keeps a vanished committed card rendering in place until the next commit", () => {
@@ -337,10 +336,10 @@ describe("useStableBoardView", () => {
     expect(result.current.posts.map((p) => p.id)).toEqual(["i"])
   })
 
-  it("keeps the reveal arm across a filter reset — posting from a filtered view reveals on All", () => {
+  it("reveals the viewer's own pending post after a filter reset (posting from a filtered view)", () => {
     // Posting from a filtered board navigates back to the All home (the new post
-    // might not match the filter); the reveal armed by the post must survive that
-    // reset so the authored card surfaces instead of hiding behind its own pill.
+    // might not match the filter); the pending optimistic card reveals itself at
+    // top there via reconcile, no arm to carry across the reset.
     const stalled = lensPost("s", 300, { status: "stalled" })
     mockLive(feed(stalled))
     const { result, rerender } = renderHook(({ filter }) => useStableBoardView("ws_1", filter), {
@@ -348,12 +347,9 @@ describe("useStableBoardView", () => {
     })
     expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
 
-    act(() => result.current.revealNext())
+    // Navigate to All, then the authored card lands after the fresh view's commit.
     rerender({ filter: ALL })
-    expect(result.current.posts.map((p) => p.id)).toEqual(["s"])
-
-    // The authored post lands after the fresh view's wholesale commit.
-    act(() => mockLive(feed(lensPost("mine", 900, { status: "active" }), stalled)))
+    act(() => mockLive(feed(pendingPost("mine", 900), stalled)))
     rerender({ filter: ALL })
     expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "s"])
     expect(result.current.newCount).toBe(0)

--- a/apps/frontend/src/hooks/use-stable-board-view.test.tsx
+++ b/apps/frontend/src/hooks/use-stable-board-view.test.tsx
@@ -187,6 +187,20 @@ describe("useStableBoardView", () => {
     expect(result.current.newCount).toBe(0)
   })
 
+  it("reveals a post that already buffered before revealNext armed (the optimistic write landed first)", () => {
+    mockLive(feed(post("a", 300)))
+    const { result, rerender } = renderHook(() => useStableBoardView("ws_1", ALL))
+    // The optimistic IDB write lands and buffers BEFORE the send resolves and arms.
+    act(() => mockLive(feed(post("mine", 600), post("a", 300))))
+    rerender()
+    expect(result.current.posts.map((p) => p.id)).toEqual(["a"])
+    expect(result.current.newCount).toBe(1)
+    // Arming now flushes the already-buffered card instead of stranding it.
+    act(() => result.current.revealNext())
+    expect(result.current.posts.map((p) => p.id)).toEqual(["mine", "a"])
+    expect(result.current.newCount).toBe(0)
+  })
+
   it("disarms revealNext after its window, so a later unrelated arrival buffers", () => {
     vi.useFakeTimers()
     try {

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { matchesBoardLens, type BoardLens, type BoardScopeStreamType } from "@threa/types"
 import { useBoardPosts } from "@/stores/board-store"
 import { projectNestedBoardView } from "@/lib/board/nested-board-view"
@@ -8,11 +8,6 @@ import {
   branchParentConversationId,
 } from "@/hooks/use-conversation-graph"
 import type { CachedBoardPost } from "@/db"
-
-/** How long `revealNext` stays armed after the viewer posts. Bounds the auto-
- *  reveal to the window right after their own action, so a stale arm can't later
- *  fire on an unrelated incoming conversation. */
-const REVEAL_ARM_MS = 8000
 
 /** A board post in the stable view — re-exported so UI (which can't import `@/db`
  *  directly, INV-15) shares the exact shape the hook renders from. */
@@ -198,18 +193,25 @@ function sameIds(a: string[], b: string[]): boolean {
 }
 
 /**
- * Fold the live IDB feed into the committed view. Two kinds of "not yet
- * committed" rows are told apart by the committed window's frozen lower bound:
+ * Fold the live IDB feed into the committed view. A "not yet committed" row is
+ * classified against the committed window's frozen lower bound:
  *
  *  - **Below the floor** — older content paged in by "Load more". It lands below
  *    the viewport, so appending it to the frozen order shifts nothing on-screen;
  *    fold it in immediately (no pill).
- *  - **At or above the floor** — a fresh arrival (new conversation, or a card
- *    bumped up past where it was). Revealing it would reorder the view, so it
- *    waits in the buffer and is surfaced as the "N new" pill count instead.
+ *  - **The viewer's own optimistic post** (`_status === "pending"`, only ever set
+ *    by `putOptimisticBoardPost` for the author's own send) — revealed at top
+ *    immediately, regardless of any timer. The authored card must surface as soon
+ *    as it lands, whether that's inline (existing-stream) or after the promote-on-
+ *    send drain (a new scratchpad, arbitrarily later). Revealing ONLY the pending
+ *    card leaves unrelated arrivals still buffered, so posting never reorders the
+ *    cards the viewer was reading (board-view-design.md "don't move shit on me").
+ *  - **Any other at-or-above-floor arrival** — a new conversation from someone
+ *    else, or a card bumped up. Revealing it would reorder the view, so it waits
+ *    in the buffer and is surfaced as the "N new" pill count instead.
  *
- * Returns the same `committed` reference when nothing pages in, so the caller can
- * skip a state write.
+ * Returns the same `committed` reference when nothing pages in or reveals, so the
+ * caller can skip a state write.
  */
 export function reconcileStableView(
   committed: CommittedView,
@@ -227,23 +229,31 @@ export function reconcileStableView(
   for (const ms of committed.activityById.values()) if (ms < floor) floor = ms
 
   const paged: CachedBoardPost[] = []
+  const revealed: CachedBoardPost[] = []
   const buffered: string[] = []
   for (const post of live) {
     if (committedSet.has(postId(post))) continue
-    if (postMs(post) < floor) paged.push(post)
+    if (post._status === "pending") revealed.push(post)
+    else if (postMs(post) < floor) paged.push(post)
     else buffered.push(postId(post))
   }
 
-  if (paged.length === 0) {
+  if (paged.length === 0 && revealed.length === 0) {
     return { committed, buffered }
   }
 
-  // Append paged-in older rows below the frozen window, activity-desc.
+  // The viewer's own pending posts prepend at top (newest); paged-in older rows
+  // append below the frozen window. Both activity-desc; the committed cards
+  // between keep their frozen positions.
+  revealed.sort((a, b) => postMs(b) - postMs(a))
   paged.sort((a, b) => postMs(b) - postMs(a))
   const activityById = new Map(committed.activityById)
-  for (const post of paged) activityById.set(postId(post), postMs(post))
+  for (const post of [...revealed, ...paged]) activityById.set(postId(post), postMs(post))
   return {
-    committed: { order: [...committed.order, ...paged.map(postId)], activityById },
+    committed: {
+      order: [...revealed.map(postId), ...committed.order, ...paged.map(postId)],
+      activityById,
+    },
     buffered,
   }
 }
@@ -257,8 +267,6 @@ export interface StableBoardView {
   newCount: number
   /** Reveal buffered changes: re-snapshot the live order as the committed view. */
   commit: () => void
-  /** Arm a one-shot auto-commit on the next live change (the viewer's own post). */
-  revealNext: () => void
   /** True until the underlying IDB read first resolves. */
   isLoading: boolean
   /**
@@ -365,31 +373,6 @@ export function useStableBoardView(
   // drops it — a removal never shifts the rows below it.
   const retainedRef = useRef<Map<string, CachedBoardPost>>(new Map())
   const liveRef = useRef<CachedBoardPost[]>([])
-  // Mirror of `buffered` for `revealNext` to read synchronously: the viewer's own
-  // post can land in the buffer BEFORE `revealNext` arms (the optimistic IDB write
-  // fires its liveQuery a tick before the send resolves), so arming also flushes
-  // whatever is already buffered — otherwise the just-posted card would strand
-  // behind its own pill.
-  const bufferedRef = useRef<string[]>([])
-  bufferedRef.current = buffered
-  // One-shot: when armed, the next live change with fresh arrivals commits
-  // instead of buffering — so the viewer's own just-posted card is revealed, not
-  // hidden behind its own pill. Auto-disarms after REVEAL_ARM_MS so a post that
-  // never lands a visible conversation can't leave it armed to fire on an
-  // unrelated arrival minutes later. Deliberately survives the view reset below:
-  // posting from a filtered view navigates back to the All home (the post might
-  // not match the filter), and the arm must still be live there to surface the
-  // authored card when it arrives after the fresh view's wholesale commit.
-  const revealNextRef = useRef(false)
-  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const disarmReveal = useCallback(() => {
-    revealNextRef.current = false
-    if (revealTimerRef.current) {
-      clearTimeout(revealTimerRef.current)
-      revealTimerRef.current = null
-    }
-  }, [])
-  useEffect(() => disarmReveal, [disarmReveal])
 
   // Reset the view when the workspace OR the filter (lens/scope/types) changes
   // in place (the board route keeps the same component instance across
@@ -430,16 +413,11 @@ export function useStableBoardView(
   if (live) {
     liveRef.current = live
     for (const post of live) retainedRef.current.set(postId(post), post)
+    // `reconcileStableView` reveals the viewer's own pending post (at top) and
+    // paged-in older rows; everything else stays buffered behind the pill.
     const next = reconcileStableView(committedInput, live)
     if (next.committed !== committedInput) setCommitted(next.committed)
-    if (revealNextRef.current && next.buffered.length > 0) {
-      disarmReveal()
-      const snap = snapshot(live)
-      if (!sameIds(snap.order, committedInput.order)) setCommitted(snap)
-      if (bufferedInput.length > 0) setBuffered([])
-    } else if (!sameIds(bufferedInput, next.buffered)) {
-      setBuffered(next.buffered)
-    }
+    if (!sameIds(bufferedInput, next.buffered)) setBuffered(next.buffered)
   }
 
   const commit = useCallback(() => {
@@ -449,18 +427,6 @@ export function useStableBoardView(
     const keep = new Set(snap.order)
     for (const id of [...retainedRef.current.keys()]) if (!keep.has(id)) retainedRef.current.delete(id)
   }, [])
-
-  const revealNext = useCallback(() => {
-    // Flush anything already buffered (the post may have landed before this armed)…
-    if (bufferedRef.current.length > 0) commit()
-    // …and arm for an arrival still in flight (the send hasn't echoed yet).
-    revealNextRef.current = true
-    if (revealTimerRef.current) clearTimeout(revealTimerRef.current)
-    revealTimerRef.current = setTimeout(() => {
-      revealNextRef.current = false
-      revealTimerRef.current = null
-    }, REVEAL_ARM_MS)
-  }, [commit])
 
   const posts = useMemo(() => {
     const liveById = new Map((live ?? []).map((post) => [postId(post), post]))
@@ -484,7 +450,6 @@ export function useStableBoardView(
     activityById: committed.activityById,
     newCount: buffered.length,
     commit,
-    revealNext,
     isLoading: live === undefined,
     hasRawPosts: (rawLive?.length ?? 0) > 0,
   }

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -365,6 +365,13 @@ export function useStableBoardView(
   // drops it — a removal never shifts the rows below it.
   const retainedRef = useRef<Map<string, CachedBoardPost>>(new Map())
   const liveRef = useRef<CachedBoardPost[]>([])
+  // Mirror of `buffered` for `revealNext` to read synchronously: the viewer's own
+  // post can land in the buffer BEFORE `revealNext` arms (the optimistic IDB write
+  // fires its liveQuery a tick before the send resolves), so arming also flushes
+  // whatever is already buffered — otherwise the just-posted card would strand
+  // behind its own pill.
+  const bufferedRef = useRef<string[]>([])
+  bufferedRef.current = buffered
   // One-shot: when armed, the next live change with fresh arrivals commits
   // instead of buffering — so the viewer's own just-posted card is revealed, not
   // hidden behind its own pill. Auto-disarms after REVEAL_ARM_MS so a post that
@@ -444,13 +451,16 @@ export function useStableBoardView(
   }, [])
 
   const revealNext = useCallback(() => {
+    // Flush anything already buffered (the post may have landed before this armed)…
+    if (bufferedRef.current.length > 0) commit()
+    // …and arm for an arrival still in flight (the send hasn't echoed yet).
     revealNextRef.current = true
     if (revealTimerRef.current) clearTimeout(revealTimerRef.current)
     revealTimerRef.current = setTimeout(() => {
       revealNextRef.current = false
       revealTimerRef.current = null
     }, REVEAL_ARM_MS)
-  }, [])
+  }, [commit])
 
   const posts = useMemo(() => {
     const liveById = new Map((live ?? []).map((post) => [postId(post), post]))

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -356,7 +356,6 @@ function BoardPageInner({
     activityById,
     newCount,
     commit,
-    revealNext,
     isLoading: viewLoading,
     hasRawPosts,
   } = useStableBoardView(workspaceId, filter, exclusions)
@@ -476,13 +475,14 @@ function BoardPageInner({
     // current view can contain it — an unfiltered `all`/`mine` lens — so stay
     // put there (a `mine` home shouldn't bounce the author off their own home).
     // Any other view (a status/memo lens, or an active scope filter) might not
-    // match the fresh post, so return to the All baseline; the reveal arm
-    // survives the view reset and floats the authored card to the top.
+    // match the fresh post, so return to the All baseline; the optimistic card
+    // (written `_status: "pending"`) then reveals itself at top there via
+    // `reconcileStableView`, whether it lands inline or later from the
+    // promote-on-send drain — no reveal arm to carry across the reset.
     const currentViewSurfacesOwnPost = SELF_POST_VISIBLE_LENSES.has(lens) && !hasFilterParams
     if (!currentViewSurfacesOwnPost) {
       navigate(boardHome)
     }
-    revealNext()
   }
 
   // Where the post lives — the stream's own name (channel #slug, DM peer,

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { seedBoardPosts, mergeBoardConversation } from "./board-store"
+import { seedBoardPosts, mergeBoardConversation, putOptimisticBoardPost } from "./board-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 
 const WORKSPACE_ID = "ws_1"
@@ -135,5 +135,49 @@ describe("mergeBoardConversation", () => {
     const merged = await mergeBoardConversation("conv_absent", emptied)
     expect(merged).toBe(true)
     expect(await readBoard()).toHaveLength(0)
+  })
+})
+
+describe("putOptimisticBoardPost", () => {
+  const input = {
+    conversationId: "conv_new",
+    messageId: "msg_1",
+    streamId: "stream_1",
+    authorId: "usr_1",
+    contentMarkdown: "just posted",
+    rootStreamId: "stream_1",
+    rootStreamType: "channel" as const,
+    createdAt: "2026-06-22T12:00:00.000Z",
+  }
+
+  it("slots a pending card keyed by the real conversation id, renderable from the send alone", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, input)
+    const row = await db.conversations.get("conv_new")
+    expect(row).toMatchObject({
+      id: "conv_new",
+      workspaceId: WORKSPACE_ID,
+      _status: "pending",
+      openingMessage: expect.objectContaining({ id: "msg_1", contentMarkdown: "just posted", authorId: "usr_1" }),
+      isMine: true,
+      rootStreamType: "channel",
+    })
+    expect(row?.conversation.status).toBe("active")
+    expect(row?.conversation.messageIds).toEqual(["msg_1"])
+  })
+
+  it("reconciles in place: the conversation echo merges over it and clears the pending flag", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, input)
+    await mergeBoardConversation("conv_new", makeConversation("conv_new", "2026-06-22T12:00:05.000Z"))
+    const row = await db.conversations.get("conv_new")
+    expect(row?._status).toBeUndefined()
+    // Merge keeps the optimistic opening body (the echo carries no message bodies).
+    expect(row?.openingMessage?.contentMarkdown).toBe("just posted")
+  })
+
+  it("never regresses a live row to pending when the echo/refetch won the race", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_new", "2026-06-22T12:00:09.000Z")])
+    await putOptimisticBoardPost(WORKSPACE_ID, input)
+    const row = await db.conversations.get("conv_new")
+    expect(row?._status).toBeUndefined()
   })
 })

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -180,4 +180,15 @@ describe("putOptimisticBoardPost", () => {
     const row = await db.conversations.get("conv_new")
     expect(row?._status).toBeUndefined()
   })
+
+  it("renders the post's attachments immediately so the thumbnail doesn't pop in on reconcile", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, {
+      ...input,
+      attachments: [{ id: "att_1", filename: "shot.png", mimeType: "image/png", sizeBytes: 2048 }],
+    })
+    const row = await db.conversations.get("conv_new")
+    expect(row?.openingMessage?.attachments).toEqual([
+      { id: "att_1", filename: "shot.png", mimeType: "image/png", sizeBytes: 2048 },
+    ])
+  })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedBoardPost } from "@/db"
-import type { BoardPost, ConversationWithStaleness } from "@threa/types"
+import type { BoardPost, BoardScopeStreamType, ConversationWithStaleness } from "@threa/types"
 
 /**
  * How many trailing replies a board card previews. Mirrors the backend's
@@ -69,6 +69,89 @@ export function useBoardPost(conversationId: string | null): CachedBoardPost | n
 export async function seedBoardPosts(workspaceId: string, posts: BoardPost[]): Promise<void> {
   if (posts.length === 0) return
   await db.conversations.bulkPut(posts.map((post) => toCached(workspaceId, post)))
+}
+
+/** The known facts about a board post the instant the send returns — enough to
+ *  render its card before the `conversation:*` echo carries the full aggregate. */
+export interface OptimisticBoardPostInput {
+  /** The conversation the backend minted for this post, returned on the send. */
+  conversationId: string
+  /** The opening message's server id (from the send response). */
+  messageId: string
+  /** The stream the post was authored into (a channel or DM). */
+  streamId: string
+  /** The author — the current user. */
+  authorId: string
+  /** The post body, already serialized to markdown for the card preview. */
+  contentMarkdown: string
+  /** The stream's effective root (a channel/DM is its own root). */
+  rootStreamId: string
+  rootStreamType: BoardScopeStreamType
+  /** ISO timestamp used for the opening message and the card's activity sort. */
+  createdAt: string
+}
+
+/**
+ * Slot an authored board post into the reactive feed the instant the send
+ * returns, keyed by the REAL conversation id the backend assigned synchronously
+ * (surfaced on the send response) — so the card appears as the composer clears
+ * rather than after the socket echo + board-head refetch round-trips. Written
+ * `_status: "pending"`; the `conversation:*` echo (`mergeBoardConversation`) and
+ * the board-head refetch (`seedBoardPosts`) reconcile it in place by the same id,
+ * clearing `_status` with no card swap or flash. Skipped if a row already exists
+ * for the id (the echo/refetch won the race), so a live aggregate is never
+ * regressed to a pending stub.
+ */
+export async function putOptimisticBoardPost(workspaceId: string, input: OptimisticBoardPostInput): Promise<void> {
+  const conversation: ConversationWithStaleness = {
+    id: input.conversationId,
+    streamId: input.streamId,
+    workspaceId,
+    messageIds: [input.messageId],
+    participantIds: [input.authorId],
+    secondaryMessageIds: [],
+    topicSummary: null,
+    summary: null,
+    completenessScore: 1,
+    confidence: 1,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: input.createdAt,
+    createdAt: input.createdAt,
+    updatedAt: input.createdAt,
+    temporalStaleness: 0,
+    effectiveCompleteness: 1,
+  }
+  const post: BoardPost = {
+    conversation,
+    openingMessage: {
+      id: input.messageId,
+      streamId: input.streamId,
+      authorId: input.authorId,
+      authorType: "user",
+      contentMarkdown: input.contentMarkdown,
+      reactions: {},
+      // Attachments (if any) fill in from the echo/refetch a beat later; the
+      // opening body renders immediately.
+      attachments: [],
+      linkPreviews: [],
+      createdAt: input.createdAt,
+      editedAt: null,
+    },
+    recentMessages: [],
+    totalReplies: 0,
+    streamIds: [input.streamId],
+    hasCapturedMemo: false,
+    // The author's own post is trivially theirs — shows on the Mine lens at once.
+    isMine: true,
+    rootStreamId: input.rootStreamId,
+    rootStreamType: input.rootStreamType,
+    rootArchived: false,
+  }
+  await db.transaction("rw", db.conversations, async () => {
+    if (await db.conversations.get(input.conversationId)) return
+    await db.conversations.put(toCached(workspaceId, post, "pending"))
+  })
 }
 
 /**

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -1,7 +1,7 @@
 import Dexie from "dexie"
 import { useLiveQuery } from "dexie-react-hooks"
 import { db, type CachedBoardPost } from "@/db"
-import type { BoardPost, BoardScopeStreamType, ConversationWithStaleness } from "@threa/types"
+import type { AttachmentSummary, BoardPost, BoardScopeStreamType, ConversationWithStaleness } from "@threa/types"
 
 /**
  * How many trailing replies a board card previews. Mirrors the backend's
@@ -89,6 +89,9 @@ export interface OptimisticBoardPostInput {
   rootStreamType: BoardScopeStreamType
   /** ISO timestamp used for the opening message and the card's activity sort. */
   createdAt: string
+  /** The post's uploaded attachments, so the card renders them immediately
+   *  instead of popping the thumbnail in when the board-head refetch reconciles. */
+  attachments?: AttachmentSummary[]
 }
 
 /**
@@ -131,9 +134,7 @@ export async function putOptimisticBoardPost(workspaceId: string, input: Optimis
       authorType: "user",
       contentMarkdown: input.contentMarkdown,
       reactions: {},
-      // Attachments (if any) fill in from the echo/refetch a beat later; the
-      // opening body renders immediately.
-      attachments: [],
+      attachments: input.attachments ?? [],
       linkPreviews: [],
       createdAt: input.createdAt,
       editedAt: null,


### PR DESCRIPTION
## Problem

A board post showed **no card until several round-trips finished**, leaving a visible gap after the composer cleared:

- **Existing channel/DM post** — `useCreateBoardPost` sent the message inline, but the board reads `db.conversations` reactively (`useBoardPosts`) and that row didn't exist locally until the `conversation:created` echo (`mergeBoardConversation` returns `false` for an uncached card → `handleConversationUpserted` invalidates the board-head query) → refetch → `seedBoardPosts`. Send round-trip + echo + refetch before anything appeared.
- **New scratchpad / quick note** — worse: the send is deferred to the promote-on-send queue, and the first message declared no conversation, so the card waited on the **async boundary extractor** to mint the conversation, then its echo, then the refetch.

The conversation is already minted synchronously in the send's transaction (`conversationAssigner.assignInTransaction`), but its id was discarded — so the client had no id to key an optimistic row by.

## Solution

Surface the synchronously-minted conversation id on the send response and write a **real** optimistic board row keyed by it — the design-doc "one primitive" path (`docs/board-view-design.md` § "Optimism = a local pending IDB write"), not a temp-id swap or a second render lane. The `conversation:created` echo (`mergeBoardConversation`) and the board-head refetch (`seedBoardPosts`) reconcile the row in place by the same id and clear `_status`, so there's no card swap or flash.

### How it works

**Backend — surface the id:**
1. `ConversationAssigner.assignInTransaction` now returns the assigned conversation id (minted for `new`, joined for `existing`/`threadFromMessage`/`newSubtopic`).
2. `EventService.createMessageReturningConversation` exposes `{ message, conversationId? }`; `createMessage` delegates to it and unwraps `.message`, so it keeps returning `Message` and its callers are untouched. Only the message-create handler switches to the new method.
3. The message-create handler puts `conversationId` on the 201 response for a declared directive. Internal endpoint — no OpenAPI change (gate confirmed "spec is up to date").

**Frontend — slot the card:**
4. `putOptimisticBoardPost` (board-store) writes a `_status: "pending"` `CachedBoardPost` keyed by the real id, in a transaction that **skips if a row already exists** so a live aggregate is never regressed to a pending stub (echo/refetch race).
5. **Existing channel/DM** — `useCreateBoardPost` writes it right after the inline send returns (card at composer-clear), reusing `currentUserId` from `useQueueDraftMessage`.
6. **New scratchpad** — declares `conversation: { intent: "new" }` on the queued send so the backend mints synchronously; the queue drain (`useMessageQueue`) seeds the card from the send response after promotion, keyed by the **real** conversation + post-promotion stream ids. Guarded on `intent === "new"` so `existing`/`threadFromMessage` replies (whose card already exists) no-op.
7. `useStableBoardView.revealNext` now flushes an already-buffered arrival before arming, closing the race where the optimistic IDB write's liveQuery fires *before* the send resolves and `revealNext` arms — otherwise the just-posted card would strand behind its own "N new" pill.

### Key design decisions

**1. One conversation-row primitive, not a dual render lane.** The design doc's open decision (§ "Keep the conversation as the single board card") leaned toward "one primitive, no dual render path, INV-29/43-clean." A temp-conversation-id approach would also fight the stable view: `useStableBoardView`'s committed order is keyed by conversation id, so swapping a temp id for the real one on echo would make the committed card vanish until the next commit — a real disappear-flash. Keying by the real id from the start avoids it entirely.

**2. Scratchpad card seeds *after* the send, not at composer-clear.** A new scratchpad genuinely has no server identity until promotion. Seeding the card in the drain (post-send, real ids) rather than eagerly (client-minted id, pre-send) means a queued send that fails never leaves a phantom card keyed by a conversation the server never created — consistent with the existing-stream path's "card on success" rule. The residual: the card appears when the scratchpad materializes, not at composer-clear. That's inherent to the promote-on-send queue; it still collapses the old latency (async extractor → echo → refetch) to a single send.

**3. `createMessage` signature preserved.** `createMessageReturningConversation` is a sibling method rather than a return-type change, so every `createMessage` caller (`system-messages`, `scheduled-messages`, `bot-runtimes`, `enclave-runtimes`, `server.ts`, public-API, the handler's E2E branch) stays on `Promise<Message>`. Only the three public-API `createMessageInTransaction` call sites had to unwrap `.message`.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/conversation-assigner.ts` | `assignInTransaction` + the mint/attach helpers return the assigned conversation id |
| `apps/backend/src/features/messaging/event-service.ts` | `createMessageReturningConversation` + `createMessageInTransaction`/`_createMessageTxn` return `{ message, conversationId? }`; `createMessage` unwraps to `Message`; assigner interface returns `Promise<string>` |
| `apps/backend/src/features/messaging/handlers.ts` | message-create handler surfaces `conversationId` on the 201 response |
| `apps/backend/src/features/public-api/handlers.ts` | 3 direct `createMessageInTransaction` call sites unwrap `.message` |
| `apps/frontend/src/api/messages.ts` | `messagesApi.create` returns `{ message, conversationId? }` |
| `apps/frontend/src/stores/board-store.ts` | `putOptimisticBoardPost` + `OptimisticBoardPostInput` — pending row keyed by the real id, skip-if-present |
| `apps/frontend/src/hooks/use-conversations.ts` | `useCreateBoardPost` seeds the card for existing-stream posts; declares `intent: "new"` on the scratchpad send |
| `apps/frontend/src/hooks/use-message-queue.ts` | drain seeds the card from the send response for a newly-minted conversation |
| `apps/frontend/src/hooks/use-stable-board-view.ts` | `revealNext` flushes an already-buffered arrival before arming (`bufferedRef`) |
| `apps/backend/.../*.test.ts`, `apps/frontend/.../*.test.{ts,tsx}` | assigner return-id, `createMessageReturningConversation`, `putOptimisticBoardPost` (slot / reconcile / no-regress), revealNext flush-race, drain seed / skip; updated mocks for the new return shape |

## Out of scope (deliberate)

- **Existing-stream posts are not switched to client-minted ids.** They already show the card at composer-clear via the server-returned id; client-minting would only lose message-id fidelity during the pending window.
- **E2E scratchpad posts** — the board composer doesn't seal, so this path is plaintext-only; the drain's E2E branch is untouched.

## Test plan

- [x] Backend `bun test src/features/messaging src/features/conversations src/features/public-api` — 329 pass
- [x] Frontend `vitest run` board/queue/conversation/stable-view suites (`src/components/board`, `use-message-queue`, `use-conversations`, `use-stable-board-view`, `board-store`, `board.test`) — 147 pass
- [x] Full monorepo pre-commit gate on both commits: prettier, all-app eslint, 14-workspace `tsc`, dockerfile/migration checks, OpenAPI `--check` ("spec is up to date")
- [x] Self-review (correctness + claim-verification pass over the diff) folded into the two commits
- [ ] `/code-review` on the branch runs immediately after this PR opens (results posted as a review comment)
- [ ] No authed-app harness in this environment — the end-to-end board flow (post → card slots in → echo reconciles) is covered by unit tests over each seam, not driven in a live browser

<details>
<summary>📋 Full implementation plan</summary>

**Goal.** Board posts slot their card optimistically instead of waiting on the conversation echo + board-head refetch.

**What was built.**
1. Backend surfaces the synchronously-minted conversation id on the message-create response (`createMessageReturningConversation`; assigner returns its id).
2. `putOptimisticBoardPost` writes a real pending `CachedBoardPost` keyed by that id, skip-if-present.
3. Existing channel/DM posts seed it inline (composer-clear); new scratchpad posts seed it from the queue drain after promotion, having declared `intent: "new"` so the backend mints synchronously.
4. `revealNext` flushes an already-buffered arrival before arming, closing the optimistic-write-lands-before-arm race.

**Design decisions.** One conversation-row primitive keyed by the real id (no temp-id swap flash, no dual render lane); scratchpad card seeds post-send to avoid phantom cards on queued-send failure; `createMessage` signature preserved via a sibling method.

**What's NOT included.** Existing-stream posts keep the server-returned id (not client-minted); E2E scratchpad posts unchanged (plaintext path only).

**Status.** Two commits, full gate green, pushed.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQB3C2bxS3K5yg3336yVGE)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786121203&installation_id=129946197&pr_number=1248&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1248&signature=681b5e05aeb300d842f6e18661bf885a34794150f1177095dee0a557a4d47c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->