### PR TITLE
fix(timeline): suppress jump-window edge pagination

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -6,6 +6,7 @@ import {
   canActOnDeepLinkNavigation,
   computeScrollEdges,
   shouldPrefetchOlderHistory,
+  shouldRunEdgePagination,
   shouldShowOlderSkeletons,
   resolveDateJumpAnchor,
 } from "./stream-content"
@@ -314,6 +315,24 @@ describe("shouldPrefetchOlderHistory", () => {
 
   it("does not stack a second fetch while one is already in flight", () => {
     expect(shouldPrefetchOlderHistory({ ...base, isFetchingOlder: true })).toBe(false)
+  })
+})
+
+describe("shouldRunEdgePagination", () => {
+  it("blocks edge prefetch while a programmatic jump is still refining", () => {
+    expect(shouldRunEdgePagination({ scrollRefineActive: true, isJumpMode: false, userInteractedAt: 0 })).toBe(false)
+  })
+
+  it("blocks automatic edge prefetch after landing in a jump window before user scroll", () => {
+    expect(shouldRunEdgePagination({ scrollRefineActive: false, isJumpMode: true, userInteractedAt: 0 })).toBe(false)
+  })
+
+  it("allows edge prefetch in jump mode after a genuine user scroll", () => {
+    expect(shouldRunEdgePagination({ scrollRefineActive: false, isJumpMode: true, userInteractedAt: 123 })).toBe(true)
+  })
+
+  it("allows normal edge prefetch outside jump mode", () => {
+    expect(shouldRunEdgePagination({ scrollRefineActive: false, isJumpMode: false, userInteractedAt: 0 })).toBe(true)
   })
 })
 

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -291,6 +291,16 @@ export function shouldPrefetchOlderHistory(args: {
   return !(args.followingLiveTail && args.scrollerScrollable)
 }
 
+export function shouldRunEdgePagination(args: {
+  scrollRefineActive: boolean
+  isJumpMode: boolean
+  userInteractedAt: number
+}): boolean {
+  if (args.scrollRefineActive) return false
+  if (args.isJumpMode && args.userInteractedAt <= 0) return false
+  return true
+}
+
 /** How long an older-page fetch must be in flight before skeleton rows render,
  *  so a fast response never flashes them. */
 export const OLDER_SKELETON_APPEAR_DELAY_MS = 150
@@ -2133,6 +2143,8 @@ export function StreamContent({
                           registerScroller={registerVirtualScroller}
                           contentRef={virtualContentRef}
                           scrollAbortRef={scrollAbortRef}
+                          isJumpMode={isJumpMode}
+                          userInteractedAtRef={userInteractedAtRef}
                           shift={shift}
                           isInitialSettling={virtualIsInitialSettling}
                           onTimelineScroll={handleVirtualScroll}
@@ -2393,6 +2405,8 @@ function TimelineMessageList({
   registerScroller,
   contentRef,
   scrollAbortRef,
+  isJumpMode,
+  userInteractedAtRef,
   shift,
   isInitialSettling,
   onTimelineScroll,
@@ -2439,6 +2453,10 @@ function TimelineMessageList({
   /** Non-null while a scrollToMessage refine loop is in flight. Programmatic
    *  scroll-into-view must not trigger edge pagination. */
   scrollAbortRef: React.MutableRefObject<(() => void) | null>
+  /** True while reading a deep-linked / searched history window. */
+  isJumpMode: boolean
+  /** Last genuine user scroll gesture on the scroller. */
+  userInteractedAtRef: React.MutableRefObject<number>
   /** virtua `shift`: maintain scroll from the end on this render (older page
    *  prepended) so the viewport doesn't move. */
   shift: boolean
@@ -2645,7 +2663,15 @@ function TimelineMessageList({
   const handleScroll = useCallback(() => {
     onTimelineScroll()
     updateDatePill()
-    if (scrollAbortRef.current !== null) return
+    if (
+      !shouldRunEdgePagination({
+        scrollRefineActive: scrollAbortRef.current !== null,
+        isJumpMode,
+        userInteractedAt: userInteractedAtRef.current,
+      })
+    ) {
+      return
+    }
     const el = scrollerRef.current
     if (!el) return
     const { reachedStart, reachedEnd } = computeScrollEdges({
@@ -2656,7 +2682,16 @@ function TimelineMessageList({
     })
     if (reachedStart) handleStartReached()
     if (reachedEnd) handleEndReached()
-  }, [onTimelineScroll, updateDatePill, scrollAbortRef, scrollerRef, handleStartReached, handleEndReached])
+  }, [
+    onTimelineScroll,
+    updateDatePill,
+    scrollAbortRef,
+    isJumpMode,
+    userInteractedAtRef,
+    scrollerRef,
+    handleStartReached,
+    handleEndReached,
+  ])
 
   // virtua has no rangeChanged, so a window that fits the viewport (not
   // scrollable) would never fire a scroll to page in older history the user


### PR DESCRIPTION
## Problem

Message jumps (`?m=` deep links, in-stream search, date jumps) can land on the right row and still feel broken. The target centers, then `TimelineMessageList`'s edge prefetch sees the jump window near the top/bottom and immediately starts `fetchOlderEvents` / `fetchNewerEvents`. Those page inserts change scroll height around the highlighted row and produce the visible bounce shown in the prod Pierre DM recordings.

## Solution

Gate edge pagination while a programmatic jump owns the viewport. The jump still centers through the existing `scrollToMessage` refine loop; older/newer prefetch resumes only after a genuine user scroll gesture.

### How it works

1. `shouldRunEdgePagination` in `apps/frontend/src/components/timeline/stream-content.tsx` returns false while `scrollAbortRef.current` is non-null, preserving the existing “refine loop owns scroll” behavior.
2. The same helper returns false for `isJumpMode && userInteractedAtRef.current <= 0`, blocking automatic edge prefetch after a jump window lands but before the user scrolls.
3. `TimelineMessageList` now receives `isJumpMode` and `userInteractedAtRef` from `StreamContent`; its native scroll handler still runs read/frontier/date-pill work, but skips `computeScrollEdges` / `handleStartReached` / `handleEndReached` until the gate opens.
4. `shouldRunEdgePagination` is covered in `stream-content.test.ts` for refine-active, jump-before-user-scroll, jump-after-user-scroll, and normal scrolling.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Adds the edge-pagination gate and wires jump/user-scroll state into `TimelineMessageList`. |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | Adds unit coverage for the gate. |

## Out of scope

- No change to the jump/refine algorithm itself.
- No change to page size, `EDGE_PREFETCH_PX`, or skeleton rendering.
- No backend/API change.

## Test plan

- [x] `bun --cwd apps/frontend test src/components/timeline/stream-content.test.ts` — 45 pass
- [x] `bun run --cwd apps/frontend typecheck` — clean
- [x] Commit hook — repo lint, monorepo typecheck, Dockerfile workspace check, migration check, OpenAPI check all passed
- [x] Prod repro analysis — reviewed the two attached Pierre DM recordings; issue is immediate older/newer edge pagination after target landing

🤖 _PR by [Codex](https://github.com/openai/codex)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786198257&installation_id=129946197&pr_number=1251&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1251&signature=27598ebd12acf44620cfa2f105201af06ee8ef8b3dd736dc3d7e5c21e2c0aa1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->