### PR TITLE
fix(agents): keep mention turns anchored to the trigger question through mid-turn reconsideration

### DIFF
--- a/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
+++ b/apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts
@@ -253,6 +253,8 @@ describe("buildSystemPrompt", () => {
 
     expect(prompt).toContain("## Invocation Context")
     expect(prompt).toContain("You were explicitly @mentioned by **Kris**")
+    expect(prompt).toContain("Your reply must directly answer that mention message.")
+    expect(prompt).toContain("never let them displace the question you were asked")
   })
 
   test("omits the mention invocation section for a catch-up turn", () => {

--- a/apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts
+++ b/apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts
@@ -45,7 +45,7 @@ function buildMentionSection(context: StreamContext, mentionerName?: string): st
 
 ## Invocation Context
 
-You were explicitly @mentioned by ${mentionerDesc} who wants your assistance.`
+You were explicitly @mentioned by ${mentionerDesc} who wants your assistance. Your reply must directly answer that mention message. If more messages arrive while you are working, treat them as context — in group conversations they are often participants talking to each other, not to you — and never let them displace the question you were asked.`
 
   if (context.streamType === StreamTypes.CHANNEL) {
     section += ` This conversation is happening in a thread created specifically for your response.`
@@ -56,7 +56,12 @@ You were explicitly @mentioned by ${mentionerDesc} who wants your assistance.`
 
 function buildFollowUpSection(context: StreamContext, followUp: { note: string; scheduledFor: Date }): string {
   const scheduledForDisplay = context.temporal
-    ? formatCurrentTime(followUp.scheduledFor, context.temporal.timezone, context.temporal.dateFormat, context.temporal.timeFormat)
+    ? formatCurrentTime(
+        followUp.scheduledFor,
+        context.temporal.timezone,
+        context.temporal.dateFormat,
+        context.temporal.timeFormat
+      )
     : followUp.scheduledFor.toISOString()
 
   return `

--- a/packages/agent-runtime/src/runtime/agent-runtime.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.test.ts
@@ -865,4 +865,56 @@ describe("AgentRuntime mid-turn reconsideration", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1)
     expect(result.sentContents).toEqual(["Final answer to the OTP question."])
   })
+
+  it("re-anchors a keep_response decision when messages arrive after it", async () => {
+    const { nm } = newMessagesOnce()
+    const prompts: Array<Array<{ role: string; content: unknown }>> = []
+    let call = 0
+    const generateTextWithTools = mock(
+      async ({ messages }: { messages: Array<{ role: string; content: unknown }> }) => {
+        prompts.push(messages)
+        call += 1
+        const reason =
+          call === 1
+            ? "Prior response still covers the request."
+            : "Interjection is a side conversation; prior response stands."
+        return {
+          text: "",
+          toolCalls: [{ toolCallId: `tool_${call}`, toolName: "keep_response", input: { reason } }],
+          response: { messages: [{ role: "assistant", content: "" } as any] },
+        }
+      }
+    )
+    const sendMessage = mock(async () => ({ messageId: "msg_unused", operation: "created" as const }))
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [
+        { role: "user", content: "What about a 5-digit OTP plus a check digit?" },
+        { role: "assistant", content: "Check digits shrink the search space - bad idea." },
+      ],
+      tools: [],
+      allowNoMessageOutput: true,
+      newMessages: nm,
+      sendMessage,
+    })
+
+    const result = await runtime.run()
+
+    expect(generateTextWithTools).toHaveBeenCalledTimes(2)
+    const runtimePrompt = prompts[1]!.at(-1)!
+    expect(runtimePrompt.role).toBe("user")
+    // No unsent-draft framing here - the kept response was already delivered.
+    // The prompt must carry the shared side-conversation guidance and the
+    // keep_response/send_message choice instead of implying completion.
+    expect(runtimePrompt.content).toContain("Prior response still covers the request.")
+    expect(runtimePrompt.content).toContain("talking to each other")
+    expect(runtimePrompt.content).toContain("call keep_response again")
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(result.messagesSent).toBe(0)
+    expect(result.noMessageReason).toBe("Interjection is a side conversation; prior response stands.")
+  })
 })

--- a/packages/agent-runtime/src/runtime/agent-runtime.test.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.test.ts
@@ -729,3 +729,140 @@ describe("AgentRuntime runAbortSignal (graceful session Stop)", () => {
     await expect(runtime.run()).rejects.toThrow("upstream 500")
   })
 })
+
+describe("AgentRuntime mid-turn reconsideration", () => {
+  // Regression for the Ariadne/Pierre production failure: a mention question was
+  // drafted correctly, an unrelated interjection landed mid-turn, and the model —
+  // believing its draft had already been sent — replied only to the interjection.
+  const interjection = {
+    sequence: BigInt(4265),
+    messageId: "msg_banter",
+    changeType: "message_created" as const,
+    content: "Now you know how to fix sessions ;)",
+    authorId: "usr_pierre",
+    authorName: "Pierre Boberg",
+    authorType: "user" as const,
+    createdAt: "2026-07-09T19:34:29.123Z",
+  }
+
+  function newMessagesOnce(): { nm: any; updateSequence: ReturnType<typeof mock> } {
+    let delivered = false
+    const updateSequence = mock(async () => {})
+    const nm = {
+      check: async () => {
+        if (delivered) return []
+        delivered = true
+        return [interjection]
+      },
+      updateSequence,
+      awaitAttachments: async () => {},
+      streamId: "stream_1",
+      sessionId: "session_1",
+      personaId: "persona_1",
+      lastProcessedSequence: BigInt(4263),
+    }
+    return { nm, updateSequence }
+  }
+
+  it("tells the model its text draft was not sent and re-anchors the original request", async () => {
+    const { nm, updateSequence } = newMessagesOnce()
+    const prompts: Array<Array<{ role: string; content: unknown }>> = []
+    let call = 0
+    const generateTextWithTools = mock(
+      async ({ messages }: { messages: Array<{ role: string; content: unknown }> }) => {
+        prompts.push(messages)
+        call += 1
+        const text =
+          call === 1
+            ? "Check digits reduce the OTP search space — bad idea."
+            : "Final: check digits reduce the OTP search space — bad idea."
+        return {
+          text,
+          toolCalls: [],
+          response: { messages: [{ role: "assistant", content: text } as any] },
+        }
+      }
+    )
+    const sendMessage = mock(async () => ({ messageId: "msg_reply", operation: "created" as const }))
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [
+        {
+          role: "user",
+          content: "[msg:msg_q author:usr_pierre] [@Pierre Boberg] What about a 5-digit OTP plus a check digit?",
+        },
+      ],
+      tools: [],
+      newMessages: nm,
+      sendMessage,
+    })
+
+    const result = await runtime.run()
+
+    expect(generateTextWithTools).toHaveBeenCalledTimes(2)
+    // Injected interjection carries the same author surface as turn-start history.
+    const secondCall = prompts[1]!
+    const injected = secondCall.find((m) => typeof m.content === "string" && m.content.includes("msg_banter"))
+    expect(injected).toMatchObject({
+      role: "user",
+      content: `[msg:msg_banter author:usr_pierre] [@Pierre Boberg] Now you know how to fix sessions ;)`,
+    })
+    // The reconsideration prompt must not imply the draft was delivered, and must
+    // keep the original request as the thing to answer.
+    const runtimePrompt = secondCall.at(-1)!
+    expect(runtimePrompt.role).toBe("user")
+    expect(runtimePrompt.content).toContain("NOT sent")
+    expect(runtimePrompt.content).toContain("Check digits reduce the OTP search space")
+    expect(runtimePrompt.content).toContain("answer the original request")
+    expect(runtimePrompt.content).toContain("talking to each other")
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(result.sentContents).toEqual(["Final: check digits reduce the OTP search space — bad idea."])
+    expect(updateSequence).toHaveBeenCalledWith("session_1", BigInt(4265))
+    expect(result.lastProcessedSequence).toBe(BigInt(4265))
+  })
+
+  it("tells the model a pending send_message draft was not committed and re-anchors the original request", async () => {
+    const { nm } = newMessagesOnce()
+    const prompts: Array<Array<{ role: string; content: unknown }>> = []
+    let call = 0
+    const generateTextWithTools = mock(
+      async ({ messages }: { messages: Array<{ role: string; content: unknown }> }) => {
+        prompts.push(messages)
+        call += 1
+        const content = call === 1 ? "Draft answer to the OTP question." : "Final answer to the OTP question."
+        return {
+          text: "",
+          toolCalls: [{ toolCallId: `tool_${call}`, toolName: AgentToolNames.SEND_MESSAGE, input: { content } }],
+          response: { messages: [{ role: "assistant", content: "" } as any] },
+        }
+      }
+    )
+    const sendMessage = mock(async () => ({ messageId: "msg_reply", operation: "created" as const }))
+
+    const runtime = new AgentRuntime({
+      ai: { generateTextWithTools } as any,
+      model: {} as any,
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: "What about a 5-digit OTP plus a check digit?" }],
+      tools: [],
+      newMessages: nm,
+      sendMessage,
+    })
+
+    const result = await runtime.run()
+
+    expect(generateTextWithTools).toHaveBeenCalledTimes(2)
+    const runtimePrompt = prompts[1]!.at(-1)!
+    expect(runtimePrompt.role).toBe("user")
+    expect(runtimePrompt.content).toContain("NOT sent")
+    expect(runtimePrompt.content).toContain("Draft answer to the OTP question.")
+    expect(runtimePrompt.content).toContain("answer the original request")
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(result.sentContents).toEqual(["Final answer to the OTP question."])
+  })
+})

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -17,6 +17,11 @@ const KEEP_RESPONSE_TOOL_NAME = "keep_response"
 const MAX_REPEATED_INVALID_DRAFTS = 3
 const MAX_EMPTY_FINAL_DECISION_ATTEMPTS = 3
 
+// Shared by all three mid-turn reconsideration prompts so the guidance can't
+// drift between the text-draft, pending-send, and keep-response paths.
+const SIDE_CONVERSATION_GUIDANCE =
+  "Check who authored the new messages and who they address — in group conversations they are often participants talking to each other, not to you."
+
 export interface NewMessageAwareness {
   check: (streamId: string, sinceSequence: bigint, excludeAuthorId: string) => Promise<NewMessageInfo[]>
   updateSequence: (sessionId: string, sequence: bigint) => Promise<void>
@@ -370,8 +375,7 @@ export class AgentRuntime {
                 conversation,
                 `[New messages arrived while you were composing]\n\n` +
                   `Your draft below was NOT sent — no one has seen it:\n"${lastAssistantText}"\n\n` +
-                  `The request you were originally responding to is still unanswered. Check who authored the new messages ` +
-                  `and who they address — in group conversations they are often participants talking to each other, not to you. ` +
+                  `The request you were originally responding to is still unanswered. ${SIDE_CONVERSATION_GUIDANCE} ` +
                   `Send your final response now: it must still answer the original request, revised only if the new messages ` +
                   `genuinely change or answer it. Do not reply to the new messages instead of the original request.`
               )
@@ -482,8 +486,7 @@ export class AgentRuntime {
               conversation,
               `[New messages arrived before your response was committed]\n\n` +
                 `Your draft${execResult.pendingMessages.length > 1 ? "s below were" : " below was"} NOT sent — no one has seen ${execResult.pendingMessages.length > 1 ? "them" : "it"}:\n"${pendingContents}"\n\n` +
-                `The request you were originally responding to is still unanswered. Check who authored the new messages ` +
-                `and who they address — in group conversations they are often participants talking to each other, not to you. ` +
+                `The request you were originally responding to is still unanswered. ${SIDE_CONVERSATION_GUIDANCE} ` +
                 `Call send_message with your final response now: it must still answer the original request. Keep the draft if it ` +
                 `still holds; revise only if the new messages genuinely change or answer the original request. Do not reply to ` +
                 `the new messages instead of the original request.`
@@ -512,8 +515,7 @@ export class AgentRuntime {
             conversation,
             `[New messages arrived after you decided to keep the existing response]\n\n` +
               `Your keep-response reason was:\n"${execResult.keepResponseReason}"\n\n` +
-              `Check who authored the new messages and who they address — they may be a side conversation that does not ` +
-              `concern your response. If the previous response is still correct, call keep_response again with an updated reason. ` +
+              `${SIDE_CONVERSATION_GUIDANCE} If the previous response is still correct, call keep_response again with an updated reason. ` +
               `If the new messages genuinely change what your response should say, call send_message with the updated response.`
           )
         } else if (newMessages.length > 0) {

--- a/packages/agent-runtime/src/runtime/agent-runtime.ts
+++ b/packages/agent-runtime/src/runtime/agent-runtime.ts
@@ -368,9 +368,12 @@ export class AgentRuntime {
               hasTextReconsidered = true
               this.pushRuntimePrompt(
                 conversation,
-                `[New context arrived while you were responding]\n\n` +
-                  `Your draft response was:\n"${lastAssistantText}"\n\n` +
-                  `Please incorporate the new messages and respond.`
+                `[New messages arrived while you were composing]\n\n` +
+                  `Your draft below was NOT sent — no one has seen it:\n"${lastAssistantText}"\n\n` +
+                  `The request you were originally responding to is still unanswered. Check who authored the new messages ` +
+                  `and who they address — in group conversations they are often participants talking to each other, not to you. ` +
+                  `Send your final response now: it must still answer the original request, revised only if the new messages ` +
+                  `genuinely change or answer it. Do not reply to the new messages instead of the original request.`
               )
               continue
             }
@@ -477,10 +480,13 @@ export class AgentRuntime {
 
             this.pushRuntimePrompt(
               conversation,
-              `[New context arrived while you were responding]\n\n` +
-                `Your draft response${execResult.pendingMessages.length > 1 ? "s were" : " was"}:\n"${pendingContents}"\n\n` +
-                `Please respond to all messages, incorporating the new context. ` +
-                `You may send the same response${execResult.pendingMessages.length > 1 ? "s" : ""} if still appropriate, or revise based on the new information.`
+              `[New messages arrived before your response was committed]\n\n` +
+                `Your draft${execResult.pendingMessages.length > 1 ? "s below were" : " below was"} NOT sent — no one has seen ${execResult.pendingMessages.length > 1 ? "them" : "it"}:\n"${pendingContents}"\n\n` +
+                `The request you were originally responding to is still unanswered. Check who authored the new messages ` +
+                `and who they address — in group conversations they are often participants talking to each other, not to you. ` +
+                `Call send_message with your final response now: it must still answer the original request. Keep the draft if it ` +
+                `still holds; revise only if the new messages genuinely change or answer the original request. Do not reply to ` +
+                `the new messages instead of the original request.`
             )
           }
         } else if (execResult.keepResponseReason) {
@@ -504,10 +510,11 @@ export class AgentRuntime {
 
           this.pushRuntimePrompt(
             conversation,
-            `[New context arrived after you decided to keep the existing response]\n\n` +
+            `[New messages arrived after you decided to keep the existing response]\n\n` +
               `Your keep-response reason was:\n"${execResult.keepResponseReason}"\n\n` +
-              `Please reconsider. If the previous response is still correct, call keep_response again with an updated reason. ` +
-              `If changes are needed, call send_message with the updated response.`
+              `Check who authored the new messages and who they address — they may be a side conversation that does not ` +
+              `concern your response. If the previous response is still correct, call keep_response again with an updated reason. ` +
+              `If the new messages genuinely change what your response should say, call send_message with the updated response.`
           )
         } else if (newMessages.length > 0) {
           const maxSeq = await this.injectNewMessages(newMessages, lastProcessedSequence, nm, conversation)
@@ -859,7 +866,14 @@ export class AgentRuntime {
 
     await this.emit({ type: "context:received", messages: newMessages })
 
-    const userMessages: ModelMessage[] = newMessages.map((m) => ({ role: "user" as const, content: m.content }))
+    // Same `[msg:… author:…] [@Name]` surface as turn-start history (pointer-tag
+    // contract) — without it the model cannot tell who a mid-turn message is
+    // from, and mistakes side conversation between participants for input
+    // addressed to it.
+    const userMessages: ModelMessage[] = newMessages.map((m) => ({
+      role: "user" as const,
+      content: `[msg:${m.messageId} author:${m.authorId}] [@${m.authorName}] ${m.content}`,
+    }))
     conversation.push(...userMessages)
 
     return maxSequence


### PR DESCRIPTION
## Problem

A production incident (2026-07-09, DM `stream_01KJMS776MNP2Q382MJ639Y2JD`): Pierre @mentioned Ariadne with a direct question ("six-digit OTP made of five random digits plus one check digit?"). Session `session_01KX45Z1N8…` drafted a correct answer (trace step 2), then Pierre's unrelated WorkOS banter to Kristoffer landed mid-turn and was injected by the reconsideration flow. Trace step 4: *"My previous response already covered the OTP check digit question for Pierre."* — the model believed its **unsent draft had been delivered**, discarded it, and replied only to the banter. The follow-up session repeated the failure in miniature: ambient chatter ("Alldeles för mycket ser det ut som") injected mid-turn was read as feedback on a message no one had seen, so it gutted its answer and apologized for a reply it never sent.

Three defects in `AgentRuntime` and the mention prompt combined to cause this:

1. The reconsideration runtime prompts (`[New context arrived while you were responding] Your draft response was: … Please incorporate the new messages and respond.`) never state the draft is unsent, never re-anchor the original request, and actively point the model at the interjection.
2. `injectNewMessages` pushed injected messages as bare `m.content` — turn-start history carries `[msg:… author:…] (time) [@Name]` (`message-format.ts`), so mid-turn messages lost all attribution and the model could not tell Pierre was talking to Kristoffer, not to it.
3. The mention Invocation Context section said only "You were explicitly @mentioned by **X** who wants your assistance" — nothing binds the reply to the mention message itself.

## Solution

Keep the turn anchored to the request it was invoked for: tell the model the truth about what has and hasn't been sent, restore who-is-talking-to-whom on mid-turn injections, and make the mention section state the job explicitly. Prompt/attribution changes only — no seam, schema, or behavioral-contract changes.

### How it works

1. **All three reconsideration prompts** in `packages/agent-runtime/src/runtime/agent-runtime.ts` (text-draft path, pending-`send_message` path, post-`keep_response` path) now state the draft "was NOT sent — no one has seen it", instruct the model to check who authored the new messages and who they address ("in group conversations they are often participants talking to each other, not to you"), and require the final response to still answer the original request, revised only if the new messages genuinely change or answer it.
2. **`injectNewMessages`** formats each injected message as `[msg:<messageId> author:<authorId>] [@<authorName>] <content>` — the same pointer-tag surface as turn-start history, so attribution and the quote-pointer contract survive mid-turn. `NewMessageInfo` already carried `authorId`/`authorName`; they were simply unused.
3. **`buildMentionSection`** (`apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts`) adds: "Your reply must directly answer that mention message. If more messages arrive while you are working, treat them as context … and never let them displace the question you were asked."

### Key design decisions

**1. Fix the prompts, not the loop.** The loop's mechanics (inject → prompt → reconsider) worked as designed; the model was misinformed about delivery state. An alternative — suppressing injection until the trigger is answered — would break the legitimate case where the interjection *does* answer or moot the question (the reconsideration flow's reason to exist). Rejected in favor of accurate framing.

**2. Inline tag formatting in the runtime rather than importing `pointer-tags.ts`.** `pointer-tags.ts` centralizes the `[msg:… author:…]` format for backend prompt surfaces (INV-33), but `packages/agent-runtime` cannot depend on `apps/backend`, so the prefix is composed inline in `injectNewMessages` with a comment tying it to the history format.

**3. No trigger-message replay in the reconsideration prompt.** The runtime doesn't know which history message was the trigger (host concern); threading it through `AgentRuntimeConfig` is a seam change out of scope for this fix. The mention section (system prompt, always in context) plus "answer the original request" wording covers it; revisit if incidents recur.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/agent-runtime/src/runtime/agent-runtime.ts` | Rewrote 3 reconsideration prompts (draft-not-sent + original-request anchoring); `injectNewMessages` prefixes `[msg:… author:…] [@Name]` |
| `packages/agent-runtime/src/runtime/agent-runtime.test.ts` | 2 regression tests modeled on the incident: text-draft and pending-`send_message` reconsideration paths (attribution, prompt content, sequence advancement, final commit) |
| `apps/backend/src/features/agents/companion/prompt/turn-purpose-prompt.ts` | Mention section binds the reply to the mention message |
| `apps/backend/src/features/agents/companion/prompt/system-prompt.test.ts` | Asserts the new mention-section anchoring lines |

## Out of scope (deliberate)

- Nothing needed for **enclave turns**: they run the same `AgentRuntime`, so the rewritten prompts and attribution apply there automatically when `pollNewMessages` is wired (`run-turn.ts:401-410`; `buildInterjectionAwareness` already populates `authorId`/`authorName`). Sessions without it keep `declaredUnsupported` — no reconsideration at all. _(Corrected in self-review: first draft claimed the enclave was out of scope via UX-12; it actually pulls mid-turn messages.)_
- **Trace-visibility UX**: the humans' "Alldeles för mycket" reaction was most likely to the live trace steps streaming in a group DM; whether traces should render for non-invoking participants is a product question, not touched here.
- **Response language choice** (Ariadne answered an English question in Swedish) — followed the ambient conversation; arguably correct, not addressed.

## Test plan

- [x] `packages/agent-runtime`: `bun test` — 216 pass (includes the 2 new regression tests)
- [x] `apps/backend`: `bun test src/features/agents/` — 424 pass
- [x] `bun run typecheck` (full monorepo) + lint via pre-commit hook — clean
- [x] Pre-PR review (2 Opus reviewer agents: spec+design incl. CLAUDE.md audit, correctness+data-flow incl. all three reconsideration paths, salvage fallback, and injection prefix): 0 code findings; 1 description correction (enclave scope, noted above)
- [ ] `apps/enclave` `run-turn.test.ts` fails in this sandbox with or without the change (WebCrypto lacks X25519 HPKE) — verified pre-existing by stashing the diff; CI covers it

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Stop mention turns from abandoning the trigger question when unrelated messages land mid-turn (Ariadne/Pierre OTP incident, sessions `session_01KX45Z1N8…` / `session_01KX461FQ0…`).

**Diagnosis (prod traces):** Model drafted a correct answer, mid-turn interjection was injected, model concluded the unsent draft was already delivered and replied only to the interjection. Root causes: reconsideration prompts imply delivery, injected messages lose author attribution, mention section doesn't bind the reply to the mention.

**What was built:**
1. Reconsideration prompts state draft-not-sent, warn of side conversations, require answering the original request (3 paths in `agent-runtime.ts`).
2. `injectNewMessages` restores `[msg:… author:…] [@Name]` attribution.
3. Mention section anchors the reply to the mention message.
4. Regression tests for both reconsideration paths + mention-section assertions.

**Design evolution:** none — shipped as planned after trace analysis.

**Schema changes:** none.

**What's NOT included:** trigger-message replay through `AgentRuntimeConfig` (seam change), trace-visibility UX for group DMs. Enclave turns are covered automatically (shared runtime).

**Status:** complete; suites green (216 agent-runtime, 424 backend agents, monorepo typecheck).

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5sJXSTotkjpKs2u5q1aVb)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786221233&installation_id=129946197&pr_number=1253&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1253&signature=665300317ba45a26340079212557a9353b9172879c460eb8aa674b8215cc9290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->