### PR TITLE
fix(timeline): resolve thread read watermark against the rendered window (ghost unread threads)

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -9,8 +9,10 @@ import {
   shouldRunEdgePagination,
   shouldShowOlderSkeletons,
   resolveDateJumpAnchor,
+  remapSuppressedWatermark,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
+import type { StreamEvent } from "@threa/types"
 
 const DEADLINE = 4000
 
@@ -466,5 +468,43 @@ describe("resolveDateJumpAnchor", () => {
       { eventType: "message_created" as const, createdAt: REF.toISOString(), payload: {} },
     ]
     expect(resolveDateJumpAnchor({ events, targetDayMs, hasOlderEvents: true })).toBeNull()
+  })
+})
+
+describe("remapSuppressedWatermark", () => {
+  const evt = (id: string, eventType: string) => ({ id, eventType }) as unknown as StreamEvent
+  // A fresh two-event thread: the member_added seeding event is suppressed
+  // from the rendered window; only the reply renders.
+  const events = [evt("e_member", "member_added"), evt("e_reply", "message_created")]
+  const displayEvents = [evt("e_reply", "message_created")]
+
+  it("remaps a suppressed watermark with no rendered predecessor to null (nothing read)", () => {
+    // The ghost-unread-thread bug: the watermark on member_added was
+    // unresolvable in the rendered window, so no divider rendered and
+    // auto-read never fired — the thread stayed unread forever.
+    expect(remapSuppressedWatermark("e_member", events, displayEvents)).toBeNull()
+  })
+
+  it("remaps a suppressed watermark to the nearest preceding rendered event", () => {
+    const longer = [
+      evt("e_msg1", "message_created"),
+      evt("e_member2", "member_added"),
+      evt("e_msg2", "message_created"),
+    ]
+    const rendered = [evt("e_msg1", "message_created"), evt("e_msg2", "message_created")]
+    expect(remapSuppressedWatermark("e_member2", longer, rendered)).toBe("e_msg1")
+  })
+
+  it("passes a rendered watermark through unchanged", () => {
+    expect(remapSuppressedWatermark("e_reply", events, displayEvents)).toBe("e_reply")
+  })
+
+  it("passes a watermark outside the loaded window through unchanged (suppression semantics apply)", () => {
+    expect(remapSuppressedWatermark("e_below_window", events, displayEvents)).toBe("e_below_window")
+  })
+
+  it("passes null/undefined (nothing read / still hydrating) through unchanged", () => {
+    expect(remapSuppressedWatermark(null, events, displayEvents)).toBeNull()
+    expect(remapSuppressedWatermark(undefined, events, displayEvents)).toBeUndefined()
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -242,6 +242,35 @@ export function canActOnDeepLinkNavigation<T extends string>(args: {
   return args.hasEvents
 }
 
+/**
+ * Remap a thread watermark that points at a suppressed membership event to the
+ * nearest PRECEDING rendered event (null when none precedes it — "nothing read
+ * yet", an equivalent read position since suppressed events aren't readable
+ * content). A fresh thread member's watermark is seeded on their member_added
+ * event by the backend, but threads hide membership events from the rendered
+ * window — so consumers that resolve the watermark against `displayEvents`
+ * (the read frontier, the unread divider) would see an unresolvable pointer
+ * and give up: no divider renders and auto-read never fires, leaving the
+ * thread permanently unread (the ghost-unread-thread bug). A watermark outside
+ * the loaded window entirely is returned as-is: read progress is unknowable
+ * there, and the consumers' existing suppression semantics must keep applying.
+ */
+export function remapSuppressedWatermark(
+  lastReadEventId: string | null | undefined,
+  events: StreamEvent[],
+  displayEvents: StreamEvent[]
+): string | null | undefined {
+  if (!lastReadEventId) return lastReadEventId
+  const displayIds = new Set(displayEvents.map((e) => e.id))
+  if (displayIds.has(lastReadEventId)) return lastReadEventId
+  const idx = events.findIndex((e) => e.id === lastReadEventId)
+  if (idx < 0) return lastReadEventId
+  for (let i = idx - 1; i >= 0; i--) {
+    if (displayIds.has(events[i].id)) return events[i].id
+  }
+  return null
+}
+
 /** Lead distance (px) from either edge of the scroll range at which the next
  *  page is prefetched, so it lands before a fast scroll reaches the boundary. */
 export const EDGE_PREFETCH_PX = 1500
@@ -717,6 +746,14 @@ export function StreamContent({
         return a.id.localeCompare(b.id)
       })
   }, [events, isThread])
+
+  // See remapSuppressedWatermark: a fresh thread member's watermark sits on a
+  // membership event that threads hide from the rendered window; the read
+  // frontier and the unread divider need it remapped to a rendered position.
+  const frontierLastReadEventId = useMemo(
+    () => (isThread ? remapSuppressedWatermark(lastReadEventId, events, displayEvents) : lastReadEventId),
+    [isThread, lastReadEventId, events, displayEvents]
+  )
 
   // Conversation lookup for the always-on provenance chips (mechanism A below).
   const conversationsById = useMemo(() => {
@@ -1746,7 +1783,7 @@ export function StreamContent({
     contentRef: useVirtualized ? virtualContentRef : plainContentRef,
     events: displayEvents,
     streamId,
-    lastReadEventId,
+    lastReadEventId: frontierLastReadEventId,
     enabled: autoMarkEnabled,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
@@ -1775,7 +1812,7 @@ export function StreamContent({
   // the divider via the "N new" jump button or by scrolling up.
   const { dividerEventId, dismiss: dismissUnreadDivider } = useUnreadDivider({
     events: displayEvents,
-    lastReadEventId,
+    lastReadEventId: frontierLastReadEventId,
     currentUserId: currentWorkspaceUserId ?? undefined,
     streamId,
     isLoading,
@@ -1788,7 +1825,7 @@ export function StreamContent({
     // latch a divider on the first message (which would then stick for the
     // session). `idbStream` alone isn't enough — its denormalized copy can be a
     // stale null while the authoritative membership value is still loading.
-    readStateResolved: lastReadEventId !== undefined,
+    readStateResolved: frontierLastReadEventId !== undefined,
     // Skip overlay-read events so the divider anchors on the first *effectively*
     // unread row, not one already read from a conversation surface.
     overlayReadIds: readOverlay,

--- a/apps/frontend/src/hooks/use-last-seen-event.test.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.test.ts
@@ -555,6 +555,45 @@ describe("useLastSeenEvent re-scan triggers", () => {
     expect(result.current.lastSeenEventId).toBe("evt_real")
   })
 
+  it("ignores foreign rows (the thread parent banner) instead of vetoing the scan", () => {
+    // A thread renders its parent message as a timeline row carrying the PARENT
+    // stream's event id — never present in the thread's own window. In a short
+    // thread that row stays at the top of the viewport forever, so if the scan
+    // bails on the unmappable id (instead of skipping the row), the frontier
+    // never advances and the thread never auto-reads: the prod ghost-unread bug.
+    const positions: Record<string, { top: number; bottom: number }> = {
+      parent_evt: { top: 5, bottom: 45 }, // parent-stream event id, not in `events`
+      e0: { top: 55, bottom: 95 }, // the thread's only reply — visible
+    }
+
+    const container = document.createElement("div")
+    container.getBoundingClientRect = () => rect(0, 100)
+    for (const id of Object.keys(positions)) {
+      const row = document.createElement("div")
+      row.setAttribute("data-event-id", id)
+      row.getBoundingClientRect = () => rect(positions[id].top, positions[id].bottom)
+      container.appendChild(row)
+    }
+
+    const events = [{ id: "e0", sequence: "2" }] as unknown as StreamEvent[]
+    const scrollContainerRef = { current: container }
+
+    const { result } = renderHook(() =>
+      useLastSeenEvent({
+        scrollContainerRef,
+        events,
+        streamId: "stream_thread",
+        // A fresh thread member's member_added watermark is remapped to null by
+        // StreamContent (it's suppressed from the rendered window): nothing read.
+        lastReadEventId: null,
+        enabled: true,
+      })
+    )
+
+    expect(result.current.lastSeenEventId).toBe("e0")
+    expect(result.current.atLastRow).toBe(true)
+  })
+
   it("does not emit a mark target while the read pointer sits outside the loaded window", () => {
     // Mark-as-unread on the oldest loaded row moves the pointer to a message below
     // the loaded window, so it is unresolvable in `events`. Emitting the stale

--- a/apps/frontend/src/hooks/use-last-seen-event.ts
+++ b/apps/frontend/src/hooks/use-last-seen-event.ts
@@ -177,17 +177,23 @@ export function useLastSeenEvent({
 
     const rowEls = el.querySelectorAll<HTMLElement>("[data-event-id]")
     if (rowEls.length === 0) return
+    const map = indexByIdRef.current
     const rows: VisibleRow[] = []
     for (let i = 0; i < rowEls.length; i++) {
       const id = rowEls[i].dataset.eventId
-      if (!id) continue
+      // Skip rows that aren't in the loaded window rather than letting them
+      // poison the range lookup below. The thread view renders its parent
+      // message as a row carrying the PARENT stream's event id — in a short
+      // thread it sits at the top of the viewport permanently, and bailing on
+      // its unmappable id would veto every scan, so the thread never auto-reads.
+      if (!id || !map.has(id)) continue
       const r = rowEls[i].getBoundingClientRect()
       rows.push({ id, top: r.top, bottom: r.bottom })
     }
+    if (rows.length === 0) return
 
     const range = pickVisibleRange(rows, viewportTop, viewportBottom)
     if (!range) return
-    const map = indexByIdRef.current
     const topIdx = map.get(range.topId)
     const botIdx = map.get(range.bottomId)
     if (topIdx === undefined || botIdx === undefined) return


### PR DESCRIPTION
## Problem

Prod report (DM conversation `conv_01KX47HPDDXPA5P1BC3QPCFMFH`): a user has a `(1)` in the tab title that survives a hard refresh, and the thread "Sinnet 4.6 och kil på 5" keeps its blue unread strip in the sidebar even after opening the thread. Opening it also shows **no red unread divider** — the thread *looks* fully read while the server keeps counting 1 unread.

The server is right: `stream_members.last_read_event_id` for the reporter still pointed at seq 1 (`member_added`) with the reply at seq 2. The frontend never fired `POST /streams/:id/read` while the user was viewing the thread. Reproduced end-to-end against a local `dev:test` stack with Playwright: a second thread member opening the thread (focused, visible, rows on screen) never issues the read call — via `?m=` deep link *and* via plain open.

Two stacked frontend bugs, one shared root: **a fresh thread member's read watermark is seeded on their `member_added` event (backend `addToStream`), but threads suppress membership events from the rendered window** (`THREAD_HIDDEN_EVENT_TYPES` in `stream-content.tsx`).

1. **Auto-read never fires** — `useLastSeenEvent` resolves the watermark against the rendered window (`displayEvents`). `member_added` isn't in it → `readSeq` resolves to `null` ("pointer outside the loaded window") → the emit guard suppresses `lastSeenEventId` permanently → `useAutoMarkAsRead` has no target, so the read POST never happens. **Every non-creator thread member was unable to auto-read any thread without replying in it.**
2. **The frontier scan was vetoed anyway** — the thread view renders its parent message via `ThreadParentMessage` → `EventItem`, emitting `data-event-id` with the *parent stream's* event id. `recompute()` bailed entirely when the visible range's boundary row wasn't mappable (`topIdx === undefined`). In a short thread the parent banner never leaves the viewport, so every scan was vetoed even where bug 1 didn't apply.
3. **No red unread strip** (same root as 1) — `useUnreadDivider` returns `undefined` when `lastReadEventId` isn't found in its `events` (`use-unread-divider.ts:97-100`), so no divider latched: the thread renders with no unread marking at all while genuinely unread.

## Solution

Resolve the watermark into rendered-window space once, in `StreamContent`, and make the frontier scan tolerate foreign rows.

### How it works

- **`remapSuppressedWatermark(lastReadEventId, events, displayEvents)`** (new pure helper in `stream-content.tsx`): a watermark present in the loaded `events` but hidden from `displayEvents` is remapped to the nearest **preceding** rendered event, or `null` when none precedes it — equivalent read positions, since suppressed events aren't readable content. A watermark outside the loaded window is returned unchanged so the existing mark-unread-below-window suppression semantics keep applying. Threads only (`isThread` guard); channels/DMs render membership events and are unaffected.
- The remapped `frontierLastReadEventId` feeds `useLastSeenEvent`, `useUnreadDivider`, and the divider's `readStateResolved` gate. `isDividerReadPast` and `useNewMessageIndicator` keep the raw watermark — they resolve against unfiltered `events`, where `member_added` exists.
- **`useLastSeenEvent.recompute`**: rows whose `data-event-id` isn't in the loaded window map are now skipped when collecting visible rows, instead of poisoning the range lookup and vetoing the scan. Only `EventItem` emits `data-event-id`, and gap placeholders don't, so the only foreign row today is the thread parent banner — but any future out-of-window row gets the same treatment.

### Key design decisions

**1. Remap in `StreamContent`, not inside the hooks** — both consumers (`useLastSeenEvent`, `useUnreadDivider`) resolve against the same filtered window, and the filtering (`THREAD_HIDDEN_EVENT_TYPES`) lives in `StreamContent`. One remap where the filter is defined beats teaching each hook about thread display rules. The hooks' null-pointer suppression stays intact for its real purpose (mark-as-unread below the loaded window).

**2. Nearest *preceding* rendered event, not nearest following** — the watermark means "read through here"; mapping forward would silently mark the next message read. Mapping backward (or to `null`) can only surface *more* as unread, matching the server's count (messages with sequence > watermark).

**3. Skip foreign rows rather than excluding the parent banner's `data-event-id`** — the attribute is load-bearing for scroll targeting and the divider `querySelector`; removing it from `ThreadParentMessage` would break deep-linking to the parent. Filtering at the consumer keeps one emit path.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | New `remapSuppressedWatermark` helper + `frontierLastReadEventId` memo; feeds the read frontier, unread divider, and its `readStateResolved` gate |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | 5 remap tests: no-predecessor → null, mid-thread → nearest preceding, rendered/out-of-window/null passthrough |
| `apps/frontend/src/hooks/use-last-seen-event.ts` | `recompute` skips rows not in the loaded window instead of bailing on unmappable range boundaries |
| `apps/frontend/src/hooks/use-last-seen-event.test.ts` | Regression test: foreign parent-banner row visible at top, reply still marks seen |

## Out of scope (deliberate)

- **Sidebar highlight ambiguity** — the reporter's second complaint (active-stream highlight and unread highlight look alike) is a UX/design change, untouched here.
- **Fresh threads not appearing in the sidebar without a refresh** — both users needed a reload to see the new thread at all; a separate live-delivery gap to investigate.
- Existing stuck-unread rows in prod self-heal on next open (the read now fires); no backfill needed.

## Test plan

- [x] Live repro before/after on `dev:test` + Playwright (two users, thread on B's message, A replies, B opens): before — no `POST /read`, watermark stuck at `member_added`; after — `POST /read` fires with the reply's event id, `stream_members.last_read_event_id` advances to seq 2 (verified in Postgres)
- [x] `vitest run` on the four touched suites + `use-unread-divider` + `use-auto-mark-as-read` — 97 pass
- [x] `vitest run src/components/timeline src/hooks src/sync` — 116 files pass; 3 files fail identically on a clean tree (known Node-25 localStorage reds, verified via `git stash` A/B)
- [x] Full monorepo lint + typecheck clean (pre-commit hook runs both across all workspaces)
- [ ] `bun run test:e2e` not run — the affected flow is covered by the scripted Playwright repro above; no existing e2e spec exercises thread read state

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786221897&installation_id=129946197&pr_number=1254&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1254&signature=ea66a740d61dec57936280f2f8be1f788748096cedc87187068f05ad7bfe7b7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->