### PR TITLE
fix(agents): stream trace steps to all participants — reconnect re-arm, INV-62 trace access, parent-stream indicator for in-thread sessions

### DIFF
--- a/apps/backend/src/features/agents/persona-agent.ts
+++ b/apps/backend/src/features/agents/persona-agent.ts
@@ -367,7 +367,8 @@ export class PersonaAgent {
     // Create the thread eagerly so session events go there for channel mentions.
     const isChannelMention = purpose.kind === "mention" && stream.type === StreamTypes.CHANNEL
     let sessionStreamId = streamId
-    let channelStreamId: string | undefined
+    let parentStreamId: string | undefined
+    let parentMessageId: string | undefined
     if (isChannelMention) {
       const thread = await createThread({
         workspaceId,
@@ -376,8 +377,16 @@ export class PersonaAgent {
         createdBy: persona.id,
       })
       sessionStreamId = thread.id
-      channelStreamId = streamId
+      parentStreamId = streamId
+      parentMessageId = messageId
       logger.info({ threadId: thread.id, streamId, messageId }, "Created thread for channel mention (eager)")
+    } else if (stream.type === StreamTypes.THREAD && stream.parentStreamId && stream.parentMessageId) {
+      // Session in an existing thread: viewers of the parent timeline watch it
+      // through the thread slot on the parent message, so the inline indicator
+      // events must reach the parent stream's room too — the same wiring
+      // channel mentions get via their eagerly created thread.
+      parentStreamId = stream.parentStreamId
+      parentMessageId = stream.parentMessageId
     }
 
     const result = await withCompanionSession(
@@ -403,7 +412,8 @@ export class PersonaAgent {
           streamId: sessionStreamId,
           triggerMessageId: messageId,
           personaName: persona.name,
-          channelStreamId,
+          parentStreamId,
+          parentMessageId,
         })
         trace.notifyActivityStarted()
 
@@ -1151,7 +1161,8 @@ export class PersonaAgent {
         streamId: sessionStreamId,
         triggerMessageId: messageId,
         personaName: persona.name,
-        channelStreamId,
+        parentStreamId,
+        parentMessageId,
       })
       if (result.status === "completed") {
         trace.notifyCompleted()

--- a/apps/backend/src/features/agents/session-handlers.test.ts
+++ b/apps/backend/src/features/agents/session-handlers.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, afterEach, spyOn, mock } from "bun:test"
+import type { Pool } from "pg"
+import { createAgentSessionHandlers } from "./session-handlers"
+import { AgentSessionRepository } from "./session-repository"
+import { PersonaRepository } from "./persona-repository"
+import { BotRepository } from "../public-api"
+import { StreamEventRepository } from "../streams"
+import * as streamsModule from "../streams"
+
+const SESSION = {
+  id: "session_1",
+  streamId: "thread_1",
+  personaId: "persona_1",
+  triggerMessageId: "msg_1",
+  triggerMessageRevision: null,
+  supersedesSessionId: null,
+  status: "running",
+  currentStepType: null,
+  sentMessageIds: [],
+  createdAt: new Date("2026-07-09T10:00:00.000Z"),
+  completedAt: null,
+} as never
+
+const THREAD_STREAM = {
+  id: "thread_1",
+  workspaceId: "ws_1",
+  rootStreamId: "stream_dm_1",
+} as never
+
+const STEP = {
+  id: "step_1",
+  sessionId: "session_1",
+  stepNumber: 1,
+  stepType: "thinking",
+  content: undefined,
+  contentCiphertext: null,
+  contentEnvelope: null,
+  sources: null,
+  messageId: null,
+  tokensUsed: null,
+  startedAt: new Date("2026-07-09T10:00:01.000Z"),
+  completedAt: new Date("2026-07-09T10:00:02.000Z"),
+} as never
+
+function mockReq() {
+  return {
+    user: { id: "usr_viewer" },
+    workspaceId: "ws_1",
+    params: { sessionId: "session_1" },
+  } as never
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null as unknown,
+    status(code: number) {
+      res.statusCode = code
+      return res
+    },
+    json(data: unknown) {
+      res.body = data
+      return res
+    },
+  }
+  return res
+}
+
+function stubCommonReads() {
+  spyOn(AgentSessionRepository, "findById").mockResolvedValue(SESSION)
+  spyOn(AgentSessionRepository, "findStepsBySession").mockResolvedValue([STEP])
+  spyOn(AgentSessionRepository, "listByTriggerMessage").mockResolvedValue([SESSION])
+  spyOn(PersonaRepository, "findById").mockResolvedValue({
+    id: "persona_1",
+    name: "Ariadne",
+    avatarEmoji: null,
+  } as never)
+  spyOn(BotRepository, "findById").mockResolvedValue(null)
+  spyOn(StreamEventRepository, "listRerunContextBySessionIds").mockResolvedValue(new Map())
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("getSession access (INV-62)", () => {
+  test("grants a viewer with inherited thread access (no direct thread membership row)", async () => {
+    stubCommonReads()
+    // The canonical predicate resolves thread→root: a DM member reading a
+    // thread they never posted in gets the root's access, not a 403.
+    const accessSpy = spyOn(streamsModule, "checkStreamAccess").mockResolvedValue(THREAD_STREAM)
+
+    const handlers = createAgentSessionHandlers({ pool: {} as Pool })
+    const res = mockRes()
+    await handlers.getSession(mockReq(), res as never)
+
+    expect(accessSpy).toHaveBeenCalledWith(expect.anything(), "thread_1", "ws_1", "usr_viewer")
+    expect(res.statusCode).toBe(200)
+    expect((res.body as { steps: unknown[] }).steps).toHaveLength(1)
+  })
+
+  test("returns 404 when the canonical access check denies the viewer", async () => {
+    stubCommonReads()
+    spyOn(streamsModule, "checkStreamAccess").mockResolvedValue(null)
+
+    const handlers = createAgentSessionHandlers({ pool: {} as Pool })
+    const res = mockRes()
+    await handlers.getSession(mockReq(), res as never)
+
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toEqual({ error: "Session not found" })
+  })
+})

--- a/apps/backend/src/features/agents/session-handlers.ts
+++ b/apps/backend/src/features/agents/session-handlers.ts
@@ -1,8 +1,7 @@
 import type { Request, Response } from "express"
 import type { Pool } from "pg"
 import { AgentSessionRepository } from "./session-repository"
-import { StreamRepository, StreamEventRepository } from "../streams"
-import { StreamMemberRepository } from "../streams"
+import { StreamEventRepository, checkStreamAccess } from "../streams"
 import { PersonaRepository } from "./persona-repository"
 import { BotRepository } from "../public-api"
 import type { AgentSessionWithSteps, AgentStepType } from "@threa/types"
@@ -34,19 +33,19 @@ export function createAgentSessionHandlers({ pool }: Dependencies) {
           return { error: "Session not found", status: 404 }
         }
 
-        const [stream, membership, persona, bot, steps] = await Promise.all([
-          StreamRepository.findById(pool, session.streamId),
-          StreamMemberRepository.findByStreamAndMember(pool, session.streamId, userId),
+        // Access resolves through the canonical thread→root predicate (INV-62):
+        // a session in a thread must be visible to anyone with access to the
+        // root stream — a direct `stream_members` check on the thread would 403
+        // DM/channel members who never got their own thread membership row.
+        const [stream, persona, bot, steps] = await Promise.all([
+          checkStreamAccess(pool, session.streamId, workspaceId, userId),
           PersonaRepository.findById(pool, session.personaId, workspaceId),
           BotRepository.findById(pool, workspaceId, session.personaId),
           AgentSessionRepository.findStepsBySession(pool, sessionId),
         ])
 
-        if (!stream || stream.workspaceId !== workspaceId) {
+        if (!stream) {
           return { error: "Session not found", status: 404 }
-        }
-        if (!membership) {
-          return { error: "Not authorized to view this session", status: 403 }
         }
         let actor: { id: string; name: string; avatarUrl: string | null; avatarEmoji?: string | null } | null = null
         if (persona) {

--- a/apps/backend/src/features/agents/trace-emitter.test.ts
+++ b/apps/backend/src/features/agents/trace-emitter.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, afterEach, spyOn, mock } from "bun:test"
+import type { Server } from "socket.io"
+import type { Pool } from "pg"
+import { TraceEmitter } from "./trace-emitter"
+import { AgentSessionRepository } from "./session-repository"
+
+interface CapturedEmit {
+  rooms: string[]
+  event: string
+  payload: Record<string, unknown>
+}
+
+function fakeIo() {
+  const emits: CapturedEmit[] = []
+  function operator(rooms: string[]) {
+    return {
+      to: (room: string) => operator([...rooms, room]),
+      emit: (event: string, payload: Record<string, unknown>) => {
+        emits.push({ rooms, event, payload })
+      },
+    }
+  }
+  const io = { to: (room: string) => operator([room]) } as unknown as Server
+  return { io, emits }
+}
+
+function sessionTrace(io: Server, overrides?: Partial<{ parentStreamId: string; parentMessageId: string }>) {
+  return new TraceEmitter({ io, pool: {} as Pool }).forSession({
+    sessionId: "session_1",
+    workspaceId: "ws_1",
+    streamId: "thread_1",
+    triggerMessageId: "msg_trigger",
+    personaName: "Ariadne",
+    ...overrides,
+  })
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("SessionTrace parent-stream routing", () => {
+  test("startStep emits progress to the thread room AND the parent room with parentMessageId", async () => {
+    spyOn(AgentSessionRepository, "upsertStep").mockResolvedValue({
+      id: "step_1",
+      sessionId: "session_1",
+      stepNumber: 1,
+      stepType: "thinking",
+      content: undefined,
+      startedAt: new Date("2026-07-09T10:00:00.000Z"),
+    } as never)
+    spyOn(AgentSessionRepository, "updateCurrentStepType").mockResolvedValue(undefined as never)
+
+    const { io, emits } = fakeIo()
+    const trace = sessionTrace(io, { parentStreamId: "stream_dm_1", parentMessageId: "msg_parent" })
+    await trace.startStep({ stepType: "thinking" })
+
+    const progress = emits.find((e) => e.event === "agent_session:progress")
+    expect(progress).toMatchObject({
+      rooms: ["ws:ws_1:stream:thread_1", "ws:ws_1:stream:stream_dm_1"],
+      payload: {
+        sessionId: "session_1",
+        triggerMessageId: "msg_trigger",
+        parentMessageId: "msg_parent",
+        threadStreamId: "thread_1",
+        stepCount: 1,
+      },
+    })
+  })
+
+  test("activity_started reaches the parent room with parentMessageId; no parent → no emit", () => {
+    const { io, emits } = fakeIo()
+    sessionTrace(io, { parentStreamId: "stream_dm_1", parentMessageId: "msg_parent" }).notifyActivityStarted()
+    expect(emits).toEqual([
+      {
+        rooms: ["ws:ws_1:stream:stream_dm_1"],
+        event: "agent_session:activity_started",
+        payload: {
+          sessionId: "session_1",
+          triggerMessageId: "msg_trigger",
+          personaName: "Ariadne",
+          threadStreamId: "thread_1",
+          parentMessageId: "msg_parent",
+        },
+      },
+    ])
+
+    const bare = fakeIo()
+    sessionTrace(bare.io).notifyActivityStarted()
+    expect(bare.emits).toEqual([])
+  })
+
+  test("substeps fan out to the parent room for in-thread sessions", () => {
+    const { io, emits } = fakeIo()
+    sessionTrace(io, { parentStreamId: "stream_dm_1", parentMessageId: "msg_parent" }).emitSubstep({
+      stepType: "workspace_search",
+      substep: "Planning queries",
+    })
+
+    const roomsHit = emits.filter((e) => e.event === "agent_session:substep").flatMap((e) => e.rooms)
+    expect(roomsHit).toContain("ws:ws_1:stream:stream_dm_1")
+    expect(roomsHit).toContain("ws:ws_1:stream:thread_1")
+    expect(roomsHit).toContain("ws:ws_1:agent_session:session_1")
+  })
+})

--- a/apps/backend/src/features/agents/trace-emitter.ts
+++ b/apps/backend/src/features/agents/trace-emitter.ts
@@ -25,8 +25,19 @@ export class TraceEmitter {
     streamId: string
     triggerMessageId: string
     personaName: string
-    /** For channel mentions: the channel stream ID for inline indicator progress events */
-    channelStreamId?: string
+    /**
+     * When the session runs in a thread: the parent stream's id, so inline
+     * indicator events (activity/progress/substeps) also reach viewers of the
+     * parent timeline — the channel for channel mentions, the enclosing
+     * stream for mentions inside an existing thread.
+     */
+    parentStreamId?: string
+    /**
+     * The thread's parent message id. Parent-timeline viewers can't see the
+     * trigger message (it's inside the thread), so the frontend keys the
+     * indicator off this message instead.
+     */
+    parentMessageId?: string
   }): SessionTrace {
     return new SessionTrace(this.deps, params)
   }
@@ -41,7 +52,7 @@ export class SessionTrace {
   private messageCount = 0
   private readonly sessionRoom: string
   private readonly streamRoom: string
-  private readonly channelRoom: string | null
+  private readonly parentRoom: string | null
 
   constructor(
     private readonly deps: TraceEmitterDeps,
@@ -51,12 +62,13 @@ export class SessionTrace {
       streamId: string
       triggerMessageId: string
       personaName: string
-      channelStreamId?: string
+      parentStreamId?: string
+      parentMessageId?: string
     }
   ) {
     this.sessionRoom = `ws:${params.workspaceId}:agent_session:${params.sessionId}`
     this.streamRoom = `ws:${params.workspaceId}:stream:${params.streamId}`
-    this.channelRoom = params.channelStreamId ? `ws:${params.workspaceId}:stream:${params.channelStreamId}` : null
+    this.parentRoom = params.parentStreamId ? `ws:${params.workspaceId}:stream:${params.parentStreamId}` : null
   }
 
   /**
@@ -100,7 +112,7 @@ export class SessionTrace {
     })
 
     // Emit to stream room (lightweight, for timeline card + trigger message indicator)
-    // When channelRoom is set, also emit to the channel for the inline indicator
+    // When parentRoom is set, also emit to the parent stream for the inline indicator
     // Include threadStreamId so frontend can link directly to thread before stream:created arrives
     const progressPayload = {
       workspaceId: this.params.workspaceId,
@@ -111,11 +123,12 @@ export class SessionTrace {
       stepCount: stepNumber,
       messageCount: this.messageCount,
       currentStepType: stepType,
-      threadStreamId: this.params.channelStreamId ? this.params.streamId : undefined,
+      threadStreamId: this.params.parentStreamId ? this.params.streamId : undefined,
+      parentMessageId: this.params.parentMessageId,
     }
     let target = this.deps.io.to(this.streamRoom)
-    if (this.channelRoom) {
-      target = target.to(this.channelRoom)
+    if (this.parentRoom) {
+      target = target.to(this.parentRoom)
     }
     target.emit("agent_session:progress", progressPayload)
 
@@ -149,10 +162,10 @@ export class SessionTrace {
       substep: params.substep,
       updatedAt: new Date().toISOString(),
     }
-    // Stream room (timeline inline) — include channel room for channel-mention threads
+    // Stream room (timeline inline) — include the parent stream's room for thread sessions
     let target = this.deps.io.to(this.streamRoom)
-    if (this.channelRoom) {
-      target = target.to(this.channelRoom)
+    if (this.parentRoom) {
+      target = target.to(this.parentRoom)
     }
     target.emit("agent_session:substep", payload)
     // Session room (trace dialog live streaming)
@@ -173,23 +186,24 @@ export class SessionTrace {
     })
   }
 
-  /** Notify channel room that agent activity started. For immediate inline indicator. */
+  /** Notify the parent stream's room that agent activity started. For immediate inline indicator. */
   notifyActivityStarted(): void {
-    if (!this.channelRoom) return
+    if (!this.parentRoom) return
     // Include threadStreamId (which is this.params.streamId) so frontend can link
     // directly to the thread before the slower stream:created event arrives
-    this.deps.io.to(this.channelRoom).emit("agent_session:activity_started", {
+    this.deps.io.to(this.parentRoom).emit("agent_session:activity_started", {
       sessionId: this.params.sessionId,
       triggerMessageId: this.params.triggerMessageId,
       personaName: this.params.personaName,
       threadStreamId: this.params.streamId,
+      parentMessageId: this.params.parentMessageId,
     })
   }
 
-  /** Notify channel room that agent activity ended. For inline indicator cleanup. */
+  /** Notify the parent stream's room that agent activity ended. For inline indicator cleanup. */
   notifyActivityEnded(): void {
-    if (!this.channelRoom) return
-    this.deps.io.to(this.channelRoom).emit("agent_session:activity_ended", {
+    if (!this.parentRoom) return
+    this.deps.io.to(this.parentRoom).emit("agent_session:activity_ended", {
       sessionId: this.params.sessionId,
       triggerMessageId: this.params.triggerMessageId,
     })

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -102,4 +102,55 @@ describe("useAgentActivity", () => {
       messageCount: 0,
     })
   })
+
+  test("keys in-thread session activity under the thread's parent message for the parent view", () => {
+    const { socket, handlers } = fakeSocket()
+    // Parent stream view: no session lifecycle events in the events array —
+    // the session lives in the thread. Everything arrives via socket.
+    const { result } = renderHook(() => useAgentActivity([], socket, "ws_test", "usr_test"))
+
+    act(() => {
+      handlers.get("agent_session:activity_started")?.({
+        sessionId: "asess_1",
+        triggerMessageId: "msg_in_thread",
+        personaName: "Ariadne",
+        threadStreamId: "thread_1",
+        parentMessageId: "msg_parent",
+      })
+    })
+
+    // Both the trigger message (thread view) and the thread's parent message
+    // (parent stream view) resolve to the same activity.
+    expect(result.current.get("msg_parent")).toMatchObject({
+      sessionId: "asess_1",
+      personaName: "Ariadne",
+      threadStreamId: "thread_1",
+    })
+    expect(result.current.get("msg_in_thread")?.sessionId).toBe("asess_1")
+
+    act(() => {
+      handlers.get("agent_session:progress")?.({
+        workspaceId: "ws_test",
+        streamId: "thread_1",
+        sessionId: "asess_1",
+        triggerMessageId: "msg_in_thread",
+        personaName: "Ariadne",
+        stepCount: 2,
+        messageCount: 0,
+        currentStepType: "workspace_search",
+        threadStreamId: "thread_1",
+        parentMessageId: "msg_parent",
+      })
+    })
+    expect(result.current.get("msg_parent")).toMatchObject({ stepCount: 2, currentStepType: "workspace_search" })
+
+    act(() => {
+      handlers.get("agent_session:activity_ended")?.({
+        sessionId: "asess_1",
+        triggerMessageId: "msg_in_thread",
+      })
+    })
+    expect(result.current.get("msg_parent")).toBeUndefined()
+    expect(result.current.get("msg_in_thread")).toBeUndefined()
+  })
 })

--- a/apps/frontend/src/hooks/use-agent-activity.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-activity.test.tsx
@@ -1,8 +1,17 @@
-import { describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 import { act, renderHook } from "@testing-library/react"
 import type { Socket } from "socket.io-client"
 import { AuthorTypes, type StreamEvent } from "@threa/types"
+import * as contextsModule from "@/contexts"
 import { useAgentActivity } from "./use-agent-activity"
+
+let reconnectCount = 0
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  reconnectCount = 0
+  vi.spyOn(contextsModule, "useSocketReconnectCount").mockImplementation(() => reconnectCount)
+})
 
 function streamEvent(payload: unknown): StreamEvent {
   return {
@@ -150,6 +159,30 @@ describe("useAgentActivity", () => {
         triggerMessageId: "msg_in_thread",
       })
     })
+    expect(result.current.get("msg_parent")).toBeUndefined()
+    expect(result.current.get("msg_in_thread")).toBeUndefined()
+  })
+
+  test("clears socket-only entries on reconnect so a swallowed activity_ended can't strand the indicator", () => {
+    const { socket, handlers } = fakeSocket()
+    const { result, rerender } = renderHook(() => useAgentActivity([], socket, "ws_test", "usr_test"))
+
+    act(() => {
+      handlers.get("agent_session:activity_started")?.({
+        sessionId: "asess_1",
+        triggerMessageId: "msg_in_thread",
+        personaName: "Ariadne",
+        threadStreamId: "thread_1",
+        parentMessageId: "msg_parent",
+      })
+    })
+    expect(result.current.get("msg_parent")).toBeDefined()
+
+    // Disconnect/reconnect: activity_ended may have been swallowed while the
+    // socket was down. The slate resets; a still-running session re-announces
+    // itself on its next progress emit.
+    reconnectCount = 1
+    rerender()
     expect(result.current.get("msg_parent")).toBeUndefined()
     expect(result.current.get("msg_in_thread")).toBeUndefined()
   })

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -1,5 +1,6 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from "react"
 import type { Socket } from "socket.io-client"
+import { useSocketReconnectCount } from "@/contexts"
 import type {
   StreamEvent,
   AgentStepType,
@@ -76,6 +77,7 @@ export function useAgentActivity(
   userId: string | null
 ): Map<string, MessageAgentActivity> {
   const [progressBySession, setProgressBySession] = useState<Map<string, ProgressEntry>>(new Map())
+  const reconnectCount = useSocketReconnectCount()
 
   // Mirror of `progressBySession` for synchronous reads inside event handlers —
   // lets a substep capture the session's step generation at *arrival* time so a
@@ -84,6 +86,18 @@ export function useAgentActivity(
   useEffect(() => {
     progressRef.current = progressBySession
   }, [progressBySession])
+
+  // Socket-only entries have exactly one deletion path: the activity_ended
+  // event. A disconnect that swallows it would strand a "working" indicator
+  // forever (the parent-view alias has no events-array cleanup — the session's
+  // lifecycle events live in the thread, not this stream). Reset the slate on
+  // reconnect (INV-53): a session still running re-announces itself on its next
+  // progress/substep emit, and the stream-room rejoin bootstrap re-seeds the
+  // session's own stream immediately.
+  useEffect(() => {
+    if (reconnectCount === 0) return
+    setProgressBySession((prev) => (prev.size === 0 ? prev : new Map()))
+  }, [reconnectCount])
 
   // Derive running sessions from events array (bootstrap source of truth for streams
   // that contain session lifecycle events, e.g. threads and scratchpads)

--- a/apps/frontend/src/hooks/use-agent-activity.ts
+++ b/apps/frontend/src/hooks/use-agent-activity.ts
@@ -50,6 +50,13 @@ interface ProgressEntry {
    */
   substepUpdatedAt?: string
   threadStreamId?: string
+  /**
+   * For sessions running inside a thread: the thread's parent message id. The
+   * parent stream's timeline has no row for the trigger message, so the result
+   * map also keys the activity under this id — that's what lights up the
+   * thread slot on the parent message.
+   */
+  parentMessageId?: string
 }
 
 /**
@@ -160,6 +167,7 @@ export function useAgentActivity(
         messageCount: 0,
         substep: null,
         threadStreamId: payload.threadStreamId,
+        parentMessageId: payload.parentMessageId,
       })
       return next
     })
@@ -183,6 +191,7 @@ export function useAgentActivity(
         substep: sameStep ? (prior?.substep ?? null) : null,
         substepUpdatedAt: sameStep ? prior?.substepUpdatedAt : undefined,
         threadStreamId: payload.threadStreamId,
+        parentMessageId: payload.parentMessageId,
       })
       return next
     })
@@ -271,10 +280,21 @@ export function useAgentActivity(
   return useMemo(() => {
     const result = new Map<string, MessageAgentActivity>()
 
+    // For a session running inside a thread, the parent stream's timeline has
+    // no row for the trigger message — the visible anchor there is the thread's
+    // parent message. Alias the same activity under that id so the thread slot
+    // lights up. Trigger-message keys win on collision (set first, never
+    // clobbered) since they anchor the session's own stream view.
+    const aliasUnderParentMessage = (parentMessageId: string | undefined, activity: MessageAgentActivity) => {
+      if (parentMessageId && !result.has(parentMessageId)) {
+        result.set(parentMessageId, activity)
+      }
+    }
+
     // Sessions known from events (thread/scratchpad view)
     for (const [sessionId, session] of runningSessions) {
       const progress = progressBySession.get(sessionId)
-      result.set(session.triggerMessageId, {
+      const activity: MessageAgentActivity = {
         sessionId,
         personaName: progress?.personaName ?? session.personaName,
         currentStepType: progress ? progress.currentStepType : session.currentStepType,
@@ -282,13 +302,15 @@ export function useAgentActivity(
         messageCount: progress ? progress.messageCount : session.messageCount,
         substep: progress?.substep ?? null,
         threadStreamId: progress?.threadStreamId,
-      })
+      }
+      result.set(session.triggerMessageId, activity)
+      aliasUnderParentMessage(progress?.parentMessageId, activity)
     }
 
-    // Sessions known only from socket (channel view where lifecycle events are in thread)
+    // Sessions known only from socket (parent view where lifecycle events are in the thread)
     for (const [sessionId, progress] of progressBySession) {
       if (runningSessions.has(sessionId)) continue
-      result.set(progress.triggerMessageId, {
+      const activity: MessageAgentActivity = {
         sessionId,
         personaName: progress.personaName,
         currentStepType: progress.currentStepType,
@@ -296,7 +318,9 @@ export function useAgentActivity(
         messageCount: progress.messageCount,
         substep: progress.substep,
         threadStreamId: progress.threadStreamId,
-      })
+      }
+      result.set(progress.triggerMessageId, activity)
+      aliasUnderParentMessage(progress.parentMessageId, activity)
     }
 
     return result

--- a/apps/frontend/src/hooks/use-agent-trace.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-trace.test.tsx
@@ -126,6 +126,11 @@ describe("useAgentTrace", () => {
     reconnectCount = 1
     rerender()
 
+    // The re-arm must be a background heal: already-fetched steps stay on
+    // screen (no skeleton swap) while the room is re-joined and refetched.
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.steps).toHaveLength(1)
+
     await waitFor(() => expect(joinSpy).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(getSessionSpy).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(result.current.steps.map((s) => s.stepNumber)).toEqual([1, 2, 3]))

--- a/apps/frontend/src/hooks/use-agent-trace.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-trace.test.tsx
@@ -142,4 +142,37 @@ describe("useAgentTrace", () => {
     })
     expect(result.current.status).toBe("completed")
   })
+
+  it("preserves terminal status across a reconnect (monotonic per session)", async () => {
+    const { socket, fire } = makeFakeSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    vi.spyOn(socketRoomModule, "joinRoomWithAck").mockResolvedValue(undefined)
+    // Bootstrap keeps reporting "running" — the terminal socket event raced
+    // ahead of the session row's status flip becoming visible to the fetch.
+    const getSessionSpy = vi.spyOn(agentSessionsApi, "getSession").mockResolvedValue(makeSessionResponse([makeStep(1)]))
+
+    const { result, rerender } = renderHook(() => useAgentTrace(WORKSPACE_ID, SESSION_ID), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.steps).toHaveLength(1))
+
+    act(() => {
+      fire("agent_session:step:progress", { sessionId: SESSION_ID, stepId: "step_1", content: "partial reasoning" })
+      fire("agent_session:completed", { sessionId: SESSION_ID })
+    })
+    expect(result.current.status).toBe("completed")
+
+    reconnectCount = 1
+    rerender()
+
+    // Terminal status must not flash back to the bootstrap's "running" while
+    // the re-join + refetch are in flight. In-flight streaming content is
+    // deliberately dropped (stale after the gap; full content re-arrives on
+    // the next progress tick).
+    expect(result.current.status).toBe("completed")
+    expect(result.current.streamingContent).toEqual({})
+
+    await waitFor(() => expect(getSessionSpy).toHaveBeenCalledTimes(2))
+    expect(result.current.status).toBe("completed")
+  })
 })

--- a/apps/frontend/src/hooks/use-agent-trace.test.tsx
+++ b/apps/frontend/src/hooks/use-agent-trace.test.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { Socket } from "socket.io-client"
+import type { AgentSessionStep, AgentSessionWithSteps } from "@threa/types"
+import * as contextsModule from "@/contexts"
+import * as workspacesModule from "@/hooks/use-workspaces"
+import * as socketRoomModule from "@/lib/socket-room"
+import { agentSessionsApi } from "@/api"
+import { useAgentTrace } from "./use-agent-trace"
+
+const WORKSPACE_ID = "ws_1"
+const SESSION_ID = "session_1"
+const SESSION_ROOM = `ws:${WORKSPACE_ID}:agent_session:${SESSION_ID}`
+
+type Handler = (payload: unknown) => void
+
+/** Minimal socket stub that records listeners so tests can fire server events. */
+function makeFakeSocket() {
+  const handlers = new Map<string, Set<Handler>>()
+  const socket = {
+    connected: true,
+    on: vi.fn((event: string, handler: Handler) => {
+      let set = handlers.get(event)
+      if (!set) {
+        set = new Set()
+        handlers.set(event, set)
+      }
+      set.add(handler)
+      return socket
+    }),
+    off: vi.fn((event: string, handler: Handler) => {
+      handlers.get(event)?.delete(handler)
+      return socket
+    }),
+    emit: vi.fn(),
+  }
+  const fire = (event: string, payload: unknown) => {
+    for (const handler of handlers.get(event) ?? []) handler(payload)
+  }
+  return { socket: socket as unknown as Socket, fire }
+}
+
+function makeStep(stepNumber: number): AgentSessionStep {
+  return {
+    id: `step_${stepNumber}`,
+    sessionId: SESSION_ID,
+    stepNumber,
+    stepType: "thinking",
+    startedAt: "2026-07-09T10:00:00.000Z",
+  }
+}
+
+function makeSessionResponse(steps: AgentSessionStep[]): AgentSessionWithSteps {
+  return {
+    session: {
+      id: SESSION_ID,
+      streamId: "stream_1",
+      personaId: "persona_1",
+      triggerMessageId: "msg_1",
+      triggerMessageRevision: 1,
+      supersedesSessionId: null,
+      status: "running",
+      sentMessageIds: [],
+      createdAt: "2026-07-09T10:00:00.000Z",
+    },
+    steps,
+    persona: { id: "persona_1", name: "Ariadne", avatarUrl: null },
+    relatedSessions: [],
+  }
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+let reconnectCount = 0
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  reconnectCount = 0
+  vi.spyOn(contextsModule, "useSocketReconnectCount").mockImplementation(() => reconnectCount)
+  vi.spyOn(workspacesModule, "useWorkspaceUserId").mockReturnValue("member_1")
+})
+
+describe("useAgentTrace", () => {
+  it("joins the session room, bootstraps, and applies realtime step events", async () => {
+    const { socket, fire } = makeFakeSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    const joinSpy = vi.spyOn(socketRoomModule, "joinRoomWithAck").mockResolvedValue(undefined)
+    const getSessionSpy = vi.spyOn(agentSessionsApi, "getSession").mockResolvedValue(makeSessionResponse([makeStep(1)]))
+
+    const { result } = renderHook(() => useAgentTrace(WORKSPACE_ID, SESSION_ID), { wrapper: createWrapper() })
+
+    await waitFor(() => expect(result.current.steps).toHaveLength(1))
+    expect(joinSpy).toHaveBeenCalledWith(socket, SESSION_ROOM, expect.anything())
+    expect(getSessionSpy).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      fire("agent_session:step:started", { sessionId: SESSION_ID, step: makeStep(2) })
+    })
+    expect(result.current.steps.map((s) => s.stepNumber)).toEqual([1, 2])
+  })
+
+  it("re-joins the session room and refetches bootstrap after a socket reconnect (INV-53)", async () => {
+    const { socket, fire } = makeFakeSocket()
+    vi.spyOn(contextsModule, "useSocket").mockReturnValue(socket)
+    const joinSpy = vi.spyOn(socketRoomModule, "joinRoomWithAck").mockResolvedValue(undefined)
+    const getSessionSpy = vi
+      .spyOn(agentSessionsApi, "getSession")
+      .mockResolvedValueOnce(makeSessionResponse([makeStep(1)]))
+      // Steps 2-3 landed while the socket was down; only a refetch can recover them.
+      .mockResolvedValue(makeSessionResponse([makeStep(1), makeStep(2), makeStep(3)]))
+
+    const { result, rerender } = renderHook(() => useAgentTrace(WORKSPACE_ID, SESSION_ID), {
+      wrapper: createWrapper(),
+    })
+    await waitFor(() => expect(result.current.steps).toHaveLength(1))
+
+    reconnectCount = 1
+    rerender()
+
+    await waitFor(() => expect(joinSpy).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(getSessionSpy).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.steps.map((s) => s.stepNumber)).toEqual([1, 2, 3]))
+
+    // The re-armed subscription must keep receiving live events — including the
+    // terminal one, which is what lets the dialog leave the "running" state.
+    act(() => {
+      fire("agent_session:completed", { sessionId: SESSION_ID })
+    })
+    expect(result.current.status).toBe("completed")
+  })
+})

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -81,6 +81,11 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
   // an older/equal timestamp belongs to that finished instance — dropping it stops
   // a late E2E decrypt from resurrecting a cleared step's phase timeline.
   const closedAtByTypeRef = useRef<Map<AgentStepType, string>>(new Map())
+  // Which session the accumulated terminalStatus belongs to. The subscribe
+  // effect also re-runs on reconnect (reconnectCount dep), and terminal status
+  // is monotonic per session — resetting it there would flash a completed
+  // dialog back to data.session.status ("running") until the refetch lands.
+  const terminalSessionKeyRef = useRef<string | null>(null)
   // Track if socket is subscribed (enables query after subscription)
   const [isSubscribed, setIsSubscribed] = useState(false)
   const [isSubscribing, setIsSubscribing] = useState(false)
@@ -237,14 +242,27 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
     if (!socket || !workspaceId || !sessionId) return
 
     const room = `ws:${workspaceId}:agent_session:${sessionId}`
+    const sessionKey = `${workspaceId}:${sessionId}`
     const abortController = new AbortController()
 
-    // Reset state for new session
+    // Reset accumulated state — on session change AND on reconnect. The steps
+    // and streaming-text wipes are deliberate for reconnects: mergeSteps
+    // prefers realtime on id collision, so a stale realtime "started" step
+    // held across the gap would permanently mask the refetched "completed"
+    // row; the refetch rebuilds the slate. Streaming text is stale after a
+    // gap and each progress event carries full content, so it self-heals on
+    // the next tick.
     setRealtimeSteps(new Map())
     setStreamingContent({})
     setStreamingSubsteps({})
     closedAtByTypeRef.current = new Map()
-    setTerminalStatus(null)
+    // Terminal status is the exception: monotonic per session, so it only
+    // resets when the dialog actually switches sessions (see
+    // terminalSessionKeyRef above).
+    if (terminalSessionKeyRef.current !== sessionKey) {
+      terminalSessionKeyRef.current = sessionKey
+      setTerminalStatus(null)
+    }
     setIsSubscribed(false)
     setIsSubscribing(true)
     setSubscriptionError(null)

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -316,7 +316,12 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
     relatedSessions: data?.relatedSessions ?? [],
     persona: data?.persona ?? null,
     status,
-    isLoading: isSubscribing || isQueryLoading,
+    // Gate the subscribing spinner on having no data yet: a reconnect re-arm
+    // flips isSubscribing while the dialog already shows steps, and surfacing
+    // it would swap the rendered list for skeletons (losing scroll) on every
+    // network blip. With data present the re-join + refetch heal in the
+    // background; skeletons appear only before the first bootstrap.
+    isLoading: (isSubscribing && !data) || isQueryLoading,
     error: (queryError as Error | null) ?? (data ? null : subscriptionError),
   }
 }

--- a/apps/frontend/src/hooks/use-agent-trace.ts
+++ b/apps/frontend/src/hooks/use-agent-trace.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { useSocket } from "@/contexts"
+import { useSocket, useSocketReconnectCount } from "@/contexts"
 import { agentSessionsApi } from "@/api"
 import { debugBootstrap } from "@/lib/bootstrap-debug"
 import { joinRoomWithAck } from "@/lib/socket-room"
@@ -64,6 +64,12 @@ interface UseAgentTraceResult {
  */
 export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentTraceResult {
   const socket = useSocket()
+  // Socket.io reuses the same Socket instance across reconnects, but the server
+  // forgets room membership on every disconnect. Keying the subscribe effect on
+  // the reconnect counter re-joins the session room and re-runs the bootstrap
+  // fetch (INV-53) — without it a reconnect leaves the dialog subscribed to
+  // nothing: steps freeze and the terminal completed/failed events never arrive.
+  const reconnectCount = useSocketReconnectCount()
   const userId = useWorkspaceUserId(workspaceId)
 
   // Real-time state accumulated from socket events
@@ -224,6 +230,9 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
 
   // Subscribe to session room and listen for events
   // CRITICAL: Subscription must complete BEFORE query is enabled to avoid race conditions
+  // Re-runs on reconnect (reconnectCount): re-joins the room and, by toggling
+  // isSubscribed, re-enables the stale bootstrap query so the refetch closes the
+  // event gap the disconnect opened (INV-53).
   useEffect(() => {
     if (!socket || !workspaceId || !sessionId) return
 
@@ -282,6 +291,7 @@ export function useAgentTrace(workspaceId: string, sessionId: string): UseAgentT
     }
   }, [
     socket,
+    reconnectCount,
     workspaceId,
     sessionId,
     handleStepStarted,

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -127,6 +127,12 @@ export interface AgentSessionProgressPayload {
   currentStepType: AgentStepType
   /** Thread stream ID for channel mentions - allows frontend to link directly to thread */
   threadStreamId?: string
+  /**
+   * The thread's parent message id when the session runs in a thread. The
+   * parent stream's timeline has no row for the trigger message (it lives
+   * inside the thread), so the inline indicator keys off this instead.
+   */
+  parentMessageId?: string
 }
 
 // Stream event payloads for agent session lifecycle
@@ -239,13 +245,15 @@ export interface AgentSessionSubstepPayload {
   updatedAt: string
 }
 
-// Emitted to channel room when agent session starts (for immediate inline indicator)
+// Emitted to the parent stream's room when agent session starts (for immediate inline indicator)
 export interface AgentActivityStartedPayload {
   sessionId: string
   triggerMessageId: string
   personaName: string
   /** Thread stream ID - allows frontend to link directly to thread before stream:created arrives */
   threadStreamId: string
+  /** The thread's parent message id — keys the indicator in the parent stream's timeline (see AgentSessionProgressPayload). */
+  parentMessageId?: string
 }
 
 // Emitted to channel room when agent session ends (for inline indicator cleanup)


### PR DESCRIPTION
## Problem

Reported live: in a DM, when the other participant invoked @Ariadne in a thread, the reporter got no trace steps streamed until the whole flow finished, and the trace surface never left "running". Three real defects behind it:

1. **Trace dialog goes permanently deaf across socket reconnects.** `useAgentTrace` joins `ws:<ws>:agent_session:<id>` once per dialog-open. Socket.io reuses the same `Socket` instance across reconnects, but the server forgets room membership on every disconnect — and the hook never re-joined or refetched (`SocketProvider` exposes `reconnectCount` for exactly this; the hook didn't use it, violating INV-53). After any blip — backgrounded tab, network drop, or the socket being mid-reconnect at dialog-open (the join ack fails after 5s and the hook deliberately proceeds with just the fetch) — the dialog shows the open-time snapshot forever: no live steps, and the terminal `agent_session:completed`/`failed` (session-room only, socket-only) never arrives.
2. **`getSession` 403s viewers with inherited thread access (INV-62).** The trace bootstrap handler gated on a direct `stream_members` row for the session's stream. A session invoked inside a thread lives on the thread stream, and thread membership rows exist only for the thread creator and the parent-message author — a DM/channel member with inherited access could join the session socket room (that path already used `checkStreamAccess`) but got "Failed to load trace" from the REST fetch. This is the exact "membership ≠ access" footgun the INV-62 playbook entry names.
3. **In-thread sessions are invisible from the parent stream.** `TraceEmitter` routed inline-indicator events (`activity_started`, `progress`, `substep`, `activity_ended`) to a parent room only for channel-root mentions (`channelStreamId`). A mention inside an existing thread emitted only to the thread's room, so a viewer of the parent timeline (DM root, channel) saw nothing live — the thread slot stayed dark until the reply landed.

## Solution

Re-arm the socket subscription on reconnect, gate trace access on the canonical predicate, and give in-thread sessions the same parent-room wiring channel mentions already had.

### How it works

1. **Reconnect re-arm** — `useAgentTrace` keys its subscribe effect on `useSocketReconnectCount()`. A reconnect re-runs the effect: reset realtime state, re-join the session room via `joinRoomWithAck`, and toggle `isSubscribed` false→true, which re-enables the `staleTime: 0` bootstrap query so the refetch closes the event gap the disconnect opened (INV-53's subscribe-then-fetch pattern, reused for the reconnect path). A failed initial join also heals on the next reconnect tick.
2. **Canonical access** — `getSession` (`session-handlers.ts`) replaces `StreamRepository.findById` + `StreamMemberRepository.findByStreamAndMember` with one `checkStreamAccess(pool, session.streamId, workspaceId, userId)` call (thread→root resolution, public-root grant, workspace boundary — all inside the predicate). Denied access now returns 404 "Session not found" instead of 403, matching the predicate's information-hiding null.
3. **Parent-room routing** — `TraceEmitter.forSession` renames `channelStreamId` → `parentStreamId` (it can now be any parent stream, not just a channel) and takes `parentMessageId`. `persona-agent.ts` sets both for channel mentions (channel id + trigger message id, unchanged behavior) and now also when the session's stream is a `THREAD` (`stream.parentStreamId` / `stream.parentMessageId`). Progress and `activity_started` payloads carry `parentMessageId` because the parent timeline has no row for the trigger message (it's inside the thread) — `useAgentActivity` aliases each activity under that id, so `agentActivity.get(parentMessage.id)` hits and the existing `ThreadSlot` lights up (ThinkingRow with live substep text, or `ThreadCard isActive` gold weave when replies are visible). Trigger-message keys win on collision; aliases never clobber.

### Key design decisions

**1. Re-run the whole subscribe effect on reconnect rather than only re-joining.** Re-joining alone leaves the missed-events gap open — steps and terminal events that fired while disconnected are socket-only and unrecoverable except through the bootstrap fetch. Toggling `isSubscribed` reuses the hook's existing subscribe-before-fetch ordering, so the reconnect path can't introduce a new race the open path doesn't already handle.

**2. 403 → 404 for denied trace access.** `checkStreamAccess` collapses "doesn't exist", "wrong workspace", and "no access" into one null by design; preserving the 403 would have required a second direct membership read — the exact pattern being removed. No frontend code branches on the distinction (the dialog shows one generic error).

**3. Generalize `channelStreamId` to `parentStreamId` instead of adding a second param.** Channel-root mentions and in-thread mentions are the same shape: session in a thread, watcher on the parent. One param + one room keeps `startStep`/`emitSubstep`/`notifyActivity*` on a single path (INV-29/43 spirit); the rename is mechanical and confined to `trace-emitter.ts` + `persona-agent.ts`.

**4. Alias in the derived map, not in the socket-event state.** `progressBySession` stays keyed by sessionId (its cleanup paths — `activity_ended`, terminal events in the events array — are id-based and unchanged); only the returned `Map<messageId, activity>` gains the parent-message alias. Both keys reference the same object, so consumers that iterate values (board rail, session live counts) see idempotent duplicates, not divergent state.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/hooks/use-agent-trace.test.tsx` | Hook joins/bootstraps/applies realtime steps; re-joins + refetches on reconnect and still receives the terminal event (INV-53) |
| `apps/backend/src/features/agents/session-handlers.test.ts` | `getSession` grants inherited-thread-access viewers via `checkStreamAccess`; denies with 404 |
| `apps/backend/src/features/agents/trace-emitter.test.ts` | Progress/substep fan-out to thread + parent rooms with `parentMessageId`; `activity_started` no-ops without a parent |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-agent-trace.ts` | Subscribe effect keyed on `useSocketReconnectCount()`; re-join + bootstrap refetch on reconnect; subscribing spinner gated on no-data so a reconnect heals in the background instead of swapping the step list to skeletons |
| `apps/backend/src/features/agents/session-handlers.ts` | Access via `checkStreamAccess` (INV-62); direct membership check removed; denied → 404 |
| `apps/backend/src/features/agents/trace-emitter.ts` | `channelStreamId`/`channelRoom` → `parentStreamId`/`parentRoom`; payloads carry `parentMessageId` |
| `apps/backend/src/features/agents/persona-agent.ts` | Parent routing computed for sessions in existing threads, not just eager channel-mention threads |
| `apps/frontend/src/hooks/use-agent-activity.ts` | Result map aliases activities under `parentMessageId` (trigger keys win); socket-only entries cleared on reconnect so a swallowed `activity_ended` can't strand a "Working…" indicator |
| `packages/types/src/agent-trace.ts` | `parentMessageId?` on `AgentSessionProgressPayload` + `AgentActivityStartedPayload` |

## Out of scope (deliberate)

- **No synthetic progress bootstrap on parent-room join.** `emitRunningSessionBootstrap` (socket.ts) only covers joining the session's own stream room; a viewer opening the parent view mid-run sees the indicator on the next progress event (every step) rather than instantly. Pre-existing gap for channel mentions; fixing it needs a parent/root-stream index on running sessions, per the existing comment in `socket.ts`.
- **Enclave (E2E scratchpad) sessions** emit through their own callback path (`enclave-runtimes/session-handlers.ts`) and already notify the session room on complete; untouched.
- **The initial join-ack-failure path still proceeds fetch-only** (deliberate existing behavior in `useAgentTrace`); it now self-heals on the next reconnect instead of never.

## Test plan

- [x] `bun test src/features/agents/` (backend) — 429 pass
- [x] `bun run test -- src/hooks/ src/components/timeline/ src/components/board/` (frontend) — 1203 pass
- [x] `bun run test -- src/hooks/ src/components/trace/` (frontend) — 719 pass (pre-third-fix run)
- [x] `bun run typecheck` — all 14 workspaces clean (also re-run by the pre-commit hook on every commit)
- [x] `bun run test -- src/hooks/use-agent-activity.test.tsx src/hooks/use-agent-trace.test.tsx` — 6 pass (post-review fixes)
- [x] Pre-PR review — 4 Sonnet reviewer agents (spec+design, correctness+data-flow, UX, mobile) + Opus verification pass: 2 findings confirmed and fixed in the last commit (reconnect re-arm swapped the open dialog's step list to skeletons and lost scroll; parent-view "Working…" indicator had a single, droppable cleanup path and could stick forever). Opus pass confirmed both fixes, judged all sub-threshold dismissals sound, found no new issues ≥80. Accepted residual: after a reconnect mid-step, the parent-view indicator stays absent until the next progress/substep emit (the join bootstrap only re-seeds the session's own stream room)
- [ ] Not verified against a live multi-user session (two browsers + a real persona run) — no runnable persona/API credentials in this environment; the reconnect and routing paths are covered by the hook/emitter tests above

<details>
<summary>📋 Full implementation plan</summary>

**Goal:** Fix "no trace steps streamed until the flow finished" reported for a DM where the other participant invoked @Ariadne in a thread.

**Diagnosis:** Three independent defects — (1) `useAgentTrace` never re-joins the session room after a socket reconnect, so an open trace dialog goes deaf (steps freeze, terminal events never arrive); (2) `getSession` gated on direct thread membership, 403ing viewers with inherited access (INV-62 footgun); (3) sessions in existing threads emitted inline-activity events only to the thread room, so parent-stream viewers saw nothing live (channel-root mentions had parent wiring; in-thread mentions had none).

**What was built:** Reconnect re-arm keyed on `useSocketReconnectCount()` with bootstrap refetch (INV-53); canonical `checkStreamAccess` in the trace bootstrap handler; `parentStreamId`/`parentMessageId` routing in `TraceEmitter` + `persona-agent` and parent-message aliasing in `useAgentActivity`.

**Design evolution (self-review + multi-agent review):** (1) The first backend handler test imported `../streams/access` directly; the pre-commit INV-52 barrel lint rejected it — switched to spying on the `../streams` barrel. (2) The first reconnect re-arm surfaced `isSubscribing` unconditionally, so an open dialog flashed to skeletons on every reconnect (worst on mobile, where backgrounding drops the socket) — fixed by gating the spinner on having no data. (3) Review caught that `useAgentActivity`'s socket-only entries had one droppable cleanup path (`activity_ended`), so the new parent-view indicator could stick at "Working…" forever after a bad disconnect — fixed with a clear-on-reconnect that lets live emits re-establish only what's actually running.

**Schema changes:** None. Two optional wire-payload fields (`parentMessageId`) on socket-only events; no persisted shape changed.

**What's NOT included:** Parent-room join bootstrap for mid-run joins (pre-existing gap, needs a root-stream index per the socket.ts comment); enclave-session path untouched.

**Status:** Complete; all suites green.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_014Lrrm5qbnzcp9WJeKTnyK3)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786222263&installation_id=129946197&pr_number=1255&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1255&signature=7b4251acd8e11fad95c6213b3a10d983ab9e0fc9be811b07e0a21a9e9dbdd9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->