### PR TITLE
fix(sidebar): reserve the tinted row background for the active stream

### DIFF
--- a/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx
@@ -169,8 +169,9 @@ export function ScratchpadItem({
             onContextMenu={touchCapable ? longPress.handlers.onContextMenu : undefined}
             className={cn(
               "flex items-stretch rounded-lg text-sm transition-colors",
+              // The tinted background means exactly one thing: "you are here" —
+              // see StreamItem; unread is the bold title + urgency strip.
               isActive ? "bg-primary/10" : "hover:bg-muted/50",
-              hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
               isTouchInput && actions.length > 0 && "select-none",
               longPress.isPressed && "opacity-70 transition-opacity duration-100"
             )}

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -363,8 +363,10 @@ export function StreamItem({
             onContextMenu={touchCapable ? longPress.handlers.onContextMenu : undefined}
             className={cn(
               "flex items-stretch rounded-lg text-sm transition-colors",
+              // The tinted background means exactly one thing: "you are here".
+              // Unread is signaled by the bold title + urgency strip — giving it
+              // a near-identical primary tint made unread rows read as active.
               isActive ? "bg-primary/10" : "hover:bg-muted/50",
-              hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10",
               isTouchInput && canOpenDrawer && "select-none",
               longPress.isPressed && "opacity-70 transition-opacity duration-100"
             )}


### PR DESCRIPTION
## Problem

From the same prod report as #1254: the sidebar uses a primary-tinted background for **both** the active stream (`bg-primary/10`) and any unread stream (`bg-primary/5 hover:bg-primary/10`). The tints are nearly indistinguishable, so an unread row reads as "you are here" — the reporter's screenshots show the unread thread and the actually-open DM looking like two active streams.

## Solution

Drop the unread background tint in `StreamItem` and `ScratchpadItem` (the only two places that had it). The tinted background now means exactly one thing: the active stream. Unread keeps its existing, distinct signals — bold title (`font-semibold`), the colored urgency strip, and the mention badge.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | Remove `hasUnread && !isActive && "bg-primary/5 hover:bg-primary/10"`; comment the ruling |
| `apps/frontend/src/components/layout/sidebar/scratchpad-item.tsx` | Same removal (scratchpad variant) |

## Test plan

- [x] `vitest run src/components/layout/sidebar` — 156 pass (no test pinned the unread tint)
- [x] Lint + full monorepo typecheck via pre-commit hook

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786222451&installation_id=129946197&pr_number=1256&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1256&signature=3eb128e82f0d7b9fbf4991445a4b9ac49daeb7f2d1853c3f608b227ca2d77a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->