### PR TITLE
fix(threads): thread card heals on stream open — threadId on reply patches + threadStates on append bootstrap

### DIFF
--- a/apps/backend/src/features/messaging/event-service.test.ts
+++ b/apps/backend/src/features/messaging/event-service.test.ts
@@ -1104,3 +1104,87 @@ describe("EventService.listEventsAroundDate", () => {
     expect(result).toEqual({ ...around, anchorMessageId: "msg_anchor" })
   })
 })
+
+describe("EventService.createMessage parent thread update (reply in thread)", () => {
+  const baseParams = {
+    workspaceId: "ws_1",
+    streamId: "stream_thread",
+    authorId: "usr_1",
+    authorType: "user" as const,
+    contentJson: { type: "doc", content: [] },
+    contentMarkdown: "a reply",
+  }
+
+  beforeEach(() => {
+    spyOn(db, "withTransaction").mockImplementation(((_db: unknown, callback: (client: any) => Promise<unknown>) =>
+      callback({})) as any)
+    spyOn(StreamRepository, "findById").mockResolvedValue({
+      id: "stream_thread",
+      type: "thread",
+      parentStreamId: "stream_root",
+      parentMessageId: "msg_parent",
+    } as any)
+    spyOn(AttachmentRepository, "findByIds").mockResolvedValue([])
+    spyOn(AttachmentRepository, "attachToMessage").mockResolvedValue(0)
+    spyOn(StreamEventRepository, "countMessagesThrough").mockResolvedValue(1)
+    spyOn(StreamMemberRepository, "isMember").mockResolvedValue(true)
+    spyOn(StreamMemberRepository, "update").mockResolvedValue(undefined as any)
+    spyOn(StreamEventRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: "evt_1",
+      streamId: params.streamId,
+      sequence: 1n,
+      eventType: params.eventType,
+      payload: params.payload,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "insert").mockImplementation((async (_client: any, params: any) => ({
+      id: params.id,
+      streamId: params.streamId,
+      sequence: params.sequence,
+      authorId: params.authorId,
+      authorType: params.authorType,
+      contentJson: params.contentJson,
+      contentMarkdown: params.contentMarkdown,
+      replyCount: 0,
+      clientMessageId: null,
+      sentVia: null,
+      reactions: {},
+      metadata: {},
+      editedAt: null,
+      deletedAt: null,
+      createdAt: new Date(),
+    })) as any)
+    spyOn(MessageRepository, "incrementReplyCount").mockResolvedValue(undefined as any)
+    spyOn(MessageRepository, "findById").mockResolvedValue({ id: "msg_parent", replyCount: 4 } as any)
+    spyOn(StreamRepository, "findThreadSummaryByParentMessage").mockResolvedValue(null)
+    spyOn(StreamRepository, "findByParentMessage").mockResolvedValue({ id: "stream_thread" } as any)
+    spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as any)
+    spyOn(messagesTotal, "inc").mockImplementation(() => undefined)
+    spyOn(SharedMessageRepository, "deleteByShareMessageId").mockResolvedValue(undefined)
+    spyOn(SharedMessageRepository, "insert").mockResolvedValue({} as any)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("publishes message:updated carrying threadId so one patch suffices to render the thread card", async () => {
+    const service = new EventService({} as any)
+
+    await service.createMessage(baseParams)
+
+    expect(OutboxRepository.insert).toHaveBeenCalledWith(
+      expect.anything(),
+      "message:updated",
+      expect.objectContaining({
+        streamId: "stream_root",
+        messageId: "msg_parent",
+        updateType: "reply_count",
+        replyCount: 4,
+        threadId: "stream_thread",
+      })
+    )
+  })
+})

--- a/apps/backend/src/features/messaging/event-service.ts
+++ b/apps/backend/src/features/messaging/event-service.ts
@@ -409,7 +409,10 @@ export class EventService {
     const parentMessage = await MessageRepository.findById(client, params.parentMessageId)
     if (!parentMessage) return
 
-    const threadSummary = await StreamRepository.findThreadSummaryByParentMessage(client, params.parentMessageId)
+    const [threadSummary, thread] = await Promise.all([
+      StreamRepository.findThreadSummaryByParentMessage(client, params.parentMessageId),
+      StreamRepository.findByParentMessage(client, params.parentStreamId, params.parentMessageId),
+    ])
     await OutboxRepository.insert(client, "message:updated", {
       workspaceId: params.workspaceId,
       streamId: params.parentStreamId,
@@ -417,6 +420,7 @@ export class EventService {
       updateType: "reply_count",
       replyCount: parentMessage.replyCount,
       threadSummary,
+      threadId: thread?.id ?? null,
     })
   }
 

--- a/apps/backend/src/features/streams/handlers.ts
+++ b/apps/backend/src/features/streams/handlers.ts
@@ -985,14 +985,32 @@ export function createStreamHandlers({
       // scope the (otherwise whole-stream) thread queries to the loaded message
       // IDs. Runs after the event window is finalized rather than in the upfront
       // Promise.all — keeps deep streams from scanning every thread they own.
+      //
+      // Append mode widens the scan to the whole stream: an append response only
+      // carries events past the client's cursor, so a thread patch the client
+      // missed live (`message:updated` is a broadcast-sequence-less patch — gap
+      // detection can't see it, and the parent row is behind the cursor) would
+      // otherwise stay stale until a hard refresh. The full map rides the
+      // response as `threadStates` so the client can heal already-persisted
+      // parent rows.
       const parentMessageIds = events
         .filter((e) => e.eventType === "message_created")
         .map((e) => (e.payload as { messageId?: string }).messageId)
         .filter((id): id is string => !!id)
+      const threadScope = syncMode === "append" ? undefined : parentMessageIds
       const [threadDataMap, threadSummaryMap] = await Promise.all([
-        streamService.getThreadsWithReplyCounts(streamId, parentMessageIds),
-        streamService.getThreadSummaries(streamId, parentMessageIds),
+        streamService.getThreadsWithReplyCounts(streamId, threadScope),
+        streamService.getThreadSummaries(streamId, threadScope),
       ])
+      const threadStates =
+        syncMode === "append"
+          ? [...threadDataMap.entries()].map(([parentMessageId, thread]) => ({
+              parentMessageId,
+              threadId: thread.threadId,
+              replyCount: thread.replyCount,
+              threadSummary: threadSummaryMap.get(parentMessageId) ?? null,
+            }))
+          : undefined
 
       const enrichedEvents = await eventService.enrichBootstrapEvents(events, threadDataMap, threadSummaryMap)
       const eventsWithLinkPreviews = await enrichEventsWithLinkPreviews(
@@ -1030,6 +1048,7 @@ export function createStreamHandlers({
           snapshotAt,
           hasOlderEvents,
           syncMode,
+          threadStates,
           unreadCount,
           mentionCount: activityCounts?.mentionCount ?? 0,
           activityCount: activityCounts?.totalCount ?? 0,

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -237,6 +237,14 @@ export interface MessageUpdatedOutboxPayload extends StreamScopedPayload {
    * the next bootstrap.
    */
   threadSummary?: import("@threa/types").ThreadSummary | null
+  /**
+   * When `updateType === "reply_count"`, the thread stream's id. A viewer who
+   * missed `stream:created` (delivered only to clients in the parent's room at
+   * creation time) cannot render the thread card from `replyCount` alone — the
+   * card needs a navigable thread id — so every reply patch carries it, making
+   * each patch self-sufficient.
+   */
+  threadId?: string | null
 }
 
 export interface ReactionOutboxPayload extends StreamScopedPayload {

--- a/apps/frontend/src/sync/stream-sync.test.ts
+++ b/apps/frontend/src/sync/stream-sync.test.ts
@@ -1913,3 +1913,212 @@ describe("registerStreamSocketHandlers — read-state counter wiring", () => {
     cleanup()
   })
 })
+
+describe("registerStreamSocketHandlers — message:updated reply_count patch", () => {
+  function createTestSocket() {
+    const handlers = new Map<string, Set<(payload: unknown) => void>>()
+    const socket = {
+      on(event: string, handler: (payload: unknown) => void) {
+        const set = handlers.get(event) ?? new Set()
+        set.add(handler)
+        handlers.set(event, set)
+        return this
+      },
+      off(event: string, handler: (payload: unknown) => void) {
+        handlers.get(event)?.delete(handler)
+        return this
+      },
+    } as unknown as Socket
+    return {
+      socket,
+      async emit(event: string, payload: unknown) {
+        await Promise.all(Array.from(handlers.get(event) ?? []).map((handler) => handler(payload)))
+      },
+    }
+  }
+
+  beforeEach(async () => {
+    await db.events.clear()
+  })
+
+  it("sets threadId from the patch so the card renders without a prior stream:created", async () => {
+    const streamId = "stream_patch_threadid"
+
+    // Parent row as a viewer who never saw stream:created holds it: no threadId.
+    await db.events.put({
+      ...makeEvent({ id: "evt_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_parent", contentMarkdown: "parent" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    const threadSummary = {
+      lastReplyAt: new Date().toISOString(),
+      participants: [{ id: "user_2", type: "user" }],
+      latestReply: { messageId: "msg_r1", actorId: "user_2", actorType: "user", contentMarkdown: "a reply" },
+    }
+    await emit("message:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      messageId: "msg_parent",
+      updateType: "reply_count",
+      replyCount: 1,
+      threadSummary,
+      threadId: "stream_thread_9",
+    })
+
+    const row = await db.events.get("evt_parent")
+    expect(row?.payload).toMatchObject({
+      messageId: "msg_parent",
+      replyCount: 1,
+      threadId: "stream_thread_9",
+      threadSummary,
+    })
+
+    cleanup()
+  })
+
+  it("does not clear an existing threadId when the patch carries threadId: null", async () => {
+    const streamId = "stream_patch_null_threadid"
+
+    await db.events.put({
+      ...makeEvent({ id: "evt_parent2", streamId, sequence: "11" }),
+      payload: { messageId: "msg_parent2", contentMarkdown: "parent", threadId: "stream_thread_kept", replyCount: 3 },
+      workspaceId: "ws_1",
+      _sequenceNum: 11,
+      _cachedAt: Date.now(),
+    })
+
+    const { socket, emit } = createTestSocket()
+    const cleanup = registerStreamSocketHandlers(socket, "ws_1", streamId, new QueryClient())
+
+    await emit("message:updated", {
+      workspaceId: "ws_1",
+      streamId,
+      messageId: "msg_parent2",
+      updateType: "reply_count",
+      replyCount: 2,
+      threadId: null,
+    })
+
+    const row = await db.events.get("evt_parent2")
+    expect(row?.payload).toMatchObject({ replyCount: 2, threadId: "stream_thread_kept" })
+
+    cleanup()
+  })
+})
+
+describe("applyStreamBootstrap — threadStates healing (append mode)", () => {
+  beforeEach(async () => {
+    await db.events.clear()
+    await db.streams.clear()
+    await db.pendingMessages.clear()
+  })
+
+  const healSummary = {
+    lastReplyAt: new Date().toISOString(),
+    participants: [{ id: "user_2", type: "user" as const }],
+    latestReply: { messageId: "msg_r9", actorId: "user_2", actorType: "user" as const, contentMarkdown: "latest" },
+  }
+
+  it("heals a stale parent row behind the append cursor from threadStates", async () => {
+    const streamId = "stream_heal"
+
+    // Parent row persisted long ago; every live thread patch for it was missed.
+    await db.events.put({
+      ...makeEvent({ id: "evt_stale_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_stale_parent", contentMarkdown: "parent" },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now() - 60_000,
+    })
+
+    // Append response: only a newer unrelated event, plus the threadStates map.
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([makeEvent({ id: "evt_new", streamId, sequence: "20" })], streamId),
+      syncMode: "append",
+      snapshotAt: new Date().toISOString(),
+      threadStates: [
+        { parentMessageId: "msg_stale_parent", threadId: "stream_thread_1", replyCount: 6, threadSummary: healSummary },
+      ],
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const row = await db.events.get("evt_stale_parent")
+    expect(row?.payload).toMatchObject({
+      messageId: "msg_stale_parent",
+      threadId: "stream_thread_1",
+      replyCount: 6,
+      threadSummary: healSummary,
+    })
+    // Bootstrap data, not a socket patch — the freshness watermark stays unset.
+    expect(row?._patchedAt).toBeUndefined()
+  })
+
+  it("preserves a parent row patched by a socket handler after the snapshot", async () => {
+    const streamId = "stream_heal_fresh"
+    const snapshotAt = new Date(Date.now() - 5_000).toISOString()
+
+    // Socket patch landed AFTER the bootstrap snapshot — it is fresher.
+    await db.events.put({
+      ...makeEvent({ id: "evt_fresh_parent", streamId, sequence: "10" }),
+      payload: { messageId: "msg_fresh_parent", contentMarkdown: "parent", threadId: "stream_thread_2", replyCount: 7 },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: Date.now(),
+      _patchedAt: Date.now(),
+    })
+
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([], streamId),
+      syncMode: "append",
+      snapshotAt,
+      threadStates: [
+        { parentMessageId: "msg_fresh_parent", threadId: "stream_thread_2", replyCount: 6, threadSummary: null },
+      ],
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const row = await db.events.get("evt_fresh_parent")
+    expect(row?.payload).toMatchObject({ replyCount: 7, threadId: "stream_thread_2" })
+  })
+
+  it("does not rewrite rows whose thread state already matches (no useless liveQuery churn)", async () => {
+    const streamId = "stream_heal_noop"
+    const cachedAt = Date.now() - 60_000
+
+    await db.events.put({
+      ...makeEvent({ id: "evt_noop_parent", streamId, sequence: "10" }),
+      payload: {
+        messageId: "msg_noop_parent",
+        contentMarkdown: "parent",
+        threadId: "stream_thread_3",
+        replyCount: 2,
+        threadSummary: null,
+      },
+      workspaceId: "ws_1",
+      _sequenceNum: 10,
+      _cachedAt: cachedAt,
+    })
+
+    const bootstrap: StreamBootstrap = {
+      ...makeBootstrap([], streamId),
+      syncMode: "append",
+      snapshotAt: new Date().toISOString(),
+      threadStates: [
+        { parentMessageId: "msg_noop_parent", threadId: "stream_thread_3", replyCount: 2, threadSummary: null },
+      ],
+    }
+
+    await applyStreamBootstrap("ws_1", streamId, bootstrap)
+
+    const row = await db.events.get("evt_noop_parent")
+    expect(row?._cachedAt).toBe(cachedAt)
+  })
+})

--- a/apps/frontend/src/sync/stream-sync.ts
+++ b/apps/frontend/src/sync/stream-sync.ts
@@ -300,6 +300,8 @@ async function writeBootstrapEventsAndStream(
     }
   }
 
+  await applyBootstrapThreadStates(streamId, bootstrap, now)
+
   // Merge stream metadata without destroying fields that only exist on the
   // workspace bootstrap's StreamWithPreview (e.g. lastMessagePreview, which
   // is the sidebar's activity sort key). Use update() for existing records
@@ -329,6 +331,51 @@ async function writeBootstrapEventsAndStream(
   if (updated === 0) {
     await db.streams.put(fullStreamData)
   }
+}
+
+/**
+ * Heal thread state on already-persisted parent rows from the bootstrap's
+ * `threadStates` map (append-mode responses). Thread patches (`message:updated`
+ * reply_count) have no broadcast sequence and mutate rows behind the append
+ * cursor, so one missed live patch would otherwise stay stale until a hard
+ * refresh — this makes every stream open converge on the server's state.
+ *
+ * Same freshness rule as the event merge above: rows patched by a socket
+ * handler AFTER the bootstrap snapshot keep their (newer) values. Only
+ * `_cachedAt` is bumped — this is bootstrap data, not a socket patch, so
+ * `_patchedAt` must stay untouched for later bootstraps to reason against.
+ */
+async function applyBootstrapThreadStates(streamId: string, bootstrap: StreamBootstrap, now: number): Promise<void> {
+  if (!bootstrap.threadStates || bootstrap.threadStates.length === 0) return
+
+  const snapshotMs = bootstrap.snapshotAt ? Date.parse(bootstrap.snapshotAt) : null
+  const stateByMessageId = new Map(bootstrap.threadStates.map((state) => [state.parentMessageId, state]))
+
+  await db.events
+    .where("[streamId+eventType]")
+    .equals([streamId, "message_created"])
+    .filter((event) => {
+      const state = stateByMessageId.get((event.payload as { messageId?: string })?.messageId ?? "")
+      if (!state) return false
+      if (snapshotMs !== null && event._patchedAt !== undefined && event._patchedAt > snapshotMs) return false
+      const payload = event.payload as { threadId?: string; replyCount?: number; threadSummary?: unknown }
+      return (
+        payload.threadId !== state.threadId ||
+        (payload.replyCount ?? 0) !== state.replyCount ||
+        JSON.stringify(payload.threadSummary ?? null) !== JSON.stringify(state.threadSummary)
+      )
+    })
+    .modify((event) => {
+      const state = stateByMessageId.get((event.payload as { messageId?: string })?.messageId ?? "")
+      if (!state) return
+      event.payload = {
+        ...(event.payload as Record<string, unknown>),
+        threadId: state.threadId,
+        replyCount: state.replyCount,
+        threadSummary: state.threadSummary,
+      }
+      event._cachedAt = now
+    })
 }
 
 /**
@@ -437,6 +484,13 @@ interface MessageUpdatedPayload {
    * without waiting for the next bootstrap. `null` = last reply was deleted.
    */
   threadSummary?: ThreadSummary | null
+  /**
+   * For reply_count updates, the thread stream's id. The card needs a
+   * navigable thread id, and `stream:created` (its usual source) reaches only
+   * clients in the parent's room at creation time — carrying the id on every
+   * reply patch makes each patch self-sufficient for rendering the card.
+   */
+  threadId?: string | null
 }
 
 interface CommandEventPayload {
@@ -978,6 +1032,12 @@ export function registerStreamSocketHandlers(
         const next: Record<string, unknown> = { ...p, replyCount: payload.replyCount }
         if (payload.threadSummary !== undefined) {
           next.threadSummary = payload.threadSummary
+        }
+        // A truthy threadId makes the patch self-sufficient for the thread
+        // card when stream:created was missed. `null` (thread gone) is left
+        // alone — replyCount 0 already hides the card.
+        if (payload.threadId) {
+          next.threadId = payload.threadId
         }
         return next
       }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -36,6 +36,7 @@ import type {
   Persona,
   Bot,
   BoardView,
+  ThreadSummary,
 } from "./domain"
 import type { UserPreferences } from "./preferences"
 import type { WorkspaceSettings } from "./workspace-settings"
@@ -203,6 +204,22 @@ export interface StreamBootstrap {
   snapshotAt?: string
   hasOlderEvents: boolean
   syncMode: "append" | "replace"
+  /**
+   * Present on append-mode responses only: current thread state for every
+   * thread parented in this stream. An append response carries only events
+   * past the client's cursor, but thread patches (`message:updated`
+   * reply_count) mutate parent rows BEHIND the cursor and carry no broadcast
+   * sequence — a patch missed live is invisible to gap detection and never
+   * re-fetched, so opening the stream applies this map to heal stale thread
+   * cards. `threadSummary: null` = thread exists but has no non-deleted
+   * replies.
+   */
+  threadStates?: Array<{
+    parentMessageId: string
+    threadId: string
+    replyCount: number
+    threadSummary: ThreadSummary | null
+  }>
   unreadCount: number
   mentionCount: number
   activityCount: number


### PR DESCRIPTION
## Problem

A thread reply updates its parent message via a `message:updated` (reply_count) socket patch. Two structural holes meant one missed patch left the thread card permanently missing from the timeline until a hard refresh:

1. **Patches can't heal.** Patch events carry no `broadcastSequence` (INV-61's dense chain covers rows, not patches), so `computeTimelineHoles` can't see a missed one. And the navigate-back stream bootstrap is append-only (`?after=cursor`) — it returns events past the cursor, while the reply-count patch mutates a parent row *behind* the cursor. Nothing ever re-reads that row.
2. **The card needs a thread id the patch never carried.** `ThreadSlot` renders only when `replyCount > 0` **and** a navigable `threadId` exists. The only live source of `threadId` was `stream:created` — delivered once, to clients in the parent's room at that instant. A viewer who missed it could receive every subsequent reply-count patch and still render nothing.

Prod incident (2026-07-09, DM `stream_01KJMS776…`, thread `stream_01KX467V…`): the backend was fully correct — `stream:created` (sync_id 49902) and all six reply-count patches (49905→50152) were broadcast to the right room and persisted to the sync log, `messages.reply_count` = 6 — yet neither member's timeline showed the thread card until refresh. Refresh works because a cold load runs a replace-mode bootstrap whose window enrichment recomputes thread state; navigate-back (append mode) never did.

## Solution

Make thread-card state converge through two independent channels: every reply patch is self-sufficient, and every stream open heals whatever was missed live.

### How it works

1. **`message:updated` carries `threadId`.** `publishParentThreadUpdate` (event-service.ts) resolves the thread via `StreamRepository.findByParentMessage` inside the same transaction and puts `threadId` on the outbox payload. `handleMessageUpdated` (stream-sync.ts) sets it on the parent row when truthy — `null` (no thread) leaves the existing value alone, since `replyCount: 0` already hides the card. Any single delivered patch now renders the card correctly even if `stream:created` was missed.
2. **Append-mode bootstrap returns `threadStates`.** The bootstrap handler already scoped `getThreadsWithReplyCounts`/`getThreadSummaries` to the response window; in append mode it now widens the scope to the whole stream (the same two queries, `parentMessageIds: undefined`) and ships the map as `threadStates: [{parentMessageId, threadId, replyCount, threadSummary}]`. Replace mode is unchanged — its window enrichment already resets every visible row.
3. **Client applies `threadStates` under the existing freshness rule.** `applyBootstrapThreadStates` (stream-sync.ts) runs inside the same IDB transaction as the event merge: rows whose `_patchedAt` is newer than the response's `snapshotAt` keep their socket-delivered values; rows whose state already matches are skipped (every `db.events` write re-runs the timeline's `useLiveQuery`); healed rows bump `_cachedAt` only, never `_patchedAt` (bootstrap data is not a socket patch).

### Key design decisions

**1. Heal at the surface the user opens, not by hardening delivery.** The forensics showed live delivery, reconnect catch-up, and offline-gap replay all work when exercised (verified in dev:test with two-context Playwright repros). Whatever dropped the six patches in prod — a lost room join, a cursor ratchet past undelivered stream-scoped entries — is a delivery-layer failure the client cannot detect (the workspace sync cursor legitimately skips entries for streams you're not a member of, so a skipped entry is indistinguishable from a not-for-you entry). Convergence on stream open is the fix that holds regardless of cause; INV-53's "bootstrap must close event gaps on resubscribe" now covers patch-shaped state too.

**2. Whole-stream thread scan in append mode, not a bounded window.** The scan is the pre-window-scoping behavior of the same queries (one `streams`-by-`parent_stream_id` join to `messages` each), bounded by the stream's thread count. A recency cap would reopen the hole for old threads that get a late reply.

**3. `threadId: null` does not clear.** A patch after the last reply's deletion carries `threadId` for a thread that still exists; the delete path decrements `replyCount`, which is what hides the card. Clearing `threadId` on `null` would break re-opening the thread from an existing card mid-flight.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/messaging/event-service.ts` | `publishParentThreadUpdate` resolves the thread id (`findByParentMessage`) and puts it on the `message:updated` payload |
| `apps/backend/src/lib/outbox/repository.ts` | `MessageUpdatedOutboxPayload.threadId` |
| `apps/backend/src/features/streams/handlers.ts` | Append-mode bootstrap widens thread enrichment to the whole stream and returns `threadStates` |
| `packages/types/src/api.ts` | `StreamBootstrap.threadStates` |
| `apps/frontend/src/sync/stream-sync.ts` | `handleMessageUpdated` applies `threadId`; `applyBootstrapThreadStates` heals persisted parent rows on bootstrap apply |
| `apps/backend/src/features/messaging/event-service.test.ts` | Reply-in-thread publishes `message:updated` carrying `threadId` |
| `apps/frontend/src/sync/stream-sync.test.ts` | Patch sets `threadId` / `null` doesn't clear; threadStates heal, freshness skip, no-op skip |

## Out of scope (deliberate)

- **Root cause of the prod delivery miss.** The backend outbox/sync-log rows prove emission was correct and immediate; the client-side machinery passed every failure simulation I could drive (offline gap, reconnect, second socket). Left open: lost socket room membership with a live connection, and the workspace cursor ratcheting past undelivered stream-scoped entries via later user-scoped ones. If it recurs with this fix deployed, the healed-on-open behavior bounds the damage to "stale until you look at it".
- **Other patch-shaped state** (reactions, edited content) has the same theoretical hole — much lower stakes (no missing UI affordance, and edits ship their own timeline events), so not widened here.

## Test plan

- [x] Backend `bun test src/features/messaging src/features/streams` — 265 pass
- [x] Frontend `vitest run src/sync/stream-sync.test.ts` — 66 pass (5 new)
- [x] Monorepo typecheck clean (all workspaces)
- [x] Live end-to-end against dev:test (Playwright, temp scripts since deleted): baseline live flow (2 contexts), offline-gap reconnect heal, and the incident repro — parent row stripped of `threadId`/`replyCount` in IDB, navigate away and back. Old code: row stays stale (bug reproduced). This branch: append bootstrap heals the row.
- [x] Negative control: same repro with the frontend change stashed leaves the row corrupted — confirms the heal is this diff, not an existing path.
- [ ] `bun run test:e2e` full suite not run locally (contention-flaky on this machine per repo memory); CI runs it on the PR.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_017BHpWufrQcFq75LK34n7SF

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786222981&installation_id=129946197&pr_number=1257&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1257&signature=3753724726d54ba6809d062e29157e5f738f53e0aa885c8d86bacb684df3aa47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->