### PR TITLE
feat(board): mobile inline composers float in the stream's shared shell, pinned above the keyboard

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -664,6 +664,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
                 post={post}
                 hostStreamType={streamType}
                 openReplySignal={openReplySignal}
+                contextChip={conversation.topicSummary ?? contextLabel}
                 // The conversation's most-recently-active stream — the latest displayed
                 // reply's own stream (a thread under the root), INCLUDING the viewer's own
                 // pending reply and any expand-backfilled rows, so a continuation follows

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { useState, type ReactNode } from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { InlineComposerForm } from "./board-inline-composer"
+import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/components/composer"
+import { spyOnExport } from "@/test"
+import * as composerModule from "@/components/composer"
+import * as useMobileModule from "@/hooks/use-mobile"
+import * as hooksModule from "@/hooks"
+import * as contextsModule from "@/contexts"
+import * as mentionablesModule from "@/hooks/use-mentionables"
+import * as workspaceStoreModule from "@/stores/workspace-store"
+import * as streamStoreModule from "@/stores/stream-store"
+import type { MessageComposerProps } from "@/components/composer"
+
+// The behavior under test is the floating-anchor layer (portal placement,
+// slot exclusivity, close semantics, height publication) — not editor
+// mechanics — so the heavy tiptap editor is swapped for a marker div.
+const EditorStub = (props: MessageComposerProps) => <div data-testid="editor-stub">{props.placeholder}</div>
+
+const EMPTY_DOC = { type: "doc", content: [] }
+
+function draftComposerStub() {
+  return {
+    content: EMPTY_DOC,
+    isLoaded: true,
+    setContent: vi.fn(),
+    canSend: false,
+    pendingAttachments: [],
+    getPendingAttachmentsSnapshot: () => [],
+    setIsSending: vi.fn(),
+    resolveDraft: vi.fn().mockResolvedValue(undefined),
+    clearAttachments: vi.fn(),
+    handleContentChange: vi.fn(),
+    handleRemoveAttachment: vi.fn(),
+    fileInputRef: { current: null },
+    handleFileSelect: vi.fn(),
+    uploadFile: vi.fn(),
+    imageCount: 0,
+    isSending: false,
+    hasFailed: false,
+    flushDraft: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+let flushDraft: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView ??= () => {}
+  spyOnExport(composerModule, "MessageComposer").mockReturnValue(EditorStub as never)
+  const stub = draftComposerStub()
+  flushDraft = stub.flushDraft
+  spyOnExport(hooksModule, "useDraftComposer").mockReturnValue((() => stub) as never)
+  vi.spyOn(contextsModule, "usePreferences").mockReturnValue({ preferences: undefined } as never)
+  vi.spyOn(mentionablesModule, "useMentionStreamContext").mockReturnValue(undefined as never)
+  vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+  vi.spyOn(streamStoreModule, "useStreamFromStore").mockReturnValue(undefined as never)
+})
+
+/** Anchor container + provider, the shape the board page / panel supply. */
+function Anchored({ children }: { children: ReactNode }) {
+  const [el, setEl] = useState<HTMLElement | null>(null)
+  return (
+    <div>
+      <div data-testid="anchor" ref={setEl} />
+      <div data-testid="in-place">
+        <FloatingComposerAnchorProvider el={el}>{children}</FloatingComposerAnchorProvider>
+      </div>
+    </div>
+  )
+}
+
+function form(overrides: Partial<Parameters<typeof InlineComposerForm>[0]> = {}) {
+  return (
+    <InlineComposerForm
+      workspaceId="ws_1"
+      streamId="stream_1"
+      memoAnchorStreamId="stream_1"
+      draftKey="board:test"
+      placeholder="Write a reply…"
+      onSubmit={vi.fn().mockResolvedValue(undefined)}
+      onClose={vi.fn()}
+      {...overrides}
+    />
+  )
+}
+
+describe("InlineComposerForm floating anchor (mobile)", () => {
+  it("renders in place on desktop even when an anchor exists", () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(false)
+    render(<Anchored>{form()}</Anchored>)
+
+    const anchor = screen.getByTestId("anchor")
+    const editor = screen.getByTestId("editor-stub")
+    expect(anchor.contains(editor)).toBe(false)
+    expect(screen.getByTestId("in-place").contains(editor)).toBe(true)
+    expect(screen.queryByRole("button", { name: "Close composer" })).toBeNull()
+  })
+
+  it("portals into the anchor's floating shell on mobile and publishes its height", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const { unmount } = render(<Anchored>{form({ contextChip: "Replying in GPU budget" })}</Anchored>)
+
+    const anchor = screen.getByTestId("anchor")
+    await waitFor(() => expect(anchor.contains(screen.getByTestId("editor-stub"))).toBe(true))
+    // The target chip travels with the floating form (the pill is far from the card).
+    expect(anchor.textContent).toContain("Replying in GPU budget")
+    // The in-place marker stands in for the portaled form as the scroll target.
+    expect(screen.getByTestId("in-place").querySelector("[data-floating-composer-marker]")).not.toBeNull()
+    // Height published for the scroller's bottom reservation; cleared on close.
+    expect(anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR)).not.toBe("")
+    unmount()
+    expect(anchor.style.getPropertyValue(FLOATING_COMPOSER_HEIGHT_VAR)).toBe("")
+  })
+
+  it("dismisses via the close button, flushing the draft", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const onClose = vi.fn()
+    render(<Anchored>{form({ onClose })}</Anchored>)
+
+    await userEvent.click(await screen.findByRole("button", { name: "Close composer" }))
+    expect(onClose).toHaveBeenCalledWith({ hadContent: false })
+    expect(flushDraft).toHaveBeenCalled()
+  })
+
+  it("collapses the previous composer when a second one claims the slot", async () => {
+    vi.spyOn(useMobileModule, "useIsMobile").mockReturnValue(true)
+    const closeFirst = vi.fn()
+    const closeSecond = vi.fn()
+    const { rerender } = render(<Anchored>{form({ onClose: closeFirst, placeholder: "First" })}</Anchored>)
+    await screen.findByText("First")
+    expect(closeFirst).not.toHaveBeenCalled()
+
+    rerender(
+      <Anchored>
+        {form({ onClose: closeFirst, placeholder: "First" })}
+        {form({ onClose: closeSecond, placeholder: "Second" })}
+      </Anchored>
+    )
+    await waitFor(() => expect(closeFirst).toHaveBeenCalledWith({ hadContent: false }))
+    expect(closeSecond).not.toHaveBeenCalled()
+    await screen.findByText("Second")
+  })
+})

--- a/apps/frontend/src/components/board/board-inline-composer.test.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.test.tsx
@@ -141,5 +141,14 @@ describe("InlineComposerForm floating anchor (mobile)", () => {
     await waitFor(() => expect(closeFirst).toHaveBeenCalledWith({ hadContent: false }))
     expect(closeSecond).not.toHaveBeenCalled()
     await screen.findByText("Second")
+
+    // The render gate, not just the close callback, enforces exclusivity: the
+    // superseded form is still mounted here (onClose is a spy, nothing unmounted
+    // it), yet only the claimant's pill exists in the anchor — two pills can
+    // never stack during a hand-off.
+    const anchor = screen.getByTestId("anchor")
+    const pills = anchor.querySelectorAll('[data-testid="editor-stub"]')
+    expect(pills).toHaveLength(1)
+    expect(pills[0]?.textContent).toBe("Second")
   })
 })

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -134,6 +134,14 @@ export function InlineComposerForm({
   const anchorEl = anchor?.el
   const claim = anchor?.claim
   const release = anchor?.release
+  const claimantId = anchor?.claimantId
+  // The portal renders only while the slot is free or held by this form. Two
+  // forms are briefly mounted during a hand-off (the loser closes via a passive
+  // effect, one commit after the winner's claim lands) — gating the render, not
+  // just the close, is what keeps two pills from ever stacking in the anchor.
+  // `null` renders immediately so the common single-open case doesn't flash a
+  // frame of nothing while its own claim effect is still pending.
+  const holdsFloatingSlot = floating && (claimantId === null || claimantId === formId)
 
   useEffect(() => {
     if (!floating || !claim || !release) return
@@ -148,7 +156,6 @@ export function InlineComposerForm({
   const wasClaimantRef = useRef(false)
   const onCloseRef = useRef(onClose)
   onCloseRef.current = onClose
-  const claimantId = anchor?.claimantId
   useEffect(() => {
     if (!floating) return
     if (claimantId === formId) {
@@ -166,7 +173,7 @@ export function InlineComposerForm({
   // measured, and must not wipe the incoming form's value.
   const shellRef = useRef<HTMLDivElement>(null)
   useLayoutEffect(() => {
-    if (!floating || !anchorEl) return
+    if (!holdsFloatingSlot || !anchorEl) return
     const shell = shellRef.current
     if (!shell) return
     const write = () => {
@@ -183,7 +190,7 @@ export function InlineComposerForm({
         delete anchorEl.dataset.floatingComposerOwner
       }
     }
-  }, [floating, anchorEl, formId])
+  }, [holdsFloatingSlot, anchorEl, formId])
 
   // Keep the reply target visible: the marker sits where the form would render
   // in place, so scrolling it into view parks the tail of the conversation above
@@ -192,7 +199,7 @@ export function InlineComposerForm({
   // bottom of the scroller — then scrolling is the user's.
   const markerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
-    if (!floating || !anchorEl) return
+    if (!holdsFloatingSlot || !anchorEl) return
     const center = () => markerRef.current?.scrollIntoView({ block: "center" })
     const raf = requestAnimationFrame(center)
     const deadline = performance.now() + 2000
@@ -209,7 +216,7 @@ export function InlineComposerForm({
       clearTimeout(timer)
       ro.disconnect()
     }
-  }, [floating, anchorEl])
+  }, [holdsFloatingSlot, anchorEl])
 
   const handleFloatingClose = useCallback(() => {
     void composerRef.current.flushDraft()
@@ -310,25 +317,26 @@ export function InlineComposerForm({
         {/* In-place marker: the scroll target that stands in for the portaled
             form, keeping the reply target in view above the floating pill. */}
         <div ref={markerRef} data-floating-composer-marker aria-hidden />
-        {createPortal(
-          <FloatingComposerShell ref={shellRef}>
-            <div ref={containerRef} onBlur={handleBlur}>
-              <div className="mb-1 flex items-center gap-2">
-                {contextChipNode}
-                <button
-                  type="button"
-                  aria-label="Close composer"
-                  onClick={handleFloatingClose}
-                  className="ml-auto shrink-0 rounded-full bg-muted p-1.5 text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
+        {holdsFloatingSlot &&
+          createPortal(
+            <FloatingComposerShell ref={shellRef}>
+              <div ref={containerRef} onBlur={handleBlur}>
+                <div className="mb-1 flex items-center gap-2">
+                  {contextChipNode}
+                  <button
+                    type="button"
+                    aria-label="Close composer"
+                    onClick={handleFloatingClose}
+                    className="ml-auto shrink-0 rounded-full bg-muted p-2 text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                {editor}
               </div>
-              {editor}
-            </div>
-          </FloatingComposerShell>,
-          anchorEl
-        )}
+            </FloatingComposerShell>,
+            anchorEl
+          )}
       </>
     )
   }

--- a/apps/frontend/src/components/board/board-inline-composer.tsx
+++ b/apps/frontend/src/components/board/board-inline-composer.tsx
@@ -1,7 +1,15 @@
-import { useCallback, useEffect, useMemo, useRef } from "react"
-import { CornerDownRight } from "lucide-react"
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef } from "react"
+import { createPortal } from "react-dom"
+import { CornerDownRight, X } from "lucide-react"
 import { toast } from "sonner"
-import { MessageComposer, type ComposerControlHandle } from "@/components/composer"
+import {
+  MessageComposer,
+  FloatingComposerShell,
+  useFloatingComposerAnchor,
+  FLOATING_COMPOSER_HEIGHT_VAR,
+  type ComposerControlHandle,
+} from "@/components/composer"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { appendQuoteReplyNode, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
 import { useDraftComposer } from "@/hooks"
 import { usePreferences } from "@/contexts"
@@ -115,6 +123,101 @@ export function InlineComposerForm({
   const isEmptyRef = useRef(true)
   isEmptyRef.current = isEmptyContent(composer.content) && composer.pendingAttachments.length === 0
 
+  // Mobile: portal the open form into the surface's floating-composer anchor as
+  // the stream's floating pill (shared FloatingComposerShell), pinned to the
+  // visible bottom above the keyboard, instead of expanding in place mid-scroll.
+  // Desktop (or a surface without an anchor) keeps the in-place form.
+  const isMobile = useIsMobile()
+  const anchor = useFloatingComposerAnchor()
+  const floating = isMobile && anchor !== null
+  const formId = useId()
+  const anchorEl = anchor?.el
+  const claim = anchor?.claim
+  const release = anchor?.release
+
+  useEffect(() => {
+    if (!floating || !claim || !release) return
+    claim(formId)
+    return () => release(formId)
+  }, [floating, claim, release, formId])
+
+  // The anchor's floating slot is exclusive: when another form claims it,
+  // collapse back to the resting affordance. Only after having *held* the claim
+  // — on mount this effect runs before our own claim lands, and closing on that
+  // stale claimant would collapse the form the instant it opens.
+  const wasClaimantRef = useRef(false)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const claimantId = anchor?.claimantId
+  useEffect(() => {
+    if (!floating) return
+    if (claimantId === formId) {
+      wasClaimantRef.current = true
+      return
+    }
+    if (!wasClaimantRef.current) return
+    void composerRef.current.flushDraft()
+    onCloseRef.current({ hadContent: !isEmptyRef.current })
+  }, [floating, claimantId, formId])
+
+  // Publish the shell's height so the anchor's scrollable content can reserve
+  // bottom space while the composer floats over it. Ownership-tagged: during a
+  // slot hand-off the outgoing form unmounts after the incoming one has already
+  // measured, and must not wipe the incoming form's value.
+  const shellRef = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    if (!floating || !anchorEl) return
+    const shell = shellRef.current
+    if (!shell) return
+    const write = () => {
+      anchorEl.style.setProperty(FLOATING_COMPOSER_HEIGHT_VAR, `${Math.ceil(shell.getBoundingClientRect().height)}px`)
+      anchorEl.dataset.floatingComposerOwner = formId
+    }
+    write()
+    const ro = new ResizeObserver(write)
+    ro.observe(shell)
+    return () => {
+      ro.disconnect()
+      if (anchorEl.dataset.floatingComposerOwner === formId) {
+        anchorEl.style.removeProperty(FLOATING_COMPOSER_HEIGHT_VAR)
+        delete anchorEl.dataset.floatingComposerOwner
+      }
+    }
+  }, [floating, anchorEl, formId])
+
+  // Keep the reply target visible: the marker sits where the form would render
+  // in place, so scrolling it into view parks the tail of the conversation above
+  // the floating pill. Re-centered on anchor shrink for the opening beat only —
+  // the keyboard resizes the layout viewport shortly after focus, hiding the
+  // bottom of the scroller — then scrolling is the user's.
+  const markerRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!floating || !anchorEl) return
+    const center = () => markerRef.current?.scrollIntoView({ block: "center" })
+    const raf = requestAnimationFrame(center)
+    const deadline = performance.now() + 2000
+    let lastHeight = anchorEl.clientHeight
+    const ro = new ResizeObserver(() => {
+      const height = anchorEl.clientHeight
+      if (height < lastHeight && performance.now() < deadline) center()
+      lastHeight = height
+    })
+    ro.observe(anchorEl)
+    const timer = setTimeout(() => ro.disconnect(), 2200)
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timer)
+      ro.disconnect()
+    }
+  }, [floating, anchorEl])
+
+  const handleFloatingClose = useCallback(() => {
+    void composerRef.current.flushDraft()
+    // No refocus: returning focus to the resting button after a touch dismissal
+    // would draw a focus ring the user never keyboard-navigated to.
+    onCloseRef.current({ hadContent: !isEmptyRef.current })
+  }, [])
+
   const handleBlur = useCallback(() => {
     requestAnimationFrame(() => {
       const container = containerRef.current
@@ -162,43 +265,78 @@ export function InlineComposerForm({
     }
   }
 
+  const contextChipNode = contextChip ? (
+    <div className="flex w-fit min-w-0 max-w-full items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      <CornerDownRight className="h-3 w-3 shrink-0" />
+      <span className="truncate">{contextChip}</span>
+    </div>
+  ) : null
+
+  const editor = (
+    <MessageComposer
+      composerRef={composerControlRef}
+      content={composer.content}
+      onContentChange={composer.handleContentChange}
+      pendingAttachments={composer.pendingAttachments}
+      onRemoveAttachment={composer.handleRemoveAttachment}
+      workspaceId={workspaceId}
+      streamId={hostStream?.id}
+      memoAnchorStreamId={memoAnchorStreamId}
+      fileInputRef={composer.fileInputRef}
+      onFileSelect={composer.handleFileSelect}
+      onFileUpload={composer.uploadFile}
+      imageCount={composer.imageCount}
+      onSubmit={handleSubmit}
+      canSubmit={canSubmit}
+      isSubmitting={composer.isSending}
+      hasFailed={composer.hasFailed}
+      placeholder={placeholder}
+      messageSendMode={preferences?.messageSendMode ?? "enter"}
+      autoFocus={autoFocus}
+      initialMobileChromeOpen
+      scopeId={draftKey}
+      streamContext={streamContext}
+      onEscapeBlur={() => {
+        const hadContent = !isEmptyRef.current
+        void composer.flushDraft()
+        onClose({ refocus: true, hadContent })
+      }}
+    />
+  )
+
+  if (floating && anchorEl) {
+    return (
+      <>
+        {/* In-place marker: the scroll target that stands in for the portaled
+            form, keeping the reply target in view above the floating pill. */}
+        <div ref={markerRef} data-floating-composer-marker aria-hidden />
+        {createPortal(
+          <FloatingComposerShell ref={shellRef}>
+            <div ref={containerRef} onBlur={handleBlur}>
+              <div className="mb-1 flex items-center gap-2">
+                {contextChipNode}
+                <button
+                  type="button"
+                  aria-label="Close composer"
+                  onClick={handleFloatingClose}
+                  className="ml-auto shrink-0 rounded-full bg-muted p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+              {editor}
+            </div>
+          </FloatingComposerShell>,
+          anchorEl
+        )}
+      </>
+    )
+  }
+
   return (
     <div ref={containerRef} className="mt-3" onBlur={handleBlur}>
-      {contextChip && (
-        <div className="mb-1 flex w-fit max-w-full items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-          <CornerDownRight className="h-3 w-3 shrink-0" />
-          <span className="truncate">{contextChip}</span>
-        </div>
-      )}
-      <MessageComposer
-        composerRef={composerControlRef}
-        content={composer.content}
-        onContentChange={composer.handleContentChange}
-        pendingAttachments={composer.pendingAttachments}
-        onRemoveAttachment={composer.handleRemoveAttachment}
-        workspaceId={workspaceId}
-        streamId={hostStream?.id}
-        memoAnchorStreamId={memoAnchorStreamId}
-        fileInputRef={composer.fileInputRef}
-        onFileSelect={composer.handleFileSelect}
-        onFileUpload={composer.uploadFile}
-        imageCount={composer.imageCount}
-        onSubmit={handleSubmit}
-        canSubmit={canSubmit}
-        isSubmitting={composer.isSending}
-        hasFailed={composer.hasFailed}
-        placeholder={placeholder}
-        messageSendMode={preferences?.messageSendMode ?? "enter"}
-        autoFocus={autoFocus}
-        initialMobileChromeOpen
-        scopeId={draftKey}
-        streamContext={streamContext}
-        onEscapeBlur={() => {
-          const hadContent = !isEmptyRef.current
-          void composer.flushDraft()
-          onClose({ refocus: true, hadContent })
-        }}
-      />
+      {contextChipNode && <div className="mb-1">{contextChipNode}</div>}
+      {editor}
     </div>
   )
 }

--- a/apps/frontend/src/components/board/board-reply-composer.tsx
+++ b/apps/frontend/src/components/board/board-reply-composer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useQuoteReply, type QuoteReplyData } from "@/components/timeline/quote-reply-context"
 import { useReplyToBoardPost } from "@/hooks/use-conversations"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { InlineComposerForm, type InlineComposerSubmit } from "@/components/board/board-inline-composer"
 import type { BoardPost } from "@threa/types"
 
@@ -31,6 +32,15 @@ interface BoardReplyComposerProps {
    * manual collapse; `0`/absent leaves it collapsed (board cards open on tap).
    */
   openReplySignal?: number
+  /**
+   * Names the reply target ("Replying in <topic/stream>") when the mobile
+   * composer floats away from its card into the page-level pill — the feed can
+   * scroll on under it, so proximity no longer identifies the conversation. The
+   * board card passes its topic/locator; the panel omits it (single-conversation
+   * surface, the header already names it). Mobile-only: the in-place desktop
+   * form keeps its context by position.
+   */
+  contextChip?: string
 }
 
 /**
@@ -119,12 +129,14 @@ function BoardReplyComposerForm({
   onClose,
   pendingQuote,
   onQuoteConsumed,
+  contextChip,
 }: BoardReplyComposerProps & {
   onClose: (opts?: { refocus?: boolean; hadContent?: boolean }) => void
   pendingQuote: QuoteReplyData | null
   onQuoteConsumed: () => void
 }) {
   const reply = useReplyToBoardPost(workspaceId)
+  const isMobile = useIsMobile()
   const streamId = post.conversation.streamId
 
   const onSubmit = useCallback(
@@ -150,6 +162,7 @@ function BoardReplyComposerForm({
       memoAnchorStreamId={streamId}
       draftKey={`board:reply:${post.conversation.id}`}
       placeholder="Write a reply…"
+      contextChip={isMobile && contextChip ? `Replying in ${contextChip}` : undefined}
       pendingQuote={pendingQuote}
       onQuoteConsumed={onQuoteConsumed}
       rejectE2e="Encrypted notes can't be replied to from the board yet — open the note to reply there."

--- a/apps/frontend/src/components/composer/floating-composer-anchor.tsx
+++ b/apps/frontend/src/components/composer/floating-composer-anchor.tsx
@@ -1,0 +1,48 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+
+/**
+ * CSS variable the floating inline composer publishes its shell height to (on
+ * the anchor element), so the anchor's scrollable content can reserve bottom
+ * space while the composer is open — same contract as the stream page's
+ * `--composer-height`, but transient: cleared when the composer closes.
+ */
+export const FLOATING_COMPOSER_HEIGHT_VAR = "--floating-composer-height"
+
+interface FloatingComposerAnchor {
+  /** Positioned container the floating composer shell portals into. */
+  el: HTMLElement
+  /** Form currently owning the floating slot (one per anchor). */
+  claimantId: string | null
+  claim: (id: string) => void
+  release: (id: string) => void
+}
+
+const FloatingComposerAnchorContext = createContext<FloatingComposerAnchor | null>(null)
+
+/**
+ * Marks a positioned container as the floating-composer slot for the inline
+ * composer surfaces below it. On mobile an open `InlineComposerForm` portals
+ * into the anchor inside the shared `FloatingComposerShell` — the same pill the
+ * stream composer uses — instead of expanding in place mid-scroll, so it pins
+ * to the visible bottom and rides above the keyboard
+ * (`interactive-widget=resizes-content` resizes the layout viewport). Desktop
+ * surfaces ignore the anchor and keep their in-place composers.
+ *
+ * The claimant id keeps the slot exclusive: opening a second composer under the
+ * same anchor collapses the first back to its resting affordance (its draft
+ * persists via the per-target draft key).
+ */
+export function FloatingComposerAnchorProvider({ el, children }: { el: HTMLElement | null; children: ReactNode }) {
+  const [claimantId, setClaimantId] = useState<string | null>(null)
+  const claim = useCallback((id: string) => setClaimantId(id), [])
+  const release = useCallback((id: string) => setClaimantId((current) => (current === id ? null : current)), [])
+  const value = useMemo<FloatingComposerAnchor | null>(
+    () => (el ? { el, claimantId, claim, release } : null),
+    [el, claimantId, claim, release]
+  )
+  return <FloatingComposerAnchorContext.Provider value={value}>{children}</FloatingComposerAnchorContext.Provider>
+}
+
+export function useFloatingComposerAnchor(): FloatingComposerAnchor | null {
+  return useContext(FloatingComposerAnchorContext)
+}

--- a/apps/frontend/src/components/composer/index.ts
+++ b/apps/frontend/src/components/composer/index.ts
@@ -1,5 +1,10 @@
 export { MessageComposer, type MessageComposerProps, type ComposerControlHandle } from "./message-composer"
 export { FloatingComposerShell } from "./floating-composer-shell"
+export {
+  FloatingComposerAnchorProvider,
+  useFloatingComposerAnchor,
+  FLOATING_COMPOSER_HEIGHT_VAR,
+} from "./floating-composer-anchor"
 export { StashedDraftsPicker } from "./stashed-drafts-picker"
 export { ScheduledMessagesPicker } from "./scheduled-messages-picker"
 export { ContextRefStrip } from "./context-ref-strip"

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -44,6 +44,11 @@ import { ConversationReadProvider, useConversationReadController } from "@/compo
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
+import {
+  FloatingComposerAnchorProvider,
+  useFloatingComposerAnchor,
+  FLOATING_COMPOSER_HEIGHT_VAR,
+} from "@/components/composer"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { SidebarToggle } from "@/components/layout"
@@ -81,6 +86,7 @@ interface ConversationPanelProps {
  */
 export function ConversationPanel({ workspaceId, onClose }: ConversationPanelProps) {
   const { isMobile } = useSidebar()
+  const [floatingAnchorEl, setFloatingAnchorEl] = useState<HTMLElement | null>(null)
   const { panelId } = usePanel()
   const conversationId = panelId ? parseConversationPanel(panelId) : null
   const { post, isLoading, notFound, refetch } = useConversationBoardPost(workspaceId, conversationId)
@@ -281,7 +287,12 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
         )}
         {!isMobile && <SidePanelClose onClose={onClose} />}
       </SidePanelHeader>
-      <SidePanelContent className="flex flex-col">{body}</SidePanelContent>
+      {/* `relative` + the anchor: on mobile an open reply/branch composer portals
+          to this container's bottom as the shared floating pill (same as the
+          stream page) instead of sitting in the scrolled flow. */}
+      <SidePanelContent ref={setFloatingAnchorEl} className="relative flex flex-col">
+        <FloatingComposerAnchorProvider el={floatingAnchorEl}>{body}</FloatingComposerAnchorProvider>
+      </SidePanelContent>
     </SidePanel>
   )
 }
@@ -543,6 +554,10 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // Scopes text-selection quoting to this panel's message list.
   const listRef = useRef<HTMLDivElement>(null)
 
+  // True while any of the panel's composers (footer reply, branch tail, new
+  // sub-topic) floats in the mobile pill over this panel.
+  const floatingComposerOpen = useFloatingComposerAnchor()?.claimantId != null
+
   // Viewport auto-read: every rendered row is eligible. While older replies are
   // still backfilling, the cutoff through a rendered row also covers the not-
   // yet-fetched middle — deliberate, same as the board card: reading the
@@ -564,7 +579,13 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       <QuoteReplyProvider>
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
-        <div ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 pb-3">
+        <div
+          ref={listRef}
+          className="min-h-0 flex-1 overflow-y-auto px-4"
+          // pb-3 baseline, plus room for the mobile floating composer while one
+          // is open so the conversation tail can scroll above the pill.
+          style={{ paddingBottom: `calc(var(${FLOATING_COMPOSER_HEIGHT_VAR}, 0px) + 0.75rem)` }}
+        >
           {provenance && (
             <BranchProvenanceRow conversationId={provenance.parentConversationId} title={provenance.title} />
           )}
@@ -589,7 +610,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
             </button>
           )}
         </div>
-        <div className="border-t px-4 py-3">
+        {/* Hidden while a mobile composer floats over the panel (the pill replaces
+            the footer's affordance; a second bottom bar under it would double up).
+            `hidden`, not unmount — the reply composer inside must stay mounted to
+            keep its portal, draft, and open state alive. */}
+        <div className={cn("border-t px-4 py-3", floatingComposerOpen && "hidden")}>
           <BoardReplyComposer
             workspaceId={workspaceId}
             post={post}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -32,6 +32,7 @@ import { useBoardRailsReady } from "@/hooks/use-board-card-messages"
 import { useBoardRevealLatch } from "@/hooks/use-board-reveal-latch"
 import { useConversationGraphReady } from "@/hooks/use-conversation-graph"
 import { SKELETON_DELAY_MS } from "@/contexts/coordinated-loading-context"
+import { FloatingComposerAnchorProvider, FLOATING_COMPOSER_HEIGHT_VAR } from "@/components/composer"
 import { BoardCard } from "@/components/board/board-card"
 import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
@@ -654,6 +655,11 @@ function BoardPageInner({
     }
   }
 
+  // Anchor for the mobile floating reply composer: an open card composer portals
+  // into this positioned container (pinned above the keyboard) instead of
+  // expanding in place mid-feed. Desktop composers ignore it.
+  const [floatingAnchorEl, setFloatingAnchorEl] = useState<HTMLElement | null>(null)
+
   const boardColumn = (
     <div className="flex h-full flex-col">
       <header className="flex h-12 shrink-0 items-center gap-2 border-b px-4">
@@ -693,36 +699,43 @@ function BoardPageInner({
           so buffered posts never shove the composer/feed down the way the old
           in-flow banner did. Anchored to the viewport top (fixed `top-2`), not the
           composer's height, so a mobile-expanded composer can't clip it. */}
-      <div className="relative flex-1 overflow-hidden">
+      <div ref={setFloatingAnchorEl} className="relative flex-1 overflow-hidden">
         {newCount > 0 && <BoardNewPostsPill count={newCount} onReveal={revealNew} scrollerRef={scrollerRef} />}
         {/* Owned scroller (a plain overflow div, like the timeline): virtua drives
             it via `scrollRef`, so scroll decisions read native metrics with no
             library tug-of-war. `overflowAnchor: none` keeps the browser's own
             scroll anchoring from fighting virtua. `data-board-scroll-viewport` is
             the IntersectionObserver root the cards' sticky-header sentinel reads. */}
-        <div
-          ref={registerScroller}
-          data-board-scroll-viewport
-          className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
-          style={{ overflowAnchor: "none" }}
-        >
-          <main className="mx-auto w-full max-w-[800px] px-2 sm:px-4">
-            {/* Composer sits above the virtualized rows in the same scroller; its
-                measured height feeds virtua's `startMargin` so item offsets stay
-                aligned. It is not virtualized, so its open/draft state survives a
-                scroll away and back. */}
-            <div ref={setComposerEl} className="pt-3">
-              <BoardComposer workspaceId={workspaceId} onPosted={handlePosted} />
-            </div>
-            {showFeed ? (
-              <BoardFeedList scrollRef={scrollerRef} listRef={listRef} startMargin={startMargin}>
-                {renderedRows}
-              </BoardFeedList>
-            ) : (
-              stateContent
-            )}
-          </main>
-        </div>
+        <FloatingComposerAnchorProvider el={floatingAnchorEl}>
+          <div
+            ref={registerScroller}
+            data-board-scroll-viewport
+            className="h-full overflow-y-auto overflow-x-hidden overscroll-y-contain"
+            style={{ overflowAnchor: "none" }}
+          >
+            <main
+              className="mx-auto w-full max-w-[800px] px-2 sm:px-4"
+              // Reserve space under the feed while a mobile floating composer is
+              // open, so the reply target can scroll above the pill; 0 otherwise.
+              style={{ paddingBottom: `var(${FLOATING_COMPOSER_HEIGHT_VAR}, 0px)` }}
+            >
+              {/* Composer sits above the virtualized rows in the same scroller; its
+                  measured height feeds virtua's `startMargin` so item offsets stay
+                  aligned. It is not virtualized, so its open/draft state survives a
+                  scroll away and back. */}
+              <div ref={setComposerEl} className="pt-3">
+                <BoardComposer workspaceId={workspaceId} onPosted={handlePosted} />
+              </div>
+              {showFeed ? (
+                <BoardFeedList scrollRef={scrollerRef} listRef={listRef} startMargin={startMargin}>
+                  {renderedRows}
+                </BoardFeedList>
+              ) : (
+                stateContent
+              )}
+            </main>
+          </div>
+        </FloatingComposerAnchorProvider>
       </div>
     </div>
   )


### PR DESCRIPTION
## Problem

On mobile, the board's inline composers are the odd ones out. The stream page and thread panel render their composer in the shared `FloatingComposerShell` (`components/composer/floating-composer-shell.tsx`) — a pill pinned to the bottom of the view that rides above the keyboard (`interactive-widget=resizes-content` resizes the layout viewport, and `absolute bottom-0` tracks it). The board's four composer surfaces — card reply (`board-reply-composer.tsx`), conversation-panel footer reply, branch-tail reply, and the "new sub-topic" gesture (all mounting `InlineComposerForm` in `board-inline-composer.tsx`) — expanded **in place, mid-scroll**: different chrome from the stream pill, and an open composer that scrolls away with the feed instead of staying with the keyboard.

## Solution

On mobile, an open `InlineComposerForm` portals into the surface's positioned container inside the same `FloatingComposerShell` the stream composer uses — one pill, pinned to the visible bottom, identical chrome. Desktop keeps the in-place form untouched. Because all four board composer surfaces share `InlineComposerForm` (INV-35), one portal branch covers them all.

### How it works

1. **`FloatingComposerAnchorProvider`** (`components/composer/floating-composer-anchor.tsx`, new) marks a positioned container as the floating slot. The board page provides its feed container (`relative flex-1 overflow-hidden` in `pages/board.tsx`); the conversation panel provides `SidePanelContent` (now `relative`). No anchor, or desktop width (`useIsMobile`, <640px) → the form renders in place exactly as before.
2. **The slot is exclusive per anchor.** Each form claims it with a `useId()` on open; a second composer opening collapses the first back to its resting affordance via its own `onClose` (draft flushed and kept — the card reply's resting label flips to "Continue reply…"). A `wasClaimantRef` guard keeps the mount-order race from closing a form the instant it opens (the supersession effect runs once before the form's own claim lands).
3. **Scroll-space reservation.** The floating form publishes its shell height as `--floating-composer-height` on the anchor element (layout effect + ResizeObserver); the board feed's `<main>` and the panel's message list pad their bottom by it, so the conversation tail can scroll above the pill. The write is ownership-tagged (`data-floating-composer-owner`): during a slot hand-off the outgoing form unmounts *after* the incoming one measured, and must not wipe the incoming value. Cleared on close — the var is transient, unlike the stream page's persisted `--composer-height`.
4. **The reply target stays in view.** A zero-height marker renders where the form would sit inline; on open it's scrolled to center, and re-centered while the anchor shrinks during the first 2 s (the keyboard opening resizes the layout viewport). After that beat, scrolling belongs to the user.
5. **X dismiss.** Mobile has no Escape, and blur-to-collapse deliberately keeps a non-empty composer open — without an explicit close, a floating composer with content would be stuck on screen. The X flushes the draft and collapses; it does not refocus the resting button (a touch dismissal shouldn't paint a focus ring). Escape keeps its refocus behavior for keyboard users.
6. **Panel footer.** While a composer floats over the panel, the `border-t` footer hides via CSS (`hidden`, not unmount — the reply composer inside owns the portal, draft, and open state) so the pill doesn't stack on a second bottom bar; it returns on close.

### Key design decisions

**1. Portal from `InlineComposerForm`, not per surface.** The alternative — wrapping each of the four call sites in shell plumbing — re-creates the drift this change removes. The form already owns open/close, draft, and blur semantics; the portal branch is the one place that decides *where* the open form lives.

**2. Exclusive claimant instead of allowing stacked pills.** Two open composers both portal to `absolute bottom-0` and overlap illegibly. Desktop tolerates multiple in-place composers (each lives in its card); mobile resolves to last-opened-wins, with the loser collapsing to its draft-preserving resting state rather than losing content.

**3. A separate transient CSS var rather than reusing `--composer-height`.** The stream var is deliberately never cleared (navigation keeps a height approximation) and mirrors to localStorage as the next boot's default. A board reply pill's height feeding the stream page's first-paint spacer would corrupt that approximation; the board var is scoped to the anchor and removed on close.

### Design evolution (self-review)

Pre-PR `/code-review` (4 sonnet reviewers: spec/design, correctness/data-flow, UX, mobile) found 2 issues, both fixed in commit 2:

1. **Transient double pill** (correctness, spec/design): the portal was gated on `floating` alone; exclusivity ran through passive effects, so during a hand-off the browser could paint a frame with two stacked, both-interactive pills. Fixed by gating the render itself: the portal (and the height/marker effects) mounts only while the slot is free or held by this form (`holdsFloatingSlot`), so two pills structurally cannot coexist — the superseded form drops its portal in the same commit the winner's claim lands, with its `onClose` collapsing it to resting a beat later. The exclusivity test now asserts single-pill DOM with the loser still mounted.
2. **Unlabeled card reply** (UX): the card reply passed no `contextChip`, and the floating pill sits far from its card while the feed can scroll on under it. The card now passes `topicSummary ?? contextLabel` and the pill shows "Replying in <topic/locator>" — mobile-only, so the in-place desktop form (context by position) is unchanged; the panel omits it (its header already names the conversation).

The mobile reviewer also noted the X dismiss target at ~26px — clear of the WCAG 24px floor but small; bumped to ~30px (`p-2`).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/composer/floating-composer-anchor.tsx` | Anchor context: positioned container + exclusive claimant slot + `FLOATING_COMPOSER_HEIGHT_VAR` |
| `apps/frontend/src/components/board/board-inline-composer.test.tsx` | Floating-branch tests: portal placement, height var publish/cleanup, X dismiss + draft flush, slot exclusivity |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-inline-composer.tsx` | Floating branch: claim/supersede effects, height publication, marker scroll, X header row; desktop render path unchanged |
| `apps/frontend/src/components/composer/index.ts` | Export the anchor provider/hook/var |
| `apps/frontend/src/pages/board.tsx` | Feed container registers as anchor; feed `<main>` pads bottom by the var |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | `SidePanelContent` made `relative` + anchor; list pads by the var; footer hides while a composer floats |
| `apps/frontend/src/components/board/board-reply-composer.tsx` | New `contextChip` prop, forwarded to the form on mobile as "Replying in <target>" |
| `apps/frontend/src/components/board/board-card.tsx` | Card passes `topicSummary ?? contextLabel` as the reply chip |

## Out of scope (deliberate)

- **`BoardComposer` ("Write a post…") stays in place.** It carries a target `Select` and is at the top of the feed, not mid-scroll; item 5 named the reply composers.
- **Desktop behavior untouched** (settled decision: mobile-only).
- **Stream page / thread panel composers untouched** — they already use the shell.

## Test plan

- [x] New `board-inline-composer.test.tsx` — 4 pass (desktop in-place, mobile portal + height var + cleanup, X dismiss + flush, slot exclusivity incl. single-pill DOM with the loser still mounted)
- [x] Existing board suites (`board-card*` ×5, `board-composer`, `board-saved-views`, `board-row-item`), `conversation-panel`, `pages/board`, `message-composer`, `composer-action-bar` — all green (137 pass across both runs; the 8 suites touching this change re-run after the review fixes, 72 pass)
- [x] Pre-PR `/code-review`, 4 sonnet reviewers — 2 findings, both fixed pre-PR (see Design evolution); mobile lens otherwise clean (breakpoints, z-order, keyboard choreography, pointer-events)
- [x] Monorepo typecheck (all 14 workspaces) + full pre-commit gate (prettier, all-app eslint, dockerfile/migration checks) — clean
- [x] **Live verify** (dev:test + Playwright, 390×844 touch emulation): board feed — tap "Write a reply…" → pill floats in the shared shell 16 px from the viewport bottom, `--floating-composer-height: 162px` on the anchor, marker present; X restores the resting affordance and clears the var. Conversation panel — footer reply floats identically; footer band hides while floating, returns on close. (Ran before the two review fixes; the portal mechanics they touch are covered by the updated unit tests.)
- [ ] Real-device keyboard choreography (visual viewport vs layout viewport) not exercised — Playwright can't raise a soft keyboard; the pinning relies on the same `interactive-widget=resizes-content` mechanism the stream composer already ships.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786223061&installation_id=129946197&pr_number=1258&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1258&signature=fe71bab21be88e4379f420aca17b875365c05a0f79c49b01e4a4fec08c1ec4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->