### PR TITLE
feat(board): slot a new-scratchpad post's card at composer-clear via a client-minted conversation id

### DIFF
--- a/apps/backend/src/features/conversations/conversation-assigner.test.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.test.ts
@@ -269,3 +269,54 @@ describe("conversationAssigner — existing (same-root guard)", () => {
     ).rejects.toMatchObject({ code: "CONVERSATION_NOT_FOUND" })
   })
 })
+
+describe("conversationAssigner — new (client-minted id)", () => {
+  let insert: ReturnType<typeof spyOn>
+  let addPrimaryMessage: ReturnType<typeof spyOn>
+  let emitAssignmentEvents: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    insert = spyOn(ConversationRepository, "insert").mockResolvedValue({ id: "conv_new" } as never)
+    addPrimaryMessage = spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never)
+    spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+    emitAssignmentEvents = spyOn(assignmentEvents, "emitAssignmentEvents").mockResolvedValue(undefined as never)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  async function mintNew(conversationId?: string): Promise<string> {
+    return conversationAssigner.assignInTransaction(CLIENT, {
+      workspaceId: WORKSPACE_ID,
+      message: makeReply("chan_1"),
+      directive: { intent: "new", conversationId },
+    })
+  }
+
+  test("honors the client-minted id verbatim so the optimistic card reconciles by it", async () => {
+    const returned = await mintNew("conv_client")
+
+    expect(insert.mock.calls[0][1]).toMatchObject({
+      id: "conv_client",
+      streamId: "chan_1",
+      workspaceId: WORKSPACE_ID,
+    })
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, "conv_client", "msg_reply", "usr_1")
+    expect(returned).toBe("conv_client")
+    expect(emitAssignmentEvents.mock.calls[0][1]).toMatchObject({
+      conversationId: "conv_client",
+      created: true,
+      reason: "declared",
+    })
+  })
+
+  test("mints a server id when the sender supplies none (every non-board `new` caller)", async () => {
+    const returned = await mintNew(undefined)
+
+    const mintedId = insert.mock.calls[0][1].id as string
+    expect(mintedId).toMatch(/^conv_/)
+    expect(returned).toBe(mintedId)
+    expect(addPrimaryMessage).toHaveBeenCalledWith(CLIENT, WORKSPACE_ID, mintedId, "msg_reply", "usr_1")
+  })
+})

--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -49,7 +49,11 @@ export const conversationAssigner: ConversationAssigner = {
     }
 
     if (directive.intent === ConversationIntents.NEW) {
-      return mintConversationForMessage(client, workspaceId, message)
+      // Honor a client-minted id when the sender supplied one (a board post that
+      // slotted its card optimistically keyed by this id — INV-20 idempotency
+      // rides the upstream `clientMessageId` dedup, which skips this assigner on a
+      // retry, so the id inserts exactly once). Omitted → mint server-side.
+      return mintConversationForMessage(client, workspaceId, message, directive.conversationId)
     }
 
     // `existing`. Workspace-scoped + row-locked (INV-8, INV-20): a stale/foreign
@@ -91,9 +95,15 @@ export const conversationAssigner: ConversationAssigner = {
 }
 
 /** Mint a fresh conversation in the message's stream, seeded with the message.
- *  Returns the minted id. */
-async function mintConversationForMessage(client: PoolClient, workspaceId: string, message: Message): Promise<string> {
-  const newId = conversationId()
+ *  Returns the id — the client-minted `preferredId` when supplied (a board post
+ *  that already slotted its optimistic card by it), else a fresh server id. */
+async function mintConversationForMessage(
+  client: PoolClient,
+  workspaceId: string,
+  message: Message,
+  preferredId?: string
+): Promise<string> {
+  const newId = preferredId ?? conversationId()
   await ConversationRepository.insert(client, {
     id: newId,
     streamId: message.streamId,

--- a/apps/backend/src/features/messaging/handlers.ts
+++ b/apps/backend/src/features/messaging/handlers.ts
@@ -31,8 +31,11 @@ import { messageMetadataSchema } from "./metadata-schema"
 // Optional conversation directive: declare the message's conversation instead
 // of leaving the extractor to infer it. The id is a sibling of the discriminant,
 // so `existing` without a non-empty id is a validation error, distinct from `new`.
+// `new` may carry a client-minted `conversationId` (a `conv_` ULID) the send
+// honors instead of minting one — the prefix guard rejects a stray id from the
+// wrong id-space (INV-11) rather than persisting it.
 export const conversationDirectiveSchema = z.discriminatedUnion("intent", [
-  z.object({ intent: z.literal("new") }),
+  z.object({ intent: z.literal("new"), conversationId: z.string().startsWith("conv_").optional() }),
   z.object({ intent: z.literal("existing"), conversationId: z.string().min(1) }),
   z.object({ intent: z.literal("threadFromMessage"), sourceConversationId: z.string().min(1) }),
   z.object({ intent: z.literal("newSubtopic") }),

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -103,6 +103,7 @@
     "socket.io-client": "^4.8",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "ulid": "^2",
     "vaul": "^1.1.2",
     "virtua": "^0.49.1",
     "zod": "^4.2.1"

--- a/apps/frontend/src/contexts/pending-messages-context.test.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, act, waitFor } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { PendingMessagesProvider, usePendingMessages } from "./pending-messages-context"
 import * as dbModule from "@/db"
+import * as boardStoreModule from "@/stores/board-store"
 
 const mockGet = vi.fn()
 const mockUpdate = vi.fn().mockResolvedValue(1)
@@ -321,6 +322,40 @@ describe("PendingMessagesContext", () => {
       expect(mockDelete).toHaveBeenCalledWith("temp_del")
       expect(mockEventsDelete).toHaveBeenCalledWith("temp_del")
       expect(result.current.getStatus("temp_del")).toBeNull()
+    })
+
+    it("drops the optimistic board card when a cancelled new-scratchpad post is deleted", async () => {
+      const dropCard = vi.fn().mockResolvedValue(undefined)
+      spyOnExport(boardStoreModule, "deleteOptimisticBoardPost").mockReturnValue(dropCard)
+      mockGet.mockResolvedValue({
+        clientId: "temp_board",
+        retryCount: 0,
+        status: undefined,
+        conversation: { intent: "new", conversationId: "conv_board" },
+      })
+
+      const { result } = renderHook(() => usePendingMessages(), { wrapper })
+
+      await act(async () => {
+        await result.current.deleteMessage("temp_board")
+      })
+
+      expect(mockDelete).toHaveBeenCalledWith("temp_board")
+      expect(dropCard).toHaveBeenCalledWith("conv_board")
+    })
+
+    it("leaves the board untouched when deleting a non-board pending message", async () => {
+      const dropCard = vi.fn().mockResolvedValue(undefined)
+      spyOnExport(boardStoreModule, "deleteOptimisticBoardPost").mockReturnValue(dropCard)
+      mockGet.mockResolvedValue({ clientId: "temp_plain", retryCount: 0, status: undefined })
+
+      const { result } = renderHook(() => usePendingMessages(), { wrapper })
+
+      await act(async () => {
+        await result.current.deleteMessage("temp_plain")
+      })
+
+      expect(dropCard).not.toHaveBeenCalled()
     })
 
     it("should clear editing state when deleting an editing message", async () => {

--- a/apps/frontend/src/contexts/pending-messages-context.tsx
+++ b/apps/frontend/src/contexts/pending-messages-context.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react"
 import { db } from "@/db"
 import { serializeToMarkdown } from "@threa/prosemirror"
-import type { JSONContent } from "@threa/types"
+import { ConversationIntents, type JSONContent } from "@threa/types"
+import { deleteOptimisticBoardPost } from "@/stores/board-store"
 
 type MessageStatus = "pending" | "failed" | "editing"
 /** Status the message had before the user entered editing mode */
@@ -298,10 +299,17 @@ export function PendingMessagesProvider({ children }: PendingMessagesProviderPro
   )
 
   const deleteMessage = useCallback(async (id: string) => {
+    // Read the directive before deleting: a cancelled new-scratchpad board post
+    // also drops its composer-clear optimistic card (keyed by the client-minted
+    // conversation id) so it doesn't linger as a phantom that never reconciles.
+    const pending = await db.pendingMessages.get(id)
     await db.transaction("rw", db.pendingMessages, db.events, async () => {
       await db.pendingMessages.delete(id)
       await db.events.delete(id)
     })
+    if (pending?.conversation?.intent === ConversationIntents.NEW && pending.conversation.conversationId) {
+      await deleteOptimisticBoardPost(pending.conversation.conversationId)
+    }
     setPendingIds((prev) => {
       const next = new Set(prev)
       next.delete(id)

--- a/apps/frontend/src/hooks/use-conversations.test.tsx
+++ b/apps/frontend/src/hooks/use-conversations.test.tsx
@@ -269,7 +269,7 @@ describe("useCreateBoardPost", () => {
     vi.spyOn(draftScratchpadsModule, "useDraftScratchpads").mockReturnValue({
       createScratchpad,
     } as unknown as ReturnType<typeof draftScratchpadsModule.useDraftScratchpads>)
-    const queueDraftMessage = vi.fn().mockResolvedValue(undefined)
+    const queueDraftMessage = vi.fn().mockResolvedValue({ clientId: "temp_scratch" })
     vi.spyOn(queueDraftModule, "useQueueDraftMessage").mockReturnValue({
       queueDraftMessage,
       currentUserId: "user_1",
@@ -377,8 +377,8 @@ describe("useCreateBoardPost", () => {
     expect(putOptimistic).toHaveBeenCalled()
   })
 
-  it("creates a draft scratchpad and queues the first message via the promote-on-send queue (no eager server stream)", async () => {
-    const { create, createScratchpad, queueDraftMessage } = mockBoardDeps()
+  it("creates a draft scratchpad, declares a client-minted conversation id, and slots the card at composer-clear", async () => {
+    const { create, createScratchpad, queueDraftMessage, putOptimistic } = mockBoardDeps()
 
     const { wrapper } = createWrapper()
     const { result } = renderHook(() => useCreateBoardPost(WORKSPACE_ID), { wrapper })
@@ -392,6 +392,11 @@ describe("useCreateBoardPost", () => {
 
     expect(create).not.toHaveBeenCalled()
     expect(createScratchpad).toHaveBeenCalledWith("on")
+    // The directive carries a client-minted `conv_` id so the send honors it and
+    // the card can reconcile by the same id.
+    const directive = queueDraftMessage.mock.calls[0][1].conversation
+    expect(directive.intent).toBe("new")
+    expect(directive.conversationId).toMatch(/^conv_/)
     expect(queueDraftMessage).toHaveBeenCalledWith(
       { contentJson: { type: "doc", content: [] }, attachmentIds: undefined },
       expect.objectContaining({
@@ -399,6 +404,21 @@ describe("useCreateBoardPost", () => {
         streamId: "draft_1",
         draftId: "draft_1",
         streamCreation: { type: StreamTypes.SCRATCHPAD, companionMode: "on" },
+      })
+    )
+
+    // The card is seeded at composer-clear — keyed by the SAME minted id, a stub
+    // under the draft stream id (messageId = the optimistic clientId), so it lands
+    // before the promote+send round-trips complete.
+    expect(putOptimistic).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      expect.objectContaining({
+        conversationId: directive.conversationId,
+        messageId: "temp_scratch",
+        streamId: "draft_1",
+        authorId: "user_1",
+        rootStreamId: "draft_1",
+        rootStreamType: StreamTypes.SCRATCHPAD,
       })
     )
   })

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -17,6 +17,8 @@ import type { BoardViewPost } from "./use-stable-board-view"
 import { useDraftScratchpads } from "./use-draft-scratchpads"
 import { useQueueDraftMessage } from "./use-queue-draft-message"
 import { generateClientId } from "./use-stream-or-draft"
+import { generateConversationId } from "@/lib/ids"
+import { serializeToMarkdown } from "@threa/prosemirror"
 import { type AttachmentSummary } from "./create-optimistic-bootstrap"
 import type { SplitGroupInput } from "@/api/conversations"
 import { StreamTypes } from "@threa/types"
@@ -255,21 +257,50 @@ export function useCreateBoardPost(workspaceId: string) {
     mutationFn: async ({ target, contentJson, attachmentIds, attachments }: CreateBoardPostInput) => {
       if (target.type === "newScratchpad") {
         const draftId = await createScratchpad(target.companionMode)
-        await queueDraftMessage(
+        // Mint the conversation id up front so the card can land the instant the
+        // composer clears (below) and the send honors the same id — the card
+        // reconciles by it, no promote+send wait, no temp-id swap.
+        const conversationId = generateConversationId()
+        const { clientId } = await queueDraftMessage(
           { contentJson, attachmentIds, attachments },
           {
             workspaceId,
             streamId: draftId,
             streamCreation: { type: StreamTypes.SCRATCHPAD, companionMode: target.companionMode },
             draftId,
-            // Declare the fresh conversation so the promote-on-send backend mints
-            // it synchronously (and returns its id) instead of leaving it to the
-            // async extractor — the queue drain seeds the board card off that id
-            // the moment the scratchpad materializes. `intent: "new"` because an
-            // authored post is always a new topic boundary.
-            conversation: { intent: "new" },
+            // Declare the fresh conversation with our client-minted id so the
+            // promote-on-send backend assigns it synchronously (honoring the id)
+            // instead of leaving it to the async extractor. `intent: "new"` because
+            // an authored post is always a new topic boundary.
+            conversation: { intent: "new", conversationId },
           }
         )
+
+        // Slot the card at composer-clear, keyed by the minted conversation id —
+        // a new scratchpad post appears immediately, like a timeline optimistic
+        // message, rather than after the promote+send round-trips. It's a stub
+        // under the DRAFT stream id (rootStreamType scratchpad); the queue drain
+        // refines it with the real stream/message ids + server-resolved markdown
+        // post-promotion, and the echo/refetch clears `_status` — all by the same
+        // id. Best-effort: a local IDB failure must not fail the send. A cancelled
+        // send drops the stub via `deleteOptimisticBoardPost` (see deleteMessage).
+        if (currentUserId) {
+          try {
+            await putOptimisticBoardPost(workspaceId, {
+              conversationId,
+              messageId: clientId,
+              streamId: draftId,
+              authorId: currentUserId,
+              contentMarkdown: serializeToMarkdown(contentJson),
+              rootStreamId: draftId,
+              rootStreamType: StreamTypes.SCRATCHPAD,
+              createdAt: new Date().toISOString(),
+              attachments,
+            })
+          } catch (err) {
+            console.error("Failed to seed optimistic board post at composer-clear", err)
+          }
+        }
         return
       }
 

--- a/apps/frontend/src/hooks/use-message-queue.test.ts
+++ b/apps/frontend/src/hooks/use-message-queue.test.ts
@@ -402,10 +402,12 @@ describe("useMessageQueue", () => {
     })
   })
 
-  it("seeds an optimistic board card once a new-scratchpad post's send returns its conversation id", async () => {
+  it("reconciles the optimistic board card to real ids once a new-scratchpad post's send returns", async () => {
     // A promoted scratchpad send: streamId is already the real stream, and the
-    // send declares the fresh conversation (`intent: "new"`) so the backend mints
-    // and returns it. (Promotion itself is covered by its own tests.)
+    // send declares the fresh conversation (`intent: "new"`, carrying the
+    // client-minted id) so the backend honors and returns it. (Promotion itself is
+    // covered by its own tests.) The card was seeded at composer-clear under the
+    // draft ids; the drain rewrites it to the real ones.
     const realStream = { id: "stream_real", type: "scratchpad", rootStreamId: null }
     vi.spyOn(dbModule.db.streams, "get").mockResolvedValue(realStream as never)
     mockCreate.mockResolvedValue({
@@ -418,7 +420,7 @@ describe("useMessageQueue", () => {
       },
       conversationId: "conv_new",
     })
-    const putOptimistic = vi.spyOn(boardStoreModule, "putOptimisticBoardPost").mockResolvedValue(undefined)
+    const reconcile = vi.spyOn(boardStoreModule, "reconcileOptimisticBoardPost").mockResolvedValue(undefined)
 
     mockPendingMessages = [
       {
@@ -430,7 +432,7 @@ describe("useMessageQueue", () => {
         contentJson: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "first note" }] }] },
         createdAt: 1000,
         retryCount: 0,
-        conversation: { intent: "new" },
+        conversation: { intent: "new", conversationId: "conv_new" },
       } as unknown as MockPendingMessage,
     ]
 
@@ -439,9 +441,9 @@ describe("useMessageQueue", () => {
       await new Promise((r) => setTimeout(r, 10))
     })
 
-    // The card is seeded from the response, keyed by the real conversation +
-    // stream ids, so it lands the moment the scratchpad materializes.
-    expect(putOptimistic).toHaveBeenCalledWith(
+    // The card reconciles to the real conversation + stream + message ids the
+    // moment the scratchpad materializes.
+    expect(reconcile).toHaveBeenCalledWith(
       "ws_1",
       expect.objectContaining({
         conversationId: "conv_new",
@@ -455,8 +457,8 @@ describe("useMessageQueue", () => {
     )
   })
 
-  it("does not seed a board card for an ordinary send that declared no new conversation", async () => {
-    const putOptimistic = vi.spyOn(boardStoreModule, "putOptimisticBoardPost").mockResolvedValue(undefined)
+  it("does not touch a board card for an ordinary send that declared no new conversation", async () => {
+    const reconcile = vi.spyOn(boardStoreModule, "reconcileOptimisticBoardPost").mockResolvedValue(undefined)
     mockPendingMessages = [
       {
         clientId: "temp_plain",
@@ -475,6 +477,6 @@ describe("useMessageQueue", () => {
       await new Promise((r) => setTimeout(r, 10))
     })
 
-    expect(putOptimistic).not.toHaveBeenCalled()
+    expect(reconcile).not.toHaveBeenCalled()
   })
 })

--- a/apps/frontend/src/hooks/use-message-queue.ts
+++ b/apps/frontend/src/hooks/use-message-queue.ts
@@ -7,7 +7,7 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { emitDraftPromoted } from "@/lib/draft-promotions"
 import { setParentThreadId } from "@/sync/stream-sync"
 import { deleteDraftScratchpadFromCache } from "@/stores/draft-store"
-import { putOptimisticBoardPost } from "@/stores/board-store"
+import { reconcileOptimisticBoardPost } from "@/stores/board-store"
 import { rescopeScopeDrafts } from "./use-draft-message"
 import { workspaceKeys } from "./use-workspaces"
 import { StreamTypes, ShareErrorCodes, draftStreamScope } from "@threa/types"
@@ -256,14 +256,15 @@ export function useMessageQueue(): void {
           })
 
           // A board post to a NEW scratchpad minted a fresh conversation on send
-          // (`intent: "new"`). Seed its board card from the response — keyed by the
-          // real conversation + (post-promotion) stream ids — so it appears the
-          // moment the scratchpad materializes rather than after the async
-          // `conversation:created` echo + board-head refetch. Reconciled in place by
-          // both (same id, `_status` cleared). `existing`/`threadFromMessage` replies
-          // also return an id, but their card already exists so the write no-ops.
-          // Best-effort: the send already succeeded, so a local IDB failure must not
-          // drop the iteration into the retry/failed path for a delivered message.
+          // (`intent: "new"`). The card is already on screen — the composer-clear
+          // stub `useCreateBoardPost` seeded, keyed by the SAME client-minted id,
+          // under the draft stream id. Now that promotion returned the real stream +
+          // message, reconcile the stub to those real ids (and server-resolved
+          // markdown) so it deep-links correctly and doesn't render twice. Lands in
+          // any echo↔drain ordering, and no-ops if the user cancelled the post mid-
+          // send (its card is gone — don't resurrect it). Best-effort: the send
+          // already succeeded, so a local IDB failure must not drop the iteration
+          // into the retry/failed path for a delivered message.
           if (conversationId && next.conversation?.intent === "new") {
             try {
               const stream = await db.streams.get(next.streamId)
@@ -273,7 +274,7 @@ export function useMessageQueue(): void {
                 const optimisticEvent = await db.events.get(next.clientId)
                 const attachments = (optimisticEvent?.payload as { attachments?: AttachmentSummary[] } | undefined)
                   ?.attachments
-                await putOptimisticBoardPost(next.workspaceId, {
+                await reconcileOptimisticBoardPost(next.workspaceId, {
                   conversationId,
                   messageId: message.id,
                   streamId: next.streamId,
@@ -286,7 +287,7 @@ export function useMessageQueue(): void {
                 })
               }
             } catch (err) {
-              console.error("Failed to seed optimistic board post from queue drain", err)
+              console.error("Failed to reconcile optimistic board post from queue drain", err)
             }
           }
         }

--- a/apps/frontend/src/hooks/use-stable-board-view.ts
+++ b/apps/frontend/src/hooks/use-stable-board-view.ts
@@ -200,12 +200,13 @@ function sameIds(a: string[], b: string[]): boolean {
  *    the viewport, so appending it to the frozen order shifts nothing on-screen;
  *    fold it in immediately (no pill).
  *  - **The viewer's own optimistic post** (`_status === "pending"`, only ever set
- *    by `putOptimisticBoardPost` for the author's own send) — revealed at top
- *    immediately, regardless of any timer. The authored card must surface as soon
- *    as it lands, whether that's inline (existing-stream) or after the promote-on-
- *    send drain (a new scratchpad, arbitrarily later). Revealing ONLY the pending
- *    card leaves unrelated arrivals still buffered, so posting never reorders the
- *    cards the viewer was reading (board-view-design.md "don't move shit on me").
+ *    by `putOptimisticBoardPost`/`reconcileOptimisticBoardPost` for the author's
+ *    own send) — revealed at top immediately, regardless of any timer. The authored
+ *    card must surface as soon as it lands, whether that's inline (existing-stream)
+ *    or at composer-clear (a new scratchpad, keyed by the client-minted id).
+ *    Revealing ONLY the pending card leaves unrelated arrivals still buffered, so
+ *    posting never reorders the cards the viewer was reading (board-view-design.md
+ *    "don't move shit on me").
  *  - **Any other at-or-above-floor arrival** — a new conversation from someone
  *    else, or a card bumped up. Revealing it would reorder the view, so it waits
  *    in the buffer and is surfaced as the "N new" pill count instead.

--- a/apps/frontend/src/lib/ids.ts
+++ b/apps/frontend/src/lib/ids.ts
@@ -1,0 +1,14 @@
+import { ulid } from "ulid"
+
+/**
+ * Client-mint a conversation id (`conv_` ULID, INV-2 — same shape as the
+ * backend's `conversationId()`). A board post mints its conversation id up front
+ * so it can slot the card the instant the composer clears, then have the send
+ * honor the same id (the `{ intent: "new", conversationId }` directive) — the
+ * card reconciles by that one id when the echo lands, no temp-id swap. Idempotent
+ * on the wire: the send dedupes on `clientMessageId` before the assigner runs, so
+ * a retried send inserts the conversation exactly once.
+ */
+export function generateConversationId(): string {
+  return `conv_${ulid()}`
+}

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -5,6 +5,7 @@ import {
   seedBoardPosts,
   mergeBoardConversation,
   putOptimisticBoardPost,
+  reconcileOptimisticBoardPost,
   deleteOptimisticBoardPost,
 } from "./board-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
@@ -179,11 +180,14 @@ describe("putOptimisticBoardPost", () => {
     expect(row?.openingMessage?.contentMarkdown).toBe("just posted")
   })
 
-  it("never regresses a live row to pending when the echo/refetch won the race", async () => {
+  it("is insert-if-absent: never overwrites an existing row (echo/refetch won, or the stub is already down)", async () => {
     await seedBoardPosts(WORKSPACE_ID, [makePost("conv_new", "2026-06-22T12:00:09.000Z")])
     await putOptimisticBoardPost(WORKSPACE_ID, input)
     const row = await db.conversations.get("conv_new")
     expect(row?._status).toBeUndefined()
+    // The existing row's opening (msg m1 from makePost) is untouched, not clobbered
+    // with the seed's msg_1.
+    expect(row?.openingMessage?.id).toBe("m1")
   })
 
   it("renders the post's attachments immediately so the thumbnail doesn't pop in on reconcile", async () => {
@@ -196,32 +200,73 @@ describe("putOptimisticBoardPost", () => {
       { id: "att_1", filename: "shot.png", mimeType: "image/png", sizeBytes: 2048 },
     ])
   })
+})
 
-  it("refines a still-pending stub in place: the drain rewrites the composer-clear draft ids with the real ones", async () => {
-    // Composer-clear stub: keyed by the client-minted id, under the DRAFT stream id.
-    await putOptimisticBoardPost(WORKSPACE_ID, {
-      ...input,
-      messageId: "temp_scratch",
-      streamId: "draft_1",
-      rootStreamId: "draft_1",
-      rootStreamType: "scratchpad",
-      contentMarkdown: "client markdown",
-    })
-    // Drain post-promotion: same conversation id, now the real stream/message ids
-    // and server-resolved markdown — refines the pending stub, still pending.
-    await putOptimisticBoardPost(WORKSPACE_ID, {
-      ...input,
-      messageId: "msg_real",
-      streamId: "stream_real",
-      rootStreamId: "stream_real",
-      rootStreamType: "scratchpad",
-      contentMarkdown: "server markdown",
-    })
+describe("reconcileOptimisticBoardPost (new-scratchpad drain refine)", () => {
+  // The composer-clear stub: keyed by the client-minted id, under the DRAFT stream
+  // id, with a client temp message id and client-serialized markdown.
+  const stub = {
+    conversationId: "conv_new",
+    messageId: "temp_scratch",
+    streamId: "draft_1",
+    authorId: "usr_1",
+    contentMarkdown: "client markdown",
+    rootStreamId: "draft_1",
+    rootStreamType: "scratchpad" as const,
+    createdAt: "2026-06-22T12:00:00.000Z",
+  }
+  // The drain's post-promotion refine: real stream + message ids, server markdown.
+  const real = {
+    ...stub,
+    messageId: "msg_real",
+    streamId: "stream_real",
+    rootStreamId: "stream_real",
+    contentMarkdown: "server markdown",
+  }
+
+  it("drain beat the echo (still pending): replaces the stub wholesale with the real ids", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, stub)
+    await reconcileOptimisticBoardPost(WORKSPACE_ID, real)
     const row = await db.conversations.get("conv_new")
     expect(row?._status).toBe("pending")
     expect(row?.conversation.streamId).toBe("stream_real")
+    expect(row?.conversation.messageIds).toEqual(["msg_real"])
     expect(row?.openingMessage?.id).toBe("msg_real")
     expect(row?.openingMessage?.contentMarkdown).toBe("server markdown")
+    // openingId === messageIds[0] → the card renders the post once, not twice.
+    expect(row?.openingMessage?.id).toBe(row?.conversation.messageIds[0])
+  })
+
+  it("echo won first: patches the real opening/stream onto the reconciled aggregate without a duplicate", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, stub)
+    // The `conversation:created` echo reconciles the aggregate (real messageIds,
+    // clears `_status`) but keeps the stub's stale opening (mergeBoardConversation
+    // carries no message bodies).
+    await mergeBoardConversation("conv_new", {
+      ...makeConversation("conv_new", "2026-06-22T12:00:05.000Z"),
+      streamId: "stream_real",
+      messageIds: ["msg_real"],
+    })
+    const afterEcho = await db.conversations.get("conv_new")
+    expect(afterEcho?._status).toBeUndefined()
+    expect(afterEcho?.openingMessage?.id).toBe("temp_scratch") // stale, mismatched → would render twice
+    expect(afterEcho?.openingMessage?.id).not.toBe(afterEcho?.conversation.messageIds[0])
+
+    // The drain's later refine patches the real opening onto the reconciled row.
+    await reconcileOptimisticBoardPost(WORKSPACE_ID, real)
+    const row = await db.conversations.get("conv_new")
+    expect(row?._status).toBeUndefined() // not regressed back to pending
+    expect(row?.openingMessage?.id).toBe("msg_real")
+    expect(row?.openingMessage?.contentMarkdown).toBe("server markdown")
+    expect(row?.conversation.streamId).toBe("stream_real")
+    // openingId === messageIds[0] again → no double-render.
+    expect(row?.openingMessage?.id).toBe(row?.conversation.messageIds[0])
+  })
+
+  it("cancelled mid-send (no row): does NOT resurrect the card", async () => {
+    // The user deleted the post while the send was in flight — its card is gone.
+    await reconcileOptimisticBoardPost(WORKSPACE_ID, real)
+    expect(await db.conversations.get("conv_new")).toBeUndefined()
   })
 })
 

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import Dexie from "dexie"
 import { db } from "@/db"
-import { seedBoardPosts, mergeBoardConversation, putOptimisticBoardPost } from "./board-store"
+import {
+  seedBoardPosts,
+  mergeBoardConversation,
+  putOptimisticBoardPost,
+  deleteOptimisticBoardPost,
+} from "./board-store"
 import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
 
 const WORKSPACE_ID = "ws_1"
@@ -190,5 +195,62 @@ describe("putOptimisticBoardPost", () => {
     expect(row?.openingMessage?.attachments).toEqual([
       { id: "att_1", filename: "shot.png", mimeType: "image/png", sizeBytes: 2048 },
     ])
+  })
+
+  it("refines a still-pending stub in place: the drain rewrites the composer-clear draft ids with the real ones", async () => {
+    // Composer-clear stub: keyed by the client-minted id, under the DRAFT stream id.
+    await putOptimisticBoardPost(WORKSPACE_ID, {
+      ...input,
+      messageId: "temp_scratch",
+      streamId: "draft_1",
+      rootStreamId: "draft_1",
+      rootStreamType: "scratchpad",
+      contentMarkdown: "client markdown",
+    })
+    // Drain post-promotion: same conversation id, now the real stream/message ids
+    // and server-resolved markdown — refines the pending stub, still pending.
+    await putOptimisticBoardPost(WORKSPACE_ID, {
+      ...input,
+      messageId: "msg_real",
+      streamId: "stream_real",
+      rootStreamId: "stream_real",
+      rootStreamType: "scratchpad",
+      contentMarkdown: "server markdown",
+    })
+    const row = await db.conversations.get("conv_new")
+    expect(row?._status).toBe("pending")
+    expect(row?.conversation.streamId).toBe("stream_real")
+    expect(row?.openingMessage?.id).toBe("msg_real")
+    expect(row?.openingMessage?.contentMarkdown).toBe("server markdown")
+  })
+})
+
+describe("deleteOptimisticBoardPost", () => {
+  const input = {
+    conversationId: "conv_new",
+    messageId: "temp_scratch",
+    streamId: "draft_1",
+    authorId: "usr_1",
+    contentMarkdown: "just posted",
+    rootStreamId: "draft_1",
+    rootStreamType: "scratchpad" as const,
+    createdAt: "2026-06-22T12:00:00.000Z",
+  }
+
+  it("drops a pending stub (a cancelled queued post) so it doesn't linger as a phantom", async () => {
+    await putOptimisticBoardPost(WORKSPACE_ID, input)
+    await deleteOptimisticBoardPost("conv_new")
+    expect(await db.conversations.get("conv_new")).toBeUndefined()
+  })
+
+  it("leaves a reconciled card alone (a stale cancel must not delete a committed post)", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_new", "2026-06-22T12:00:00.000Z")])
+    await deleteOptimisticBoardPost("conv_new")
+    expect(await db.conversations.get("conv_new")).toBeDefined()
+  })
+
+  it("no-ops when the card doesn't exist", async () => {
+    await deleteOptimisticBoardPost("conv_absent")
+    expect(await db.conversations.get("conv_absent")).toBeUndefined()
   })
 })

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -95,14 +95,19 @@ export interface OptimisticBoardPostInput {
 }
 
 /**
- * Slot an authored board post into the reactive feed the instant the send
- * returns, keyed by the REAL conversation id the backend assigned synchronously
- * (surfaced on the send response) — so the card appears as the composer clears
- * rather than after the socket echo + board-head refetch round-trips. Written
- * `_status: "pending"`; the `conversation:*` echo (`mergeBoardConversation`) and
- * the board-head refetch (`seedBoardPosts`) reconcile it in place by the same id,
- * clearing `_status` with no card swap or flash. Skipped if a row already exists
- * for the id (the echo/refetch won the race), so a live aggregate is never
+ * Slot an authored board post into the reactive feed, keyed by the conversation
+ * id — client-minted up front for a new scratchpad (so the card lands the instant
+ * the composer clears, before the promote+send round-trips) or the real id for an
+ * existing-stream post (surfaced on the send response). Written `_status:
+ * "pending"`; the `conversation:*` echo (`mergeBoardConversation`) and the
+ * board-head refetch (`seedBoardPosts`) reconcile it in place by the same id,
+ * clearing `_status` with no card swap or flash.
+ *
+ * Re-callable for the SAME id while pending: the composer-clear seed writes a stub
+ * under the draft stream id, then the queue drain calls again post-promotion with
+ * the real stream/message ids and server-resolved markdown — both `_status:
+ * "pending"`, so the second call refines the first. Only a row the server already
+ * reconciled (`_status` cleared) is left untouched, so a live aggregate is never
  * regressed to a pending stub.
  */
 export async function putOptimisticBoardPost(workspaceId: string, input: OptimisticBoardPostInput): Promise<void> {
@@ -150,8 +155,26 @@ export async function putOptimisticBoardPost(workspaceId: string, input: Optimis
     rootArchived: false,
   }
   await db.transaction("rw", db.conversations, async () => {
-    if (await db.conversations.get(input.conversationId)) return
+    const existing = await db.conversations.get(input.conversationId)
+    // A row the echo/refetch already reconciled (`_status` cleared) — or any
+    // non-pending row — is authoritative; don't regress it. A still-pending stub
+    // (our own composer-clear seed) is refined by the drain's post-promotion call.
+    if (existing && existing._status !== "pending") return
     await db.conversations.put(toCached(workspaceId, post, "pending"))
+  })
+}
+
+/**
+ * Drop a still-pending optimistic board card — the composer-clear stub of a new
+ * scratchpad post whose queued send the user cancelled/deleted before it landed,
+ * so the card doesn't linger as a phantom that will never reconcile. Guarded on
+ * `_status: "pending"`: a card the send already committed (server-reconciled, or
+ * even mid-flight) is never removed by a stale cancel.
+ */
+export async function deleteOptimisticBoardPost(conversationId: string): Promise<void> {
+  await db.transaction("rw", db.conversations, async () => {
+    const existing = await db.conversations.get(conversationId)
+    if (existing?._status === "pending") await db.conversations.delete(conversationId)
   })
 }
 

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -94,23 +94,9 @@ export interface OptimisticBoardPostInput {
   attachments?: AttachmentSummary[]
 }
 
-/**
- * Slot an authored board post into the reactive feed, keyed by the conversation
- * id — client-minted up front for a new scratchpad (so the card lands the instant
- * the composer clears, before the promote+send round-trips) or the real id for an
- * existing-stream post (surfaced on the send response). Written `_status:
- * "pending"`; the `conversation:*` echo (`mergeBoardConversation`) and the
- * board-head refetch (`seedBoardPosts`) reconcile it in place by the same id,
- * clearing `_status` with no card swap or flash.
- *
- * Re-callable for the SAME id while pending: the composer-clear seed writes a stub
- * under the draft stream id, then the queue drain calls again post-promotion with
- * the real stream/message ids and server-resolved markdown — both `_status:
- * "pending"`, so the second call refines the first. Only a row the server already
- * reconciled (`_status` cleared) is left untouched, so a live aggregate is never
- * regressed to a pending stub.
- */
-export async function putOptimisticBoardPost(workspaceId: string, input: OptimisticBoardPostInput): Promise<void> {
+/** Build the `BoardPost` projection an authored post renders from before its
+ *  aggregate echoes — shared by the seed and the post-promotion reconcile. */
+function buildOptimisticPost(workspaceId: string, input: OptimisticBoardPostInput): BoardPost {
   const conversation: ConversationWithStaleness = {
     id: input.conversationId,
     streamId: input.streamId,
@@ -130,7 +116,7 @@ export async function putOptimisticBoardPost(workspaceId: string, input: Optimis
     temporalStaleness: 0,
     effectiveCompleteness: 1,
   }
-  const post: BoardPost = {
+  return {
     conversation,
     openingMessage: {
       id: input.messageId,
@@ -154,13 +140,68 @@ export async function putOptimisticBoardPost(workspaceId: string, input: Optimis
     rootStreamType: input.rootStreamType,
     rootArchived: false,
   }
+}
+
+/**
+ * Slot an authored board post into the reactive feed, keyed by the conversation
+ * id — client-minted up front for a new scratchpad (so the card lands the instant
+ * the composer clears, before the promote+send round-trips) or the real id for an
+ * existing-stream post (surfaced on the send response). Written `_status:
+ * "pending"`; the `conversation:*` echo (`mergeBoardConversation`) and the
+ * board-head refetch (`seedBoardPosts`) reconcile it in place by the same id,
+ * clearing `_status` with no card swap or flash.
+ *
+ * Insert-if-absent: it never overwrites an existing row (the echo/refetch won the
+ * race, or a new scratchpad's composer-clear stub is already down). The drain's
+ * post-promotion refine goes through {@link reconcileOptimisticBoardPost}, which is
+ * the only writer allowed to rewrite an existing card's draft ids with the real
+ * ones.
+ */
+export async function putOptimisticBoardPost(workspaceId: string, input: OptimisticBoardPostInput): Promise<void> {
+  const post = buildOptimisticPost(workspaceId, input)
+  await db.transaction("rw", db.conversations, async () => {
+    if (await db.conversations.get(input.conversationId)) return
+    await db.conversations.put(toCached(workspaceId, post, "pending"))
+  })
+}
+
+/**
+ * Rewrite a new-scratchpad post's card with its real ids once the send promotes
+ * the draft and returns the server message. The composer-clear stub
+ * ({@link putOptimisticBoardPost}) carried the DRAFT stream id and the client temp
+ * message id; this lands the real stream/message ids + server-resolved markdown so
+ * the card deep-links correctly and `openingId === messageIds[0]` (else the flat
+ * projection renders the post twice — the stub as opening, the real row as a reply).
+ *
+ * Three cases, so it's correct under any echo↔drain ordering:
+ *  - **No row** — the user cancelled the post mid-send (its card + queued message
+ *    were deleted). Do NOT resurrect it.
+ *  - **Still pending** — the drain beat the `conversation:created` echo; the stub's
+ *    aggregate is synthetic, so replace the card wholesale with the real projection
+ *    (still pending; the echo/refetch clears `_status`).
+ *  - **Already reconciled** — the echo cleared `_status` first but `mergeBoardConversation`
+ *    kept the stub's stale opening. Patch only the authoritative opening + stream
+ *    onto it; never regress the echo's real aggregate/recentMessages back to a stub.
+ */
+export async function reconcileOptimisticBoardPost(
+  workspaceId: string,
+  input: OptimisticBoardPostInput
+): Promise<void> {
+  const post = buildOptimisticPost(workspaceId, input)
   await db.transaction("rw", db.conversations, async () => {
     const existing = await db.conversations.get(input.conversationId)
-    // A row the echo/refetch already reconciled (`_status` cleared) — or any
-    // non-pending row — is authoritative; don't regress it. A still-pending stub
-    // (our own composer-clear seed) is refined by the drain's post-promotion call.
-    if (existing && existing._status !== "pending") return
-    await db.conversations.put(toCached(workspaceId, post, "pending"))
+    if (!existing) return
+    if (existing._status === "pending") {
+      await db.conversations.put(toCached(workspaceId, post, "pending"))
+      return
+    }
+    await db.conversations.put({
+      ...existing,
+      openingMessage: post.openingMessage,
+      rootStreamId: input.rootStreamId,
+      rootStreamType: input.rootStreamType,
+      conversation: { ...existing.conversation, streamId: input.streamId },
+    })
   })
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -309,6 +309,7 @@
         "socket.io-client": "^4.8",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
+        "ulid": "^2",
         "vaul": "^1.1.2",
         "virtua": "^0.49.1",
         "zod": "^4.2.1",

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -354,9 +354,17 @@ export interface SyncHeartbeatPayload {
  * sibling of the discriminant (not folded into one field) so a missing/garbage id
  * on `existing`/`threadFromMessage` is a validation error, distinct from `new`
  * and `newSubtopic`.
+ *
+ * `new` may carry a client-minted `conversationId`: the sender mints the id up
+ * front (a `conv_` ULID, INV-2) so it can slot the board card the instant the
+ * composer clears — rather than waiting for the send response to learn the
+ * server-minted id — and the card reconciles by the SAME id when the echo lands.
+ * Idempotent like `clientMessageId`: the send dedupes on that key before the
+ * assigner runs, so a retried send inserts the conversation exactly once. Omit to
+ * let the backend mint one (every non-board `new` caller does).
  */
 export type ConversationDirective =
-  | { intent: "new" }
+  | { intent: "new"; conversationId?: string }
   | { intent: "existing"; conversationId: string }
   | { intent: "threadFromMessage"; sourceConversationId: string }
   | { intent: "newSubtopic" }


### PR DESCRIPTION
## Summary

A board post to a **new scratchpad** slotted its card only after `promoteDraft` + the send returned the server-minted conversation id (~2 round-trips). This brings the id forward so the card lands the instant the composer clears — the same mechanism the stream timeline uses for optimistic messages (client-mint the correlation id, reconcile by the same id), applied to the conversation id.

Builds directly on #1248 (real-id-keyed board optimism). No `useStableBoardView` changes — reconcile is by the same id, exactly #1248's path, just with the id known up front.

## Design decisions

- **Client-mint the conversation id.** `useCreateBoardPost` (new scratchpad) mints a `conv_` ULID, declares it on the send directive `{intent:"new", conversationId}`, and the backend honors it in `mintConversationForMessage` (`preferredId ?? conversationId()`). This is the faithful port of the timeline's `clientMessageId` trick; today only `clientMessageId` was client-supplied (dedup-only), so this makes the conversation id client-authoritative.
- **Retry-safe without ON CONFLICT.** `createMessageInTransaction` dedupes on `clientMessageId` *before* the assigner runs, so a retried send returns the existing message and never re-runs assignment — the client id inserts exactly once. ULIDs make cross-send collision impossible.
- **Two writers, cleanly split** (this is the fix the pre-PR review drove out):
  - `putOptimisticBoardPost` → **insert-if-absent** (composer-clear stub + existing-stream seed). Never overwrites a row the echo/refetch reconciled.
  - `reconcileOptimisticBoardPost` (drain, post-promotion) → **no row → no-op** (a cancelled post is not resurrected); **still pending → replace wholesale** with real ids; **already reconciled (echo won the race) → patch the real opening id/stream** onto the echo's aggregate. Lands the real ids in every echo↔drain ordering, so `openingId === messageIds[0]` always holds and the card never double-renders / strands on the deleted draft stream id.
- **Cancel drops the card.** `pending-messages-context.deleteMessage` calls `deleteOptimisticBoardPost` (pending-guarded) so a cancelled queued post leaves no phantom; the drain's no-op-on-missing-row means an in-flight cancel isn't re-seeded either.

## Why the second commit

The first commit had a latent race: if the `conversation:created` echo (a live workspace push) reconciled the composer-clear stub before the drain's refine, the card was stranded on the draft stream id (deleted by `promoteDraft`) and rendered the post twice. The pre-PR review (3 reviewers, all converged) caught it; the second commit splits the writers so real ids land under any ordering. Tests cover all three orderings + the insert-if-absent guard + cancel.

## File changes

**Backend**
- `packages/types/src/api.ts` — `ConversationDirective {intent:"new"}` gains optional `conversationId`.
- `apps/backend/src/features/messaging/handlers.ts` — Zod `new` variant accepts a `conv_`-prefixed id (INV-11 guard).
- `apps/backend/src/features/conversations/conversation-assigner.ts` — `mintConversationForMessage(..., preferredId?)`.

**Frontend**
- `apps/frontend/src/lib/ids.ts` (new) — `generateConversationId()` (`conv_` ULID; `ulid` dep added).
- `apps/frontend/src/hooks/use-conversations.ts` — new-scratchpad path mints + declares the id and seeds the card at composer-clear.
- `apps/frontend/src/stores/board-store.ts` — `buildOptimisticPost` helper; `putOptimisticBoardPost` insert-if-absent; new `reconcileOptimisticBoardPost`; new `deleteOptimisticBoardPost`.
- `apps/frontend/src/hooks/use-message-queue.ts` — drain refines via `reconcileOptimisticBoardPost`.
- `apps/frontend/src/contexts/pending-messages-context.tsx` — `deleteMessage` drops the optimistic card on cancel.

## Testing

- Full monorepo pre-commit gate green (prettier, all-app eslint, 14× tsc, dockerfile/migration checks, OpenAPI up-to-date — internal endpoint, no spec change).
- Unit: assigner honors/omits the client id; board-store all three reconcile orderings (drain-first, echo-first, cancelled) + insert-if-absent guard; useCreateBoardPost composer-clear seed; drain reconcile call; deleteMessage card-drop.
- **Live dogfood pending** — the "feels instant, no flash, no duplicate card" property needs the authed app; `staging` label added for a preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786223583&installation_id=129946197&pr_number=1259&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1259&signature=d07e5c3ec51984f1d01e92f60b8883dab0f74eecb6aecde3a10b6faca276c2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->