### PR TITLE
fix(timeline): latch the unread divider at messages arriving while blurred

### DIFF
--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -12,6 +12,7 @@ import {
   useStreamBootstrap,
   useWorkspaceUserId,
   useAutoMarkAsRead,
+  useAutoReadAttention,
   useLastSeenEvent,
   useUnreadCounts,
   useUnreadDivider,
@@ -1750,6 +1751,7 @@ export function StreamContent({
     enabled: autoMarkEnabled,
   })
   useAutoMarkAsRead(workspaceId, streamId, lastSeenEventId, { enabled: autoMarkEnabled, partial: !atLastRow })
+  const canAutoRead = useAutoReadAttention()
 
   const isMobile = useIsMobile()
   const { markAsRead, markUnread, getUnreadCount } = useUnreadCounts(workspaceId)
@@ -1792,6 +1794,10 @@ export function StreamContent({
     // Skip overlay-read events so the divider anchors on the first *effectively*
     // unread row, not one already read from a conversation surface.
     overlayReadIds: readOverlay,
+    // Same signal that gates auto-read: while the viewer is away the divider may
+    // re-latch forward at the first away-arrival (messages that came in while
+    // blurred get the persistent red→grey strip, as if the stream were re-opened).
+    isAttentive: canAutoRead,
   })
 
   // The divider is red while unread still sits at/after it, and turns muted-gray

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -1769,7 +1769,9 @@ export function StreamContent({
     currentWorkspaceUserId ?? undefined,
     streamId,
     lastReadEventId,
-    readOverlay
+    readOverlay,
+    // Away arrivals get the divider (blur re-latch below), not the flash.
+    canAutoRead
   )
 
   // Unread divider state — a bookmark line at the first unread message. The

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -105,7 +105,7 @@ export { useActivityCounts } from "./use-activity-counts"
 
 export { useActivityFeed, useMarkActivityRead, useMarkAllActivityRead, activityKeys } from "./use-activity"
 
-export { useAutoMarkAsRead } from "./use-auto-mark-as-read"
+export { useAutoMarkAsRead, useAutoReadAttention } from "./use-auto-mark-as-read"
 
 export { useLastSeenEvent } from "./use-last-seen-event"
 

--- a/apps/frontend/src/hooks/use-new-message-indicator.test.ts
+++ b/apps/frontend/src/hooks/use-new-message-indicator.test.ts
@@ -125,6 +125,45 @@ describe("useNewMessageIndicator", () => {
     expect(result.current.size).toBe(0)
   })
 
+  it("does not flash events that arrive while the viewer is away, even after refocus", () => {
+    // Away-arrivals get the persistent unread divider (blur re-latch) instead;
+    // flashing them too would double-signal the same rows on refocus.
+    const initial = [makeEvent({ id: "evt_1", sequence: "1" })]
+
+    const { result, rerender } = renderHook(
+      ({ events, isAttentive }: { events: StreamEvent[]; isAttentive: boolean }) =>
+        useNewMessageIndicator(events, currentUserId, streamId, "evt_1", undefined, isAttentive),
+      { initialProps: { events: initial, isAttentive: true } }
+    )
+
+    const withAwayArrival = [...initial, makeEvent({ id: "evt_2", sequence: "2" })]
+    rerender({ events: withAwayArrival, isAttentive: false })
+    expect(result.current.size).toBe(0)
+
+    // Refocus: the away-arrival is already known — it must not flash late.
+    rerender({ events: withAwayArrival, isAttentive: true })
+    expect(result.current.size).toBe(0)
+  })
+
+  it("flashes events arriving after refocus as usual", () => {
+    const initial = [makeEvent({ id: "evt_1", sequence: "1" })]
+
+    const { result, rerender } = renderHook(
+      ({ events, isAttentive }: { events: StreamEvent[]; isAttentive: boolean }) =>
+        useNewMessageIndicator(events, currentUserId, streamId, "evt_1", undefined, isAttentive),
+      { initialProps: { events: initial, isAttentive: true } }
+    )
+
+    const withAwayArrival = [...initial, makeEvent({ id: "evt_2", sequence: "2" })]
+    rerender({ events: withAwayArrival, isAttentive: false })
+
+    const withFocusedArrival = [...withAwayArrival, makeEvent({ id: "evt_3", sequence: "3" })]
+    rerender({ events: withFocusedArrival, isAttentive: true })
+
+    expect(result.current.has("evt_3")).toBe(true)
+    expect(result.current.has("evt_2")).toBe(false)
+  })
+
   it("expires flashed IDs after 2 seconds", () => {
     const initial = [makeEvent({ id: "evt_1", sequence: "1" })]
 

--- a/apps/frontend/src/hooks/use-new-message-indicator.ts
+++ b/apps/frontend/src/hooks/use-new-message-indicator.ts
@@ -14,13 +14,19 @@ import type { StreamEvent } from "@threa/types"
  * Events after it that were already present when the stream opened get the
  * divider instead (handled by useUnreadDivider). Only events that arrive
  * via socket while viewing AND are after the read boundary flash here.
+ *
+ * `isAttentive` (the shared auto-read attention signal) splits live arrivals
+ * between the two signals: attentive arrivals flash here, away arrivals are
+ * recorded as known without flashing — they get the persistent unread divider
+ * (blur re-latch in useUnreadDivider) instead, never both.
  */
 export function useNewMessageIndicator(
   events: StreamEvent[],
   currentUserId: string | undefined,
   streamId: string,
   lastReadEventId?: string | null,
-  overlayReadIds?: ReadonlySet<string>
+  overlayReadIds?: ReadonlySet<string>,
+  isAttentive: boolean = true
 ): Set<string> {
   const [newIds, setNewIds] = useState<Set<string>>(new Set())
   /** Event IDs present when the stream was opened. With the eventCache removed,
@@ -64,6 +70,7 @@ export function useNewMessageIndicator(
       if (knownEventIdsRef.current.has(event.id)) break
       const messageId = (event.payload as { messageId?: string } | null)?.messageId
       if (
+        isAttentive &&
         !trackedIdsRef.current.has(event.id) &&
         event.actorId !== currentUserId &&
         event.actorType === "user" &&
@@ -96,7 +103,7 @@ export function useNewMessageIndicator(
       })
     }, 2000)
     timersRef.current.add(timer)
-  }, [events, currentUserId, lastReadEventId, overlayReadIds])
+  }, [events, currentUserId, lastReadEventId, overlayReadIds, isAttentive])
 
   return newIds
 }

--- a/apps/frontend/src/hooks/use-unread-divider.test.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.test.ts
@@ -282,6 +282,196 @@ describe("useUnreadDivider", () => {
     expect(result.current.dividerEventId).toBe("event_2")
   })
 
+  it("re-latches forward at the first blurred-arrival after the session latch was consumed", () => {
+    // The dogfooding bug: an earlier focused arrival consumed the session latch
+    // (then auto-read greyed it). Messages arriving while the window is blurred
+    // must move the divider FORWARD to the first away-arrival — as if the stream
+    // had been re-opened — instead of leaving a stale grey line far above.
+    const { result, rerender } = renderHook(
+      ({
+        events,
+        lastReadEventId,
+        isAttentive,
+      }: {
+        events: ReturnType<typeof makeMessageEvent>[]
+        lastReadEventId: string | null
+        isAttentive: boolean
+      }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId,
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+          isAttentive,
+        }),
+      {
+        initialProps: {
+          events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
+          lastReadEventId: null as string | null,
+          isAttentive: true,
+        },
+      }
+    )
+
+    // Focused session: latch consumed at event_1, then auto-read passes it.
+    expect(result.current.dividerEventId).toBe("event_1")
+    rerender({
+      events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
+      lastReadEventId: "event_2",
+      isAttentive: true,
+    })
+    expect(result.current.dividerEventId).toBe("event_1")
+
+    // Window blurs; a message arrives while away → divider re-latches at it.
+    const withBlurredArrival = [
+      makeMessageEvent("event_1", "other"),
+      makeMessageEvent("event_2", "other"),
+      makeMessageEvent("event_3", "other"),
+    ]
+    rerender({ events: withBlurredArrival, lastReadEventId: "event_2", isAttentive: false })
+    expect(result.current.dividerEventId).toBe("event_3")
+
+    // isDividerReadPast compares numeric bigint sequences; the helper's
+    // sequence is its id string, so remap for the red→grey assertions.
+    const sequenced = withBlurredArrival.map((e, i) => ({ ...e, sequence: String(i + 1) })) as typeof withBlurredArrival
+
+    // Refocus: the divider stays on the away block while it is still unread…
+    rerender({ events: withBlurredArrival, lastReadEventId: "event_2", isAttentive: true })
+    expect(result.current.dividerEventId).toBe("event_3")
+    expect(isDividerReadPast(sequenced, "event_3", "event_2")).toBe(false)
+
+    // …and holds position (dimming to grey) once auto-read passes it.
+    rerender({ events: withBlurredArrival, lastReadEventId: "event_3", isAttentive: true })
+    expect(result.current.dividerEventId).toBe("event_3")
+    expect(isDividerReadPast(sequenced, "event_3", "event_3")).toBe(true)
+  })
+
+  it("does NOT move the divider forward while the viewer is attentive", () => {
+    // Focused live arrivals get the transient flash, not a moving divider — the
+    // forward re-latch is exclusively an away-time behavior.
+    const { result, rerender } = renderHook(
+      ({
+        events,
+        lastReadEventId,
+      }: {
+        events: ReturnType<typeof makeMessageEvent>[]
+        lastReadEventId: string | null
+      }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId,
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+          isAttentive: true,
+        }),
+      {
+        initialProps: {
+          events: [makeMessageEvent("event_1", "other")],
+          lastReadEventId: null as string | null,
+        },
+      }
+    )
+
+    expect(result.current.dividerEventId).toBe("event_1")
+    rerender({ events: [makeMessageEvent("event_1", "other")], lastReadEventId: "event_1" })
+
+    // A focused live arrival: first unread is now event_2, but the latch holds.
+    rerender({
+      events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
+      lastReadEventId: "event_1",
+    })
+    expect(result.current.dividerEventId).toBe("event_1")
+  })
+
+  it("latches at the first blurred-arrival in a fully-read stream with no prior divider", () => {
+    const readEvents = [makeMessageEvent("event_1", "other")]
+    const { result, rerender } = renderHook(
+      ({ events, isAttentive }: { events: ReturnType<typeof makeMessageEvent>[]; isAttentive: boolean }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId: "event_1",
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+          isAttentive,
+        }),
+      { initialProps: { events: readEvents, isAttentive: true } }
+    )
+
+    expect(result.current.dividerEventId).toBeUndefined()
+
+    rerender({
+      events: [...readEvents, makeMessageEvent("event_2", "other")],
+      isAttentive: false,
+    })
+    expect(result.current.dividerEventId).toBe("event_2")
+  })
+
+  it("does not latch on the viewer's own message arriving while blurred", () => {
+    // Sent from another device while this window is blurred — own messages are
+    // never unread, so no divider.
+    const readEvents = [makeMessageEvent("event_1", "other")]
+    const { result, rerender } = renderHook(
+      ({ events, isAttentive }: { events: ReturnType<typeof makeMessageEvent>[]; isAttentive: boolean }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId: "event_1",
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+          isAttentive,
+        }),
+      { initialProps: { events: readEvents, isAttentive: true } }
+    )
+
+    rerender({ events: [...readEvents, makeMessageEvent("event_2", "me")], isAttentive: false })
+    expect(result.current.dividerEventId).toBeUndefined()
+  })
+
+  it("re-shows a dismissed divider when a blur re-latch moves it to the away block", () => {
+    // Dismissal is keyed to the latched position; new messages while away are a
+    // fresh unread block the viewer has not escaped.
+    const { result, rerender } = renderHook(
+      ({
+        events,
+        lastReadEventId,
+        isAttentive,
+      }: {
+        events: ReturnType<typeof makeMessageEvent>[]
+        lastReadEventId: string | null
+        isAttentive: boolean
+      }) =>
+        useUnreadDivider({
+          events,
+          lastReadEventId,
+          currentUserId: "me",
+          streamId: "stream_1",
+          readStateResolved: true,
+          isAttentive,
+        }),
+      {
+        initialProps: {
+          events: [makeMessageEvent("event_1", "other")],
+          lastReadEventId: null as string | null,
+          isAttentive: true,
+        },
+      }
+    )
+
+    expect(result.current.dividerEventId).toBe("event_1")
+    act(() => result.current.dismiss())
+    expect(result.current.dividerEventId).toBeUndefined()
+
+    rerender({
+      events: [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")],
+      lastReadEventId: "event_1",
+      isAttentive: false,
+    })
+    expect(result.current.dividerEventId).toBe("event_2")
+  })
+
   it("shows no divider when every candidate unread row is overlay-read", () => {
     const events = [makeMessageEvent("event_1", "other"), makeMessageEvent("event_2", "other")]
     const { result } = renderHook(() =>

--- a/apps/frontend/src/hooks/use-unread-divider.ts
+++ b/apps/frontend/src/hooks/use-unread-divider.ts
@@ -36,6 +36,16 @@ interface UseUnreadDividerOptions {
    * surface is skipped. See docs/sparse-read-overlay-design.md.
    */
   overlayReadIds?: ReadonlySet<string>
+  /**
+   * Whether the viewer's attention is plausibly on this page — the same signal
+   * that gates auto-read (`useAutoReadAttention`). While false, the read pointer
+   * is frozen, so the first unread IS the first message that arrived while away;
+   * the latch is allowed to move FORWARD to it, marking the away block exactly
+   * as a re-open would. While true, forward moves stay suppressed (focused live
+   * arrivals get the transient flash, not a moving divider). Defaults to true so
+   * callers without an attention signal keep the latch-once behavior.
+   */
+  isAttentive?: boolean
 }
 
 interface UseUnreadDividerResult {
@@ -88,6 +98,7 @@ export function useUnreadDivider({
   isLoading = false,
   readStateResolved = false,
   overlayReadIds,
+  isAttentive = true,
 }: UseUnreadDividerOptions): UseUnreadDividerResult {
   const firstUnreadEventId = useMemo(() => {
     if (events.length === 0 || !readStateResolved) return undefined
@@ -128,12 +139,16 @@ export function useUnreadDivider({
   }
   if (firstUnreadEventId && latchRef.current.eventId !== firstUnreadEventId) {
     // Capture the first unread, then hold it for the session — auto-mark-as-read
-    // advancing the live unread forward does NOT move it. The one exception is a
-    // BACKWARD move (mark-as-unread re-surfaced messages above the divider): the
-    // first unread is now earlier, so the divider must follow it up.
+    // advancing the live unread forward does NOT move it. Two exceptions:
+    // - A BACKWARD move (mark-as-unread re-surfaced messages above the divider):
+    //   the first unread is now earlier, so the divider must follow it up.
+    // - A FORWARD move while the viewer is away (`!isAttentive`): auto-read is
+    //   frozen by the same signal, so the first unread is the first message that
+    //   arrived while away — re-latch there, as if the stream were re-opened.
     const latchedIdx = latchRef.current.eventId ? events.findIndex((e) => e.id === latchRef.current.eventId) : -1
     const firstIdx = events.findIndex((e) => e.id === firstUnreadEventId)
-    if (!latchRef.current.eventId || (firstIdx >= 0 && (latchedIdx < 0 || firstIdx < latchedIdx))) {
+    const movesEarlier = firstIdx >= 0 && (latchedIdx < 0 || firstIdx < latchedIdx)
+    if (!latchRef.current.eventId || movesEarlier || !isAttentive) {
       latchRef.current.eventId = firstUnreadEventId
     }
   }


### PR DESCRIPTION
## Problem

When an already-open stream receives messages while the window is blurred, the viewer never gets the persistent red→grey unread strip — only the transient yellow flash (`use-new-message-indicator`). Found dogfooding with Pierre (2026-07-09): he kept a DM open, tabbed away, and on return had no marker for what arrived while he was gone. Kris's call: away-arrivals should read like a re-open — "som användare är det typ samma grej som om man öppnar appen på nytt."

Root cause: the session latch in `useUnreadDivider` (`apps/frontend/src/hooks/use-unread-divider.ts`) only ever moves **backward** (the mark-as-unread exception). Once the latch is consumed — e.g. an earlier focused live arrival captured it and auto-read then greyed it — a later `firstUnreadEventId` pointing at blurred arrivals is a *forward* move, which the latch suppresses. The strip either sits stale and grey far above, or (with no prior latch) works only by accident.

## Solution

Allow the latch to move forward while the viewer is away, gated on the exact signal that freezes auto-read.

### How it works

- `useUnreadDivider` gains `isAttentive?: boolean` (default `true`). The render-phase latch now re-latches on a forward move when `!isAttentive`, alongside the existing backward (mark-as-unread) exception.
- The invariant that makes this correct: auto-read is gated on the same signal (`useAutoReadAttention()` in `use-auto-mark-as-read.ts` — `isVisible && (isFocused || phone-like)`), so while `!isAttentive` the read pointer is frozen and `firstUnreadEventId` **is** the first message that arrived while away. Re-latching there marks the away block exactly as a re-open would.
- `StreamContent` passes `isAttentive: useAutoReadAttention()` (now exported from the hooks barrel). No change to when messages are marked read.
- On refocus the divider is red (pointer still behind it); auto-read passes it and `isDividerReadPast` dims it to grey, same as the reopen path.

### Key design decisions

**1. Reuse `useAutoReadAttention()`, not raw `isFocused`** — `document.hasFocus()` is unreliable on phones (routinely false while the page is the visible foreground; see the long comment in `use-auto-mark-as-read.ts`). A raw focus gate would mis-latch dividers on mobile mid-reading. The attention signal treats a visible phone as attentive (no misfire) while a hidden page still latches — and it keeps divider movement and read-pointer freezing driven by one signal, so they can't drift apart.

**2. Forward moves stay suppressed while attentive** — focused live arrivals keep today's behavior (transient flash, latch holds). The re-latch is exclusively an away-time behavior, so the strip and the flash don't double up during active reading. Guarded by an explicit regression test.

**3. Dismissal does not survive a blur re-latch** — dismissal is already keyed to the latched position, so a forward move to the away block re-shows the divider. Deliberate: messages that arrived while away are a fresh unread block the viewer never escaped.

**4. Divider stays independent of contiguity (INV-61)** — this is purely a read-state marker; `computeTimelineHoles` and backfill are untouched.

### Design evolution (review)

An Opus + Sonnet review pass flagged a double-signal: `useNewMessageIndicator` had no attention gating, so an away-arrival fired its 2s yellow flash at arrival — refocusing within that window showed the row with both the flash and the new divider. Fixed in commit 2: the flash hook takes the same `isAttentive` signal; away arrivals are recorded as known without flashing (they get the divider instead), so each arrival gets exactly one signal — flash when focused, divider when away.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-unread-divider.ts` | `isAttentive` option; latch permits forward moves while `!isAttentive` |
| `apps/frontend/src/hooks/use-unread-divider.test.ts` | 5 new tests: forward re-latch after consumed latch (red→grey through refocus), no forward move while attentive, fresh-latch on fully-read stream, own-message no-op, dismissed-divider re-show |
| `apps/frontend/src/hooks/use-new-message-indicator.ts` | `isAttentive` param (default `true`); away arrivals become known without flashing |
| `apps/frontend/src/hooks/use-new-message-indicator.test.ts` | 2 new tests: no flash for away arrivals (even after refocus), focused arrivals still flash |
| `apps/frontend/src/components/timeline/stream-content.tsx` | Pass the attention signal to `useUnreadDivider` and `useNewMessageIndicator` |
| `apps/frontend/src/hooks/index.ts` | Export `useAutoReadAttention` from the barrel |

## Out of scope (deliberate)

- **No `StreamContent` integration test.** The handover asked for one (INV-39), but no mount harness exists for `StreamContent` (2,200 lines of store/socket/virtua scaffolding, zero existing tests) and building one is a project of its own. The behavior is captured at the hook seam; the component change is a one-line prop pass.
- **No e2e run.** Read-marking paths are untouched (`use-auto-mark-as-read.ts` has no diff); the existing blur-gating tests there still pass.
- **No coordination needed with #1254/#1256** — this is the timeline strip only; and the in-flight `trigger-read-only-when-window-is-focused` branch hardens `use-page-activity`, which this PR reads but does not modify.

## Test plan

- [x] `bunx vitest run src/hooks/use-unread-divider.test.ts src/hooks/use-auto-mark-as-read.test.ts src/hooks/use-new-message-indicator.test.ts` — 39 pass (7 new across both commits, all written failing-first)
- [x] Opus + Sonnet review pass (full lens set, ≥80 filter): 1 finding (flash/divider double-signal) — fixed in commit 2; all load-bearing claims verified clean
- [x] `src/components/timeline` + `src/hooks` sweep — 1127 pass; 9 failures in `use-draft-message` / `use-push-notifications` confirmed pre-existing by stash-check (known Node 25 local flakes)
- [x] `tsc --noEmit` frontend clean (pre-commit hook also ran the full monorepo typecheck + lint)
- [ ] Live blur/refocus dogfood in a real browser — `document.hasFocus()` can't be driven faithfully in jsdom; worth a manual pass in the Pierre scenario before merging

<details>
<summary>📋 Full implementation plan</summary>

## Goal

When an already-open stream receives messages while the window/tab is blurred, latch the unread divider (red→grey strip) above those messages — as if the user had just re-opened the stream. From the 2026-07-09 dogfooding handover (HANDOVER.md on this branch, not committed).

## What Was Built

A forward re-latch trigger in `useUnreadDivider`, active only while the viewer is away (`!isAttentive`), wired from `StreamContent` via `useAutoReadAttention()`.

## Design Decisions

1. Attention signal = `useAutoReadAttention()` (shared with auto-read), not raw focus — mobile focus is unreliable, and sharing the signal guarantees the pointer is frozen whenever the latch may move forward.
2. Forward moves suppressed while attentive — preserves the flash-only behavior for focused arrivals.
3. Dismissal keyed to position (existing) — a blur re-latch to a new position re-shows a previously dismissed divider.

## What's NOT Included

- `StreamContent` mount-level integration test (no existing harness; hook-seam coverage instead).
- Any change to read gating — blur already suppresses auto-read; this is the visual latch only.

## Status

Complete; tests green; manual browser dogfood recommended.

</details>

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
