### PR TITLE
feat(link-previews): rich preview card for conversation links

### DIFF
--- a/apps/backend/src/db/migrations/20260709120000_add_link_preview_target_conversation_id.sql
+++ b/apps/backend/src/db/migrations/20260709120000_add_link_preview_target_conversation_id.sql
@@ -1,0 +1,5 @@
+-- Add a target reference column for in-app conversation link previews.
+-- Populated only when content_type = 'conversation_link'; NULL for every other preview.
+-- No foreign keys per INV-1.
+
+ALTER TABLE link_previews ADD COLUMN target_conversation_id TEXT;

--- a/apps/backend/src/features/link-previews/repository.ts
+++ b/apps/backend/src/features/link-previews/repository.ts
@@ -34,6 +34,7 @@ export interface LinkPreview {
   targetStreamId: string | null
   targetMessageId: string | null
   targetMemoId: string | null
+  targetConversationId: string | null
   fetchedAt: Date | null
   expiresAt: Date | null
   createdAt: Date
@@ -49,6 +50,7 @@ export interface InsertLinkPreviewParams {
   targetStreamId?: string
   targetMessageId?: string
   targetMemoId?: string
+  targetConversationId?: string
 }
 
 export interface UpdateLinkPreviewParams {
@@ -89,6 +91,7 @@ function mapRow(row: Record<string, unknown>): LinkPreview {
     targetStreamId: (row.target_stream_id as string | null) ?? null,
     targetMessageId: (row.target_message_id as string | null) ?? null,
     targetMemoId: (row.target_memo_id as string | null) ?? null,
+    targetConversationId: (row.target_conversation_id as string | null) ?? null,
     fetchedAt: row.fetched_at ? new Date(row.fetched_at as string) : null,
     expiresAt: row.expires_at ? new Date(row.expires_at as string) : null,
     createdAt: new Date(row.created_at as string),
@@ -102,15 +105,16 @@ export const LinkPreviewRepository = {
     const status = isInAppLinkContentType(params.contentType) ? "completed" : "pending"
     const result = await querier.query(
       sql`INSERT INTO link_previews (id, workspace_id, url, normalized_url, content_type, status,
-              target_workspace_id, target_stream_id, target_message_id, target_memo_id)
-          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+              target_workspace_id, target_stream_id, target_message_id, target_memo_id, target_conversation_id)
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
           ON CONFLICT (workspace_id, normalized_url) DO UPDATE SET
               content_type = EXCLUDED.content_type,
               status = EXCLUDED.status,
               target_workspace_id = EXCLUDED.target_workspace_id,
               target_stream_id = EXCLUDED.target_stream_id,
               target_message_id = EXCLUDED.target_message_id,
-              target_memo_id = EXCLUDED.target_memo_id
+              target_memo_id = EXCLUDED.target_memo_id,
+              target_conversation_id = EXCLUDED.target_conversation_id
           WHERE link_previews.content_type != EXCLUDED.content_type
           RETURNING *`,
       [
@@ -124,6 +128,7 @@ export const LinkPreviewRepository = {
         params.targetStreamId ?? null,
         params.targetMessageId ?? null,
         params.targetMemoId ?? null,
+        params.targetConversationId ?? null,
       ]
     )
     if (result.rows.length > 0) {

--- a/apps/backend/src/features/link-previews/service.test.ts
+++ b/apps/backend/src/features/link-previews/service.test.ts
@@ -4,6 +4,7 @@ import { LinkPreviewService } from "./service"
 import { LinkPreviewRepository, type LinkPreview } from "./repository"
 import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
+import { ConversationRepository, type Conversation } from "../conversations"
 import { SearchRepository } from "../search"
 import type { StreamService } from "../streams"
 import { StreamMemberRepository } from "../streams"
@@ -34,6 +35,7 @@ function makePreview(overrides: Partial<LinkPreview>): LinkPreview {
     targetStreamId: "stream_1",
     targetMessageId: null,
     targetMemoId: null,
+    targetConversationId: null,
     fetchedAt: null,
     expiresAt: null,
     createdAt: new Date(),
@@ -61,6 +63,27 @@ function makeStream(overrides: Partial<AccessibleStream> = {}): AccessibleStream
     archivedAt: null,
     ...overrides,
   } as AccessibleStream
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_1",
+    streamId: "stream_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["msg_1", "msg_2", "msg_3"],
+    participantIds: ["user_a", "user_b"],
+    secondaryMessageIds: [],
+    topicSummary: "Auth redesign",
+    summary: "Deciding how auth flows through the router.",
+    completenessScore: 3,
+    confidence: 0.8,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
 }
 
 function makeService(streamService: Partial<StreamService>, memoExplorerService: Partial<MemoExplorerService>) {
@@ -170,6 +193,76 @@ describe("LinkPreviewService.resolveInAppLink", () => {
     const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
 
     expect(result).toEqual({ kind: "memo", accessTier: "private" })
+  })
+
+  test("returns cross_workspace for a conversation link in another workspace without inspecting it", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({
+        contentType: "conversation_link",
+        targetStreamId: null,
+        targetWorkspaceId: "ws_other",
+        targetConversationId: "conv_1",
+      })
+    )
+    const findById = spyOn(ConversationRepository, "findById").mockResolvedValue(makeConversation())
+    const tryAccess = spyOn({ tryAccess: async () => null }, "tryAccess")
+    const service = makeService({ tryAccess: tryAccess as never }, {})
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toEqual({ kind: "conversation", accessTier: "cross_workspace" })
+    expect(findById).not.toHaveBeenCalled()
+    expect(tryAccess).not.toHaveBeenCalled()
+  })
+
+  test("returns private when the conversation is missing", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({ contentType: "conversation_link", targetStreamId: null, targetConversationId: "conv_1" })
+    )
+    spyOn(ConversationRepository, "findById").mockResolvedValue(null)
+    const service = makeService({ tryAccess: async () => makeStream() }, {})
+
+    expect(await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")).toEqual({
+      kind: "conversation",
+      accessTier: "private",
+    })
+  })
+
+  test("returns private when the viewer cannot access the conversation's anchor stream", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({ contentType: "conversation_link", targetStreamId: null, targetConversationId: "conv_1" })
+    )
+    spyOn(ConversationRepository, "findById").mockResolvedValue(makeConversation())
+    const service = makeService({ tryAccess: async () => null }, {})
+
+    expect(await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")).toEqual({
+      kind: "conversation",
+      accessTier: "private",
+    })
+  })
+
+  test("returns full conversation metadata when the viewer has access", async () => {
+    spyOn(LinkPreviewRepository, "findById").mockResolvedValue(
+      makePreview({ contentType: "conversation_link", targetStreamId: null, targetConversationId: "conv_1" })
+    )
+    spyOn(ConversationRepository, "findById").mockResolvedValue(
+      makeConversation({ status: "resolved", messageIds: ["msg_1", "msg_2", "msg_3", "msg_4"] })
+    )
+    const service = makeService({ tryAccess: async () => makeStream({ slug: "eng", type: "channel" }) }, {})
+
+    const result = await service.resolveInAppLink(WORKSPACE_ID, VIEWER_ID, "lp_1")
+
+    expect(result).toEqual({
+      kind: "conversation",
+      accessTier: "full",
+      topicSummary: "Auth redesign",
+      summary: "Deciding how auth flows through the router.",
+      status: "resolved",
+      messageCount: 4,
+      participantIds: ["user_a", "user_b"],
+      streamName: "eng",
+      streamType: "channel",
+    })
   })
 
   test("returns null for a non-existent preview", async () => {

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -360,7 +360,7 @@ export class LinkPreviewService {
   }
 
   /**
-   * Resolve an in-app link preview (message, stream, or memo) for a specific viewer.
+   * Resolve an in-app link preview (message, stream, memo, or conversation) for a specific viewer.
    * Returns access-tiered data: full content for accessible targets, limited info
    * for private targets, and a minimal card for cross-workspace links. A
    * cross-workspace target is never inspected — same-workspace check happens first

--- a/apps/backend/src/features/link-previews/service.ts
+++ b/apps/backend/src/features/link-previews/service.ts
@@ -4,6 +4,7 @@ import { logger } from "@threa/backend-common"
 import { withTransaction } from "../../db"
 import { linkPreviewId } from "../../lib/id"
 import type {
+  ConversationLinkPreviewData,
   InAppLinkPreviewData,
   LinkPreviewContentType,
   LinkPreviewSummary,
@@ -15,6 +16,7 @@ import { MessageRepository } from "../messaging"
 import { UserRepository } from "../workspaces"
 import type { StreamService } from "../streams"
 import { StreamMemberRepository } from "../streams"
+import { ConversationRepository } from "../conversations"
 import type { MemoExplorerService } from "../memos"
 import { resolveUserAccessibleStreamIds } from "../search"
 import { OutboxRepository } from "../../lib/outbox"
@@ -53,6 +55,7 @@ interface InAppLinkTarget {
   targetStreamId?: string | null
   targetMessageId?: string | null
   targetMemoId?: string | null
+  targetConversationId?: string | null
 }
 
 /**
@@ -68,6 +71,7 @@ function inAppLinkInsertFields(
   targetStreamId?: string
   targetMessageId?: string
   targetMemoId?: string
+  targetConversationId?: string
 } {
   if (!ref) return { contentType: detectContentType(url) }
   switch (ref.kind) {
@@ -89,6 +93,12 @@ function inAppLinkInsertFields(
         contentType: "memo_link",
         targetWorkspaceId: ref.workspaceId,
         targetMemoId: ref.memoId,
+      }
+    case "conversation":
+      return {
+        contentType: "conversation_link",
+        targetWorkspaceId: ref.workspaceId,
+        targetConversationId: ref.conversationId,
       }
   }
 }
@@ -394,6 +404,8 @@ export class LinkPreviewService {
         return this.resolveStreamTarget(workspaceId, userId, target)
       case "memo_link":
         return this.resolveMemoTarget(workspaceId, userId, target, opts?.accessibleStreamIds)
+      case "conversation_link":
+        return this.resolveConversationTarget(workspaceId, userId, target)
       default:
         return Promise.resolve(null)
     }
@@ -535,6 +547,48 @@ export class LinkPreviewService {
       abstract,
       knowledgeType: memo.memo.knowledgeType,
       sourceStreamName: memo.sourceStream?.name ?? undefined,
+    }
+  }
+
+  private async resolveConversationTarget(
+    workspaceId: string,
+    userId: string,
+    target: InAppLinkTarget
+  ): Promise<ConversationLinkPreviewData | null> {
+    const { targetWorkspaceId, targetConversationId } = target
+    if (!targetWorkspaceId || !targetConversationId) return null
+
+    if (targetWorkspaceId !== workspaceId) {
+      return { kind: "conversation", accessTier: "cross_workspace" }
+    }
+
+    // Collapse "not found", "wrong workspace", and "no access to the anchor
+    // stream" into the private tier so a conversation link never leaks whether
+    // the conversation exists (matches the message/stream/memo resolvers).
+    const conversation = await ConversationRepository.findById(this.deps.pool, targetConversationId)
+    if (!conversation || conversation.workspaceId !== workspaceId) {
+      return { kind: "conversation", accessTier: "private" }
+    }
+
+    // A conversation inherits access from its anchor stream (INV-62 resolves a
+    // thread anchor through its root inside tryAccess).
+    const stream = await this.deps.streamService.tryAccess(conversation.streamId, workspaceId, userId)
+    if (!stream) {
+      return { kind: "conversation", accessTier: "private" }
+    }
+
+    const summary = conversation.summary ? buildPreviewSnippet(conversation.summary) : undefined
+
+    return {
+      kind: "conversation",
+      accessTier: "full",
+      topicSummary: conversation.topicSummary ?? undefined,
+      summary,
+      status: conversation.status,
+      messageCount: conversation.messageIds.length,
+      participantIds: conversation.participantIds,
+      streamName: stream.displayName ?? stream.slug ?? undefined,
+      streamType: stream.type,
     }
   }
 

--- a/apps/backend/src/features/link-previews/url-utils.test.ts
+++ b/apps/backend/src/features/link-previews/url-utils.test.ts
@@ -306,9 +306,31 @@ describe("parseInAppLink", () => {
     })
   })
 
+  test("parses a conversation link (board panel)", () => {
+    expect(parseInAppLink("https://app.threa.io/w/ws_123/board?panel=conv:conv_1", origins)).toEqual({
+      kind: "conversation",
+      workspaceId: "ws_123",
+      conversationId: "conv_1",
+    })
+  })
+
+  test("parses a conversation link that also deep-links a message", () => {
+    expect(parseInAppLink("https://app.threa.io/w/ws_123/board?panel=conv:conv_1&m=msg_9", origins)).toEqual({
+      kind: "conversation",
+      workspaceId: "ws_123",
+      conversationId: "conv_1",
+    })
+  })
+
+  test("returns null for a board URL with a non-conversation panel", () => {
+    expect(parseInAppLink("https://app.threa.io/w/ws_123/board?panel=stream:stream_1", origins)).toBeNull()
+    expect(parseInAppLink("https://app.threa.io/w/ws_123/board", origins)).toBeNull()
+  })
+
   test("returns null for unrecognized origin", () => {
     expect(parseInAppLink("https://evil.com/w/ws_123/s/stream_456", origins)).toBeNull()
     expect(parseInAppLink("https://evil.com/w/ws_123/memos/memo_1", origins)).toBeNull()
+    expect(parseInAppLink("https://evil.com/w/ws_123/board?panel=conv:conv_1", origins)).toBeNull()
   })
 
   test("returns null for non-resource paths", () => {

--- a/apps/backend/src/features/link-previews/url-utils.ts
+++ b/apps/backend/src/features/link-previews/url-utils.ts
@@ -8,6 +8,10 @@ export type InAppLinkRef =
   | { kind: "message"; workspaceId: string; streamId: string; messageId: string }
   | { kind: "stream"; workspaceId: string; streamId: string }
   | { kind: "memo"; workspaceId: string; memoId: string }
+  | { kind: "conversation"; workspaceId: string; conversationId: string }
+
+/** Panel-id prefix a conversation deep-link carries in `?panel=` (mirrors the frontend `CONVERSATION_PANEL_PREFIX`). */
+const CONVERSATION_PANEL_PREFIX = "conv:"
 
 export type LinearUrlMatch =
   | {
@@ -73,6 +77,7 @@ export type GitHubUrlMatch =
  * - `{origin}/w/{workspaceId}/s/{streamId}?m={messageId}` → message
  * - `{origin}/w/{workspaceId}/s/{streamId}` → stream
  * - `{origin}/w/{workspaceId}/memos/{memoId}` → memo
+ * - `{origin}/w/{workspaceId}/board?panel=conv:{conversationId}` → conversation
  * Returns null if the origin isn't recognized or no shape matches.
  */
 export function parseInAppLink(url: string, appOrigins: string[]): InAppLinkRef | null {
@@ -93,6 +98,18 @@ export function parseInAppLink(url: string, appOrigins: string[]): InAppLinkRef 
     if (memoMatch) {
       const [, workspaceId, memoId] = memoMatch
       return { kind: "memo", workspaceId, memoId }
+    }
+
+    // A conversation has no `/s/:id` permalink — it spans a root stream + threads
+    // — so it deep-links to the board panel host. The id rides the `panel` param.
+    const boardMatch = parsed.pathname.match(/^\/w\/([^/]+)\/board$/)
+    if (boardMatch) {
+      const [, workspaceId] = boardMatch
+      const panel = parsed.searchParams.get("panel")
+      if (panel?.startsWith(CONVERSATION_PANEL_PREFIX)) {
+        const conversationId = panel.slice(CONVERSATION_PANEL_PREFIX.length)
+        if (conversationId) return { kind: "conversation", workspaceId, conversationId }
+      }
     }
 
     return null

--- a/apps/frontend/src/components/composer/composer-link-chip.tsx
+++ b/apps/frontend/src/components/composer/composer-link-chip.tsx
@@ -1,16 +1,17 @@
 import { type ComponentType } from "react"
-import { Brain, Lock, Globe, Link2 } from "lucide-react"
+import { Brain, Lock, Globe, Link2, MessagesSquare } from "lucide-react"
 import { AttachmentPill } from "./attachment-pill"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import type { BelowRowDraftLink } from "@/lib/in-app-links"
 
 /**
- * One compact chip for a below-row draft link — web or memo only. Stream/message
- * in-app links never reach here: they render as an inline chip in the draft body
- * (`ComposerLinkPreviews` filters them via `isBelowRowDraftLink`), matching the
- * posted message (#1103). Stealing the attachment-pill semantics keeps several
- * links from eating the screen (a full preview card per link buries the composer
- * on mobile). Memo links resolve via the backend; web links chip their host.
+ * One compact chip for a below-row draft link — web, memo, or conversation.
+ * Stream/message in-app links never reach here: they render as an inline chip in
+ * the draft body (`ComposerLinkPreviews` filters them via `isBelowRowDraftLink`),
+ * matching the posted message (#1103). Stealing the attachment-pill semantics
+ * keeps several links from eating the screen (a full preview card per link buries
+ * the composer on mobile). Memo/conversation links resolve via the backend; web
+ * links chip their host.
  *
  * Non-navigable on purpose: clicking must not abandon the draft mid-compose.
  */
@@ -29,7 +30,26 @@ export function ComposerLinkChip({
     return <MemoChip workspaceId={workspaceId} url={link.url} onRemove={remove} />
   }
 
+  if (link.kind === "conversation") {
+    return <ConversationChip workspaceId={workspaceId} url={link.url} onRemove={remove} />
+  }
+
   return <AttachmentPill icon={Globe} label={link.host} tooltip={link.url} onRemove={remove} removeLabel="Hide link" />
+}
+
+function ConversationChip({ workspaceId, url, onRemove }: { workspaceId: string; url: string; onRemove: () => void }) {
+  const { data, loading } = useResolvedInAppLink(workspaceId, undefined, url, true)
+
+  if (loading) return <PendingChip onRemove={onRemove} />
+  if (data?.accessTier === "cross_workspace") {
+    return <RestrictedChip icon={Globe} label="Another workspace" onRemove={onRemove} />
+  }
+  if (data?.accessTier === "private") {
+    return <RestrictedChip icon={Lock} label="Private conversation" onRemove={onRemove} />
+  }
+
+  const title = (data?.kind === "conversation" && data.topicSummary) || "Conversation"
+  return <AttachmentPill icon={MessagesSquare} label={title} onRemove={onRemove} removeLabel="Hide link" />
 }
 
 function MemoChip({ workspaceId, url, onRemove }: { workspaceId: string; url: string; onRemove: () => void }) {

--- a/apps/frontend/src/components/composer/composer-link-chip.tsx
+++ b/apps/frontend/src/components/composer/composer-link-chip.tsx
@@ -1,17 +1,17 @@
 import { type ComponentType } from "react"
-import { Brain, Lock, Globe, Link2, MessagesSquare } from "lucide-react"
+import { Brain, Lock, Globe, Link2 } from "lucide-react"
 import { AttachmentPill } from "./attachment-pill"
 import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import type { BelowRowDraftLink } from "@/lib/in-app-links"
 
 /**
- * One compact chip for a below-row draft link — web, memo, or conversation.
- * Stream/message in-app links never reach here: they render as an inline chip in
- * the draft body (`ComposerLinkPreviews` filters them via `isBelowRowDraftLink`),
- * matching the posted message (#1103). Stealing the attachment-pill semantics
- * keeps several links from eating the screen (a full preview card per link buries
- * the composer on mobile). Memo/conversation links resolve via the backend; web
- * links chip their host.
+ * One compact chip for a below-row draft link — web or memo only. Stream,
+ * message, and conversation in-app links never reach here: they render as an
+ * inline chip in the draft body (`ComposerLinkPreviews` filters them via
+ * `isBelowRowDraftLink`), matching the posted message (#1103). Stealing the
+ * attachment-pill semantics keeps several links from eating the screen (a full
+ * preview card per link buries the composer on mobile). Memo links resolve via
+ * the backend; web links chip their host.
  *
  * Non-navigable on purpose: clicking must not abandon the draft mid-compose.
  */
@@ -30,26 +30,7 @@ export function ComposerLinkChip({
     return <MemoChip workspaceId={workspaceId} url={link.url} onRemove={remove} />
   }
 
-  if (link.kind === "conversation") {
-    return <ConversationChip workspaceId={workspaceId} url={link.url} onRemove={remove} />
-  }
-
   return <AttachmentPill icon={Globe} label={link.host} tooltip={link.url} onRemove={remove} removeLabel="Hide link" />
-}
-
-function ConversationChip({ workspaceId, url, onRemove }: { workspaceId: string; url: string; onRemove: () => void }) {
-  const { data, loading } = useResolvedInAppLink(workspaceId, undefined, url, true)
-
-  if (loading) return <PendingChip onRemove={onRemove} />
-  if (data?.accessTier === "cross_workspace") {
-    return <RestrictedChip icon={Globe} label="Another workspace" onRemove={onRemove} />
-  }
-  if (data?.accessTier === "private") {
-    return <RestrictedChip icon={Lock} label="Private conversation" onRemove={onRemove} />
-  }
-
-  const title = (data?.kind === "conversation" && data.topicSummary) || "Conversation"
-  return <AttachmentPill icon={MessagesSquare} label={title} onRemove={onRemove} removeLabel="Hide link" />
 }
 
 function MemoChip({ workspaceId, url, onRemove }: { workspaceId: string; url: string; onRemove: () => void }) {

--- a/apps/frontend/src/components/composer/composer-link-previews.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.tsx
@@ -25,8 +25,8 @@ interface ComposerLinkPreviewsProps {
 /**
  * Compact chip row for the links in a draft — the same attachment-pill surface
  * file uploads use, so several links don't bury the composer on mobile the way a
- * full preview card each would. In-app links chip to their stream/memo name;
- * web links chip their host. Dismiss hides a chip (the link text stays); a
+ * full preview card each would. In-app links chip to their stream/memo/conversation
+ * name; web links chip their host. Dismiss hides a chip (the link text stays); a
  * dismissal is forgotten once its link leaves the draft.
  */
 export function ComposerLinkPreviews({ content, workspaceId, className }: ComposerLinkPreviewsProps) {
@@ -49,8 +49,8 @@ export function ComposerLinkPreviews({ content, workspaceId, className }: Compos
   }, [urls])
 
   // Stream/message in-app links render as an inline chip in the draft body, not
-  // a below-row chip (`isBelowRowDraftLink`) — so this row carries only web and
-  // memo links, matching the timeline's inline-chip card suppression (#1103).
+  // a below-row chip (`isBelowRowDraftLink`) — so this row carries web, memo, and
+  // conversation links, matching the timeline's inline-chip card suppression (#1103).
   const visible = useMemo(
     () =>
       urls

--- a/apps/frontend/src/components/composer/composer-link-previews.tsx
+++ b/apps/frontend/src/components/composer/composer-link-previews.tsx
@@ -25,8 +25,8 @@ interface ComposerLinkPreviewsProps {
 /**
  * Compact chip row for the links in a draft — the same attachment-pill surface
  * file uploads use, so several links don't bury the composer on mobile the way a
- * full preview card each would. In-app links chip to their stream/memo/conversation
- * name; web links chip their host. Dismiss hides a chip (the link text stays); a
+ * full preview card each would. Memo in-app links chip to their memo name; web
+ * links chip their host. Dismiss hides a chip (the link text stays); a
  * dismissal is forgotten once its link leaves the draft.
  */
 export function ComposerLinkPreviews({ content, workspaceId, className }: ComposerLinkPreviewsProps) {
@@ -48,9 +48,9 @@ export function ComposerLinkPreviews({ content, workspaceId, className }: Compos
     })
   }, [urls])
 
-  // Stream/message in-app links render as an inline chip in the draft body, not
-  // a below-row chip (`isBelowRowDraftLink`) — so this row carries web, memo, and
-  // conversation links, matching the timeline's inline-chip card suppression (#1103).
+  // Stream/message/conversation in-app links render as an inline chip in the draft
+  // body, not a below-row chip (`isBelowRowDraftLink`) — so this row carries only
+  // web and memo links, matching the timeline's inline-chip card suppression (#1103).
   const visible = useMemo(
     () =>
       urls

--- a/apps/frontend/src/components/editor/in-app-link-extension.ts
+++ b/apps/frontend/src/components/editor/in-app-link-extension.ts
@@ -3,10 +3,14 @@ import { ReactNodeViewRenderer } from "@tiptap/react"
 import { InAppLinkView } from "./in-app-link-view"
 
 export interface InAppLinkAttrs {
-  /** Canonical in-app URL of the referenced stream or message. */
+  /** Canonical in-app URL of the referenced stream, message, or conversation. */
   url: string
-  /** Target stream id, parsed from the URL — the name-resolution key. */
-  streamId: string
+  /**
+   * Target stream id, parsed from the URL — the name-resolution key for
+   * stream/message links. Null for a conversation link (it has no `/s/:id`
+   * permalink); the node-view resolves a conversation by its URL instead.
+   */
+  streamId: string | null
   /** Target message id when the link points at a message, else null. */
   messageId: string | null
   /** Resolved name cached at insert time so the chip renders before hydration. */
@@ -16,10 +20,10 @@ export interface InAppLinkAttrs {
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     inAppLink: {
-      /** Insert an inline chip for an in-app stream/message link. */
+      /** Insert an inline chip for an in-app stream/message/conversation link. */
       insertInAppLink: (attrs: {
         url: string
-        streamId: string
+        streamId?: string | null
         messageId?: string | null
         name?: string
       }) => ReturnType
@@ -28,8 +32,8 @@ declare module "@tiptap/core" {
 }
 
 /**
- * Inline atom node that replaces an in-app stream/message URL with a compact
- * chip (the name instead of a raw link). Mirrors the inline-atom shape of
+ * Inline atom node that replaces an in-app stream/message/conversation URL with a
+ * compact chip (the name instead of a raw link). Mirrors the inline-atom shape of
  * `MemoEmbedExtension`. The wire format stays a normal markdown link
  * `[name](url)` (see `serializeToMarkdown`) so external/API consumers get a real
  * navigable URL and the timeline renders the same chip from the link alone —
@@ -99,7 +103,7 @@ export const InAppLinkExtension = Node.create({
                 type: this.name,
                 attrs: {
                   url: attrs.url,
-                  streamId: attrs.streamId,
+                  streamId: attrs.streamId ?? null,
                   messageId: attrs.messageId ?? null,
                   name: attrs.name ?? "",
                 },

--- a/apps/frontend/src/components/editor/in-app-link-view.tsx
+++ b/apps/frontend/src/components/editor/in-app-link-view.tsx
@@ -1,24 +1,48 @@
 import { useEffect } from "react"
-import { MessageSquare } from "lucide-react"
+import { MessageSquare, MessagesSquare, Globe, Lock } from "lucide-react"
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react"
 import { useParams } from "react-router-dom"
 import { InAppLinkChip } from "@/components/in-app-link/in-app-link-chip"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
+import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import type { InAppLinkAttrs } from "./in-app-link-extension"
 
 /**
- * In-composer chip for an in-app stream/message link (TipTap NodeView).
- * Resolves the live name (local cache → access-tiered backend) via the shared
- * `useInAppLinkChip` and renders the shared `InAppLinkChip`. When the node was
- * inserted without a cached name (pasted link), the resolved name is written
- * back so serialization carries a real label instead of the generic fallback.
+ * In-composer chip for an in-app link (TipTap NodeView). A conversation link has
+ * no `streamId` (no `/s/:id` permalink), so it resolves by URL through the
+ * conversation resolver; a stream/message link resolves its live name through the
+ * shared `useInAppLinkChip`. Split into two sub-views so each calls exactly the
+ * hook its kind needs (a NodeView can't branch its hooks) — the dispatcher picks
+ * by the presence of `streamId`.
  */
 export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   const attrs = node.attrs as InAppLinkAttrs
   const { workspaceId } = useParams<{ workspaceId: string }>()
+
+  if (!attrs.streamId) {
+    return <ConversationChipView attrs={attrs} workspaceId={workspaceId ?? ""} updateAttributes={updateAttributes} />
+  }
+  return <StreamMessageChipView attrs={attrs} workspaceId={workspaceId ?? ""} updateAttributes={updateAttributes} />
+}
+
+/**
+ * Resolves the live name (local cache → access-tiered backend) via the shared
+ * `useInAppLinkChip`. When the node was inserted without a cached name (pasted
+ * link), the resolved name is written back so serialization carries a real label
+ * instead of the generic fallback.
+ */
+function StreamMessageChipView({
+  attrs,
+  workspaceId,
+  updateAttributes,
+}: {
+  attrs: InAppLinkAttrs
+  workspaceId: string
+  updateAttributes: (attrs: Record<string, unknown>) => void
+}) {
   const state = useInAppLinkChip({
-    workspaceId: workspaceId ?? "",
-    streamId: attrs.streamId,
+    workspaceId,
+    streamId: attrs.streamId ?? "",
     messageId: attrs.messageId,
     isMessage: Boolean(attrs.messageId),
     url: attrs.url,
@@ -43,6 +67,50 @@ export function InAppLinkView({ node, updateAttributes }: NodeViewProps) {
   return (
     <NodeViewWrapper as="span" data-type="in-app-link">
       <InAppLinkChip icon={icon} prefix={prefix} label={label} />
+    </NodeViewWrapper>
+  )
+}
+
+/**
+ * Conversation chip: resolves the topic through the access-tiered resolver
+ * (shared cache with the below-message card and the timeline chip). A restricted
+ * tier renders a non-navigable placeholder the way an inaccessible channel does;
+ * the resolved topic is stamped back so serialization carries a real label.
+ */
+function ConversationChipView({
+  attrs,
+  workspaceId,
+  updateAttributes,
+}: {
+  attrs: InAppLinkAttrs
+  workspaceId: string
+  updateAttributes: (attrs: Record<string, unknown>) => void
+}) {
+  const { data } = useResolvedInAppLink(workspaceId, undefined, attrs.url, true)
+
+  const resolvedName = data?.kind === "conversation" && data.accessTier === "full" ? (data.topicSummary ?? null) : null
+
+  useEffect(() => {
+    if (resolvedName && !attrs.name) {
+      updateAttributes({ name: resolvedName })
+    }
+  }, [resolvedName, attrs.name, updateAttributes])
+
+  let icon = MessagesSquare
+  let label = attrs.name || "Conversation"
+  if (data?.accessTier === "cross_workspace") {
+    icon = Globe
+    label = "Another workspace"
+  } else if (data?.accessTier === "private") {
+    icon = Lock
+    label = "Private conversation"
+  } else if (resolvedName) {
+    label = resolvedName
+  }
+
+  return (
+    <NodeViewWrapper as="span" data-type="in-app-link">
+      <InAppLinkChip icon={icon} label={label} />
     </NodeViewWrapper>
   )
 }

--- a/apps/frontend/src/components/editor/rich-editor.tsx
+++ b/apps/frontend/src/components/editor/rich-editor.tsx
@@ -193,17 +193,18 @@ function emojiAtomToEditableText(node: JSONContent, toEmoji?: (shortcode: string
 }
 
 /**
- * Convert a bare in-app stream/message URL into an inline chip, replacing the
- * link text. Shared by the clipboard `paste` path and the Gboard/SwiftKey
- * `beforeinput` path so mobile clipboard-bar pastes chip the same as desktop.
- * Returns whether a chip was inserted.
+ * Convert a bare in-app stream/message/conversation URL into an inline chip,
+ * replacing the link text. Shared by the clipboard `paste` path and the
+ * Gboard/SwiftKey `beforeinput` path so mobile clipboard-bar pastes chip the same
+ * as desktop. Returns whether a chip was inserted. A conversation link carries no
+ * streamId — the node-view resolves it by URL.
  */
 function tryInsertInAppLinkChip(editor: import("@tiptap/react").Editor, text: string): boolean {
   const ref = classifyDraftLink(text.trim())
-  if (!ref || (ref.kind !== "stream" && ref.kind !== "message")) return false
+  if (!ref || (ref.kind !== "stream" && ref.kind !== "message" && ref.kind !== "conversation")) return false
   editor.commands.insertInAppLink({
     url: ref.url,
-    streamId: ref.streamId,
+    streamId: ref.kind === "conversation" ? null : ref.streamId,
     messageId: ref.kind === "message" ? ref.messageId : null,
   })
   return true

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.test.tsx
@@ -5,9 +5,24 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { linkPreviewsApi } from "@/api"
 import * as workspaceStore from "@/stores/workspace-store"
 import * as currentUserModule from "@/hooks/use-current-workspace-user-id"
-import { InAppLinkInline } from "./in-app-link-inline"
+import { InAppLinkInline, ConversationLinkInline } from "./in-app-link-inline"
 
 const origin = window.location.origin
+
+function renderConversationLink() {
+  const href = `${origin}/w/ws_1/board?panel=conv:conv_1`
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return {
+    href,
+    ...render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <ConversationLinkInline href={href} workspaceId="ws_1" />
+        </MemoryRouter>
+      </QueryClientProvider>
+    ),
+  }
+}
 
 function renderMessageLink(streamId: string) {
   const href = `${origin}/w/ws_1/s/${streamId}?m=msg_1`
@@ -57,9 +72,7 @@ describe("InAppLinkInline (message chip)", () => {
 
     renderMessageLink("stream_1")
 
-    await waitFor(() =>
-      expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument()
-    )
+    await waitFor(() => expect(screen.getByText("Kristoffer Remback in #tech-big-new-prop")).toBeInTheDocument())
   })
 
   it("settles a fully-resolved but unnamed (bot/persona) message to 'Message', not the parent stream name", async () => {
@@ -91,5 +104,49 @@ describe("InAppLinkInline (message chip)", () => {
     renderMessageLink("stream_1")
 
     await waitFor(() => expect(screen.getByText("Deleted message")).toBeInTheDocument())
+  })
+})
+
+describe("ConversationLinkInline (conversation chip)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders the conversation topic as a navigable chip", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "conversation",
+      accessTier: "full",
+      topicSummary: "GPU budget for Q3",
+    })
+
+    const { href } = renderConversationLink()
+
+    const chip = await screen.findByText("GPU budget for Q3")
+    expect(chip.closest("a")).toHaveAttribute("href", href)
+  })
+
+  it("shows a non-navigable placeholder for an inaccessible (private) conversation", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "conversation",
+      accessTier: "private",
+    })
+
+    renderConversationLink()
+
+    await waitFor(() => expect(screen.getByText("Private conversation")).toBeInTheDocument())
+    expect(screen.queryByText("GPU budget for Q3")).not.toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  it("shows a cross-workspace placeholder without leaking the topic", async () => {
+    vi.spyOn(linkPreviewsApi, "resolveInAppLinkByUrl").mockResolvedValue({
+      kind: "conversation",
+      accessTier: "cross_workspace",
+    })
+
+    renderConversationLink()
+
+    await waitFor(() => expect(screen.getByText("Another workspace")).toBeInTheDocument())
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
+++ b/apps/frontend/src/components/in-app-link/in-app-link-inline.tsx
@@ -1,8 +1,9 @@
 import { type MouseEvent } from "react"
-import { MessageSquare } from "lucide-react"
+import { MessageSquare, MessagesSquare, Globe, Lock } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 import { resolveInternalAppPath } from "@/lib/internal-url"
 import { useInAppLinkChip } from "@/hooks/use-in-app-link-chip"
+import { useResolvedInAppLink } from "@/components/timeline/in-app-link-preview-card"
 import { InAppLinkChip } from "./in-app-link-chip"
 
 /**
@@ -38,6 +39,45 @@ export function InAppLinkInline({
   const label = state.status === "pending" ? fallbackLabel || "Link" : state.label
   const prefix = state.status === "resolved" ? state.prefix : undefined
   const chip = <InAppLinkChip icon={icon} prefix={prefix} label={label} />
+
+  const internalPath = resolveInternalAppPath(href)
+  if (!internalPath) return chip
+
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+    e.preventDefault()
+    navigate(internalPath)
+  }
+
+  return (
+    <a href={href} onClick={handleClick} className="no-underline">
+      {chip}
+    </a>
+  )
+}
+
+/**
+ * Posted-message rendering of an in-app conversation link as a compact chip
+ * (`💬 {topicSummary}`), the inline sibling of the below-message conversation
+ * card. Resolves its title through the same access-tiered resolver the card uses
+ * (shared query cache), so the chip and card never round-trip twice. A restricted
+ * tier (cross-workspace / private) renders a non-navigable placeholder chip; a
+ * cold resolve shows the generic "Conversation" label behind the same glyph, so
+ * resolving only swaps the text, never the icon (INV-21).
+ */
+export function ConversationLinkInline({ href, workspaceId }: { href: string; workspaceId: string }) {
+  const navigate = useNavigate()
+  const { data } = useResolvedInAppLink(workspaceId, undefined, href, true)
+
+  if (data?.accessTier === "cross_workspace") {
+    return <InAppLinkChip icon={Globe} label="Another workspace" />
+  }
+  if (data?.accessTier === "private") {
+    return <InAppLinkChip icon={Lock} label="Private conversation" />
+  }
+
+  const label = (data?.kind === "conversation" && data.topicSummary) || "Conversation"
+  const chip = <InAppLinkChip icon={MessagesSquare} label={label} />
 
   const internalPath = resolveInternalAppPath(href)
   if (!internalPath) return chip

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
@@ -119,6 +119,42 @@ describe("InAppLinkPreviewCard", () => {
     expect(screen.getByText("From #eng")).toBeInTheDocument()
   })
 
+  it("renders a full-access conversation link with title, summary, status and count", async () => {
+    vi.spyOn(workspaceStoreModule, "useWorkspaceStreams").mockReturnValue([] as never)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceUsers").mockReturnValue([] as never)
+    vi.spyOn(workspaceStoreModule, "useWorkspaceDmPeers").mockReturnValue([] as never)
+
+    renderWith(
+      {
+        kind: "conversation",
+        accessTier: "full",
+        topicSummary: "Auth redesign",
+        summary: "Deciding how auth flows through the router.",
+        status: "resolved",
+        messageCount: 4,
+        participantIds: ["usr_a", "usr_b"],
+        streamName: "eng",
+        streamType: "channel",
+      },
+      makePreview({ contentType: "conversation_link", url: "https://app.threa.io/w/ws_123/board?panel=conv:conv_1" })
+    )
+
+    await waitFor(() => expect(screen.getByText("Auth redesign")).toBeInTheDocument())
+    expect(screen.getByText("Deciding how auth flows through the router.")).toBeInTheDocument()
+    expect(screen.getByText("Resolved")).toBeInTheDocument()
+    expect(screen.getByText("4 messages")).toBeInTheDocument()
+  })
+
+  it("shows a minimal card for a private conversation without leaking content", async () => {
+    renderWith(
+      { kind: "conversation", accessTier: "private" },
+      makePreview({ contentType: "conversation_link", url: "https://app.threa.io/w/ws_123/board?panel=conv:conv_1" })
+    )
+
+    await waitFor(() => expect(screen.getByText("Private conversation")).toBeInTheDocument())
+    expect(screen.queryByText("Auth redesign")).not.toBeInTheDocument()
+  })
+
   it("shows a minimal card for a private stream without leaking content", async () => {
     renderWith({ kind: "stream", accessTier: "private" }, makePreview())
 

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.test.tsx
@@ -143,6 +143,7 @@ describe("InAppLinkPreviewCard", () => {
     expect(screen.getByText("Deciding how auth flows through the router.")).toBeInTheDocument()
     expect(screen.getByText("Resolved")).toBeInTheDocument()
     expect(screen.getByText("4 messages")).toBeInTheDocument()
+    expect(screen.getByText("#eng")).toBeInTheDocument()
   })
 
   it("shows a minimal card for a private conversation without leaking content", async () => {

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -117,7 +117,7 @@ function skeletonVariant(contentType: LinkPreviewSummary["contentType"]): CardVa
 const CARD_HEADER_H = "min-h-[2.0625rem]" // text/icon line + py-1.5 + border, fits the h-5 dismiss button
 const CARD_BODY_MESSAGE = "min-h-[5.5rem]" // avatar + author line + 2-line clamp
 const CARD_BODY_MEMO = "min-h-[7rem]" // tile + title + 2-line clamp + source line
-const CARD_BODY_CONVERSATION = "min-h-[7.5rem]" // tile + title + 2-line clamp + participants/count line
+const CARD_BODY_CONVERSATION = "min-h-[8.5rem]" // tile + title + 2-line clamp + participants/count line + source stream line
 
 type CardVariant = "message" | "memo" | "conversation"
 
@@ -515,6 +515,14 @@ function ConversationLinkCard({
               </span>
             )}
           </div>
+          {data.streamName && (
+            <span className="mt-1.5 inline-flex max-w-full items-center gap-1 text-[11px] text-muted-foreground [&>svg]:h-3 [&>svg]:w-3 [&>svg]:shrink-0">
+              {streamKindIcon(data.streamType)}
+              <span className="truncate">
+                {data.streamType === "channel" ? `#${data.streamName}` : data.streamName}
+              </span>
+            </span>
+          )}
         </div>
       </div>
     </CardBody>

--- a/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
+++ b/apps/frontend/src/components/timeline/in-app-link-preview-card.tsx
@@ -1,10 +1,22 @@
 import { useMemo, type ReactNode } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "react-router-dom"
-import { MessageSquare, Hash, Brain, Lock, Globe, NotebookPen, ArrowUpRight, X } from "lucide-react"
+import {
+  MessageSquare,
+  MessagesSquare,
+  Hash,
+  Brain,
+  Lock,
+  Globe,
+  NotebookPen,
+  ArrowUpRight,
+  CheckCircle2,
+  X,
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { ActorAvatar } from "@/components/actor-avatar"
+import { actorTypeFromId } from "@/hooks/use-actors"
 import { stripMarkdownToInline } from "@/lib/markdown"
 import { classifyDraftLink } from "@/lib/in-app-links"
 import { useStreamName } from "@/hooks/use-stream-name"
@@ -16,6 +28,8 @@ import type {
   MessageLinkPreviewData,
   StreamLinkPreviewData,
   MemoLinkPreviewData,
+  ConversationLinkPreviewData,
+  ConversationStatus,
   StreamType,
 } from "@threa/types"
 
@@ -83,8 +97,14 @@ export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate 
     )
   }
 
-  if (loading) return <CardSkeleton variant={preview.contentType === "memo_link" ? "memo" : "message"} />
+  if (loading) return <CardSkeleton variant={skeletonVariant(preview.contentType)} />
   return null
+}
+
+function skeletonVariant(contentType: LinkPreviewSummary["contentType"]): CardVariant {
+  if (contentType === "memo_link") return "memo"
+  if (contentType === "conversation_link") return "conversation"
+  return "message"
 }
 
 // The timeline does not compensate a row that grows after its first paint — its
@@ -97,8 +117,15 @@ export function InAppLinkPreviewCard({ preview, workspaceId, onDismiss, hydrate 
 const CARD_HEADER_H = "min-h-[2.0625rem]" // text/icon line + py-1.5 + border, fits the h-5 dismiss button
 const CARD_BODY_MESSAGE = "min-h-[5.5rem]" // avatar + author line + 2-line clamp
 const CARD_BODY_MEMO = "min-h-[7rem]" // tile + title + 2-line clamp + source line
+const CARD_BODY_CONVERSATION = "min-h-[7.5rem]" // tile + title + 2-line clamp + participants/count line
 
-type CardVariant = "message" | "memo"
+type CardVariant = "message" | "memo" | "conversation"
+
+function cardBodyHeight(variant: CardVariant): string {
+  if (variant === "memo") return CARD_BODY_MEMO
+  if (variant === "conversation") return CARD_BODY_CONVERSATION
+  return CARD_BODY_MESSAGE
+}
 
 /** Stream id of an in-app stream/message link, for client-side name resolution. */
 function streamIdFromUrl(url: string): string | null {
@@ -129,6 +156,10 @@ function ResolvedInAppLink({
   if (data.kind === "stream")
     return <StreamLinkCard data={data} url={url} workspaceId={workspaceId} onDismiss={onDismiss} />
   if (data.kind === "memo") return <MemoLinkCard data={data} url={url} reserve={reserve} onDismiss={onDismiss} />
+  if (data.kind === "conversation")
+    return (
+      <ConversationLinkCard data={data} url={url} workspaceId={workspaceId} reserve={reserve} onDismiss={onDismiss} />
+    )
   return <MessageLinkCard data={data} url={url} workspaceId={workspaceId} reserve={reserve} onDismiss={onDismiss} />
 }
 
@@ -386,6 +417,116 @@ function MemoLinkCard({
   )
 }
 
+/** Up to this many participant avatars render on a conversation card; the rest roll into "+N". */
+const CONVERSATION_MAX_AVATARS = 5
+
+function conversationStatusBadge(status?: ConversationStatus): ReactNode {
+  if (status === "resolved") return <MetaBadge icon={<CheckCircle2 />}>Resolved</MetaBadge>
+  if (status === "stalled") return <MetaBadge>Stalled</MetaBadge>
+  return null
+}
+
+function ConversationLinkCard({
+  data,
+  url,
+  workspaceId,
+  reserve,
+  onDismiss,
+}: {
+  data: ConversationLinkPreviewData
+  url: string
+  workspaceId: string
+  reserve: boolean
+  onDismiss?: () => void
+}) {
+  if (data.accessTier === "cross_workspace") {
+    return (
+      <MinimalCard
+        kindIcon={<MessagesSquare />}
+        kindLabel="Conversation"
+        label="In another workspace"
+        variant="conversation"
+        reserve={reserve}
+        onDismiss={onDismiss}
+      />
+    )
+  }
+
+  if (data.accessTier === "private") {
+    return (
+      <MinimalCard
+        kindIcon={<MessagesSquare />}
+        kindLabel="Conversation"
+        bodyIcon={<Lock />}
+        label="Private conversation"
+        variant="conversation"
+        reserve={reserve}
+        onDismiss={onDismiss}
+      />
+    )
+  }
+
+  const internalPath = getInternalPath(url)
+  const participantIds = data.participantIds ?? []
+  const shownParticipants = participantIds.slice(0, CONVERSATION_MAX_AVATARS)
+  const overflow = participantIds.length - shownParticipants.length
+  const messageCount = data.messageCount ?? 0
+
+  const body = (
+    <CardBody className={reserve ? CARD_BODY_CONVERSATION : undefined}>
+      <div className="flex items-start gap-3">
+        <IconTile>
+          <MessagesSquare />
+        </IconTile>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <h4 className="truncate text-sm font-semibold leading-snug text-foreground">
+              {data.topicSummary ?? "Conversation"}
+            </h4>
+            {conversationStatusBadge(data.status)}
+          </div>
+          {data.summary && (
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground line-clamp-2">
+              {stripMarkdownToInline(data.summary)}
+            </p>
+          )}
+          <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+            {shownParticipants.length > 0 && (
+              <div className="flex -space-x-1.5">
+                {shownParticipants.map((id) => (
+                  <ActorAvatar
+                    key={id}
+                    actorId={id}
+                    actorType={actorTypeFromId(id)}
+                    workspaceId={workspaceId}
+                    size="xs"
+                    alt=""
+                    showStatus={false}
+                    className="ring-2 ring-card"
+                  />
+                ))}
+              </div>
+            )}
+            {overflow > 0 && <span>+{overflow}</span>}
+            {messageCount > 0 && (
+              <span className="inline-flex items-center gap-1">
+                <MessageSquare className="h-3 w-3 shrink-0" />
+                {messageCount} message{messageCount === 1 ? "" : "s"}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </CardBody>
+  )
+
+  return (
+    <CardShell header={<CardHeader label="Conversation" onDismiss={onDismiss} />}>
+      <InternalLink path={internalPath}>{body}</InternalLink>
+    </CardShell>
+  )
+}
+
 /** Rounded primary-tinted tile that anchors a stream/memo card the way an avatar anchors a message. */
 function IconTile({ children }: { children: ReactNode }) {
   return (
@@ -461,9 +602,7 @@ function CardSkeleton({ variant }: { variant: CardVariant }) {
       <div className={cn("flex items-center gap-2 border-b bg-muted/30 px-3 py-1.5", CARD_HEADER_H)}>
         <div className="h-3 w-20 rounded bg-muted" />
       </div>
-      <div
-        className={cn("flex items-start gap-3 px-3.5 py-3", variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE)}
-      >
+      <div className={cn("flex items-start gap-3 px-3.5 py-3", cardBodyHeight(variant))}>
         <div className="h-9 w-9 shrink-0 rounded-lg bg-muted" />
         <div className="flex-1 space-y-1.5 pt-0.5">
           <div className="h-3.5 w-32 rounded bg-muted" />
@@ -511,10 +650,7 @@ function MinimalCard({
         <DismissButton onDismiss={onDismiss} />
       </div>
       <div
-        className={cn(
-          "flex items-center gap-3 px-3.5 py-3 text-muted-foreground",
-          reserve && (variant === "memo" ? CARD_BODY_MEMO : CARD_BODY_MESSAGE)
-        )}
+        className={cn("flex items-center gap-3 px-3.5 py-3 text-muted-foreground", reserve && cardBodyHeight(variant))}
       >
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40 [&>svg]:h-[18px] [&>svg]:w-[18px]">
           {bodyIcon ?? kindIcon}

--- a/apps/frontend/src/components/timeline/link-preview-list.tsx
+++ b/apps/frontend/src/components/timeline/link-preview-list.tsx
@@ -103,7 +103,7 @@ export function LinkPreviewList({
   return (
     <div className={cn("flex flex-col gap-2 mt-2", className)}>
       {displayedPreviews.map((preview) => {
-        // In-app links (message / stream / memo) use a specialized card with
+        // In-app links (message / stream / memo / conversation) use a specialized card with
         // permission-checked resolve instead of a network-fetched web card.
         if (isInAppLinkContentType(preview.contentType)) {
           return (

--- a/apps/frontend/src/lib/in-app-links.test.ts
+++ b/apps/frontend/src/lib/in-app-links.test.ts
@@ -35,6 +35,28 @@ describe("classifyDraftLink", () => {
     })
   })
 
+  it("classifies a conversation board-panel link at this origin", () => {
+    expect(classifyDraftLink(`${ORIGIN}/w/ws_1/board?panel=conv:conv_1`, ORIGIN)).toEqual({
+      kind: "conversation",
+      url: `${ORIGIN}/w/ws_1/board?panel=conv:conv_1`,
+      workspaceId: "ws_1",
+      conversationId: "conv_1",
+    })
+    // A message deep-link on the same conversation panel still classifies as the conversation.
+    expect(classifyDraftLink(`${ORIGIN}/w/ws_1/board?panel=conv:conv_1&m=msg_9`, ORIGIN)).toMatchObject({
+      kind: "conversation",
+      conversationId: "conv_1",
+    })
+  })
+
+  it("treats a board URL without a conversation panel as a web link", () => {
+    expect(classifyDraftLink(`${ORIGIN}/w/ws_1/board`, ORIGIN)).toMatchObject({ kind: "web", host: "app.threa.io" })
+    expect(classifyDraftLink(`${ORIGIN}/w/ws_1/board?panel=stream:stream_1`, ORIGIN)).toMatchObject({
+      kind: "web",
+      host: "app.threa.io",
+    })
+  })
+
   it("treats external and same-origin non-resource URLs as web links", () => {
     expect(classifyDraftLink("https://example.com/post", ORIGIN)).toEqual({
       kind: "web",

--- a/apps/frontend/src/lib/in-app-links.ts
+++ b/apps/frontend/src/lib/in-app-links.ts
@@ -4,7 +4,11 @@ import { collectLinkUrls } from "@threa/prosemirror"
 /** Mirrors the backend `parseInAppLink` path shapes (`url-utils.ts`). */
 const STREAM_PATH = /^\/w\/[^/]+\/s\/([^/]+)$/
 const MEMO_PATH = /^\/w\/[^/]+\/memos\/([^/]+)$/
+const BOARD_PATH = /^\/w\/[^/]+\/board$/
 const WORKSPACE_PATH = /^\/w\/([^/]+)\//
+
+/** Panel-id prefix a conversation deep-link carries in `?panel=` (mirrors `CONVERSATION_PANEL_PREFIX`). */
+const CONVERSATION_PANEL_PREFIX = "conv:"
 
 /**
  * Matches the server's MAX_PREVIEWS_PER_MESSAGE so the composer never chips more
@@ -22,19 +26,20 @@ export type DraftLinkRef =
   | { kind: "stream"; url: string; workspaceId: string; streamId: string }
   | { kind: "message"; url: string; workspaceId: string; streamId: string; messageId: string }
   | { kind: "memo"; url: string; workspaceId: string; memoId: string }
+  | { kind: "conversation"; url: string; workspaceId: string; conversationId: string }
 
 /**
  * Draft link kinds that earn a below-composer chip. Stream/message in-app links
  * are excluded: like a posted message (#1103), they render as an inline chip in
  * the draft body (a pasted one becomes an atom node; a typed one converts on
  * send), so a below-row chip would double the surface. This mirrors the
- * timeline's `isInlineChipContentType` card suppression — web and memo links
- * keep their below-row chip exactly as they keep their card.
+ * timeline's `isInlineChipContentType` card suppression — web, memo, and
+ * conversation links keep their below-row chip exactly as they keep their card.
  */
-export type BelowRowDraftLink = Extract<DraftLinkRef, { kind: "web" | "memo" }>
+export type BelowRowDraftLink = Extract<DraftLinkRef, { kind: "web" | "memo" | "conversation" }>
 
 export function isBelowRowDraftLink(link: DraftLinkRef): link is BelowRowDraftLink {
-  return link.kind === "web" || link.kind === "memo"
+  return link.kind === "web" || link.kind === "memo" || link.kind === "conversation"
 }
 
 function currentOrigin(): string | null {
@@ -42,8 +47,8 @@ function currentOrigin(): string | null {
 }
 
 /**
- * Classify a draft URL into an in-app target (stream / message / memo at this
- * app's origin) or a plain web link. In-app path shapes mirror the backend
+ * Classify a draft URL into an in-app target (stream / message / memo /
+ * conversation at this app's origin) or a plain web link. In-app path shapes mirror the backend
  * `parseInAppLink`; a same-origin URL that isn't a recognized resource (e.g.
  * `/settings`) falls through to a web chip. Returns null for non-http(s) URLs.
  */
@@ -68,6 +73,13 @@ export function classifyDraftLink(url: string, origin: string | null = currentOr
       }
       const memoId = parsed.pathname.match(MEMO_PATH)?.[1]
       if (memoId) return { kind: "memo", url, workspaceId, memoId }
+      if (BOARD_PATH.test(parsed.pathname)) {
+        const panel = parsed.searchParams.get("panel")
+        if (panel?.startsWith(CONVERSATION_PANEL_PREFIX)) {
+          const conversationId = panel.slice(CONVERSATION_PANEL_PREFIX.length)
+          if (conversationId) return { kind: "conversation", url, workspaceId, conversationId }
+        }
+      }
     }
   }
 

--- a/apps/frontend/src/lib/in-app-links.ts
+++ b/apps/frontend/src/lib/in-app-links.ts
@@ -29,17 +29,16 @@ export type DraftLinkRef =
   | { kind: "conversation"; url: string; workspaceId: string; conversationId: string }
 
 /**
- * Draft link kinds that earn a below-composer chip. Stream/message in-app links
- * are excluded: like a posted message (#1103), they render as an inline chip in
- * the draft body (a pasted one becomes an atom node; a typed one converts on
- * send), so a below-row chip would double the surface. This mirrors the
- * timeline's `isInlineChipContentType` card suppression — web, memo, and
- * conversation links keep their below-row chip exactly as they keep their card.
+ * Draft link kinds that earn a below-composer chip. Stream/message/conversation
+ * in-app links are excluded: like a posted message (#1103), they render as an
+ * inline chip in the draft body (a pasted one becomes an atom node; a typed one
+ * converts on send), so a below-row chip would double the surface. Only web and
+ * memo links keep their below-row chip (memo is card-only, no inline chip).
  */
-export type BelowRowDraftLink = Extract<DraftLinkRef, { kind: "web" | "memo" | "conversation" }>
+export type BelowRowDraftLink = Extract<DraftLinkRef, { kind: "web" | "memo" }>
 
 export function isBelowRowDraftLink(link: DraftLinkRef): link is BelowRowDraftLink {
-  return link.kind === "web" || link.kind === "memo" || link.kind === "conversation"
+  return link.kind === "web" || link.kind === "memo"
 }
 
 function currentOrigin(): string | null {

--- a/apps/frontend/src/lib/markdown/components.tsx
+++ b/apps/frontend/src/lib/markdown/components.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from "@/lib/utils"
 import { resolveInternalAppPath } from "@/lib/internal-url"
 import { classifyDraftLink } from "@/lib/in-app-links"
-import { InAppLinkInline } from "@/components/in-app-link/in-app-link-inline"
+import { InAppLinkInline, ConversationLinkInline } from "@/components/in-app-link/in-app-link-inline"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { MemoChip } from "@/components/memo-embed/memo-chip"
@@ -209,9 +209,11 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
 
   const internalPath = href ? resolveInternalAppPath(href) : null
 
-  // In-app stream/message links render as the same named chip the composer
-  // shows (the below-message preview card is suppressed in `link-preview-list`).
-  // Keyed on URL classification so old and new messages render identically.
+  // In-app stream/message/conversation links render as the same named chip the
+  // composer shows. Stream cards are suppressed in `link-preview-list`; message
+  // and conversation keep their below-message card (the chip is a compact
+  // reference, the card the rich preview). Keyed on URL classification so old and
+  // new messages render identically.
   const inAppRef = href ? classifyDraftLink(href) : null
   if (inAppRef && (inAppRef.kind === "stream" || inAppRef.kind === "message") && workspaceId) {
     return (
@@ -223,6 +225,9 @@ function MarkdownLink({ href, children }: { href?: string; children: ReactNode }
         fallbackLabel={extractTextFromChildren(children)}
       />
     )
+  }
+  if (inAppRef && inAppRef.kind === "conversation" && workspaceId) {
+    return <ConversationLinkInline href={inAppRef.url} workspaceId={workspaceId} />
   }
 
   if (internalPath) {

--- a/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
+++ b/apps/frontend/src/lib/markdown/in-app-link-block.test.tsx
@@ -126,6 +126,21 @@ describe("MarkdownContent — inline in-app link chip", () => {
     expect(resolve).not.toHaveBeenCalled()
   })
 
+  it("renders an in-app conversation link as an inline chip named by its topic, not the link text", async () => {
+    seedStreams([])
+    const resolve = vi
+      .spyOn(linkPreviewsApi, "resolveInAppLinkByUrl")
+      .mockResolvedValue({ kind: "conversation", accessTier: "full", topicSummary: "GPU budget for Q3" })
+
+    const url = `${origin}/w/ws_1/board?panel=conv:conv_1`
+    renderMarkdown(`see [whatever](${url}) here`)
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "GPU budget for Q3" })).toBeInTheDocument())
+    expect(screen.getByRole("link", { name: "GPU budget for Q3" })).toHaveAttribute("href", url)
+    expect(screen.queryByText("whatever")).not.toBeInTheDocument()
+    expect(resolve).toHaveBeenCalledWith("ws_1", url)
+  })
+
   it("leaves a plain web link as an anchor showing its own link text", () => {
     seedStreams([])
     renderMarkdown("read [the blog](https://example.com/post)")

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -761,6 +761,7 @@ export const LINK_PREVIEW_CONTENT_TYPES = [
   "message_link",
   "stream_link",
   "memo_link",
+  "conversation_link",
 ] as const
 export type LinkPreviewContentType = (typeof LINK_PREVIEW_CONTENT_TYPES)[number]
 
@@ -772,6 +773,7 @@ export const LinkPreviewContentTypes = {
   MESSAGE_LINK: "message_link",
   STREAM_LINK: "stream_link",
   MEMO_LINK: "memo_link",
+  CONVERSATION_LINK: "conversation_link",
 } as const satisfies Record<string, LinkPreviewContentType>
 
 /**
@@ -780,7 +782,7 @@ export const LinkPreviewContentTypes = {
  * and never fetched over the network, so the worker skips them and the frontend
  * routes them to the in-app preview card instead of the generic web card.
  */
-export const IN_APP_LINK_CONTENT_TYPES = ["message_link", "stream_link", "memo_link"] as const
+export const IN_APP_LINK_CONTENT_TYPES = ["message_link", "stream_link", "memo_link", "conversation_link"] as const
 export type InAppLinkContentType = (typeof IN_APP_LINK_CONTENT_TYPES)[number]
 
 export function isInAppLinkContentType(contentType: LinkPreviewContentType): contentType is InAppLinkContentType {
@@ -790,12 +792,12 @@ export function isInAppLinkContentType(contentType: LinkPreviewContentType): con
 /**
  * In-app link kinds that render as an inline chip inside the message body
  * (replacing the URL text) rather than a card below it. Their below-message
- * preview card is suppressed — the inline chip is the single surface. Memo
- * links keep their card (`MemoPreviewList`), so they are excluded.
+ * preview card is suppressed — the inline chip is the single surface. Memo and
+ * conversation links keep their metadata card, so they are excluded.
  */
-export type InlineChipContentType = Exclude<InAppLinkContentType, "memo_link">
+export type InlineChipContentType = Exclude<InAppLinkContentType, "memo_link" | "conversation_link">
 export const INLINE_CHIP_CONTENT_TYPES = IN_APP_LINK_CONTENT_TYPES.filter(
-  (t): t is InlineChipContentType => t !== "memo_link"
+  (t): t is InlineChipContentType => t !== "memo_link" && t !== "conversation_link"
 )
 
 export function isInlineChipContentType(contentType: LinkPreviewContentType): contentType is InlineChipContentType {

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -791,13 +791,14 @@ export function isInAppLinkContentType(contentType: LinkPreviewContentType): con
 
 /**
  * In-app link kinds that render as an inline chip inside the message body
- * (replacing the URL text) rather than a card below it. Their below-message
- * preview card is suppressed — the inline chip is the single surface. Memo and
- * conversation links keep their metadata card, so they are excluded.
+ * (replacing the URL text). Message and conversation links pair the inline chip
+ * with a below-message card (the chip is a compact reference, the card the rich
+ * preview); a stream link's card is suppressed (the chip says it all). Only memo
+ * links have no inline chip — they are card-only — so they are excluded here.
  */
-export type InlineChipContentType = Exclude<InAppLinkContentType, "memo_link" | "conversation_link">
+export type InlineChipContentType = Exclude<InAppLinkContentType, "memo_link">
 export const INLINE_CHIP_CONTENT_TYPES = IN_APP_LINK_CONTENT_TYPES.filter(
-  (t): t is InlineChipContentType => t !== "memo_link" && t !== "conversation_link"
+  (t): t is InlineChipContentType => t !== "memo_link"
 )
 
 export function isInlineChipContentType(contentType: LinkPreviewContentType): contentType is InlineChipContentType {

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1526,8 +1526,9 @@ export interface ConversationLinkPreviewData {
   /** Count of primary-membership messages (full tier only) */
   messageCount?: number
   /**
-   * Distinct participant (author) ids, so the card renders their avatars live
-   * from the workspace store. Capped to a small display set (full tier only).
+   * Distinct participant (author) ids (full set), so the card renders their
+   * avatars live from the workspace store; the card caps how many it shows and
+   * rolls the rest into a "+N". Full tier only.
    */
   participantIds?: string[]
   /** Anchor stream display label the conversation lives in (full tier only) */

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -1509,7 +1509,39 @@ export interface MemoLinkPreviewData {
 }
 
 /**
+ * Resolved in-app conversation link data. A conversation carries its own title
+ * (`topicSummary`) and rolling prose `summary`, so the card renders from that
+ * metadata rather than a raw message body. Content fields are only populated for
+ * the "full" access tier.
+ */
+export interface ConversationLinkPreviewData {
+  kind: "conversation"
+  accessTier: InAppLinkAccessTier
+  /** LLM-generated 2–5 word title (full tier only) */
+  topicSummary?: string
+  /** Rolling prose summary of the conversation (full tier only) */
+  summary?: string
+  /** active / stalled / resolved (full tier only) */
+  status?: ConversationStatus
+  /** Count of primary-membership messages (full tier only) */
+  messageCount?: number
+  /**
+   * Distinct participant (author) ids, so the card renders their avatars live
+   * from the workspace store. Capped to a small display set (full tier only).
+   */
+  participantIds?: string[]
+  /** Anchor stream display label the conversation lives in (full tier only) */
+  streamName?: string
+  /** Anchor stream type — channel / scratchpad / dm (full tier only) */
+  streamType?: StreamType
+}
+
+/**
  * Discriminated union returned by the permission-checked in-app link resolve
  * endpoint. The `kind` mirrors the link preview's in-app content type.
  */
-export type InAppLinkPreviewData = MessageLinkPreviewData | StreamLinkPreviewData | MemoLinkPreviewData
+export type InAppLinkPreviewData =
+  | MessageLinkPreviewData
+  | StreamLinkPreviewData
+  | MemoLinkPreviewData
+  | ConversationLinkPreviewData

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -391,6 +391,7 @@ export type {
   MessageLinkPreviewData,
   StreamLinkPreviewData,
   MemoLinkPreviewData,
+  ConversationLinkPreviewData,
   InAppLinkPreviewData,
 } from "./domain"
 


### PR DESCRIPTION
## Problem

Conversation links are shareable (`copyConversationLink` → `/w/:ws/board?panel=conv:<id>`, `lib/stream-links.ts`) but never unfurled. Stream, message, and memo links render a rich in-app preview; a pasted conversation link matched neither `STREAM_PATH` nor `MEMO_PATH` in `classifyDraftLink` (and had no `parseInAppLink` branch), so it fell through to a plain **web** chip — same-origin, SSRF-allowlisted, so it'd fetch the SPA shell and show junk. No `conversation_link` content type existed on either side.

## Solution

Add conversation as a fourth in-app link kind, modeled on the **memo** preview (the existing card-type in-app link): a permission-checked, per-viewer resolve into a metadata card. The card is built from the conversation's own `topicSummary` + prose `summary` + participant set — not a raw message body — so it sidesteps the "previewing a message is fragile" concern entirely.

### How it works

1. **Parse.** `parseInAppLink` (`url-utils.ts`) gains a `/w/:ws/board?panel=conv:<id>` branch returning `{ kind: "conversation", workspaceId, conversationId }`; `classifyDraftLink` (`in-app-links.ts`) mirrors it. The `conv:` prefix matches the frontend `CONVERSATION_PANEL_PREFIX`. A `&m=` message deep-link on the same panel still classifies as the conversation.
2. **Persist.** New nullable column `link_previews.target_conversation_id` (migration `20260709120000`). `inAppLinkInsertFields` maps the ref to `conversation_link` + the column; `insert` marks in-app types `completed` (no network fetch — the worker skips them via `isInAppLinkContentType`, which now includes `conversation_link`).
3. **Resolve.** `resolveConversationTarget` (`service.ts`) checks `targetWorkspaceId !== workspaceId` **before** reading the row (no cross-workspace existence leak), then `ConversationRepository.findById` + `streamService.tryAccess(conversation.streamId)`. Returns `full` with `topicSummary`, `summary` (stripped + truncated via `buildPreviewSnippet`), `status`, `messageCount` (`messageIds.length`), `participantIds`, and the anchor stream's name/type; else `cross_workspace` / `private`.
4. **Render.** `ConversationLinkCard` (`in-app-link-preview-card.tsx`): title, prose summary (INV-60 strip), participant avatars (`actorTypeFromId` per id so personas/bots render right), message count, status pill (Resolved/Stalled). Cross-workspace/private collapse to a `MinimalCard`. Composer draft chip added to `composer-link-chip.tsx`.

### Key design decisions

**1. Resolve via `ConversationRepository.findById`, not the board-post projection.** `getBoardPost` 404s without the `board-view` feature flag; a link preview must render for anyone with access to the stream. The ungated `findById` + `tryAccess` path carries everything the card needs. This was the load-bearing correctness call.

**2. Card-type (like memo), not inline-chip (like stream/message).** The inline chip replaces the URL text in the body via a tiptap atom node (`InAppLinkExtension`) whose node-view and `useInAppLinkChip` are stream/message-only. Conversation stays a plain navigable link in the body + a card below — the card *is* the rich preview, and this touches none of that machinery. `tryInsertInAppLinkChip` and `MarkdownLink` already guard to `stream`/`message`, so classifying conversation is safe for the composer.

**3. Access via the anchor stream (INV-62).** A conversation inherits access from its `streamId`; `tryAccess` resolves a thread anchor through its root. Same collapse-all-failure-modes-into-`private` shape as the message/stream/memo resolvers — no existence side-channel.

**4. Structured data on the wire (INV-46).** Backend returns raw `status`/`messageCount`/`participantIds`; the frontend formats "Resolved"/"N messages" and resolves avatars from the workspace store.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | `conversation_link` in `LINK_PREVIEW_CONTENT_TYPES` / `IN_APP_LINK_CONTENT_TYPES`; excluded from `INLINE_CHIP_CONTENT_TYPES` (card-type, like memo) |
| `packages/types/src/domain.ts` | `ConversationLinkPreviewData` + union member |
| `packages/types/src/index.ts` | Export the new type |
| `apps/backend/.../link-previews/url-utils.ts` | `parseInAppLink` board-panel branch + `conversation` ref |
| `apps/backend/.../link-previews/repository.ts` | `target_conversation_id` through interface / mapRow / insert |
| `apps/backend/.../link-previews/service.ts` | `resolveConversationTarget`, insert-field mapping, dispatch case |
| `apps/frontend/.../lib/in-app-links.ts` | `classifyDraftLink` branch + below-row draft-link membership |
| `apps/frontend/.../timeline/in-app-link-preview-card.tsx` | `ConversationLinkCard`, skeleton variant, body-height helper |
| `apps/frontend/.../composer/composer-link-chip.tsx` | Conversation draft chip |

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/db/migrations/20260709120000_add_link_preview_target_conversation_id.sql` | Nullable `target_conversation_id` column (INV-1: no FK) |

## Out of scope (deliberate)

- **Memo `/memory?memo=` classifier bug.** `classifyDraftLink` only matches the *legacy* `/memos/:id` shape; the canonical memo URL falls through to a web chip too. Same class of bug, separate fix — flagged, not folded in.
- **Inline body chip for conversations.** Kept as a plain link (memo behaves the same). The card is the rich surface.


## Update — inline chip (composer + timeline)

Follow-up on Kris's request: a conversation link now also renders as a compact inline chip (`💬 topic`) in the message body AND the composer draft, in addition to the card — i.e. `message_link` behavior (chip + card), not memo-style card-only.

- Reclassified conversation from card-only to an inline-chip type: out of `isBelowRowDraftLink` (in-app-links.ts), into `INLINE_CHIP_CONTENT_TYPES` (constants.ts); removed the now-dead below-row `ComposerLinkChip` conversation branch.
- **Composer:** `InAppLinkExtension` atom node now accepts `streamId: string | null` (null for conversation — no `/s/:id` permalink); `InAppLinkView` dispatches on `!streamId` to a module-scope `ConversationChipView` that resolves by URL (`useResolvedInAppLink`). `tryInsertInAppLinkChip` converts a pasted conversation URL to the chip node.
- **Timeline:** `MarkdownLink` routes a conversation ref to a new `ConversationLinkInline`.
- **Inaccessible** conversations render a non-navigable placeholder (Another workspace / Private conversation) like an inaccessible channel chip — no topic leak.
- Node serializes to `[topic](url)` (streamId unused), so it round-trips losslessly and the timeline re-derives the chip from the link alone.

## Self-review (2 reviewer agents)

- **Correctness/security:** clean — cross-workspace check precedes the DB read (no existence side-channel), access gated via `tryAccess` (INV-62), URL parse symmetric front/back, migration append-only + no FK, worker skips the new in-app type.
- **Consistency:** 1 real finding fixed — the resolver shipped `streamName`/`streamType` that no surface rendered (dead data, INV-36); now rendered as a source line on the card (MemoLinkCard "From #eng" parity). Plus stale comments refreshed.

## Test plan

- [x] Backend `bun test .../link-previews/{url-utils,service}.test.ts` — 104 pass (conversation parse + full/cross_workspace/private/missing resolve cases)
- [x] Frontend `vitest` — classifier + card (full/private/source-line) cases pass; timeline suite 450 pass
- [x] Full-monorepo `typecheck` + all-app `lint` + `check:migrations` + api-docs — clean (pre-commit gate, both commits)
- [x] **Live end-to-end on dev:test** — created a workspace + public channel + conversation row, then:
  - `GET …/link-previews/resolve?url=…/board?panel=conv:<id>` → `full` with `topicSummary`/`summary`/`status`/`messageCount:3`/`participantIds`/`streamName:gpu-budget`/`streamType:channel`; markdown `**burst**` stripped to `burst` on the wire (INV-60)
  - cross-workspace URL → `{accessTier:"cross_workspace"}` (no content); nonexistent id → `private`; board URL with no `conv:` panel → 404
  - posting a message containing the link persisted a `link_previews` row: `content_type=conversation_link`, `status=completed`, `target_conversation_id`/`target_workspace_id` set
- [ ] Visual card pixel render — Chrome extension not connected this session; the resolve payload the card consumes is verified live, and card rendering is covered by the component test

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

