### PR TITLE
feat(board): move a message to a sub-topic — one-root re-file on the card and panel

### DIFF
--- a/apps/backend/src/features/conversations/conversation-assigner.ts
+++ b/apps/backend/src/features/conversations/conversation-assigner.ts
@@ -203,8 +203,10 @@ async function attachThreadReplyToSource(
  * The stream's effective access root: a top-level stream is its own root, a
  * thread defers to `root_stream_id` (board-view-design.md / INV-62). Falls back
  * to the stream's own id when the row is missing (FK-less schema, INV-1).
+ * Shared with the reassign path (`ConversationService.reassignMessage`), whose
+ * one-root rule must match the assigner's `existing` directive exactly.
  */
-async function effectiveRootId(client: PoolClient, streamId: string): Promise<string> {
+export async function effectiveRootId(client: PoolClient, streamId: string): Promise<string> {
   const stream = await StreamRepository.findById(client, streamId)
   return stream?.rootStreamId ?? streamId
 }

--- a/apps/backend/src/features/conversations/service.reassign.test.ts
+++ b/apps/backend/src/features/conversations/service.reassign.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, spyOn, mock, test } from "bun:test"
+import type { PoolClient } from "pg"
+import { ConversationService } from "./service"
+import { ConversationRepository, type Conversation } from "./repository"
+import { ConversationFeedbackRepository } from "./feedback-repository"
+import * as delivery from "./conversation-delivery"
+import { StreamRepository } from "../streams"
+import { MessageRepository, type Message } from "../messaging"
+import { OutboxRepository } from "../../lib/outbox"
+import * as dbModule from "../../db"
+
+const WORKSPACE_ID = "ws_1"
+const ACTOR_ID = "usr_1"
+
+// One root channel with a thread under it, plus a foreign root: the three
+// stream shapes the one-root rule must distinguish.
+const STREAMS: Record<string, { id: string; type: string; rootStreamId: string | null }> = {
+  chan_1: { id: "chan_1", type: "channel", rootStreamId: null },
+  thread_1: { id: "thread_1", type: "thread", rootStreamId: "chan_1" },
+  chan_2: { id: "chan_2", type: "channel", rootStreamId: null },
+}
+
+const MESSAGES: Record<string, { streamId: string; authorId: string }> = {
+  m1: { streamId: "chan_1", authorId: "usr_1" },
+  m_thread: { streamId: "thread_1", authorId: "usr_2" },
+}
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: "conv_main",
+    streamId: "chan_1",
+    workspaceId: WORKSPACE_ID,
+    messageIds: ["m1"],
+    participantIds: ["usr_1"],
+    secondaryMessageIds: [],
+    topicSummary: "Fable",
+    summary: null,
+    completenessScore: 1,
+    confidence: 1,
+    status: "active",
+    parentConversationId: null,
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+interface Spies {
+  removePrimaryMessage: ReturnType<typeof spyOn>
+  addPrimaryMessage: ReturnType<typeof spyOn>
+  feedbackInsert: ReturnType<typeof spyOn>
+  outboxInsert: ReturnType<typeof spyOn>
+}
+
+function setup(options: {
+  conversations: Record<string, Conversation>
+  /** messageId → current primary conversation id. */
+  primaries: Record<string, string>
+}): Spies {
+  const fakeClient = { query: mock(async () => ({ rows: [] })) } as unknown as PoolClient
+  spyOn(dbModule, "withTransaction").mockImplementation((async (_pool: unknown, fn: (c: PoolClient) => unknown) =>
+    fn(fakeClient)) as typeof dbModule.withTransaction)
+
+  spyOn(StreamRepository, "findById").mockImplementation(
+    async (_c: unknown, id: string) => (STREAMS[id] ?? null) as never
+  )
+  spyOn(MessageRepository, "findByIdForUpdate").mockImplementation(async (_c: unknown, id: string) => {
+    const base = MESSAGES[id]
+    return base ? ({ id, streamId: base.streamId, authorId: base.authorId } as unknown as Message) : null
+  })
+
+  spyOn(ConversationRepository, "findById").mockImplementation(
+    async (_c: unknown, id: string) => options.conversations[id] ?? null
+  )
+  spyOn(ConversationRepository, "findPrimaryByMessageId").mockImplementation(async (_c, _ws, messageId: string) => {
+    const convId = options.primaries[messageId]
+    return convId ? (options.conversations[convId] ?? null) : null
+  })
+  spyOn(ConversationRepository, "findByIds").mockImplementation(async (_c, _ws, ids: string[]) =>
+    ids.map((id) => options.conversations[id]).filter((c): c is Conversation => c !== undefined)
+  )
+  spyOn(ConversationRepository, "resolveIfEmpty").mockResolvedValue(undefined as never)
+  spyOn(ConversationRepository, "reactivateIfInactive").mockResolvedValue(undefined as never)
+  spyOn(ConversationRepository, "bumpActivityForIds").mockResolvedValue(undefined as never)
+
+  // Real thread→root delivery shape without hitting the DB: the thread resolves
+  // to its parent channel, a root stream to itself.
+  spyOn(delivery, "resolveConversationDelivery").mockImplementation(async (_c, stream) => {
+    const s = stream as { id?: string } | null
+    if (s?.id === "thread_1") return { parentStreamId: "chan_1", streamVisibility: "public" as const }
+    return { parentStreamId: undefined, streamVisibility: "public" as const }
+  })
+
+  return {
+    removePrimaryMessage: spyOn(ConversationRepository, "removePrimaryMessage").mockResolvedValue(undefined as never),
+    addPrimaryMessage: spyOn(ConversationRepository, "addPrimaryMessage").mockResolvedValue(undefined as never),
+    feedbackInsert: spyOn(ConversationFeedbackRepository, "insert").mockResolvedValue(undefined as never),
+    outboxInsert: spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never),
+  }
+}
+
+function service(): ConversationService {
+  return new ConversationService({} as never)
+}
+
+function reassign(messageId: string, conversationId: string) {
+  return service().reassignMessage({ workspaceId: WORKSPACE_ID, conversationId, messageId, userId: ACTOR_ID })
+}
+
+type Event = { type: string; payload: Record<string, any> }
+function events(outboxInsert: ReturnType<typeof spyOn>): Event[] {
+  return outboxInsert.mock.calls.map((c: unknown[]) => ({
+    type: c[1] as string,
+    payload: c[2] as Record<string, any>,
+  }))
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("ConversationService.reassignMessage", () => {
+  test("moves a root-stream message into a thread-anchored conversation under the same root", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_1", messageIds: ["m1", "m2"] })
+    const convSub = makeConversation({ id: "conv_sub", streamId: "thread_1", messageIds: ["m_thread"] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_sub: convSub },
+      primaries: { m1: "conv_main" },
+    })
+
+    const result = await reassign("m1", "conv_sub")
+
+    expect(spies.removePrimaryMessage.mock.calls[0]?.slice(1)).toEqual([WORKSPACE_ID, "conv_main", "m1"])
+    expect(spies.addPrimaryMessage.mock.calls[0]?.slice(1)).toEqual([WORKSPACE_ID, "conv_sub", "m1", "usr_1"])
+    expect(result.conversation.id).toBe("conv_sub")
+    expect(result.previousConversation?.id).toBe("conv_main")
+
+    const emitted = events(spies.outboxInsert)
+    expect(emitted.find((e) => e.type === "conversation:message_reassigned")?.payload).toMatchObject({
+      // The event names the MESSAGE's stream — membership moved, the row didn't.
+      streamId: "chan_1",
+      messageId: "m1",
+      fromConversationId: "conv_main",
+      toConversationId: "conv_sub",
+      reason: "user_correction",
+    })
+    // Delivery is per conversation stream: the thread-anchored conversation
+    // routes with its parent channel, the root-anchored one with none.
+    const updated = emitted.filter((e) => e.type === "conversation:updated")
+    expect(updated.find((e) => e.payload.conversationId === "conv_sub")?.payload.parentStreamId).toBe("chan_1")
+    expect(updated.find((e) => e.payload.conversationId === "conv_main")?.payload.parentStreamId).toBeUndefined()
+  })
+
+  test("moves a thread message out to the root-anchored conversation (the undo direction)", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_1", messageIds: ["m1"] })
+    const convSub = makeConversation({ id: "conv_sub", streamId: "thread_1", messageIds: ["m_thread"] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_sub: convSub },
+      primaries: { m_thread: "conv_sub" },
+    })
+
+    const result = await reassign("m_thread", "conv_main")
+
+    expect(spies.addPrimaryMessage.mock.calls[0]?.slice(1)).toEqual([WORKSPACE_ID, "conv_main", "m_thread", "usr_2"])
+    expect(result.conversation.id).toBe("conv_main")
+  })
+
+  test("rejects a target under a different root with CONVERSATION_NOT_IN_ROOT and writes nothing", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_1", messageIds: ["m1"] })
+    const convForeign = makeConversation({ id: "conv_foreign", streamId: "chan_2", messageIds: [] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_foreign: convForeign },
+      primaries: { m1: "conv_main" },
+    })
+
+    await expect(reassign("m1", "conv_foreign")).rejects.toMatchObject({ code: "CONVERSATION_NOT_IN_ROOT" })
+    expect(spies.removePrimaryMessage).not.toHaveBeenCalled()
+    expect(spies.addPrimaryMessage).not.toHaveBeenCalled()
+    expect(spies.feedbackInsert).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+
+  test("same-stream move keeps working (the overlay path)", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_1", messageIds: ["m1"] })
+    const convOther = makeConversation({ id: "conv_other", streamId: "chan_1", messageIds: [] })
+    const spies = setup({
+      conversations: { conv_main: convMain, conv_other: convOther },
+      primaries: { m1: "conv_main" },
+    })
+
+    const result = await reassign("m1", "conv_other")
+
+    expect(result.conversation.id).toBe("conv_other")
+    expect(spies.feedbackInsert).toHaveBeenCalledTimes(1)
+  })
+
+  test("no-op when the target is already the primary", async () => {
+    const convMain = makeConversation({ id: "conv_main", streamId: "chan_1", messageIds: ["m1"] })
+    const spies = setup({
+      conversations: { conv_main: convMain },
+      primaries: { m1: "conv_main" },
+    })
+
+    const result = await reassign("m1", "conv_main")
+
+    expect(result.previousConversation).toBeNull()
+    expect(spies.feedbackInsert).not.toHaveBeenCalled()
+    expect(spies.outboxInsert).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/features/conversations/service.ts
+++ b/apps/backend/src/features/conversations/service.ts
@@ -11,6 +11,7 @@ import { MemoRepository } from "../memos"
 import { OutboxRepository } from "../../lib/outbox"
 import { addStalenessFields, type ConversationWithStaleness } from "./staleness"
 import { resolveConversationDelivery } from "./conversation-delivery"
+import { effectiveRootId } from "./conversation-assigner"
 import { conversationFeedbackId, conversationId as generateConversationId } from "../../lib/id"
 import { HttpError } from "../../lib/errors"
 import { logger } from "../../lib/logger"
@@ -458,9 +459,12 @@ export class ConversationService {
 
   /**
    * User correction: move a message's primary membership to another
-   * conversation in the same stream. Applies the move immediately (same
-   * repository operations the boundary extractor uses) and records a
-   * `conversation_feedback` row as ground truth for improving extraction.
+   * conversation under the same effective root — same stream, or between the
+   * root and one of its threads (the board's "move to sub-topic" re-file).
+   * Membership only; the message row never changes streams. Applies the move
+   * immediately (same repository operations the boundary extractor uses) and
+   * records a `conversation_feedback` row as ground truth for improving
+   * extraction.
    *
    * Mirrors the boundary extractor's persist phase: message row locked
    * FOR UPDATE before reading the current primary (INV-20), membership
@@ -484,11 +488,22 @@ export class ConversationService {
       if (!message) {
         throw new HttpError("Message not found", { status: 404, code: "MESSAGE_NOT_FOUND" })
       }
+      // One-root rule, same as the assigner's `existing` directive: same stream
+      // passes trivially; a cross-stream move between the root and its threads
+      // (the board's "move to sub-topic" re-file) passes; a cross-root move is
+      // rejected. Membership moves only — the message row itself never leaves
+      // its stream (re-file, not relocation).
       if (message.streamId !== target.streamId) {
-        throw new HttpError("Message does not belong to the conversation's stream", {
-          status: 400,
-          code: "MESSAGE_NOT_IN_CONVERSATION_STREAM",
-        })
+        const [targetRoot, messageRoot] = await Promise.all([
+          effectiveRootId(client, target.streamId),
+          effectiveRootId(client, message.streamId),
+        ])
+        if (targetRoot !== messageRoot) {
+          throw new HttpError("Conversation is in a different root stream", {
+            status: 400,
+            code: "CONVERSATION_NOT_IN_ROOT",
+          })
+        }
       }
 
       const previous = await ConversationRepository.findPrimaryByMessageId(client, workspaceId, messageId)
@@ -523,17 +538,24 @@ export class ConversationService {
       const touchedIds = previous ? [previous.id, target.id] : [target.id]
       await ConversationRepository.bumpActivityForIds(client, workspaceId, touchedIds)
 
-      // One delivery resolution for every touched conversation is correct here
-      // (unlike the boundary extractor, which spans streams): both `previous` and
-      // `target` live in the message's stream — the guard above pins `target` to
-      // it, and a primary membership is always in the message's own stream — so
-      // they share one access-root visibility (INV-62). Routing `previous` by
-      // `target`'s stream can't leak because they're the same stream.
-      const stream = await StreamRepository.findById(client, target.streamId)
-      const { parentStreamId, streamVisibility } = await resolveConversationDelivery(client, stream)
+      // `previous` and `target` share one access root (the one-root guard above,
+      // INV-62) but can be anchored in different streams under it — the root and
+      // one of its threads — so delivery is resolved per conversation stream,
+      // mirroring the boundary extractor's cross-stream persist.
+      const deliveryByStreamId = new Map<string, Awaited<ReturnType<typeof resolveConversationDelivery>>>()
+      const deliveryFor = async (streamId: string) => {
+        let resolved = deliveryByStreamId.get(streamId)
+        if (!resolved) {
+          const stream = await StreamRepository.findById(client, streamId)
+          resolved = await resolveConversationDelivery(client, stream)
+          deliveryByStreamId.set(streamId, resolved)
+        }
+        return resolved
+      }
 
       const touched = await ConversationRepository.findByIds(client, workspaceId, touchedIds)
       for (const conv of touched) {
+        const { parentStreamId, streamVisibility } = await deliveryFor(conv.streamId)
         await OutboxRepository.insert(client, "conversation:updated", {
           workspaceId,
           streamId: conv.streamId,
@@ -557,7 +579,7 @@ export class ConversationService {
         await OutboxRepository.insert(client, "conversation:message_assigned", {
           workspaceId,
           streamId: message.streamId,
-          parentStreamId,
+          parentStreamId: (await deliveryFor(message.streamId)).parentStreamId,
           messageId,
           conversationId: target.id,
           isPrimary: true,

--- a/apps/backend/tests/integration/conversation-reassign.test.ts
+++ b/apps/backend/tests/integration/conversation-reassign.test.ts
@@ -306,7 +306,7 @@ describe("ConversationService.reassignMessage", () => {
     expect(sideEffects).toEqual({ feedbackRows: [], outboxRows: [] })
   })
 
-  test("rejects a message from a different stream than the conversation", async () => {
+  test("rejects a message from a different root than the conversation", async () => {
     const { convBId } = await seedTwoConversations()
     const otherStreamId = streamId()
     const foreignMsgId = messageId()
@@ -337,7 +337,73 @@ describe("ConversationService.reassignMessage", () => {
         messageId: foreignMsgId,
         userId: testUserId,
       })
-    ).rejects.toMatchObject({ code: "MESSAGE_NOT_IN_CONVERSATION_STREAM" })
+    ).rejects.toMatchObject({ code: "CONVERSATION_NOT_IN_ROOT" })
+  })
+
+  test("moves a root-stream message into a conversation anchored in a thread under the same root", async () => {
+    const { convAId, msg1Id, msg2Id } = await seedTwoConversations()
+    const threadStreamId = streamId()
+    const threadMsgId = messageId()
+    const convSubId = conversationId()
+
+    await withTransaction(pool, async (client) => {
+      // A thread under msg1 in the shared root channel, holding a sub-topic
+      // conversation — the board's nested-branch shape.
+      await StreamRepository.insert(client, {
+        id: threadStreamId,
+        workspaceId: testWorkspaceId,
+        type: "thread",
+        visibility: "private",
+        companionMode: "off",
+        createdBy: testUserId,
+        parentStreamId: testStreamId,
+        parentMessageId: msg1Id,
+        rootStreamId: testStreamId,
+      })
+      await MessageRepository.insert(client, {
+        id: threadMsgId,
+        streamId: threadStreamId,
+        sequence: BigInt(1),
+        authorId: testUserId,
+        authorType: "user",
+        ...testMessageContent("Sub-topic opener"),
+      })
+      await ConversationRepository.insert(client, {
+        id: convSubId,
+        streamId: threadStreamId,
+        workspaceId: testWorkspaceId,
+        topicSummary: "Sub-topic",
+      })
+      await ConversationRepository.addPrimaryMessage(client, testWorkspaceId, convSubId, threadMsgId, testUserId)
+    })
+
+    // Re-file: membership moves across streams under one root; the message row
+    // stays in the root channel.
+    const result = await service.reassignMessage({
+      workspaceId: testWorkspaceId,
+      conversationId: convSubId,
+      messageId: msg2Id,
+      userId: testUserId,
+    })
+
+    expect(result.conversation).toMatchObject({ id: convSubId, messageIds: [threadMsgId, msg2Id] })
+    expect(result.previousConversation).toMatchObject({ id: convAId, messageIds: [msg1Id] })
+
+    const movedRow = await withTransaction(pool, (client) => MessageRepository.findById(client, msg2Id))
+    expect(movedRow?.streamId).toBe(testStreamId)
+
+    // Delivery resolves per conversation stream: the thread-anchored target
+    // routes with its parent channel, the root-anchored source with none.
+    const events = await withTransaction(pool, async (client) => {
+      const res = await client.query<{ payload: { conversationId: string; parentStreamId?: string } }>(
+        `SELECT payload FROM outbox WHERE event_type = 'conversation:updated'`
+      )
+      return res.rows
+    })
+    const updatedSub = events.find((e) => e.payload.conversationId === convSubId)
+    const updatedA = events.find((e) => e.payload.conversationId === convAId)
+    expect(updatedSub?.payload.parentStreamId).toBe(testStreamId)
+    expect(updatedA?.payload.parentStreamId).toBeUndefined()
   })
 
   test("rejects a conversation from a different workspace", async () => {

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -34,6 +34,7 @@ import { cn } from "@/lib/utils"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
+import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { QuoteReplyProvider } from "@/components/timeline/quote-reply-context"
 import { TextSelectionQuote } from "@/components/timeline/text-selection-quote"
 import { useActors, useVisibleStreams } from "@/hooks"
@@ -304,6 +305,10 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
       branchesByForkMessageId,
       openingMessage?.id
     )
+  // "Move to sub-topic" re-file: membership move between this conversation and
+  // its nested sub-topics (one root). The hook hides the action when a row has
+  // nowhere to go.
+  const moveToSubtopic = useMoveToSubtopic({ workspaceId, conversation, branchesByForkMessageId })
   // A spanning-overflow row from a card opens the whole conversation in the panel.
   const continueThreadTo = () => getPanelUrl(createConversationPanelId(conversation.id))
   // Heal a soft-thread seam into its own topic (the card re-forms as a nested
@@ -442,6 +447,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
         surfaceClassName="bg-card px-3 sm:px-4"
         rowInsetClassName="-mx-3 sm:-mx-4"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
+        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id)}
       />
     )
   }
@@ -469,6 +475,9 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
               : undefined
           }
+          onMoveToSubtopic={
+            branch.pending ? undefined : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId)
+          }
         />
       </ConversationReadProvider>
     )
@@ -481,6 +490,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
       <QuoteReplyProvider>
         {/* Desktop text-selection → floating "Quote" button, scoped to this card. */}
         <TextSelectionQuote streamId={streamId} containerRef={cardRef} />
+        {moveToSubtopic.moveDialog}
         <div ref={cardRef} className="rounded-xl border bg-card p-3 sm:p-4">
           {/* Zero-height marker at the card top: drives the header's stuck state
               (see the observer above). In flow but h-0, so it shifts nothing. */}

--- a/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ServicesProvider } from "@/contexts"
+import { useMoveToSubtopic } from "./use-move-to-subtopic"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
+
+const WS = "ws_1"
+
+function branch(overrides: Partial<BranchConversationView>): BranchConversationView {
+  return {
+    conversationId: "conv_sub",
+    threadStreamId: "thread_1",
+    forkMessageId: "m1",
+    title: "GPU budget",
+    displayDepth: 1,
+    overflow: false,
+    messages: [],
+    hiddenCount: 0,
+    children: [],
+    ...overrides,
+  }
+}
+
+function MoveSurface({
+  branches,
+  currentConversationId,
+}: {
+  branches: BranchConversationView[]
+  currentConversationId: string
+}) {
+  const move = useMoveToSubtopic({
+    workspaceId: WS,
+    conversation: { id: "conv_main", streamId: "chan_1", topicSummary: "Main thing" },
+    branchesByForkMessageId: new Map([["m1", branches]]),
+  })
+  const handler = move.moveHandlerFor("m_target", currentConversationId)
+  return (
+    <>
+      {handler ? (
+        <button type="button" onClick={handler}>
+          Move to sub-topic
+        </button>
+      ) : (
+        <span>no action</span>
+      )}
+      {move.moveDialog}
+    </>
+  )
+}
+
+function Harness({
+  branches,
+  currentConversationId,
+  reassignMessage,
+}: {
+  branches: BranchConversationView[]
+  currentConversationId: string
+  reassignMessage: (...args: unknown[]) => Promise<unknown>
+}) {
+  return (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <ServicesProvider services={{ conversations: { reassignMessage } as never }}>
+        <MoveSurface branches={branches} currentConversationId={currentConversationId} />
+      </ServicesProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe("useMoveToSubtopic", () => {
+  it("hides the action when the row has nowhere to go", () => {
+    // Primary row, no branches: the only conversation under the root is the
+    // row's own, so there is no target.
+    render(<Harness branches={[]} currentConversationId="conv_main" reassignMessage={vi.fn()} />)
+    expect(screen.getByText("no action")).toBeDefined()
+
+    // A pending branch is not a real target either (its id is a draft panel id).
+    render(
+      <Harness branches={[branch({ pending: true })]} currentConversationId="conv_main" reassignMessage={vi.fn()} />
+    )
+    expect(screen.getAllByText("no action")).toHaveLength(2)
+  })
+
+  it("offers the branches to a primary row and reassigns to the picked one", async () => {
+    const reassignMessage = vi.fn().mockResolvedValue({ conversation: { id: "conv_sub" }, previousConversation: null })
+    render(<Harness branches={[branch({})]} currentConversationId="conv_main" reassignMessage={reassignMessage} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    // The row's own conversation (main) is not offered; the branch is.
+    expect(screen.queryByText("Main thing")).toBeNull()
+    await userEvent.click(screen.getByRole("button", { name: /GPU budget/ }))
+
+    await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_sub", "m_target"))
+    // Selecting closes the picker (no confirm step — the move is reversible).
+    expect(screen.queryByText("GPU budget")).toBeNull()
+  })
+
+  it("offers the main topic to a branch row", async () => {
+    const reassignMessage = vi.fn().mockResolvedValue({ conversation: { id: "conv_main" }, previousConversation: null })
+    render(<Harness branches={[branch({})]} currentConversationId="conv_sub" reassignMessage={reassignMessage} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    // Its own branch is excluded; the main topic is the target.
+    expect(screen.queryByText("GPU budget")).toBeNull()
+    await userEvent.click(screen.getByRole("button", { name: /Main thing/ }))
+
+    await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_main", "m_target"))
+  })
+})

--- a/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ServicesProvider } from "@/contexts"
 import { useMoveToSubtopic } from "./use-move-to-subtopic"
+import * as boardStoreModule from "@/stores/board-store"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
 const WS = "ws_1"
@@ -94,6 +95,43 @@ describe("useMoveToSubtopic", () => {
     await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_sub", "m_target"))
     // Selecting closes the picker (no confirm step — the move is reversible).
     expect(screen.queryByText("GPU budget")).toBeNull()
+  })
+
+  it("offers nested (depth-2) sub-topics as targets, and applies the response to the board store", async () => {
+    const merge = vi.spyOn(boardStoreModule, "mergeBoardConversation").mockResolvedValue(true)
+    const conversationResult = { id: "conv_grandchild" }
+    const previousResult = { id: "conv_main" }
+    const reassignMessage = vi
+      .fn()
+      .mockResolvedValue({ conversation: conversationResult, previousConversation: previousResult })
+    const nested = branch({
+      children: [branch({ conversationId: "conv_grandchild", threadStreamId: "thread_2", title: "Deep dive" })],
+    })
+    render(<Harness branches={[nested]} currentConversationId="conv_main" reassignMessage={reassignMessage} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    await userEvent.click(screen.getByRole("button", { name: /Deep dive/ }))
+
+    await waitFor(() => expect(reassignMessage).toHaveBeenCalledWith(WS, "conv_grandchild", "m_target"))
+    // The board store re-files on the HTTP response, not the socket echo.
+    await waitFor(() => expect(merge).toHaveBeenCalledWith("conv_grandchild", conversationResult))
+    expect(merge).toHaveBeenCalledWith("conv_main", previousResult)
+    merge.mockRestore()
+  })
+
+  it("ignores re-opens while a move is in flight", async () => {
+    // A move that never settles: the action must not open the picker again (a
+    // second pick would enqueue a duplicate correction).
+    const reassignMessage = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<Harness branches={[branch({})]} currentConversationId="conv_main" reassignMessage={reassignMessage} />)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    await userEvent.click(screen.getByRole("button", { name: /GPU budget/ }))
+    expect(reassignMessage).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByRole("button", { name: "Move to sub-topic" }))
+    expect(screen.queryByRole("button", { name: /GPU budget/ })).toBeNull()
+    expect(reassignMessage).toHaveBeenCalledTimes(1)
   })
 
   it("offers the main topic to a branch row", async () => {

--- a/apps/frontend/src/components/board/use-move-to-subtopic.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react"
+import { toast } from "sonner"
+import { GitBranch, Layers } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
+import { useReassignConversationMessage } from "@/hooks/use-conversations"
+import type { BranchConversationView } from "@/lib/board/branch-grouping"
+
+interface MoveTarget {
+  conversationId: string
+  title: string
+  kind: "main" | "branch"
+}
+
+/**
+ * The board's "Move to sub-topic" re-file gesture, shared by the card and the
+ * conversation panel (INV-35): moves a message's primary membership between the
+ * main conversation and its nested sub-topic conversations under one root —
+ * `reassignMessage` on the server relaxes its guard to the same effective-root
+ * rule, so the timeline itself never changes (re-file, not relocation).
+ *
+ * `moveHandlerFor` yields a row-action handler only when the row has somewhere
+ * to go (≥1 other non-pending conversation under the root); the action hides
+ * otherwise, the same field-one-side-sets gate as `onNewSubtopic`. Selecting a
+ * target fires the move and closes — membership moves are reversible, so
+ * there's no confirm step; a failure restores nothing and reports via toast.
+ */
+export function useMoveToSubtopic(params: {
+  workspaceId: string
+  conversation: { id: string; streamId: string; topicSummary: string | null }
+  branchesByForkMessageId: Map<string, BranchConversationView[]>
+}): {
+  moveHandlerFor: (messageId: string, currentConversationId: string) => (() => void) | undefined
+  moveDialog: ReactNode
+} {
+  const { workspaceId, conversation, branchesByForkMessageId } = params
+  const [pendingMove, setPendingMove] = useState<{ messageId: string; currentConversationId: string } | null>(null)
+  const reassign = useReassignConversationMessage(workspaceId, conversation.streamId)
+
+  // A pending branch's conversation doesn't exist server-side yet (its id is the
+  // draft panel id), so it can be neither source nor target.
+  const branches = useMemo(
+    () => [...branchesByForkMessageId.values()].flat().filter((b) => !b.pending),
+    [branchesByForkMessageId]
+  )
+
+  const targetsFor = useCallback(
+    (currentConversationId: string): MoveTarget[] => [
+      ...(currentConversationId !== conversation.id
+        ? [
+            {
+              conversationId: conversation.id,
+              title: conversation.topicSummary ?? "Main topic",
+              kind: "main" as const,
+            },
+          ]
+        : []),
+      ...branches
+        .filter((b) => b.conversationId !== currentConversationId)
+        .map((b) => ({ conversationId: b.conversationId, title: b.title, kind: "branch" as const })),
+    ],
+    [conversation.id, conversation.topicSummary, branches]
+  )
+
+  const moveHandlerFor = useCallback(
+    (messageId: string, currentConversationId: string): (() => void) | undefined => {
+      if (targetsFor(currentConversationId).length === 0) return undefined
+      return () => setPendingMove({ messageId, currentConversationId })
+    },
+    [targetsFor]
+  )
+
+  const selectTarget = useCallback(
+    (target: MoveTarget) => {
+      if (!pendingMove) return
+      reassign.mutate(
+        { messageId: pendingMove.messageId, toConversationId: target.conversationId },
+        { onError: () => toast.error("Couldn't move the message. Please try again.") }
+      )
+      setPendingMove(null)
+    },
+    [pendingMove, reassign]
+  )
+
+  const targets = pendingMove ? targetsFor(pendingMove.currentConversationId) : []
+
+  const moveDialog = (
+    <Dialog open={pendingMove !== null} onOpenChange={(open) => !open && setPendingMove(null)}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Move to sub-topic</DialogTitle>
+          <DialogDescription>
+            Re-file this message into another topic of this conversation. The message stays where it was posted.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex max-h-[50dvh] flex-col gap-1 overflow-y-auto">
+          {targets.map((target) => (
+            <button
+              key={target.conversationId}
+              type="button"
+              onClick={() => selectTarget(target)}
+              className="flex min-h-11 items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+            >
+              {target.kind === "main" ? (
+                <Layers className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              ) : (
+                <GitBranch className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+              )}
+              <span className="min-w-0 flex-1 truncate">{target.title}</span>
+            </button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+
+  return { moveHandlerFor, moveDialog }
+}

--- a/apps/frontend/src/components/board/use-move-to-subtopic.tsx
+++ b/apps/frontend/src/components/board/use-move-to-subtopic.tsx
@@ -36,12 +36,21 @@ export function useMoveToSubtopic(params: {
   const [pendingMove, setPendingMove] = useState<{ messageId: string; currentConversationId: string } | null>(null)
   const reassign = useReassignConversationMessage(workspaceId, conversation.streamId)
 
-  // A pending branch's conversation doesn't exist server-side yet (its id is the
-  // draft panel id), so it can be neither source nor target.
-  const branches = useMemo(
-    () => [...branchesByForkMessageId.values()].flat().filter((b) => !b.pending),
-    [branchesByForkMessageId]
-  )
+  // Every branch at any depth (sub-topics nest to depth 2 — a grandchild is as
+  // valid a target as its parent; the server's one-root rule resolves any depth
+  // to the same root). A pending branch's conversation doesn't exist server-side
+  // yet (its id is the draft panel id), so it can be neither source nor target.
+  const branches = useMemo(() => {
+    const out: BranchConversationView[] = []
+    const walk = (list: BranchConversationView[]) => {
+      for (const branch of list) {
+        if (!branch.pending) out.push(branch)
+        walk(branch.children)
+      }
+    }
+    walk([...branchesByForkMessageId.values()].flat())
+    return out
+  }, [branchesByForkMessageId])
 
   const targetsFor = useCallback(
     (currentConversationId: string): MoveTarget[] => [
@@ -61,17 +70,24 @@ export function useMoveToSubtopic(params: {
     [conversation.id, conversation.topicSummary, branches]
   )
 
+  // Ignore opens and picks while a move is already in flight (mirrors the
+  // conversation overlay's per-message pending guard): the re-file lands on the
+  // mutation response, but a rapid re-tap before it settles must not enqueue a
+  // second correction.
   const moveHandlerFor = useCallback(
     (messageId: string, currentConversationId: string): (() => void) | undefined => {
       if (targetsFor(currentConversationId).length === 0) return undefined
-      return () => setPendingMove({ messageId, currentConversationId })
+      return () => {
+        if (reassign.isPending) return
+        setPendingMove({ messageId, currentConversationId })
+      }
     },
-    [targetsFor]
+    [targetsFor, reassign.isPending]
   )
 
   const selectTarget = useCallback(
     (target: MoveTarget) => {
-      if (!pendingMove) return
+      if (!pendingMove || reassign.isPending) return
       reassign.mutate(
         { messageId: pendingMove.messageId, toConversationId: target.conversationId },
         { onError: () => toast.error("Couldn't move the message. Please try again.") }

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -37,6 +37,7 @@ import {
   deriveBranchProvenance,
 } from "@/hooks/use-conversation-graph"
 import { useInlineBranchComposer } from "@/components/board/use-inline-branch-composer"
+import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
 import { cn } from "@/lib/utils"
@@ -488,6 +489,9 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
     branchesByForkMessageId,
     openingMessage?.id
   )
+  // "Move to sub-topic" re-file — same gesture as the board card (membership move
+  // within one root; the hook hides the action when a row has nowhere to go).
+  const moveToSubtopic = useMoveToSubtopic({ workspaceId, conversation, branchesByForkMessageId })
   const renderMessage = (message: RenderableMessage, continuation: boolean) => {
     // Each row renders against its own stream so reactions and the permalink
     // target where the message actually lives (one root, many streams); fall
@@ -515,6 +519,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
         surfaceClassName="bg-background px-4"
         rowInsetClassName="-mx-4"
         onNewSubtopic={canBranch ? () => inlineComposer.openNewSubtopic(rowStreamId, message.id) : undefined}
+        onMoveToSubtopic={moveToSubtopic.moveHandlerFor(message.id, conversation.id)}
       />
     )
   }
@@ -539,6 +544,9 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
             canBranch
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)
               : undefined
+          }
+          onMoveToSubtopic={
+            branch.pending ? undefined : moveToSubtopic.moveHandlerFor(message.id, branch.conversationId)
           }
         />
       </ConversationReadProvider>
@@ -579,6 +587,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
       <QuoteReplyProvider>
         {/* Desktop text-selection → floating "Quote" button, scoped to this list. */}
         <TextSelectionQuote streamId={conversation.streamId} containerRef={listRef} />
+        {moveToSubtopic.moveDialog}
         <div
           ref={listRef}
           className="min-h-0 flex-1 overflow-y-auto px-4"

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -144,6 +144,11 @@ interface MessageItemProps {
    * — so the action shows exactly where a fresh branch is valid; other surfaces
    * leave it undefined and the action hides. */
   onNewSubtopic?: () => void
+  /** Open the surface's "Move to sub-topic" target picker for this row — re-file
+   * the message's membership into another conversation under the same root.
+   * Passed already-gated by the conversation surfaces (set only when the row has
+   * a valid target); other surfaces leave it undefined and the action hides. */
+  onMoveToSubtopic?: () => void
 }
 
 /**
@@ -170,6 +175,7 @@ export function MessageItem({
   surfaceClassName,
   rowInsetClassName,
   onNewSubtopic,
+  onMoveToSubtopic,
 }: MessageItemProps) {
   const { formatTime, formatFull } = useFormattedDate()
   const messageCollapse = useMessageCollapseSettings()
@@ -420,6 +426,7 @@ export function MessageItem({
     },
     onLabelMessage: () => setLabelPickerOpen(true),
     onNewSubtopic,
+    onMoveToSubtopic,
     onMarkReadUpToHere:
       conversationRead && rowRead !== "read" ? () => conversationRead.markReadUpToHere(message.id) : undefined,
     onMarkUnread: conversationRead && rowRead !== "unread" ? () => conversationRead.markUnread(message.id) : undefined,

--- a/apps/frontend/src/components/timeline/message-actions.ts
+++ b/apps/frontend/src/components/timeline/message-actions.ts
@@ -22,6 +22,7 @@ import {
   ArrowUpRight,
   PanelRight,
   GitBranch,
+  FolderInput,
 } from "lucide-react"
 import { toast } from "sonner"
 import { stripMarkdown } from "@/lib/markdown"
@@ -101,6 +102,14 @@ export interface MessageActionContext {
    * D). The plain timeline never sets it.
    */
   onNewSubtopic?: () => void
+  /**
+   * Re-file the message's primary membership into another conversation under
+   * the same root — the main topic or one of its nested sub-topics (the target
+   * picker the conversation surfaces host). Membership only: the message row
+   * never leaves its stream. Set ONLY by the conversation surfaces (board card /
+   * conversation panel), and only when the row has somewhere to go.
+   */
+  onMoveToSubtopic?: () => void
   /**
    * Share-to-root fast path: queue a pointer share into the top-level non-thread
    * ancestor (channel/dm/scratchpad) and navigate there. Always preferred over
@@ -370,6 +379,16 @@ export const messageActions: MessageAction[] = [
     icon: GitBranch,
     when: (ctx) => !!ctx.onNewSubtopic,
     action: (ctx) => ctx.onNewSubtopic?.(),
+  },
+  {
+    // Re-file into another conversation under the same root (main topic or a
+    // nested sub-topic) — the conversation surfaces set the handler only when
+    // the row has a valid target. Membership move, not a message move.
+    id: "move-to-subtopic",
+    label: "Move to sub-topic…",
+    icon: FolderInput,
+    when: (ctx) => !!ctx.onMoveToSubtopic,
+    action: (ctx) => ctx.onMoveToSubtopic?.(),
   },
   {
     // In-stream → conversation panel (the mirror of "View in channel"). Only

--- a/apps/frontend/src/hooks/use-conversations.ts
+++ b/apps/frontend/src/hooks/use-conversations.ts
@@ -698,6 +698,11 @@ export function useReassignConversationMessage(workspaceId: string, streamId: st
         conversationKeys.list(workspaceId, streamId, {}),
         (old: ConversationWithStaleness[] | undefined) => old?.map((c) => updatedById.get(c.id) ?? c)
       )
+      // Apply the returned aggregates to the board store now, so the board card /
+      // panel re-file on the HTTP response instead of waiting for the socket echo
+      // (which then lands as an idempotent overwrite). No-op for uncached rows.
+      void mergeBoardConversation(conversation.id, conversation)
+      if (previousConversation) void mergeBoardConversation(previousConversation.id, previousConversation)
       // The expanded per-conversation message panels refetch their row sets.
       queryClient.invalidateQueries({ queryKey: conversationKeys.messages(conversation.id) })
       if (previousConversation) {

--- a/apps/frontend/src/stores/board-store.test.ts
+++ b/apps/frontend/src/stores/board-store.test.ts
@@ -93,17 +93,51 @@ describe("seedBoardPosts", () => {
 })
 
 describe("mergeBoardConversation", () => {
-  it("merges the aggregate, re-sorts on activity, and keeps the cached preview", async () => {
+  it("merges the aggregate, re-sorts on activity, and keeps the cached preview of members", async () => {
     await seedBoardPosts(WORKSPACE_ID, [
       makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1")]),
       makePost("conv_2", "2026-06-21T12:00:00.000Z"),
     ])
-    const merged = await mergeBoardConversation("conv_1", makeConversation("conv_1", "2026-06-22T12:00:00.000Z"))
+    const conversation = {
+      ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"),
+      messageIds: ["m1", "r1"],
+    }
+    const merged = await mergeBoardConversation("conv_1", conversation)
     expect(merged).toBe(true)
     const board = await readBoard()
     expect(board.map((p) => p.id)).toEqual(["conv_1", "conv_2"])
-    // The event carries the aggregate, not message bodies — preview is preserved.
+    // The event carries the aggregate, not message bodies — a member's cached
+    // preview is preserved.
     expect(board[0]?.recentMessages.map((m) => m.id)).toEqual(["r1"])
+  })
+
+  it("drops a re-filed message from the preview when it leaves the membership", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [
+      makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1"), makeMessage("r2")]),
+    ])
+    // r2 moved to another conversation (reassignMessage): the aggregate lists
+    // m1 + r1 only, so the stale preview row must leave with it.
+    const conversation = {
+      ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"),
+      messageIds: ["m1", "r1"],
+    }
+    const merged = await mergeBoardConversation("conv_1", conversation)
+    expect(merged).toBe(true)
+    expect((await db.conversations.get("conv_1"))?.recentMessages.map((m) => m.id)).toEqual(["r1"])
+  })
+
+  it("reports unhandled when the opening itself moved away, so the caller refetches", async () => {
+    await seedBoardPosts(WORKSPACE_ID, [makePost("conv_1", "2026-06-20T12:00:00.000Z", [makeMessage("r1")])])
+    // The opening (m1) re-filed elsewhere; its replacement's body isn't in the
+    // event, so the merge lands what it knows and signals a board-head refetch.
+    const conversation = {
+      ...makeConversation("conv_1", "2026-06-22T12:00:00.000Z"),
+      messageIds: ["r1"],
+    }
+    const merged = await mergeBoardConversation("conv_1", conversation)
+    expect(merged).toBe(false)
+    // The row stays put (no vanish-and-return) with the aggregate applied.
+    expect((await db.conversations.get("conv_1"))?.conversation.messageIds).toEqual(["r1"])
   })
 
   it("returns false when the card isn't cached (caller hydrates instead)", async () => {

--- a/apps/frontend/src/stores/board-store.ts
+++ b/apps/frontend/src/stores/board-store.ts
@@ -266,13 +266,30 @@ export async function mergeBoardConversation(
     }
     const existing = await db.conversations.get(conversationId)
     if (!existing) return false
+    // The aggregate names the members but carries no bodies, so the projection
+    // snapshots must be reconciled here: a message re-filed OUT of this
+    // conversation (`reassignMessage`) must leave `recentMessages`, or a card
+    // whose rail hasn't synced keeps rendering the moved row off the stale
+    // snapshot until the next board refetch. Removal only — a message re-filed
+    // IN has no body in the event; its row fills from the rail or the refetch.
+    const memberIds = Array.isArray(conversation.messageIds) ? new Set(conversation.messageIds) : null
+    const recentMessages = memberIds
+      ? existing.recentMessages.filter((m) => memberIds.has(m.id))
+      : existing.recentMessages
+    // An opening that moved away can't be patched in place (its replacement's
+    // body isn't in the event): merge what's known but report unhandled, so the
+    // caller refetches the board head and re-seeds the card with its real new
+    // opener — the row stays put meanwhile (no vanish-and-return motion).
+    const openingMoved =
+      memberIds !== null && existing.openingMessage !== null && !memberIds.has(existing.openingMessage.id)
     await db.conversations.put({
       ...existing,
       conversation,
+      recentMessages,
       _lastActivityMs: lastActivityMs(conversation),
       _cachedAt: Date.now(),
       _status: undefined,
     })
-    return true
+    return !openingMoved
   })
 }


### PR DESCRIPTION
## Problem

A conversation's messages sometimes belong in one of its sub-topics (or back in the main topic), but the only membership-correction gesture, `reassignMessage`, was pinned to one stream: `MESSAGE_NOT_IN_CONVERSATION_STREAM` rejected any target not anchored in the message's own stream (`conversations/service.ts`). A conversation legitimately spans its root + threads under one effective root (board-view-design.md), and the synchronous assigner's `existing` directive already accepts exactly that shape — the correction path was stricter than the authoring path. There was also no UI for it on the board surfaces.

## Solution

Re-file only — a membership move under one root, never a stream relocation. The message row never changes streams (`moveMessagesToThread` is deliberately not involved); what moves is the primary conversation membership, the same repository operations the boundary extractor uses.

### How it works

1. **Guard relaxed to the one-root rule.** `reassignMessage` now runs the assigner's exact check: same stream passes trivially; otherwise both streams resolve through `effectiveRootId` (now exported from `conversation-assigner.ts`, the single copy) and a mismatch throws 400 `CONVERSATION_NOT_IN_ROOT` — the same code the `existing` directive returns. The FOR-UPDATE message lock, feedback row, reactivate/resolve lifecycle, and outbox-in-transaction (INV-4/7) are unchanged.
2. **Delivery per conversation stream.** `previous` and `target` share one access root but can anchor in different streams (root vs thread), so the `conversation:updated` outbox events resolve `resolveConversationDelivery` per touched conversation's stream (memoized per stream), mirroring the boundary extractor's cross-stream persist — the old single resolution assumed both lived in the message's stream.
3. **Row action + picker.** `MessageActionContext` gains `onMoveToSubtopic` and the registry a `move-to-subtopic` entry ("Move to sub-topic…", `FolderInput`), rendered by the shared ⋯ menu and the touch long-press drawer. Board card and conversation panel wire it through the new `useMoveToSubtopic` hook (`components/board/use-move-to-subtopic.tsx`): targets are the main topic (when the row is in a branch) plus each non-pending branch, current conversation excluded; the handler is `undefined` — action hidden — when a row has nowhere to go, the same field-one-side-sets gate as `onNewSubtopic`. Selecting fires the existing `reassignMessage` endpoint through `useReassignConversationMessage` and closes — no confirm step (the move is reversible; already-primary is a server-side no-op); failure reports via `toast.error`.
4. **Live re-file on the source card** (found in live verify, see Design evolution): `mergeBoardConversation` now reconciles the cached `recentMessages` projection against the incoming membership — a message that left `messageIds` leaves the preview — and returns `false` (the caller refetches the board head) when the *opening* itself moved away, since its replacement's body isn't in the event. Removal only: a message re-filed *in* has no body in the aggregate; its row fills from the rail or the refetch.

### Key design decisions

**1. Reuse the assigner's rule, not a parallel one.** The correction path and the authoring path must accept the same shapes or they drift (the pre-existing guard was exactly that drift). Exporting `effectiveRootId` keeps one copy; the error code is shared so clients treat both rejections identically.

**2. Picker targets = the card's own graph, not a search.** The valid targets are structurally known (the conversation + its non-pending branches, from `branchesByForkMessageId` both surfaces already derive); a free search would offer cross-root targets the server rejects. Pending branches are excluded as both source and target — their conversation id is a draft-panel id that doesn't exist server-side.

**3. Membership-aware preview merge instead of a board refetch per move.** The alternative — invalidate the board query on `conversation:message_reassigned` — refetches the whole head for a one-row change and still races the projection path. Filtering `recentMessages` in the merge is exact, local, and keeps the no-refetch live board intact. The opening-moved case is the one shape the merge can't patch (no replacement body), so it degrades to the existing `!merged → refetch` path while keeping the row rendered (no vanish-and-return motion).

### Design evolution (self-review)

The live verify caught the projection-path staleness fixed in step 4 above (the DB moved, the source card kept rendering the row until reload — `mergeBoardConversation` never reconciled `recentMessages`).

Pre-PR `/code-review` (4 sonnet reviewers: spec/design, correctness/data-flow, UX, mobile) found 3 issues, all fixed in commit 2:

1. **Depth-2 sub-topics missing from the picker** (correctness, 82): `[...values()].flat()` never descended into `BranchConversationView.children`, so a grandchild branch — a reachable, action-bearing row — could never be *offered* as a target the server would accept. Fixed with a recursive walk; test covers a nested target.
2. **Re-file waited for the socket echo** (UX, 85): `useReassignConversationMessage.onSuccess` patched only the timeline-overlay list cache; the board surfaces render from the board store, which only the socket `conversation:updated` fed — on a slow socket, nothing on screen changed after the pick. The mutation response carries both updated aggregates, so `onSuccess` now applies them via `mergeBoardConversation` (the echo lands as an idempotent overwrite); this also benefits the pre-existing overlay path.
3. **No in-flight guard** (UX, 82): re-opening the picker mid-flight could enqueue a duplicate correction (the overlay's `ConversationPickerDrawer` guards this with per-message pending ids). Opens and picks are now ignored while `reassign.isPending`; test covers a never-settling move.

Spec/design and mobile lenses were otherwise clean (INV-20 lock ordering, INV-62 root-derived access sufficiency, drawer→dialog hand-off matching the shipped delete/label pattern all explicitly checked).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/board/use-move-to-subtopic.tsx` | Shared re-file gesture: per-row handler gating + target picker dialog + mutation |
| `apps/frontend/src/components/board/use-move-to-subtopic.test.tsx` | Hook tests: action gating, target sets both directions, reassign call |
| `apps/backend/src/features/conversations/service.reassign.test.ts` | `reassignMessage` tests: thread-target move, undo direction, cross-root rejection writes nothing, same-stream regression, already-primary no-op |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/conversations/service.ts` | One-root guard, per-stream delivery resolution, docstring |
| `apps/backend/src/features/conversations/conversation-assigner.ts` | `effectiveRootId` exported (shared with the reassign path) |
| `apps/frontend/src/components/timeline/message-actions.ts` | `onMoveToSubtopic` context field + `move-to-subtopic` registry entry |
| `apps/frontend/src/components/message/message-item.tsx` | Prop plumbed into the action context |
| `apps/frontend/src/components/board/board-card.tsx` | Hook wired; handler passed for primary + branch rows (pending branches excluded); dialog mounted |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Same wiring as the card |
| `apps/frontend/src/stores/board-store.ts` | `mergeBoardConversation` reconciles `recentMessages` to membership; opening-moved → report unhandled (refetch) |
| `apps/frontend/src/stores/board-store.test.ts` | Member-aware preview semantics + re-file removal + opening-moved cases |
| `apps/frontend/src/hooks/use-conversations.ts` | Reassign `onSuccess` applies both returned aggregates to the board store (re-file on HTTP response) |

## Out of scope (deliberate)

- **Batch reassign (`reassignMessagesToConversation`) stays same-stream** — the timeline split UI it backs is a same-stream gesture; widening it is a separate decision.
- **No body back-fill for the target's preview** — the aggregate event carries no message bodies; the target card fills from its rail or the next refetch (the source-side removal is the correctness-critical half).
- **Timeline rows get no "Move to sub-topic"** — the timeline's membership correction remains the conversation overlay; this action is scoped to the conversation surfaces where branches are visible.

## Test plan

- [x] Backend `bun test src/features/conversations/` — 127 pass (5 new in `service.reassign.test.ts`)
- [x] DB-backed integration `tests/integration/conversation-reassign.test.ts` — 10 pass (commit 3, after the first CI run caught the stale `MESSAGE_NOT_IN_CONVERSATION_STREAM` expectation: cross-root rejection updated to `CONVERSATION_NOT_IN_ROOT`, plus a new positive case — root message into a thread-anchored conversation, membership moved, message row unmoved, per-stream `conversation:updated` payloads asserted)
- [x] Frontend affected suites (`board-store`, `use-move-to-subtopic` incl. nested-target/response-merge/in-flight-guard, `board-card*` ×5, `conversation-panel`, `message-actions`, `use-conversations`, `pages/board`, `board-inline-composer`) — all green across runs (161 + 44 + 129 after the review fixes)
- [x] Pre-PR `/code-review`, 4 sonnet reviewers — 3 findings, all fixed pre-PR (see Design evolution); spec/design + mobile lenses clean
- [x] Monorepo typecheck + full pre-commit gate — clean; rebased onto `ce85bad8` (over #1259's board-store changes), post-rebase suites re-run green
- [x] **Live verify** (dev:test + Playwright, desktop 1280×900): row ⋯ menu → "Move to sub-topic…" → picker → target: DB membership moved (source lost the id, target gained it), `conversation_feedback` row recorded, child panel renders the moved message with branch provenance, **the source card drops the row live** (no reload) — re-run twice after the merge fix, stable. Cross-root reassign via direct API returns 400 `CONVERSATION_NOT_IN_ROOT`.
- [ ] Mobile long-press drawer path not driven live (Playwright long-press emulation is unreliable); the drawer renders the same shared registry the ⋯ menu does, and the action's dialog is registry-standard.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
