### PR TITLE
feat(prefs): configurable unread open position — open at marker or latest

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -10,6 +10,7 @@ import {
   BOARD_CARD_COLLAPSE_TO_HEIGHT_MIN,
   VOICE_STEERING_WORDS_MAX,
   VOICE_STEERING_WORD_MAX_LENGTH,
+  DEFAULT_USER_PREFERENCES,
 } from "@threa/types"
 import { updatePreferencesSchema } from "./handlers"
 
@@ -49,6 +50,22 @@ describe("updatePreferencesSchema boardDefaultLens", () => {
 
   it("treats the field as optional", () => {
     expect(updatePreferencesSchema.parse({}).boardDefaultLens).toBeUndefined()
+  })
+})
+
+describe("updatePreferencesSchema unreadOpenPosition", () => {
+  it("accepts both positions", () => {
+    expect(updatePreferencesSchema.parse({ unreadOpenPosition: "latest" }).unreadOpenPosition).toBe("latest")
+    expect(updatePreferencesSchema.parse({ unreadOpenPosition: "marker" }).unreadOpenPosition).toBe("marker")
+  })
+
+  it("rejects an unknown position", () => {
+    expect(updatePreferencesSchema.safeParse({ unreadOpenPosition: "top" }).success).toBe(false)
+  })
+
+  it("treats the field as optional and defaults to latest", () => {
+    expect(updatePreferencesSchema.parse({}).unreadOpenPosition).toBeUndefined()
+    expect(DEFAULT_USER_PREFERENCES.unreadOpenPosition).toBe("latest")
   })
 })
 

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -12,6 +12,7 @@ import {
   MESSAGE_SEND_MODE_OPTIONS,
   LINK_PREVIEW_DEFAULT_OPTIONS,
   LABEL_REMOVE_ON_MOVE_OPTIONS,
+  UNREAD_OPEN_POSITION_OPTIONS,
   VOICE_POLISH_LEVEL_OPTIONS,
   VOICE_STEERING_WORDS_MAX,
   VOICE_STEERING_WORD_MAX_LENGTH,
@@ -48,6 +49,7 @@ const updatePreferencesSchema = z.object({
   messageSendMode: z.enum(MESSAGE_SEND_MODE_OPTIONS).optional(),
   linkPreviewDefault: z.enum(LINK_PREVIEW_DEFAULT_OPTIONS).optional(),
   labelRemoveOnMove: z.enum(LABEL_REMOVE_ON_MOVE_OPTIONS).optional(),
+  unreadOpenPosition: z.enum(UNREAD_OPEN_POSITION_OPTIONS).optional(),
   scratchpadCustomPrompt: z.string().max(8000).nullable().optional(),
   codeBlockCollapseThreshold: z
     .number()

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -70,6 +70,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "messageSendMode",
     "linkPreviewDefault",
     "labelRemoveOnMove",
+    "unreadOpenPosition",
     "scratchpadCustomPrompt",
     "codeBlockCollapseThreshold",
     "blockquoteCollapseThreshold",

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -9,6 +9,7 @@ import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
   THEME_OPTIONS,
   MESSAGE_DISPLAY_OPTIONS,
+  UNREAD_OPEN_POSITION_OPTIONS,
   LABEL_REMOVE_ON_MOVE_OPTIONS,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MIN,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MAX,
@@ -32,6 +33,7 @@ import {
   DEFAULT_BOARD_LENS,
   type Theme,
   type MessageDisplay,
+  type UnreadOpenPosition,
   type LabelRemoveOnMove,
   type BoardLens,
 } from "@threa/types"
@@ -52,6 +54,16 @@ const MESSAGE_DISPLAY_DESCRIPTIONS: Record<MessageDisplay, string> = {
   comfortable: "More spacing between messages",
 }
 
+const UNREAD_OPEN_LABELS: Record<UnreadOpenPosition, string> = {
+  latest: "At the latest message",
+  marker: "At the first unread",
+}
+
+const UNREAD_OPEN_DESCRIPTIONS: Record<UnreadOpenPosition, string> = {
+  latest: "Land at the bottom; a “N new messages” button jumps up to where you left off",
+  marker: "Land where you left off; a “Jump to latest” button gets you back to the bottom",
+}
+
 const LABEL_REMOVE_LABELS: Record<LabelRemoveOnMove, string> = {
   ask: "Ask each time",
   always: "Remove the old label",
@@ -70,6 +82,7 @@ export function AppearanceSettings() {
   const theme = preferences?.theme ?? "system"
   const messageDisplay = preferences?.messageDisplay ?? "comfortable"
   const labelRemoveOnMove = preferences?.labelRemoveOnMove ?? "ask"
+  const unreadOpenPosition = preferences?.unreadOpenPosition ?? "latest"
   const codeBlockThreshold = preferences?.codeBlockCollapseThreshold ?? DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD
   const blockquoteThreshold = preferences?.blockquoteCollapseThreshold ?? DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD
   const messageCollapseEnabled = preferences?.messageCollapseEnabled ?? false
@@ -256,6 +269,32 @@ export function AppearanceSettings() {
                   {MESSAGE_DISPLAY_LABELS[option]}
                 </Label>
                 <p className="text-sm text-muted-foreground">{MESSAGE_DISPLAY_DESCRIPTIONS[option]}</p>
+              </div>
+            </div>
+          ))}
+        </RadioGroup>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <div>
+          <h3 className="text-sm font-medium">Opening unread streams</h3>
+          <p className="text-sm text-muted-foreground">Where a stream opens when it has unread messages</p>
+        </div>
+        <RadioGroup
+          value={unreadOpenPosition}
+          onValueChange={(value) => updatePreference("unreadOpenPosition", value as UnreadOpenPosition)}
+          className="space-y-3"
+        >
+          {UNREAD_OPEN_POSITION_OPTIONS.map((option) => (
+            <div key={option} className="flex items-start space-x-3">
+              <RadioGroupItem value={option} id={`unread-open-${option}`} className="mt-1" />
+              <div className="grid gap-1">
+                <Label htmlFor={`unread-open-${option}`} className="cursor-pointer">
+                  {UNREAD_OPEN_LABELS[option]}
+                </Label>
+                <p className="text-sm text-muted-foreground">{UNREAD_OPEN_DESCRIPTIONS[option]}</p>
               </div>
             </div>
           ))}

--- a/apps/frontend/src/components/timeline/stream-content.test.ts
+++ b/apps/frontend/src/components/timeline/stream-content.test.ts
@@ -10,6 +10,7 @@ import {
   shouldShowOlderSkeletons,
   resolveDateJumpAnchor,
   remapSuppressedWatermark,
+  resolveUnreadMarkerOpen,
 } from "./stream-content"
 import { localStartOfDayMs } from "@/lib/dates"
 import type { StreamEvent } from "@threa/types"
@@ -506,5 +507,58 @@ describe("remapSuppressedWatermark", () => {
   it("passes null/undefined (nothing read / still hydrating) through unchanged", () => {
     expect(remapSuppressedWatermark(null, events, displayEvents)).toBeNull()
     expect(remapSuppressedWatermark(undefined, events, displayEvents)).toBeUndefined()
+  })
+})
+
+describe("resolveUnreadMarkerOpen", () => {
+  const base = {
+    unreadOpenPosition: "marker" as const,
+    alreadyDecided: false,
+    isLoading: false,
+    isSettling: false,
+    readStateResolved: true,
+    isJumpMode: false,
+    hasDeepLink: false,
+    userInteractedAt: 0,
+    dividerEventId: "event_5" as string | undefined,
+  }
+
+  it("scrolls to the marker once loading, settle, and read state have all resolved", () => {
+    expect(resolveUnreadMarkerOpen(base)).toBe("scroll")
+  })
+
+  it("waits (without consuming the decision) while the window is loading, the cold-load settle is masking, or the read position is unresolved", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, isLoading: true })).toBe("wait")
+    expect(resolveUnreadMarkerOpen({ ...base, isSettling: true })).toBe("wait")
+    expect(resolveUnreadMarkerOpen({ ...base, readStateResolved: false })).toBe("wait")
+  })
+
+  it("skips in latest mode — the default open-at-bottom behaviour is untouched", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, unreadOpenPosition: "latest" })).toBe("skip")
+  })
+
+  it("waits while the preference itself has not hydrated (null), so a marker user's cold boot still lands right", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, unreadOpenPosition: null })).toBe("wait")
+  })
+
+  it("skips when there is nothing unread (no divider latched)", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, dividerEventId: undefined })).toBe("skip")
+  })
+
+  it("skips when a deep-link or jump owns the scroll position", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, hasDeepLink: true })).toBe("skip")
+    expect(resolveUnreadMarkerOpen({ ...base, isJumpMode: true })).toBe("skip")
+  })
+
+  it("skips once the user has scrolled — a late-resolving divider must not yank a position they chose", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, userInteractedAt: 123.4 })).toBe("skip")
+  })
+
+  it("decides at most once per stream open — a live message latching a new divider later must not re-scroll", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, alreadyDecided: true })).toBe("skip")
+  })
+
+  it("consumes the decision as skip (not wait) for a deep-link even while still loading — a deep-linked stream never marker-scrolls", () => {
+    expect(resolveUnreadMarkerOpen({ ...base, hasDeepLink: true, isLoading: true })).toBe("skip")
   })
 })

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -26,7 +26,7 @@ import {
   streamKeys,
   workspaceKeys,
 } from "@/hooks"
-import { useSocket, useCoordinatedLoading } from "@/contexts"
+import { useSocket, useCoordinatedLoading, usePreferencesOptional } from "@/contexts"
 import { useMessageService } from "@/contexts"
 import { useStreamEvents } from "@/stores/stream-store"
 import { useWorkspaceStreams, useWorkspaceStreamMemberships } from "@/stores/workspace-store"
@@ -55,6 +55,7 @@ import {
   type StreamBootstrap,
   type ConversationWithStaleness,
   type DelegationStatusChangedEventPayload,
+  type UnreadOpenPosition,
 } from "@threa/types"
 import {
   EventList,
@@ -411,6 +412,45 @@ export function resolveDateJumpAnchor(args: {
     sawEarlierMessage = true
   }
   return null
+}
+
+/**
+ * Decide the initial scroll for a stream opened under the "marker"
+ * unread-open-position preference (Discord-style: land on the first unread).
+ *
+ * Returns:
+ *  - "wait"   — inputs still resolving (window loading, cold-load settle
+ *               masking, read position or the preference itself unhydrated);
+ *               do NOT consume the once-per-stream decision yet.
+ *  - "skip"   — decision consumed, open at the bottom as usual ("latest" mode,
+ *               nothing unread, a deep-link/jump owns the scroll, or the user
+ *               already scrolled).
+ *  - "scroll" — decision consumed, scroll to the unread divider.
+ *
+ * A deep-link or jump consumes the decision even mid-load: a stream entered
+ * via `?m=` must never marker-scroll for that view, including after the param
+ * auto-clears (the PR #1099 yank pattern). A user gesture consumes it too — a
+ * late-resolving divider must not move a position the user chose.
+ */
+export function resolveUnreadMarkerOpen(args: {
+  unreadOpenPosition: UnreadOpenPosition | null
+  alreadyDecided: boolean
+  isLoading: boolean
+  isSettling: boolean
+  readStateResolved: boolean
+  isJumpMode: boolean
+  hasDeepLink: boolean
+  userInteractedAt: number
+  dividerEventId: string | undefined
+}): "wait" | "skip" | "scroll" {
+  if (args.alreadyDecided) return "skip"
+  if (args.hasDeepLink || args.isJumpMode) return "skip"
+  if (args.userInteractedAt > 0) return "skip"
+  if (args.unreadOpenPosition === null) return "wait"
+  if (args.unreadOpenPosition !== "marker") return "skip"
+  if (args.isLoading || args.isSettling || !args.readStateResolved) return "wait"
+  if (!args.dividerEventId) return "skip"
+  return "scroll"
 }
 
 interface StreamContentProps {
@@ -1832,7 +1872,10 @@ export function StreamContent({
     streamId,
     isLoading,
     highlightMessageId,
-    // Never auto-scroll to the unread line — opening lands at the live bottom.
+    // The hook never drives the scroll itself. The "marker" open-position
+    // preference is handled by the resolveUnreadMarkerOpen effect below, which
+    // scrolls via the virtua-aware scrollToFirstUnread instead of the hook's
+    // querySelector path (off-screen rows aren't in the DOM when virtualized).
     scrollToUnread: false,
     // `lastReadEventId` is `string | null` once resolved; it is only `undefined`
     // while the read sources (stream row / membership) are still hydrating. Gate
@@ -2006,6 +2049,62 @@ export function StreamContent({
         ?.scrollIntoView({ block: "start" })
     }
   }, [dividerEventId, useVirtualized, visibleItems, listRef, disableAutoScroll, scrollContainerRef])
+
+  // "Open at the unread marker" (unreadOpenPosition: "marker"). One decision
+  // per stream open, made by resolveUnreadMarkerOpen once the window has
+  // loaded, the cold-load settle has revealed, and the read position is known.
+  // A layout effect so the scroll lands pre-paint in the reveal commit — the
+  // viewer's first painted frame is already at the marker, not a bottom flash.
+  // "latest" mode (the default) consumes the decision without scrolling, so
+  // existing behaviour is untouched.
+  const preferencesCtx = usePreferencesOptional()
+  const unreadOpenPosition = preferencesCtx?.preferences?.unreadOpenPosition ?? null
+  const unreadMarkerOpenRef = useRef<{ streamId: string; decided: boolean }>({ streamId, decided: false })
+  if (unreadMarkerOpenRef.current.streamId !== streamId) {
+    unreadMarkerOpenRef.current = { streamId, decided: false }
+  }
+  useLayoutEffect(() => {
+    const decision = resolveUnreadMarkerOpen({
+      unreadOpenPosition,
+      alreadyDecided: unreadMarkerOpenRef.current.decided,
+      isLoading,
+      isSettling: useVirtualized && virtualIsInitialSettling,
+      // `lastReadEventId` is only undefined while the read sources are still
+      // hydrating (same gate as readStateResolved on useUnreadDivider above).
+      readStateResolved: lastReadEventId !== undefined,
+      isJumpMode,
+      // The per-stream deep-link latch, not the transient ?m= param — a stream
+      // entered via deep-link must never marker-scroll, even after ?m= clears.
+      hasDeepLink: skipInitialScroll,
+      userInteractedAt: userInteractedAtRef.current,
+      dividerEventId,
+    })
+    if (decision === "wait") return
+    unreadMarkerOpenRef.current.decided = true
+    if (decision !== "scroll") return
+    // Prefer scrollToMessage: its refine loop converges over rows virtua hasn't
+    // measured yet (a one-shot scrollToIndex on a fresh window lands pages off
+    // target). Falls back to the one-shot path for non-message divider rows and
+    // the plain thread scroller, where all rows are real DOM already.
+    const dividerEvent = events.find((e) => e.id === dividerEventId)
+    const messageId = (dividerEvent?.payload as { messageId?: string } | null)?.messageId
+    if (!useVirtualized || !messageId || !scrollToMessage(messageId)) {
+      scrollToFirstUnread()
+    }
+  }, [
+    unreadOpenPosition,
+    streamId,
+    isLoading,
+    useVirtualized,
+    virtualIsInitialSettling,
+    lastReadEventId,
+    isJumpMode,
+    skipInitialScroll,
+    dividerEventId,
+    events,
+    scrollToMessage,
+    scrollToFirstUnread,
+  ])
 
   const editLastMessageCtxWithScroll = useMemo(
     () => ({ ...editLastMessageCtx, scrollToMessage }),

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -78,6 +78,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
+      unreadOpenPosition: "latest",
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -87,6 +87,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       sidebarCollapsed: false,
       linkPreviewDefault: "open",
       labelRemoveOnMove: "ask",
+      unreadOpenPosition: "latest",
       scratchpadCustomPrompt: null,
       codeBlockCollapseThreshold: 10,
       blockquoteCollapseThreshold: 6,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -729,6 +729,10 @@ export {
   LABEL_REMOVE_ON_MOVE_OPTIONS,
   type LabelRemoveOnMove,
   LabelRemoveOnMoveOptions,
+  // Unread open position
+  UNREAD_OPEN_POSITION_OPTIONS,
+  type UnreadOpenPosition,
+  UnreadOpenPositions,
   // Code block collapse threshold
   CODE_BLOCK_COLLAPSE_THRESHOLD_MIN,
   CODE_BLOCK_COLLAPSE_THRESHOLD_MAX,

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -85,6 +85,18 @@ export const MessageSendModes = {
   CMD_ENTER: "cmdEnter",
 } as const satisfies Record<string, MessageSendMode>
 
+// Where a stream opens when there are unread messages. "latest" (default)
+// lands at the newest message with an "N new messages" affordance pointing up
+// at the unread marker; "marker" (Discord-style) lands on the first unread
+// with a jump-to-latest affordance pointing down.
+export const UNREAD_OPEN_POSITION_OPTIONS = ["latest", "marker"] as const
+export type UnreadOpenPosition = (typeof UNREAD_OPEN_POSITION_OPTIONS)[number]
+
+export const UnreadOpenPositions = {
+  LATEST: "latest",
+  MARKER: "marker",
+} as const satisfies Record<string, UnreadOpenPosition>
+
 // Label-remove-on-move behavior — when a labeled stream is dragged out of its
 // label section in the sidebar (into a custom section or a different label),
 // whether to also strip the label it was sitting under. "ask" prompts each time
@@ -269,6 +281,11 @@ export interface UserPreferences {
    * label. "ask" prompts each time; "always"/"never" act without prompting.
    */
   labelRemoveOnMove: LabelRemoveOnMove
+  /**
+   * Where a stream with unread messages opens: at the newest message
+   * ("latest", the default) or at the first unread ("marker", Discord-style).
+   */
+  unreadOpenPosition: UnreadOpenPosition
   scratchpadCustomPrompt: string | null
   codeBlockCollapseThreshold: number
   blockquoteCollapseThreshold: number
@@ -353,6 +370,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   messageSendMode: "enter",
   linkPreviewDefault: "open",
   labelRemoveOnMove: "ask",
+  unreadOpenPosition: "latest",
   scratchpadCustomPrompt: null,
   codeBlockCollapseThreshold: DEFAULT_CODE_BLOCK_COLLAPSE_THRESHOLD,
   blockquoteCollapseThreshold: DEFAULT_BLOCKQUOTE_COLLAPSE_THRESHOLD,
@@ -390,6 +408,7 @@ export interface UpdateUserPreferencesInput {
   messageSendMode?: MessageSendMode
   linkPreviewDefault?: LinkPreviewDefault
   labelRemoveOnMove?: LabelRemoveOnMove
+  unreadOpenPosition?: UnreadOpenPosition
   scratchpadCustomPrompt?: string | null
   codeBlockCollapseThreshold?: number
   blockquoteCollapseThreshold?: number


### PR DESCRIPTION
## Problem

A stream with unread messages always opens at the latest message, with an "N new messages ↑" affordance to scroll up to the unread marker. Discord does the opposite — open at the marker, jump down to latest. Kris has flip-flopped on which is right (dogfooding with Pierre, 2026-07-09) and ruled it should be a user preference:

> "Jag valde tvärtom på det — öppnar på latest men med N unreads istället. Velade fram och tillbaks där, borde göra det configurable!"

## Solution

A per-user preference `unreadOpenPosition: "latest" | "marker"`, default `"latest"` — nothing changes unless a user opts in. Marker mode reuses the scroll machinery that already exists: the unread divider from `useUnreadDivider` supplies the target, and the deep-link `scrollToMessage` refine loop lands on it.

### How it works

1. **Preference plumbing.** `UNREAD_OPEN_POSITION_OPTIONS` in `packages/types/src/preferences.ts` drives the Zod enum in `user-preferences/handlers.ts` (INV-55/31) and the `simpleKeys` entry in `service.ts`. The default is never stored as an override (`matchesDefault`), and the backend returns the enum — labels live in the frontend (INV-46).
2. **The open decision.** `resolveUnreadMarkerOpen` (exported pure helper in `stream-content.tsx`, tested alongside `shouldHoldForDeepLink` et al.) returns `"wait" | "skip" | "scroll"`. A layout effect evaluates it each commit and consumes a once-per-stream latch on the first non-wait result: it *waits* while the window loads, the cold-load settle masks, the read position hydrates (`lastReadEventId === undefined`), or the preference itself hasn't hydrated from IDB (`null`); it *skips* — permanently for that open — in latest mode, when nothing is unread, when a deep-link/jump owns the scroll, or after any user gesture.
3. **The scroll itself.** Marker mode resolves the divider event's `messageId` and calls `scrollToMessage` — the existing convergent refine loop (60ms ticks, 1200ms bound, user-gesture abort) that centers a row virtua hasn't measured yet. Falls back to the one-shot `scrollToFirstUnread` for non-message divider rows and the plain (thread) scroller. `useUnreadDivider`'s own `scrollToUnread` stays `false`: its `querySelector` path can't see rows virtua hasn't rendered.
4. **Affordances need no new code.** Landing at the marker leaves the viewer >600px above the tail, so the existing "Jump to latest" pill shows; latest mode keeps the existing "N new messages ↑" pill.
5. **Settings UI.** A RadioGroup section under Appearance (Shadcn primitives, INV-14), between Message Display and Code Blocks. No success toast — the control shows its own state (INV-63).

### Key design decisions

**1. Drive the scroll from stream-content, not the divider hook.** The handover suggested wiring the pref into `useUnreadDivider`'s `scrollToUnread` flag, but that path scrolls via `document.querySelector` + `scrollIntoView` — a no-op for rows the virtualized list hasn't rendered. The effect in `stream-content.tsx` instead reuses the deep-link machinery that already solves this.

**2. One decision per stream open, vetoed by anything that owns the scroll.** The read-pointer flow has burned four past PRs (#1037, #1254, #1096, #1099), all variants of a late-firing scroll yanking a position the user or a deep-link chose. So the decision is a per-stream latch: a deep-link (`skipInitialScroll`, the per-stream latch, not the transient `?m=` param), jump mode, or a user gesture consumes it as "skip" even mid-load — a divider resolving late can never move the viewport afterwards.

**3. Marker landing reads from the read boundary, centered.** `scrollToMessage` centers the first unread, so the viewer gets the last read messages as context above the red "New" line — verified live (screenshot in test plan flow): divider mid-upper viewport, read run above, unread run below.

**4. Stale-pref window accepted.** If the pref changes on another device, a client whose IDB still holds the old value opens streams under it until sync lands, then self-corrects. Waiting for a server round-trip on every stream open to avoid this would be worse.

### Design evolution (self-review / live verify)

The first version scrolled with a one-shot `listRef.scrollToIndex(idx, { align: "start" })`. On a fresh window with tall multi-line rows, virtua's size estimates put the landing ~14 messages below the divider (caught in the Playwright live verify, not by unit tests). Replaced with the `scrollToMessage` refine loop, which converges as rows measure.

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/preferences.ts` | `UNREAD_OPEN_POSITION_OPTIONS` / `UnreadOpenPosition` / `UnreadOpenPositions`; field on `UserPreferences`, `DEFAULT_USER_PREFERENCES` (`"latest"`), `UpdateUserPreferencesInput` |
| `packages/types/src/index.ts` | Barrel exports |
| `apps/backend/src/features/user-preferences/handlers.ts` | `unreadOpenPosition: z.enum(...)` on `updatePreferencesSchema` |
| `apps/backend/src/features/user-preferences/service.ts` | `simpleKeys` entry |
| `apps/backend/src/features/user-preferences/handlers.test.ts` | Schema round-trip: both values accepted, unknown rejected, optional, default `"latest"` |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `resolveUnreadMarkerOpen` helper + the once-per-stream layout effect wiring pref → `scrollToMessage`/`scrollToFirstUnread` |
| `apps/frontend/src/components/timeline/stream-content.test.ts` | 9 tests over the decision helper (wait/skip/scroll matrix incl. deep-link, gesture, null-pref hydration) |
| `apps/frontend/src/components/settings/appearance-settings.tsx` | "Opening unread streams" RadioGroup |
| `apps/frontend/src/hooks/use-streams.test.tsx`, `use-unread-counts.test.tsx` | Fixture gains the new required field |

## Out of scope (deliberate)

- **First unread outside the loaded window** — if the unread backlog exceeds the bootstrap window, `firstUnreadEventId` can't resolve and marker mode falls back to opening at latest (same limitation the existing "N new messages" jump has). A load-window-around-the-marker is a follow-up if it bites.
- No mobile-specific treatment; the affordances are the existing ones.

## Test plan

- [x] Backend `bun test src/features/user-preferences` — 17 pass
- [x] Backend `bun run test:e2e` — 321 pass, 0 fail
- [x] Frontend `stream-content.test.ts` + `use-unread-divider.test.ts` — 68 pass
- [x] Full frontend vitest — 339/355 files pass; the 16 failing files (136 tests) verified identical on a stashed baseline (known Node-25 localStorage reds, none in touched surface)
- [x] Monorepo typecheck clean (all 14 workspaces, incl. test tsconfigs)
- [x] Live Playwright verify against `dev:test` (two users, 30 read + 45 tall unread): **marker** — red "New" divider + msg 31 in viewport, latest message off-screen, "Jump to latest" shown; **latest** — lands at bottom, "38 new messages" shown. Both PASS; also confirmed default-pref landing unchanged vs a stashed baseline (identical bounding boxes)
- [ ] Browser e2e suite (`tests/browser`) not run — no spec covers the open position; the dedicated live verify above exercises the real flow instead

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229044&installation_id=129946197&pr_number=1265&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1265&signature=48b94406a4a5e86c826919ae11175aad0468595d7b7c47c1f6a7f47b94d7a98d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->