### PR TITLE
fix(bot-runtimes): unarchive reattaches a stream's live runtime session — recoverable link status, bot:session_restored, channel grace window

### DIFF
--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.test.ts
@@ -108,6 +108,32 @@ describe("BotInvocationOutboxHandler E2E delivery verdict", () => {
   })
 })
 
+describe("BotInvocationOutboxHandler stream lifecycle", () => {
+  it("stream:archived ends the stream's runtime session links", async () => {
+    const endSpy = spyOn(BotRuntimeService.prototype, "endSessionsForArchivedStream").mockResolvedValue(1)
+    const handler = new BotInvocationOutboxHandler({} as Pool)
+
+    await (handler as unknown as { processStreamArchived(p: unknown): Promise<void> }).processStreamArchived({
+      workspaceId: "ws_1",
+      streamId: "stream_root",
+    })
+
+    expect(endSpy).toHaveBeenCalledWith({ workspaceId: "ws_1", rootStreamId: "stream_root" })
+  })
+
+  it("stream:unarchived restores the links the archive ended", async () => {
+    const restoreSpy = spyOn(BotRuntimeService.prototype, "restoreSessionsForUnarchivedStream").mockResolvedValue(1)
+    const handler = new BotInvocationOutboxHandler({} as Pool)
+
+    await (handler as unknown as { processStreamUnarchived(p: unknown): Promise<void> }).processStreamUnarchived({
+      workspaceId: "ws_1",
+      streamId: "stream_root",
+    })
+
+    expect(restoreSpy).toHaveBeenCalledWith({ workspaceId: "ws_1", rootStreamId: "stream_root" })
+  })
+})
+
 describe("BotInvocationOutboxHandler mention extraction (INV-54/INV-58)", () => {
   const channelStream = {
     id: "stream_1",

--- a/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
+++ b/apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts
@@ -8,6 +8,7 @@ import {
   parseMessagePayload,
   type OutboxHandler,
   type StreamArchivedOutboxPayload,
+  type StreamUnarchivedOutboxPayload,
 } from "../../lib/outbox"
 import { logger } from "../../lib/logger"
 import { StreamRepository } from "../streams"
@@ -102,6 +103,8 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
           await this.processMessageCreated(event.payload)
         } else if (event.eventType === "stream:archived") {
           await this.processStreamArchived(event.payload as StreamArchivedOutboxPayload)
+        } else if (event.eventType === "stream:unarchived") {
+          await this.processStreamUnarchived(event.payload as StreamUnarchivedOutboxPayload)
         }
         seen.push(event.id)
       }
@@ -117,6 +120,20 @@ export class BotInvocationOutboxHandler implements OutboxHandler {
   private async processStreamArchived(payload: StreamArchivedOutboxPayload): Promise<void> {
     if (!payload?.workspaceId || !payload?.streamId) return
     await this.service.endSessionsForArchivedStream({
+      workspaceId: payload.workspaceId,
+      rootStreamId: payload.streamId,
+    })
+  }
+
+  /**
+   * The unarchive counterpart: revive the links the archive ended and notify
+   * each linked runtime so a live agent reattaches without a restart. Same
+   * idempotency shape as the archive branch — already-active links return no
+   * rows, so a retried batch re-notifies nothing.
+   */
+  private async processStreamUnarchived(payload: StreamUnarchivedOutboxPayload): Promise<void> {
+    if (!payload?.workspaceId || !payload?.streamId) return
+    await this.service.restoreSessionsForUnarchivedStream({
       workspaceId: payload.workspaceId,
       rootStreamId: payload.streamId,
     })

--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -308,11 +308,15 @@ describe("BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession", (
     })
 
     // CTE picks one row race-safely (INV-20), newest first, and the stream
-    // guard keeps a still-archived scratchpad's link dead.
+    // guard keeps a still-archived scratchpad's link dead. The stream row is
+    // share-locked in the same select — an unlocked EXISTS would be TOCTOU
+    // against a concurrent re-archive.
     expect(captured.text).toContain("SET status = 'active'")
     expect(captured.text).toContain("status = 'archived'")
+    expect(captured.text).toContain("JOIN streams s")
     expect(captured.text).toContain("archived_at IS NULL")
-    expect(captured.text).toContain("FOR UPDATE")
+    expect(captured.text).toContain("FOR UPDATE OF l SKIP LOCKED")
+    expect(captured.text).toContain("FOR SHARE OF s")
     expect(captured.text).toContain("LIMIT 1")
     expect(captured.values).toEqual(
       expect.arrayContaining(["ws_1", "bot_alice", "claude-code-channel", "inst_99", "sess_1"])

--- a/apps/backend/src/features/bot-runtimes/repository.test.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.test.ts
@@ -247,6 +247,103 @@ describe("BotRuntimeSessionLinkRepository.rebindInstance", () => {
   })
 })
 
+describe("BotRuntimeSessionLinkRepository.archiveActiveByRootStream", () => {
+  afterEach(() => mock.restore())
+
+  it("flips only active links to 'archived' in one set-based UPDATE (INV-20/56)", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeSessionLinkRow({ status: "archived" })])
+
+    const result = await BotRuntimeSessionLinkRepository.archiveActiveByRootStream(db, {
+      workspaceId: "ws_1",
+      rootStreamId: "stream_root",
+    })
+
+    expect(captured.text).toContain("UPDATE bot_runtime_session_links")
+    // Archive-ended, not shutdown-ended: 'archived' is the recoverable state
+    // stream:unarchived revives; plain 'ended' stays dead.
+    expect(captured.text).toContain("SET status = 'archived'")
+    expect(captured.text).toContain("status = 'active'")
+    expect(captured.text).toContain("RETURNING")
+    expect(captured.values).toEqual(expect.arrayContaining(["ws_1", "stream_root"]))
+    expect(result[0]?.status).toBe("archived")
+  })
+})
+
+describe("BotRuntimeSessionLinkRepository.reactivateArchivedByRootStream", () => {
+  afterEach(() => mock.restore())
+
+  it("revives only archive-ended links — shutdown-ended rows stay dead", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeSessionLinkRow({ status: "active" })])
+
+    const result = await BotRuntimeSessionLinkRepository.reactivateArchivedByRootStream(db, {
+      workspaceId: "ws_1",
+      rootStreamId: "stream_root",
+    })
+
+    expect(captured.text).toContain("UPDATE bot_runtime_session_links")
+    expect(captured.text).toContain("SET status = 'active'")
+    expect(captured.text).toContain("status = 'archived'")
+    expect(captured.text).not.toContain("'ended'")
+    expect(captured.text).toContain("RETURNING")
+    expect(captured.values).toEqual(expect.arrayContaining(["ws_1", "stream_root"]))
+    expect(result[0]?.status).toBe("active")
+  })
+})
+
+describe("BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession", () => {
+  afterEach(() => mock.restore())
+
+  it("revives the newest archived link for the runtime session only when its root stream is unarchived", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeSessionLinkRow({ status: "active" })])
+
+    const result = await BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      runtimeKind: "claude-code-channel",
+      instanceId: "inst_99",
+      runtimeSessionId: "sess_1",
+    })
+
+    // CTE picks one row race-safely (INV-20), newest first, and the stream
+    // guard keeps a still-archived scratchpad's link dead.
+    expect(captured.text).toContain("SET status = 'active'")
+    expect(captured.text).toContain("status = 'archived'")
+    expect(captured.text).toContain("archived_at IS NULL")
+    expect(captured.text).toContain("FOR UPDATE")
+    expect(captured.text).toContain("LIMIT 1")
+    expect(captured.values).toEqual(
+      expect.arrayContaining(["ws_1", "bot_alice", "claude-code-channel", "inst_99", "sess_1"])
+    )
+    expect(result?.status).toBe("active")
+  })
+})
+
+describe("BotRuntimeSessionLinkRepository.findArchivedByRuntimeSession", () => {
+  afterEach(() => mock.restore())
+
+  it("selects only archived-status links for the runtime session identity", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeSessionLinkRow({ status: "archived" })])
+
+    const result = await BotRuntimeSessionLinkRepository.findArchivedByRuntimeSession(db, {
+      workspaceId: "ws_1",
+      botId: "bot_alice",
+      runtimeKind: "claude-code-channel",
+      instanceId: "inst_99",
+      runtimeSessionId: "sess_1",
+    })
+
+    expect(captured.text).toContain("status = 'archived'")
+    expect(captured.values).toEqual(
+      expect.arrayContaining(["ws_1", "bot_alice", "claude-code-channel", "inst_99", "sess_1"])
+    )
+    expect(result?.status).toBe("archived")
+  })
+})
+
 describe("BotInvocationRepository.claimOne", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -482,20 +482,105 @@ export const BotRuntimeSessionLinkRepository = {
 
   /**
    * End every active link rooted at a stream (its scratchpad was archived) and
-   * return the ended rows so the caller can notify each runtime. One set-based
+   * return the ended rows so the caller can notify each runtime. Writes the
+   * recoverable 'archived' status — not terminal 'ended' — so a later
+   * stream:unarchived can revive exactly these links. One set-based
    * UPDATE … RETURNING so concurrent archive/consumer retries can't double-end
    * or race a link back to life (INV-20, INV-56).
    */
-  async endActiveByRootStream(
+  async archiveActiveByRootStream(
     db: Querier,
     params: { workspaceId: string; rootStreamId: string }
   ): Promise<BotRuntimeSessionLink[]> {
     const result = await db.query<BotRuntimeSessionLinkRow>(
-      sql`UPDATE bot_runtime_session_links SET status = 'ended', updated_at = NOW()
+      sql`UPDATE bot_runtime_session_links SET status = 'archived', updated_at = NOW()
       WHERE workspace_id = ${params.workspaceId} AND root_stream_id = ${params.rootStreamId} AND status = 'active'
       RETURNING *`
     )
     return result.rows.map(mapSessionLink)
+  },
+
+  /**
+   * Revive every archive-ended link rooted at a stream (its scratchpad was
+   * unarchived). Scoped to status = 'archived' so links a runtime ended by
+   * shutting down normally stay dead (INV-20, INV-56).
+   */
+  async reactivateArchivedByRootStream(
+    db: Querier,
+    params: { workspaceId: string; rootStreamId: string }
+  ): Promise<BotRuntimeSessionLink[]> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`UPDATE bot_runtime_session_links SET status = 'active', last_seen_at = NOW(), updated_at = NOW()
+      WHERE workspace_id = ${params.workspaceId} AND root_stream_id = ${params.rootStreamId} AND status = 'archived'
+      RETURNING *`
+    )
+    return result.rows.map(mapSessionLink)
+  },
+
+  /**
+   * Revive the newest archive-ended link for one runtime session identity —
+   * the session-create reattach path. The stream guard keeps a still-archived
+   * scratchpad's link dead (the caller 409s instead of minting a duplicate
+   * scratchpad), and the locked CTE makes concurrent reattach/unarchive
+   * consumers converge on one winner (INV-20).
+   */
+  async reactivateArchivedByRuntimeSession(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      runtimeKind: BotRuntimeKind
+      instanceId: string
+      runtimeSessionId: string
+    }
+  ): Promise<BotRuntimeSessionLink | null> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(sql`WITH candidate AS (
+        SELECT l.id FROM bot_runtime_session_links l
+        WHERE l.workspace_id = ${params.workspaceId}
+          AND l.bot_id = ${params.botId}
+          AND l.runtime_kind = ${params.runtimeKind}
+          AND l.instance_id = ${params.instanceId}
+          AND l.runtime_session_id = ${params.runtimeSessionId}
+          AND l.status = 'archived'
+          AND EXISTS (
+            SELECT 1 FROM streams s
+            WHERE s.workspace_id = l.workspace_id AND s.id = l.root_stream_id AND s.archived_at IS NULL
+          )
+        ORDER BY l.updated_at DESC
+        FOR UPDATE OF l SKIP LOCKED
+        LIMIT 1
+      )
+      UPDATE bot_runtime_session_links l
+      SET status = 'active', last_seen_at = NOW(), updated_at = NOW()
+      FROM candidate
+      WHERE l.id = candidate.id
+      RETURNING l.*`)
+    return result.rows[0] ? mapSessionLink(result.rows[0]) : null
+  },
+
+  /** Newest archive-ended link for one runtime session identity (regardless of the stream's archive state). */
+  async findArchivedByRuntimeSession(
+    db: Querier,
+    params: {
+      workspaceId: string
+      botId: string
+      runtimeKind: BotRuntimeKind
+      instanceId: string
+      runtimeSessionId: string
+    }
+  ): Promise<BotRuntimeSessionLink | null> {
+    const result = await db.query<BotRuntimeSessionLinkRow>(
+      sql`SELECT * FROM bot_runtime_session_links
+        WHERE workspace_id = ${params.workspaceId}
+          AND bot_id = ${params.botId}
+          AND runtime_kind = ${params.runtimeKind}
+          AND instance_id = ${params.instanceId}
+          AND runtime_session_id = ${params.runtimeSessionId}
+          AND status = 'archived'
+        ORDER BY updated_at DESC
+        LIMIT 1`
+    )
+    return result.rows[0] ? mapSessionLink(result.rows[0]) : null
   },
 
   async findActiveByStream(

--- a/apps/backend/src/features/bot-runtimes/repository.ts
+++ b/apps/backend/src/features/bot-runtimes/repository.ts
@@ -523,6 +523,14 @@ export const BotRuntimeSessionLinkRepository = {
    * scratchpad's link dead (the caller 409s instead of minting a duplicate
    * scratchpad), and the locked CTE makes concurrent reattach/unarchive
    * consumers converge on one winner (INV-20).
+   *
+   * The stream row is locked FOR SHARE in the same candidate select — an
+   * unlocked read (EXISTS) would be TOCTOU against a concurrent re-archive:
+   * the re-archive's stream:archived consumer could skip this link (its
+   * 'active' write still uncommitted here) and leave an active link on an
+   * archived stream that nothing ever corrects. With the share lock, a
+   * concurrent archive of the stream waits for this commit, and its consumer
+   * then archives the freshly revived link. Call inside a transaction.
    */
   async reactivateArchivedByRuntimeSession(
     db: Querier,
@@ -536,19 +544,18 @@ export const BotRuntimeSessionLinkRepository = {
   ): Promise<BotRuntimeSessionLink | null> {
     const result = await db.query<BotRuntimeSessionLinkRow>(sql`WITH candidate AS (
         SELECT l.id FROM bot_runtime_session_links l
+        JOIN streams s
+          ON s.workspace_id = l.workspace_id AND s.id = l.root_stream_id AND s.archived_at IS NULL
         WHERE l.workspace_id = ${params.workspaceId}
           AND l.bot_id = ${params.botId}
           AND l.runtime_kind = ${params.runtimeKind}
           AND l.instance_id = ${params.instanceId}
           AND l.runtime_session_id = ${params.runtimeSessionId}
           AND l.status = 'archived'
-          AND EXISTS (
-            SELECT 1 FROM streams s
-            WHERE s.workspace_id = l.workspace_id AND s.id = l.root_stream_id AND s.archived_at IS NULL
-          )
         ORDER BY l.updated_at DESC
-        FOR UPDATE OF l SKIP LOCKED
         LIMIT 1
+        FOR UPDATE OF l SKIP LOCKED
+        FOR SHARE OF s
       )
       UPDATE bot_runtime_session_links l
       SET status = 'active', last_seen_at = NOW(), updated_at = NOW()

--- a/apps/backend/src/features/bot-runtimes/service.test.ts
+++ b/apps/backend/src/features/bot-runtimes/service.test.ts
@@ -3,6 +3,7 @@ import { BotRuntimeService } from "./service"
 import {
   BOT_CLAIM_MAX_ATTEMPTS,
   BotInvocationRepository,
+  BotRuntimeInstanceRepository,
   BotRuntimeSessionLinkRepository,
   StreamActiveActorRepository,
   type BotInvocation,
@@ -601,6 +602,155 @@ describe("BotRuntimeService outbox emission", () => {
       expect(createLinkSpy).not.toHaveBeenCalled()
     })
   })
+  describe("archive/unarchive session-link lifecycle", () => {
+    function makeLink(overrides: Partial<BotRuntimeSessionLink> = {}): BotRuntimeSessionLink {
+      const now = new Date("2026-07-10T12:00:00Z")
+      return {
+        id: "brsl_1",
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        runtimeKind: "claude-code-channel",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+        rootStreamId: "stream_root",
+        activeStreamId: "stream_root",
+        status: "active",
+        linkedBy: "usr_owner",
+        metadata: {},
+        lastSeenAt: now,
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+      }
+    }
+
+    it("endSessionsForArchivedStream marks links archived and emits bot:session_archived per link", async () => {
+      patchWithTransaction()
+      spyOn(BotRuntimeSessionLinkRepository, "archiveActiveByRootStream").mockResolvedValue([
+        makeLink({ status: "archived" }),
+      ])
+      const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const count = await service.endSessionsForArchivedStream({ workspaceId: "ws_1", rootStreamId: "stream_root" })
+
+      expect(count).toBe(1)
+      expect(insertSpy.mock.calls[0]?.[1]).toBe("bot:session_archived")
+      expect(insertSpy.mock.calls[0]?.[2]).toEqual({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+        rootStreamId: "stream_root",
+      })
+    })
+
+    it("restoreSessionsForUnarchivedStream revives archive-ended links and emits bot:session_restored per link", async () => {
+      patchWithTransaction()
+      const reactivateSpy = spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRootStream").mockResolvedValue([
+        makeLink({ status: "active" }),
+      ])
+      const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const count = await service.restoreSessionsForUnarchivedStream({
+        workspaceId: "ws_1",
+        rootStreamId: "stream_root",
+      })
+
+      expect(count).toBe(1)
+      expect(reactivateSpy.mock.calls[0]?.[1]).toEqual({ workspaceId: "ws_1", rootStreamId: "stream_root" })
+      expect(insertSpy.mock.calls[0]?.[1]).toBe("bot:session_restored")
+      expect(insertSpy.mock.calls[0]?.[2]).toEqual({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+        rootStreamId: "stream_root",
+      })
+    })
+
+    it("restoreSessionsForUnarchivedStream emits nothing when no archived links exist (normal-shutdown links stay dead)", async () => {
+      patchWithTransaction()
+      spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRootStream").mockResolvedValue([])
+      const insertSpy = spyOn(OutboxRepository, "insert").mockResolvedValue(undefined as never)
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const count = await service.restoreSessionsForUnarchivedStream({
+        workspaceId: "ws_1",
+        rootStreamId: "stream_root",
+      })
+
+      expect(count).toBe(0)
+      expect(insertSpy).not.toHaveBeenCalled()
+    })
+
+    it("reattachArchivedRuntimeSession revives the link, refreshes presence, and re-claims the active-actor slot", async () => {
+      patchWithTransaction()
+      const revived = makeLink({ status: "active" })
+      spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(revived)
+      const presenceSpy = spyOn(BotRuntimeInstanceRepository, "upsertPresence").mockResolvedValue({} as never)
+      const setActorSpy = spyOn(BotRuntimeService.prototype, "setActiveActorInTransaction").mockResolvedValue(
+        {} as never
+      )
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const result = await service.reattachArchivedRuntimeSession({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        runtimeKind: "claude-code-channel",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+      })
+
+      expect(result).toEqual({ status: "reattached", link: revived })
+      expect(presenceSpy).toHaveBeenCalled()
+      expect(setActorSpy.mock.calls[0]?.[1]).toMatchObject({
+        workspaceId: "ws_1",
+        rootStreamId: "stream_root",
+        actorType: "bot",
+        actorId: "bot_alice",
+        createdBy: "usr_owner",
+      })
+    })
+
+    it("reattachArchivedRuntimeSession reports archived_stream when the link exists but its stream is still archived", async () => {
+      patchWithTransaction()
+      spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(null)
+      spyOn(BotRuntimeSessionLinkRepository, "findArchivedByRuntimeSession").mockResolvedValue(
+        makeLink({ status: "archived" })
+      )
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const result = await service.reattachArchivedRuntimeSession({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        runtimeKind: "claude-code-channel",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+      })
+
+      expect(result).toEqual({ status: "archived_stream" })
+    })
+
+    it("reattachArchivedRuntimeSession reports none when no archived link exists for the runtime session", async () => {
+      patchWithTransaction()
+      spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(null)
+      spyOn(BotRuntimeSessionLinkRepository, "findArchivedByRuntimeSession").mockResolvedValue(null)
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const result = await service.reattachArchivedRuntimeSession({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        runtimeKind: "claude-code-channel",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+      })
+
+      expect(result).toEqual({ status: "none" })
+    })
+  })
+
   describe("requestResyncInTransaction", () => {
     it("rejects instanceId without botId", async () => {
       const service = new BotRuntimeService({ pool: fakePool })

--- a/apps/backend/src/features/bot-runtimes/service.test.ts
+++ b/apps/backend/src/features/bot-runtimes/service.test.ts
@@ -714,9 +714,32 @@ describe("BotRuntimeService outbox emission", () => {
       })
     })
 
+    it("reattachArchivedRuntimeSession reports a concurrently revived link as reattached, not archived_stream", async () => {
+      patchWithTransaction()
+      // SKIP LOCKED found no 'archived' row because a concurrent reattach (or
+      // the unarchive consumer) already committed the revival.
+      spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(null)
+      const active = makeLink({ status: "active" })
+      spyOn(BotRuntimeSessionLinkRepository, "findActiveByRuntimeSession").mockResolvedValue(active)
+      const findArchived = spyOn(BotRuntimeSessionLinkRepository, "findArchivedByRuntimeSession")
+
+      const service = new BotRuntimeService({ pool: fakePool })
+      const result = await service.reattachArchivedRuntimeSession({
+        workspaceId: "ws_1",
+        botId: "bot_alice",
+        runtimeKind: "claude-code-channel",
+        instanceId: "inst_42",
+        runtimeSessionId: "sess_1",
+      })
+
+      expect(result).toEqual({ status: "reattached", link: active })
+      expect(findArchived).not.toHaveBeenCalled()
+    })
+
     it("reattachArchivedRuntimeSession reports archived_stream when the link exists but its stream is still archived", async () => {
       patchWithTransaction()
       spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(null)
+      spyOn(BotRuntimeSessionLinkRepository, "findActiveByRuntimeSession").mockResolvedValue(null)
       spyOn(BotRuntimeSessionLinkRepository, "findArchivedByRuntimeSession").mockResolvedValue(
         makeLink({ status: "archived" })
       )
@@ -736,6 +759,7 @@ describe("BotRuntimeService outbox emission", () => {
     it("reattachArchivedRuntimeSession reports none when no archived link exists for the runtime session", async () => {
       patchWithTransaction()
       spyOn(BotRuntimeSessionLinkRepository, "reactivateArchivedByRuntimeSession").mockResolvedValue(null)
+      spyOn(BotRuntimeSessionLinkRepository, "findActiveByRuntimeSession").mockResolvedValue(null)
       spyOn(BotRuntimeSessionLinkRepository, "findArchivedByRuntimeSession").mockResolvedValue(null)
 
       const service = new BotRuntimeService({ pool: fakePool })

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -443,7 +443,7 @@ export class BotRuntimeService {
    */
   async endSessionsForArchivedStream(params: { workspaceId: string; rootStreamId: string }): Promise<number> {
     return withTransaction(this.pool, async (db) => {
-      const ended = await BotRuntimeSessionLinkRepository.endActiveByRootStream(db, params)
+      const ended = await BotRuntimeSessionLinkRepository.archiveActiveByRootStream(db, params)
       for (const link of ended) {
         await OutboxRepository.insert(db, "bot:session_archived", {
           workspaceId: params.workspaceId,
@@ -460,6 +460,79 @@ export class BotRuntimeService {
         )
       }
       return ended.length
+    })
+  }
+
+  /**
+   * The unarchive counterpart: revive exactly the links the archive ended
+   * (status 'archived' → 'active'; normal-shutdown 'ended' links stay dead) and
+   * tell each linked runtime over the /bot socket so a live agent reattaches
+   * without a restart. Same INV-4/INV-7 shape as the archive path: revival and
+   * the notify events commit together, and the set-based UPDATE makes consumer
+   * retries idempotent.
+   */
+  async restoreSessionsForUnarchivedStream(params: { workspaceId: string; rootStreamId: string }): Promise<number> {
+    return withTransaction(this.pool, async (db) => {
+      const restored = await BotRuntimeSessionLinkRepository.reactivateArchivedByRootStream(db, params)
+      for (const link of restored) {
+        await OutboxRepository.insert(db, "bot:session_restored", {
+          workspaceId: params.workspaceId,
+          botId: link.botId,
+          instanceId: link.instanceId,
+          runtimeSessionId: link.runtimeSessionId,
+          rootStreamId: params.rootStreamId,
+        })
+      }
+      if (restored.length > 0) {
+        logger.info(
+          { workspaceId: params.workspaceId, rootStreamId: params.rootStreamId, restoredLinks: restored.length },
+          "Restored runtime session links for unarchived stream"
+        )
+      }
+      return restored.length
+    })
+  }
+
+  /**
+   * Session-create reattach: a runtime whose scratchpad was archived and then
+   * unarchived re-issues session-create with the same identity; revive its
+   * archive-ended link instead of minting a duplicate scratchpad. Presence and
+   * the active-actor slot are refreshed in the same transaction so the revived
+   * link dispatches turns immediately. `archived_stream` tells the caller the
+   * link exists but its scratchpad is still archived (the handler 409s).
+   */
+  async reattachArchivedRuntimeSession(params: {
+    workspaceId: string
+    botId: string
+    runtimeKind: BotRuntimeKind
+    instanceId: string
+    runtimeSessionId: string
+  }): Promise<{ status: "reattached"; link: BotRuntimeSessionLink } | { status: "archived_stream" | "none" }> {
+    return withTransaction(this.pool, async (db) => {
+      const link = await BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession(db, params)
+      if (!link) {
+        const archived = await BotRuntimeSessionLinkRepository.findArchivedByRuntimeSession(db, params)
+        return { status: archived ? ("archived_stream" as const) : ("none" as const) }
+      }
+      await this.upsertPiRemoteSessionPresenceInTransaction(db, {
+        workspaceId: params.workspaceId,
+        botId: params.botId,
+        runtimeKind: params.runtimeKind,
+        instanceId: params.instanceId,
+        runtimeSessionId: params.runtimeSessionId,
+      })
+      await this.setActiveActorInTransaction(db, {
+        workspaceId: params.workspaceId,
+        rootStreamId: link.rootStreamId,
+        actorType: "bot",
+        actorId: params.botId,
+        createdBy: link.linkedBy,
+      })
+      logger.info(
+        { workspaceId: params.workspaceId, botId: params.botId, rootStreamId: link.rootStreamId, linkId: link.id },
+        "Reattached archived runtime session link"
+      )
+      return { status: "reattached" as const, link }
     })
   }
 

--- a/apps/backend/src/features/bot-runtimes/service.ts
+++ b/apps/backend/src/features/bot-runtimes/service.ts
@@ -511,6 +511,14 @@ export class BotRuntimeService {
     return withTransaction(this.pool, async (db) => {
       const link = await BotRuntimeSessionLinkRepository.reactivateArchivedByRuntimeSession(db, params)
       if (!link) {
+        // A concurrent reattach/unarchive that already committed leaves the
+        // link 'active' (SKIP LOCKED skipped nothing; the CTE just found no
+        // 'archived' row) — report it as the reattach rather than
+        // misclassifying via the stale 'archived' read below. A racer that is
+        // still uncommitted can't be told apart without blocking; that case
+        // stays a transient archived_stream the client's probe absorbs.
+        const active = await BotRuntimeSessionLinkRepository.findActiveByRuntimeSession(db, params)
+        if (active) return { status: "reattached" as const, link: active }
         const archived = await BotRuntimeSessionLinkRepository.findArchivedByRuntimeSession(db, params)
         return { status: archived ? ("archived_stream" as const) : ("none" as const) }
       }

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -944,6 +944,44 @@ export function createPublicApiHandlers({
         })
       }
 
+      // Archive→unarchive reattach: the runtime re-issues session-create with
+      // the same identity after its link was archive-ended. Revive that link
+      // (same scratchpad) rather than minting a duplicate; while the scratchpad
+      // is still archived, refuse loudly so a self-healing client can tell
+      // "wait" apart from "create" (INV-11).
+      const reattach = await botRuntimeService.reattachArchivedRuntimeSession({
+        workspaceId: req.workspaceId!,
+        botId: bot.id,
+        runtimeKind: data.runtimeKind,
+        instanceId: data.instanceId,
+        runtimeSessionId: data.runtimeSessionId,
+      })
+      if (reattach.status === "archived_stream") {
+        throw new HttpError("The linked scratchpad is archived; unarchive it to reattach", {
+          status: 409,
+          code: "SCRATCHPAD_ARCHIVED",
+        })
+      }
+      if (reattach.status === "reattached") {
+        await withTransaction(pool, (client) =>
+          botRuntimeService.repairBotTraitsInTransaction(client, {
+            workspaceId: req.workspaceId!,
+            botId: bot.id,
+            traits: requiredRuntimeTraits,
+          })
+        )
+        return res.json({
+          data: {
+            linkId: reattach.link.id,
+            rootStreamId: reattach.link.rootStreamId,
+            activeStreamId: reattach.link.activeStreamId,
+            runtimeSessionId: reattach.link.runtimeSessionId,
+            streamUrlPath: `/w/${req.workspaceId!}/s/${reattach.link.activeStreamId}`,
+            e2eEnabled: await E2eStreamsRepository.isE2eStream(pool, req.workspaceId!, reattach.link.rootStreamId),
+          },
+        })
+      }
+
       const { link, stream } = await botRuntimeService.createLinkedScratchpadSession({
         workspaceId: req.workspaceId!,
         botId: bot.id,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -1013,6 +1013,13 @@ export function createPublicApiHandlers({
             runtimeKind: data.runtimeKind,
           })
           if (revived) {
+            await withTransaction(pool, (client) =>
+              botRuntimeService.repairBotTraitsInTransaction(client, {
+                workspaceId: req.workspaceId!,
+                botId: bot.id,
+                traits: requiredRuntimeTraits,
+              })
+            )
             return res.json({
               data: {
                 linkId: revived.id,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -982,21 +982,52 @@ export function createPublicApiHandlers({
         })
       }
 
-      const { link, stream } = await botRuntimeService.createLinkedScratchpadSession({
-        workspaceId: req.workspaceId!,
-        botId: bot.id,
-        ownerUserId: bot.ownerUserId,
-        runtimeKind: data.runtimeKind,
-        instanceId: data.instanceId,
-        runtimeSessionId: data.runtimeSessionId,
-        displayName: data.displayName,
-        localCwd: data.localCwd,
-        memoryMode: data.memoryMode,
-        labelName: data.labelName,
-        description: data.description,
-        traits: requiredRuntimeTraits,
-        ...(data.e2e ? { e2e: { ownerKeyId: data.e2e.ownerKeyId } } : {}),
-      })
+      let created: Awaited<ReturnType<typeof botRuntimeService.createLinkedScratchpadSession>>
+      try {
+        created = await botRuntimeService.createLinkedScratchpadSession({
+          workspaceId: req.workspaceId!,
+          botId: bot.id,
+          ownerUserId: bot.ownerUserId,
+          runtimeKind: data.runtimeKind,
+          instanceId: data.instanceId,
+          runtimeSessionId: data.runtimeSessionId,
+          displayName: data.displayName,
+          localCwd: data.localCwd,
+          memoryMode: data.memoryMode,
+          labelName: data.labelName,
+          description: data.description,
+          traits: requiredRuntimeTraits,
+          ...(data.e2e ? { e2e: { ownerKeyId: data.e2e.ownerKeyId } } : {}),
+        })
+      } catch (error) {
+        // Unique violation on the runtime-session identity: the unarchive
+        // consumer revived the archived link between our reads above and this
+        // insert. The whole create rolled back (no orphan scratchpad) — resume
+        // the revived link instead of surfacing a 500.
+        if ((error as { code?: string }).code === "23505") {
+          const revived = await botRuntimeService.findActivePiRemoteSession({
+            workspaceId: req.workspaceId!,
+            botId: bot.id,
+            instanceId: data.instanceId,
+            runtimeSessionId: data.runtimeSessionId,
+            runtimeKind: data.runtimeKind,
+          })
+          if (revived) {
+            return res.json({
+              data: {
+                linkId: revived.id,
+                rootStreamId: revived.rootStreamId,
+                activeStreamId: revived.activeStreamId,
+                runtimeSessionId: revived.runtimeSessionId,
+                streamUrlPath: `/w/${req.workspaceId!}/s/${revived.activeStreamId}`,
+                e2eEnabled: await E2eStreamsRepository.isE2eStream(pool, req.workspaceId!, revived.rootStreamId),
+              },
+            })
+          }
+        }
+        throw error
+      }
+      const { link, stream } = created
 
       res.json({
         data: {

--- a/apps/backend/src/features/public-api/runtime-session-label.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-label.test.ts
@@ -29,6 +29,7 @@ function createHandlers(overrides: Partial<PublicApiDeps> = {}) {
     botChannelService: {} as PublicApiDeps["botChannelService"],
     botRuntimeService: {
       findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
       createLinkedScratchpadSession: mock(() =>
         Promise.resolve({
           link: {
@@ -79,6 +80,7 @@ describe("bot runtime session labels", () => {
     const { handlers } = createHandlers({
       botRuntimeService: {
         findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+        reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
         createLinkedScratchpadSession,
       } as unknown as PublicApiDeps["botRuntimeService"],
     })
@@ -123,6 +125,7 @@ describe("bot runtime session labels", () => {
     const { handlers } = createHandlers({
       botRuntimeService: {
         findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+        reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
         createLinkedScratchpadSession,
       } as unknown as PublicApiDeps["botRuntimeService"],
     })

--- a/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
@@ -102,6 +102,35 @@ describe("createBotRuntimeSession reattach after unarchive", () => {
     expect(createLinkedScratchpadSession).not.toHaveBeenCalled()
   })
 
+  it("resumes the revived link when the create loses a race to the unarchive consumer (23505)", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    const revivedLink = {
+      id: "brsl_1",
+      rootStreamId: "stream_old",
+      activeStreamId: "stream_old",
+      runtimeSessionId: "sess_1",
+    }
+    // First read misses (link still 'archived'); by the time the insert runs the
+    // unarchive consumer has flipped it 'active' → identity unique violation.
+    const findActive = mock()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(revivedLink as never)
+    const uniqueViolation = Object.assign(new Error("duplicate key value"), { code: "23505" })
+    const handlers = createHandlers({
+      findActivePiRemoteSession: findActive,
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
+      createLinkedScratchpadSession: mock(() => Promise.reject(uniqueViolation)),
+    })
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(botRequest(), cap.res)
+
+    expect(cap.body()).toMatchObject({
+      data: { linkId: "brsl_1", rootStreamId: "stream_old", runtimeSessionId: "sess_1" },
+    })
+  })
+
   it("falls through to scratchpad creation when the runtime session has no archived link", async () => {
     spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
     const createLinkedScratchpadSession = mock(() =>

--- a/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
@@ -117,10 +117,13 @@ describe("createBotRuntimeSession reattach after unarchive", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(revivedLink as never)
     const uniqueViolation = Object.assign(new Error("duplicate key value"), { code: "23505" })
+    spyOn(db, "withTransaction").mockImplementation(async (_pool, fn) => fn({} as never))
+    const repairBotTraitsInTransaction = mock(() => Promise.resolve())
     const handlers = createHandlers({
       findActivePiRemoteSession: findActive,
       reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
       createLinkedScratchpadSession: mock(() => Promise.reject(uniqueViolation)),
+      repairBotTraitsInTransaction,
     })
     const cap = createResponse()
 
@@ -129,6 +132,9 @@ describe("createBotRuntimeSession reattach after unarchive", () => {
     expect(cap.body()).toMatchObject({
       data: { linkId: "brsl_1", rootStreamId: "stream_old", runtimeSessionId: "sess_1" },
     })
+    // The recovery path repairs runtime traits like the other resume paths, so
+    // the revived session can still receive active-scratchpad dispatches.
+    expect(repairBotTraitsInTransaction).toHaveBeenCalled()
   })
 
   it("falls through to scratchpad creation when the runtime session has no archived link", async () => {

--- a/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
+++ b/apps/backend/src/features/public-api/runtime-session-reattach.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test"
+import type { Request, Response } from "express"
+import { createPublicApiHandlers, type PublicApiDeps } from "./handlers"
+import { BotRepository } from "./bot-repository"
+import { E2eStreamsRepository } from "../e2e-streams"
+import * as db from "../../db"
+
+function personalBot(ownerUserId: string) {
+  return { id: "bot_1", workspaceId: "ws_1", type: "personal", ownerUserId, archivedAt: null } as never
+}
+
+function createResponse() {
+  let body: unknown
+  const res = {} as Response
+  res.status = mock(() => res) as unknown as Response["status"]
+  res.json = mock((payload: unknown) => {
+    body = payload
+    return res
+  }) as unknown as Response["json"]
+  return { res, body: () => body }
+}
+
+function createHandlers(botRuntimeService: Record<string, unknown>) {
+  const deps: PublicApiDeps = {
+    eventService: {} as PublicApiDeps["eventService"],
+    streamService: {} as PublicApiDeps["streamService"],
+    searchService: {} as PublicApiDeps["searchService"],
+    memoExplorerService: {} as PublicApiDeps["memoExplorerService"],
+    attachmentService: {} as PublicApiDeps["attachmentService"],
+    botChannelService: {} as PublicApiDeps["botChannelService"],
+    botRuntimeService: botRuntimeService as unknown as PublicApiDeps["botRuntimeService"],
+    labelService: {} as PublicApiDeps["labelService"],
+    labelAssignmentService: {} as PublicApiDeps["labelAssignmentService"],
+    pool: {} as PublicApiDeps["pool"],
+    io: {} as PublicApiDeps["io"],
+  }
+  return createPublicApiHandlers(deps)
+}
+
+function botRequest(): Request {
+  return {
+    workspaceId: "ws_1",
+    body: {
+      runtimeKind: "claude-code-channel",
+      instanceId: "inst_1",
+      runtimeSessionId: "sess_1",
+      displayName: "Claude Code - threa",
+    },
+    params: {},
+    query: {},
+    botApiKey: { id: "bkey_1", botId: "bot_1" },
+  } as unknown as Request
+}
+
+describe("createBotRuntimeSession reattach after unarchive", () => {
+  afterEach(() => mock.restore())
+
+  it("revives the archived link for the same runtime session instead of creating a new scratchpad", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    spyOn(E2eStreamsRepository, "isE2eStream").mockResolvedValue(false)
+    spyOn(db, "withTransaction").mockImplementation(async (_pool, fn) => fn({} as never))
+    const createLinkedScratchpadSession = mock(() => Promise.reject(new Error("must not create a new scratchpad")))
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() =>
+        Promise.resolve({
+          status: "reattached",
+          link: {
+            id: "brsl_1",
+            rootStreamId: "stream_old",
+            activeStreamId: "stream_old",
+            runtimeSessionId: "sess_1",
+          },
+        })
+      ),
+      repairBotTraitsInTransaction: mock(() => Promise.resolve()),
+      createLinkedScratchpadSession,
+    })
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(botRequest(), cap.res)
+
+    expect(createLinkedScratchpadSession).not.toHaveBeenCalled()
+    expect(cap.body()).toMatchObject({
+      data: { linkId: "brsl_1", rootStreamId: "stream_old", activeStreamId: "stream_old", runtimeSessionId: "sess_1" },
+    })
+  })
+
+  it("409s with SCRATCHPAD_ARCHIVED while the linked scratchpad is still archived — never mints a duplicate", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const createLinkedScratchpadSession = mock(() => Promise.reject(new Error("must not create a new scratchpad")))
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "archived_stream" })),
+      createLinkedScratchpadSession,
+    })
+
+    await expect(handlers.createBotRuntimeSession(botRequest(), createResponse().res)).rejects.toMatchObject({
+      status: 409,
+      code: "SCRATCHPAD_ARCHIVED",
+    })
+    expect(createLinkedScratchpadSession).not.toHaveBeenCalled()
+  })
+
+  it("falls through to scratchpad creation when the runtime session has no archived link", async () => {
+    spyOn(BotRepository, "findById").mockResolvedValue(personalBot("usr_owner"))
+    const createLinkedScratchpadSession = mock(() =>
+      Promise.resolve({
+        link: { id: "brsl_new", rootStreamId: "stream_new", activeStreamId: "stream_new", runtimeSessionId: "sess_1" },
+        stream: { id: "stream_new" },
+      })
+    )
+    const handlers = createHandlers({
+      findActivePiRemoteSession: mock(() => Promise.resolve(null)),
+      reattachArchivedRuntimeSession: mock(() => Promise.resolve({ status: "none" })),
+      createLinkedScratchpadSession,
+    })
+    const cap = createResponse()
+
+    await handlers.createBotRuntimeSession(botRequest(), cap.res)
+
+    expect(createLinkedScratchpadSession).toHaveBeenCalled()
+    expect(cap.body()).toMatchObject({ data: { linkId: "brsl_new", rootStreamId: "stream_new" } })
+  })
+})

--- a/apps/backend/src/lib/outbox/broadcast-handler.ts
+++ b/apps/backend/src/lib/outbox/broadcast-handler.ts
@@ -9,6 +9,7 @@ import {
   type BotActiveActorChangedOutboxPayload,
   type BotResyncOutboxPayload,
   type BotSessionArchivedOutboxPayload,
+  type BotSessionRestoredOutboxPayload,
 } from "./repository"
 import { resolveDeliveryGroups, emitToGroups } from "./delivery-groups"
 import { logger } from "../logger"
@@ -274,6 +275,17 @@ export class BroadcastHandler implements OutboxHandler {
       const payload = event.payload as BotSessionArchivedOutboxPayload
       // Narrow session room first (the link identifies one session); instance
       // room as fallback for runtimes that registered without a session id.
+      botNs
+        .to(`bot:${workspaceId}:bot:${payload.botId}:session:${payload.runtimeSessionId}`)
+        .to(`bot:${workspaceId}:bot:${payload.botId}:instance:${payload.instanceId}`)
+        .emit(event.eventType, payload)
+      return
+    }
+
+    if (isOutboxEventType(event, "bot:session_restored")) {
+      const payload = event.payload as BotSessionRestoredOutboxPayload
+      // Same routing as bot:session_archived — the restore must reach exactly
+      // the session whose wind-down it cancels.
       botNs
         .to(`bot:${workspaceId}:bot:${payload.botId}:session:${payload.runtimeSessionId}`)
         .to(`bot:${workspaceId}:bot:${payload.botId}:instance:${payload.instanceId}`)

--- a/apps/backend/src/lib/outbox/repository.ts
+++ b/apps/backend/src/lib/outbox/repository.ts
@@ -104,6 +104,7 @@ export type OutboxEventType =
   | "bot:active_actor_changed"
   | "bot:resync"
   | "bot:session_archived"
+  | "bot:session_restored"
   | "label:created"
   | "label:updated"
   | "label:deleted"
@@ -857,6 +858,18 @@ export interface BotSessionArchivedOutboxPayload extends WorkspaceScopedPayload 
   rootStreamId: string
 }
 
+/**
+ * The unarchive counterpart of `bot:session_archived`: the scratchpad a runtime
+ * session was linked to has been unarchived and the link is 'active' again
+ * server-side. A live runtime cancels its wind-down and reattaches on receipt.
+ */
+export interface BotSessionRestoredOutboxPayload extends WorkspaceScopedPayload {
+  botId: string
+  instanceId: string
+  runtimeSessionId: string
+  rootStreamId: string
+}
+
 // Label event payloads. Labels are owner-scoped, so `targetUserId` is always the
 // owning actor and the broadcast handler delivers to that actor's user room only.
 export interface LabelUpsertedOutboxPayload extends WorkspaceScopedPayload {
@@ -987,6 +1000,7 @@ export interface OutboxEventPayloadMap {
   "bot:active_actor_changed": BotActiveActorChangedOutboxPayload
   "bot:resync": BotResyncOutboxPayload
   "bot:session_archived": BotSessionArchivedOutboxPayload
+  "bot:session_restored": BotSessionRestoredOutboxPayload
   "label:created": LabelUpsertedOutboxPayload
   "label:updated": LabelUpsertedOutboxPayload
   "label:deleted": LabelDeletedOutboxPayload
@@ -1143,6 +1157,7 @@ export type BotScopedEventType =
   | "bot:active_actor_changed"
   | "bot:resync"
   | "bot:session_archived"
+  | "bot:session_restored"
 
 const BOT_SCOPED_EVENTS: BotScopedEventType[] = [
   "bot_invocation:available",
@@ -1150,6 +1165,7 @@ const BOT_SCOPED_EVENTS: BotScopedEventType[] = [
   "bot:active_actor_changed",
   "bot:resync",
   "bot:session_archived",
+  "bot:session_restored",
 ]
 
 /**

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { BotTraits, WORKSPACE_PERMISSION_SCOPES } from "@threa/types"
 import {
+  archiveStream,
   botApiGet,
   botApiPost,
   botUploadFile,
@@ -21,6 +22,7 @@ import {
   sendMessage,
   sendMessageWithAttachments,
   TestClient,
+  unarchiveStream,
   uploadAttachment,
 } from "../client"
 
@@ -116,6 +118,102 @@ describe("claude-code-channel runtime sessions", () => {
     // Same scratchpad, not a fresh one (and not a 500).
     expect(second.data.data.linkId).toBe(first.data.data.linkId)
     expect(second.data.data.activeStreamId).toBe(first.data.data.activeStreamId)
+  })
+
+  // Archive→unarchive symmetry: archiving ends the session link (recoverably);
+  // while archived, session-create refuses with SCRATCHPAD_ARCHIVED instead of
+  // minting a duplicate scratchpad; after unarchive the SAME link revives and
+  // dispatch works again — the reattach a self-healing live channel relies on.
+  test("archive ends the link, unarchive revives the same scratchpad, and dispatch resumes", async () => {
+    const client = new TestClient()
+    await loginAs(client, `cc-arch-${testRunId}@test.com`, "CC Archive User")
+    const workspace = await createWorkspace(client, `CC Archive WS ${testRunId}`)
+    const bot = await createBot(client, workspace.id, {
+      type: "personal",
+      name: `CCA ${testRunId}`,
+      slug: `cca-${testRunId}`,
+      traits: [BotTraits.ACTIVE_SCRATCHPAD, BotTraits.MENTIONABLE],
+    })
+    const apiKey = await createBotKey(client, workspace.id, bot.id, [
+      WORKSPACE_PERMISSION_SCOPES.BOT_RUNTIME_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.BOT_INVOCATIONS_WRITE,
+      WORKSPACE_PERMISSION_SCOPES.MESSAGES_WRITE,
+    ])
+
+    const instanceId = `cca-inst-${testRunId}`
+    const runtimeSessionId = `cca-sess-${testRunId}`
+    const body = {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      displayName: "Claude Code - arch",
+      localCwd: "/tmp/threa-cc-arch",
+    }
+    const first = await botApiPost<{ data: SessionLinkData }>(
+      client,
+      workspace.id,
+      "/bot-runtime/sessions",
+      apiKey,
+      body
+    )
+    expect(first.status).toBe(200)
+    const rootStreamId = first.data.data.rootStreamId
+
+    await archiveStream(client, workspace.id, rootStreamId)
+
+    // The link-end rides the outbox, so poll until session-create stops seeing
+    // an active link and reports the archived state (never a duplicate create).
+    let sawArchivedConflict = false
+    for (let i = 0; i < 50 && !sawArchivedConflict; i++) {
+      const whileArchived = await botApiPost<{ data?: SessionLinkData; code?: string }>(
+        client,
+        workspace.id,
+        "/bot-runtime/sessions",
+        apiKey,
+        body
+      )
+      if (whileArchived.status === 409) {
+        expect(whileArchived.data.code).toBe("SCRATCHPAD_ARCHIVED")
+        sawArchivedConflict = true
+      } else {
+        // Outbox not processed yet: the still-active link is reused (same id).
+        expect(whileArchived.status).toBe(200)
+        expect(whileArchived.data.data!.linkId).toBe(first.data.data.linkId)
+        await new Promise((resolve) => setTimeout(resolve, 200))
+      }
+    }
+    expect(sawArchivedConflict).toBe(true)
+
+    await unarchiveStream(client, workspace.id, rootStreamId)
+
+    // After unarchive the link revives (via the outbox branch or this reattach
+    // call) — the SAME scratchpad, not a new one.
+    let revived: SessionLinkData | null = null
+    for (let i = 0; i < 50 && !revived; i++) {
+      const res = await botApiPost<{ data: SessionLinkData }>(
+        client,
+        workspace.id,
+        "/bot-runtime/sessions",
+        apiKey,
+        body
+      )
+      if (res.status === 200) revived = res.data.data
+      else await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    expect(revived).not.toBeNull()
+    expect(revived!.linkId).toBe(first.data.data.linkId)
+    expect(revived!.rootStreamId).toBe(rootStreamId)
+
+    // The revived link dispatches turns again.
+    await sendMessage(client, workspace.id, rootStreamId, "Reply with exactly: back-from-archive")
+    const claimed = await claimInvocation(client, workspace.id, apiKey, {
+      runtimeKind: "claude-code-channel",
+      instanceId,
+      runtimeSessionId,
+      supportedCapabilities: ["active-scratchpad", "mentionable"],
+      claimTtlSeconds: 120,
+    })
+    expect(claimed.promptMarkdown).toContain("back-from-archive")
   })
 
   test("rejects a link-free runtime kind", async () => {

--- a/apps/backend/tests/e2e/claude-code-channel-session.test.ts
+++ b/apps/backend/tests/e2e/claude-code-channel-session.test.ts
@@ -179,6 +179,7 @@ describe("claude-code-channel runtime sessions", () => {
         // Outbox not processed yet: the still-active link is reused (same id).
         expect(whileArchived.status).toBe(200)
         expect(whileArchived.data.data!.linkId).toBe(first.data.data.linkId)
+        expect(whileArchived.data.data!.activeStreamId).toBe(first.data.data.activeStreamId)
         await new Promise((resolve) => setTimeout(resolve, 200))
       }
     }
@@ -203,6 +204,7 @@ describe("claude-code-channel runtime sessions", () => {
     expect(revived).not.toBeNull()
     expect(revived!.linkId).toBe(first.data.data.linkId)
     expect(revived!.rootStreamId).toBe(rootStreamId)
+    expect(revived!.activeStreamId).toBe(first.data.data.activeStreamId)
 
     // The revived link dispatches turns again.
     await sendMessage(client, workspace.id, rootStreamId, "Reply with exactly: back-from-archive")

--- a/extensions/bot-runtime-client/src/transport.test.ts
+++ b/extensions/bot-runtime-client/src/transport.test.ts
@@ -251,6 +251,35 @@ describe("socket self-heal (the wedge that burns the edge quota)", () => {
     }
   })
 
+  it("routes bot:session_archived and bot:session_restored to their callbacks", async () => {
+    const fake = makeFakeSocket()
+    const ioSpy = spyOn(socketIoClient, "io").mockReturnValue(fake as unknown as ReturnType<typeof socketIoClient.io>)
+    try {
+      stubHintFetch()
+      const archived: unknown[] = []
+      const restored: unknown[] = []
+      const transport = new BotRuntimeTransport({
+        baseUrl: "https://app.example.test",
+        workspaceId: "ws_1",
+        apiKey: "threa_bk_test",
+        hello: HELLO,
+        callbacks: {
+          onSessionArchived: (payload) => void archived.push(payload),
+          onSessionRestored: (payload) => void restored.push(payload),
+        },
+      })
+      await transport.connect()
+
+      fake.handlers["bot:session_archived"]!({ runtimeSessionId: "rts_1" })
+      fake.handlers["bot:session_restored"]!({ runtimeSessionId: "rts_1", rootStreamId: "stream_root" })
+
+      expect(archived).toEqual([{ runtimeSessionId: "rts_1" }])
+      expect(restored).toEqual([{ runtimeSessionId: "rts_1", rootStreamId: "stream_root" }])
+    } finally {
+      ioSpy.mockRestore()
+    }
+  })
+
   it("connect() leaves a fresh outage to Socket.IO but tears down and redials a stale one", async () => {
     const first = makeFakeSocket()
     const second = makeFakeSocket()

--- a/extensions/bot-runtime-client/src/transport.ts
+++ b/extensions/bot-runtime-client/src/transport.ts
@@ -153,6 +153,7 @@ export class BotRuntimeTransport {
     socket.on("bot_invocation:claimed", (payload: unknown) => this.callbacks.onInvocationClaimed?.(payload))
     socket.on("bot:active_actor_changed", (payload: unknown) => this.callbacks.onActiveActorChanged?.(payload))
     socket.on("bot:session_archived", (payload: unknown) => this.callbacks.onSessionArchived?.(payload))
+    socket.on("bot:session_restored", (payload: unknown) => this.callbacks.onSessionRestored?.(payload))
     socket.on("bot:resync", () => {
       this.sendHello()
       this.callbacks.onResync?.()

--- a/extensions/bot-runtime-client/src/types.ts
+++ b/extensions/bot-runtime-client/src/types.ts
@@ -63,6 +63,8 @@ export interface BotRuntimeTransportCallbacks {
   onResync?: () => void
   /** The scratchpad this runtime session is linked to was archived; the link is ended server-side. Wind down. */
   onSessionArchived?: (payload: unknown) => void
+  /** The archived scratchpad was unarchived; the link is active again server-side. Cancel the wind-down and reattach. */
+  onSessionRestored?: (payload: unknown) => void
   /** The `bot:hello` ack landed; carries the bootstrap snapshot. */
   onBootstrap?: (bootstrap: BotHelloBootstrap) => void
 }

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -416,7 +416,72 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     expect(asInternal(session).archivePending).toBeDefined()
     // Detached: no claims while the scratchpad is archived, and the poll probes at the reattach cadence.
     expect(await asInternal(session).claimDrain()).toBe(false)
-    expect(asInternal(session).nextPollDelay(false)).toBe(45_000)
+    expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
+    await session.shutdown()
+  })
+
+  test("a missed restore push still reattaches via the poll probe inside the grace window", async () => {
+    const created: unknown[] = []
+    const client = {
+      fail: async () => {},
+      createSession: async (body: unknown) => {
+        created.push(body)
+        return {
+          linkId: "brsl_1",
+          rootStreamId: "stream_root",
+          activeStreamId: "stream_root",
+          runtimeSessionId: "rts-test",
+          streamUrlPath: "/w/ws_1/s/stream_root",
+        }
+      },
+      claim: async () => null,
+    } as unknown as ThreaClient
+    const { transport } = makeFakeTransport()
+    const archived: Array<{ rootStreamId: string }> = []
+    const session = makeGraceSession({
+      client,
+      transport,
+      archiveGraceMs: 400,
+      onArchived: (payload) => void archived.push(payload),
+    })
+
+    // No bot:session_restored ever arrives; the probe (grace/4 = 100ms) must
+    // find the server-side revived link before the grace (400ms) expires.
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+    await new Promise((resolve) => setTimeout(resolve, 250))
+
+    expect(created.length).toBeGreaterThanOrEqual(1)
+    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
+    expect(archived).toEqual([])
+    await session.shutdown()
+  })
+
+  test("a link response that raced the archive push is dropped — it must not cancel the wind-down", async () => {
+    let resolveCreate: ((link: unknown) => void) | undefined
+    const client = {
+      fail: async () => {},
+      createSession: () => new Promise((resolve) => (resolveCreate = resolve)),
+      claim: async () => null,
+    } as unknown as ThreaClient
+    const { transport } = makeFakeTransport()
+    const session = makeGraceSession({ client, transport, archiveGraceMs: 60_000 })
+
+    // A pre-archive ensureLink is in flight when the archive push lands; its
+    // stale (pre-archive) link response resolves afterwards.
+    const inflightLink = (session as unknown as { ensureLink: () => Promise<void> }).ensureLink()
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+    resolveCreate!({
+      linkId: "brsl_stale",
+      rootStreamId: "stream_root",
+      activeStreamId: "stream_root",
+      runtimeSessionId: "rts-test",
+      streamUrlPath: "/w/ws_1/s/stream_root",
+    })
+    await inflightLink
+
+    expect(asInternal(session).link).toBeUndefined()
+    expect(asInternal(session).archivePending).toBeDefined()
     await session.shutdown()
   })
 

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -363,8 +363,34 @@ describe("RemoteSession.onReplyTimeout", () => {
   })
 })
 
-describe("RemoteSession session-archived handling", () => {
-  test("goes offline, fails in-flight turns, and hands the connector the final word", async () => {
+describe("RemoteSession session-archived handling (grace window)", () => {
+  function makeGraceSession(params: {
+    client: ThreaClient
+    transport: BotRuntimeTransport
+    archiveGraceMs: number
+    onArchived?: (payload: { rootStreamId: string }) => void
+  }): RemoteSession {
+    return new RemoteSession({
+      config: makeConfig(),
+      client: params.client,
+      delegate: { deliverTurn: async () => {}, ...(params.onArchived ? { onArchived: params.onArchived } : {}) },
+      runtime: RUNTIME,
+      transport: params.transport,
+      archiveGraceMs: params.archiveGraceMs,
+    })
+  }
+
+  const asInternal = (session: RemoteSession) =>
+    session as unknown as {
+      handleSessionArchived: (p: unknown) => Promise<void>
+      handleSessionRestored: (p: unknown) => Promise<void>
+      claimDrain: () => Promise<boolean>
+      nextPollDelay: (claimed: boolean) => number
+      link: unknown
+      archivePending: unknown
+    }
+
+  test("detaches on archive: goes offline, fails in-flight turns, but does NOT wind down within the grace window", async () => {
     const failed: string[] = []
     const client = {
       fail: async (id: string) => {
@@ -373,32 +399,102 @@ describe("RemoteSession session-archived handling", () => {
     } as unknown as ThreaClient
     const { transport, presence } = makeFakeTransport()
     const archived: Array<{ rootStreamId: string }> = []
-    const session = makeSession(client, transport, { onArchived: (payload) => void archived.push(payload) })
+    const session = makeGraceSession({
+      client,
+      transport,
+      archiveGraceMs: 60_000,
+      onArchived: (payload) => void archived.push(payload),
+    })
     seedInflight(session, makeInvocation({ id: "binv_running" }))
 
-    await (session as unknown as { handleSessionArchived: (p: unknown) => Promise<void> }).handleSessionArchived({
-      runtimeSessionId: "rts-test",
-      rootStreamId: "stream_root",
-    })
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
 
     expect(presence.at(-1)?.status).toBe("offline")
     expect(failed).toEqual(["binv_running"])
-    expect(archived).toEqual([{ rootStreamId: "stream_root" }])
+    // The wind-down is deferred: an unarchive within the grace window reattaches instead.
+    expect(archived).toEqual([])
+    expect(asInternal(session).archivePending).toBeDefined()
+    // Detached: no claims while the scratchpad is archived, and the poll probes at the reattach cadence.
+    expect(await asInternal(session).claimDrain()).toBe(false)
+    expect(asInternal(session).nextPollDelay(false)).toBe(45_000)
+    await session.shutdown()
   })
 
-  test("ignores an event for a different runtime session (stale re-registration)", async () => {
+  test("bot:session_restored within the grace cancels the wind-down and reattaches the same scratchpad", async () => {
+    const created: unknown[] = []
+    const client = {
+      fail: async () => {},
+      getMe: async () => ({ kind: "bot" }),
+      createSession: async (body: unknown) => {
+        created.push(body)
+        return {
+          linkId: "brsl_1",
+          rootStreamId: "stream_root",
+          activeStreamId: "stream_root",
+          runtimeSessionId: "rts-test",
+          streamUrlPath: "/w/ws_1/s/stream_root",
+        }
+      },
+      claim: async () => null,
+    } as unknown as ThreaClient
+    const { transport, presence } = makeFakeTransport()
+    const archived: Array<{ rootStreamId: string }> = []
+    const session = makeGraceSession({
+      client,
+      transport,
+      archiveGraceMs: 60_000,
+      onArchived: (payload) => void archived.push(payload),
+    })
+
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+    await asInternal(session).handleSessionRestored({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+
+    // Reattached: session-create re-issued (the server revives the same link),
+    // presence back to available, wind-down cancelled, claims live again.
+    expect(created).toHaveLength(1)
+    expect(asInternal(session).archivePending).toBeUndefined()
+    expect(asInternal(session).link).toMatchObject({ rootStreamId: "stream_root" })
+    expect(presence.at(-1)?.status).toBe("available")
+    expect(archived).toEqual([])
+    await session.shutdown()
+  })
+
+  test("winds down (onArchived) when the grace expires without a restore", async () => {
+    const client = { fail: async () => {} } as unknown as ThreaClient
+    const { transport, presence } = makeFakeTransport()
+    const archived: Array<{ rootStreamId: string }> = []
+    const session = makeGraceSession({
+      client,
+      transport,
+      archiveGraceMs: 10,
+      onArchived: (payload) => void archived.push(payload),
+    })
+
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(archived).toEqual([{ rootStreamId: "stream_root" }])
+    expect(presence.at(-1)?.status).toBe("offline")
+  })
+
+  test("ignores archive and restore events for a different runtime session (stale re-registration)", async () => {
     const { client } = makeFakeClient()
     const { transport, presence } = makeFakeTransport()
     const archived: unknown[] = []
     const session = makeSession(client, transport, { onArchived: (payload) => void archived.push(payload) })
 
-    await (session as unknown as { handleSessionArchived: (p: unknown) => Promise<void> }).handleSessionArchived({
+    await asInternal(session).handleSessionArchived({
+      runtimeSessionId: "rts-someone-else",
+      rootStreamId: "stream_root",
+    })
+    await asInternal(session).handleSessionRestored({
       runtimeSessionId: "rts-someone-else",
       rootStreamId: "stream_root",
     })
 
     expect(archived).toEqual([])
     expect(presence).toEqual([])
+    expect(asInternal(session).archivePending).toBeUndefined()
   })
 })
 

--- a/extensions/remote-session/src/session.test.ts
+++ b/extensions/remote-session/src/session.test.ts
@@ -524,6 +524,31 @@ describe("RemoteSession session-archived handling (grace window)", () => {
     await session.shutdown()
   })
 
+  test("a restore whose re-link fails transiently keeps the detached state so the probe cadence survives", async () => {
+    let attempts = 0
+    const client = {
+      fail: async () => {},
+      createSession: async () => {
+        attempts += 1
+        throw new Error("threa unreachable")
+      },
+      claim: async () => null,
+    } as unknown as ThreaClient
+    const { transport } = makeFakeTransport()
+    const session = makeGraceSession({ client, transport, archiveGraceMs: 60_000 })
+
+    await asInternal(session).handleSessionArchived({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+    await asInternal(session).handleSessionRestored({ runtimeSessionId: "rts-test", rootStreamId: "stream_root" })
+
+    expect(attempts).toBe(1)
+    // Still detached-pending: probe cadence + claim suppression survive the
+    // transient failure instead of dropping to the 15-min backstop unlinked.
+    expect(asInternal(session).link).toBeUndefined()
+    expect(asInternal(session).archivePending).toBeDefined()
+    expect(asInternal(session).nextPollDelay(false)).toBe(15_000)
+    await session.shutdown()
+  })
+
   test("winds down (onArchived) when the grace expires without a restore", async () => {
     const client = { fail: async () => {} } as unknown as ThreaClient
     const { transport, presence } = makeFakeTransport()

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -1354,10 +1354,11 @@ export class RemoteSession {
     this.inflight.clear()
     this.activeTurnStream = undefined
     this.link = undefined
-    this.archivePending = {
+    const pending = {
       rootStreamId,
       deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
     }
+    this.archivePending = pending
     // Pull the next poll tick onto the probe cadence NOW — the pending tick was
     // scheduled with the slow socket-backstop delay (15 min), which could land
     // zero probes inside the grace window if the restore push is then missed.
@@ -1371,6 +1372,9 @@ export class RemoteSession {
         })
       )
     )
+    // A restore can reattach and publish 'available' during the awaits above —
+    // don't overwrite it with a stale 'offline'.
+    if (this.stopped || this.archivePending !== pending) return
     await this.transport.updatePresence(this.presenceBody("offline")).catch(() => undefined)
   }
 
@@ -1398,9 +1402,19 @@ export class RemoteSession {
     if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
     if (this.stopped) return
     if (this.archivePending) {
+      // Don't clear the pending state yet — only ensureLink's confirmed link
+      // does that. If the createSession below fails transiently, the probe
+      // cadence and claim suppression must survive; clearing here would drop
+      // the session onto the 15-min backstop unlinked. The restore does cancel
+      // the CURRENT wind-down, but a fresh grace deadline re-arms so a
+      // reattach that never succeeds still winds down bounded.
       clearTimeout(this.archivePending.deadline)
-      this.archivePending = undefined
-      this.log(`scratchpad ${typeof data.rootStreamId === "string" ? data.rootStreamId : ""} restored — reattaching`)
+      const rootStreamId = this.archivePending.rootStreamId
+      this.archivePending = {
+        rootStreamId,
+        deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
+      }
+      this.log(`scratchpad ${rootStreamId} restored — reattaching`)
     }
     if (!this.link) await this.ensureLink()
     else await this.syncPresence()
@@ -1441,6 +1455,7 @@ export class RemoteSession {
 
   /** (Re)arm the poll timer. Replaces any pending tick so a state change can pull the next tick closer. */
   private reschedulePoll(delayMs: number): void {
+    if (this.stopped) return
     if (this.pollTimer) clearTimeout(this.pollTimer)
     this.pollTimer = setTimeout(() => void this.pollTick(), delayMs)
   }
@@ -1450,7 +1465,9 @@ export class RemoteSession {
     if (!this.link) await this.ensureLink()
     if (!this.transport.socketConnected) await this.transport.connect()
     const claimed = await this.claimDrain()
-    this.reschedulePoll(this.nextPollDelay(claimed))
+    // shutdown() can land during the awaits above; re-arming then would leave
+    // a live timer past teardown.
+    if (!this.stopped) this.reschedulePoll(this.nextPollDelay(claimed))
   }
 
   /** Reattach-probe cadence while detached: scaled to the grace window so several probes always fit inside it. */

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -407,8 +407,19 @@ export class RemoteSession {
   /** Create (or recover) the scratchpad link. Best-effort so a transient Threa outage self-heals on the next poll tick. */
   private async ensureLink(): Promise<void> {
     if (this.link || this.stopped) return
+    // Snapshot the detach state so a response that raced an archive push is
+    // dropped: a createSession issued BEFORE the archive can resolve with the
+    // pre-archive link after archivePending was set — accepting it would cancel
+    // the wind-down against a scratchpad that is still archived server-side.
+    const pendingAtStart = this.archivePending
     try {
-      this.link = await this.createSession()
+      const link = await this.createSession()
+      if (this.stopped) return
+      if (this.archivePending !== pendingAtStart) {
+        this.log("link response raced an archive state change — dropped; the next probe decides")
+        return
+      }
+      this.link = link
       // A successful link while detached-pending-restore is the reattach (the
       // server revived the archived link for this runtime session) — the probe
       // beat the bot:session_restored push. Cancel the wind-down.
@@ -1347,6 +1358,10 @@ export class RemoteSession {
       rootStreamId,
       deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
     }
+    // Pull the next poll tick onto the probe cadence NOW — the pending tick was
+    // scheduled with the slow socket-backstop delay (15 min), which could land
+    // zero probes inside the grace window if the restore push is then missed.
+    this.reschedulePoll(this.archiveProbeDelayMs)
     await Promise.allSettled(
       inflight.map(([id, entry]) =>
         this.client.fail(id, {
@@ -1421,14 +1436,26 @@ export class RemoteSession {
   }
 
   private startPoll(): void {
-    const tick = async () => {
-      if (this.stopped) return
-      if (!this.link) await this.ensureLink()
-      if (!this.transport.socketConnected) await this.transport.connect()
-      const claimed = await this.claimDrain()
-      this.pollTimer = setTimeout(() => void tick(), this.nextPollDelay(claimed))
-    }
-    this.pollTimer = setTimeout(() => void tick(), this.config.pollMs)
+    this.reschedulePoll(this.config.pollMs)
+  }
+
+  /** (Re)arm the poll timer. Replaces any pending tick so a state change can pull the next tick closer. */
+  private reschedulePoll(delayMs: number): void {
+    if (this.pollTimer) clearTimeout(this.pollTimer)
+    this.pollTimer = setTimeout(() => void this.pollTick(), delayMs)
+  }
+
+  private async pollTick(): Promise<void> {
+    if (this.stopped) return
+    if (!this.link) await this.ensureLink()
+    if (!this.transport.socketConnected) await this.transport.connect()
+    const claimed = await this.claimDrain()
+    this.reschedulePoll(this.nextPollDelay(claimed))
+  }
+
+  /** Reattach-probe cadence while detached: scaled to the grace window so several probes always fit inside it. */
+  private get archiveProbeDelayMs(): number {
+    return Math.min(ARCHIVE_RESTORE_PROBE_MS, Math.max(Math.floor(this.archiveGraceMs / 4), 10))
   }
 
   /**
@@ -1441,7 +1468,7 @@ export class RemoteSession {
     // Detached-pending-restore: probe at a fixed cadence so a missed
     // bot:session_restored push still reattaches within the grace window. The
     // window bounds the total probes, so this cannot become a quota burn.
-    if (this.archivePending) return ARCHIVE_RESTORE_PROBE_MS
+    if (this.archivePending) return this.archiveProbeDelayMs
     if (this.transport.socketConnected) {
       this.emptyNoSocketPolls = 0
       return WS_BACKSTOP_POLL_MS

--- a/extensions/remote-session/src/session.ts
+++ b/extensions/remote-session/src/session.ts
@@ -59,6 +59,16 @@ const WS_BACKSTOP_POLL_MS = 15 * 60 * 1000
 // socket reconnect resets to the fast cadence. Worst-case degraded latency for
 // a socketless session is one cap interval.
 const NO_SOCKET_POLL_CAP_MS = 2 * 60 * 1000
+// How long a session survives its scratchpad being archived before winding
+// down. An unarchive within this window reattaches the live agent in place
+// (bot:session_restored push, or the reattach probe below when the push was
+// missed); only after it expires does the connector's destructive wind-down
+// (branch push, tmux teardown) run.
+const ARCHIVE_RESTORE_GRACE_MS = 5 * 60 * 1000
+// Poll cadence while detached-pending-restore. Bounded by the grace window
+// (≤ ~7 requests), so it cannot become a quota burn; each probe is a
+// session-create that either reattaches (scratchpad unarchived) or 409s.
+const ARCHIVE_RESTORE_PROBE_MS = 45_000
 const MAX_CLAIMS_PER_DRAIN = 20
 // Server-side cap on frames per bot:invocation:steps call (`stepsFrameSchema`
 // in apps/backend/src/features/bot-runtimes/socket-handler.ts).
@@ -135,9 +145,11 @@ export interface RemoteSessionDelegate {
   sessionControl?: SessionControlActuator
   /**
    * The linked scratchpad was archived (the server already ended the session
-   * link). Called after the SDK has gone offline and failed its in-flight
-   * turns; the connector finishes the wind-down — the Claude channel pushes
-   * its branch and kills its own tmux window, so this hook may never return.
+   * link) and stayed archived through the restore grace window. Called after
+   * the SDK has gone offline and failed its in-flight turns; the connector
+   * finishes the wind-down — the Claude channel pushes its branch and kills
+   * its own tmux window, so this hook may never return. An unarchive within
+   * the grace window reattaches the session instead and this never fires.
    */
   onArchived?: (payload: { rootStreamId: string }) => Promise<void> | void
 }
@@ -279,6 +291,8 @@ export interface RemoteSessionOptions {
   /** Injectable for tests. */
   transport?: BotRuntimeTransport
   log?: (message: string) => void
+  /** Override the archive→restore grace window (tests). */
+  archiveGraceMs?: number
 }
 
 /**
@@ -299,6 +313,14 @@ export class RemoteSession {
   private link: RuntimeSessionLink | undefined
   private claiming = false
   private stopped = false
+  private readonly archiveGraceMs: number
+  /**
+   * Set while the linked scratchpad is archived and the session is waiting out
+   * the restore grace window. Claims are suspended; the poll probes
+   * session-create at ARCHIVE_RESTORE_PROBE_MS; the deadline runs the
+   * connector wind-down that used to fire immediately on archive.
+   */
+  private archivePending: { rootStreamId: string; deadline: ReturnType<typeof setTimeout> } | undefined
   private pollTimer: ReturnType<typeof setTimeout> | undefined
   private renewTimer: ReturnType<typeof setInterval> | undefined
   /** Consecutive empty poll ticks while the socket is down; drives the poll backoff. */
@@ -317,6 +339,7 @@ export class RemoteSession {
     this.delegate = options.delegate
     this.runtime = options.runtime
     this.log = options.log ?? (() => undefined)
+    this.archiveGraceMs = options.archiveGraceMs ?? ARCHIVE_RESTORE_GRACE_MS
     this.bik = new BikKeystore({
       path: this.config.bikPath ?? join(homedir(), ".threa", `bik-${sanitizeId(this.runtime.kind)}.json`),
       log: this.log,
@@ -345,6 +368,7 @@ export class RemoteSession {
             if (bootstrap.availableInvocations.length > 0 || bootstrap.ownedClaims.length > 0) void this.claimDrain()
           },
           onSessionArchived: (payload) => void this.handleSessionArchived(payload),
+          onSessionRestored: (payload) => void this.handleSessionRestored(payload),
         },
         log: this.log,
       })
@@ -385,6 +409,14 @@ export class RemoteSession {
     if (this.link || this.stopped) return
     try {
       this.link = await this.createSession()
+      // A successful link while detached-pending-restore is the reattach (the
+      // server revived the archived link for this runtime session) — the probe
+      // beat the bot:session_restored push. Cancel the wind-down.
+      if (this.archivePending) {
+        clearTimeout(this.archivePending.deadline)
+        this.archivePending = undefined
+        this.log("scratchpad restored — reattached")
+      }
       this.log(`linked to scratchpad ${this.config.baseUrl}${this.link.streamUrlPath}`)
       await this.syncPresence()
     } catch (error) {
@@ -397,6 +429,10 @@ export class RemoteSession {
     this.stopped = true
     if (this.pollTimer) clearTimeout(this.pollTimer)
     if (this.renewTimer) clearInterval(this.renewTimer)
+    if (this.archivePending) {
+      clearTimeout(this.archivePending.deadline)
+      this.archivePending = undefined
+    }
     // Fast, idempotent teardown first so SIGTERM cleanup isn't held hostage by
     // slow writes when Threa is the thing that's unreachable. Dropping the socket
     // before the offline push means updatePresence falls straight to HTTP rather
@@ -518,7 +554,10 @@ export class RemoteSession {
 
   /** Returns whether at least one invocation was claimed (feeds the poll backoff reset). */
   private async claimDrain(): Promise<boolean> {
-    if (this.stopped || this.claiming) return false
+    // No claims while detached-pending-restore: the scratchpad is archived, so
+    // any claimable work predates the archive and would reply into a closed
+    // stream. Restore re-runs the drain.
+    if (this.stopped || this.claiming || this.archivePending) return false
     let claimedAny = false
     this.claiming = true
     try {
@@ -1282,23 +1321,75 @@ export class RemoteSession {
 
   /**
    * The linked scratchpad was archived. The server has already ended the
-   * session link, so no more work can arrive; go offline (shutdown also fails
-   * any in-flight turn) and hand the connector the final word. Scoped to this
-   * session: the event is room-targeted, but a runtime that re-registered
-   * under a new session id must not die to a stale event for the old one.
+   * session link, so no more work can arrive: fail any in-flight turn (its
+   * reply could no longer land), go offline, and detach — but do NOT wind down
+   * yet. An unarchive within the grace window revives the link server-side and
+   * reattaches this live session (bot:session_restored, or the ensureLink
+   * probe); only when the grace expires does the connector's destructive
+   * wind-down run. Scoped to this session: the event is room-targeted, but a
+   * runtime that re-registered under a new session id must not die to a stale
+   * event for the old one.
    */
   private async handleSessionArchived(payload: unknown): Promise<void> {
     const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
     if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
-    if (this.stopped) return
+    if (this.stopped || this.archivePending) return
     const rootStreamId = typeof data.rootStreamId === "string" ? data.rootStreamId : (this.link?.rootStreamId ?? "")
-    this.log(`scratchpad ${rootStreamId} archived — winding down`)
+    this.log(
+      `scratchpad ${rootStreamId} archived — detaching (reattaches if unarchived within ${Math.round(this.archiveGraceMs / 1000)}s)`
+    )
+    const inflight = [...this.inflight]
+    for (const [, entry] of inflight) clearTimeout(entry.deadline)
+    this.inflight.clear()
+    this.activeTurnStream = undefined
+    this.link = undefined
+    this.archivePending = {
+      rootStreamId,
+      deadline: setTimeout(() => void this.windDownAfterGrace(rootStreamId), this.archiveGraceMs),
+    }
+    await Promise.allSettled(
+      inflight.map(([id, entry]) =>
+        this.client.fail(id, {
+          instanceId: this.config.instanceId,
+          claimToken: entry.invocation.claimToken,
+          errorMessage: this.runtime.shutdownErrorMessage,
+        })
+      )
+    )
+    await this.transport.updatePresence(this.presenceBody("offline")).catch(() => undefined)
+  }
+
+  /** The grace expired with the scratchpad still archived: run the wind-down that used to fire on archive. */
+  private async windDownAfterGrace(rootStreamId: string): Promise<void> {
+    if (this.stopped || !this.archivePending) return
+    this.archivePending = undefined
+    this.log(`scratchpad ${rootStreamId} stayed archived — winding down`)
     await this.shutdown()
     try {
       await this.delegate.onArchived?.({ rootStreamId })
     } catch (error) {
       this.log(`onArchived hook failed: ${this.summarize(error)}`)
     }
+  }
+
+  /**
+   * The archived scratchpad was unarchived and the server revived this
+   * session's link: cancel the pending wind-down, re-establish the link (the
+   * session-create path returns the revived link for the SAME scratchpad), and
+   * resume claiming — the live agent reattaches with no restart.
+   */
+  private async handleSessionRestored(payload: unknown): Promise<void> {
+    const data = (payload ?? {}) as { runtimeSessionId?: unknown; rootStreamId?: unknown }
+    if (typeof data.runtimeSessionId === "string" && data.runtimeSessionId !== this.config.runtimeSessionId) return
+    if (this.stopped) return
+    if (this.archivePending) {
+      clearTimeout(this.archivePending.deadline)
+      this.archivePending = undefined
+      this.log(`scratchpad ${typeof data.rootStreamId === "string" ? data.rootStreamId : ""} restored — reattaching`)
+    }
+    if (!this.link) await this.ensureLink()
+    else await this.syncPresence()
+    await this.claimDrain()
   }
 
   // --- Timers ---------------------------------------------------------------
@@ -1347,6 +1438,10 @@ export class RemoteSession {
    * can't burn the edge-request quota. Claimed work resets the backoff.
    */
   private nextPollDelay(claimed: boolean): number {
+    // Detached-pending-restore: probe at a fixed cadence so a missed
+    // bot:session_restored push still reattaches within the grace window. The
+    // window bounds the total probes, so this cannot become a quota burn.
+    if (this.archivePending) return ARCHIVE_RESTORE_PROBE_MS
     if (this.transport.socketConnected) {
       this.emptyNoSocketPolls = 0
       return WS_BACKSTOP_POLL_MS

--- a/packages/types/src/constants.ts
+++ b/packages/types/src/constants.ts
@@ -1026,13 +1026,17 @@ export const PiToolTraceSectionLabels = {
   DETAILS: "Details",
 } as const satisfies Record<string, PiToolTraceSectionLabel>
 
-export const BOT_RUNTIME_SESSION_LINK_STATUSES = ["active", "paused", "ended"] as const
+// 'archived' is the recoverable end state written when the linked scratchpad is
+// archived — stream:unarchived revives exactly these links back to 'active'.
+// 'ended' is terminal (normal shutdown) and is never revived.
+export const BOT_RUNTIME_SESSION_LINK_STATUSES = ["active", "paused", "ended", "archived"] as const
 export type BotRuntimeSessionLinkStatus = (typeof BOT_RUNTIME_SESSION_LINK_STATUSES)[number]
 
 export const BotRuntimeSessionLinkStatuses = {
   ACTIVE: "active",
   PAUSED: "paused",
   ENDED: "ended",
+  ARCHIVED: "archived",
 } as const satisfies Record<string, BotRuntimeSessionLinkStatus>
 
 export const BOT_RUNTIME_STATUSES = ["available", "busy", "offline", "error"] as const


### PR DESCRIPTION
## Problem

Archiving a scratchpad ends every bot-runtime session link rooted at it (`stream:archived` → `endSessionsForArchivedStream` → link `status='ended'`), but unarchiving had no consumer in `bot-runtimes` — and a runtime only ever creates a link at startup (`POST /bot-runtime/sessions` from the channel's boot path). So after archive→unarchive, a live agent stayed detached until its channel was restarted. Worse, the `bot:session_archived` push made the claude-code-channel wind down *instantly* (push branch, kill its own tmux window), so an accidental archive destroyed the session before an unarchive could reach it.

## Solution

Make archive-ended links a recoverable state, give unarchive a symmetric consumer that revives them and pushes `bot:session_restored`, teach session-create to reattach instead of minting a duplicate scratchpad, and replace the channel's instant wind-down with a 5-minute detach grace that a restore cancels.

### How it works

**Backend symmetry.** Archive now writes link `status='archived'` (new value in `BOT_RUNTIME_SESSION_LINK_STATUSES`; `'ended'` stays terminal — nothing revives it). A `stream:unarchived` branch in `BotInvocationOutboxHandler` calls `restoreSessionsForUnarchivedStream`, which flips exactly the `'archived'` links back to `'active'` in one set-based `UPDATE … RETURNING` and emits a `bot:session_restored` outbox row per link in the same transaction (INV-4/7, INV-20/56). The event routes on the `/bot` namespace to the same session/instance rooms as `bot:session_archived`.

**Session-create reattach.** When `createBotRuntimeSession` finds no active link, it now tries `reattachArchivedRuntimeSession`: a locked CTE (`FOR UPDATE OF l SKIP LOCKED` on the link + `FOR SHARE OF s` on the stream row) revives the newest `'archived'` link for the same (bot, kind, instance, runtimeSessionId) identity iff its root stream is unarchived, then refreshes presence and the active-actor slot in the same transaction. If the link exists but the stream is still archived, the handler answers **409 `SCRATCHPAD_ARCHIVED`** — a self-healing client can tell "wait" apart from "create", and a duplicate scratchpad is never minted.

**Client grace window (`extensions/remote-session`).** On `bot:session_archived`, `RemoteSession` no longer shuts down: it fails in-flight turns, goes offline, suspends claiming, clears its link, and arms a 5-minute grace deadline. Reattach happens through two paths: the `bot:session_restored` push (new transport callback), or a session-create probe on the poll loop at `min(45s, grace/4)` — the poll timer is explicitly rescheduled onto that cadence at detach, since the pending tick could be holding the 15-minute socket backstop delay. Only when the grace expires does the old wind-down (`delegate.onArchived` — branch push + tmux teardown for the claude channel) run.

### Key design decisions

**1. `'archived'` vs reusing `'ended'`** — the handover's scoping subtlety: unarchive must revive only archive-ended links, never ones a runtime ended by shutting down. A distinct TEXT status (INV-3, no migration) makes the revive predicate exact. Every existing links query filters `status = 'active'`, so `'archived'` rows are excluded everywhere without further changes.

**2. 409 instead of creating a new scratchpad while archived** — a blind client re-create while the stream is archived would silently mint a duplicate scratchpad (the exact failure the reattach path exists to prevent). Refusing loudly (INV-11) lets the detached client keep probing until the unarchive lands.

**3. Grace window instead of instant wind-down** — required by the definition of done ("unarchiving reattaches the live agent without a restart"): the previous behavior destroyed the channel on receipt of the archive push, so there was no live agent left to reattach. 5 minutes bounds the probe traffic (≤ ~7 requests per detach) — no hot re-create poll, per the CF-quota history.

**4. Share-lock the stream row in the reattach CTE** — an unlocked `EXISTS (… archived_at IS NULL)` is TOCTOU against a concurrent re-archive: the re-archive's consumer could skip the link (its `'active'` write uncommitted) and strand an active link on an archived stream. With `FOR SHARE OF s`, a concurrent archive waits for the reattach commit and its consumer then archives the revived link (caught in self-review; commit 2).

### Design evolution (self-review)

A pre-PR correctness review found four issues, all fixed in the second commit: (a) the reattach probe was never actually scheduled at detach — the pending poll tick held the 15-min backstop delay, so a missed restore push could see zero probes inside the grace; (b) the reattach CTE's stream check was TOCTOU (decision 4); (c) a `createSession` response that raced the archive push could cancel the wind-down against a still-archived scratchpad — responses now drop when the detach state changed mid-flight; (d) the unarchive consumer committing between session-create's two reads produced a transient 23505 → 500 — the handler now resumes the revived link on that code.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/src/features/public-api/runtime-session-reattach.test.ts` | Handler tests: reattach 200, still-archived 409, 23505 resume, fall-through create |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/constants.ts` | `'archived'` added to `BOT_RUNTIME_SESSION_LINK_STATUSES` |
| `apps/backend/src/features/bot-runtimes/repository.ts` | `endActiveByRootStream` → `archiveActiveByRootStream` (writes `'archived'`); new `reactivateArchivedByRootStream`, `reactivateArchivedByRuntimeSession` (locked CTE), `findArchivedByRuntimeSession` |
| `apps/backend/src/features/bot-runtimes/service.ts` | New `restoreSessionsForUnarchivedStream` (revive + `bot:session_restored`, one tx) and `reattachArchivedRuntimeSession` (revive + presence + active actor) |
| `apps/backend/src/features/bot-runtimes/invocation-outbox-handler.ts` | `stream:unarchived` branch → restore |
| `apps/backend/src/lib/outbox/repository.ts` | `bot:session_restored` event type, payload, `BOT_SCOPED_EVENTS` |
| `apps/backend/src/lib/outbox/broadcast-handler.ts` | Route `bot:session_restored` like `bot:session_archived` |
| `apps/backend/src/features/public-api/handlers.ts` | Reattach + 409 + 23505 resume in `createBotRuntimeSession` |
| `extensions/bot-runtime-client/src/{types,transport}.ts` | `onSessionRestored` transport callback |
| `extensions/remote-session/src/session.ts` | Detach-with-grace on archive, restore handler, reattach probe, poll rescheduling, raced-response guard |
| `apps/backend/tests/e2e/claude-code-channel-session.test.ts` | Full archive→409→unarchive→same-link→dispatch round-trip against real PG |
| `*.test.ts` (bot-runtimes, remote-session, transport, runtime-session-label) | Coverage for all of the above |

## Out of scope (deliberate)

- Pi's own connector (`extensions/pi-remote`) — it shares the transport, but its session loop is separate; the backend revive alone already heals a live Pi agent that missed the archive push (its link simply works again).
- Re-targeting invocations created while a runtime was detached; they follow the normal claim/expiry lifecycle.
- The running dogfood channel executes the *old* client build — live dogfood (archive this scratchpad, unarchive, agent reattaches) needs a channel restart onto this branch and is the post-merge verification step.

## Test plan

- [x] `bun test src/features/bot-runtimes src/features/public-api/…` — 114 pass (repo SQL, service outbox emission, outbox-handler branches, handler reattach/409/23505)
- [x] `extensions/remote-session` — 96 pass (detach grace, restore push, missed-push probe, raced-response drop, expiry wind-down)
- [x] `extensions/bot-runtime-client` — 50 pass (restored-event routing)
- [x] Backend e2e — 322 pass, incl. new archive→unarchive round-trip (real PG validates the CTE locking clauses); integration — 568 pass
- [x] Typecheck clean across the monorepo + all three extensions
- [x] Pre-PR review (correctness agent): 4 findings, all fixed (commit 2); clean on re-run of affected suites
- [ ] Live dogfood on this scratchpad — requires restarting the channel on the new build (post-merge)

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786258554&installation_id=129946197&pr_number=1266&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1266&signature=da5a70f0bfe4a4be7d480a493c94edb5bb9f042de61bd3dc21d8af7e718f2631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->