### PR TITLE
fix(channel): link the scratchpad only when Claude actually loaded the server as a channel

### DIFF
--- a/docs/claude-code-channel.md
+++ b/docs/claude-code-channel.md
@@ -31,7 +31,7 @@ So Claude Code wants to _receive pushes_, and Threa wants to _be pulled from_. T
 
 ## What runs where
 
-The extension is a single MCP server (`src/index.ts` → `ChannelServer`). Claude Code spawns it with `bun src/index.ts` when you start with `--dangerously-load-development-channels server:threa`. Inside that one process:
+The extension is a single MCP server (`src/index.ts` → `ChannelServer`). Claude Code spawns it with `bun src/index.ts` when you start with `--dangerously-load-development-channels server:threa`. Scratchpad linking is gated on that flag: `channel-detect.ts` reads the parent Claude process's command line, and without `--dangerously-load-development-channels server:threa` the server serves as a plain idle MCP (no scratchpad, no Threa traffic). Claude Code negotiates identical MCP client capabilities in channel and plain mode, so the launch flag is the only observable channel signal — and it makes a global user-scope registration safe. Inside that one process:
 
 - `ThreaClient` (`src/threa-client.ts`) is a thin HTTP client for the Threa bot-runtime API plus a websocket-hint resolver.
 - `ChannelServer` (`src/channel-server.ts`) owns the MCP `Server`, a socket.io connection to the `/bot` namespace, and the bridge logic.
@@ -43,10 +43,11 @@ It talks to Threa over HTTPS and a websocket, reusing the public bot-runtime API
 
 When the process starts it:
 
-1. Reads `THREA_WORKSPACE_ID` / `THREA_API_KEY` (env or `~/.claude/threa-channel/config.json`) and derives an `instanceId` and `runtimeSessionId` by hashing `hostname + cwd`. Deriving them from the directory means relaunching Claude Code in the same project reuses the same scratchpad instead of spawning a new one each time.
-2. `POST /bot-runtime/sessions`, which **creates a scratchpad**, sets the bot as that scratchpad's **active actor**, registers presence, and returns the session link (and the scratchpad URL, which it logs).
-3. Resolves the region websocket URL (`GET /api/workspaces/:ws/config`) and connects the `/bot` socket, sending `bot:hello`.
-4. Marks presence `available` and starts a backstop claim poll.
+1. Checks the parent Claude process's command line for `--dangerously-load-development-channels server:threa` (`channel-detect.ts`). Absent — a plain Claude session that merely has the `threa` MCP server registered — it stops here and idles; nothing below runs.
+2. Reads `THREA_WORKSPACE_ID` / `THREA_API_KEY` (env or `~/.claude/threa-channel/config.json`) and derives an `instanceId` and `runtimeSessionId` by hashing `hostname + cwd`. Deriving them from the directory means relaunching Claude Code in the same project reuses the same scratchpad instead of spawning a new one each time.
+3. `POST /bot-runtime/sessions`, which **creates a scratchpad**, sets the bot as that scratchpad's **active actor**, registers presence, and returns the session link (and the scratchpad URL, which it logs).
+4. Resolves the region websocket URL (`GET /api/workspaces/:ws/config`) and connects the `/bot` socket, sending `bot:hello`.
+5. Marks presence `available` and starts a backstop claim poll.
 
 ### A first-class runtime kind
 

--- a/extensions/claude-code-remote/README.md
+++ b/extensions/claude-code-remote/README.md
@@ -103,6 +103,8 @@ claude --dangerously-load-development-channels server:threa
 
 A dim line under the banner confirms the channel registered. The channel logs the scratchpad URL to stderr on startup (see `~/.claude/debug/<session-id>.txt`); the scratchpad also appears in the Threa sidebar as `Claude Code - <project>`.
 
+The flag is required for the scratchpad to link at all: the server checks its parent Claude process's command line for `--dangerously-load-development-channels server:threa` and, when absent, serves as a plain (idle) MCP server without creating anything. This makes a global (user-scope) registration safe — a bare `claude` session loads the server but links no scratchpad. Two consequences: the launch command must reference the server by the name `threa`, and the registration must run `bun` directly (a shell wrapper that doesn't `exec` would hide the Claude process's command line from the gate).
+
 ### 6. Drive it from Threa
 
 Open the scratchpad in Threa and type a message. No `@`-mention needed: the bot is the scratchpad's active actor, so every message you post is forwarded to your Claude Code session. The presence pill shows **Available** / **Working**. Claude's answer posts back as a `BOT` message.

--- a/extensions/claude-code-remote/src/channel-detect.test.ts
+++ b/extensions/claude-code-remote/src/channel-detect.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { isChannelLaunch, readParentCommand } from "./channel-detect"
+
+// Real launch shapes captured from running sessions (spawn.sh and harnessd).
+const SPAWN_SH_CMD =
+  "/Users/kris/.local/bin/claude --name threa.channel-gate-scratchpad --dangerously-load-development-channels server:threa --dangerously-skip-permissions"
+const HARNESSD_CMD =
+  "/Users/kris/.local/bin/claude --name threa.background-uploads --mcp-config /Users/kris/.threa/harnessd/mcp/background-uploads.json --dangerously-load-development-channels server:threa --dangerously-skip-permissions"
+
+describe("isChannelLaunch", () => {
+  test("recognizes both real spawn paths", () => {
+    expect(isChannelLaunch(SPAWN_SH_CMD, "threa")).toBe(true)
+    expect(isChannelLaunch(HARNESSD_CMD, "threa")).toBe(true)
+  })
+
+  test("rejects a plain claude launch", () => {
+    expect(isChannelLaunch("/Users/kris/.local/bin/claude --dangerously-skip-permissions", "threa")).toBe(false)
+    expect(isChannelLaunch("", "threa")).toBe(false)
+  })
+
+  test("rejects a dev-channel launch for a different server", () => {
+    expect(isChannelLaunch("claude --dangerously-load-development-channels server:other", "threa")).toBe(false)
+  })
+
+  test("requires an exact server name, not a prefix", () => {
+    expect(isChannelLaunch("claude --dangerously-load-development-channels server:threa2", "threa")).toBe(false)
+  })
+
+  test("accepts flag=value and comma-separated channel lists", () => {
+    expect(isChannelLaunch("claude --dangerously-load-development-channels=server:threa", "threa")).toBe(true)
+    expect(isChannelLaunch("claude --dangerously-load-development-channels server:other,server:threa", "threa")).toBe(
+      true
+    )
+  })
+})
+
+describe("readParentCommand", () => {
+  test("reads a live process's command line", () => {
+    expect(readParentCommand(process.pid)).toContain("bun")
+  })
+
+  test("returns empty for a dead pid instead of throwing", () => {
+    // PID beyond macOS/Linux defaults — ps errors, we degrade to "".
+    expect(readParentCommand(99999999)).toBe("")
+  })
+})

--- a/extensions/claude-code-remote/src/channel-detect.ts
+++ b/extensions/claude-code-remote/src/channel-detect.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from "node:child_process"
+
+const DEV_CHANNELS_FLAG = "--dangerously-load-development-channels"
+
+/**
+ * Whether the parent Claude Code invocation loaded this server as a dev
+ * channel. Claude Code negotiates identical MCP capabilities in channel and
+ * plain mode (verified against 2.1.206 — the client declares no
+ * `experimental["claude/channel"]`, sends no channel-specific message, and
+ * sets no env var), so the launch flag on the parent process's command line
+ * is the only observable channel signal. It is also the ground truth: the
+ * flag is exactly what makes Claude Code treat this server as a channel.
+ */
+export function isChannelLaunch(parentCommand: string, channelSource: string): boolean {
+  const tokens = parentCommand.split(/\s+/)
+  const target = `server:${channelSource}`
+  return tokens.some((token, i) => {
+    if (token === DEV_CHANNELS_FLAG) return (tokens[i + 1] ?? "").split(",").includes(target)
+    if (token.startsWith(`${DEV_CHANNELS_FLAG}=`)) {
+      return token
+        .slice(DEV_CHANNELS_FLAG.length + 1)
+        .split(",")
+        .includes(target)
+    }
+    return false
+  })
+}
+
+/** The full command line of a process, or "" when unreadable (dead pid, no ps). */
+export function readParentCommand(pid: number): string {
+  try {
+    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" }).trim()
+  } catch {
+    return ""
+  }
+}

--- a/extensions/claude-code-remote/src/channel-server.test.ts
+++ b/extensions/claude-code-remote/src/channel-server.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test"
-import { buildInstructions, parsePermissionVerdict } from "./channel-server"
+import { describe, expect, spyOn, test } from "bun:test"
+import type { BotRuntimeTransport } from "@threa/bot-runtime-client"
+import { ThreaClient, type RemoteSessionConfig } from "@threa/remote-session"
+import { ChannelServer, buildInstructions, parsePermissionVerdict } from "./channel-server"
 
 describe("parsePermissionVerdict", () => {
   test("parses allow/deny in long and short forms", () => {
@@ -41,5 +43,59 @@ describe("buildInstructions", () => {
   test("mentions permission forwarding only when relay is enabled", () => {
     expect(buildInstructions(true).toLowerCase()).toContain("approv")
     expect(buildInstructions(false).toLowerCase()).not.toContain("approv")
+  })
+
+  test("in plain-MCP mode says the channel is inactive instead of claiming a scratchpad link", () => {
+    const text = buildInstructions(false, false)
+    expect(text).not.toContain("You are linked")
+    expect(text.toLowerCase()).toContain("inactive")
+  })
+})
+
+function makeConfig(): RemoteSessionConfig {
+  return {
+    baseUrl: "https://threa.test",
+    workspaceId: "ws_1",
+    apiKey: "threa_bk_test",
+    displayName: "Claude Code - test",
+    instanceId: "cc-test",
+    runtimeSessionId: "ccs-test",
+    permissionRelay: false,
+    pollMs: 60_000,
+    idleTimeoutMs: 60_000,
+    sealedFullTrace: true,
+  }
+}
+
+function makeFakeTransport(): BotRuntimeTransport {
+  return {
+    connect: async () => {},
+    disconnect: () => {},
+    socketConnected: false,
+    sendHello: () => {},
+    recordSteps: async () => {},
+    renewClaim: async () => ({ notFound: false }),
+    updatePresence: async () => {},
+  } as unknown as BotRuntimeTransport
+}
+
+describe("ChannelServer lifecycle gating", () => {
+  test("shutdown before start never touches the Threa session", async () => {
+    const config = makeConfig()
+    const server = new ChannelServer(config, new ThreaClient(config), makeFakeTransport())
+    const sessionShutdown = spyOn(server.session, "shutdown")
+    await server.shutdown()
+    expect(sessionShutdown).not.toHaveBeenCalled()
+  })
+
+  test("shutdown after start shuts the session down", async () => {
+    const config = makeConfig()
+    const server = new ChannelServer(config, new ThreaClient(config), makeFakeTransport())
+    const sessionStart = spyOn(server.session, "start").mockResolvedValue()
+    const sessionShutdown = spyOn(server.session, "shutdown").mockResolvedValue()
+    await server.start()
+    await server.shutdown()
+    expect(sessionStart).toHaveBeenCalled()
+    expect(sessionShutdown).toHaveBeenCalled()
   })
 })

--- a/extensions/claude-code-remote/src/channel-server.ts
+++ b/extensions/claude-code-remote/src/channel-server.ts
@@ -61,7 +61,13 @@ export function parsePermissionVerdict(text: string): PermissionVerdict | null {
   }
 }
 
-export function buildInstructions(permissionRelay: boolean): string {
+export function buildInstructions(permissionRelay: boolean, channelActive = true): string {
+  if (!channelActive) {
+    return (
+      `This Threa channel server is loaded as a plain MCP server — the current Claude session was not launched as a "${CHANNEL_SOURCE}" channel and is not linked to a Threa scratchpad. ` +
+      "The send and reply tools are inactive; do not call them."
+    )
+  }
   const lines = [
     `You are linked to a Threa scratchpad through the "${CHANNEL_SOURCE}" channel.`,
     "",
@@ -194,11 +200,13 @@ export class ChannelServer {
   private readonly tracer: TranscriptTracer
   private readonly carryOn: CarryOnController | undefined
   private readonly openPermissions = new Map<string, { cleanup: ReturnType<typeof setTimeout> }>()
+  private started = false
 
   constructor(
     private readonly config: RemoteSessionConfig,
     client: ThreaClient,
-    transport?: BotRuntimeTransport
+    transport?: BotRuntimeTransport,
+    channelActive = true
   ) {
     const capabilities: Record<string, unknown> = {
       experimental: { "claude/channel": {} },
@@ -209,7 +217,7 @@ export class ChannelServer {
     }
     this.mcp = new Server(
       { name: CHANNEL_SOURCE, version: "0.1.0" },
-      { capabilities, instructions: buildInstructions(config.permissionRelay) }
+      { capabilities, instructions: buildInstructions(config.permissionRelay, channelActive) }
     )
     this.session = new RemoteSession({
       config,
@@ -263,6 +271,7 @@ export class ChannelServer {
   }
 
   async start(): Promise<void> {
+    this.started = true
     await this.session.start()
   }
 
@@ -271,7 +280,10 @@ export class ChannelServer {
     this.carryOn?.stop()
     for (const [, open] of this.openPermissions) clearTimeout(open.cleanup)
     this.openPermissions.clear()
-    await this.session.shutdown()
+    // A never-started session has nothing linked — skipping its shutdown keeps
+    // plain-MCP teardown from writing an offline-presence row for an instance
+    // that never existed on the Threa side.
+    if (this.started) await this.session.shutdown()
   }
 
   /**

--- a/extensions/claude-code-remote/src/index.ts
+++ b/extensions/claude-code-remote/src/index.ts
@@ -2,7 +2,8 @@
 import { existsSync, readFileSync } from "node:fs"
 import { hostname } from "node:os"
 import { ThreaClient, parseConfigFile, wireLifecycle, type RawConfig } from "@threa/remote-session"
-import { ChannelServer } from "./channel-server"
+import { isChannelLaunch, readParentCommand } from "./channel-detect"
+import { CHANNEL_SOURCE, ChannelServer } from "./channel-server"
 import { CONFIG_PATH, loadChannelConfig } from "./config"
 
 function readFileConfig(): RawConfig | undefined {
@@ -29,8 +30,15 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
+  // The user-scope `threa` registration loads this server in EVERY Claude
+  // session, channel or not. Only a session Claude Code actually treats as a
+  // channel may link a scratchpad — see channel-detect.ts for why the parent
+  // process's launch flag is the only observable (and authoritative) signal.
+  const parentCommand = readParentCommand(process.ppid)
+  const channelActive = isChannelLaunch(parentCommand, CHANNEL_SOURCE)
+
   const client = new ThreaClient(result.config)
-  const server = new ChannelServer(result.config, client)
+  const server = new ChannelServer(result.config, client, undefined, channelActive)
 
   // Connect stdio first so Claude Code registers the channel and discovers the
   // reply tool even while the Threa bridge is still spinning up. This also puts
@@ -42,6 +50,15 @@ async function main(): Promise<void> {
   // stdio MCP server mid-session, so a silent drop strands the scratchpad as
   // "busy" with nobody to answer until a human restarts.
   wireLifecycle(server, process, { logPrefix: "[threa-channel]" })
+
+  if (!channelActive) {
+    process.stderr.write(
+      `[threa-channel] parent Claude session did not load this server as a channel ` +
+        `(--dangerously-load-development-channels server:${CHANNEL_SOURCE} absent from: ${parentCommand || "<unreadable>"}) — ` +
+        `serving as a plain MCP server; no scratchpad linked\n`
+    )
+    return
+  }
 
   // start() is best-effort internally (link/socket/presence self-heal on the
   // poll loop); an error escaping it is an unexpected init failure, so fail loud


### PR DESCRIPTION
## Problem

`extensions/claude-code-remote/src/index.ts` called `server.start()` unconditionally after `connectStdio()`, so every Claude session that loads the `threa` MCP server linked a scratchpad (`RemoteSession.start()` → `ensureLink()` → `POST /bot-runtime/sessions`) — whether or not Claude Code loaded it as a channel. Since `spawn-claude-channel-worktree` moved the registration to user scope (pointing at the main checkout), the server loads in *every* Claude session on the machine, and each plain session mints a stray scratchpad for its cwd.

## Solution

Gate scratchpad linking on the one signal that actually distinguishes a channel session: the parent Claude process's command line carrying `--dangerously-load-development-channels server:threa`. A plain session keeps the server as an idle MCP — stdio connected, tools listed, zero Threa traffic.

### The discriminator (verified empirically, not guessed)

The handover proposed gating on the client declaring `experimental["claude/channel"]` in its MCP capabilities, flagged as unverified. Verified against Claude Code 2.1.206 with a logging stub server run in both modes (headless and interactive tmux, real dev-channel banner confirmed):

- The `initialize` request is **byte-identical** in channel and plain mode: `capabilities: {"roots":{"listChanged":true},"elicitation":{}}` — no `experimental` key. The proposed gate would have broken every channel.
- No channel-specific client message exists: `strings` over the 2.1.206 binary yields only the two server-capability keys and the three `notifications/claude/channel*` methods (all server-bound or turn-scoped).
- Env keys of the spawned server process are identical in both modes.
- The parent process (verified `ps -o command= -p $PPID` for every running channel: spawn.sh and harnessd paths alike) is the `claude` process itself, no intermediate shell, with the flag visible. The flag is not a proxy — it is literally the input that makes Claude Code treat the server as a channel.

### How it works

1. `channel-detect.ts` — `readParentCommand(process.ppid)` (`ps -o command=`, `""` on failure) and `isChannelLaunch(parentCommand, channelSource)`, a pure token-wise matcher for `--dangerously-load-development-channels` with `server:threa` in space- or `=`-separated, comma-listable form. Exact-token match, so `server:threa2` does not pass.
2. `index.ts` — decides before constructing `ChannelServer`; `connectStdio()` and `wireLifecycle()` stay unconditional (Claude must discover tools; teardown must stay routed). Non-channel: log one stderr line naming the parent command and return — no `start()`.
3. `ChannelServer` — `started` flag; `shutdown()` skips `session.shutdown()` when never started, so plain-session teardown doesn't write an offline-presence row for an instance that never existed. `buildInstructions(permissionRelay, channelActive)` returns a two-line "this server is idle, don't call send/reply" in plain mode instead of claiming a scratchpad link in every Claude session's context.

### Key design decisions

**1. Parent cmdline over a spawn-tooling env var.** An env var set by spawn.sh/harnessd would need coordinated updates across `pi-extensions` and the daemon, and any missed launch path (including the README's manual `claude --dangerously-load-development-channels server:threa`) would silently break the happy path. The parent cmdline covers all launch paths with zero coordination and no rollout ordering: both spawners already pass the flag today.

**2. Idle MCP over exit.** A plain session keeps the server connected (tools still list); exiting would surface a failed-server status in `/mcp` for every plain session. Calling `send`/`reply` unlinked returns the normal unknown-invocation error, and the plain-mode instructions say not to.

**3. Match `server:threa` exactly, not just the flag.** Flag-only would re-create the bug in exactly the sessions used for developing *other* dev channels. Trade-off: the server can't know its client-side registration alias (MCP doesn't expose it), so a rename away from `threa` in a spawner would not link — acceptable; every path hardcodes/defaults `threa`.

**Known edge (documented in README):** a registration that wraps the server in a non-`exec` shell would make the shell the parent and hide the flag. No real launch path does this.

## New files

| File | Purpose |
| ---- | ------- |
| `extensions/claude-code-remote/src/channel-detect.ts` | `isChannelLaunch` + `readParentCommand` |
| `extensions/claude-code-remote/src/channel-detect.test.ts` | Real captured cmdlines (both spawners), rejection/edge cases, live-pid + dead-pid `ps` behavior |

## Modified files

| File | Change |
| ---- | ------ |
| `extensions/claude-code-remote/src/index.ts` | Gate `start()` on `isChannelLaunch`; plain path logs and idles |
| `extensions/claude-code-remote/src/channel-server.ts` | `started` guard on shutdown; `channelActive` instructions variant |
| `extensions/claude-code-remote/src/channel-server.test.ts` | Plain-mode instructions test; shutdown-before/after-start lifecycle tests (scoped `spyOn`, INV-48) |
| `extensions/claude-code-remote/README.md` | Documents the gate + the exec-wrapper caveat |
| `docs/claude-code-channel.md` | Gate as step 1 of startup; architecture note |

## Out of scope (deliberate)

- No changes to `spawn.sh` (pi-extensions) or `harness-daemon` — the gate reads the flag they already pass; that independence is the point of the design.
- Claude Code 2.1.206 quirk found while verifying: `--strict-mcp-config` breaks dev-channel name resolution ("no MCP server configured with that name"). Not our bug; no path uses that combination.
- Existing stray scratchpads from plain sessions are not cleaned up here.

## Test plan

- [x] `bun test` in `extensions/claude-code-remote` — 85 pass (7 new channel-detect, 3 new lifecycle/instructions)
- [x] `bun test` in `extensions/remote-session` — 92 pass
- [x] `tsc --noEmit` in `extensions/claude-code-remote` clean; repo-wide pre-commit lint + typecheck green
- [x] Live negative: real server run with a plain shell parent → `serving as a plain MCP server; no scratchpad linked`, clean stdin-close shutdown, no link POST
- [x] Live positive (dogfood): real `claude --dangerously-load-development-channels server:threa` in tmux running **this branch's** server → stderr `linked to scratchpad https://app.threa.io/w/…/s/stream_01KX5DKPX96N4Q994JH0E2MVBZ` (disposable scratchpad "GATE-VERIFY-DISPOSABLE" — archive at will)
- [ ] Plain-session verify inside a *real* interactive Claude session with the user-scope registration — equivalent to the live negative above (same parent-cmdline input), not separately run

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786259649&installation_id=129946197&pr_number=1267&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1267&signature=3c178c8419f9348fa785c23555a82b3d94289b28b324f48a3987ab349c1f5010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->