### PR TITLE
fix(board): disable message text-selection on touch (timeline parity)

### DIFF
--- a/apps/frontend/src/components/board/board-card.test.tsx
+++ b/apps/frontend/src/components/board/board-card.test.tsx
@@ -23,6 +23,7 @@ import * as syncEngineModule from "@/sync/sync-engine"
 import * as contextsModule from "@/contexts"
 import * as queueDraftModule from "@/hooks/use-queue-draft-message"
 import * as inlineComposerModule from "@/components/board/board-inline-composer"
+import * as inputModeModule from "@/hooks/use-input-mode"
 import { spyOnExport } from "@/test/spy"
 import { MESSAGE_ROW_HEAD_PADDING } from "@/components/message/message-row-layout"
 
@@ -511,5 +512,53 @@ describe("BoardCard row layout", () => {
     for (const cls of MESSAGE_ROW_HEAD_PADDING.split(" ")) {
       expect(accent!.className).toContain(cls)
     }
+  })
+
+  // Parity with the timeline row (MessageEvent): on touch the row hands selection
+  // to the long-press drawer / swipe-to-quote, so native selection is disabled;
+  // on mouse the row stays selectable so the desktop quote-on-selection works.
+  // Assert across EVERY rendered row — MessageItem has separate head- and
+  // continuation-row containers, so a same-author follow-up covers both paths
+  // (an earlier version only patched the head container).
+  const withContinuationReply = (): BoardViewPost => {
+    const post = makePost()
+    return {
+      ...post,
+      conversation: { ...(post.conversation as object), messageIds: ["m_open", "m_reply"] },
+      // Same author, inside GROUP_WINDOW_MS of the opening → renders as a continuation row.
+      recentMessages: [
+        {
+          id: "m_reply",
+          streamId: STREAM,
+          authorId: "usr_other",
+          authorType: "user",
+          contentMarkdown: "Reply body.",
+          reactions: {},
+          attachments: [],
+          linkPreviews: [],
+          createdAt: "2026-06-22T12:01:00.000Z",
+          editedAt: null,
+        },
+      ],
+      totalReplies: 1,
+    } as unknown as BoardViewPost
+  }
+
+  it("disables text selection on touch input across head and continuation rows", async () => {
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("touch")
+    mountCard(withContinuationReply())
+    await screen.findByText("Reply body.")
+    const rows = document.querySelectorAll("[data-message-row]")
+    expect(rows.length).toBe(2)
+    for (const row of rows) expect(row.className).toContain("select-none")
+  })
+
+  it("keeps text selectable on mouse input across head and continuation rows", async () => {
+    vi.spyOn(inputModeModule, "useInputMode").mockReturnValue("mouse")
+    mountCard(withContinuationReply())
+    await screen.findByText("Reply body.")
+    const rows = document.querySelectorAll("[data-message-row]")
+    expect(rows.length).toBe(2)
+    for (const row of rows) expect(row.className).not.toContain("select-none")
   })
 })

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -650,6 +650,10 @@ export function MessageItem({
         data-actor-type={message.authorType}
         className={cn(
           "relative scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
+          // Touch owns selection to the long-press drawer / swipe-to-quote, so kill
+          // native selection on mobile — matches the timeline row (message-event).
+          // Desktop keeps it selectable for the quote-on-selection affordance.
+          isTouchInput && !isEditing && "select-none",
           rowInsetClassName
         )}
         {...touchHandlers}
@@ -703,6 +707,10 @@ export function MessageItem({
       data-actor-type={message.authorType}
       className={cn(
         "relative scroll-mt-12 overflow-hidden outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:overflow-visible",
+        // Touch owns selection to the long-press drawer / swipe-to-quote, so kill
+        // native selection on mobile — matches the timeline row (message-event).
+        // Desktop keeps it selectable for the quote-on-selection affordance.
+        isTouchInput && !isEditing && "select-none",
         rowInsetClassName
       )}
       {...touchHandlers}


### PR DESCRIPTION
## Problem

Text-selection behavior diverged between the stream timeline and the board / conversation-panel surfaces.

The timeline row (`MessageEvent`, `apps/frontend/src/components/timeline/message-event.tsx`) already does two things: on desktop a mouse text selection inside a message surfaces a floating **Quote** button (`TextSelectionQuote` → `QuoteReplyProvider`), and on touch it sets `isTouchInput && !isEditing && "select-none"` on the row so a long-press goes to the action drawer / swipe-to-quote instead of starting a native OS text selection.

The board card (`board-card.tsx`) and conversation panel (`conversation-panel.tsx`) already mounted the desktop half — both wrap their rows in `QuoteReplyProvider` + `TextSelectionQuote` (scoped by a container ref), and the `.message-content .markdown-content` selector chain resolves inside their shared row component `MessageItem`. So desktop quote-on-selection already worked there.

The mobile half was missing: `MessageItem` (`apps/frontend/src/components/message/message-item.tsx`) never applied `select-none` on touch. On a phone, long-pressing a board/panel message started an OS text selection instead of handing off to the long-press drawer / swipe-to-quote.

## Solution

Add `isTouchInput && !isEditing && "select-none"` to the `MessageItem` row container, mirroring the timeline row. `isTouchInput` (`useInputMode() === "touch"`) and `isEditing` were already in scope. Desktop stays selectable so quote-on-selection keeps working; touch hands selection to the gesture layer.

`MessageItem` has two return paths — a head row and a same-author **continuation** row — each with its own container `<div>`. The class was added to **both**.

## Design evolution (self-review)

The first pass only patched the **head** row: the two container `className` blocks differ by indentation (the continuation block sits inside `if (continuation) return (…)`), so the intended "replace both" edit matched only one. Same-author follow-up rows on the board/panel would have stayed selectable on mobile — the exact partial-edit failure this change is meant to close. Caught in self-review (and independently by the review agent); fixed by patching the continuation container too, and the test now renders a grouped follow-up so both paths are exercised.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/message/message-item.tsx` | Add `isTouchInput && !isEditing && "select-none"` to both row containers (head + continuation). |
| `apps/frontend/src/components/board/board-card.test.tsx` | Render a card with a same-author reply (a continuation row) and assert `select-none` is present on **every** rendered row under touch, absent under mouse. |

## Out of scope (deliberate)

- **Desktop quote-on-selection** — already wired on both board surfaces before this change; not touched.
- **Label landing page** — also renders `MessageItem` but mounts no quote provider (selection there does nothing actionable). It now also disables selection on touch, which is harmless and keeps the shared component uniform.
- Mechanism matches the timeline exactly (Tailwind `select-none` / `user-select: none`); no `-webkit-touch-callout` was added since the timeline doesn't use one either.

## Test plan

- [x] `apps/frontend` `board-card.test.tsx` — 18 pass (incl. the two new touch/mouse tests; the touch test asserts `rows.length === 2`, proving both the head and continuation paths render and carry the class)
- [x] `apps/frontend` `conversation-panel.test.tsx` — 18 pass (shares `MessageItem`, no regression)
- [x] `tsc --noEmit` (`tsconfig.app.json` + `tsconfig.test.json`) clean for the changed files
- [x] Pre-commit hook (full-monorepo lint + typecheck) green
- [x] Pre-PR review (1 combined Sonnet agent, trivial-diff tier): 1 correctness finding + 1 test-coverage finding — both were already fixed in self-review before the report landed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmkWNvvBbRdJ9Jiwc7ihXV)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786267221&installation_id=129946197&pr_number=1271&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1271&signature=0c51d779eeb38598ddeb084a200c3fa03316bff9454e42e559661d0b69fb97e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->