### PR TITLE
chore(harnessd): default Pi remote label to "coding" at spawn

### DIFF
--- a/extensions/harness-daemon/src/spawners.ts
+++ b/extensions/harness-daemon/src/spawners.ts
@@ -30,6 +30,7 @@ export class PiRuntimeSpawner extends RuntimeSpawner {
 
     const session = tmuxSession(options)
     ensureTmuxSession(session)
+    ensurePiDefaultLabel()
     const { worktree, branch } = this.createWorktree(options)
     const window = pickTmuxWindow(session, options.name)
     const windowId = createWindow(session, window, worktree, piBin)
@@ -202,6 +203,19 @@ export class ClaudeRuntimeSpawner extends RuntimeSpawner {
     }
     const json = (await response.json()) as { data?: { streamUrlPath?: string } }
     return json.data?.streamUrlPath ? `${baseUrl}${json.data.streamUrlPath}` : undefined
+  }
+}
+
+function ensurePiDefaultLabel(): void {
+  const path = join(homedir(), ".pi", "agent", "threa-remote.json")
+  if (!existsSync(path)) return
+  try {
+    const config = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>
+    if (typeof config.defaultLabel === "string" && config.defaultLabel.trim()) return
+    writeFileSync(path, `${JSON.stringify({ ...config, defaultLabel: "coding" }, null, 2)}\n`)
+    console.log("harnessd: set Pi remote defaultLabel=coding")
+  } catch (error) {
+    console.warn(`harnessd: could not ensure Pi default label: ${error}`)
   }
 }
 


### PR DESCRIPTION
## Problem

Pi runtimes spawned by harnessd create scratchpads with no label when `~/.pi/agent/threa-remote.json` lacks a `defaultLabel`. The fix existed only as an uncommitted working-tree edit in the main checkout (found during the #1266 rollout), so it was one `git reset` away from vanishing.

## Solution

`ensurePiDefaultLabel()` runs in `PiRuntimeSpawner.spawn` before the worktree is created: if the Pi remote config exists and has no non-empty `defaultLabel`, it writes `"coding"`. An existing value is never overwritten; a missing config file is a no-op; parse/write failures warn and continue (spawn must not die over a label).

## Files changed

| File | Change |
| ---- | ------ |
| `extensions/harness-daemon/src/spawners.ts` | `ensurePiDefaultLabel()` + call at Pi spawn |

## Test plan

- [x] `bunx tsc --noEmit` in `extensions/harness-daemon` clean
- [ ] harness-daemon has no test suite; verified by reading — the function is a guarded read-modify-write with existing imports

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786283511&installation_id=129946197&pr_number=1276&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1276&signature=c0814f030e9883c7038d7778ea86601f8b9ecd66a34a7df618a33d0a65484a92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->