### PR TITLE
feat: agent-memo read-time provenance + reflective knowledge-type allowlist (roadmap 6.6)

### DIFF
--- a/apps/backend/evals/fixtures/memo.ts
+++ b/apps/backend/evals/fixtures/memo.ts
@@ -72,6 +72,8 @@ export function toMemo(m: { title: string; abstract: string; createdDaysAgo?: nu
     status: MemoStatuses.ACTIVE,
     version: 1,
     revisionReason: null,
+    authoredByKind: "pipeline",
+    sourceSessionId: null,
     createdAt,
     updatedAt: createdAt,
     archivedAt: null,

--- a/apps/backend/src/features/agents/researcher/researcher.ts
+++ b/apps/backend/src/features/agents/researcher/researcher.ts
@@ -4,7 +4,7 @@ import { withClient } from "../../../db"
 import { composeAbortSignal, isAbortError, type AI } from "@threa/agent-runtime"
 import type { ConfigResolver, ResearcherConfig } from "../../../lib/ai/config-resolver"
 import { COMPONENT_PATHS } from "../../../lib/ai/config-resolver"
-import type { TraceSource } from "@threa/types"
+import type { AuthoredByKind, TraceSource } from "@threa/types"
 import type { EmbeddingServiceLike } from "../../memos"
 import { MessageRepository, type Message } from "../../messaging"
 import { MemoRepository, classifyMemoQueryIntent } from "../../memos"
@@ -52,6 +52,8 @@ export interface WorkspaceSourceItem {
   streamName?: string
   messageId?: string
   authorName?: string
+  /** Memo sources: who authored the cited memo (agent-captured knowledge is flagged in citations). */
+  authoredByKind?: AuthoredByKind
 }
 
 /**
@@ -1329,6 +1331,7 @@ Each query must have:
         memoId: memo.id,
         streamId: sourceStream?.id,
         streamName: sourceStream?.name ?? sourceStream?.type,
+        authoredByKind: memo.authoredByKind,
       })
     }
 

--- a/apps/backend/src/features/agents/tools/describe-memo-tool.test.ts
+++ b/apps/backend/src/features/agents/tools/describe-memo-tool.test.ts
@@ -42,6 +42,8 @@ describe("describe_memo tool", () => {
         status: "active",
         version: 1,
         revisionReason: null,
+        authoredByKind: "pipeline",
+        sourceSessionId: null,
         createdAt: new Date("2026-04-30T09:00:00Z"),
         updatedAt: new Date("2026-04-30T09:00:00Z"),
         archivedAt: null,
@@ -50,6 +52,7 @@ describe("describe_memo tool", () => {
       sourceStream: { id: "stream_1", type: "channel", name: "general" },
       rootStream: { id: "stream_1", type: "channel", name: "general" },
       successorMemoId: null,
+      capturedByPersonaName: null,
       sourceMessages: [
         {
           id: "msg_1",
@@ -144,6 +147,8 @@ describe("describe_memo tool", () => {
         status: "active",
         version: 1,
         revisionReason: null,
+        authoredByKind: "pipeline",
+        sourceSessionId: null,
         createdAt: new Date("2026-04-30T09:00:00Z"),
         updatedAt: new Date("2026-04-30T09:00:00Z"),
         archivedAt: null,
@@ -152,6 +157,7 @@ describe("describe_memo tool", () => {
       sourceStream: { id: "stream_1", type: "channel", name: "g" },
       rootStream: null,
       successorMemoId: null,
+      capturedByPersonaName: null,
       sourceMessages: [
         {
           id: "msg_1",

--- a/apps/backend/src/features/agents/tools/workspace-research-tool.ts
+++ b/apps/backend/src/features/agents/tools/workspace-research-tool.ts
@@ -130,6 +130,7 @@ When you do call it, incorporate retrieved context naturally into your response.
             streamName: s.streamName,
             messageId: s.messageId,
             authorName: s.authorName,
+            authoredByKind: s.authoredByKind,
           }
         }),
     },

--- a/apps/backend/src/features/memos/config.ts
+++ b/apps/backend/src/features/memos/config.ts
@@ -78,6 +78,28 @@ export const MEMO_MAX_PER_CONVERSATION = 5
 export const MEMO_REFLECTIVE_MAX_MEMOS = 2
 
 /**
+ * Knowledge types a reflective session capture may mint (roadmap 6.6). An agent
+ * distilling its own research must not author `decision` memos — a decision is
+ * organizational authority the team commits to (and the highest-boosted type in
+ * {@link MEMO_KNOWLEDGE_TYPE_BOOST}), so agent-minted ones would let a persona's
+ * own conclusions masquerade as team rulings and compound through retrieval.
+ * A disallowed type is coerced to `learning` (the honest label for a research
+ * conclusion) rather than dropped, so the finding itself survives. Real
+ * decisions stated in conversation are captured by the passive pipeline — and
+ * `save_memo` is deliberately NOT gated by this list, since it acts on explicit
+ * in-conversation direction, not the agent's own reflection.
+ */
+export const MEMO_REFLECTIVE_KNOWLEDGE_TYPES: readonly KnowledgeType[] = [
+  "learning",
+  "procedure",
+  "reference",
+  "context",
+]
+
+/** Coercion target for a reflective memo whose type is outside the allowlist. */
+export const MEMO_REFLECTIVE_FALLBACK_KNOWLEDGE_TYPE: KnowledgeType = "learning"
+
+/**
  * Cross-conversation dedup threshold (pgvector cosine distance, 0 = identical).
  * A candidate memo within this distance of an existing active memo in the same
  * stream — but from a different conversation — is treated as the same knowledge

--- a/apps/backend/src/features/memos/explorer-service.test.ts
+++ b/apps/backend/src/features/memos/explorer-service.test.ts
@@ -3,6 +3,7 @@ import type { Pool } from "pg"
 import { MemoExplorerService } from "./explorer-service"
 import { MemoRepository, type Memo } from "./repository"
 import { MessageRepository } from "../messaging"
+import { AgentSessionRepository, PersonaRepository } from "../agents"
 import { StreamRepository, type Stream } from "../streams"
 import * as dbModule from "../../db"
 import type { EmbeddingServiceLike } from "./embedding-service"
@@ -30,6 +31,8 @@ function fakeMemo(overrides: Partial<Memo> = {}): Memo {
     status: "active",
     version: 1,
     revisionReason: null,
+    authoredByKind: "pipeline",
+    sourceSessionId: null,
     createdAt: new Date("2026-05-01T00:00:00Z"),
     updatedAt: new Date("2026-05-01T00:00:00Z"),
     archivedAt: null,
@@ -190,5 +193,47 @@ describe("MemoExplorerService.getById (roadmap 6.1)", () => {
 
     expect(result?.memo.status).toBe("superseded")
     expect(result?.successorMemoId).toBe("memo_2")
+  })
+})
+
+describe("MemoExplorerService.getById — agent provenance (roadmap 6.6)", () => {
+  it("resolves the capturing persona's name for an agent-authored memo", async () => {
+    const { service } = buildService()
+    stubSourceStreamResolution()
+    spyOn(MemoRepository, "findById").mockResolvedValue(
+      fakeMemo({ authoredByKind: "agent", sourceSessionId: "agsess_1" })
+    )
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue({ personaId: "persona_1" } as never)
+    spyOn(PersonaRepository, "findByIds").mockResolvedValue([{ id: "persona_1", name: "Ariadne" }] as never)
+
+    const result = await service.getById(WORKSPACE_ID, MEMO_ID, ACCESS)
+
+    expect(result?.memo.authoredByKind).toBe("agent")
+    expect(result?.capturedByPersonaName).toBe("Ariadne")
+  })
+
+  it("skips the session lookup entirely for a pipeline-authored memo", async () => {
+    const { service } = buildService()
+    stubSourceStreamResolution()
+    spyOn(MemoRepository, "findById").mockResolvedValue(fakeMemo())
+    const sessionLookup = spyOn(AgentSessionRepository, "findById").mockResolvedValue(null)
+
+    const result = await service.getById(WORKSPACE_ID, MEMO_ID, ACCESS)
+
+    expect(result?.capturedByPersonaName).toBeNull()
+    expect(sessionLookup).not.toHaveBeenCalled()
+  })
+
+  it("returns null provenance when the writing session no longer resolves", async () => {
+    const { service } = buildService()
+    stubSourceStreamResolution()
+    spyOn(MemoRepository, "findById").mockResolvedValue(
+      fakeMemo({ authoredByKind: "agent", sourceSessionId: "agsess_gone" })
+    )
+    spyOn(AgentSessionRepository, "findById").mockResolvedValue(null)
+
+    const result = await service.getById(WORKSPACE_ID, MEMO_ID, ACCESS)
+
+    expect(result?.capturedByPersonaName).toBeNull()
   })
 })

--- a/apps/backend/src/features/memos/explorer-service.ts
+++ b/apps/backend/src/features/memos/explorer-service.ts
@@ -10,7 +10,7 @@ import { resolveMemoSearchMode, DEFAULT_MEMO_SEARCH_MODE, MEMO_RERANKER_CANDIDAT
 import type { RerankerLike } from "./reranker"
 import type { EmbeddingServiceLike } from "./embedding-service"
 import { StreamRepository, type Stream } from "../streams"
-import { PersonaRepository } from "../agents"
+import { AgentSessionRepository, PersonaRepository } from "../agents"
 import { UserRepository } from "../workspaces"
 
 const DEFAULT_LIMIT = 30
@@ -73,6 +73,12 @@ export interface MemoExplorerDetail extends MemoExplorerResult {
   sourceMessages: MemoExplorerSourceMessage[]
   /** For a superseded memo, the id of the active memo that replaced it. */
   successorMemoId: string | null
+  /**
+   * For an agent-authored memo, the display name of the persona whose session
+   * wrote it (resolved via `sourceSessionId`) — null when unresolvable or when
+   * the memo is pipeline-authored.
+   */
+  capturedByPersonaName: string | null
 }
 
 export interface MemoExplorerServiceDeps {
@@ -318,6 +324,7 @@ export class MemoExplorerService {
     const sourceMessages = await this.loadSourceMessages(workspaceId, memo, permissions.accessibleStreamIds)
     const successor =
       memo.status === "superseded" ? await MemoRepository.findSupersededBy(this.pool, workspaceId, memo.id) : null
+    const capturedByPersonaName = await this.resolveCapturedByPersonaName(workspaceId, memo)
 
     return {
       memo,
@@ -326,7 +333,21 @@ export class MemoExplorerService {
       rootStream: this.toStreamRef(sourceContext.rootStream),
       sourceMessages,
       successorMemoId: successor?.id ?? null,
+      capturedByPersonaName,
     }
+  }
+
+  /** Agent provenance for the detail surface: `sourceSessionId` → session → persona name. */
+  private async resolveCapturedByPersonaName(workspaceId: string, memo: Memo): Promise<string | null> {
+    if (memo.authoredByKind !== "agent" || !memo.sourceSessionId) {
+      return null
+    }
+    const session = await AgentSessionRepository.findById(this.pool, memo.sourceSessionId)
+    if (!session) {
+      return null
+    }
+    const [persona] = await PersonaRepository.findByIds(this.pool, [session.personaId], workspaceId)
+    return persona?.name ?? null
   }
 
   private resolveStreamIds(accessibleStreamIds: string[], requestedStreamIds?: string[]): string[] {

--- a/apps/backend/src/features/memos/handlers.ts
+++ b/apps/backend/src/features/memos/handlers.ts
@@ -118,6 +118,7 @@ function serializeMemoDetail(detail: MemoExplorerDetail) {
   return {
     ...serializeMemoResult(detail),
     successorMemoId: detail.successorMemoId,
+    capturedByPersonaName: detail.capturedByPersonaName,
     sourceMessages: detail.sourceMessages.map((message) => ({
       ...message,
       createdAt: message.createdAt.toISOString(),

--- a/apps/backend/src/features/memos/repository.ts
+++ b/apps/backend/src/features/memos/repository.ts
@@ -48,6 +48,8 @@ interface MemoRow {
   status: string
   version: number
   revision_reason: string | null
+  authored_by_kind: string
+  source_session_id: string | null
   created_at: Date
   updated_at: Date
   archived_at: Date | null
@@ -70,6 +72,8 @@ export interface Memo {
   status: MemoStatus
   version: number
   revisionReason: string | null
+  authoredByKind: AuthoredByKind
+  sourceSessionId: string | null
   createdAt: Date
   updatedAt: Date
   archivedAt: Date | null
@@ -191,6 +195,8 @@ function mapRowToMemo(row: MemoRow): Memo {
     status: row.status as MemoStatus,
     version: row.version,
     revisionReason: row.revision_reason,
+    authoredByKind: row.authored_by_kind as AuthoredByKind,
+    sourceSessionId: row.source_session_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     archivedAt: row.archived_at,
@@ -201,6 +207,7 @@ const SELECT_FIELDS = `
   id, workspace_id, memo_type, source_message_id, source_conversation_id,
   title, abstract, key_points, source_message_ids, participant_ids,
   knowledge_type, tags, parent_memo_id, status, version, revision_reason,
+  authored_by_kind, source_session_id,
   created_at, updated_at, archived_at
 `
 
@@ -208,6 +215,7 @@ const SELECT_FIELDS_PREFIXED = `
   m.id, m.workspace_id, m.memo_type, m.source_message_id, m.source_conversation_id,
   m.title, m.abstract, m.key_points, m.source_message_ids, m.participant_ids,
   m.knowledge_type, m.tags, m.parent_memo_id, m.status, m.version, m.revision_reason,
+  m.authored_by_kind, m.source_session_id,
   m.created_at, m.updated_at, m.archived_at
 `
 

--- a/apps/backend/src/features/memos/service.test.ts
+++ b/apps/backend/src/features/memos/service.test.ts
@@ -449,6 +449,8 @@ function fakeMemoRow(id: string, overrides: Partial<import("./repository").Memo>
     status: "active",
     version: 1,
     revisionReason: null,
+    authoredByKind: "pipeline",
+    sourceSessionId: null,
     createdAt: new Date(),
     updatedAt: new Date(),
     archivedAt: null,
@@ -783,6 +785,28 @@ describe("MemoService.captureSessionReflection — reflective capture (roadmap 6
 
     expect(result.captured).toBe(MEMO_REFLECTIVE_MAX_MEMOS)
     expect(insert).toHaveBeenCalledTimes(MEMO_REFLECTIVE_MAX_MEMOS)
+  })
+
+  it("coerces a disallowed knowledge type to the fallback — agents don't mint decisions (roadmap 6.6)", async () => {
+    const { service, insert } = setupReflection({
+      memoContents: [
+        { ...memoContent, title: "Self-minted ruling", knowledgeType: "decision" },
+        { ...memoContent, title: "Genuine finding", abstract: "Distinct second finding.", knowledgeType: "procedure" },
+      ],
+    })
+
+    const result = await service.captureSessionReflection(reflectionInput)
+
+    expect(result.captured).toBe(2)
+    expect(insert).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ title: "Self-minted ruling", knowledgeType: "learning" })
+    )
+    // An allowed type passes through untouched.
+    expect(insert).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ title: "Genuine finding", knowledgeType: "procedure" })
+    )
   })
 
   it("dedups a reflective memo whose knowledge already exists in the stream", async () => {

--- a/apps/backend/src/features/memos/service.ts
+++ b/apps/backend/src/features/memos/service.ts
@@ -31,6 +31,8 @@ import {
   MEMO_DEDUP_DISTANCE,
   MEMO_SUPERSEDE_DISTANCE,
   MEMO_REFLECTIVE_MAX_MEMOS,
+  MEMO_REFLECTIVE_KNOWLEDGE_TYPES,
+  MEMO_REFLECTIVE_FALLBACK_KNOWLEDGE_TYPE,
 } from "./config"
 
 const MEMORY_CONTEXT_LIMIT = 20
@@ -936,7 +938,20 @@ export class MemoService implements MemoServiceLike {
         authorTimezone,
         memoLanguage: context.memoLanguage,
       })
-    ).slice(0, MEMO_REFLECTIVE_MAX_MEMOS)
+    )
+      .slice(0, MEMO_REFLECTIVE_MAX_MEMOS)
+      .map((content) => {
+        // Allowlist gate (see MEMO_REFLECTIVE_KNOWLEDGE_TYPES): an agent must
+        // not mint decision-authority memos from its own reflection.
+        if (MEMO_REFLECTIVE_KNOWLEDGE_TYPES.includes(content.knowledgeType)) {
+          return content
+        }
+        logger.info(
+          { sessionId, streamId, title: content.title, knowledgeType: content.knowledgeType },
+          "reflective capture — disallowed knowledge type coerced"
+        )
+        return { ...content, knowledgeType: MEMO_REFLECTIVE_FALLBACK_KNOWLEDGE_TYPE }
+      })
     if (contents.length === 0) {
       logger.info({ sessionId, streamId }, "reflective capture — memorizer returned no memos")
       return { classified: true, captured: 0, deduped: 0 }
@@ -1059,6 +1074,8 @@ export class MemoService implements MemoServiceLike {
       status: memo.status,
       version: memo.version,
       revisionReason: memo.revisionReason,
+      authoredByKind: memo.authoredByKind,
+      sourceSessionId: memo.sourceSessionId,
       createdAt: memo.createdAt.toISOString(),
       updatedAt: memo.updatedAt.toISOString(),
       archivedAt: memo.archivedAt ? memo.archivedAt.toISOString() : null,
@@ -1085,6 +1102,8 @@ export class MemoService implements MemoServiceLike {
       status: memoData.status,
       version: 1,
       revisionReason: null,
+      authoredByKind: AuthoredByKinds.PIPELINE,
+      sourceSessionId: null,
       createdAt: now,
       updatedAt: now,
       archivedAt: null,

--- a/apps/backend/src/features/public-api/handlers.ts
+++ b/apps/backend/src/features/public-api/handlers.ts
@@ -354,6 +354,7 @@ function serializeMemoDetail(detail: MemoExplorerDetail): WireMemoDetail {
   return {
     ...serializeMemoSearchResult(detail),
     successorMemoId: detail.successorMemoId,
+    capturedByPersonaName: detail.capturedByPersonaName,
     sourceMessages: detail.sourceMessages.map((message) => ({
       ...message,
       createdAt: message.createdAt.toISOString(),

--- a/apps/backend/src/features/public-api/routes.ts
+++ b/apps/backend/src/features/public-api/routes.ts
@@ -20,6 +20,7 @@ import {
   LABELABLE_RESOURCE_TYPES,
   MEMO_TYPES,
   KNOWLEDGE_TYPES,
+  AUTHORED_BY_KINDS,
   PROCESSING_STATUSES,
   EXTRACTION_CONTENT_TYPES,
   THREA_CALLBACK_TOKEN_HEADER,
@@ -266,6 +267,8 @@ const memoSchema = z.object({
   status: z.string(),
   version: z.number().int(),
   revisionReason: z.string().nullable(),
+  authoredByKind: z.enum(AUTHORED_BY_KINDS),
+  sourceSessionId: z.string().nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   archivedAt: z.string().datetime().nullable(),
@@ -292,6 +295,7 @@ const memoSourceMessageSchema = z.object({
 const memoDetailSchema = memoSearchResultSchema.extend({
   sourceMessages: z.array(memoSourceMessageSchema),
   successorMemoId: z.string().nullable(),
+  capturedByPersonaName: z.string().nullable(),
 })
 
 const attachmentExtractionSchema = z.object({

--- a/apps/frontend/src/api/memos.ts
+++ b/apps/frontend/src/api/memos.ts
@@ -29,6 +29,8 @@ export interface MemoExplorerDetail extends MemoExplorerResult {
   sourceMessages: MemoExplorerSourceMessage[]
   /** For a superseded memo, the id of the active memo that replaced it. */
   successorMemoId: string | null
+  /** For an agent-authored memo, the persona that captured it (null when unresolvable or pipeline-authored). */
+  capturedByPersonaName: string | null
 }
 
 export interface MemoSearchFilters {

--- a/apps/frontend/src/components/memo/memo-detail.test.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.test.tsx
@@ -24,6 +24,8 @@ function buildDetail(overrides: Partial<MemoExplorerDetail["memo"]> = {}): MemoE
       status: "active",
       version: 1,
       revisionReason: null,
+      authoredByKind: "pipeline",
+      sourceSessionId: null,
       createdAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
       archivedAt: null,
@@ -34,6 +36,7 @@ function buildDetail(overrides: Partial<MemoExplorerDetail["memo"]> = {}): MemoE
     rootStream: null,
     sourceMessages: [],
     successorMemoId: null,
+    capturedByPersonaName: null,
   }
 }
 
@@ -152,5 +155,34 @@ describe("MemoDetailContent edit controls (roadmap 6.1)", () => {
     renderDetail(<MemoDetailContent data={detail} workspaceId="ws_1" isLoading={false} />)
     const link = screen.getByRole("link", { name: /replaced by a newer memo/i })
     expect(link).toHaveAttribute("href", expect.stringContaining("memo=memo_2"))
+  })
+})
+
+describe("MemoDetailContent agent provenance (roadmap 6.6)", () => {
+  beforeEach(() => {
+    vi.spyOn(relativeTimeModule, "RelativeTime").mockImplementation(() => <span>just now</span>)
+  })
+
+  it("flags an agent-authored memo with the capturing persona's name", () => {
+    const detail = {
+      ...buildDetail({ authoredByKind: "agent", sourceSessionId: "agsess_1" }),
+      capturedByPersonaName: "Ariadne",
+    }
+    renderDetail(<MemoDetailContent data={detail} workspaceId="ws_1" isLoading={false} />)
+    expect(screen.getByText("Captured by Ariadne")).toBeInTheDocument()
+    expect(screen.getByText(/written by Ariadne from its own session work/i)).toBeInTheDocument()
+  })
+
+  it("falls back to a generic label when the persona is unresolvable", () => {
+    const detail = buildDetail({ authoredByKind: "agent", sourceSessionId: "agsess_gone" })
+    renderDetail(<MemoDetailContent data={detail} workspaceId="ws_1" isLoading={false} />)
+    expect(screen.getByText("AI-captured")).toBeInTheDocument()
+    expect(screen.getByText(/written by an AI agent from its own session work/i)).toBeInTheDocument()
+  })
+
+  it("shows no provenance flag on a pipeline-authored memo", () => {
+    renderDetail(<MemoDetailContent data={buildDetail()} workspaceId="ws_1" isLoading={false} />)
+    expect(screen.queryByText(/AI-captured|Captured by/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/written by .* session work/i)).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/components/memo/memo-detail.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.tsx
@@ -3,6 +3,7 @@ import {
   Archive,
   ArchiveRestore,
   BookOpen,
+  Bot,
   Check,
   Copy,
   ExternalLink,
@@ -209,6 +210,20 @@ function MemoEditForm({
   )
 }
 
+/**
+ * Agent-provenance badge (roadmap 6.6): an agent-authored memo (`save_memo` /
+ * reflective capture) must be legible as such wherever it renders, so a reader
+ * can weigh it differently from conversation-extracted knowledge.
+ */
+export function AgentAuthoredBadge({ personaName }: { personaName?: string | null }) {
+  return (
+    <Badge variant="outline" className="gap-1 text-[10px] text-muted-foreground">
+      <Bot className="h-2.5 w-2.5" />
+      {personaName ? `Captured by ${personaName}` : "AI-captured"}
+    </Badge>
+  )
+}
+
 function MemoStatusBadge({ status }: { status: string }) {
   if (status === "archived") {
     return (
@@ -351,6 +366,7 @@ export function MemoDetailContent({
               {memoLabel(data.memo.memoType)}
             </Badge>
             <MemoStatusBadge status={data.memo.status} />
+            {data.memo.authoredByKind === "agent" && <AgentAuthoredBadge personaName={data.capturedByPersonaName} />}
             <span className="text-[11px] tabular-nums text-muted-foreground/50">v{data.memo.version}</span>
             <span className="text-muted-foreground/30">&middot;</span>
             <RelativeTime date={data.memo.updatedAt} className="text-[11px] text-muted-foreground/50" />
@@ -450,6 +466,13 @@ export function MemoDetailContent({
       )}
 
       <DetailSection title="Provenance">
+        {data.memo.authoredByKind === "agent" && (
+          <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Bot className="h-3.5 w-3.5 shrink-0" />
+            Written by {data.capturedByPersonaName ?? "an AI agent"} from its own session work, not extracted from a
+            team conversation.
+          </p>
+        )}
         <div className="flex min-w-0 flex-wrap gap-2">
           {data.sourceStream && (
             <Link

--- a/apps/frontend/src/components/trace/trace-step.test.tsx
+++ b/apps/frontend/src/components/trace/trace-step.test.tsx
@@ -318,6 +318,37 @@ describe("TraceStep", () => {
     )
   })
 
+  it("flags an agent-captured memo source (roadmap 6.6)", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <TraceStep
+          step={createStep({
+            stepType: "workspace_search",
+            content: JSON.stringify({ memoCount: 1, messageCount: 0 }),
+            sources: [
+              {
+                type: "workspace_memo",
+                title: "Agent research finding",
+                memoId: "memo_agent",
+                streamId: "stream_2",
+                streamName: "#launch",
+                authoredByKind: "agent",
+              },
+            ],
+          })}
+          workspaceId="ws_1"
+          streamId="stream_1"
+        />
+      </MemoryRouter>
+    )
+
+    await user.click(screen.getByRole("button", { name: /sources/i }))
+
+    expect(screen.getByText(/from #launch · AI-captured/)).toBeInTheDocument()
+  })
+
   it("reveals the full research brief from a collapsed disclosure", async () => {
     const user = userEvent.setup()
 

--- a/apps/frontend/src/components/trace/trace-step.tsx
+++ b/apps/frontend/src/components/trace/trace-step.tsx
@@ -1079,8 +1079,12 @@ function SourceItem({ source, workspaceId, isLast }: { source: TraceSource; work
           {source.streamName && ` in ${source.streamName}`}
         </div>
       )}
-      {source.streamName && source.type === "workspace_memo" && (
-        <div className="text-[11px] text-muted-foreground mb-1">from {source.streamName}</div>
+      {(source.streamName || source.authoredByKind === "agent") && source.type === "workspace_memo" && (
+        <div className="text-[11px] text-muted-foreground mb-1">
+          {source.streamName ? `from ${source.streamName}` : null}
+          {source.streamName && source.authoredByKind === "agent" ? " · " : null}
+          {source.authoredByKind === "agent" ? "AI-captured" : null}
+        </div>
       )}
       {source.snippet && (
         <div className="text-muted-foreground text-[11px] leading-snug line-clamp-2">{source.snippet}</div>

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -60,7 +60,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 6.3  | Reflective capture at session completion                 | ☑      | #1273 |
 | 6.4  | `memoScope` (user/stream/workspace)                      | ☐      |       |
 | 6.5  | Retrieval feedback decay                                 | ☐      |       |
-| 6.6  | Agent-memo safety: read-time provenance + type allowlist | ☑      |       |
+| 6.6  | Agent-memo safety: read-time provenance + type allowlist | ☑      | #1277 |
 | 7.1  | Workspace persona CRUD API                               | ☐      |       |
 | 7.2  | Persona picker UI                                        | ☐      |       |
 | 8.1  | Ambient classifier on settled conversations              | ☐      |       |

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -32,39 +32,40 @@ Two concurrent efforts share primitives with this work; steps below reference th
 
 ## Status
 
-| Step | Deliverable                                           | Status | PR    |
-| ---- | ----------------------------------------------------- | ------ | ----- |
-| 1.1  | `schedule_follow_up` tool + follow-up infra           | ☑      | #1138 |
-| 1.2  | Follow-up turn invocation (context + prompt)          | ☑      | #1142 |
-| 1.3  | Follow-up visibility: timeline card + cancel          | ☑      | #1176 |
-| 1.4  | Configurable follow-up limits (workspace setting)     | ☑      | #1223 |
-| 1.5  | Turn-purpose consolidation (invocation variants)      | ☑      | #1155 |
-| 1.6  | Follow-up admin tools (list/cancel/update)            | ☑      | #1159 |
-| 2.1  | Generalized session abort                             | ☑      | #1177 |
-| 2.2  | Stop/Redirect affordances on the activity card        | ☑      | #1190 |
-| 2.3  | Per-turn model resolution + first escalation rule     | ☑      | #1202 |
-| 3.1  | Persisted episode summaries                           | ☑      | #1162 |
-| 3.2  | Per-thread session concurrency                        | ☑      | #1167 |
-| 3.3  | Conversation-anchored agent replies                   | ☑      | #1170 |
-| 4.1  | `stream_briefs` storage + endpoints + injection       | ☑      | #1214 |
-| 4.2  | `update_stream_brief` tool + timeline event           | ☑      | #1220 |
-| 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2) | ☑      | #1218 |
-| 4.4  | Brief correction eval                                 | ☐      |       |
-| 5.1  | `delegate_task` tool + delegation substrate + INV-65  | ☑      | #1261 |
-| 5.2  | Delegation card UI                                    | ☑      | #1261 |
-| 5.3  | Delegation public API (claim/status/complete)         | ☐      |       |
-| 5.4  | claude-code-remote delegation support                 | ☐      |       |
-| 5.5  | `@threa/mcp` server                                   | ☐      |       |
-| 6.1  | Memo edit/archive endpoints + explorer UI             | ☑      | #1246 |
-| 6.2  | `save_memo` tool                                      | ☑      | #1260 |
-| 6.3  | Reflective capture at session completion              | ☑      |       |
-| 6.4  | `memoScope` (user/stream/workspace)                   | ☐      |       |
-| 6.5  | Retrieval feedback decay                              | ☐      |       |
-| 7.1  | Workspace persona CRUD API                            | ☐      |       |
-| 7.2  | Persona picker UI                                     | ☐      |       |
-| 8.1  | Ambient classifier on settled conversations           | ☐      |       |
-| 8.2  | "Ariadne noticed" card + budget + toggle              | ☐      |       |
-| 8.3  | Ambient precision eval                                | ☐      |       |
+| Step | Deliverable                                              | Status | PR    |
+| ---- | -------------------------------------------------------- | ------ | ----- |
+| 1.1  | `schedule_follow_up` tool + follow-up infra              | ☑      | #1138 |
+| 1.2  | Follow-up turn invocation (context + prompt)             | ☑      | #1142 |
+| 1.3  | Follow-up visibility: timeline card + cancel             | ☑      | #1176 |
+| 1.4  | Configurable follow-up limits (workspace setting)        | ☑      | #1223 |
+| 1.5  | Turn-purpose consolidation (invocation variants)         | ☑      | #1155 |
+| 1.6  | Follow-up admin tools (list/cancel/update)               | ☑      | #1159 |
+| 2.1  | Generalized session abort                                | ☑      | #1177 |
+| 2.2  | Stop/Redirect affordances on the activity card           | ☑      | #1190 |
+| 2.3  | Per-turn model resolution + first escalation rule        | ☑      | #1202 |
+| 3.1  | Persisted episode summaries                              | ☑      | #1162 |
+| 3.2  | Per-thread session concurrency                           | ☑      | #1167 |
+| 3.3  | Conversation-anchored agent replies                      | ☑      | #1170 |
+| 4.1  | `stream_briefs` storage + endpoints + injection          | ☑      | #1214 |
+| 4.2  | `update_stream_brief` tool + timeline event              | ☑      | #1220 |
+| 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2)    | ☑      | #1218 |
+| 4.4  | Brief correction eval                                    | ☐      |       |
+| 5.1  | `delegate_task` tool + delegation substrate + INV-65     | ☑      | #1261 |
+| 5.2  | Delegation card UI                                       | ☑      | #1261 |
+| 5.3  | Delegation public API (claim/status/complete)            | ☐      |       |
+| 5.4  | claude-code-remote delegation support                    | ☐      |       |
+| 5.5  | `@threa/mcp` server                                      | ☐      |       |
+| 6.1  | Memo edit/archive endpoints + explorer UI                | ☑      | #1246 |
+| 6.2  | `save_memo` tool                                         | ☑      | #1260 |
+| 6.3  | Reflective capture at session completion                 | ☑      | #1273 |
+| 6.4  | `memoScope` (user/stream/workspace)                      | ☐      |       |
+| 6.5  | Retrieval feedback decay                                 | ☐      |       |
+| 6.6  | Agent-memo safety: read-time provenance + type allowlist | ☑      |       |
+| 7.1  | Workspace persona CRUD API                               | ☐      |       |
+| 7.2  | Persona picker UI                                        | ☐      |       |
+| 8.1  | Ambient classifier on settled conversations              | ☐      |       |
+| 8.2  | "Ariadne noticed" card + budget + toggle                 | ☐      |       |
+| 8.3  | Ambient precision eval                                   | ☐      |       |
 
 Suggested order: Phase 1 → 2 → 4 → 5, with 3/6/7 interleavable anytime and 8 strictly last (it depends on 1, 1.5, and 4). Pull **3.1 forward to right after Phase 1** — fired follow-up turns consume episode summaries (see 3.1), and until it lands the 1.2 prompt hint is compensating for their absence.
 
@@ -602,6 +603,21 @@ Completes GAM into the two-tier private/shared shape (Collaborative Memory, arXi
 **Tests:** decay ordering in hybrid search; idempotent per-user feedback (INV-20 upsert).
 
 **Done when:** a twice-downvoted memo demonstrably ranks below an equivalent un-downvoted one.
+
+### 6.6 Agent-memo safety contract: read-time provenance + knowledge-type allowlist
+
+**Goal:** close the two open items in the agent-memory co-storage ruling (recorded on merging #1273: one GAM pool, tiered by provenance — with visible capture, rank damping, and correctability already shipped). (a) `authored_by_kind` existed only as a DB column and boost input — invisible at read time; (b) `captureSessionReflection` had no knowledge-type restriction, so an agent could mint `decision` memos (the highest-boosted type) from its own research.
+
+**Shape (shipped):**
+
+- **Provenance threads the full read path.** `authoredByKind` + `sourceSessionId` join the memo SELECT/mapping (`memos/repository.ts`), the wire `Memo` (`packages/types/src/domain.ts`, both `toWireMemo` shapes), and the v1 public-api `memoSchema` (openapi regenerated). `MemoExplorerDetail` gains `capturedByPersonaName` — resolved in `buildDetail` via `sourceSessionId` → `AgentSessionRepository.findById` → `PersonaRepository` (detail-surface only; null for pipeline memos or when the session no longer resolves).
+- **Two read surfaces flag it.** `MemoDetailContent` (shared by the explorer and the in-stream preview dialog): a `Captured by <persona>` / `AI-captured` badge in the metadata row plus a Provenance-section line ("Written by <persona> from its own session work, not extracted from a team conversation"). Citations: `TraceSource`/`WorkspaceSourceItem` gain optional `authoredByKind` (set in the researcher's `buildSources`), and the trace dialog's memo source rows render "· AI-captured".
+- **Reflective capture is allowlisted.** `MEMO_REFLECTIVE_KNOWLEDGE_TYPES` (`learning|procedure|reference|context`) in `memos/config.ts`; a disallowed type (i.e. `decision`) is **coerced to `learning`** with a log rather than dropped — the finding survives under the honest label for a research conclusion, without decision-authority rank (decisions boost 1.3×, so even 0.9-damped an agent-minted decision would outrank pipeline learnings). `save_memo` is deliberately NOT gated: it acts on explicit in-conversation direction, and real decisions stated in conversation are the passive pipeline's to capture.
+- E2E/enclave sealed-source parity omitted, consistent with the roadmap-wide deferral.
+
+**Tests:** explorer-service persona resolution (agent memo → name; pipeline memo skips the lookup; vanished session → null); reflective coercion (disallowed → `learning`, allowed passes through); `MemoDetailContent` badge/provenance across authored kinds; trace source AI-captured flag.
+
+**Done when:** an agent-authored memo is legible as such in the explorer, the preview dialog, the public API, and reply citations — and no reflective capture can mint a `decision`.
 
 ---
 

--- a/docs/public-api/openapi.json
+++ b/docs/public-api/openapi.json
@@ -218,6 +218,8 @@
                                 "maximum": 9007199254740991
                               },
                               "revisionReason": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
+                              "authoredByKind": { "type": "string", "enum": ["pipeline", "agent"] },
+                              "sourceSessionId": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
                               "createdAt": { "type": "string", "format": "date-time" },
                               "updatedAt": { "type": "string", "format": "date-time" },
                               "archivedAt": {
@@ -241,6 +243,8 @@
                               "status",
                               "version",
                               "revisionReason",
+                              "authoredByKind",
+                              "sourceSessionId",
                               "createdAt",
                               "updatedAt",
                               "archivedAt"
@@ -373,6 +377,8 @@
                             "status": { "type": "string" },
                             "version": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
                             "revisionReason": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
+                            "authoredByKind": { "type": "string", "enum": ["pipeline", "agent"] },
+                            "sourceSessionId": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
                             "createdAt": { "type": "string", "format": "date-time" },
                             "updatedAt": { "type": "string", "format": "date-time" },
                             "archivedAt": { "anyOf": [{ "type": "string", "format": "date-time" }, { "type": "null" }] }
@@ -394,6 +400,8 @@
                             "status",
                             "version",
                             "revisionReason",
+                            "authoredByKind",
+                            "sourceSessionId",
                             "createdAt",
                             "updatedAt",
                             "archivedAt"
@@ -458,7 +466,8 @@
                             "additionalProperties": false
                           }
                         },
-                        "successorMemoId": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
+                        "successorMemoId": { "anyOf": [{ "type": "string" }, { "type": "null" }] },
+                        "capturedByPersonaName": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
                       },
                       "required": [
                         "memo",
@@ -466,7 +475,8 @@
                         "sourceStream",
                         "rootStream",
                         "sourceMessages",
-                        "successorMemoId"
+                        "successorMemoId",
+                        "capturedByPersonaName"
                       ],
                       "additionalProperties": false
                     }

--- a/packages/types/src/agent-trace.ts
+++ b/packages/types/src/agent-trace.ts
@@ -1,4 +1,4 @@
-import type { AgentSessionStatus, AgentStepType } from "./constants"
+import type { AgentSessionStatus, AgentStepType, AuthoredByKind } from "./constants"
 
 export const TRACE_SOURCE_TYPES = ["web", "workspace", "workspace_message", "workspace_memo", "github"] as const
 export type TraceSourceType = (typeof TRACE_SOURCE_TYPES)[number]
@@ -15,6 +15,8 @@ export interface TraceSource {
   messageId?: string
   authorName?: string
   timestamp?: string
+  /** `workspace_memo` sources: who authored the cited memo, so citations can flag agent-captured knowledge. */
+  authoredByKind?: AuthoredByKind
 }
 
 /**

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -35,6 +35,7 @@ import type {
   MemoType,
   KnowledgeType,
   MemoStatus,
+  AuthoredByKind,
   PendingItemType,
   SourceType,
   ExtractionContentType,
@@ -843,6 +844,10 @@ export interface Memo {
   status: MemoStatus
   version: number
   revisionReason: string | null
+  /** Who wrote the memo: the passive extraction pipeline, or an agent (`save_memo` / reflective capture). */
+  authoredByKind: AuthoredByKind
+  /** The agent session that wrote this memo (agent authorship only). */
+  sourceSessionId: string | null
   createdAt: string
   updatedAt: string
   archivedAt: string | null


### PR DESCRIPTION
## Problem

The agent-memory co-storage ruling (recorded on merging #1273) left two items of the safety contract open:

1. **Provenance was write-only.** `memos.authored_by_kind` / `source_session_id` (added in 6.2, #1260) existed as DB columns and a rank-damping input (`MEMO_AUTHORED_BY_KIND_BOOST`), but appeared nowhere in the repository's `SELECT`/mapping, the wire `Memo`, or any UI — a reader could not tell an agent-captured memo from conversation-extracted knowledge in the explorer, the preview dialog, the public API, or reply citations.
2. **Reflective capture could mint decisions.** `captureSessionReflection` (6.3, #1273) passed the memorizer's `knowledgeType` straight through. `decision` is the highest-boosted type (1.3× in `MEMO_KNOWLEDGE_TYPE_BOOST`), so even with the 0.9 agent damping, an agent-minted "decision" (1.17) would outrank pipeline-authored learnings (1.05) — a persona's own research conclusions masquerading as team rulings, compounding through retrieval.

## Solution

Close both gaps as roadmap step **6.6**: thread provenance through the full read path and flag it on the two read surfaces, and allowlist the knowledge types reflective capture may write.

### How it works

**Provenance read path**

- `authored_by_kind` / `source_session_id` join `SELECT_FIELDS` / `SELECT_FIELDS_PREFIXED` and `mapRowToMemo` in `memos/repository.ts` — every query path (findById, findByStream, findNearDuplicate, semantic/fullText/exact/hybrid search) uses those shared constants, so the fields flow everywhere a `Memo` is mapped.
- The wire `Memo` (`packages/types/src/domain.ts`) and both backend serializers (`MemoService.toWireMemo`, `toWireMemoFromData`) carry `authoredByKind` + `sourceSessionId`; the v1 public-api `memoSchema` gains both fields and `memoDetailSchema` gains `capturedByPersonaName` (openapi.json regenerated, drift check green).
- `MemoExplorerDetail.capturedByPersonaName`: resolved in `buildDetail` via `sourceSessionId` → `AgentSessionRepository.findById` → `PersonaRepository.findByIds` → name. Detail surface only (one extra lookup on a single-memo fetch, skipped entirely for pipeline memos); search-result lists carry the raw `authoredByKind` but no persona name.

**Read surfaces**

- `MemoDetailContent` (shared by the memory explorer and the in-stream `MemoPreviewDialog`): a `Captured by <persona>` / `AI-captured` badge in the metadata row, plus a Provenance-section line — "Written by <persona> from its own session work, not extracted from a team conversation."
- Citations: `TraceSource` and the researcher's `WorkspaceSourceItem` gain optional `authoredByKind`, set in `buildSources` (`researcher.ts`) and carried through `workspace-research-tool.ts`'s `extractSources`; the trace dialog's memo source rows (`trace-step.tsx`) render "from #stream · AI-captured".

**Reflective allowlist**

- `MEMO_REFLECTIVE_KNOWLEDGE_TYPES` = `learning | procedure | reference | context` in `memos/config.ts`. In `captureSessionReflection`, a memo outside the list is **coerced to `learning`** (logged), not dropped — the finding survives under the honest label for a research conclusion, without decision-authority rank.

### Key design decisions

**1. Coerce, don't drop.** Dropping a decision-typed reflective memo loses the finding; the objectionable part is the *label* (rank boost + organizational authority), not the content — a session's "we should use X because…" is literally a learning. Coercions are logged so over-triggering is observable.

**2. `save_memo` is deliberately NOT gated by the allowlist.** It acts on explicit in-conversation direction ("remember that we decided X") anchored to real user messages — a genuine decision relayed through the tool keeps its type. The allowlist targets the agent's *own reflection*, per the ruling's "agents must not mint decision-type memos from their own research."

**3. Persona-name resolution is detail-only.** Naming the capturing persona needs session→persona lookups; doing that per row in the retrieval hot path buys nothing (lists and citations show a generic "AI-captured" flag; the deep-link target names the persona). Null when the session no longer resolves — the badge falls back to "AI-captured".

**4. E2E sealed-source parity omitted**, consistent with the roadmap-wide deferral (`MessageSourceList` over `SealedSourceItem` is untouched).

Also backfills the 6.3 status-row PR number (#1273) and documents 6.6 in `docs/plans/ariadne-collaborator-roadmap.md` — both flagged in the session handover.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/src/features/memos/repository.ts` | `authored_by_kind`/`source_session_id` in `MemoRow`, `Memo`, both SELECT constants, `mapRowToMemo` |
| `apps/backend/src/features/memos/service.ts` | Both wire serializers carry the fields; reflective allowlist coercion in `captureSessionReflection` |
| `apps/backend/src/features/memos/config.ts` | `MEMO_REFLECTIVE_KNOWLEDGE_TYPES` + `MEMO_REFLECTIVE_FALLBACK_KNOWLEDGE_TYPE` |
| `apps/backend/src/features/memos/explorer-service.ts` | `MemoExplorerDetail.capturedByPersonaName` + `resolveCapturedByPersonaName` in `buildDetail` |
| `apps/backend/src/features/memos/handlers.ts` | First-party detail serializer includes `capturedByPersonaName` |
| `apps/backend/src/features/public-api/{routes,handlers}.ts` | v1 `memoSchema` + `memoDetailSchema` extended; detail serializer updated |
| `apps/backend/src/features/agents/researcher/researcher.ts` | `WorkspaceSourceItem.authoredByKind`, set for memo sources in `buildSources` |
| `apps/backend/src/features/agents/tools/workspace-research-tool.ts` | `extractSources` carries `authoredByKind` onto the persisted `TraceSource` |
| `packages/types/src/domain.ts`, `packages/types/src/agent-trace.ts` | Wire `Memo` + `TraceSource` provenance fields |
| `apps/frontend/src/api/memos.ts` | `MemoExplorerDetail.capturedByPersonaName` |
| `apps/frontend/src/components/memo/memo-detail.tsx` | `AgentAuthoredBadge` + Provenance-section line |
| `apps/frontend/src/components/trace/trace-step.tsx` | Memo source rows flag "AI-captured" |
| `apps/backend/evals/fixtures/memo.ts`, `*.test.{ts,tsx}` fixtures | Fixtures gain the new required fields |
| `docs/plans/ariadne-collaborator-roadmap.md` | 6.3 PR backfill; 6.6 status row + step section |
| `docs/public-api/openapi.json` | Regenerated |

## Out of scope (deliberate)

- Explorer **list-row** badge (detail + citations are the specced surfaces; the list row can pick up `memo.authoredByKind` later without any backend change).
- Enclave/E2E sealed sources (roadmap-wide parity deferral).
- Rank/retrieval behavior — untouched; the boost already existed (6.2).

## Test plan

- [x] Backend `bun test` memos + describe-memo-tool — 33 pass (new: explorer persona resolution ×3 — agent memo resolves name / pipeline skips lookup / vanished session → null; reflective coercion — `decision` → `learning`, `procedure` passes through)
- [x] Frontend `memo-detail.test.tsx` + `trace-step.test.tsx` — 30 pass (new: badge + provenance line across authored kinds ×3; AI-captured source flag ×1); `pages/memory.test.tsx` — 6 pass
- [x] `bun run typecheck` — all 14 workspaces clean
- [x] OpenAPI regenerated; pre-commit drift check green
- [x] Self-review pass: verified every `Memo`-mapping query path uses the shared SELECT constants (no path returns rows without the new columns); verified `PersonaRepository.findByIds`/`AgentSessionRepository.findById` signatures at the call site
- [ ] No live-DB integration run — column reads are covered by the shared constants + stubbed-repo tests, same as the sibling 6.1–6.3 PRs

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

https://claude.ai/code/session_01PVHUdQXisgzSEMNZucA8jJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVHUdQXisgzSEMNZucA8jJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786300500&installation_id=129946197&pr_number=1277&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1277&signature=1844bb480fcb297d63ab82e5b5efce4f1d79fe5bfec6a9fd05b45dadbfc33b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->