### PR TITLE
feat: copy a memo's resource URL from the preview and explorer

### DIFF
--- a/apps/frontend/src/components/memo/memo-detail.test.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.test.tsx
@@ -130,6 +130,21 @@ describe("MemoDetailContent edit controls (roadmap 6.1)", () => {
     expect(screen.queryByRole("button", { name: /restore/i })).not.toBeInTheDocument()
   })
 
+  it("copies the memo's resource URL and confirms in place with a checkmark (INV-63/21: no toast, same footprint)", async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } })
+
+    renderDetail(<MemoDetailContent data={buildDetail()} workspaceId="ws_1" isLoading={false} />)
+
+    await user.click(screen.getByRole("button", { name: "Copy memo link" }))
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText.mock.calls[0][0]).toContain("/w/ws_1/memory?memo=memo_1")
+    // Same button, relabeled — the checkmark confirmation replaces the toast.
+    await screen.findByRole("button", { name: "Memo link copied" })
+  })
+
   it("links a superseded memo to its successor", () => {
     const detail = { ...buildDetail({ status: "superseded" }), successorMemoId: "memo_2" }
     renderDetail(<MemoDetailContent data={detail} workspaceId="ws_1" isLoading={false} />)

--- a/apps/frontend/src/components/memo/memo-detail.test.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.test.tsx
@@ -137,12 +137,14 @@ describe("MemoDetailContent edit controls (roadmap 6.1)", () => {
 
     renderDetail(<MemoDetailContent data={buildDetail()} workspaceId="ws_1" isLoading={false} />)
 
-    await user.click(screen.getByRole("button", { name: "Copy memo link" }))
+    // Accessible name is the visible label until it confirms — a superset on
+    // copy keeps voice control / WCAG 2.5.3 intact.
+    await user.click(screen.getByRole("button", { name: "Copy link" }))
 
     expect(writeText).toHaveBeenCalledTimes(1)
     expect(writeText.mock.calls[0][0]).toContain("/w/ws_1/memory?memo=memo_1")
     // Same button, relabeled — the checkmark confirmation replaces the toast.
-    await screen.findByRole("button", { name: "Memo link copied" })
+    await screen.findByRole("button", { name: "Copy link, copied" })
   })
 
   it("links a superseded memo to its successor", () => {

--- a/apps/frontend/src/components/memo/memo-detail.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.tsx
@@ -1,5 +1,15 @@
-import { useEffect, useState } from "react"
-import { Archive, ArchiveRestore, BookOpen, ExternalLink, Hash, MessageSquareQuote, Pencil } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import {
+  Archive,
+  ArchiveRestore,
+  BookOpen,
+  Check,
+  Copy,
+  ExternalLink,
+  Hash,
+  MessageSquareQuote,
+  Pencil,
+} from "lucide-react"
 import { Link } from "react-router-dom"
 import { MEMO_ABSTRACT_MAX_CHARS, MEMO_TITLE_MAX_CHARS, type StreamType } from "@threa/types"
 import { Badge } from "@/components/ui/badge"
@@ -10,6 +20,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { RelativeTime } from "@/components/relative-time"
 import { cn } from "@/lib/utils"
+import { buildMemoLink } from "@/lib/memo-url"
 import { streamFallbackLabel } from "@/lib/streams"
 import { getKnowledgeConfig, memoLabel } from "@/lib/memo-display"
 import type { MemoExplorerDetail, MemoExplorerStreamRef, MemoUpdateRequest } from "@/api"
@@ -217,6 +228,54 @@ function MemoStatusBadge({ status }: { status: string }) {
   return null
 }
 
+/**
+ * Copies the memo's shareable resource URL. Confirms in place by swapping the
+ * icon to a checkmark rather than toasting (INV-63) — the label stays fixed so
+ * the button's footprint doesn't shift (INV-21).
+ */
+function CopyMemoLinkButton({ workspaceId, memoId }: { workspaceId: string; memoId: string }) {
+  const [copied, setCopied] = useState(false)
+  const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (resetRef.current) clearTimeout(resetRef.current)
+    },
+    []
+  )
+
+  // Clear the confirmation when the memo changes so a checkmark from one memo
+  // never lingers onto the next.
+  useEffect(() => {
+    setCopied(false)
+    if (resetRef.current) clearTimeout(resetRef.current)
+  }, [memoId])
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(buildMemoLink(workspaceId, memoId))
+    } catch {
+      return
+    }
+    setCopied(true)
+    if (resetRef.current) clearTimeout(resetRef.current)
+    resetRef.current = setTimeout(() => setCopied(false), 1200)
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className={cn("h-7 gap-1.5 px-2 text-xs", copied && "text-emerald-500")}
+      onClick={() => void handleCopy()}
+      aria-label={copied ? "Memo link copied" : "Copy memo link"}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      Copy link
+    </Button>
+  )
+}
+
 export function MemoDetailContent({
   data,
   workspaceId,
@@ -285,35 +344,45 @@ export function MemoDetailContent({
             <RelativeTime date={data.memo.updatedAt} className="text-[11px] text-muted-foreground/50" />
           </div>
 
-          {edit && !isEditing && (
+          {!isEditing && (
             <div className="flex shrink-0 items-center gap-2">
-              <Button size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-xs" onClick={() => setIsEditing(true)}>
-                <Pencil className="h-3 w-3" />
-                Edit
-              </Button>
-              {isArchived && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1.5 px-2 text-xs"
-                  disabled={edit.isMutating}
-                  onClick={() => void edit.onUnarchive()}
-                >
-                  <ArchiveRestore className="h-3 w-3" />
-                  Restore
-                </Button>
-              )}
-              {isActive && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
-                  disabled={edit.isMutating}
-                  onClick={() => void edit.onArchive()}
-                >
-                  <Archive className="h-3 w-3" />
-                  Archive
-                </Button>
+              <CopyMemoLinkButton workspaceId={workspaceId} memoId={data.memo.id} />
+              {edit && (
+                <>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 gap-1.5 px-2 text-xs"
+                    onClick={() => setIsEditing(true)}
+                  >
+                    <Pencil className="h-3 w-3" />
+                    Edit
+                  </Button>
+                  {isArchived && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 gap-1.5 px-2 text-xs"
+                      disabled={edit.isMutating}
+                      onClick={() => void edit.onUnarchive()}
+                    >
+                      <ArchiveRestore className="h-3 w-3" />
+                      Restore
+                    </Button>
+                  )}
+                  {isActive && (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 gap-1.5 px-2 text-xs text-muted-foreground"
+                      disabled={edit.isMutating}
+                      onClick={() => void edit.onArchive()}
+                    >
+                      <Archive className="h-3 w-3" />
+                      Archive
+                    </Button>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/apps/frontend/src/components/memo/memo-detail.tsx
+++ b/apps/frontend/src/components/memo/memo-detail.tsx
@@ -236,6 +236,10 @@ function MemoStatusBadge({ status }: { status: string }) {
 function CopyMemoLinkButton({ workspaceId, memoId }: { workspaceId: string; memoId: string }) {
   const [copied, setCopied] = useState(false)
   const resetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Latest memo under the button — read after the async copy to tell whether the
+  // memo switched while the write was in flight.
+  const memoIdRef = useRef(memoId)
+  memoIdRef.current = memoId
 
   useEffect(
     () => () => {
@@ -245,18 +249,23 @@ function CopyMemoLinkButton({ workspaceId, memoId }: { workspaceId: string; memo
   )
 
   // Clear the confirmation when the memo changes so a checkmark from one memo
-  // never lingers onto the next.
+  // never lingers onto the next — the preview dialog reuses this instance across
+  // memo switches rather than remounting it.
   useEffect(() => {
     setCopied(false)
     if (resetRef.current) clearTimeout(resetRef.current)
   }, [memoId])
 
   async function handleCopy() {
+    const target = memoId
     try {
-      await navigator.clipboard.writeText(buildMemoLink(workspaceId, memoId))
+      await navigator.clipboard.writeText(buildMemoLink(workspaceId, target))
     } catch {
       return
     }
+    // If the memo switched while the write was pending, the clipboard holds
+    // `target`'s URL, not the one now on screen — don't flash a false confirm.
+    if (memoIdRef.current !== target) return
     setCopied(true)
     if (resetRef.current) clearTimeout(resetRef.current)
     resetRef.current = setTimeout(() => setCopied(false), 1200)
@@ -268,7 +277,10 @@ function CopyMemoLinkButton({ workspaceId, memoId }: { workspaceId: string; memo
       variant="ghost"
       className={cn("h-7 gap-1.5 px-2 text-xs", copied && "text-emerald-500")}
       onClick={() => void handleCopy()}
-      aria-label={copied ? "Memo link copied" : "Copy memo link"}
+      // Accessible name stays a superset of the visible "Copy link" so voice
+      // control matches and WCAG 2.5.3 (Label in Name) holds; only the copied
+      // suffix changes — the visible text is fixed, so nothing shifts (INV-21).
+      aria-label={copied ? "Copy link, copied" : undefined}
     >
       {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
       Copy link

--- a/apps/frontend/src/lib/memo-url.ts
+++ b/apps/frontend/src/lib/memo-url.ts
@@ -7,6 +7,15 @@ export function memoDeepLink(workspaceId: string, memoId: string): string {
 }
 
 /**
+ * Absolute, shareable URL to a memo — `memoDeepLink` prefixed with the current
+ * origin. Copy-link affordances use this so the pasted link round-trips back
+ * through `parseMemoUrl` into a memo embed.
+ */
+export function buildMemoLink(workspaceId: string, memoId: string): string {
+  return `${window.location.origin}${memoDeepLink(workspaceId, memoId)}`
+}
+
+/**
  * Extract a memo id from an in-app memory-explorer link
  * (`…/w/{workspaceId}/memory?memo=memo_xxx`). Returns `null` for any other
  * URL, off-origin link, or unparseable text. Used by the composer to turn a


### PR DESCRIPTION
## Problem

A memo has a canonical deep link (`/w/{workspaceId}/memory?memo={memoId}`), but no surface exposed a way to copy it. From the `memos:captured` timeline row a user can open a memo in the in-stream preview dialog, and from the memory explorer they can view it in full — neither offered "give me the link to this memo." Sharing a memo meant hand-copying the browser URL (which the preview dialog doesn't even change) or navigating to the explorer and lifting the address bar.

## Solution

Add a **Copy link** button to the shared memo renderer `MemoDetailContent`. Because both memo surfaces — the memory explorer page (`MemoryPage`) and the in-stream `MemoPreviewDialog` — render that one component, a single button covers both the "message preview" and the "memo view" the request named.

### How it works

- New `buildMemoLink(workspaceId, memoId)` in `apps/frontend/src/lib/memo-url.ts` — the absolute, shareable form of the existing canonical `memoDeepLink` (origin + the relative deep link). Reusing `memoDeepLink` keeps one source of truth for the memo URL shape, and the origin-prefixed result round-trips back through `parseMemoUrl` in the same file (same-origin + `/w/{id}/memory` + `memo_` prefix), so a pasted link becomes a memo embed card in the composer rather than a plain hyperlink.
- `CopyMemoLinkButton` (module-level, per INV-18) copies that URL via `navigator.clipboard.writeText` and confirms in place — Copy→Check icon swap, emerald tint — with no toast (INV-63). The label stays the constant "Copy link" so the button's footprint doesn't shift on confirm (INV-21); the `aria-label` carries the state (a superset of the visible label on copy) so voice control and WCAG 2.5.3 hold. A 1200ms timer resets the checkmark; a `memoId`-change effect clears it so a confirmation from one memo never lingers onto the next (the preview dialog keeps the instance mounted while swapping memos), and an unmount cleanup clears the pending timer.
- The header action group now renders whenever the memo isn't being edited; the copy button sits alongside Edit/Archive/Restore, which stay gated behind the explorer-only `edit` prop. So the button shows on read-only surfaces (preview dialog) too.

### Key design decisions

**1. One button in the shared renderer, not per-surface.** `MemoDetailContent` is already the single memo renderer for both the explorer and the preview dialog. Adding the affordance there covers "copy from the message preview" and "copy from the memo view" with one change, instead of wiring a copy control into `MemoCapturedEvent`/`MemoPreviewDialog` and `MemoryPage` separately and letting them drift.

**2. In-place checkmark, not a toast.** INV-63 requires clipboard copy on a surface with a persistent anchor to confirm in place (the reference is the image-gallery toolbar). The button is that anchor, so it swaps its own icon rather than firing `toast.success` — which the guard test `no-happy-path-success-toast.test.ts` would reject anyway.

**3. Fixed label, swap only the icon/color.** "Copy link" → "Copied" would change the button width and shift the row (INV-21). Keeping the label constant and swapping Copy→Check (plus emerald) gives the confirmation without reflow; the `aria-label` carries the "copied" state for the non-visual signal.

### Design evolution (self-review)

The pre-PR review (4 reviewer agents) surfaced two real issues in the first version, both fixed in commit `1bc66b0`:

- **False confirm on a mid-write memo switch.** The preview dialog reuses one `CopyMemoLinkButton` instance across memo switches (`MemoCapturedEvent` re-points a single `MemoPreviewDialog` rather than remounting). A copy whose `writeText` promise resolved after `memoId` changed would `setCopied(true)` for the wrong memo. Fixed by capturing the target id and skipping the confirmation when `memoIdRef.current` no longer matches.
- **Accessible name broke Label in Name.** The visible label is "Copy link" but the original `aria-label` ("Copy memo link") wasn't a superset, so voice control ("click Copy link") and WCAG 2.5.3 failed. Fixed by deriving the idle name from the visible text and using a superset ("Copy link, copied") only on confirm.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/lib/memo-url.ts` | Add `buildMemoLink(workspaceId, memoId)` — absolute form of `memoDeepLink`. |
| `apps/frontend/src/components/memo/memo-detail.tsx` | Add `CopyMemoLinkButton`; render it in the detail header's action group regardless of the `edit` prop. |
| `apps/frontend/src/components/memo/memo-detail.test.tsx` | Test: clicking copies the resource URL and swaps to the checkmark confirmation (no toast). |

## Out of scope (deliberate)

- No copy affordance directly on the `memos:captured` timeline row (`MemoCapturedEvent`) — the row opens the preview dialog, which now carries the copy button. Adding a second control on the row would duplicate it.
- The preview dialog's existing footer "Open in memory" link is unchanged; it navigates, the new button copies — distinct actions (INV-40).

## Test plan

- [x] `bun run test src/components/memo/memo-detail.test.tsx` — 7 pass (6 existing + the new copy test)
- [x] `bun run test src/components/timeline/memo-captured-event.test.tsx src/components/memo` — 9 pass (surfaces that mount `MemoDetailContent`)
- [x] `tsc --noEmit` (apps/frontend), ESLint, and Prettier clean on the three changed files
- [x] Pre-PR review (4 reviewer agents: spec/design, correctness/data-flow, UX, mobile): 2 findings fixed (stale-write false-confirm, Label-in-Name a11y), spec/design + mobile clean
- [ ] No live-browser check driven here — the clipboard write + checkmark swap is covered by the mounted-component test above, not an E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bo4DkLmp4pgUt2fFh5bCwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bo4DkLmp4pgUt2fFh5bCwy)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786308418&installation_id=129946197&pr_number=1278&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1278&signature=bb2adeca5f52d36d62cb5967b8a680f2ed0a2938c5a2e81e649a29755be7313b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->