### PR TITLE
feat(board): UX quick wins + saved view as board home

### DIFF
--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -69,6 +69,20 @@ describe("updatePreferencesSchema unreadOpenPosition", () => {
   })
 })
 
+describe("updatePreferencesSchema boardDefaultViewId", () => {
+  it("accepts a view id", () => {
+    expect(updatePreferencesSchema.parse({ boardDefaultViewId: "bview_1" }).boardDefaultViewId).toBe("bview_1")
+  })
+
+  it("accepts null to clear the default view", () => {
+    expect(updatePreferencesSchema.parse({ boardDefaultViewId: null }).boardDefaultViewId).toBeNull()
+  })
+
+  it("rejects an over-long id", () => {
+    expect(updatePreferencesSchema.safeParse({ boardDefaultViewId: "x".repeat(65) }).success).toBe(false)
+  })
+})
+
 describe("updatePreferencesSchema board card collapse settings", () => {
   it("accepts valid board card collapse settings", () => {
     const parsed = updatePreferencesSchema.parse({

--- a/apps/backend/src/features/user-preferences/handlers.test.ts
+++ b/apps/backend/src/features/user-preferences/handlers.test.ts
@@ -81,6 +81,10 @@ describe("updatePreferencesSchema boardDefaultViewId", () => {
   it("rejects an over-long id", () => {
     expect(updatePreferencesSchema.safeParse({ boardDefaultViewId: "x".repeat(65) }).success).toBe(false)
   })
+
+  it("rejects an empty id", () => {
+    expect(updatePreferencesSchema.safeParse({ boardDefaultViewId: "" }).success).toBe(false)
+  })
 })
 
 describe("updatePreferencesSchema board card collapse settings", () => {

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -102,9 +102,11 @@ const updatePreferencesSchema = z.object({
     .max(BOARD_CARD_COLLAPSE_THRESHOLD_MAX)
     .optional(),
   boardDefaultLens: z.enum(BOARD_LENSES).optional(),
-  // A saved board view id (prefixed ULID) or null to clear. Existence isn't
-  // checked here — a stale id degrades to the default lens client-side.
-  boardDefaultViewId: z.string().max(64).nullable().optional(),
+  // A saved board view id (`boardview_…`) or null to clear. Non-empty, matching
+  // the board-view endpoints' own id validation (board-views/handlers.ts); a
+  // well-formed but stale id is accepted and degrades to the default lens
+  // client-side, but an empty string is rejected.
+  boardDefaultViewId: z.string().min(1).max(64).nullable().optional(),
   // Model id like "elevenlabs:scribe-v2-realtime". Validated against the model
   // registry server-side when a session opens; this layer only bounds length.
   voiceTranscriptionModel: z.string().max(100).nullable().optional(),

--- a/apps/backend/src/features/user-preferences/handlers.ts
+++ b/apps/backend/src/features/user-preferences/handlers.ts
@@ -102,6 +102,9 @@ const updatePreferencesSchema = z.object({
     .max(BOARD_CARD_COLLAPSE_THRESHOLD_MAX)
     .optional(),
   boardDefaultLens: z.enum(BOARD_LENSES).optional(),
+  // A saved board view id (prefixed ULID) or null to clear. Existence isn't
+  // checked here — a stale id degrades to the default lens client-side.
+  boardDefaultViewId: z.string().max(64).nullable().optional(),
   // Model id like "elevenlabs:scribe-v2-realtime". Validated against the model
   // registry server-side when a session opens; this layer only bounds length.
   voiceTranscriptionModel: z.string().max(100).nullable().optional(),

--- a/apps/backend/src/features/user-preferences/service.ts
+++ b/apps/backend/src/features/user-preferences/service.ts
@@ -83,6 +83,7 @@ function flattenUpdates(updates: UpdateUserPreferencesInput): Array<{ key: strin
     "boardCardCollapseToHeight",
     "boardCardCollapseThreshold",
     "boardDefaultLens",
+    "boardDefaultViewId",
     "voiceTranscriptionModel",
     "voicePolishLevel",
     "voiceSteeringWords",

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -72,6 +72,13 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
  *  hidden rest sits behind an "N more replies" link into the child's panel. */
 const BRANCH_PREVIEW_CAP = 2
 
+// Softens the collapsed card's raw `max-height` clip so it doesn't slice a
+// message mid-line/mid-image. Masks the content transparent at the cut (like
+// CollapsibleBody) rather than painting a colored gradient — the rows carry the
+// actor accent, so any fixed target color would band wrong on some surface; a
+// mask lets whatever is behind show through, correct everywhere.
+const COLLAPSED_FADE_MASK = "linear-gradient(to bottom, black calc(100% - 2rem), transparent)"
+
 /**
  * One board post: a conversation rendered as a feed post that reads like the
  * stream timeline. Messages use the same primitives (`ActorAvatar`,
@@ -504,8 +511,8 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
               the elevation never shifts layout (INV-21). */}
           <div
             className={cn(
-              "sticky top-0 z-10 -mx-3 -mt-3 rounded-t-xl border-b border-transparent bg-card px-3 pt-3 pb-2 transition-[box-shadow,border-color] duration-200 sm:-mx-4 sm:-mt-4 sm:px-4 sm:pt-4",
-              headerStuck && "border-border/60 shadow-[0_4px_12px_-6px_rgb(0_0_0/0.4)]"
+              "z-10 -mx-3 -mt-3 rounded-t-xl border-b border-transparent bg-card px-3 pt-3 pb-2 transition-[box-shadow,border-color] duration-200 sm:sticky sm:top-0 sm:-mx-4 sm:-mt-4 sm:px-4 sm:pt-4",
+              headerStuck && "sm:border-border/60 sm:shadow-[0_4px_12px_-6px_rgb(0_0_0/0.4)]"
             )}
           >
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -579,7 +586,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
                 <span
                   className={cn(
                     "truncate text-sm font-medium",
-                    conversation.status === "resolved" && "text-muted-foreground line-through decoration-1"
+                    conversation.status === "resolved" && "text-muted-foreground"
                   )}
                 >
                   {conversation.topicSummary}
@@ -601,7 +608,11 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
 
           <div
             className={cn(bodyCollapsed && "overflow-hidden")}
-            style={bodyCollapsed ? { maxHeight: collapseToHeight } : undefined}
+            style={
+              bodyCollapsed
+                ? { maxHeight: collapseToHeight, maskImage: COLLAPSED_FADE_MASK, WebkitMaskImage: COLLAPSED_FADE_MASK }
+                : undefined
+            }
           >
             <div ref={bodyRef}>
               {provenance && (

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -30,7 +30,7 @@ import {
   isViewActive,
   type BoardViewSelection,
 } from "@/components/board/board-saved-views"
-import { useBoardViews } from "@/hooks/use-board-views"
+import { useBoardHomeView, useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { usePreferences } from "@/contexts"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
@@ -158,9 +158,7 @@ export function BoardFilterBar({
   // permanent "Clear filters" affordance on its own untouched landing. The home
   // is the plain home lens, or (when set) the saved view they home on, so resting
   // on that view must also read as unfiltered even though it carries scope.
-  const { preferences } = usePreferences()
-  const { data: savedViews } = useBoardViews(workspaceId)
-  const homeView = savedViews?.find((view) => view.id === (preferences?.boardDefaultViewId ?? null)) ?? null
+  const homeView = useBoardHomeView(workspaceId)
   const isFiltered = !isBoardAtHome(homeLens, homeView, {
     lens,
     scopeStreamIds,

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -24,12 +24,16 @@ import {
 } from "@/stores/workspace-store"
 import type { CachedLabel } from "@/hooks/use-labels"
 import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
-import { BoardSavedViews, isViewActive, type BoardViewSelection } from "@/components/board/board-saved-views"
+import {
+  BoardSavedViews,
+  isBoardAtHome,
+  isViewActive,
+  type BoardViewSelection,
+} from "@/components/board/board-saved-views"
 import { useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { usePreferences } from "@/contexts"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
-import { isBoardFiltered } from "@/lib/board/filter-state"
 import { cn } from "@/lib/utils"
 
 /** Stream types offered in the pickers: the board's root-stream grains (shared
@@ -150,10 +154,14 @@ export function BoardFilterBar({
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
   const labelById = useMemo(() => new Map(myLabels.map((l) => [l.id, l])), [myLabels])
 
-  // The viewer's home lens is their baseline, so being on it (with no scope
-  // narrowing) is NOT "filtered" — otherwise a non-All home shows a permanent
-  // "Clear filters" affordance on its own untouched landing view.
-  const isFiltered = isBoardFiltered(homeLens, {
+  // The viewer's home baseline is NOT "filtered" — otherwise the home shows a
+  // permanent "Clear filters" affordance on its own untouched landing. The home
+  // is the plain home lens, or (when set) the saved view they home on, so resting
+  // on that view must also read as unfiltered even though it carries scope.
+  const { preferences } = usePreferences()
+  const { data: savedViews } = useBoardViews(workspaceId)
+  const homeView = savedViews?.find((view) => view.id === (preferences?.boardDefaultViewId ?? null)) ?? null
+  const isFiltered = !isBoardAtHome(homeLens, homeView, {
     lens,
     scopeStreamIds,
     scopeStreamTypes,

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react"
 import { Link, useLocation } from "react-router-dom"
-import { Archive, Ban, Bell, BellOff, Check, ChevronDown, Hash, Layers, Tag, X } from "lucide-react"
+import { Archive, Ban, Bell, BellOff, Check, ChevronDown, Hash, Layers, Pin, Tag, X } from "lucide-react"
 import {
   BOARD_LENSES,
   BOARD_SCOPE_STREAM_TYPES,
@@ -27,6 +27,7 @@ import { resolveStreamName, STREAM_ICONS } from "@/lib/streams"
 import { BoardSavedViews, isViewActive, type BoardViewSelection } from "@/components/board/board-saved-views"
 import { useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
+import { usePreferences } from "@/contexts"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import { isBoardFiltered } from "@/lib/board/filter-state"
 import { cn } from "@/lib/utils"
@@ -455,6 +456,7 @@ function BoardLensMenu({
 }) {
   const [open, setOpen] = useState(false)
   const { search } = useLocation()
+  const { updatePreference } = usePreferences()
   const current = BOARD_LENS_DEFS[lens]
   const CurrentIcon = current.icon
 
@@ -480,24 +482,44 @@ function BoardLensMenu({
           const def = BOARD_LENS_DEFS[value]
           const Icon = def.icon
           const selected = value === lens && activeViewId === null
+          const isHome = value === homeLens
           return (
-            <Link
+            <div
               key={value}
-              to={lensHref(workspaceId, value, search, homeLens)}
-              onClick={() => setOpen(false)}
-              aria-current={selected ? "true" : undefined}
               className={cn(
-                "mx-1 flex items-start gap-2.5 rounded-item px-2.5 py-2 transition-colors hover:bg-muted",
+                "mx-1 flex items-center rounded-item transition-colors hover:bg-muted",
                 selected && "bg-muted/60"
               )}
             >
-              <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1">
-                <span className="block text-sm font-medium">{def.label}</span>
-                <span className="block text-xs text-muted-foreground">{def.description}</span>
-              </span>
-              {selected && <Check className="mt-1 h-4 w-4 shrink-0" />}
-            </Link>
+              <Link
+                to={lensHref(workspaceId, value, search, homeLens)}
+                onClick={() => setOpen(false)}
+                aria-current={selected ? "true" : undefined}
+                className="flex min-w-0 flex-1 items-start gap-2.5 rounded-item px-2.5 py-2"
+              >
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">{def.label}</span>
+                  <span className="block text-xs text-muted-foreground">{def.description}</span>
+                </span>
+                {selected && <Check className="mt-1 h-4 w-4 shrink-0" />}
+              </Link>
+              {/* Pin this lens as the board home (bare `/board`) — the same write the
+                  appearance-settings radio does, placed where lenses are picked. Filled
+                  when it's the current home; silent per INV-63 (the fill is the signal). */}
+              <button
+                type="button"
+                onClick={() => void updatePreference("boardDefaultLens", value)}
+                aria-pressed={isHome}
+                aria-label={isHome ? `${def.label} is your board home` : `Set ${def.label} as board home`}
+                className={cn(
+                  "mr-1 shrink-0 rounded p-1.5 transition-colors",
+                  isHome ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
+                )}
+              >
+                <Pin className={cn("h-3.5 w-3.5", isHome && "fill-current")} />
+              </button>
+            </div>
           )
         })}
       </nav>

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -321,9 +321,10 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          // Return to the home baseline: bare `/board`, which the page then
-          // resolves to a saved-view home if one is set (hence `false` here).
-          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens, false)}
+          // Clear to the unfiltered home lens. When a saved-view home resolves,
+          // keep the explicit segment so this doesn't route through bare `/board`
+          // (which would hold-then-redirect to the view — a blank-flash detour).
+          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeView !== null)}
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters
@@ -491,10 +492,14 @@ function BoardLensMenu({
   }
   const activeViewId = views?.find((view) => isViewActive(view, selection))?.id ?? null
 
-  // When a saved view is the board home (and still resolves), no plain lens is
-  // "home" — the pin fill belongs to that view's row, not a lens.
-  const homeViewId = preferences?.boardDefaultViewId ?? null
-  const homeViewActive = !!homeViewId && !!views?.some((view) => view.id === homeViewId)
+  // Two distinct signals: whether a saved-view home is CONFIGURED (known from the
+  // preference before the list loads) drives the lens links — the home lens must
+  // keep its explicit segment as soon as a view is set, or a click during the load
+  // window emits bare `/board` and gets bounced to the saved view (unreachable
+  // fallback lens). Whether it RESOLVES drives the pin fill: no lens reads as home
+  // while a real saved-view home exists.
+  const hasConfiguredHomeView = (preferences?.boardDefaultViewId ?? null) !== null
+  const homeViewActive = useBoardHomeView(workspaceId) != null
 
   const content = (
     <>
@@ -513,7 +518,7 @@ function BoardLensMenu({
               )}
             >
               <Link
-                to={lensHref(workspaceId, value, search, homeLens, homeViewActive)}
+                to={lensHref(workspaceId, value, search, homeLens, hasConfiguredHomeView)}
                 onClick={() => setOpen(false)}
                 aria-current={selected ? "true" : undefined}
                 className="flex min-w-0 flex-1 items-start gap-2.5 rounded-item px-2.5 py-2"

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -28,9 +28,10 @@ import {
   BoardSavedViews,
   isBoardAtHome,
   isViewActive,
+  savedViewHref,
   type BoardViewSelection,
 } from "@/components/board/board-saved-views"
-import { useBoardHomeView, useBoardViews } from "@/hooks/use-board-views"
+import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
 import { boardHomeSearch, toggleExclude, toggleInclude } from "@/components/board/board-filter-params"
 import { usePreferences } from "@/contexts"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
@@ -158,7 +159,7 @@ export function BoardFilterBar({
   // permanent "Clear filters" affordance on its own untouched landing. The home
   // is the plain home lens, or (when set) the saved view they home on, so resting
   // on that view must also read as unfiltered even though it carries scope.
-  const homeView = useBoardHomeView(workspaceId)
+  const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
   const isFiltered = !isBoardAtHome(homeLens, homeView, {
     lens,
     scopeStreamIds,
@@ -321,10 +322,16 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          // Clear to the unfiltered home lens. When a saved-view home resolves,
-          // keep the explicit segment so this doesn't route through bare `/board`
-          // (which would hold-then-redirect to the view — a blank-flash detour).
-          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeView !== null)}
+          // Return to the viewer's home — the saved-view home when one resolves
+          // (navigated straight to its URL, so it doesn't detour through bare
+          // `/board` and blank-flash), else the plain home lens (explicit segment
+          // when a home view is configured-but-not-yet-loaded, so it stays
+          // reachable). An open panel — the only non-filter query — rides along.
+          to={
+            homeView
+              ? savedViewHref(workspaceId, homeView, homeLens)
+              : lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeViewId !== null)
+          }
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters
@@ -473,7 +480,7 @@ function BoardLensMenu({
 }) {
   const [open, setOpen] = useState(false)
   const { search } = useLocation()
-  const { preferences, updatePreferences } = usePreferences()
+  const { updatePreferences } = usePreferences()
   const current = BOARD_LENS_DEFS[lens]
   const CurrentIcon = current.icon
 
@@ -498,8 +505,9 @@ function BoardLensMenu({
   // window emits bare `/board` and gets bounced to the saved view (unreachable
   // fallback lens). Whether it RESOLVES drives the pin fill: no lens reads as home
   // while a real saved-view home exists.
-  const hasConfiguredHomeView = (preferences?.boardDefaultViewId ?? null) !== null
-  const homeViewActive = useBoardHomeView(workspaceId) != null
+  const { view: homeMenuView, configuredId: homeMenuViewId } = useBoardHome(workspaceId)
+  const hasConfiguredHomeView = homeMenuViewId !== null
+  const homeViewActive = homeMenuView != null
 
   const content = (
     <>

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -456,7 +456,7 @@ function BoardLensMenu({
 }) {
   const [open, setOpen] = useState(false)
   const { search } = useLocation()
-  const { updatePreference } = usePreferences()
+  const { preferences, updatePreferences } = usePreferences()
   const current = BOARD_LENS_DEFS[lens]
   const CurrentIcon = current.icon
 
@@ -475,6 +475,11 @@ function BoardLensMenu({
   }
   const activeViewId = views?.find((view) => isViewActive(view, selection))?.id ?? null
 
+  // When a saved view is the board home (and still resolves), no plain lens is
+  // "home" — the pin fill belongs to that view's row, not a lens.
+  const homeViewId = preferences?.boardDefaultViewId ?? null
+  const homeViewActive = !!homeViewId && !!views?.some((view) => view.id === homeViewId)
+
   const content = (
     <>
       <nav aria-label="Board lens" className="py-1">
@@ -482,7 +487,7 @@ function BoardLensMenu({
           const def = BOARD_LENS_DEFS[value]
           const Icon = def.icon
           const selected = value === lens && activeViewId === null
-          const isHome = value === homeLens
+          const isHome = !homeViewActive && value === homeLens
           return (
             <div
               key={value}
@@ -504,12 +509,13 @@ function BoardLensMenu({
                 </span>
                 {selected && <Check className="mt-1 h-4 w-4 shrink-0" />}
               </Link>
-              {/* Pin this lens as the board home (bare `/board`) — the same write the
-                  appearance-settings radio does, placed where lenses are picked. Filled
-                  when it's the current home; silent per INV-63 (the fill is the signal). */}
+              {/* Pin this lens as the board home (bare `/board`) — mirrors the
+                  appearance-settings radio, placed where lenses are picked. Also
+                  clears any saved-view home so the landing actually lands here.
+                  Filled when current home; silent per INV-63 (the fill is the signal). */}
               <button
                 type="button"
-                onClick={() => void updatePreference("boardDefaultLens", value)}
+                onClick={() => void updatePreferences({ boardDefaultLens: value, boardDefaultViewId: null })}
                 aria-pressed={isHome}
                 aria-label={isHome ? `${def.label} is your board home` : `Set ${def.label} as board home`}
                 className={cn(

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -170,6 +170,19 @@ export function BoardFilterBar({
     excludeLabelIds,
   })
   const clearedSearch = useMemo(() => boardHomeSearch(location.search), [location.search])
+  // "Clear filters" returns to the viewer's home: the saved-view home when one
+  // resolves (straight to its URL — no bare `/board` detour that would blank-flash
+  // through the redirect), else the plain home lens (explicit segment while a home
+  // view is configured-but-still-loading, so it stays reachable). Either way the
+  // surviving non-filter query — an open `?panel=` — rides along, per the
+  // `boardHomeSearch` contract, so clearing filters never drops the open thread.
+  const clearFiltersTo = useMemo(() => {
+    if (!homeView) return lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeViewId !== null)
+    const href = savedViewHref(workspaceId, homeView, homeLens)
+    const extra = clearedSearch.replace(/^\?/, "")
+    if (!extra) return href
+    return href.includes("?") ? `${href}&${extra}` : `${href}?${extra}`
+  }, [homeView, homeViewId, workspaceId, homeLens, clearedSearch])
 
   const labelFor = (streamId: string) =>
     resolveStreamName(streamId, { streams, users, dmPeers }, "generic") ?? "Unknown stream"
@@ -322,16 +335,7 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          // Return to the viewer's home — the saved-view home when one resolves
-          // (navigated straight to its URL, so it doesn't detour through bare
-          // `/board` and blank-flash), else the plain home lens (explicit segment
-          // when a home view is configured-but-not-yet-loaded, so it stays
-          // reachable). An open panel — the only non-filter query — rides along.
-          to={
-            homeView
-              ? savedViewHref(workspaceId, homeView, homeLens)
-              : lensHref(workspaceId, homeLens, clearedSearch, homeLens, homeViewId !== null)
-          }
+          to={clearFiltersTo}
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters

--- a/apps/frontend/src/components/board/board-filter-bar.tsx
+++ b/apps/frontend/src/components/board/board-filter-bar.tsx
@@ -47,9 +47,17 @@ const TYPE_LABELS: Record<BoardScopeStreamType, string> = {
 /** The lens's URL (INV-59): the viewer's home lens rests at the bare `/board`,
  *  every other lens takes a segment (so `all` gets `/board/all` when it isn't
  *  home). `search` rides along so switching lens keeps the scope (and an open
- *  panel). */
-function lensHref(workspaceId: string, lens: BoardLens, search: string, homeLens: BoardLens): string {
-  const base = lens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${lens}`
+ *  panel). When a saved view is the home, the bare `/board` bounces to that view,
+ *  so the home lens must keep its explicit segment or it'd be unreachable from the
+ *  menu — omit the segment only when no saved-view home is active. */
+function lensHref(
+  workspaceId: string,
+  lens: BoardLens,
+  search: string,
+  homeLens: BoardLens,
+  hasSavedViewHome: boolean
+): string {
+  const base = !hasSavedViewHome && lens === homeLens ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${lens}`
   return `${base}${search}`
 }
 
@@ -307,7 +315,9 @@ export function BoardFilterBar({
       ))}
       {isFiltered && (
         <Link
-          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens)}
+          // Return to the home baseline: bare `/board`, which the page then
+          // resolves to a saved-view home if one is set (hence `false` here).
+          to={lensHref(workspaceId, homeLens, clearedSearch, homeLens, false)}
           className="shrink-0 px-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
           Clear filters
@@ -497,7 +507,7 @@ function BoardLensMenu({
               )}
             >
               <Link
-                to={lensHref(workspaceId, value, search, homeLens)}
+                to={lensHref(workspaceId, value, search, homeLens, homeViewActive)}
                 onClick={() => setOpen(false)}
                 aria-current={selected ? "true" : undefined}
                 className="flex min-w-0 flex-1 items-start gap-2.5 rounded-item px-2.5 py-2"

--- a/apps/frontend/src/components/board/board-home-redirect.test.ts
+++ b/apps/frontend/src/components/board/board-home-redirect.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import type { BoardView } from "@threa/types"
+import { boardHomeRedirectHref } from "@/components/board/board-saved-views"
+
+const WS = "ws_1"
+
+function view(overrides: Partial<BoardView> = {}): BoardView {
+  return {
+    id: "bview_1",
+    name: "Channels, active",
+    baseLens: "active",
+    scopeStreamIds: [],
+    scopeStreamTypes: ["channel"],
+    scopeLabelIds: [],
+    excludeStreamIds: [],
+    excludeStreamTypes: [],
+    excludeLabelIds: [],
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+describe("boardHomeRedirectHref", () => {
+  it("expands the default view to its canonical filtered URL", () => {
+    expect(boardHomeRedirectHref(WS, "bview_1", [view()], "all")).toBe(`/w/${WS}/board/active?is=channel`)
+  })
+
+  it("uses the segment-less base for a view whose lens is the viewer's home", () => {
+    const v = view({ id: "bview_2", baseLens: "all", scopeStreamTypes: ["dm"] })
+    expect(boardHomeRedirectHref(WS, "bview_2", [v], "all")).toBe(`/w/${WS}/board?is=dm`)
+  })
+
+  it("returns null when no default view is set", () => {
+    expect(boardHomeRedirectHref(WS, null, [view()], "all")).toBeNull()
+  })
+
+  it("returns null while views are still loading", () => {
+    expect(boardHomeRedirectHref(WS, "bview_1", undefined, "all")).toBeNull()
+  })
+
+  it("falls back to the lens (null) when the default id no longer resolves", () => {
+    expect(boardHomeRedirectHref(WS, "bview_gone", [view()], "all")).toBeNull()
+  })
+
+  it("returns null when the view expands to the bare home URL (no redirect loop)", () => {
+    // A view on the home lens with no filters would address `/board` itself —
+    // redirecting there from bare `/board` would loop, so the helper declines.
+    const bare = view({ id: "bview_bare", baseLens: "all", scopeStreamTypes: [] })
+    expect(boardHomeRedirectHref(WS, "bview_bare", [bare], "all")).toBeNull()
+  })
+})

--- a/apps/frontend/src/components/board/board-saved-views.test.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.test.tsx
@@ -5,7 +5,13 @@ import { MemoryRouter } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { BoardView } from "@threa/types"
 import { ServicesProvider } from "@/contexts"
-import { BoardSavedViews, savedViewHref, isViewActive, type BoardViewSelection } from "./board-saved-views"
+import {
+  BoardSavedViews,
+  savedViewHref,
+  isViewActive,
+  isBoardAtHome,
+  type BoardViewSelection,
+} from "./board-saved-views"
 
 const view = (over: Partial<BoardView> = {}): BoardView => ({
   id: "boardview_1",
@@ -72,6 +78,37 @@ describe("isViewActive", () => {
   it("is inactive when a filter axis differs", () => {
     expect(isViewActive(view(), selection({ scopeStreamIds: ["stream_2"] }))).toBe(false)
     expect(isViewActive(view(), selection({ excludeStreamTypes: ["system"] }))).toBe(false)
+  })
+})
+
+describe("isBoardAtHome", () => {
+  const selection = (over: Partial<BoardViewSelection> = {}): BoardViewSelection => ({
+    lens: "all",
+    scopeStreamIds: [],
+    scopeStreamTypes: [],
+    scopeLabelIds: [],
+    excludeStreamIds: [],
+    excludeStreamTypes: [],
+    excludeLabelIds: [],
+    ...over,
+  })
+
+  it("is home on the plain home lens with no narrowing", () => {
+    expect(isBoardAtHome("all", null, selection())).toBe(true)
+  })
+
+  it("is home when the selection exactly matches the saved-view home (though filtered)", () => {
+    const homeView = view({ baseLens: "mine", scopeStreamIds: ["stream_1"] })
+    expect(isBoardAtHome("all", homeView, selection({ lens: "mine", scopeStreamIds: ["stream_1"] }))).toBe(true)
+  })
+
+  it("is not home when narrowed off the saved-view home", () => {
+    const homeView = view({ baseLens: "mine", scopeStreamIds: ["stream_1"] })
+    expect(isBoardAtHome("all", homeView, selection({ lens: "mine", scopeStreamIds: ["stream_2"] }))).toBe(false)
+  })
+
+  it("is not home when narrowed off the plain home lens with no saved-view home", () => {
+    expect(isBoardAtHome("all", null, selection({ lens: "active" }))).toBe(false)
   })
 })
 

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { Link } from "react-router-dom"
-import { Bookmark, Check, Pencil, Plus, Trash2 } from "lucide-react"
+import { Bookmark, Check, Pencil, Pin, Plus, Trash2 } from "lucide-react"
 import {
   DEFAULT_BOARD_LENS,
   MAX_BOARD_VIEW_NAME_LENGTH,
@@ -19,6 +19,7 @@ import {
   ResponsiveDialogTitle,
 } from "@/components/ui/responsive-dialog"
 import { cn } from "@/lib/utils"
+import { usePreferencesOptional } from "@/contexts"
 import { useBoardViews, useSaveBoardView, useUpdateBoardView, useDeleteBoardView } from "@/hooks/use-board-views"
 import {
   BOARD_SCOPE_PARAM,
@@ -75,8 +76,29 @@ function countOf(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? "" : "s"}`
 }
 
+/**
+ * The URL the bare `/board` should bounce to for a viewer whose board home is a
+ * saved view (`boardDefaultViewId`) rather than a plain lens. `null` when there's
+ * nothing to redirect to: no default view, views not yet loaded, the id no longer
+ * resolves (deleted view — degrade to the home lens), or the view expands to the
+ * bare home URL anyway (guards against a redirect loop). Pure so the landing
+ * decision is unit-testable without mounting the page.
+ */
+export function boardHomeRedirectHref(
+  workspaceId: string,
+  defaultViewId: string | null,
+  views: BoardView[] | undefined,
+  homeLens: BoardLens
+): string | null {
+  if (!defaultViewId || !views) return null
+  const view = views.find((v) => v.id === defaultViewId)
+  if (!view) return null
+  const href = savedViewHref(workspaceId, view, homeLens)
+  return href === `/w/${workspaceId}/board` ? null : href
+}
+
 /** A one-line summary of what a view filters to, under its name. */
-function summarize(view: BoardView): string {
+export function summarizeBoardView(view: BoardView): string {
   const parts: string[] = []
   if (view.baseLens !== DEFAULT_BOARD_LENS) parts.push(view.baseLens.replace("-", " "))
   if (view.scopeStreamIds.length > 0) parts.push(countOf(view.scopeStreamIds.length, "stream"))
@@ -130,6 +152,8 @@ export function BoardSavedViews({
   onNavigate,
 }: BoardSavedViewsProps) {
   const { data: views } = useBoardViews(workspaceId)
+  const prefs = usePreferencesOptional()
+  const homeViewId = prefs?.preferences?.boardDefaultViewId ?? null
   const save = useSaveBoardView(workspaceId)
   const update = useUpdateBoardView(workspaceId)
   const remove = useDeleteBoardView(workspaceId)
@@ -191,9 +215,25 @@ export function BoardSavedViews({
                   <Bookmark className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                   <span className="min-w-0 flex-1">
                     <span className="block truncate text-sm font-medium">{view.name}</span>
-                    <span className="block truncate text-xs text-muted-foreground">{summarize(view)}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{summarizeBoardView(view)}</span>
                   </span>
                 </Link>
+                {/* Pin this saved view as the board home (bare `/board` bounces to
+                    it). Filled when it's the current home; silent per INV-63. */}
+                <button
+                  type="button"
+                  onClick={() => void prefs?.updatePreferences({ boardDefaultViewId: view.id })}
+                  aria-pressed={view.id === homeViewId}
+                  aria-label={
+                    view.id === homeViewId ? `${view.name} is your board home` : `Set ${view.name} as board home`
+                  }
+                  className={cn(
+                    "mt-0.5 shrink-0 rounded p-1 transition-colors",
+                    view.id === homeViewId ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
+                  )}
+                >
+                  <Pin className={cn("h-3.5 w-3.5", view.id === homeViewId && "fill-current")} />
+                </button>
                 {/* Right slot: the active check sits at the row's right edge (same
                     column as the lens list's check) and fades to the rename/delete
                     actions on hover/focus — one indicator, never both. */}

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -20,7 +20,13 @@ import {
 } from "@/components/ui/responsive-dialog"
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts"
-import { useBoardViews, useSaveBoardView, useUpdateBoardView, useDeleteBoardView } from "@/hooks/use-board-views"
+import {
+  useBoardHomeView,
+  useBoardViews,
+  useSaveBoardView,
+  useUpdateBoardView,
+  useDeleteBoardView,
+} from "@/hooks/use-board-views"
 import {
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
@@ -165,7 +171,7 @@ export function BoardSavedViews({
 }: BoardSavedViewsProps) {
   const { data: views } = useBoardViews(workspaceId)
   const prefs = usePreferencesOptional()
-  const homeViewId = prefs?.preferences?.boardDefaultViewId ?? null
+  const homeView = useBoardHomeView(workspaceId)
   const save = useSaveBoardView(workspaceId)
   const update = useUpdateBoardView(workspaceId)
   const remove = useDeleteBoardView(workspaceId)
@@ -176,7 +182,6 @@ export function BoardSavedViews({
   // Only offer "save current view" when there's actually a narrowing to bookmark
   // — the viewer's home baseline (the plain home lens, or the saved view that is
   // their home) is nothing worth saving.
-  const homeView = views?.find((view) => view.id === homeViewId) ?? null
   const isFiltered = !isBoardAtHome(homeLens, homeView, {
     lens,
     scopeStreamIds,
@@ -237,16 +242,16 @@ export function BoardSavedViews({
                 <button
                   type="button"
                   onClick={() => void prefs?.updatePreferences({ boardDefaultViewId: view.id })}
-                  aria-pressed={view.id === homeViewId}
+                  aria-pressed={view.id === homeView?.id}
                   aria-label={
-                    view.id === homeViewId ? `${view.name} is your board home` : `Set ${view.name} as board home`
+                    view.id === homeView?.id ? `${view.name} is your board home` : `Set ${view.name} as board home`
                   }
                   className={cn(
                     "mt-0.5 shrink-0 rounded p-1 transition-colors",
-                    view.id === homeViewId ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
+                    view.id === homeView?.id ? "text-foreground" : "text-muted-foreground/40 hover:text-foreground"
                   )}
                 >
-                  <Pin className={cn("h-3.5 w-3.5", view.id === homeViewId && "fill-current")} />
+                  <Pin className={cn("h-3.5 w-3.5", view.id === homeView?.id && "fill-current")} />
                 </button>
                 {/* Right slot: the active check sits at the row's right edge (same
                     column as the lens list's check) and fades to the rename/delete

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -71,6 +71,18 @@ export function isViewActive(view: BoardView, selection: BoardViewSelection): bo
   )
 }
 
+/**
+ * Whether the live selection is the viewer's untouched home baseline — the plain
+ * home lens with no narrowing, OR (when a saved view is the home) exactly that
+ * view. "Clear filters" / "Save current view" hide at home; a saved-view home is
+ * itself a filtered selection, so `isBoardFiltered` alone would wrongly read it as
+ * narrowed and offer a "Clear filters" that just bounces back to the same view.
+ */
+export function isBoardAtHome(homeLens: BoardLens, homeView: BoardView | null, selection: BoardViewSelection): boolean {
+  if (!isBoardFiltered(homeLens, selection)) return true
+  return homeView != null && isViewActive(homeView, selection)
+}
+
 /** Count phrase: `3 streams`, `1 label`. */
 function countOf(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? "" : "s"}`
@@ -162,8 +174,10 @@ export function BoardSavedViews({
   const [editing, setEditing] = useState<{ id: string | null; name: string } | null>(null)
 
   // Only offer "save current view" when there's actually a narrowing to bookmark
-  // — the viewer's plain home lens is nothing worth saving.
-  const isFiltered = isBoardFiltered(homeLens, {
+  // — the viewer's home baseline (the plain home lens, or the saved view that is
+  // their home) is nothing worth saving.
+  const homeView = views?.find((view) => view.id === homeViewId) ?? null
+  const isFiltered = !isBoardAtHome(homeLens, homeView, {
     lens,
     scopeStreamIds,
     scopeStreamTypes,

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -78,11 +78,21 @@ export function isViewActive(view: BoardView, selection: BoardViewSelection): bo
 }
 
 /**
- * Whether the live selection is the viewer's untouched home baseline — the plain
- * home lens with no narrowing, OR (when a saved view is the home) exactly that
- * view. "Clear filters" / "Save current view" hide at home; a saved-view home is
- * itself a filtered selection, so `isBoardFiltered` alone would wrongly read it as
- * narrowed and offer a "Clear filters" that just bounces back to the same view.
+ * Whether the live selection is a baseline state where "Clear filters" / "Save
+ * current view" / "Show everything" would be no-ops and should stay hidden. Two
+ * such states, and the branch order is load-bearing:
+ *   1. The plain unfiltered home lens (nothing narrowed → nothing to clear, save,
+ *      or show-more), even when a saved view is the configured home. This lens is
+ *      reachable explicitly (bare `/board` redirects to the view, but `/board/all`
+ *      does not), and on it those three affordances are all meaningless.
+ *   2. Exactly the saved-view home — itself a filtered selection, so
+ *      `isBoardFiltered` alone would wrongly read it as narrowed and offer a
+ *      "Clear filters" that just bounces back to the same view.
+ * Checking the unfiltered case first is intentional: flipping to "resolve the
+ * view first" would report the plain All lens as narrowed and wrongly surface
+ * "Show everything" (on the everything lens) and "Save current view" (on an
+ * unfiltered selection). Any genuinely narrowed selection makes `isBoardFiltered`
+ * true and falls through to `isViewActive`, which is where the real work happens.
  */
 export function isBoardAtHome(homeLens: BoardLens, homeView: BoardView | null, selection: BoardViewSelection): boolean {
   if (!isBoardFiltered(homeLens, selection)) return true

--- a/apps/frontend/src/components/board/board-saved-views.tsx
+++ b/apps/frontend/src/components/board/board-saved-views.tsx
@@ -21,7 +21,7 @@ import {
 import { cn } from "@/lib/utils"
 import { usePreferencesOptional } from "@/contexts"
 import {
-  useBoardHomeView,
+  useBoardHome,
   useBoardViews,
   useSaveBoardView,
   useUpdateBoardView,
@@ -171,7 +171,7 @@ export function BoardSavedViews({
 }: BoardSavedViewsProps) {
   const { data: views } = useBoardViews(workspaceId)
   const prefs = usePreferencesOptional()
-  const homeView = useBoardHomeView(workspaceId)
+  const { view: homeView } = useBoardHome(workspaceId)
   const save = useSaveBoardView(workspaceId)
   const update = useUpdateBoardView(workspaceId)
   const remove = useDeleteBoardView(workspaceId)

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -243,12 +243,7 @@ export function ConversationPanel({ workspaceId, onClose }: ConversationPanelPro
           )}
           {/* The topic is the conversation's identity — show it when set, falling
             back to the stream locator (the pre-topic behavior). */}
-          <span
-            className={cn(
-              "truncate",
-              post?.conversation.status === "resolved" && "text-muted-foreground line-through decoration-1"
-            )}
-          >
+          <span className={cn("truncate", post?.conversation.status === "resolved" && "text-muted-foreground")}>
             {post?.conversation.topicSummary ?? locator}
           </span>
           {post && (

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -6,7 +6,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Switch } from "@/components/ui/switch"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
-import { useBoardHomeView, useBoardViews } from "@/hooks/use-board-views"
+import { useBoardHome, useBoardViews } from "@/hooks/use-board-views"
 import { summarizeBoardView } from "@/components/board/board-saved-views"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
@@ -92,7 +92,7 @@ function BoardHomeSection({ workspaceId }: { workspaceId: string }) {
   const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
   // The resolved home view's id, or null when the home is a lens (or the stored id
   // no longer resolves) — land on the lens then.
-  const activeViewId = useBoardHomeView(workspaceId)?.id ?? null
+  const activeViewId = useBoardHome(workspaceId).view?.id ?? null
   const value = activeViewId ? `view:${activeViewId}` : `lens:${boardDefaultLens}`
 
   const onChange = (next: string) => {

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Switch } from "@/components/ui/switch"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
+import { useBoardViews } from "@/hooks/use-board-views"
+import { summarizeBoardView } from "@/components/board/board-saved-views"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
   THEME_OPTIONS,
@@ -76,8 +79,72 @@ const LABEL_REMOVE_DESCRIPTIONS: Record<LabelRemoveOnMove, string> = {
   never: "Leave labels alone — a moved stream keeps every label it had",
 }
 
+/**
+ * Board home: the lens or saved view the bare `/board` lands on. Selecting a lens
+ * clears any saved-view home (so the landing actually lands there); selecting a
+ * view leaves the lens as the fallback for a stale/deleted view. Mirrors the pins
+ * in the board's own lens menu.
+ */
+function BoardHomeSection({ workspaceId }: { workspaceId: string }) {
+  const { preferences, updatePreferences } = usePreferences()
+  const { data: views } = useBoardViews(workspaceId)
+  const savedViews = views ?? []
+  const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const defaultViewId = preferences?.boardDefaultViewId ?? null
+  // A default-view id that no longer resolves reads as "no view" — land on the lens.
+  const activeViewId = defaultViewId && savedViews.some((v) => v.id === defaultViewId) ? defaultViewId : null
+  const value = activeViewId ? `view:${activeViewId}` : `lens:${boardDefaultLens}`
+
+  const onChange = (next: string) => {
+    if (next.startsWith("view:")) void updatePreferences({ boardDefaultViewId: next.slice("view:".length) })
+    else void updatePreferences({ boardDefaultLens: next.slice("lens:".length) as BoardLens, boardDefaultViewId: null })
+  }
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="text-sm font-medium">Board home</h3>
+        <p className="text-sm text-muted-foreground">
+          The lens or saved view the board opens on. Every lens and view still has its own URL — this only picks where
+          you land
+        </p>
+      </div>
+      <RadioGroup value={value} onValueChange={onChange} className="space-y-3">
+        {BOARD_LENSES.map((option) => (
+          <div key={option} className="flex items-start space-x-3">
+            <RadioGroupItem value={`lens:${option}`} id={`board-home-lens-${option}`} className="mt-1" />
+            <div className="grid gap-1">
+              <Label htmlFor={`board-home-lens-${option}`} className="cursor-pointer">
+                {BOARD_LENS_DEFS[option].label}
+              </Label>
+              <p className="text-sm text-muted-foreground">{BOARD_LENS_DEFS[option].description}</p>
+            </div>
+          </div>
+        ))}
+        {savedViews.length > 0 && (
+          <>
+            <p className="pt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Saved views</p>
+            {savedViews.map((view) => (
+              <div key={view.id} className="flex items-start space-x-3">
+                <RadioGroupItem value={`view:${view.id}`} id={`board-home-view-${view.id}`} className="mt-1" />
+                <div className="grid gap-1">
+                  <Label htmlFor={`board-home-view-${view.id}`} className="cursor-pointer">
+                    {view.name}
+                  </Label>
+                  <p className="text-sm text-muted-foreground">{summarizeBoardView(view)}</p>
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+      </RadioGroup>
+    </section>
+  )
+}
+
 export function AppearanceSettings() {
   const { preferences, updatePreference } = usePreferences()
+  const { workspaceId } = useParams<{ workspaceId: string }>()
 
   const theme = preferences?.theme ?? "system"
   const messageDisplay = preferences?.messageDisplay ?? "comfortable"
@@ -91,7 +158,6 @@ export function AppearanceSettings() {
   const boardCardCollapseEnabled = preferences?.boardCardCollapseEnabled ?? false
   const boardCardCollapseAtHeight = preferences?.boardCardCollapseAtHeight ?? DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT
   const boardCardCollapseToHeight = preferences?.boardCardCollapseToHeight ?? DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT
-  const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
 
   // Local input state so users can type freely without each keystroke
   // hitting the preferences mutation. We commit on blur / Enter only.
@@ -545,31 +611,7 @@ export function AppearanceSettings() {
 
       <Separator />
 
-      <section className="space-y-3">
-        <div>
-          <h3 className="text-sm font-medium">Board home</h3>
-          <p className="text-sm text-muted-foreground">
-            The lens the board opens on. Every lens still has its own view — this only picks where you land
-          </p>
-        </div>
-        <RadioGroup
-          value={boardDefaultLens}
-          onValueChange={(value) => updatePreference("boardDefaultLens", value as BoardLens)}
-          className="space-y-3"
-        >
-          {BOARD_LENSES.map((option) => (
-            <div key={option} className="flex items-start space-x-3">
-              <RadioGroupItem value={option} id={`board-lens-${option}`} className="mt-1" />
-              <div className="grid gap-1">
-                <Label htmlFor={`board-lens-${option}`} className="cursor-pointer">
-                  {BOARD_LENS_DEFS[option].label}
-                </Label>
-                <p className="text-sm text-muted-foreground">{BOARD_LENS_DEFS[option].description}</p>
-              </div>
-            </div>
-          ))}
-        </RadioGroup>
-      </section>
+      {workspaceId && <BoardHomeSection workspaceId={workspaceId} />}
 
       <Separator />
 

--- a/apps/frontend/src/components/settings/appearance-settings.tsx
+++ b/apps/frontend/src/components/settings/appearance-settings.tsx
@@ -6,7 +6,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Switch } from "@/components/ui/switch"
 import { Separator } from "@/components/ui/separator"
 import { usePreferences } from "@/contexts"
-import { useBoardViews } from "@/hooks/use-board-views"
+import { useBoardHomeView, useBoardViews } from "@/hooks/use-board-views"
 import { summarizeBoardView } from "@/components/board/board-saved-views"
 import { BOARD_LENS_DEFS } from "@/lib/board/lens-defs"
 import {
@@ -90,9 +90,9 @@ function BoardHomeSection({ workspaceId }: { workspaceId: string }) {
   const { data: views } = useBoardViews(workspaceId)
   const savedViews = views ?? []
   const boardDefaultLens = preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
-  const defaultViewId = preferences?.boardDefaultViewId ?? null
-  // A default-view id that no longer resolves reads as "no view" — land on the lens.
-  const activeViewId = defaultViewId && savedViews.some((v) => v.id === defaultViewId) ? defaultViewId : null
+  // The resolved home view's id, or null when the home is a lens (or the stored id
+  // no longer resolves) — land on the lens then.
+  const activeViewId = useBoardHomeView(workspaceId)?.id ?? null
   const value = activeViewId ? `view:${activeViewId}` : `lens:${boardDefaultLens}`
 
   const onChange = (next: string) => {

--- a/apps/frontend/src/contexts/preferences-context.tsx
+++ b/apps/frontend/src/contexts/preferences-context.tsx
@@ -51,6 +51,9 @@ interface PreferencesContextValue {
     key: K,
     value: UpdateUserPreferencesInput[K]
   ) => Promise<void>
+  /** Write several keys in one request — use when two fields must move together
+   *  (e.g. setting the board home lens must also clear `boardDefaultViewId`). */
+  updatePreferences: (input: UpdateUserPreferencesInput) => Promise<void>
   updateAccessibility: (updates: Partial<AccessibilityPreferences>) => Promise<void>
   updateKeyboardShortcut: (actionId: string, keyBinding: string) => Promise<void>
   resetKeyboardShortcut: (actionId: string) => Promise<void>
@@ -169,6 +172,13 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
     [mutation]
   )
 
+  const updatePreferences = useCallback(
+    async (input: UpdateUserPreferencesInput) => {
+      await mutation.mutateAsync(input)
+    },
+    [mutation]
+  )
+
   const updateAccessibility = useCallback(
     async (updates: Partial<AccessibilityPreferences>) => {
       await mutation.mutateAsync({ accessibility: updates })
@@ -204,6 +214,7 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
       resolvedTheme,
       isLoading: mutation.isPending,
       updatePreference,
+      updatePreferences,
       updateAccessibility,
       updateKeyboardShortcut,
       resetKeyboardShortcut,
@@ -214,6 +225,7 @@ export function PreferencesProvider({ workspaceId, children }: PreferencesProvid
       resolvedTheme,
       mutation.isPending,
       updatePreference,
+      updatePreferences,
       updateAccessibility,
       updateKeyboardShortcut,
       resetKeyboardShortcut,

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -39,22 +39,35 @@ export function useBoardViews(workspaceId: string) {
   })
 }
 
+export interface BoardHome {
+  /** The RESOLVED saved view the viewer homes on — `null` when the home is a plain
+   *  lens, the id no longer resolves, or the list is still loading. Use for the
+   *  "is this the home baseline" checks (isBoardAtHome), the pin fill, the settings
+   *  radio, and the direct "return to the saved-view home" navigation. */
+  view: BoardView | null
+  /** The CONFIGURED `boardDefaultViewId` — `null` only when the home is a plain
+   *  lens. Known from the preference BEFORE the list loads, so URL-building can keep
+   *  explicit lens segments during the load window (a bare `/board` would bounce to
+   *  the view once the list resolves, making the target unreachable). */
+  configuredId: string | null
+}
+
 /**
- * The RESOLVED saved view the viewer homes on (`boardDefaultViewId`), or `null`
- * when the home is a plain lens, the id no longer resolves, or the list is still
- * loading. One resolver for every surface that needs "is this the home baseline"
- * (the filter bar's "Clear filters", the empty-state CTA, the saved-views pin, the
- * settings radio) so they can't drift. `usePreferencesOptional` so it's safe in
- * surfaces mounted without the provider (e.g. the saved-views menu in isolation).
- * The bare-`/board` redirect in `board.tsx` deliberately does NOT use this — it
- * needs the raw `boardDefaultViewId` + list to tell "still loading" from "unset",
- * a distinction this hook collapses to `null`.
+ * The viewer's board home — the resolved saved view and the raw configured id. One
+ * resolver for every surface that needs it (the filter bar, the empty-state CTA,
+ * the saved-views pin, the settings radio, the "escape to everything" links) so
+ * they can't drift. `usePreferencesOptional` so it's safe in surfaces mounted
+ * without the provider (e.g. the saved-views menu in isolation). The bare-`/board`
+ * redirect in `board.tsx` deliberately keeps its own raw `boardDefaultViewId` +
+ * list access — it must tell "still loading" from "unset" to gate the redirect,
+ * a distinction the resolved `view` collapses to `null`.
  */
-export function useBoardHomeView(workspaceId: string): BoardView | null {
+export function useBoardHome(workspaceId: string): BoardHome {
   const preferences = usePreferencesOptional()?.preferences ?? null
   const { data: views } = useBoardViews(workspaceId)
-  const homeViewId = preferences?.boardDefaultViewId ?? null
-  return views?.find((view) => view.id === homeViewId) ?? null
+  const configuredId = preferences?.boardDefaultViewId ?? null
+  const view = views?.find((v) => v.id === configuredId) ?? null
+  return { view, configuredId }
 }
 
 /**

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
-import type { WorkspaceBootstrap } from "@threa/types"
-import { useBoardViewService } from "@/contexts"
+import type { BoardView, WorkspaceBootstrap } from "@threa/types"
+import { useBoardViewService, usePreferences } from "@/contexts"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import type { SaveBoardViewInput, UpdateBoardViewInput } from "@/api"
 
@@ -37,6 +37,19 @@ export function useBoardViews(workspaceId: string) {
     staleTime: 60_000,
     refetchOnReconnect: true,
   })
+}
+
+/**
+ * The saved view the viewer homes on (`boardDefaultViewId`), or `null` when the
+ * home is a plain lens or the id no longer resolves. One resolver for every
+ * surface that needs "is this the home baseline" (the bare-`/board` redirect, the
+ * filter bar's "Clear filters", the empty-state CTA) so they can't drift.
+ */
+export function useBoardHomeView(workspaceId: string): BoardView | null {
+  const { preferences } = usePreferences()
+  const { data: views } = useBoardViews(workspaceId)
+  const homeViewId = preferences?.boardDefaultViewId ?? null
+  return views?.find((view) => view.id === homeViewId) ?? null
 }
 
 /**

--- a/apps/frontend/src/hooks/use-board-views.ts
+++ b/apps/frontend/src/hooks/use-board-views.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import type { BoardView, WorkspaceBootstrap } from "@threa/types"
-import { useBoardViewService, usePreferences } from "@/contexts"
+import { useBoardViewService, usePreferencesOptional } from "@/contexts"
 import { workspaceKeys } from "@/hooks/use-workspaces"
 import type { SaveBoardViewInput, UpdateBoardViewInput } from "@/api"
 
@@ -40,13 +40,18 @@ export function useBoardViews(workspaceId: string) {
 }
 
 /**
- * The saved view the viewer homes on (`boardDefaultViewId`), or `null` when the
- * home is a plain lens or the id no longer resolves. One resolver for every
- * surface that needs "is this the home baseline" (the bare-`/board` redirect, the
- * filter bar's "Clear filters", the empty-state CTA) so they can't drift.
+ * The RESOLVED saved view the viewer homes on (`boardDefaultViewId`), or `null`
+ * when the home is a plain lens, the id no longer resolves, or the list is still
+ * loading. One resolver for every surface that needs "is this the home baseline"
+ * (the filter bar's "Clear filters", the empty-state CTA, the saved-views pin, the
+ * settings radio) so they can't drift. `usePreferencesOptional` so it's safe in
+ * surfaces mounted without the provider (e.g. the saved-views menu in isolation).
+ * The bare-`/board` redirect in `board.tsx` deliberately does NOT use this — it
+ * needs the raw `boardDefaultViewId` + list to tell "still loading" from "unset",
+ * a distinction this hook collapses to `null`.
  */
 export function useBoardHomeView(workspaceId: string): BoardView | null {
-  const { preferences } = usePreferences()
+  const preferences = usePreferencesOptional()?.preferences ?? null
   const { data: views } = useBoardViews(workspaceId)
   const homeViewId = preferences?.boardDefaultViewId ?? null
   return views?.find((view) => view.id === homeViewId) ?? null

--- a/apps/frontend/src/hooks/use-streams.test.tsx
+++ b/apps/frontend/src/hooks/use-streams.test.tsx
@@ -91,6 +91,7 @@ function makeWorkspaceBootstrap(): WorkspaceBootstrap {
       boardCardCollapseToHeight: 320,
       boardCardCollapseThreshold: 600,
       boardDefaultLens: "all",
+      boardDefaultViewId: null,
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
       voiceSteeringWords: [],

--- a/apps/frontend/src/hooks/use-unread-counts.test.tsx
+++ b/apps/frontend/src/hooks/use-unread-counts.test.tsx
@@ -100,6 +100,7 @@ function makeBootstrap(): WorkspaceBootstrap {
       boardCardCollapseToHeight: 320,
       boardCardCollapseThreshold: 600,
       boardDefaultLens: "all",
+      boardDefaultViewId: null,
       voiceTranscriptionModel: null,
       voicePolishLevel: "opinionated",
       voiceSteeringWords: [],

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -153,7 +153,7 @@ function mountBoard(
     featureFlags: boardFlag === "unknown" ? {} : { "board-view": boardFlag },
     boardViews: boardViews ?? [],
   })
-  render(
+  const tree = (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <ServicesProvider services={{ conversations: { listByWorkspace, getBoardMessages } as never }}>
@@ -171,7 +171,8 @@ function mountBoard(
       </TooltipProvider>
     </QueryClientProvider>
   )
-  return { listByWorkspace }
+  const { rerender } = render(tree)
+  return { listByWorkspace, tree, rerender }
 }
 
 beforeEach(() => {
@@ -296,6 +297,29 @@ describe("BoardPage", () => {
     // Flag-off leaves the board route (to the workspace), never through the view URL.
     await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}`))
     expect(probe.textContent).not.toContain("is=channel")
+  })
+
+  it("keeps the board rendered when a saved view is pinned as home while resting on bare `/board`", async () => {
+    // Regression: pinning a view as home is a same-URL preference change. The
+    // redirect effect (once per `location.key`) correctly declines to navigate, so
+    // the render must keep the board visible rather than blank it waiting for a
+    // redirect that never comes.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: null },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    const post = makePost({ id: "conv_x" }, { contentMarkdown: "Board still here." })
+    const { tree, rerender } = mountBoard([post], { boardViews: [makeBoardView()] })
+    expect(await screen.findByText("Board still here.")).toBeTruthy()
+
+    // Pin a saved view as home — same URL, no navigation.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    rerender(tree)
+
+    // Still on bare `/board`, board still rendered — not blanked, not navigated.
+    expect(screen.getByTestId("location").textContent).toBe(`/w/${WORKSPACE_ID}/board`)
+    expect(screen.getByText("Board still here.")).toBeTruthy()
   })
 
   it("shows no 'Clear filters' on the plain home lens (home is the baseline)", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -299,6 +299,22 @@ describe("BoardPage", () => {
     expect(probe.textContent).not.toContain("is=channel")
   })
 
+  it("hides 'Show everything' on an empty saved-view home landing", async () => {
+    // The viewer homes on a saved view; sitting on that view's own (empty) URL is
+    // their baseline, so no "Show everything" CTA — the empty-state resolves the
+    // baseline through isBoardAtHome, not raw isBoardFiltered.
+    vi.mocked(contextsModule.usePreferences).mockReturnValue({
+      preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    // The saved view's own URL (`makeBoardView` → active + `?is=channel`).
+    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board/active?is=channel` })
+    expect(await screen.findByText("Nothing here right now")).toBeTruthy()
+    expect(screen.queryByText("Show everything")).toBeNull()
+  })
+
   it("keeps the board rendered when a saved view is pinned as home while resting on bare `/board`", async () => {
     // Regression: pinning a view as home is a same-URL preference change. The
     // redirect effect (once per `location.key`) correctly declines to navigate, so

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { Fragment, createElement } from "react"
 import * as boardFeedListModule from "@/components/board/board-feed-list"
-import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import type { BoardPost, BoardPostMessage, ConversationWithStaleness } from "@threa/types"
+import type { BoardPost, BoardPostMessage, BoardView, ConversationWithStaleness } from "@threa/types"
 import { BoardPage } from "./board"
 import * as boardStoreModule from "@/stores/board-store"
 import { ServicesProvider, SidebarProvider, PanelProvider } from "@/contexts"
@@ -90,15 +90,39 @@ function makePost(
   }
 }
 
+function makeBoardView(overrides: Partial<BoardView> = {}): BoardView {
+  return {
+    id: "boardview_1",
+    name: "Channels, active",
+    baseLens: "active",
+    scopeStreamIds: [],
+    scopeStreamTypes: ["channel"],
+    scopeLabelIds: [],
+    excludeStreamIds: [],
+    excludeStreamTypes: [],
+    excludeLabelIds: [],
+    sortOrder: 0,
+    ...overrides,
+  }
+}
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+}
+
 function mountBoard(
   posts: BoardPost[],
   opts: {
     nextCursor?: string | null
     fail?: boolean
-    boardFlag?: "on" | "off"
+    /** "unknown" leaves the flag absent from the bootstrap (still-resolving state). */
+    boardFlag?: "on" | "off" | "unknown"
     failMessages?: boolean
     /** URL to mount at — set `/w/<ws>/board/<lens>` to exercise a lens segment. */
     entry?: string
+    /** Seeds the saved-view list into the bootstrap cache (what `useBoardViews` reads). */
+    boardViews?: BoardView[]
   } = {}
 ) {
   const {
@@ -107,6 +131,7 @@ function mountBoard(
     boardFlag = "on",
     failMessages = false,
     entry = `/w/${WORKSPACE_ID}/board`,
+    boardViews,
   } = opts
   const listByWorkspace = vi.fn(async () => {
     if (fail) throw new Error("boom")
@@ -122,8 +147,12 @@ function mountBoard(
   // pagination/loading/error, so `listByWorkspace` is exercised as before.
   vi.spyOn(boardStoreModule, "useBoardPosts").mockReturnValue(posts as never)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  // The board is gated behind the board-view flag, read from the bootstrap cache.
-  queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), { featureFlags: { "board-view": boardFlag } })
+  // The board is gated behind the board-view flag, read from the bootstrap cache;
+  // `boardViews` seeds the saved-view list `useBoardViews` reads from bootstrap.
+  queryClient.setQueryData(workspaceKeys.bootstrap(WORKSPACE_ID), {
+    featureFlags: boardFlag === "unknown" ? {} : { "board-view": boardFlag },
+    boardViews: boardViews ?? [],
+  })
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
@@ -131,6 +160,7 @@ function mountBoard(
           <SidebarProvider>
             <MemoryRouter initialEntries={[entry]}>
               <PanelProvider>
+                <LocationProbe />
                 <Routes>
                   <Route path="/w/:workspaceId/board/:lens?" element={<BoardPage />} />
                 </Routes>
@@ -232,6 +262,40 @@ describe("BoardPage", () => {
 
     expect(await screen.findByText("My own topic.")).toBeTruthy()
     expect(screen.queryByText("Someone else's topic.")).toBeNull()
+  })
+
+  it("bounces bare `/board` to the saved-view home when one is set", async () => {
+    // boardDefaultViewId names a saved view; the bare `/board` resolves it to the
+    // view's canonical filtered URL (base lens segment + `?is=channel`).
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    mountBoard([], { boardViews: [makeBoardView()] })
+    const probe = await screen.findByTestId("location")
+    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board/active?is=channel`))
+  })
+
+  it("does not bounce to the saved-view home while the board-view flag is unknown", async () => {
+    // The redirect is gated behind the resolved flag (like the rest of the board),
+    // so a still-loading flag never bounces through the saved-view URL first.
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    mountBoard([], { boardFlag: "unknown", boardViews: [makeBoardView()] })
+    const probe = await screen.findByTestId("location")
+    // Stays put on bare `/board`; never navigates to the view URL.
+    expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}/board`)
+  })
+
+  it("does not bounce to the saved-view home when the board-view flag is off", async () => {
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    mountBoard([], { boardFlag: "off", boardViews: [makeBoardView()] })
+    const probe = await screen.findByTestId("location")
+    // Flag-off leaves the board route (to the workspace), never through the view URL.
+    await vi.waitFor(() => expect(probe.textContent).toBe(`/w/${WORKSPACE_ID}`))
+    expect(probe.textContent).not.toContain("is=channel")
   })
 
   it("shows no 'Clear filters' on the plain home lens (home is the baseline)", async () => {

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -315,6 +315,21 @@ describe("BoardPage", () => {
     expect(screen.queryByText("Show everything")).toBeNull()
   })
 
+  it("points 'Show everything' at the explicit All lens for a saved-view-home viewer", async () => {
+    // With a saved-view home, bare `/board` bounces to the view — so the escape to
+    // "everything" must use the explicit `/board/all` segment, not bare `/board`.
+    vi.mocked(contextsModule.usePreferences).mockReturnValue({
+      preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    // A narrowed, empty lens (not the saved-view home) → "Show everything" offered.
+    mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board/decisions` })
+    const cta = await screen.findByRole("link", { name: "Show everything" })
+    expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board/all`)
+  })
+
   it("keeps the board rendered when a saved view is pinned as home while resting on bare `/board`", async () => {
     // Regression: pinning a view as home is a same-URL preference change. The
     // redirect effect (once per `location.key`) correctly declines to navigate, so

--- a/apps/frontend/src/pages/board.test.tsx
+++ b/apps/frontend/src/pages/board.test.tsx
@@ -211,6 +211,7 @@ beforeEach(() => {
   // live; the engine isn't wired in this harness, so stub the hook.
   vi.spyOn(syncEngineModule, "useSyncEngine").mockReturnValue({
     setBoardStreamIds: vi.fn(),
+    setPanelStreamIds: vi.fn(),
   } as unknown as ReturnType<typeof syncEngineModule.useSyncEngine>)
   // Author names open the profile via UserProfileProvider, not mounted here.
   vi.spyOn(userProfileModule, "useUserProfile").mockReturnValue({ openUserProfile: vi.fn() })
@@ -328,6 +329,27 @@ describe("BoardPage", () => {
     mountBoard([], { boardViews: [makeBoardView()], entry: `/w/${WORKSPACE_ID}/board/decisions` })
     const cta = await screen.findByRole("link", { name: "Show everything" })
     expect(cta.getAttribute("href")).toBe(`/w/${WORKSPACE_ID}/board/all`)
+  })
+
+  it("preserves an open panel when clearing filters back to a saved-view home", async () => {
+    // Clearing filters returns to the saved-view home directly (no bare detour),
+    // and the surviving non-filter query — an open `?panel=` thread — rides along.
+    vi.mocked(contextsModule.usePreferences).mockReturnValue({
+      preferences: { timezone: "UTC", locale: "en-US", boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferences>)
+    vi.mocked(contextsModule.usePreferencesOptional).mockReturnValue({
+      preferences: { boardDefaultLens: "all", boardDefaultViewId: "boardview_1" },
+    } as unknown as ReturnType<typeof contextsModule.usePreferencesOptional>)
+    // Narrowed off the saved-view home (extra `in=`), with an open panel.
+    mountBoard([], {
+      boardViews: [makeBoardView()],
+      entry: `/w/${WORKSPACE_ID}/board/active?is=channel&in=stream_x&panel=conv%3Aabc`,
+    })
+    const clear = await screen.findByRole("link", { name: "Clear filters" })
+    const href = clear.getAttribute("href") ?? ""
+    expect(href).toContain("is=channel") // the saved view's own scope
+    expect(href).toContain("panel=conv") // the open thread survives
+    expect(href).not.toContain("in=stream_x") // the extra narrowing is cleared
   })
 
   it("keeps the board rendered when a saved view is pinned as home while resting on bare `/board`", async () => {

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -38,9 +38,8 @@ import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
-import { boardHomeRedirectHref } from "@/components/board/board-saved-views"
-import { useBoardViews } from "@/hooks/use-board-views"
-import { isBoardFiltered } from "@/lib/board/filter-state"
+import { boardHomeRedirectHref, isBoardAtHome } from "@/components/board/board-saved-views"
+import { useBoardViews, useBoardHomeView } from "@/hooks/use-board-views"
 import {
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
@@ -181,11 +180,13 @@ export function BoardPage() {
   // a real destination reachable from the lens menu, NOT the canonical bare URL —
   // so the home lens is not collapsed to bare here (which would just bounce back
   // to the saved view). `savedViewReady` gates every home-resolution decision on
-  // BOTH sources being loaded: `usePreferencesOptional()` returns its context
-  // object as soon as the provider mounts, so read `.preferences` (the IDB data,
-  // null until it hydrates) — otherwise a cold load misreads a saved-view home as
-  // unset and never redirects.
-  const savedViewReady = preferences?.preferences != null && boardViews !== undefined
+  // the sources it needs: `usePreferencesOptional()` returns its context object as
+  // soon as the provider mounts, so read `.preferences` (the IDB data, null until
+  // it hydrates) — otherwise a cold load misreads a saved-view home as unset and
+  // never redirects. The saved-view LIST is only needed when a default view id is
+  // actually set, so a plain-lens landing (no `boardDefaultViewId`) doesn't block
+  // on the board-views query.
+  const savedViewReady = preferences?.preferences != null && (defaultViewId === null || boardViews !== undefined)
   const homeViewActive = !!defaultViewId && !!boardViews?.some((view) => view.id === defaultViewId)
   const bareBoard = lensParam === undefined && location.search === ""
   // Bare `/board` is a "resolve where home is" route: hold (render nothing) until
@@ -548,6 +549,9 @@ function BoardPageInner({
     excludeStreamTypes.length > 0 ||
     scopeLabelIds.length > 0 ||
     excludeLabelIds.length > 0
+  // The viewer's home baseline (plain home lens, or the saved view they home on)
+  // reads as unfiltered, so an empty home landing doesn't offer "Show everything".
+  const homeView = useBoardHomeView(workspaceId)
   const handlePosted = () => {
     // The viewer's own post must ALWAYS surface. It already shows where the
     // current view can contain it — an unfiltered `all`/`mine` lens — so stay
@@ -707,7 +711,7 @@ function BoardPageInner({
       // own empty landing view shows the empty copy without a "Show everything"
       // CTA (it's already at baseline).
       const scoped = hasFilterParams
-      const isFiltered = isBoardFiltered(homeLens, {
+      const isFiltered = !isBoardAtHome(homeLens, homeView, {
         lens,
         scopeStreamIds,
         scopeStreamTypes,

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -180,11 +180,18 @@ export function BoardPage() {
   // falls back to the plain home lens. When a view is home, `/board/<homeLens>` is
   // a real destination reachable from the lens menu, NOT the canonical bare URL —
   // so the home lens is not collapsed to bare here (which would just bounce back
-  // to the saved view). `savedViewReady` distinguishes "still loading" from
-  // "no home view" so a cold load isn't misread as unset.
-  const savedViewReady = preferences != null && boardViews !== undefined
+  // to the saved view). `savedViewReady` gates every home-resolution decision on
+  // BOTH sources being loaded: `usePreferencesOptional()` returns its context
+  // object as soon as the provider mounts, so read `.preferences` (the IDB data,
+  // null until it hydrates) — otherwise a cold load misreads a saved-view home as
+  // unset and never redirects.
+  const savedViewReady = preferences?.preferences != null && boardViews !== undefined
   const homeViewActive = !!defaultViewId && !!boardViews?.some((view) => view.id === defaultViewId)
   const bareBoard = lensParam === undefined && location.search === ""
+  // Bare `/board` is a "resolve where home is" route: hold (render nothing) until
+  // the home is knowable, rather than paint the plain-lens board and then bounce
+  // to a saved-view home a frame later (mirrors the flag gate below).
+  if (bareBoard && !savedViewReady) return null
   // The bounce target for a bare `/board` arrival with a saved-view home. Resolved
   // here but NAVIGATED inside BoardPageGate — only once the board-view flag is on
   // and at most once per navigation — so it never fires ahead of the flag gate and
@@ -192,7 +199,14 @@ export function BoardPage() {
   // can't yank the user off the page.
   const savedViewTarget =
     bareBoard && savedViewReady ? boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens) : null
-  if ((!homeViewActive && lensParam === homeLens) || (lensParam !== undefined && !VALID_LENSES.has(lensParam))) {
+  // Collapse `/board/<homeLens>` to bare only once we know it isn't a saved-view
+  // home (else the home lens, a legitimate destination, would bounce to the view).
+  // Gate on `savedViewReady` so a stale `homeViewActive: false` during load can't
+  // fire the bounce prematurely.
+  if (
+    (savedViewReady && !homeViewActive && lensParam === homeLens) ||
+    (lensParam !== undefined && !VALID_LENSES.has(lensParam))
+  ) {
     return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
   }
   const lens: BoardLens = (lensParam as BoardLens | undefined) ?? homeLens
@@ -243,6 +257,10 @@ function BoardPageGate({
   }, [boardFlag, savedViewReady, savedViewTarget, location.key, navigate])
   if (boardFlag === null) return null
   if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
+  // A saved-view home is about to redirect (the effect above fires post-commit) —
+  // render nothing rather than paint one frame of the wrong lens board first,
+  // mirroring the flag gate's "render nothing rather than redirect".
+  if (savedViewTarget) return null
   return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
 }
 

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -39,7 +39,7 @@ import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
 import { boardHomeRedirectHref, isBoardAtHome } from "@/components/board/board-saved-views"
-import { useBoardViews, useBoardHomeView } from "@/hooks/use-board-views"
+import { useBoardViews, useBoardHome } from "@/hooks/use-board-views"
 import {
   BOARD_SCOPE_PARAM,
   BOARD_TYPE_PARAM,
@@ -544,13 +544,14 @@ function BoardPageInner({
   // `?panel=`) rides along so it survives clearing filters.
   // The viewer's home baseline (plain home lens, or the saved view they home on)
   // reads as unfiltered, so an empty home landing doesn't offer "Show everything".
-  const homeView = useBoardHomeView(workspaceId)
+  const { view: homeView, configuredId: homeViewId } = useBoardHome(workspaceId)
   // "Show everything" / the own-post-must-surface bounce target the truly
-  // unfiltered All lens. When a saved-view home resolves, bare `/board` bounces to
-  // that view, so All must take its explicit `/board/all` segment or these escapes
-  // land back on the (filtered) saved view instead of everything.
+  // unfiltered All lens. When a saved-view home is CONFIGURED, bare `/board` bounces
+  // to that view once the list resolves, so All must take its explicit `/board/all`
+  // segment (keyed on the configured id, not the resolved view, so the escape is
+  // reachable even during the load window) or these land back on the saved view.
   const allPathname =
-    homeLens === DEFAULT_BOARD_LENS && homeView === null
+    homeLens === DEFAULT_BOARD_LENS && homeViewId === null
       ? `/w/${workspaceId}/board`
       : `/w/${workspaceId}/board/${DEFAULT_BOARD_LENS}`
   const boardHome = { pathname: allPathname, search: boardHomeSearch(searchParams.toString()) }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -38,6 +38,8 @@ import { BoardFeedList } from "@/components/board/board-feed-list"
 import { BoardNewPostsPill } from "@/components/board/board-new-posts-pill"
 import { BoardComposer } from "@/components/board/board-composer"
 import { BoardFilterBar } from "@/components/board/board-filter-bar"
+import { boardHomeRedirectHref } from "@/components/board/board-saved-views"
+import { useBoardViews } from "@/hooks/use-board-views"
 import { isBoardFiltered } from "@/lib/board/filter-state"
 import {
   BOARD_SCOPE_PARAM,
@@ -169,7 +171,18 @@ export function BoardPage() {
   const location = useLocation()
   const preferences = usePreferencesOptional()
   const homeLens = preferences?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
+  const defaultViewId = preferences?.preferences?.boardDefaultViewId ?? null
+  // Already mounted deeper (the lens menu), so this adds no fetch — it just lets
+  // the landing resolve a saved-view home before the page renders.
+  const { data: boardViews } = useBoardViews(workspaceId ?? "")
   if (!workspaceId) return null
+  // Board home is a saved view: only the untouched `/board` entry bounces to it
+  // (an explicit filtered deep-link is never hijacked); a stale/deleted id falls
+  // through to the plain home lens below.
+  if (lensParam === undefined && location.search === "") {
+    const redirect = boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens)
+    if (redirect) return <Navigate to={redirect} replace />
+  }
   if (lensParam === homeLens || (lensParam !== undefined && !VALID_LENSES.has(lensParam))) {
     return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
   }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -259,8 +259,12 @@ function BoardPageGate({
   if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
   // A saved-view home is about to redirect (the effect above fires post-commit) —
   // render nothing rather than paint one frame of the wrong lens board first,
-  // mirroring the flag gate's "render nothing rather than redirect".
-  if (savedViewTarget) return null
+  // mirroring the flag gate's "render nothing rather than redirect". Gate this on
+  // the SAME "not yet handled this navigation" condition the effect uses: when the
+  // target only appears because the viewer pinned a view as home while sitting on
+  // `/board` (same `location.key`, already handled), the effect deliberately won't
+  // navigate — so blanking here would strand the board. Render it instead.
+  if (savedViewTarget && handledKeyRef.current !== location.key) return null
   return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
 }
 

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -173,7 +173,7 @@ export function BoardPage() {
   const defaultViewId = preferences?.preferences?.boardDefaultViewId ?? null
   // Already mounted deeper (the lens menu), so this adds no fetch — it just lets
   // the landing resolve a saved-view home.
-  const { data: boardViews } = useBoardViews(workspaceId ?? "")
+  const { data: boardViews, isError: boardViewsFailed } = useBoardViews(workspaceId ?? "")
   if (!workspaceId) return null
   // A saved view is the board home iff its id still resolves; a stale/deleted id
   // falls back to the plain home lens. When a view is home, `/board/<homeLens>` is
@@ -185,8 +185,11 @@ export function BoardPage() {
   // it hydrates) — otherwise a cold load misreads a saved-view home as unset and
   // never redirects. The saved-view LIST is only needed when a default view id is
   // actually set, so a plain-lens landing (no `boardDefaultViewId`) doesn't block
-  // on the board-views query.
-  const savedViewReady = preferences?.preferences != null && (defaultViewId === null || boardViews !== undefined)
+  // on the board-views query. A FAILED list also counts as "ready": the id can't
+  // resolve, so fall back to the lens and render rather than hold `/board` blank
+  // forever on a network blip.
+  const savedViewReady =
+    preferences?.preferences != null && (defaultViewId === null || boardViews !== undefined || boardViewsFailed)
   const homeViewActive = !!defaultViewId && !!boardViews?.some((view) => view.id === defaultViewId)
   const bareBoard = lensParam === undefined && location.search === ""
   // Bare `/board` is a "resolve where home is" route: hold (render nothing) until
@@ -539,8 +542,17 @@ function BoardPageInner({
   // rests at bare `/board` unless the viewer's home is another lens, in which
   // case All takes the `/board/all` segment. The non-filter query state (an open
   // `?panel=`) rides along so it survives clearing filters.
+  // The viewer's home baseline (plain home lens, or the saved view they home on)
+  // reads as unfiltered, so an empty home landing doesn't offer "Show everything".
+  const homeView = useBoardHomeView(workspaceId)
+  // "Show everything" / the own-post-must-surface bounce target the truly
+  // unfiltered All lens. When a saved-view home resolves, bare `/board` bounces to
+  // that view, so All must take its explicit `/board/all` segment or these escapes
+  // land back on the (filtered) saved view instead of everything.
   const allPathname =
-    homeLens === DEFAULT_BOARD_LENS ? `/w/${workspaceId}/board` : `/w/${workspaceId}/board/${DEFAULT_BOARD_LENS}`
+    homeLens === DEFAULT_BOARD_LENS && homeView === null
+      ? `/w/${workspaceId}/board`
+      : `/w/${workspaceId}/board/${DEFAULT_BOARD_LENS}`
   const boardHome = { pathname: allPathname, search: boardHomeSearch(searchParams.toString()) }
   const hasFilterParams =
     scopeStreamIds.length > 0 ||
@@ -549,9 +561,6 @@ function BoardPageInner({
     excludeStreamTypes.length > 0 ||
     scopeLabelIds.length > 0 ||
     excludeLabelIds.length > 0
-  // The viewer's home baseline (plain home lens, or the saved view they home on)
-  // reads as unfiltered, so an empty home landing doesn't offer "Show everything".
-  const homeView = useBoardHomeView(workspaceId)
   const handlePosted = () => {
     // The viewer's own post must ALWAYS surface. It already shows where the
     // current view can contain it — an unfiltered `all`/`mine` lens — so stay

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -173,21 +173,38 @@ export function BoardPage() {
   const homeLens = preferences?.preferences?.boardDefaultLens ?? DEFAULT_BOARD_LENS
   const defaultViewId = preferences?.preferences?.boardDefaultViewId ?? null
   // Already mounted deeper (the lens menu), so this adds no fetch — it just lets
-  // the landing resolve a saved-view home before the page renders.
+  // the landing resolve a saved-view home.
   const { data: boardViews } = useBoardViews(workspaceId ?? "")
   if (!workspaceId) return null
-  // Board home is a saved view: only the untouched `/board` entry bounces to it
-  // (an explicit filtered deep-link is never hijacked); a stale/deleted id falls
-  // through to the plain home lens below.
-  if (lensParam === undefined && location.search === "") {
-    const redirect = boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens)
-    if (redirect) return <Navigate to={redirect} replace />
-  }
-  if (lensParam === homeLens || (lensParam !== undefined && !VALID_LENSES.has(lensParam))) {
+  // A saved view is the board home iff its id still resolves; a stale/deleted id
+  // falls back to the plain home lens. When a view is home, `/board/<homeLens>` is
+  // a real destination reachable from the lens menu, NOT the canonical bare URL —
+  // so the home lens is not collapsed to bare here (which would just bounce back
+  // to the saved view). `savedViewReady` distinguishes "still loading" from
+  // "no home view" so a cold load isn't misread as unset.
+  const savedViewReady = preferences != null && boardViews !== undefined
+  const homeViewActive = !!defaultViewId && !!boardViews?.some((view) => view.id === defaultViewId)
+  const bareBoard = lensParam === undefined && location.search === ""
+  // The bounce target for a bare `/board` arrival with a saved-view home. Resolved
+  // here but NAVIGATED inside BoardPageGate — only once the board-view flag is on
+  // and at most once per navigation — so it never fires ahead of the flag gate and
+  // pinning a view as home while sitting on `/board` (a same-URL preference change)
+  // can't yank the user off the page.
+  const savedViewTarget =
+    bareBoard && savedViewReady ? boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens) : null
+  if ((!homeViewActive && lensParam === homeLens) || (lensParam !== undefined && !VALID_LENSES.has(lensParam))) {
     return <Navigate to={{ pathname: `/w/${workspaceId}/board`, search: location.search }} replace />
   }
   const lens: BoardLens = (lensParam as BoardLens | undefined) ?? homeLens
-  return <BoardPageGate workspaceId={workspaceId} lens={lens} homeLens={homeLens} />
+  return (
+    <BoardPageGate
+      workspaceId={workspaceId}
+      lens={lens}
+      homeLens={homeLens}
+      savedViewTarget={savedViewTarget}
+      savedViewReady={savedViewReady}
+    />
+  )
 }
 
 /**
@@ -197,8 +214,33 @@ export function BoardPage() {
  * refreshes on /board before the bootstrap cache is populated. The backend
  * endpoint 404s without the flag too, so this is the UX half of the gate.
  */
-function BoardPageGate({ workspaceId, lens, homeLens }: { workspaceId: string; lens: BoardLens; homeLens: BoardLens }) {
+function BoardPageGate({
+  workspaceId,
+  lens,
+  homeLens,
+  savedViewTarget,
+  savedViewReady,
+}: {
+  workspaceId: string
+  lens: BoardLens
+  homeLens: BoardLens
+  savedViewTarget: string | null
+  savedViewReady: boolean
+}) {
   const boardFlag = useFeatureFlagWhenKnown(workspaceId, "board-view")
+  const navigate = useNavigate()
+  const location = useLocation()
+  // Bounce a bare `/board` arrival to the saved-view home, but only once the flag
+  // is on and at most once per navigation (`location.key`): a later same-URL
+  // re-render from pinning a view as home must not re-trigger it, so the redirect
+  // follows navigation, not the live preference.
+  const handledKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (boardFlag !== "on" || !savedViewReady) return
+    if (handledKeyRef.current === location.key) return
+    handledKeyRef.current = location.key
+    if (savedViewTarget) navigate(savedViewTarget, { replace: true })
+  }, [boardFlag, savedViewReady, savedViewTarget, location.key, navigate])
   if (boardFlag === null) return null
   if (boardFlag !== "on") return <Navigate to={`/w/${workspaceId}`} replace />
   return <BoardPageInner workspaceId={workspaceId} lens={lens} homeLens={homeLens} />

--- a/packages/types/src/preferences.ts
+++ b/packages/types/src/preferences.ts
@@ -312,6 +312,13 @@ export interface UserPreferences {
    */
   boardDefaultLens: BoardLens
   /**
+   * A saved board view (by id) that overrides `boardDefaultLens` as the landing:
+   * the bare `/board` bounces to this view's filtered URL. `null` means land on
+   * `boardDefaultLens`. A deleted/unresolved id falls back to `boardDefaultLens`,
+   * so a stale pointer degrades quietly instead of dead-ending.
+   */
+  boardDefaultViewId: string | null
+  /**
    * Preferred voice dictation model id (e.g. "elevenlabs:scribe-v2-realtime",
    * "deepgram:nova-3"). When null, the backend falls back to the configured
    * default. The string is validated server-side against the model registry.
@@ -383,6 +390,7 @@ export const DEFAULT_USER_PREFERENCES: Omit<UserPreferences, "workspaceId" | "us
   boardCardCollapseToHeight: DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT,
   boardCardCollapseThreshold: DEFAULT_BOARD_CARD_COLLAPSE_THRESHOLD,
   boardDefaultLens: DEFAULT_BOARD_LENS,
+  boardDefaultViewId: null,
   voiceTranscriptionModel: null,
   voicePolishLevel: "opinionated",
   voiceSteeringWords: [],
@@ -421,6 +429,7 @@ export interface UpdateUserPreferencesInput {
   boardCardCollapseToHeight?: number
   boardCardCollapseThreshold?: number
   boardDefaultLens?: BoardLens
+  boardDefaultViewId?: string | null
   voiceTranscriptionModel?: string | null
   voicePolishLevel?: VoicePolishLevel
   voiceSteeringWords?: string[]


### PR DESCRIPTION
## Problem

A batch of board UX rough edges surfaced in the post-feature-wave review (`docs/board-view-design.md`), plus a gap raised in dogfooding:

- **Board home only accepts a structural lens.** The `boardDefaultLens` preference (and the lens-menu pins) let you land on `all`/`active`/`needs-resolution`/`decisions`/`mine`, but a **saved custom view** — a lens + the six include/exclude filter axes — could not be your default landing. If your real "home" is "channels, active, excluding the noisy agent DM", you had to re-apply it every visit.
- The resolved-status **strikethrough** on topic titles reads as cancelled/deleted, and the 7-day auto-resolve sweep strikes titles with no user action.
- The board card's **sticky header** pins on mobile and eats 60–100px of phone viewport.
- A collapsed card's raw `max-height` clip **slices a message mid-line/mid-image**.
- No way to **set a lens as home from the board itself** — only from settings.

## Solution

Two commits. The first lands four small polish items; the second closes the saved-view-as-home gap with a new nullable preference and a landing redirect.

### Polish batch (commit 1)

- **Set home from the board** — a per-row pin toggle in `BoardLensMenu` (`board-filter-bar.tsx`) writes the home preference, the same write the appearance-settings radio does. Filled pin marks the current home; silent per INV-63 (the fill is the signal).
- **Drop the resolved strikethrough** — removed `line-through decoration-1` at `board-card.tsx` and `conversation-panel.tsx`, keeping the muted tone + `CircleCheck`. Status machinery (3-state, lens filtering, staleness sweep) untouched — per the design doc's ruling to keep the machinery, quiet the presentation.
- **Un-pin the sticky header on mobile** — `sticky` → `sm:sticky`, and the stuck-elevation hairline/shadow confined to `sm:`.
- **Fade the collapse clip** — a surface-agnostic mask (`linear-gradient(... transparent)`), the same approach `CollapsibleBody` uses, so it works on the actor-accent rows where a fixed-color gradient would band wrong. The "N messages" affordance stays.

### Saved view as board home (commit 2)

- **New `boardDefaultViewId` preference** (`string | null`). When set and it resolves, the bare `/board` bounces to that view's canonical filtered URL; a deleted/stale id degrades to `boardDefaultLens`. It's a nullable field on the existing generic key/value preference store — **no migration**.
- **`boardHomeRedirectHref`** (`board-saved-views.tsx`, pure + unit-tested) resolves the landing target. `BoardPage` bounces **only** the untouched `/board` entry (`lensParam === undefined && location.search === ""`), so an explicit filtered deep-link is never hijacked; when the view expands to the bare home URL the helper returns `null` to prevent a redirect loop.
- **Settings "Board home"** now lists structural lenses **and** saved views in one radio group. Picking a lens clears the saved-view home; picking a view keeps the lens as the fallback.
- **Lens-menu pins made view-aware** — a lens reads as home only when no saved view is the home (`homeViewActive`), pinning a lens clears `boardDefaultViewId`, and saved-view rows get their own home pin.
- **`usePreferences().updatePreferences(input)`** — a multi-key atomic writer over the existing mutation, used where two fields must move together (set lens + clear view).

### How it works

1. `boardDefaultViewId` rides the same partial-update path as every other preference: Zod-validated in `updatePreferencesSchema` (`z.string().max(64).nullable().optional()`), flattened in `service.ts` `flattenUpdates`, merged over `DEFAULT_USER_PREFERENCES` (default `null`). Setting it back to a default (`null`) drops the override rather than storing it.
2. `BoardPage` reads `boardViews` via `useBoardViews` (already mounted deeper in the lens menu, so no new fetch — bootstrap-seeded, no flash) and calls `boardHomeRedirectHref(workspaceId, defaultViewId, boardViews, homeLens)`. Non-null → `<Navigate replace>` to the view URL; the view URL carries a lens segment and/or `?in=/?is=/?label=` params, so it is never bare `/board` and the redirect is stable.
3. A deleted default view (`find` misses) → `null` → falls through to the plain home-lens rendering. No loop, no dead-end.

## Key design decisions

**1. Landing redirect, not a redefinition of `homeLens`.** The default view is purely "where clicking Board takes you", implemented as an auto-navigation to the view's normal filtered URL. `homeLens` (which lens is segment-less, the "Clear filters" baseline) stays `boardDefaultLens`. Rejected: making the saved view *the* home baseline — that would break "no Clear filters on the plain home" (a saved view is filtered, so you want Clear filters to escape it) and ripple `homeLens` semantics through the filter bar.

**2. Two preferences, priority resolution.** `boardDefaultViewId` set-and-resolving wins; else `boardDefaultLens`. Rejected: overloading `boardDefaultLens: string` to hold either a lens or a view id — it widens a strict `BoardLens` type across the backend Zod + every read site and muddies "which lens is segment-less".

**3. Fade via mask, not a colored gradient.** Board rows carry the per-actor accent tint, so a `to-card` gradient (the handover's suggestion) would show a wrong-colored band on accented rows. Masking the content transparent is surface-agnostic — the same reasoning `collapsible-body.tsx` documents for `COLLAPSED_FADE_MASK`.

**4. `updatePreferences` multi-key writer.** Setting a lens as home must also clear `boardDefaultViewId` in one request. The underlying mutation already accepts a multi-key `UpdateUserPreferencesInput`; only the exposed `updatePreference` was single-key. Added the general writer rather than firing two sequential single-key mutations (two round-trips, two optimistic churns).

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/components/board/board-home-redirect.test.ts` | 6 unit tests for `boardHomeRedirectHref` (expand, home-lens base, null/loading/deleted, loop-guard) |

## Modified files

| File | Change |
| ---- | ------ |
| `packages/types/src/preferences.ts` | `boardDefaultViewId: string \| null` on the interface, default, and update input |
| `apps/backend/src/features/user-preferences/handlers.ts` | Zod field `boardDefaultViewId: z.string().max(64).nullable().optional()` |
| `apps/backend/src/features/user-preferences/service.ts` | `boardDefaultViewId` in the flatten simple-keys list |
| `apps/backend/src/features/user-preferences/handlers.test.ts` | 3 Zod cases (id / null / over-long reject) |
| `apps/frontend/src/contexts/preferences-context.tsx` | `updatePreferences(input)` atomic multi-key writer |
| `apps/frontend/src/pages/board.tsx` | Landing redirect to the default saved view |
| `apps/frontend/src/components/board/board-saved-views.tsx` | `boardHomeRedirectHref` + `summarizeBoardView` exports; per-row home pin |
| `apps/frontend/src/components/board/board-filter-bar.tsx` | Per-lens home pin; view-aware home state; `updatePreferences` |
| `apps/frontend/src/components/settings/appearance-settings.tsx` | `BoardHomeSection` — lenses + saved views in one picker |
| `apps/frontend/src/components/board/board-card.tsx` | Drop strikethrough; `sm:sticky` header; collapse fade mask |
| `apps/frontend/src/components/conversations/conversation-panel.tsx` | Drop resolved strikethrough on the panel title |
| `apps/frontend/src/hooks/use-streams.test.tsx`, `use-unread-counts.test.tsx` | `boardDefaultViewId: null` in the full-preferences fixtures |

## Out of scope (deliberate)

- **Stream-level board mute** and the other open board follow-ups (sub-topic counts, mobile composer scroll-stop, title-quality investigation, visual design pass) — separate PRs.
- **No server-side existence check** on `boardDefaultViewId` — a stale id degrades to the lens client-side, matching how the saved-views list already tolerates deleted views; the write path stays a simple validated string.

## Test plan

- [x] `apps/frontend` — board / settings / contexts suites: 174 pass; board-home-redirect 6 pass; board.test, board-saved-views, use-streams, use-unread-counts green
- [x] `apps/backend` unit — `user-preferences/handlers.test.ts` 17 pass (incl. 3 new)
- [x] `tsc --noEmit` across `packages/types`, `apps/backend`, `apps/frontend` clean
- [x] `eslint` clean on all changed frontend files
- [x] Full monorepo pre-commit hook (all-app lint + typecheck + OpenAPI/migration checks) passed on both commits
- [ ] Not driven in a live browser — no running stack this session (DB unavailable); the redirect logic is unit-tested and board/settings rendering is covered by the integration suites

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3uqURmpvZU4RAsFwF9KZx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786337139&installation_id=129946197&pr_number=1280&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1280&signature=231752e7aeebc05117358deb37119bf5700fc57c98825d7383833619addd6769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->