### PR TITLE
test: fix flaky claim/release diffing test in use-attachments

### DIFF
--- a/apps/frontend/src/hooks/use-attachments.test.ts
+++ b/apps/frontend/src/hooks/use-attachments.test.ts
@@ -325,8 +325,7 @@ describe("useAttachments", () => {
       act(() => {
         result.current.handleFileSelect(createChangeEvent([createFile("doc.pdf", "application/pdf")]))
       })
-      await waitFor(() => expect(result.current.pendingAttachments).toHaveLength(2))
-      expect(result.current.pendingAttachments.map((a) => a.id)).toEqual(["attach_1", "attach_3"])
+      await waitFor(() => expect(result.current.pendingAttachments.map((a) => a.id)).toEqual(["attach_1", "attach_3"]))
       await waitFor(() => expect(result.current.uploadedIds).toEqual(["attach_1", "attach_3"]))
 
       // And removing B must not drop A either.


### PR DESCRIPTION
## Problem

CI on main is red: the `Tests` job failed on both of the latest commits (2b9dc1f3, 63e5ce7a — runs 29140035244 and 29139920244) with the same frontend failure:

```
FAIL src/hooks/use-attachments.test.ts > useAttachments > multiple files
     > keeps an already-settled attachment when another file is added later (claim/release diffing)
AssertionError: expected [ 'attach_1', …(1) ] to deeply equal [ 'attach_1', 'attach_3' ]
```

It's a race in the test, not a product regression. The `waitFor` at `use-attachments.test.ts:328` only waited for the chip *count* to reach 2, then asserted the ids synchronously on the next line. A chip renders immediately with a `temp_…` id and only flips to the server id (`attach_3`) when the mocked reservation promise resolves — usually within the same flush, but not always. Reproduced locally at roughly 1-in-3 (received `["attach_1", "temp_1783746199510_fgmjinx"]`).

## Solution

Fold the id assertion into the `waitFor` so the test waits for the state it actually asserts:

```ts
await waitFor(() => expect(result.current.pendingAttachments.map((a) => a.id)).toEqual(["attach_1", "attach_3"]))
```

The count-only `toHaveLength(2)` wait is dropped — the id assertion subsumes it. Audited the file's other `waitFor`s: they all anchor on the settled value itself (an id, a status, a spy call), so no other instance of the pattern exists.

Also checked the Browser E2E workflow on main for flakes: one failure on July 7 (7a37a96b) was infra — `docker pull` minio retries + Playwright install exiting 100 on both shards — green since; nothing to fix there.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/frontend/src/hooks/use-attachments.test.ts` | Wait for the reservation ids instead of the chip count before asserting them |

## Test plan

- [x] `vitest run src/hooks/use-attachments.test.ts` × 10 — 14 pass every run (before the fix: 2 failures in 6 runs)
- [x] Pre-commit hook: lint + typecheck across all workspaces clean

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786338417&installation_id=129946197&pr_number=1281&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1281&signature=992c17452c9f67c24303b8535ead1625ee977306b94978c9ce250bbb2bc8ad6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->