### PR TITLE
feat(evals): brief correction eval suite (roadmap 4.4)

### DIFF
--- a/apps/backend/evals/run.ts
+++ b/apps/backend/evals/run.ts
@@ -19,6 +19,7 @@ import { boundaryExtractionSuite } from "./suites/boundary-extraction/suite"
 import { multimodalVisionSuite } from "./suites/multimodal-vision/suite"
 import { memoClassifierSuite } from "./suites/memo-classifier/suite"
 import { memorizerSuite } from "./suites/memorizer/suite"
+import { briefCorrectionSuite } from "./suites/brief-correction/suite"
 import { isConfigFilePath } from "./framework/config-loader"
 
 // All available suites
@@ -29,6 +30,7 @@ const allSuites = [
   multimodalVisionSuite,
   memoClassifierSuite,
   memorizerSuite,
+  briefCorrectionSuite,
 ]
 
 function printHelp(): void {

--- a/apps/backend/evals/slash/parse-args.test.ts
+++ b/apps/backend/evals/slash/parse-args.test.ts
@@ -59,6 +59,10 @@ describe("parseEvalCommand", () => {
     expect(() => parseEvalCommand("/eval -s not-a-suite")).toThrow(/Unknown suite/)
   })
 
+  it("accepts the brief-correction suite", () => {
+    expect(parseEvalCommand("/eval -s brief-correction").args).toEqual(["-s", "brief-correction"])
+  })
+
   it("rejects an unknown flag rather than silently dropping it", () => {
     expect(() => parseEvalCommand("/eval --danger rm")).toThrow(/Unknown argument/)
   })

--- a/apps/backend/evals/slash/parse-args.ts
+++ b/apps/backend/evals/slash/parse-args.ts
@@ -18,6 +18,7 @@ export const EVAL_SUITES = [
   "multimodal-vision",
   "memo-classifier",
   "memorizer",
+  "brief-correction",
 ] as const
 
 /** Default suite when the command names none — the cheap, high-signal one. */

--- a/apps/backend/evals/suites/brief-correction/cases.ts
+++ b/apps/backend/evals/suites/brief-correction/cases.ts
@@ -1,0 +1,114 @@
+/**
+ * Brief Correction Test Cases
+ *
+ * The three arms of the correction loop (roadmap 4.4):
+ *  (a) states-decision   — a durable decision is stated → the brief gains it
+ *  (b) contradicts-brief — a standing brief fact is reversed → the brief is
+ *                          replaced, not appended
+ *  (c) chitchat          — transient banter → the brief is left untouched
+ *
+ * The chitchat arm is the trust-critical one: over-eager brief writes are the
+ * failure mode 4.4 exists to catch, so it carries the tighter gate.
+ */
+
+import type { EvalCase } from "../../framework/types"
+import type { BriefCorrectionInput, BriefCorrectionExpected } from "./types"
+
+export const briefCorrectionCases: EvalCase<BriefCorrectionInput, BriefCorrectionExpected>[] = [
+  // --- (a) states-decision: a durable decision should land in the brief -------
+  {
+    id: "states-decision-cadence-001",
+    name: "Durable cadence decision is recorded",
+    input: {
+      category: "states-decision",
+      conversationHistory: [
+        { role: "user", content: "Been going back and forth on how often to send the newsletter." },
+        { role: "assistant", content: "What are you weighing — reach vs. the effort to fill each issue?" },
+      ],
+      message: "Alright, decision made: the newsletter ships weekly, every Tuesday morning. Locking that in.",
+    },
+    expectedOutput: {
+      shouldWrite: true,
+      briefMustState: "The newsletter ships weekly, every Tuesday.",
+    },
+  },
+  {
+    id: "states-decision-convention-001",
+    name: "Durable tooling convention is recorded",
+    input: {
+      category: "states-decision",
+      conversationHistory: [
+        { role: "user", content: "The repos are a mess — three different package managers across them." },
+      ],
+      message: "Going forward we standardize on pnpm for every repo. That's the rule now.",
+    },
+    expectedOutput: {
+      shouldWrite: true,
+      briefMustState: "pnpm is the standard package manager for all repos.",
+    },
+  },
+
+  // --- (b) contradicts-brief: reversal replaces the fact, not appends ---------
+  {
+    id: "contradicts-brief-cadence-001",
+    name: "Reversed cadence replaces the old value",
+    input: {
+      category: "contradicts-brief",
+      existingBrief: "# Newsletter\n\n- The newsletter ships weekly, every Tuesday morning.",
+      message: "Change of plan on the newsletter — we're moving it to every other Thursday instead of weekly Tuesdays.",
+    },
+    expectedOutput: {
+      shouldWrite: true,
+      briefMustState: "The newsletter ships every other Thursday.",
+      briefMustNotState: "The newsletter ships weekly on Tuesday.",
+    },
+  },
+  {
+    id: "contradicts-brief-datastore-001",
+    name: "Reversed datastore choice replaces the old value",
+    input: {
+      category: "contradicts-brief",
+      existingBrief: "# Stack\n\n- Primary database is MySQL.\n- Deploys go out on Fridays.",
+      message: "Heads up: we finished the migration off MySQL — Postgres is our primary database now.",
+    },
+    expectedOutput: {
+      shouldWrite: true,
+      briefMustState: "Postgres is the primary database.",
+      briefMustNotState: "MySQL is the primary database.",
+    },
+  },
+
+  // --- (c) chitchat: transient talk must not touch the brief ------------------
+  {
+    id: "chitchat-banter-001",
+    name: "Banter yields no brief write",
+    input: {
+      category: "chitchat",
+      message: "ugh this coffee is terrible today, third bad cup in a row lol",
+    },
+    expectedOutput: { shouldWrite: false },
+  },
+  {
+    id: "chitchat-smalltalk-002",
+    name: "Small talk yields no brief write",
+    input: {
+      category: "chitchat",
+      conversationHistory: [
+        { role: "user", content: "morning!" },
+        { role: "assistant", content: "Morning — what's on today?" },
+      ],
+      message: "did you catch the game last night? absolutely wild finish",
+    },
+    expectedOutput: { shouldWrite: false },
+  },
+  {
+    id: "chitchat-transient-with-brief-003",
+    name: "Transient status leaves an existing brief untouched",
+    input: {
+      category: "chitchat",
+      existingBrief: "# Working agreements\n\n- Standup is 9:30am daily.\n- Fridays are no-meeting days.",
+      message: "brb grabbing lunch, back in 30",
+    },
+    expectedOutput: { shouldWrite: false },
+  },
+]

--- a/apps/backend/evals/suites/brief-correction/config.ts
+++ b/apps/backend/evals/suites/brief-correction/config.ts
@@ -1,0 +1,24 @@
+/**
+ * Brief Correction Eval Config
+ *
+ * Model/temperature come from the production companion config (INV-44) so the
+ * eval drives Ariadne exactly as production does. Thresholds live here as the
+ * single source for the suite's gates.
+ */
+
+import { COMPANION_MODEL_ID, COMPANION_TEMPERATURE } from "../../../src/features/agents"
+
+export { COMPANION_MODEL_ID, COMPANION_TEMPERATURE }
+
+/** Judge model for the semantic brief-content checks — same as the companion/memorizer judges. */
+export const BRIEF_JUDGE_MODEL = "openrouter:openai/gpt-5.4-nano"
+
+/**
+ * The suite's hard floor (roadmap 4.4): the fraction of chitchat conversations
+ * that must leave the brief untouched. Over-eager brief writes are the failure
+ * mode that erodes trust, so the chitchat arm is gated tighter than accuracy.
+ */
+export const CHITCHAT_NO_WRITE_GATE = 0.9
+
+/** Run-level accuracy floor across every case (matches the other suites). */
+export const BRIEF_ACCURACY_GATE = 0.8

--- a/apps/backend/evals/suites/brief-correction/evaluators.test.ts
+++ b/apps/backend/evals/suites/brief-correction/evaluators.test.ts
@@ -3,6 +3,7 @@ import type { EvalContext, CaseResult, EvaluatorResult } from "../../framework/t
 import {
   writeDecisionEvaluator,
   singleRevisionEvaluator,
+  briefContentEvaluator,
   accuracyEvaluator,
   chitchatNoWriteRateEvaluator,
 } from "./evaluators"
@@ -13,6 +14,27 @@ import type { BriefCorrectionInput, BriefCorrectionOutput, BriefCorrectionExpect
 // evaluator needs a real ctx.ai and is exercised by the `/eval` run.
 
 const ctx = {} as EvalContext
+
+type JudgeVerdict = { assertsRequired: boolean | null; stillAssertsForbidden: boolean | null }
+
+/**
+ * An EvalContext whose `ai.generateObject` returns a fixed judge verdict (or
+ * throws), so briefContentEvaluator's requiredOk/forbiddenOk logic is testable
+ * without a live model. Throwing when a verdict isn't expected proves the early
+ * returns don't reach the model.
+ */
+function judgeCtx(verdict: JudgeVerdict | Error): EvalContext {
+  return {
+    ai: {
+      generateObject: async () => {
+        if (verdict instanceof Error) throw verdict
+        return { value: { ...verdict, reasoning: "stub" } }
+      },
+    },
+  } as unknown as EvalContext
+}
+
+const NEVER_CALLED = judgeCtx(new Error("judge should not be called"))
 
 function output(over: Partial<BriefCorrectionOutput>): BriefCorrectionOutput {
   return {
@@ -90,6 +112,83 @@ describe("singleRevisionEvaluator", () => {
       { shouldWrite: true },
       ctx
     ) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+})
+
+describe("briefContentEvaluator", () => {
+  const withBrief = (over: Partial<BriefCorrectionOutput> = {}) =>
+    output({ wrote: true, briefContent: "# Brief\n\n- a fact", revisionCount: 1, ...over })
+
+  it("passes without calling the judge when there are no content requirements", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true },
+      NEVER_CALLED
+    )) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("passes when the required fact is asserted", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "a fact" },
+      judgeCtx({ assertsRequired: true, stillAssertsForbidden: null })
+    )) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("fails when the required fact is not asserted", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "a fact" },
+      judgeCtx({ assertsRequired: false, stillAssertsForbidden: null })
+    )) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("passes a reversal when the old fact is dropped", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "Postgres", briefMustNotState: "MySQL" },
+      judgeCtx({ assertsRequired: true, stillAssertsForbidden: false })
+    )) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("fails a reversal when the old fact is still asserted (appended, not replaced)", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "Postgres", briefMustNotState: "MySQL" },
+      judgeCtx({ assertsRequired: true, stillAssertsForbidden: true })
+    )) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("fails closed when the forbidden-fact verdict is indeterminate (null)", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "Postgres", briefMustNotState: "MySQL" },
+      judgeCtx({ assertsRequired: true, stillAssertsForbidden: null })
+    )) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("fails on a judge generation error", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      withBrief(),
+      { shouldWrite: true, briefMustState: "a fact" },
+      judgeCtx(new Error("boom"))
+    )) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("fails when a fact was required but the brief is empty", async () => {
+    const r = (await briefContentEvaluator.evaluate(
+      output({ wrote: false, briefContent: null }),
+      { shouldWrite: true, briefMustState: "a fact" },
+      NEVER_CALLED
+    )) as EvaluatorResult
     expect(r.passed).toBe(false)
   })
 })

--- a/apps/backend/evals/suites/brief-correction/evaluators.test.ts
+++ b/apps/backend/evals/suites/brief-correction/evaluators.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "bun:test"
+import type { EvalContext, CaseResult, EvaluatorResult } from "../../framework/types"
+import {
+  writeDecisionEvaluator,
+  singleRevisionEvaluator,
+  accuracyEvaluator,
+  chitchatNoWriteRateEvaluator,
+} from "./evaluators"
+import type { BriefCorrectionInput, BriefCorrectionOutput, BriefCorrectionExpected } from "./types"
+
+// The deterministic and run-level evaluators are pure functions of the readback,
+// so they are gradeable without the live agent. The LLM-judged briefContent
+// evaluator needs a real ctx.ai and is exercised by the `/eval` run.
+
+const ctx = {} as EvalContext
+
+function output(over: Partial<BriefCorrectionOutput>): BriefCorrectionOutput {
+  return {
+    input: { category: "chitchat", message: "hi" } as BriefCorrectionInput,
+    wrote: false,
+    briefContent: null,
+    briefVersion: 0,
+    revisionCount: 0,
+    revisionsBefore: 0,
+    ...over,
+  }
+}
+
+function caseResult(
+  out: BriefCorrectionOutput,
+  expected: BriefCorrectionExpected,
+  evaluations: EvaluatorResult[] = []
+): CaseResult<BriefCorrectionOutput, BriefCorrectionExpected> {
+  return {
+    caseId: "c",
+    caseName: "c",
+    input: out.input,
+    output: out,
+    expectedOutput: expected,
+    evaluations,
+    durationMs: 0,
+    error: out.error ? new Error(out.error) : undefined,
+  }
+}
+
+describe("writeDecisionEvaluator", () => {
+  it("passes when a write was expected and happened", () => {
+    const r = writeDecisionEvaluator.evaluate(output({ wrote: true }), { shouldWrite: true }, ctx) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("fails when a write was expected but did not happen", () => {
+    const r = writeDecisionEvaluator.evaluate(output({ wrote: false }), { shouldWrite: true }, ctx) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("fails when the brief was written on a chitchat turn", () => {
+    const r = writeDecisionEvaluator.evaluate(output({ wrote: true }), { shouldWrite: false }, ctx) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+
+  it("fails on task error", () => {
+    const r = writeDecisionEvaluator.evaluate(
+      output({ wrote: false, error: "boom" }),
+      { shouldWrite: false },
+      ctx
+    ) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+})
+
+describe("singleRevisionEvaluator", () => {
+  it("ignores non-write cases", () => {
+    const r = singleRevisionEvaluator.evaluate(output({ wrote: false }), { shouldWrite: false }, ctx) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("passes when exactly one revision was added", () => {
+    const r = singleRevisionEvaluator.evaluate(
+      output({ wrote: true, revisionsBefore: 1, revisionCount: 2 }),
+      { shouldWrite: true },
+      ctx
+    ) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+
+  it("fails when the brief was rewritten more than once", () => {
+    const r = singleRevisionEvaluator.evaluate(
+      output({ wrote: true, revisionsBefore: 0, revisionCount: 2 }),
+      { shouldWrite: true },
+      ctx
+    ) as EvaluatorResult
+    expect(r.passed).toBe(false)
+  })
+})
+
+describe("chitchatNoWriteRateEvaluator (roadmap 4.4 gate)", () => {
+  it("passes when every chitchat turn left the brief untouched", () => {
+    const cases = [
+      caseResult(output({ wrote: false }), { shouldWrite: false }),
+      caseResult(output({ wrote: false }), { shouldWrite: false }),
+      caseResult(output({ wrote: true }), { shouldWrite: true }), // a write-expected case is ignored by the gate
+    ]
+    const r = chitchatNoWriteRateEvaluator.evaluate(cases) as EvaluatorResult
+    expect(r.score).toBe(1)
+    expect(r.passed).toBe(true)
+  })
+
+  it("fails below the 0.9 floor when a chitchat turn wrote the brief", () => {
+    const cases = [
+      caseResult(output({ wrote: false }), { shouldWrite: false }),
+      caseResult(output({ wrote: false }), { shouldWrite: false }),
+      caseResult(output({ wrote: true }), { shouldWrite: false }),
+    ]
+    const r = chitchatNoWriteRateEvaluator.evaluate(cases) as EvaluatorResult
+    expect(r.score).toBeCloseTo(2 / 3)
+    expect(r.passed).toBe(false)
+  })
+
+  it("passes vacuously when there are no chitchat cases", () => {
+    const cases = [caseResult(output({ wrote: true }), { shouldWrite: true })]
+    const r = chitchatNoWriteRateEvaluator.evaluate(cases) as EvaluatorResult
+    expect(r.passed).toBe(true)
+  })
+})
+
+describe("accuracyEvaluator", () => {
+  it("passes at or above the 0.8 floor", () => {
+    const pass: EvaluatorResult = { name: "x", score: 1, passed: true }
+    const fail: EvaluatorResult = { name: "x", score: 0, passed: false }
+    const cases = [
+      caseResult(output({ wrote: true }), { shouldWrite: true }, [pass]),
+      caseResult(output({ wrote: true }), { shouldWrite: true }, [pass]),
+      caseResult(output({ wrote: true }), { shouldWrite: true }, [pass]),
+      caseResult(output({ wrote: true }), { shouldWrite: true }, [pass]),
+      caseResult(output({ wrote: false }), { shouldWrite: true }, [fail]),
+    ]
+    const r = accuracyEvaluator.evaluate(cases) as EvaluatorResult
+    expect(r.score).toBeCloseTo(0.8)
+    expect(r.passed).toBe(true)
+  })
+})

--- a/apps/backend/evals/suites/brief-correction/evaluators.ts
+++ b/apps/backend/evals/suites/brief-correction/evaluators.ts
@@ -1,0 +1,172 @@
+/**
+ * Brief Correction Evaluators
+ *
+ * Deterministic checks on the write decision and the revision delta, plus an
+ * LLM-judged semantic check that a reversal actually replaced the old fact
+ * rather than sitting alongside it.
+ */
+
+import { z } from "zod"
+import type { Evaluator, EvaluatorResult, RunEvaluator, CaseResult } from "../../framework/types"
+import type { BriefCorrectionOutput, BriefCorrectionExpected } from "./types"
+import { BRIEF_JUDGE_MODEL, CHITCHAT_NO_WRITE_GATE, BRIEF_ACCURACY_GATE } from "./config"
+
+type BriefCase = CaseResult<BriefCorrectionOutput, BriefCorrectionExpected>
+
+/** The core arm: did the turn write the brief exactly when it should have? */
+export const writeDecisionEvaluator: Evaluator<BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "write-decision",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (output.error) {
+      return { name: "write-decision", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const passed = output.wrote === expected.shouldWrite
+    const failure = expected.shouldWrite
+      ? "Expected a brief write; none happened"
+      : "Brief was written on a turn that should have left it untouched"
+    return {
+      name: "write-decision",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed ? undefined : failure,
+    }
+  },
+}
+
+/**
+ * A brief update is a single full replacement — one new revision, one version
+ * bump. More than one added revision means the turn wrote the brief repeatedly
+ * (a loop, or append-then-fix), which the tool's full-replacement contract
+ * (roadmap 4.2) is meant to avoid. Only meaningful on write-expected cases.
+ */
+export const singleRevisionEvaluator: Evaluator<BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "single-revision",
+  evaluate: (output, expected): EvaluatorResult => {
+    if (!expected.shouldWrite) {
+      return { name: "single-revision", score: 1, passed: true, details: "Not a write-expected case" }
+    }
+    if (output.error) {
+      return { name: "single-revision", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    const added = output.revisionCount - output.revisionsBefore
+    const passed = added === 1
+    return {
+      name: "single-revision",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed ? undefined : `Turn added ${added} brief revisions (expected exactly 1)`,
+    }
+  },
+}
+
+const briefJudgeSchema = z.object({
+  assertsRequired: z
+    .boolean()
+    .nullable()
+    .describe(
+      "true if the brief states the required fact as currently true; false if it does not; null when none was required"
+    ),
+  stillAssertsForbidden: z
+    .boolean()
+    .nullable()
+    .describe(
+      "true if the brief still states the contradicted/old fact as currently true; false if it does not; null when none was forbidden"
+    ),
+  reasoning: z.string().describe("One brief sentence"),
+})
+
+/**
+ * Semantic check (LLM-judged) that the resulting brief folded the decision in
+ * and, on a reversal, dropped the old value. Keyword matching can't tell "we
+ * chose Postgres" from a brief that lists both MySQL and Postgres, which is
+ * exactly the append-instead-of-replace failure — so a judge reads the final
+ * brief and answers whether each fact is asserted as current.
+ */
+export const briefContentEvaluator: Evaluator<BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "brief-content",
+  evaluate: async (output, expected, ctx): Promise<EvaluatorResult> => {
+    if (!expected.briefMustState && !expected.briefMustNotState) {
+      return { name: "brief-content", score: 1, passed: true, details: "No content requirements" }
+    }
+    if (output.error) {
+      return { name: "brief-content", score: 0, passed: false, details: `Error: ${output.error}` }
+    }
+    if (!output.briefContent) {
+      // Nothing was written: a required fact is missing; a forbidden one is trivially absent.
+      const passed = !expected.briefMustState
+      return {
+        name: "brief-content",
+        score: passed ? 1 : 0,
+        passed,
+        details: passed ? undefined : "Brief is empty but a fact was required",
+      }
+    }
+
+    const { value } = await ctx.ai.generateObject({
+      model: BRIEF_JUDGE_MODEL,
+      schema: briefJudgeSchema,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You read a stream's brief (a durable working document) and, for each candidate fact given, answer purely factually whether the brief states that fact as currently true. A fact is asserted only when the brief presents it as what currently holds — a struck-through or explicitly-past note ('was MySQL, now Postgres') does not assert the past value as current. Only report what the brief says, not whether it is good.",
+        },
+        {
+          role: "user",
+          content: `## Brief\n${output.briefContent}\n\n## Required fact\n${expected.briefMustState ?? "(none — return null for assertsRequired)"}\n\n## Forbidden (old/contradicted) fact\n${expected.briefMustNotState ?? "(none — return null for stillAssertsForbidden)"}\n\nDoes the brief assert the required fact as current? Does it still assert the forbidden fact as current?`,
+        },
+      ],
+      temperature: 0,
+      telemetry: { functionId: "eval-brief-content" },
+    })
+
+    const requiredOk = !expected.briefMustState || value.assertsRequired === true
+    const forbiddenOk = !expected.briefMustNotState || value.stillAssertsForbidden !== true
+    const passed = requiredOk && forbiddenOk
+    return {
+      name: "brief-content",
+      score: passed ? 1 : 0,
+      passed,
+      details: passed
+        ? undefined
+        : `${!requiredOk ? "required fact not asserted" : ""}${!requiredOk && !forbiddenOk ? "; " : ""}${!forbiddenOk ? "old fact still present (appended, not replaced)" : ""} — ${value.reasoning}`,
+    }
+  },
+}
+
+export const accuracyEvaluator: RunEvaluator<BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "accuracy",
+  evaluate: (cases: BriefCase[]): EvaluatorResult => {
+    const passed = cases.filter((c) => !c.error && c.evaluations.every((e) => e.passed))
+    const score = cases.length > 0 ? passed.length / cases.length : 0
+    return {
+      name: "accuracy",
+      score,
+      passed: score >= BRIEF_ACCURACY_GATE,
+      details: `${passed.length}/${cases.length} cases passed`,
+    }
+  },
+}
+
+/**
+ * The roadmap 4.4 gate: the fraction of chitchat turns (shouldWrite === false)
+ * that correctly left the brief untouched. Tighter than accuracy because an
+ * over-eager write is the trust-eroding failure this suite exists to catch.
+ */
+export const chitchatNoWriteRateEvaluator: RunEvaluator<BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "chitchat-no-write-rate",
+  evaluate: (cases: BriefCase[]): EvaluatorResult => {
+    const chitchat = cases.filter((c) => c.expectedOutput.shouldWrite === false && c.output)
+    if (chitchat.length === 0) {
+      return { name: "chitchat-no-write-rate", score: 1, passed: true, details: "No chitchat cases in run" }
+    }
+    const clean = chitchat.filter((c) => !c.output.error && !c.output.wrote)
+    const rate = clean.length / chitchat.length
+    return {
+      name: "chitchat-no-write-rate",
+      score: rate,
+      passed: rate >= CHITCHAT_NO_WRITE_GATE,
+      details: `${clean.length}/${chitchat.length} chitchat conversations left the brief untouched`,
+    }
+  },
+}

--- a/apps/backend/evals/suites/brief-correction/evaluators.ts
+++ b/apps/backend/evals/suites/brief-correction/evaluators.ts
@@ -102,26 +102,39 @@ export const briefContentEvaluator: Evaluator<BriefCorrectionOutput, BriefCorrec
       }
     }
 
-    const { value } = await ctx.ai.generateObject({
-      model: BRIEF_JUDGE_MODEL,
-      schema: briefJudgeSchema,
-      messages: [
-        {
-          role: "system",
-          content:
-            "You read a stream's brief (a durable working document) and, for each candidate fact given, answer purely factually whether the brief states that fact as currently true. A fact is asserted only when the brief presents it as what currently holds — a struck-through or explicitly-past note ('was MySQL, now Postgres') does not assert the past value as current. Only report what the brief says, not whether it is good.",
-        },
-        {
-          role: "user",
-          content: `## Brief\n${output.briefContent}\n\n## Required fact\n${expected.briefMustState ?? "(none — return null for assertsRequired)"}\n\n## Forbidden (old/contradicted) fact\n${expected.briefMustNotState ?? "(none — return null for stillAssertsForbidden)"}\n\nDoes the brief assert the required fact as current? Does it still assert the forbidden fact as current?`,
-        },
-      ],
-      temperature: 0,
-      telemetry: { functionId: "eval-brief-content" },
-    })
+    let value: z.infer<typeof briefJudgeSchema>
+    try {
+      ;({ value } = await ctx.ai.generateObject({
+        model: BRIEF_JUDGE_MODEL,
+        schema: briefJudgeSchema,
+        messages: [
+          {
+            role: "system",
+            content:
+              "You read a stream's brief (a durable working document) and, for each candidate fact given, answer purely factually whether the brief states that fact as currently true. A fact is asserted only when the brief presents it as what currently holds — a struck-through or explicitly-past note ('was MySQL, now Postgres') does not assert the past value as current. Only report what the brief says, not whether it is good.",
+          },
+          {
+            role: "user",
+            content: `## Brief\n${output.briefContent}\n\n## Required fact\n${expected.briefMustState ?? "(none — return null for assertsRequired)"}\n\n## Forbidden (old/contradicted) fact\n${expected.briefMustNotState ?? "(none — return null for stillAssertsForbidden)"}\n\nDoes the brief assert the required fact as current? Does it still assert the forbidden fact as current?`,
+          },
+        ],
+        temperature: 0,
+        telemetry: { functionId: "eval-brief-content" },
+      }))
+    } catch (error) {
+      // A judge failure fails this case's evaluator, not the whole run.
+      return {
+        name: "brief-content",
+        score: 0,
+        passed: false,
+        details: `Judge error: ${error instanceof Error ? error.message : String(error)}`,
+      }
+    }
 
     const requiredOk = !expected.briefMustState || value.assertsRequired === true
-    const forbiddenOk = !expected.briefMustNotState || value.stillAssertsForbidden !== true
+    // Fail closed: an indeterminate (null) judgment on the forbidden fact must
+    // not pass the append-vs-replace gate — only an explicit `false` clears it.
+    const forbiddenOk = !expected.briefMustNotState || value.stillAssertsForbidden === false
     const passed = requiredOk && forbiddenOk
     return {
       name: "brief-content",

--- a/apps/backend/evals/suites/brief-correction/index.ts
+++ b/apps/backend/evals/suites/brief-correction/index.ts
@@ -1,0 +1,2 @@
+export { briefCorrectionSuite } from "./suite"
+export * from "./types"

--- a/apps/backend/evals/suites/brief-correction/suite.ts
+++ b/apps/backend/evals/suites/brief-correction/suite.ts
@@ -1,0 +1,350 @@
+/**
+ * Brief Correction Evaluation Suite
+ *
+ * Measures whether Ariadne maintains a stream's durable brief correctly across
+ * the three arms of the correction loop (roadmap 4.4): she records a stated
+ * decision, replaces (not appends) a fact the user reverses, and leaves the
+ * brief untouched on chitchat. Runs the PRODUCTION PersonaAgent.run() with the
+ * `update_stream_brief` tool wired to the production StreamBriefService (INV-45)
+ * — the same path a live companion turn takes — then reads the brief and its
+ * revision trail back from the database to grade the outcome.
+ *
+ * ## Usage
+ *
+ *   bun run eval -- -s brief-correction
+ *   bun run eval -- -s brief-correction -c chitchat-banter-001
+ *
+ * ## Gates
+ *
+ * - chitchat-no-write-rate (run-level): ≥90% of chitchat turns leave the brief
+ *   untouched — over-eager writes are the failure mode 4.4 targets.
+ * - accuracy (run-level): ≥80% of all cases pass every evaluator.
+ */
+
+import { ulid } from "ulid"
+import type { EvalSuite, EvalContext } from "../../framework/types"
+import { briefCorrectionCases } from "./cases"
+import type { BriefCorrectionInput, BriefCorrectionOutput, BriefCorrectionExpected } from "./types"
+import {
+  writeDecisionEvaluator,
+  singleRevisionEvaluator,
+  briefContentEvaluator,
+  accuracyEvaluator,
+  chitchatNoWriteRateEvaluator,
+} from "./evaluators"
+import { COMPANION_MODEL_ID, COMPANION_TEMPERATURE } from "./config"
+import {
+  ARIADNE_AGENT_ID,
+  COMPANION_SUMMARY_MODEL_ID,
+  COMPANION_SUMMARY_TEMPERATURE,
+  PersonaAgent,
+  type PersonaAgentInput,
+  type PersonaAgentDeps,
+  WorkspaceAgent,
+  GeneralResearcher,
+  PersonaRepository,
+  TraceEmitter,
+  SessionAbortRegistry,
+  ConversationSummaryService,
+} from "../../../src/features/agents"
+import { AttachmentService, createMalwareScanner } from "../../../src/features/attachments"
+import { SearchService } from "../../../src/features/search"
+import { UserPreferencesService } from "../../../src/features/user-preferences"
+import { EmbeddingService, MemoExplorerService, MemoReranker } from "../../../src/features/memos"
+import {
+  StreamRepository,
+  StreamMemberRepository,
+  StreamBriefService,
+  StreamBriefRepository,
+} from "../../../src/features/streams"
+import { EventService } from "../../../src/features/messaging"
+import { createModelRegistry } from "@threa/agent-runtime"
+import type { StorageProvider } from "../../../src/lib/storage/s3-client"
+import type { Server } from "socket.io"
+import { parseMarkdown } from "@threa/prosemirror"
+import { AuthorTypes, StreamTypes } from "@threa/types"
+import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
+
+function getModelConfig(ctx: EvalContext): { model: string; temperature: number } {
+  const override = ctx.componentOverrides?.["companion"]
+  return {
+    model: override?.model ?? ctx.permutation.model,
+    temperature: override?.temperature ?? ctx.permutation.temperature ?? COMPANION_TEMPERATURE,
+  }
+}
+
+async function countRevisions(ctx: EvalContext, streamId: string): Promise<number> {
+  const { rows } = await ctx.pool.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM stream_brief_revisions WHERE stream_id = $1`,
+    [streamId]
+  )
+  return Number(rows[0]?.count ?? "0")
+}
+
+/**
+ * Seed a private scratchpad with companion mode on, the eval Ariadne persona,
+ * optional prior turns and an optional standing brief (as a member edit), then
+ * post the trigger message. Mirrors the companion suite's setup, trimmed to the
+ * scratchpad-companion path the brief loop lives on.
+ */
+async function setupTestData(
+  input: BriefCorrectionInput,
+  ctx: EvalContext
+): Promise<{ personaId: string; streamId: string; messageId: string; revisionsBefore: number }> {
+  const pool = ctx.pool
+  const modelConfig = getModelConfig(ctx)
+
+  const templatePersona = await PersonaRepository.findById(pool, ARIADNE_AGENT_ID, ctx.workspaceId)
+  if (!templatePersona?.systemPrompt) {
+    throw new Error(`Could not resolve built-in companion persona ${ARIADNE_AGENT_ID} (see built-in-agents.ts)`)
+  }
+
+  const testPersonaId = generatePersonaId()
+  await pool.query(
+    `
+    INSERT INTO personas (id, workspace_id, slug, name, description, avatar_emoji, system_prompt, model, enabled_tools, managed_by, status)
+    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, 'system', 'active')
+    ON CONFLICT (slug, workspace_id) WHERE workspace_id IS NULL DO UPDATE SET
+      model = EXCLUDED.model,
+      system_prompt = EXCLUDED.system_prompt
+  `,
+    [
+      testPersonaId,
+      `eval-ariadne-${ulid().toLowerCase().slice(0, 8)}`,
+      "Ariadne (Eval)",
+      templatePersona.description,
+      templatePersona.avatarEmoji,
+      templatePersona.systemPrompt,
+      modelConfig.model,
+      templatePersona.enabledTools ?? ["send_message"],
+    ]
+  )
+
+  const testStreamId = generateStreamId()
+  await StreamRepository.insert(pool, {
+    id: testStreamId,
+    workspaceId: ctx.workspaceId,
+    type: StreamTypes.SCRATCHPAD,
+    displayName: "Eval scratchpad",
+    visibility: "private",
+    companionMode: "on",
+    companionPersonaId: testPersonaId,
+    createdBy: ctx.userId,
+  })
+  await StreamMemberRepository.insert(pool, testStreamId, ctx.userId)
+
+  const userPreferencesService = new UserPreferencesService(pool)
+  await userPreferencesService.updatePreferences(ctx.workspaceId, ctx.userId, { timezone: "UTC" })
+
+  const eventService = new EventService(pool)
+
+  for (const msg of input.conversationHistory ?? []) {
+    await eventService.createMessage({
+      workspaceId: ctx.workspaceId,
+      streamId: testStreamId,
+      authorId: msg.role === "user" ? ctx.userId : testPersonaId,
+      authorType: msg.role === "user" ? AuthorTypes.USER : AuthorTypes.PERSONA,
+      contentJson: parseMarkdown(msg.content),
+      contentMarkdown: msg.content,
+    })
+  }
+
+  // Seed a standing brief as a prior member edit (the contradicts-brief arm).
+  if (input.existingBrief) {
+    const briefService = new StreamBriefService({ pool })
+    const result = await briefService.update({
+      workspaceId: ctx.workspaceId,
+      streamId: testStreamId,
+      content: input.existingBrief,
+      expectedVersion: 0,
+      updatedByKind: "user",
+      updatedById: ctx.userId,
+    })
+    if (result.outcome !== "updated") {
+      throw new Error("Failed to seed the initial brief for a contradicts-brief case")
+    }
+  }
+
+  const revisionsBefore = await countRevisions(ctx, testStreamId)
+
+  const triggerMessage = await eventService.createMessage({
+    workspaceId: ctx.workspaceId,
+    streamId: testStreamId,
+    authorId: ctx.userId,
+    authorType: AuthorTypes.USER,
+    contentJson: parseMarkdown(input.message),
+    contentMarkdown: input.message,
+  })
+
+  return { personaId: testPersonaId, streamId: testStreamId, messageId: triggerMessage.id, revisionsBefore }
+}
+
+async function runBriefCorrectionTask(input: BriefCorrectionInput, ctx: EvalContext): Promise<BriefCorrectionOutput> {
+  try {
+    const { personaId, streamId, messageId, revisionsBefore } = await setupTestData(input, ctx)
+
+    const embeddingService = new EmbeddingService({ ai: ctx.ai })
+    const userPreferencesService = new UserPreferencesService(ctx.pool)
+    const workspaceAgent = new WorkspaceAgent({
+      pool: ctx.pool,
+      ai: ctx.ai,
+      configResolver: ctx.configResolver,
+      embeddingService,
+    })
+    const generalResearcher = new GeneralResearcher({ ai: ctx.ai, configResolver: ctx.configResolver })
+    const searchService = new SearchService({ pool: ctx.pool, embeddingService })
+    const memoExplorerService = new MemoExplorerService({
+      pool: ctx.pool,
+      embeddingService,
+      reranker: new MemoReranker({ ai: ctx.ai }),
+    })
+    const conversationSummaryService = new ConversationSummaryService({
+      ai: ctx.ai,
+      modelId: COMPANION_SUMMARY_MODEL_ID,
+      temperature: COMPANION_SUMMARY_TEMPERATURE,
+    })
+
+    const stubIo = { to: () => ({ to: () => ({ emit: () => {} }), emit: () => {} }) } as unknown as Server
+    const traceEmitter = new TraceEmitter({ io: stubIo, pool: ctx.pool })
+
+    const stubStorage: StorageProvider = {
+      getObjectSize: async () => 0,
+      getObjectStat: async () => ({ sizeBytes: 0, etag: "stub-etag" }),
+      getSignedDownloadUrl: async () => "",
+      getObject: async () => Buffer.alloc(0),
+      getObjectRange: async () => Buffer.alloc(0),
+      getObjectStream: async () => {
+        throw new Error("Not implemented in stub")
+      },
+      getObjectContent: async () => {
+        throw new Error("Not implemented in stub")
+      },
+      putObject: async () => {},
+      delete: async () => {},
+    }
+    const attachmentService = new AttachmentService(
+      ctx.pool,
+      stubStorage,
+      createMalwareScanner(stubStorage, { malwareScanEnabled: false })
+    )
+
+    const evalEventService = new EventService(ctx.pool)
+    const createMessage: PersonaAgentDeps["createMessage"] = async (params) => {
+      const message = await evalEventService.createMessage({
+        workspaceId: params.workspaceId,
+        streamId: params.streamId,
+        authorId: params.authorId,
+        authorType: params.authorType,
+        contentJson: parseMarkdown(params.content),
+        contentMarkdown: params.content,
+        sources: params.sources,
+      })
+      return { id: message.id }
+    }
+
+    // The brief tool under test: wired to the production StreamBriefService exactly
+    // as server.ts binds it, so the eval exercises the real write path (INV-45).
+    const briefService = new StreamBriefService({ pool: ctx.pool })
+    const updateBrief: PersonaAgentDeps["updateBrief"] = async ({ content, reason, expectedVersion }) => {
+      const result = await briefService.update({
+        workspaceId: ctx.workspaceId,
+        streamId,
+        content,
+        expectedVersion,
+        updatedByKind: AuthorTypes.PERSONA,
+        updatedById: personaId,
+        reason,
+      })
+      return result.outcome === "updated"
+        ? { ok: true, version: result.brief.version }
+        : {
+            ok: false,
+            reason: "version_conflict",
+            currentContent: result.current?.content ?? null,
+            currentVersion: result.current?.version ?? 0,
+          }
+    }
+
+    const editMessage: PersonaAgentDeps["editMessage"] = async () => null
+    const deleteMessage: PersonaAgentDeps["deleteMessage"] = async () => null
+    const personaAgent = new PersonaAgent({
+      pool: ctx.pool,
+      ai: ctx.ai,
+      traceEmitter,
+      sessionAbortRegistry: new SessionAbortRegistry(),
+      userPreferencesService,
+      workspaceAgent,
+      generalResearcher,
+      searchService,
+      conversationSummaryService,
+      attachmentService,
+      memoExplorerService,
+      storage: stubStorage,
+      modelRegistry: createModelRegistry(),
+      tavilyApiKey: ctx.credentials.tavilyApiKey,
+      createMessage,
+      editMessage,
+      deleteMessage,
+      addReaction: async () => null,
+      removeReaction: async () => null,
+      createThread: async () => {
+        throw new Error("createThread is not expected in brief-correction evals")
+      },
+      updateBrief,
+    })
+
+    const agentInput: PersonaAgentInput = {
+      workspaceId: ctx.workspaceId,
+      streamId,
+      messageId,
+      personaId,
+      serverId: `eval-server-${ulid()}`,
+      purpose: { kind: "catch_up" },
+    }
+    await personaAgent.run(agentInput)
+
+    const brief = await StreamBriefRepository.findByStreamId(ctx.pool, ctx.workspaceId, streamId)
+    const revisionCount = await countRevisions(ctx, streamId)
+
+    return {
+      input,
+      wrote: revisionCount > revisionsBefore,
+      briefContent: brief?.content ?? null,
+      briefVersion: brief?.version ?? 0,
+      revisionCount,
+      revisionsBefore,
+    }
+  } catch (error) {
+    return {
+      input,
+      wrote: false,
+      briefContent: null,
+      briefVersion: 0,
+      revisionCount: 0,
+      revisionsBefore: 0,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+export const briefCorrectionSuite: EvalSuite<BriefCorrectionInput, BriefCorrectionOutput, BriefCorrectionExpected> = {
+  name: "brief-correction",
+  description: "Tests companion brief maintenance: record decisions, replace reversals, ignore chitchat",
+
+  cases: briefCorrectionCases,
+
+  task: runBriefCorrectionTask,
+
+  evaluators: [writeDecisionEvaluator, singleRevisionEvaluator, briefContentEvaluator],
+
+  runEvaluators: [accuracyEvaluator, chitchatNoWriteRateEvaluator],
+
+  defaultPermutations: [
+    {
+      model: COMPANION_MODEL_ID,
+      temperature: COMPANION_TEMPERATURE,
+    },
+  ],
+}
+
+export default briefCorrectionSuite

--- a/apps/backend/evals/suites/brief-correction/suite.ts
+++ b/apps/backend/evals/suites/brief-correction/suite.ts
@@ -65,6 +65,9 @@ import { parseMarkdown } from "@threa/prosemirror"
 import { AuthorTypes, StreamTypes } from "@threa/types"
 import { personaId as generatePersonaId, streamId as generateStreamId } from "../../../src/lib/id"
 
+/** Fixed clock for the agent's temporal grounding so a run is reproducible. */
+const EVAL_CLOCK = new Date("2026-07-01T12:00:00Z")
+
 function getModelConfig(ctx: EvalContext): { model: string; temperature: number } {
   const override = ctx.componentOverrides?.["companion"]
   return {
@@ -75,8 +78,8 @@ function getModelConfig(ctx: EvalContext): { model: string; temperature: number 
 
 async function countRevisions(ctx: EvalContext, streamId: string): Promise<number> {
   const { rows } = await ctx.pool.query<{ count: string }>(
-    `SELECT COUNT(*)::text AS count FROM stream_brief_revisions WHERE stream_id = $1`,
-    [streamId]
+    `SELECT COUNT(*)::text AS count FROM stream_brief_revisions WHERE workspace_id = $1 AND stream_id = $2`,
+    [ctx.workspaceId, streamId]
   )
   return Number(rows[0]?.count ?? "0")
 }
@@ -300,6 +303,7 @@ async function runBriefCorrectionTask(input: BriefCorrectionInput, ctx: EvalCont
       personaId,
       serverId: `eval-server-${ulid()}`,
       purpose: { kind: "catch_up" },
+      currentTime: EVAL_CLOCK,
     }
     await personaAgent.run(agentInput)
 

--- a/apps/backend/evals/suites/brief-correction/types.ts
+++ b/apps/backend/evals/suites/brief-correction/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Brief Correction Evaluation Types
+ */
+
+export interface BriefCorrectionInput {
+  /** Which arm of the correction loop the case exercises. */
+  category: "states-decision" | "contradicts-brief" | "chitchat"
+  /** Prior scratchpad turns seeded before the trigger message. */
+  conversationHistory?: Array<{ role: "user" | "assistant"; content: string }>
+  /**
+   * Brief content seeded (as a member edit) before the turn runs. Present on the
+   * `contradicts-brief` cases so the turn has a standing fact to correct.
+   */
+  existingBrief?: string
+  /** The user message that fires the companion turn. */
+  message: string
+}
+
+export interface BriefCorrectionOutput {
+  input: BriefCorrectionInput
+  /** The turn added a brief revision (created or updated the brief). */
+  wrote: boolean
+  /** Brief content after the turn (null when no brief exists). */
+  briefContent: string | null
+  /** Brief version after the turn (0 when no brief exists). */
+  briefVersion: number
+  /** `stream_brief_revisions` rows after the turn. */
+  revisionCount: number
+  /** `stream_brief_revisions` rows before the turn (1 when a brief was seeded, else 0). */
+  revisionsBefore: number
+  error?: string
+}
+
+export interface BriefCorrectionExpected {
+  /** Whether the turn should write the brief. `false` is the over-eager-write guard. */
+  shouldWrite: boolean
+  /**
+   * LLM-judged: the resulting brief must assert this fact/decision. Checked only
+   * on write-expected cases.
+   */
+  briefMustState?: string
+  /**
+   * LLM-judged: the resulting brief must NOT still assert this — the value the
+   * user contradicted. Catches append-instead-of-replace (the brief is a full
+   * replacement, not an accretion log).
+   */
+  briefMustNotState?: string
+}

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -424,6 +424,13 @@ Tag's channel memory / Claude Code's CLAUDE.md: a persistent, human-auditable, c
 
 **Done when:** eval runs in CI (or the eval harness) with recorded baseline.
 
+**Deviations (shipped):**
+
+- **Dedicated sibling suite `evals/suites/brief-correction/`**, not an extension of the companion suite — matches the repo's one-suite-per-behavior convention (`memorizer`, `memo-classifier`, …) and keeps 4.4's chitchat gate nameable via `/eval -s brief-correction`. It runs the production `PersonaAgent.run()` on a private scratchpad with `update_stream_brief` wired to the production `StreamBriefService` exactly as `server.ts` binds it (INV-45), so the real write path is under test.
+- **Config co-located in `brief-correction/config.ts`** re-exporting `COMPANION_MODEL_ID`/`COMPANION_TEMPERATURE` from the companion config (INV-44) rather than adding brief constants to `companion/config.ts` — the eval drives Ariadne with the production model, and the suite's two gates (`CHITCHAT_NO_WRITE_GATE = 0.9`, `BRIEF_ACCURACY_GATE = 0.8`) live in one place.
+- **Graded by DB readback**, not tool-call interception: after the turn the suite reads `stream_briefs` + counts `stream_brief_revisions`. `write-decision` (deterministic) is the (a)/(c) arm; `single-revision` (deterministic) enforces one full replacement per write, not a loop/append; `brief-content` (LLM-judged, the `memorizer` conclusion-judge shape) is the (b) arm — the reversal must assert the new fact and _not still assert_ the old one as current. Run-level `chitchat-no-write-rate` is the ≥90% gate; `accuracy` the ≥80% floor.
+- **Deterministic evaluators carry a unit test** (`evaluators.test.ts`) so the scoring/gate math is verified without a live model; the `brief-content` judge and the live baseline are recorded via the `/eval brief-correction` CI comment (the harness needs `OPENROUTER_API_KEY` + a real DB, so no in-sandbox baseline).
+
 ---
 
 ## Phase 5 — Local agent delegation (big rock 2)

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -49,7 +49,7 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 4.1  | `stream_briefs` storage + endpoints + injection          | ☑      | #1214 |
 | 4.2  | `update_stream_brief` tool + timeline event              | ☑      | #1220 |
 | 4.3  | Brief UI: settings editor (+ timeline renderer → 4.2)    | ☑      | #1218 |
-| 4.4  | Brief correction eval                                    | ☐      |       |
+| 4.4  | Brief correction eval                                    | ☑      | #1289 |
 | 5.1  | `delegate_task` tool + delegation substrate + INV-65     | ☑      | #1261 |
 | 5.2  | Delegation card UI                                       | ☑      | #1261 |
 | 5.3  | Delegation public API (claim/status/complete)            | ☐      |       |


### PR DESCRIPTION
## Problem

Roadmap 4.1–4.3 shipped the stream brief and the `update_stream_brief` tool, but "the correction loop actually works" was never measured. The brief tool's whole value rests on Ariadne exercising judgment — record a durable decision, replace a fact the user reverses, and stay out of the way on chitchat — and the trust-critical case is the last one: an over-eager brief write on banter is exactly the failure that erodes confidence in the feature. No eval covered any of it. Roadmap 4.4 is that eval.

## Solution

A dedicated eval suite `evals/suites/brief-correction/` that runs the production `PersonaAgent.run()` on a private scratchpad with `update_stream_brief` wired to the production `StreamBriefService` (INV-45) — the same path a live companion turn takes — then grades the outcome by reading `stream_briefs` and its revision trail back from the database.

### How it works

- **Setup** (`suite.ts:setupTestData`) seeds a private scratchpad with `companionMode: "on"` and the eval Ariadne persona (resolved from the built-in via `PersonaRepository.findById(ARIADNE_AGENT_ID)`, using the production `enabledTools` so `update_stream_brief` binds), optional prior turns, and — for the reversal arm — a standing brief seeded as a prior member edit through `StreamBriefService.update({ expectedVersion: 0, updatedByKind: "user" })`. Then it posts the trigger message and captures `revisionsBefore`.
- **The tool under test** is wired exactly as `server.ts` binds it: `updateBrief` → `StreamBriefService.update({ updatedByKind: AuthorTypes.PERSONA, updatedById: personaId })`, mapping `outcome` back to the `UpdateStreamBriefToolResult` shape. So the eval drives the real write path, not a stub.
- **Readback** after `run()`: `StreamBriefRepository.findByStreamId` for the resulting content/version, plus a `COUNT(*)` on `stream_brief_revisions`. `wrote = revisionCount > revisionsBefore`.
- **Three arms** (`cases.ts`), 7 cases: `states-decision` (2) — a stated decision must land; `contradicts-brief` (2) — a reversed fact must be replaced, not appended; `chitchat` (3) — transient talk must leave the brief untouched.

### Evaluators

- `write-decision` (deterministic) — `wrote === shouldWrite`. The (a)/(c) arm.
- `single-revision` (deterministic) — a write adds exactly one revision; more than one means the turn wrote the brief repeatedly (a loop or append-then-fix), which the tool's full-replacement contract (roadmap 4.2) exists to avoid. Only checked on write-expected cases.
- `brief-content` (LLM-judged) — the reversal arm. Keyword matching can't tell "we chose Postgres" from a brief listing both MySQL and Postgres, which is the append-instead-of-replace failure; a judge reads the final brief and answers whether each candidate fact is asserted *as current*. Same scoped-judge shape as memorizer's `conclusion-direction` evaluator.
- Run-level `chitchat-no-write-rate` — the roadmap 4.4 gate: ≥90% of chitchat turns leave the brief untouched, tighter than accuracy because the over-eager write is the trust-eroding failure. `accuracy` — ≥80% of all cases pass every evaluator, matching the other suites' floor.

### Key design decisions

**1. Dedicated sibling suite, not an extension of `companion`.** Matches the repo's one-behavior-per-suite convention (`memorizer`, `memo-classifier`, …), keeps the chitchat gate nameable via `/eval -s brief-correction`, and leaves the working companion suite untouched — which matters because the eval harness needs live API keys + a real DB and can't be runtime-verified in-session, so a blind refactor of a shared suite was the wrong risk. The cost is the PersonaAgent construction is mirrored from `companion/suite.ts` (trimmed to the scratchpad-companion path: no mention/thread/workspace-context/web-search machinery).

**2. Graded by DB readback, not tool-call interception.** The brief is a full-replacement document with a revision trail; reading the final `stream_briefs` row + the revision count measures the *outcome* (was the fact folded in and the old one dropped) rather than the *mechanics* (which tool calls fired). It also lets `single-revision` catch a write loop that a single-call assertion would miss.

**3. Config co-located (INV-44).** `config.ts` re-exports `COMPANION_MODEL_ID`/`COMPANION_TEMPERATURE` from the companion config so the eval drives Ariadne with the production model, and holds the two gate constants (`CHITCHAT_NO_WRITE_GATE = 0.9`, `BRIEF_ACCURACY_GATE = 0.8`) as the single source.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/backend/evals/suites/brief-correction/suite.ts` | Task: seed scratchpad + brief, run production `PersonaAgent`, read brief/revisions back |
| `apps/backend/evals/suites/brief-correction/cases.ts` | 7 fixtures across the three correction-loop arms |
| `apps/backend/evals/suites/brief-correction/evaluators.ts` | `write-decision`, `single-revision`, `brief-content` (LLM-judge), run-level `accuracy` + `chitchat-no-write-rate` |
| `apps/backend/evals/suites/brief-correction/evaluators.test.ts` | Unit tests for the deterministic + run-level scoring/gate math |
| `apps/backend/evals/suites/brief-correction/config.ts` | Model (from companion config, INV-44) + gate thresholds |
| `apps/backend/evals/suites/brief-correction/types.ts` | `BriefCorrectionInput`/`Output`/`Expected` |
| `apps/backend/evals/suites/brief-correction/index.ts` | Barrel |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/backend/evals/run.ts` | Register `briefCorrectionSuite` in `allSuites` |
| `apps/backend/evals/slash/parse-args.ts` | Add `brief-correction` to the `/eval` suite allowlist |
| `docs/plans/ariadne-collaborator-roadmap.md` | 4.4 "Deviations (shipped)" note |

## Out of scope (deliberate)

- **No in-sandbox baseline.** The harness needs `OPENROUTER_API_KEY` + a real DB (template-clone per run) — unavailable in this session — so the live baseline records via the `/eval brief-correction` CI comment on this PR, the same on-demand path every other suite uses. The deterministic evaluators are unit-tested so the scoring/gate logic is verified without a model.
- **No status-box flip yet** — done in a follow-up commit once this PR has a number (the roadmap table is updated in-PR per the doc's workflow).

## Test plan

- [x] `bun test evals/suites/brief-correction/evaluators.test.ts` — 11 pass (write-decision, single-revision, chitchat-gate math incl. the 2/3-below-0.9 case, accuracy floor)
- [x] `bun test evals/slash/parse-args.test.ts` — 12 pass (allowlist unchanged behavior)
- [x] `tsc --noEmit` across the monorepo — clean (via pre-commit hook)
- [x] `eslint` on the new suite + touched files — clean (INV-47 nested-ternary fixed in `write-decision` details)
- [x] Pre-commit hook (full monorepo typecheck, astro check, migration check, OpenAPI drift) — passed
- [ ] Live `bun run eval -- -s brief-correction` — not run in-session (no `OPENROUTER_API_KEY`/DB); records via `/eval` on this PR

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9DvYrhtuVQrZqyyPY7XpX)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786396834&installation_id=129946197&pr_number=1289&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1289&signature=2a91b4efa2cce9c98318db2dc52a022c10a8b9c2f44bf926ef5667dd75a0c908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->