### PR TITLE
fix: open-at-unread-marker lands at the top of the first unread, for any row type

### DIFF
--- a/apps/frontend/src/components/timeline/event-list.test.ts
+++ b/apps/frontend/src/components/timeline/event-list.test.ts
@@ -9,6 +9,7 @@ import {
   findFirstMessageId,
   findMessageItemIndex,
   findEventItemIndex,
+  findTimelineTargetIndex,
   getTimelineItemKey,
   groupTimelineItems,
   injectGapItems,
@@ -565,6 +566,50 @@ describe("findEventItemIndex", () => {
 
   it("returns -1 when the event is not in the window so the cold-load scroll falls back to the bottom", () => {
     expect(findEventItemIndex([eventItem("evt_1")], "evt_gone")).toBe(-1)
+  })
+})
+
+describe("findTimelineTargetIndex", () => {
+  function messageItem(id: string, messageId: string): TimelineItem {
+    return {
+      type: "event",
+      event: createEvent({ id, sequence: id, eventType: "message_created", payload: { messageId } }),
+    }
+  }
+
+  it("resolves a message id like the deep-link lookup", () => {
+    const items: TimelineItem[] = [messageItem("evt_1", "msg_a"), messageItem("evt_2", "msg_b")]
+    expect(findTimelineTargetIndex(items, "msg_b")).toBe(1)
+  })
+
+  it("resolves a plain event id (a non-message divider anchor like a description row)", () => {
+    const items: TimelineItem[] = [
+      messageItem("evt_1", "msg_a"),
+      {
+        type: "event",
+        event: createEvent({ id: "evt_desc", sequence: "2", eventType: "description_set", payload: {} }),
+      },
+    ]
+    expect(findTimelineTargetIndex(items, "evt_desc")).toBe(1)
+  })
+
+  it("resolves a session group by its first event id — the marker-open case the message lookup misses", () => {
+    const items: TimelineItem[] = [
+      messageItem("evt_1", "msg_a"),
+      {
+        type: "session_group",
+        sessionId: "sess_1",
+        sessionVersion: 1,
+        events: [createEvent({ id: "evt_sess", sequence: "2", eventType: "message_created", payload: {} })],
+      },
+      messageItem("evt_3", "msg_c"),
+    ]
+    expect(findMessageItemIndex(items, "evt_sess")).toBe(-1)
+    expect(findTimelineTargetIndex(items, "evt_sess")).toBe(1)
+  })
+
+  it("returns -1 when the target is not in the window (never feed virtua a stale index)", () => {
+    expect(findTimelineTargetIndex([messageItem("evt_1", "msg_a")], "evt_gone")).toBe(-1)
   })
 })
 

--- a/apps/frontend/src/components/timeline/event-list.tsx
+++ b/apps/frontend/src/components/timeline/event-list.tsx
@@ -426,6 +426,18 @@ export function findEventItemIndex(items: TimelineItem[], eventId: string): numb
   })
 }
 
+/**
+ * Index of the timeline item addressed by `targetId` — a message id, a plain
+ * event id, or the first-event id of a command/session group. The union of
+ * `findMessageItemIndex` and `findEventItemIndex`, for scroll targets that can
+ * be any row the unread divider anchors on (a session card's first unread is
+ * an `event_…` id inside a group, which the message lookup alone misses).
+ */
+export function findTimelineTargetIndex(items: TimelineItem[], targetId: string): number {
+  const idx = findMessageItemIndex(items, targetId)
+  return idx >= 0 ? idx : findEventItemIndex(items, targetId)
+}
+
 /** Returns a stable key string for a timeline item */
 export function getTimelineItemKey(item: TimelineItem): string {
   switch (item.type) {
@@ -753,7 +765,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
     <>
       {item.type === "day_divider" && <DayDivider dayStartMs={item.dayStartMs} />}
       {item.type === "command_group" && (
-        <div className="px-3 sm:px-6">
+        <div className="px-3 sm:px-6" data-event-id={item.events[0]?.id}>
           <CommandEvent events={item.events} />
         </div>
       )}
@@ -785,7 +797,7 @@ function TimelineItemContentImpl({ item, ctx, deferSecondaryHydration }: Timelin
         </div>
       )}
       {item.type === "session_group" && !ctx.hideSessionCards && (
-        <div className="px-3 sm:px-6">
+        <div className="px-3 sm:px-6" data-event-id={item.events[0]?.id}>
           <AgentSessionEvent
             events={item.events}
             sessionVersion={item.sessionVersion}

--- a/apps/frontend/src/components/timeline/stream-content.tsx
+++ b/apps/frontend/src/components/timeline/stream-content.tsx
@@ -72,6 +72,7 @@ import {
   collectDelegationStatusPatches,
   findMessageItemIndex,
   findEventItemIndex,
+  findTimelineTargetIndex,
   getTimelineItemKey,
   filterVisibleItems,
   OLDER_SKELETON_ITEMS,
@@ -214,6 +215,14 @@ export function matchesDeepLinkTarget(event: { id: string; payload: unknown }, t
  * anchor/highlight the target when it lands.
  */
 export const DEEP_LINK_HOLD_MAX_MS = 600
+
+/**
+ * Gap between the viewport top and a top-aligned scroll target (the unread
+ * divider row): clears the sticky date header and leaves a sliver of context
+ * above so the unread run reads from the top. Shared by the jump-to-first-
+ * unread pill and the marker-open scroll so both land identically.
+ */
+const UNREAD_MARKER_TOP_GAP_PX = 56
 
 /**
  * Whether the timeline should keep showing the skeleton while a deep-link
@@ -1406,12 +1415,16 @@ export function StreamContent({
     [isJumpMode, skipInitialScroll, useVirtualized]
   )
 
-  // Scroll to a specific message and keep re-scrolling until the target
-  // element is actually visible in the scroller viewport. Items rendered
-  // with estimated heights cause the target to drift after the first scroll
-  // as surrounding items are measured; this loop keeps correcting until
-  // stable (or a short timeout). User input (wheel / touch / key) aborts
-  // the loop immediately so manual scrolling always wins.
+  // Scroll to a specific timeline row — addressed by message id or event id
+  // (any row `findTimelineTargetIndex` resolves, including session/command
+  // group cards) — and keep re-scrolling until the target element is actually
+  // visible in the scroller viewport. Items rendered with estimated heights
+  // cause the target to drift after the first scroll as surrounding items are
+  // measured; this loop keeps correcting until stable (or a short timeout).
+  // User input (wheel / touch / key) aborts the loop immediately so manual
+  // scrolling always wins. `align: "center"` (default) centers the target
+  // (deep links); `align: "start"` pins its top near the viewport top (the
+  // unread marker open).
   //
   // Implementation notes: Virtuoso's scrollToIndex expects the 0-based
   // index within the current data array (NOT firstItemIndex + idx). Once
@@ -1430,13 +1443,14 @@ export function StreamContent({
   // exactly the "I scroll up to read context, then get yanked back to the
   // linked message" deep-link bug.
   const scrollToMessage = useCallback(
-    (messageId: string) => {
+    (targetId: string, opts?: { align?: "center" | "start" }) => {
+      const align = opts?.align ?? "center"
       if (!useVirtualized) {
-        deepLinkDebug("scrollToMessage bail: not virtualized", messageId)
+        deepLinkDebug("scrollToMessage bail: not virtualized", targetId)
         return false
       }
-      if (findMessageItemIndex(visibleItems, messageId) < 0) {
-        deepLinkDebug("scrollToMessage bail: target not a timeline item yet", messageId)
+      if (findTimelineTargetIndex(visibleItems, targetId) < 0) {
+        deepLinkDebug("scrollToMessage bail: target not a timeline item yet", targetId)
         return false
       }
       // The user already took manual control for this scroll intent (e.g.
@@ -1444,7 +1458,7 @@ export function StreamContent({
       // start a retry loop that would fight them back to the target — the
       // mount anchor already placed it close enough.
       if (userInteractedAtRef.current > 0) {
-        deepLinkDebug("scrollToMessage bail: user already interacting", messageId)
+        deepLinkDebug("scrollToMessage bail: user already interacting", targetId)
         return false
       }
 
@@ -1462,7 +1476,7 @@ export function StreamContent({
 
       const scroller = virtuosoScrollerRef.current
       if (!scroller) {
-        deepLinkDebug("scrollToMessage bail: scroller not attached yet", messageId)
+        deepLinkDebug("scrollToMessage bail: scroller not attached yet", targetId)
         return false
       }
 
@@ -1499,25 +1513,43 @@ export function StreamContent({
           return
         }
 
-        const el = scroller.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(messageId)}"]`)
+        // Message rows carry both attributes; non-message rows (session cards,
+        // command groups, retitles) only data-event-id — one query serves any
+        // row the unread divider can anchor on.
+        const escaped = CSS.escape(targetId)
+        const el = scroller.querySelector<HTMLElement>(`[data-message-id="${escaped}"], [data-event-id="${escaped}"]`)
 
         if (el) {
           // Target is rendered — scroll via DOM so we get pixel-precise positioning
           const sr = scroller.getBoundingClientRect()
           const er = el.getBoundingClientRect()
-          const elCenter = (er.top + er.bottom) / 2
           const scCenter = (sr.top + sr.bottom) / 2
-          const delta = elCenter - scCenter
+          // "start" pins the target's top near the viewport top (the unread
+          // marker open: a long first-unread message must read from its start,
+          // and centering can never satisfy fullyVisible for a row taller than
+          // the viewport). "center" is the deep-link behavior, unchanged.
+          const desiredTop = sr.top + UNREAD_MARKER_TOP_GAP_PX
+          const delta = align === "start" ? er.top - desiredTop : (er.top + er.bottom) / 2 - scCenter
           if (Math.abs(delta) > 2) {
             scroller.scrollTop += delta
           }
 
           // Re-measure after the scroll
           const er2 = el.getBoundingClientRect()
-          const fullyVisible = er2.top >= sr.top - 1 && er2.bottom <= sr.bottom + 1
           const hasScrollRoom = scroller.scrollHeight > scroller.clientHeight + 8
-          const centered = !hasScrollRoom || Math.abs((er2.top + er2.bottom) / 2 - scCenter) < 40
-          if (fullyVisible && centered) {
+          let settled: boolean
+          if (align === "start") {
+            // A target too close to the tail can't reach the top — the scroller
+            // clamps at max scroll. Visible-at-clamp counts as settled.
+            const atMaxScroll = scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 1
+            const topAligned = Math.abs(er2.top - desiredTop) < 4
+            settled = !hasScrollRoom || topAligned || (atMaxScroll && er2.top >= sr.top && er2.top <= sr.bottom)
+          } else {
+            const fullyVisible = er2.top >= sr.top - 1 && er2.bottom <= sr.bottom + 1
+            const centered = !hasScrollRoom || Math.abs((er2.top + er2.bottom) / 2 - scCenter) < 40
+            settled = fullyVisible && centered
+          }
+          if (settled) {
             stableFrames += 1
             if (stableFrames >= 2) {
               abort()
@@ -1533,14 +1565,17 @@ export function StreamContent({
           // makes react-virtuoso's offset-tree binary search dereference an
           // undefined node, throwing "Cannot read properties of undefined
           // (reading 'index')" which crashes the whole route.
-          const liveIdx = findMessageItemIndex(visibleItemsRef.current, messageId)
+          const liveIdx = findTimelineTargetIndex(visibleItemsRef.current, targetId)
           // liveIdx < 0 means the target is transiently out of the window
           // (e.g. a jump-window swap mid-flight). Skip this tick rather than
           // scroll to a wrong index; a later tick retries once it reappears,
           // and MAX_MS still bounds the loop if it never does.
           if (liveIdx >= 0) {
             try {
-              listRef.current?.scrollToIndex(liveIdx, { align: "center" })
+              listRef.current?.scrollToIndex(
+                liveIdx,
+                align === "start" ? { align: "start", offset: -UNREAD_MARKER_TOP_GAP_PX } : { align: "center" }
+              )
             } catch {
               // virtua can still throw internally on a freshly mounted,
               // not-yet-measured list. Non-fatal: the next tick retries once
@@ -1558,7 +1593,7 @@ export function StreamContent({
           abort()
         }
       }
-      deepLinkDebug("scrollToMessage: refine loop engaged", messageId)
+      deepLinkDebug("scrollToMessage: refine loop engaged", targetId)
       attempt()
       return true
     },
@@ -2038,7 +2073,7 @@ export function StreamContent({
       const idx = findEventItemIndex(visibleItems, dividerEventId)
       if (idx < 0) return
       try {
-        listRef.current?.scrollToIndex(idx, { align: "start", offset: -56 })
+        listRef.current?.scrollToIndex(idx, { align: "start", offset: -UNREAD_MARKER_TOP_GAP_PX })
       } catch {
         // A not-yet-measured virtua list can throw; the row is already rendered
         // by the time this button is clickable, so this is best-effort.
@@ -2084,11 +2119,12 @@ export function StreamContent({
     if (decision !== "scroll") return
     // Prefer scrollToMessage: its refine loop converges over rows virtua hasn't
     // measured yet (a one-shot scrollToIndex on a fresh window lands pages off
-    // target). Falls back to the one-shot path for non-message divider rows and
-    // the plain thread scroller, where all rows are real DOM already.
-    const dividerEvent = events.find((e) => e.id === dividerEventId)
-    const messageId = (dividerEvent?.payload as { messageId?: string } | null)?.messageId
-    if (!useVirtualized || !messageId || !scrollToMessage(messageId)) {
+    // target), and it targets the divider row by event id so non-message rows
+    // (session cards, retitles) get the same treatment. Top-aligned so a first
+    // unread message taller than the viewport reads from its start. Falls back
+    // to the one-shot path only for the plain thread scroller, where all rows
+    // are real DOM already.
+    if (!useVirtualized || !dividerEventId || !scrollToMessage(dividerEventId, { align: "start" })) {
       scrollToFirstUnread()
     }
   }, [
@@ -2101,7 +2137,6 @@ export function StreamContent({
     isJumpMode,
     skipInitialScroll,
     dividerEventId,
-    events,
     scrollToMessage,
     scrollToFirstUnread,
   ])


### PR DESCRIPTION
## Problem

Opening a stream with `unreadOpenPosition: "marker"` (PR #1283) often landed at the bottom showing the "N new messages" pill instead of at the divider — and even when it landed, a first unread message taller than the viewport showed its middle, forcing a scroll up to find the start. Kris's video of the failure: first unread was a "Session complete" card, stream opened at the tail.

Three compounding defects in `stream-content.tsx`:

1. **Non-message divider anchors took a fragile one-shot path.** The marker-open effect extracted `payload.messageId` from the divider event and only engaged the `scrollToMessage` refine loop when one existed. A session card, `member_added`, or `description_set` anchor has none, so it fell to `scrollToFirstUnread()`'s one-shot `scrollToIndex` — on a freshly mounted virtua list with unmeasured row heights, which lands pages off target or throws (swallowed by its `catch`). The refine loop exists precisely because a one-shot scroll on a fresh window lands ~14 messages off (PR #1265 finding).
2. **Group rows were unaddressable in the DOM.** `session_group`/`command_group` wrappers rendered no `data-event-id`, so even the refine loop's DOM-precise pass (and the plain thread scroller's `querySelector`) could not find them.
3. **The refine loop centered its target and required `fullyVisible` to converge** — unsatisfiable for a row taller than the viewport, so it churned its full 1.2s bound and settled centered, top off-screen.

## Solution

Marker opens always go through the refine loop, targeting the divider row by **event id** with a new `align: "start"` mode that pins the row near the viewport top — the same landing as the jump-to-first-unread pill.

### How it works

- `findTimelineTargetIndex` (`event-list.tsx`) resolves a scroll target as message id, plain event id, or a group's first-event id — the union of `findMessageItemIndex` and `findEventItemIndex`, mirroring `isFirstUnread`'s anchor rule. The refine loop uses it for both the early in-window bail and the per-tick live index.
- The loop's DOM query is now `[data-message-id="…"], [data-event-id="…"]`, and `session_group`/`command_group` wrappers carry `data-event-id={item.events[0]?.id}`.
- `scrollToMessage(targetId, opts?)` gains `align: "center" | "start"`. Start mode scrolls the target's top to `scroller.top + UNREAD_MARKER_TOP_GAP_PX` (56px — shared constant with the pill's `scrollToIndex` offset, clears the sticky date header and leaves a sliver of read context) and converges on top-alignment instead of `fullyVisible` — a target too close to the tail settles at the scroll clamp (`atMaxScroll` + visible). Center mode is byte-for-byte the old behavior; deep links and search jumps are untouched.
- The marker-open effect drops the `payload.messageId` extraction and calls `scrollToMessage(dividerEventId, { align: "start" })`, falling back to `scrollToFirstUnread()` only for the non-virtualized thread scroller.

### Key design decisions

**1. Event-id targeting instead of teaching the one-shot path to retry** — the refine loop already owns every hard case (unmeasured rows, window shifts mid-loop, user-gesture abort, the 1.2s bound); duplicating that in `scrollToFirstUnread` would be a second convergence loop (INV-35). The pill handler keeps its one-shot: by the time it's clickable the list is measured, and it now shares `UNREAD_MARKER_TOP_GAP_PX` so both land identically.

**2. Top-align only for marker opens; deep links keep centering.** A deep-linked message is the point of interest and reads best centered; the marker is a reading *cursor* — everything below it is unread, so it belongs at the top (matches the pill, and Discord's behavior the pref was modeled on).

**3. Side effect: group cards now participate in the auto-read frontier scan.** `useLastSeenEvent` collects `[data-event-id]` rows; group first-event ids map into the loaded window, so the existing `map.has(id)` guard (the PR #1254 parent-banner fix) admits them. The frontier already absorbs row-less events (reactions) between visible rows, so this is consistent — and it closes a ghost-unread gap where a session card as the only unread row gave the scan nothing to advance on.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/stream-content.tsx` | `scrollToMessage` → generic target + `align` option; marker-open effect targets the divider event id with `align: "start"`; `UNREAD_MARKER_TOP_GAP_PX` shared with the pill path |
| `apps/frontend/src/components/timeline/event-list.tsx` | `findTimelineTargetIndex`; `data-event-id` on session/command group wrappers |
| `apps/frontend/src/components/timeline/event-list.test.ts` | `findTimelineTargetIndex` coverage incl. the group-first-event case `findMessageItemIndex` misses |

## Out of scope (deliberate)

- The `hideSessionCards` context can still leave `dividerEventId` pointing at a filtered-out row (marker open then falls back to latest, and no divider renders at all) — pre-existing, orthogonal to this fix.
- `resolveUnreadMarkerOpen`'s decision gates (deep-link/jump/gesture vetoes, pref-hydration wait) are unchanged.

## Test plan

- [x] `vitest` — `event-list.test.ts` (64), `stream-content.test.ts`, `use-unread-divider.test.ts`: 142 pass
- [x] Frontend `tsc --noEmit` clean (app + test configs); full lint/typecheck pre-commit hook green
- [x] Playwright browser specs guarding the shared refine loop: `edit-last-message` (incl. "scrolls off-screen message into view"), `infinite-scroll`, `composer-bottom-spacing` — 12 pass
- [x] Live verify against `dev:test` (scripted Playwright, desktop 1280×800 **and** mobile 390×844 emulation), fresh browser context per pref value:
  - marker + single taller-than-viewport unread message → divider lands ~36px below scroller top, `LONG-MESSAGE-START` visible
  - marker + non-message first unread (`member_added`/`description_set` anchor, unread block > viewport) → divider at top; with a short unread run it settles at the scroll clamp with the divider visible (expected)
  - `latest` pref → opens at bottom, unchanged
  - `?m=` deep link with marker pref → linked message centered, marker scroll vetoed
- [ ] Real agent-session card as divider anchor not reproduced live (dev:test has no `OPENROUTER_API_KEY`); covered by the group-first-event unit test + the `member_added` non-message anchor live scenario, which exercises the same event-id path

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786425090&installation_id=129946197&pr_number=1291&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1291&signature=0b5e10fc9b9a2ffe1bd4d71df06205ac5c21f2d8147717eccd6837d89e80d1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->