### PR TITLE
feat(board): title-led cards + surface/accent visual pass

### DIFF
--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -479,6 +479,9 @@ export function BoardCard({
     // overlays its own 2px border onto the branch's neutral rail at that row —
     // covering it at the same width — while a user row stays plain so the neutral
     // grouping rail shows. The row's own accent stripe is suppressed either way.
+    // Break out by the rail's padding PLUS its 2px border (`-mx-2.5 sm:-mx-3.5`)
+    // so the colored border lands ON the neutral rail, not beside it; `px-2 sm:px-3`
+    // re-pads so content aligns with the branch header.
     const rail = actorRowTheme(message.authorType).railClassName
     return (
       <ConversationReadProvider value={null}>
@@ -492,7 +495,7 @@ export function BoardCard({
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
           surfaceClassName={rail ? cn("bg-card border-l-2 px-2 sm:px-3", rail) : "bg-card"}
-          rowInsetClassName={rail ? "-mx-2 sm:-mx-3" : undefined}
+          rowInsetClassName={rail ? "-mx-2.5 sm:-mx-3.5" : undefined}
           suppressRowAccent
           onNewSubtopic={
             canBranch

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -10,6 +10,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
+import { actorRowTheme } from "@/components/message/actor-row-theme"
 import { buildBranchedBoardRows } from "@/components/board/board-row-item"
 import { BranchedBoardRows, BranchProvenanceRow } from "@/components/board/branch-rows"
 import { resolveBoardEventRows } from "@/lib/board/board-event-rows"
@@ -474,6 +475,11 @@ export function BoardCard({
   // surfaces) and identify as the CHILD conversation (copy-link opens its panel).
   const renderBranchMessage = (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => {
     const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    // Per-message spine color: a colored actor (persona gold / bot green / system)
+    // overlays its own 2px border onto the branch's neutral rail at that row —
+    // covering it at the same width — while a user row stays plain so the neutral
+    // grouping rail shows. The row's own accent stripe is suppressed either way.
+    const rail = actorRowTheme(message.authorType).railClassName
     return (
       <ConversationReadProvider value={null}>
         <MessageItem
@@ -485,10 +491,8 @@ export function BoardCard({
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          // The branch spine (BranchGroup rail) carries the actor color, so the row
-          // suppresses its own accent stripe (no doubled bar) and stays padded
-          // inside the rail — no edge breakout that would paint over the spine.
-          surfaceClassName="bg-card"
+          surfaceClassName={rail ? cn("bg-card border-l-2 px-2 sm:px-3", rail) : "bg-card"}
+          rowInsetClassName={rail ? "-mx-2 sm:-mx-3" : undefined}
           suppressRowAccent
           onNewSubtopic={
             canBranch

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -485,13 +485,11 @@ export function BoardCard({
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          // Same actor-accent treatment as a top-level row, scaled to the branch
-          // rail's `pl-2 sm:pl-3` indent: the row breaks out to the rail border and
-          // pads the content back (net-zero, so avatars stay aligned with the branch
-          // header). Without the `px-*`, a colored row's inset accent rail sat flush
-          // against the text.
-          surfaceClassName="bg-card px-2 sm:px-3"
-          rowInsetClassName="-mx-2 sm:-mx-3"
+          // The branch spine (BranchGroup rail) carries the actor color, so the row
+          // suppresses its own accent stripe (no doubled bar) and stays padded
+          // inside the rail — no edge breakout that would paint over the spine.
+          surfaceClassName="bg-card"
+          suppressRowAccent
           onNewSubtopic={
             canBranch
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -3,19 +3,10 @@ import type { RefObject } from "react"
 import { Link } from "react-router-dom"
 import { useQuery } from "@tanstack/react-query"
 import type { VirtualizerHandle } from "virtua"
-import {
-  Hash,
-  FileEdit,
-  User,
-  MessageSquareText,
-  ChevronDown,
-  ChevronRight,
-  CircleCheck,
-  PanelRight,
-  type LucideIcon,
-} from "lucide-react"
+import { ChevronDown, ChevronRight, CircleCheck, PanelRight } from "lucide-react"
 import { DEFAULT_BOARD_CARD_COLLAPSE_AT_HEIGHT, DEFAULT_BOARD_CARD_COLLAPSE_TO_HEIGHT } from "@threa/types"
 import { RelativeTime } from "@/components/relative-time"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MessageItem, type RenderableMessage } from "@/components/message/message-item"
@@ -31,6 +22,7 @@ import {
 } from "@/hooks/use-conversation-graph"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { cn } from "@/lib/utils"
+import { streamTypeVisual } from "@/lib/stream-visuals"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { BoardReplyComposer } from "@/components/board/board-reply-composer"
@@ -52,8 +44,11 @@ interface BoardCardProps {
   post: BoardViewPost
   /** Where the post lives (channel name, DM peer, scratchpad name), for the header. */
   contextLabel: string
-  /** Resolved stream type, selecting the context glyph. */
+  /** Resolved stream type, selecting the context glyph + tile tint. */
   streamType: string | undefined
+  /** For a DM post, the peer's user id — resolves the peer avatar shown over the
+   *  locator tile, matching the sidebar. Absent for non-DM streams. */
+  dmPeerUserId?: string | null
   /** The board's owned scroll viewport — lets a middle-gap expand hold the newest
    *  replies still instead of shoving them down (`useBoardCardRevealAnchor`).
    *  Absent when the card renders outside the virtualized board (tests). */
@@ -61,23 +56,6 @@ interface BoardCardProps {
   /** virtua's imperative handle for the board feed, paired with `scrollerRef`. */
   listRef?: RefObject<VirtualizerHandle | null>
 }
-
-const TYPE_GLYPH: Record<string, LucideIcon> = {
-  channel: Hash,
-  scratchpad: FileEdit,
-  dm: User,
-}
-
-/** The stream-type accent tile behind the context glyph — the board's one color
- *  dimension (INV-14 stays: this is a token tint, not a new primitive). The tint
- *  is keyed by stream type via `--type-*`; an unknown type falls back to the
- *  neutral muted tile so it never goes uncolored-but-mismatched. */
-const TYPE_TILE: Record<string, string> = {
-  channel: "bg-[hsl(var(--type-channel)/0.14)] text-[hsl(var(--type-channel))]",
-  scratchpad: "bg-[hsl(var(--type-scratchpad)/0.16)] text-[hsl(var(--type-scratchpad))]",
-  dm: "bg-[hsl(var(--type-dm)/0.15)] text-[hsl(var(--type-dm))]",
-}
-const NEUTRAL_TILE = "bg-muted text-muted-foreground"
 
 /** How many trailing messages a nested branch previews on a collapsed card; the
  *  hidden rest sits behind an "N more replies" link into the child's panel. */
@@ -98,9 +76,17 @@ const COLLAPSED_FADE_MASK = "linear-gradient(to bottom, black calc(100% - 2rem),
  * conversation (no reply indentation); a collapsed "N more messages" gap fills
  * in on click. The stream it lives in is the header locator, not a topic line.
  */
-export function BoardCard({ workspaceId, post, contextLabel, streamType, scrollerRef, listRef }: BoardCardProps) {
+export function BoardCard({
+  workspaceId,
+  post,
+  contextLabel,
+  streamType,
+  dmPeerUserId,
+  scrollerRef,
+  listRef,
+}: BoardCardProps) {
   const { conversation } = post
-  const { getActorName } = useActors(workspaceId)
+  const { getActorName, getActorAvatar } = useActors(workspaceId)
   const currentUserId = useWorkspaceUserId(workspaceId)
   const conversationService = useConversationService()
   const { openPanel, getPanelUrl } = usePanel()
@@ -153,8 +139,11 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
   })
 
   const streamId = conversation.streamId
-  const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
-  const tileClass = (streamType && TYPE_TILE[streamType]) || NEUTRAL_TILE
+  // Leading visual matches the sidebar's stream row: a per-type glyph on a tinted
+  // tile, except a DM shows the peer avatar over it (icon as the fallback). Shared
+  // `streamTypeVisual` keeps board and sidebar in lockstep.
+  const { Icon: TypeIcon, tileClassName } = streamTypeVisual(streamType)
+  const dmAvatarUrl = dmPeerUserId ? getActorAvatar(dmPeerUserId, "user").avatarUrl : undefined
 
   // Whole-card fold: every card can be folded from the chevron; automatic
   // collapse is opt-in and only decides whether a tall conversation starts
@@ -566,22 +555,34 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
       />
     </>
   )
-  // The stream the post lives in — a real link back into it (INV-40). The glyph
-  // sits in a stream-type-tinted tile (the board's one accent). `size` scales the
-  // tile+label for the message-led lead (where the locator IS the headline).
-  const locatorLink = (size: "sm" | "xs") => (
-    <Link
-      to={`/w/${workspaceId}/s/${streamId}`}
-      className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
-    >
-      <span className={cn("flex h-5 w-5 shrink-0 items-center justify-center rounded-md", tileClass)}>
-        <ContextGlyph className="h-3 w-3" />
-      </span>
-      <span className={cn("truncate", size === "sm" ? "text-sm font-medium text-foreground" : "font-medium")}>
-        {contextLabel}
-      </span>
-    </Link>
-  )
+  // The stream the post lives in — a real link back into it (INV-40). The leading
+  // visual mirrors the sidebar: a DM shows the peer avatar (glyph fallback), every
+  // other type shows the tinted glyph tile. `size` scales tile+label for the
+  // message-led lead (where the locator IS the headline) vs the demoted locator.
+  const locatorLink = (size: "sm" | "xs") => {
+    const tileSize = size === "sm" ? "h-6 w-6" : "h-5 w-5"
+    const glyph = <TypeIcon className={size === "sm" ? "h-3.5 w-3.5" : "h-3 w-3"} />
+    return (
+      <Link
+        to={`/w/${workspaceId}/s/${streamId}`}
+        className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
+      >
+        {dmAvatarUrl ? (
+          <Avatar className={cn("shrink-0 rounded-md", tileSize)}>
+            <AvatarImage src={dmAvatarUrl} alt={contextLabel} />
+            <AvatarFallback className={cn("rounded-md", tileClassName)}>{glyph}</AvatarFallback>
+          </Avatar>
+        ) : (
+          <span className={cn("flex shrink-0 items-center justify-center rounded-md", tileSize, tileClassName)}>
+            {glyph}
+          </span>
+        )}
+        <span className={cn("truncate", size === "sm" ? "text-sm font-medium text-foreground" : "font-medium")}>
+          {contextLabel}
+        </span>
+      </Link>
+    )
+  }
   const subtopicLabel = subtopicCount > 0 && (
     <>
       <span className="shrink-0 opacity-50">·</span>

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -68,6 +68,17 @@ const TYPE_GLYPH: Record<string, LucideIcon> = {
   dm: User,
 }
 
+/** The stream-type accent tile behind the context glyph — the board's one color
+ *  dimension (INV-14 stays: this is a token tint, not a new primitive). The tint
+ *  is keyed by stream type via `--type-*`; an unknown type falls back to the
+ *  neutral muted tile so it never goes uncolored-but-mismatched. */
+const TYPE_TILE: Record<string, string> = {
+  channel: "bg-[hsl(var(--type-channel)/0.14)] text-[hsl(var(--type-channel))]",
+  scratchpad: "bg-[hsl(var(--type-scratchpad)/0.16)] text-[hsl(var(--type-scratchpad))]",
+  dm: "bg-[hsl(var(--type-dm)/0.15)] text-[hsl(var(--type-dm))]",
+}
+const NEUTRAL_TILE = "bg-muted text-muted-foreground"
+
 /** How many trailing messages a nested branch previews on a collapsed card; the
  *  hidden rest sits behind an "N more replies" link into the child's panel. */
 const BRANCH_PREVIEW_CAP = 2
@@ -143,6 +154,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
 
   const streamId = conversation.streamId
   const ContextGlyph = (streamType && TYPE_GLYPH[streamType]) || MessageSquareText
+  const tileClass = (streamType && TYPE_TILE[streamType]) || NEUTRAL_TILE
 
   // Whole-card fold: every card can be folded from the chevron; automatic
   // collapse is opt-in and only decides whether a tall conversation starts
@@ -295,6 +307,14 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
     derivePendingBranches,
     messagesById,
   ])
+  // Direct sub-topics under this conversation — the "↳" branch groups, counted
+  // for the locator line and collapse pill. Top-level only (grandchildren nest
+  // visually but don't inflate the card's headline count).
+  const subtopicCount = useMemo(() => {
+    let n = 0
+    for (const list of branchesByForkMessageId.values()) n += list.length
+    return n
+  }, [branchesByForkMessageId])
   const provenance = useMemo(
     () =>
       deriveBranchProvenance({
@@ -490,6 +510,87 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
     )
   }
 
+  // Header chrome shared by both header shapes (title-led and message-led), so
+  // the chevron/dot/actions don't get duplicated across the two branches.
+  const chevronToggle = (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={toggleBodyCollapsed}
+          aria-expanded={!bodyCollapsed}
+          aria-label={bodyCollapsed ? "Expand conversation" : "Collapse conversation"}
+          className="-ml-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:text-foreground"
+        >
+          {bodyCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{bodyCollapsed ? "Expand" : "Collapse"}</TooltipContent>
+    </Tooltip>
+  )
+  // Quiet unread dot: the conversation holds an effectively-unread member
+  // message. Reserved fixed footprint (no layout shift, INV-21); clears live.
+  const unreadDot = (
+    <span
+      className="flex h-2 w-2 shrink-0 items-center justify-center"
+      aria-label={cardHasUnread ? "Unread" : undefined}
+    >
+      {cardHasUnread && <span className="h-2 w-2 rounded-full bg-primary" />}
+    </span>
+  )
+  const headerActions = (
+    <>
+      {/* Open the whole conversation in the side panel (Mechanism B) — reads it
+          coherently and replies scoped to it, peer to a thread. */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="Open conversation"
+            onClick={() => openPanel(createConversationPanelId(conversation.id))}
+          >
+            <PanelRight className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open conversation</TooltipContent>
+      </Tooltip>
+      <ConversationActionsMenu
+        workspaceId={workspaceId}
+        conversationId={conversation.id}
+        streamId={conversation.streamId}
+        topicSummary={conversation.topicSummary}
+        status={conversation.status}
+        triggerClassName="shrink-0"
+      />
+    </>
+  )
+  // The stream the post lives in — a real link back into it (INV-40). The glyph
+  // sits in a stream-type-tinted tile (the board's one accent). `size` scales the
+  // tile+label for the message-led lead (where the locator IS the headline).
+  const locatorLink = (size: "sm" | "xs") => (
+    <Link
+      to={`/w/${workspaceId}/s/${streamId}`}
+      className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
+    >
+      <span className={cn("flex h-5 w-5 shrink-0 items-center justify-center rounded-md", tileClass)}>
+        <ContextGlyph className="h-3 w-3" />
+      </span>
+      <span className={cn("truncate", size === "sm" ? "text-sm font-medium text-foreground" : "font-medium")}>
+        {contextLabel}
+      </span>
+    </Link>
+  )
+  const subtopicLabel = subtopicCount > 0 && (
+    <>
+      <span className="shrink-0 opacity-50">·</span>
+      <span className="shrink-0">
+        {subtopicCount} {subtopicCount === 1 ? "sub-topic" : "sub-topics"}
+      </span>
+    </>
+  )
+
   return (
     // Scope quote reply to this card: a message row's "Quote reply" routes into
     // this card's own reply composer, not another card's.
@@ -498,7 +599,14 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
         {/* Desktop text-selection → floating "Quote" button, scoped to this card. */}
         <TextSelectionQuote streamId={streamId} containerRef={cardRef} />
         {moveToSubtopic.moveDialog}
-        <div ref={cardRef} className="rounded-xl border bg-card p-3 sm:p-4">
+        {/* Rest shadow lifts the card off the page — the light-mode card/bg
+            lightness delta is ~1%, so the border alone left cards reading flat.
+            Board-scoped; global tokens untouched. Dark leans on a deeper shadow
+            since the fill delta reads weakly on the charcoal canvas. */}
+        <div
+          ref={cardRef}
+          className="rounded-xl border bg-card p-3 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_4px_14px_-8px_rgb(0_0_0/0.10)] sm:p-4 dark:shadow-[0_1px_2px_rgb(0_0_0/0.4),0_6px_16px_-8px_rgb(0_0_0/0.5)]"
+        >
           {/* Zero-height marker at the card top: drives the header's stuck state
               (see the observer above). In flow but h-0, so it shifts nothing. */}
           <div ref={stuckSentinelRef} aria-hidden className="h-0" />
@@ -515,82 +623,46 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
               headerStuck && "sm:border-border/60 sm:shadow-[0_4px_12px_-6px_rgb(0_0_0/0.4)]"
             )}
           >
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={toggleBodyCollapsed}
-                    aria-expanded={!bodyCollapsed}
-                    aria-label={bodyCollapsed ? "Expand conversation" : "Collapse conversation"}
-                    className="-ml-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground/70 transition-colors hover:text-foreground"
-                  >
-                    {bodyCollapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{bodyCollapsed ? "Expand" : "Collapse"}</TooltipContent>
-              </Tooltip>
-              {/* The stream the post lives in — a real link back into it (INV-40). */}
-              <Link
-                to={`/w/${workspaceId}/s/${streamId}`}
-                className="flex min-w-0 items-center gap-1.5 transition-colors hover:text-foreground"
-              >
-                <ContextGlyph className="h-3.5 w-3.5 shrink-0" />
-                <span className="truncate font-medium">{contextLabel}</span>
-              </Link>
-              {/* Quiet unread dot: the conversation holds an effectively-unread member
-              message. Reserved fixed footprint (no layout shift, INV-21); clears
-              live as read state changes. */}
-              <span
-                className="ml-auto flex h-2 w-2 shrink-0 items-center justify-center"
-                aria-label={cardHasUnread ? "Unread" : undefined}
-              >
-                {cardHasUnread && <span className="h-2 w-2 rounded-full bg-primary" />}
-              </span>
-              <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
-              {/* Open the whole conversation in the side panel (Mechanism B) — reads it
-            coherently and replies scoped to it, peer to a thread. */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
-                    aria-label="Open conversation"
-                    onClick={() => openPanel(createConversationPanelId(conversation.id))}
-                  >
-                    <PanelRight className="h-3.5 w-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Open conversation</TooltipContent>
-              </Tooltip>
-              <ConversationActionsMenu
-                workspaceId={workspaceId}
-                conversationId={conversation.id}
-                streamId={conversation.streamId}
-                topicSummary={conversation.topicSummary}
-                status={conversation.status}
-                triggerClassName="shrink-0"
-              />
-            </div>
-
-            {/* The conversation's topic — a quiet single-line label, shown only when
-            the extractor (or a rename) set one, so a message-led card stays
-            message-led when it hasn't. A resolved topic reads muted with a small
-            marker; the card also drops out of the Active lens (its own signal). */}
-            {conversation.topicSummary && (
-              <div className="mt-2 flex items-center gap-1.5">
-                {conversation.status === "resolved" && (
-                  <CircleCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="Resolved" />
-                )}
-                <span
-                  className={cn(
-                    "truncate text-sm font-medium",
-                    conversation.status === "resolved" && "text-muted-foreground"
+            {/* Title-led when the extractor (or a rename) set a topic: the topic is
+                the card's headline and the locator (glyph · stream · time) demotes
+                to a small line beneath it. A message-led card (no topic) keeps the
+                locator AS the lead so it never grows a fake title. A resolved topic
+                reads muted with a marker; it also drops out of the Active lens. */}
+            {conversation.topicSummary ? (
+              <>
+                <div className="flex items-center gap-1.5">
+                  {chevronToggle}
+                  {conversation.status === "resolved" && (
+                    <CircleCheck className="h-4 w-4 shrink-0 text-muted-foreground" aria-label="Resolved" />
                   )}
-                >
-                  {conversation.topicSummary}
-                </span>
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-[15px] leading-tight tracking-tight",
+                      conversation.status === "resolved" ? "font-medium text-muted-foreground" : "font-semibold"
+                    )}
+                  >
+                    {conversation.topicSummary}
+                  </span>
+                  {unreadDot}
+                  {headerActions}
+                </div>
+                <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  {locatorLink("xs")}
+                  <span className="shrink-0 opacity-50">·</span>
+                  <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
+                  {subtopicLabel}
+                </div>
+              </>
+            ) : (
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                {chevronToggle}
+                {locatorLink("sm")}
+                {subtopicLabel}
+                <div className="ml-auto flex items-center gap-1.5">
+                  {unreadDot}
+                  <RelativeTime date={conversation.lastActivityAt} terse className="shrink-0" />
+                  {headerActions}
+                </div>
               </div>
             )}
 
@@ -602,6 +674,7 @@ export function BoardCard({ workspaceId, post, contextLabel, streamType, scrolle
                 className="mt-2 flex w-fit items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
               >
                 {messageCount} {messageCount === 1 ? "message" : "messages"}
+                {subtopicCount > 0 && ` · ${subtopicCount} ${subtopicCount === 1 ? "sub-topic" : "sub-topics"}`}
               </button>
             )}
           </div>

--- a/apps/frontend/src/components/board/board-card.tsx
+++ b/apps/frontend/src/components/board/board-card.tsx
@@ -485,7 +485,13 @@ export function BoardCard({
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          surfaceClassName="bg-card"
+          // Same actor-accent treatment as a top-level row, scaled to the branch
+          // rail's `pl-2 sm:pl-3` indent: the row breaks out to the rail border and
+          // pads the content back (net-zero, so avatars stay aligned with the branch
+          // header). Without the `px-*`, a colored row's inset accent rail sat flush
+          // against the text.
+          surfaceClassName="bg-card px-2 sm:px-3"
+          rowInsetClassName="-mx-2 sm:-mx-3"
           onNewSubtopic={
             canBranch
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -16,8 +16,6 @@ import {
 } from "@/components/ui/alert-dialog"
 import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
-import { actorRowTheme } from "@/components/message/actor-row-theme"
-import { cn } from "@/lib/utils"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
 /** Indent per thread boundary (spanning), applied on a wrapper so the shared
@@ -116,12 +114,6 @@ interface BranchGroupProps {
 export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, renderAfterMessage }: BranchGroupProps) {
   const { getPanelUrl } = usePanel()
   const panelUrl = getPanelUrl(createConversationPanelId(branch.conversationId))
-  // The nested conversation's spine takes its actor's color: the first colored
-  // author in the branch (persona/bot/system) tints the rail, so the whole nested
-  // block reads as theirs. Per-message stripes are suppressed on these rows
-  // (`suppressRowAccent`), so this rail is the single 2px colored bar.
-  const accentActor = branch.messages.find((m) => m.authorType && m.authorType !== "user")?.authorType
-  const railClassName = actorRowTheme(accentActor).railClassName || "border-muted-foreground/25"
   // A pending branch (sub-topic sent, conversation echo not landed) has no real
   // conversation to open yet — its header is inert until the graph takes over.
   const header = (
@@ -142,7 +134,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
           {header}
         </Link>
       )}
-      <div className={cn("mt-1 border-l-2 pl-2 sm:pl-3 [&>*:first-child]:mt-0", railClassName)}>
+      <div className="mt-1 border-l-2 border-muted-foreground/25 pl-2 sm:pl-3 [&>*:first-child]:mt-0">
         {renderBranchMessage &&
           branch.messages.map((message, index) => {
             const prev = index > 0 ? branch.messages[index - 1] : null

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -21,8 +21,8 @@ import type { BranchConversationView } from "@/lib/board/branch-grouping"
 /** Indent per thread boundary (spanning), applied on a wrapper so the shared
  *  `MessageItem` stays untouched. A left rail reads the nesting Reddit-style. */
 const INDENT_CLASS: Record<number, string> = {
-  1: "ml-3 border-l-2 border-border pl-2 sm:pl-3",
-  2: "ml-6 border-l-2 border-border pl-2 sm:pl-3",
+  1: "ml-3 border-l-2 border-muted-foreground/20 pl-2 sm:pl-3",
+  2: "ml-6 border-l-2 border-muted-foreground/20 pl-2 sm:pl-3",
 }
 
 /**
@@ -119,7 +119,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
   const header = (
     <>
       <CornerDownRight className="h-3.5 w-3.5 shrink-0" />
-      <span className="truncate">{branch.title}</span>
+      <span className="truncate font-medium text-foreground/75">{branch.title}</span>
     </>
   )
   return (
@@ -134,7 +134,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
           {header}
         </Link>
       )}
-      <div className="mt-1 border-l-2 border-border pl-2 sm:pl-3 [&>*:first-child]:mt-0">
+      <div className="mt-1 border-l-2 border-muted-foreground/25 pl-2 sm:pl-3 [&>*:first-child]:mt-0">
         {renderBranchMessage &&
           branch.messages.map((message, index) => {
             const prev = index > 0 ? branch.messages[index - 1] : null

--- a/apps/frontend/src/components/board/branch-rows.tsx
+++ b/apps/frontend/src/components/board/branch-rows.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/components/ui/alert-dialog"
 import { BoardEventRowItem, type BoardRow } from "@/components/board/board-row-item"
 import { isContinuation, type RenderableMessage } from "@/components/message/message-item"
+import { actorRowTheme } from "@/components/message/actor-row-theme"
+import { cn } from "@/lib/utils"
 import type { BranchConversationView } from "@/lib/board/branch-grouping"
 
 /** Indent per thread boundary (spanning), applied on a wrapper so the shared
@@ -114,6 +116,12 @@ interface BranchGroupProps {
 export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, renderAfterMessage }: BranchGroupProps) {
   const { getPanelUrl } = usePanel()
   const panelUrl = getPanelUrl(createConversationPanelId(branch.conversationId))
+  // The nested conversation's spine takes its actor's color: the first colored
+  // author in the branch (persona/bot/system) tints the rail, so the whole nested
+  // block reads as theirs. Per-message stripes are suppressed on these rows
+  // (`suppressRowAccent`), so this rail is the single 2px colored bar.
+  const accentActor = branch.messages.find((m) => m.authorType && m.authorType !== "user")?.authorType
+  const railClassName = actorRowTheme(accentActor).railClassName || "border-muted-foreground/25"
   // A pending branch (sub-topic sent, conversation echo not landed) has no real
   // conversation to open yet — its header is inert until the graph takes over.
   const header = (
@@ -134,7 +142,7 @@ export function BranchGroup({ branch, renderBranchMessage, renderBranchTail, ren
           {header}
         </Link>
       )}
-      <div className="mt-1 border-l-2 border-muted-foreground/25 pl-2 sm:pl-3 [&>*:first-child]:mt-0">
+      <div className={cn("mt-1 border-l-2 pl-2 sm:pl-3 [&>*:first-child]:mt-0", railClassName)}>
         {renderBranchMessage &&
           branch.messages.map((message, index) => {
             const prev = index > 0 ? branch.messages[index - 1] : null

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -41,6 +41,7 @@ import { useMoveToSubtopic } from "@/components/board/use-move-to-subtopic"
 import { ConversationActionsMenu } from "@/components/conversations/conversation-actions-menu"
 import { useBoardHiddenConversations } from "@/stores/board-exclusions-store"
 import { cn } from "@/lib/utils"
+import { actorRowTheme } from "@/components/message/actor-row-theme"
 import { ConversationReadProvider, useConversationReadController } from "@/components/message/conversation-read-context"
 import { useConversationAutoRead } from "@/components/message/use-conversation-auto-read"
 import { RelativeTime } from "@/components/relative-time"
@@ -523,6 +524,10 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
   // so copy-link opens its panel. Same shape as the board card's.
   const renderBranchMessage = (branch: BranchConversationView, message: RenderableMessage, continuation: boolean) => {
     const canBranch = !structuralIndex.threadsByParentMessageId.has(message.id)
+    // Per-message spine color (persona gold / bot green / system) overlaying the
+    // branch's neutral rail at that row; a user row stays plain so the neutral
+    // grouping rail shows. See the board card's renderBranchMessage.
+    const rail = actorRowTheme(message.authorType).railClassName
     return (
       <ConversationReadProvider value={null}>
         <MessageItem
@@ -534,10 +539,8 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          // The branch spine (BranchGroup rail) carries the actor color, so the row
-          // suppresses its own accent stripe (no doubled bar) and stays padded
-          // inside the rail — no edge breakout that would paint over the spine.
-          surfaceClassName="bg-background"
+          surfaceClassName={rail ? cn("bg-background border-l-2 px-2 sm:px-3", rail) : "bg-background"}
+          rowInsetClassName={rail ? "-mx-2 sm:-mx-3" : undefined}
           suppressRowAccent
           onNewSubtopic={
             canBranch

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -534,7 +534,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          surfaceClassName="bg-background"
+          // Break out to the branch rail's `pl-2 sm:pl-3` and pad back (net-zero),
+          // so a colored row's inset accent rail clears the text instead of sitting
+          // flush against it — same treatment as the top-level row above.
+          surfaceClassName="bg-background px-2 sm:px-3"
+          rowInsetClassName="-mx-2 sm:-mx-3"
           onNewSubtopic={
             canBranch
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -540,7 +540,7 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
           surfaceClassName={rail ? cn("bg-background border-l-2 px-2 sm:px-3", rail) : "bg-background"}
-          rowInsetClassName={rail ? "-mx-2 sm:-mx-3" : undefined}
+          rowInsetClassName={rail ? "-mx-2.5 sm:-mx-3.5" : undefined}
           suppressRowAccent
           onNewSubtopic={
             canBranch

--- a/apps/frontend/src/components/conversations/conversation-panel.tsx
+++ b/apps/frontend/src/components/conversations/conversation-panel.tsx
@@ -534,11 +534,11 @@ function ConversationPanelBody({ workspaceId, post, hostStreamType, openReplySig
           continuation={continuation}
           conversationId={branch.conversationId}
           conversationRootStreamId={branch.threadStreamId}
-          // Break out to the branch rail's `pl-2 sm:pl-3` and pad back (net-zero),
-          // so a colored row's inset accent rail clears the text instead of sitting
-          // flush against it — same treatment as the top-level row above.
-          surfaceClassName="bg-background px-2 sm:px-3"
-          rowInsetClassName="-mx-2 sm:-mx-3"
+          // The branch spine (BranchGroup rail) carries the actor color, so the row
+          // suppresses its own accent stripe (no doubled bar) and stays padded
+          // inside the rail — no edge breakout that would paint over the spine.
+          surfaceClassName="bg-background"
+          suppressRowAccent
           onNewSubtopic={
             canBranch
               ? () => inlineComposer.openNewSubtopic(message.streamId ?? branch.threadStreamId, message.id)

--- a/apps/frontend/src/components/layout/sidebar/stream-item.tsx
+++ b/apps/frontend/src/components/layout/sidebar/stream-item.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState, type ReactNode, type RefObject } from "react"
-import { Bell, FileEdit, FolderPlus, Hash, Link2, Lock, MessageSquareText, Settings, Tag, User } from "lucide-react"
+import { FolderPlus, Hash, Link2, Lock, MessageSquareText, Settings, Tag } from "lucide-react"
 import { Link } from "react-router-dom"
 import { LabelPicker } from "@/components/labels/label-picker"
 import { SectionPicker } from "./section-picker"
@@ -15,6 +15,7 @@ import { useSidebar } from "@/contexts"
 import { useStreamSettings } from "@/components/stream-settings/use-stream-settings"
 import { cn } from "@/lib/utils"
 import { streamLabel } from "@/lib/streams"
+import { streamTypeVisual } from "@/lib/stream-visuals"
 import { copyStreamLink } from "@/lib/stream-links"
 import { BADGE_CONFIG, URGENCY_COLORS } from "./config"
 import {
@@ -225,39 +226,10 @@ export function StreamItem({
 
   useUrgencyTracking(itemRef, stream.id, stream.urgency, scrollContainerRef)
 
-  const getAvatar = () => {
-    if (stream.type === StreamTypes.CHANNEL) {
-      return {
-        icon: <Hash className="h-3.5 w-3.5" />,
-        className: "bg-muted text-[hsl(200_60%_50%)]",
-      }
-    }
-    if (stream.type === StreamTypes.SCRATCHPAD) {
-      return {
-        icon: <FileEdit className="h-3.5 w-3.5" />,
-        className: "bg-primary/10 text-primary",
-      }
-    }
-    if (stream.type === StreamTypes.SYSTEM) {
-      return {
-        icon: <Bell className="h-3.5 w-3.5" />,
-        className: "bg-blue-500/10 text-blue-500",
-      }
-    }
-    if (stream.type === StreamTypes.THREAD) {
-      return {
-        icon: <MessageSquareText className="h-3.5 w-3.5" />,
-        className: "bg-muted text-muted-foreground",
-      }
-    }
-    // DM
-    return {
-      icon: <User className="h-3.5 w-3.5" />,
-      className: "bg-muted text-muted-foreground",
-    }
-  }
-
-  const avatar = getAvatar()
+  // Per-type glyph + tile tint, shared with the board card (single source of
+  // truth so the two surfaces can't drift). A DM overlays the peer avatar below.
+  const { Icon: TypeIcon, tileClassName } = streamTypeVisual(stream.type)
+  const avatar = { icon: <TypeIcon className="h-3.5 w-3.5" />, className: tileClassName }
   const name = streamLabel(stream, "sidebar")
   const threadRootStream =
     stream.type === StreamTypes.THREAD && stream.rootStreamId

--- a/apps/frontend/src/components/message/actor-row-theme.tsx
+++ b/apps/frontend/src/components/message/actor-row-theme.tsx
@@ -18,6 +18,11 @@ export interface ActorRowTheme {
    * by the timeline (`MessageEvent`) and the board/panel (`MessageItem`).
    */
   rowAccent: string
+  /** Border-color class for a nested sub-conversation's spine (`border-l-2`), so
+   *  the whole nested block reads as that actor's — the color covers the branch
+   *  rail at the same 2px width instead of a separate per-message stripe beside
+   *  it. Empty = neutral (plain user branch). Matches `rowAccent`'s hues. */
+  railClassName: string
   /** Color class applied to the author-name element. Empty = inherit. */
   nameClassName: string
   /** Optional inline pill rendered in the header row after the author name. */
@@ -27,21 +32,25 @@ export interface ActorRowTheme {
 export const ACTOR_ROW_THEME: Record<AuthorType, ActorRowTheme> = {
   user: {
     rowAccent: "",
+    railClassName: "",
     nameClassName: "",
     badge: null,
   },
   persona: {
     rowAccent: "bg-gradient-to-r from-primary/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(var(--primary))]",
+    railClassName: "border-primary",
     nameClassName: "text-primary",
     badge: null,
   },
   bot: {
     rowAccent: "bg-gradient-to-r from-emerald-500/[0.06] to-transparent shadow-[inset_3px_0_0_hsl(152_69%_41%)]",
+    railClassName: "border-[hsl(152_69%_41%)]",
     nameClassName: "text-emerald-600",
     badge: <span className="text-[10px] text-emerald-600/70 font-medium cursor-default">BOT</span>,
   },
   system: {
     rowAccent: "bg-gradient-to-r from-blue-500/[0.04] to-transparent shadow-[inset_3px_0_0_hsl(210_100%_55%)]",
+    railClassName: "border-[hsl(210_100%_55%)]",
     nameClassName: "text-blue-500",
     badge: null,
   },

--- a/apps/frontend/src/components/message/message-item.tsx
+++ b/apps/frontend/src/components/message/message-item.tsx
@@ -138,6 +138,10 @@ interface MessageItemProps {
    * on `surfaceClassName` so content stays aligned (board: `-mx-3 sm:-mx-4` +
    * `px-3 sm:px-4`; panel: `-mx-4` + `px-4`). Omit on the label page (no accent). */
   rowInsetClassName?: string
+  /** Suppress the per-row actor accent (tint + inset stripe). Set inside a nested
+   *  sub-conversation, where the branch's own spine carries the actor color at a
+   *  single 2px width — a per-message stripe there would double the bar. */
+  suppressRowAccent?: boolean
   /** Open a thread under this message and mint its child conversation (the declared
    * "New sub-topic" branch gesture). Passed already-guarded by the conversation
    * surfaces — set only when no thread yet exists under the message (adjustment D)
@@ -174,6 +178,7 @@ export function MessageItem({
   isHighlighted,
   surfaceClassName,
   rowInsetClassName,
+  suppressRowAccent,
   onNewSubtopic,
   onMoveToSubtopic,
 }: MessageItemProps) {
@@ -210,6 +215,9 @@ export function MessageItem({
   // to the sides and the stripe sits flush — the stream-view look — with content
   // kept aligned by the matching padding in `surfaceClassName`.
   const theme = actorRowTheme(message.authorType)
+  // Inside a nested sub-conversation the branch spine carries the actor color, so
+  // the per-row stripe is suppressed to avoid a doubled bar (the name color stays).
+  const rowAccentClass = suppressRowAccent ? "" : theme.rowAccent
   const attachments = message.attachments ?? []
   const linkPreviews = message.linkPreviews ?? []
   // The row's own stream — only to pick the "View in channel/thread/…" noun.
@@ -664,7 +672,7 @@ export function MessageItem({
             "group reveal-host relative flex gap-3",
             MESSAGE_ROW_CONTINUATION_PADDING,
             surfaceClassName,
-            theme.rowAccent,
+            rowAccentClass,
             longPress.isPressed && "opacity-70 transition-opacity",
             isHighlighted && "animate-highlight-flash"
           )}
@@ -721,7 +729,7 @@ export function MessageItem({
           "group reveal-host relative flex items-start gap-3",
           MESSAGE_ROW_HEAD_PADDING,
           surfaceClassName,
-          theme.rowAccent,
+          rowAccentClass,
           longPress.isPressed && "opacity-70 transition-opacity",
           isHighlighted && "animate-highlight-flash"
         )}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -162,6 +162,14 @@
     --conversation-6: 22 70% 47%;
     --conversation-7: 245 50% 58%;
     --conversation-8: 88 45% 34%;
+
+    /* Board stream-type accent — the glyph tile's tint, keyed by stream type so a
+       card's kind is scannable at a glance. Desaturated on purpose: it's a
+       locator cue, not a second selection color (the unread dot owns the gold
+       --primary). Composed with alpha at the tile: hsl(var(--type-channel) / 0.14) */
+    --type-channel: 217 45% 48%;
+    --type-scratchpad: 38 62% 46%;
+    --type-dm: 152 38% 38%;
   }
 
   .dark {
@@ -233,6 +241,11 @@
     --conversation-6: 24 75% 60%;
     --conversation-7: 245 60% 72%;
     --conversation-8: 88 40% 52%;
+
+    /* Board stream-type accent — lifted lightness for the dark canvas */
+    --type-channel: 217 55% 66%;
+    --type-scratchpad: 40 58% 60%;
+    --type-dm: 152 40% 56%;
   }
 }
 

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -162,14 +162,6 @@
     --conversation-6: 22 70% 47%;
     --conversation-7: 245 50% 58%;
     --conversation-8: 88 45% 34%;
-
-    /* Board stream-type accent — the glyph tile's tint, keyed by stream type so a
-       card's kind is scannable at a glance. Desaturated on purpose: it's a
-       locator cue, not a second selection color (the unread dot owns the gold
-       --primary). Composed with alpha at the tile: hsl(var(--type-channel) / 0.14) */
-    --type-channel: 217 45% 48%;
-    --type-scratchpad: 38 62% 46%;
-    --type-dm: 152 38% 38%;
   }
 
   .dark {
@@ -241,11 +233,6 @@
     --conversation-6: 24 75% 60%;
     --conversation-7: 245 60% 72%;
     --conversation-8: 88 40% 52%;
-
-    /* Board stream-type accent — lifted lightness for the dark canvas */
-    --type-channel: 217 55% 66%;
-    --type-scratchpad: 40 58% 60%;
-    --type-dm: 152 40% 56%;
   }
 }
 

--- a/apps/frontend/src/lib/stream-visuals.ts
+++ b/apps/frontend/src/lib/stream-visuals.ts
@@ -1,0 +1,31 @@
+import { Bell, FileEdit, Hash, MessageSquareText, User, type LucideIcon } from "lucide-react"
+import { StreamTypes } from "@threa/types"
+
+/**
+ * The leading visual for a stream type — glyph + tile tint. The single source of
+ * truth shared by the sidebar row (`StreamItem`) and the board card so the two
+ * can't drift: a DM shows the peer avatar over this tile, everything else shows
+ * the glyph. Colors mirror the sidebar's original per-type mapping.
+ */
+export interface StreamTypeVisual {
+  Icon: LucideIcon
+  /** Tailwind classes for the icon tile: background tint + icon color. */
+  tileClassName: string
+}
+
+export function streamTypeVisual(type: string | undefined): StreamTypeVisual {
+  switch (type) {
+    case StreamTypes.CHANNEL:
+      return { Icon: Hash, tileClassName: "bg-muted text-[hsl(200_60%_50%)]" }
+    case StreamTypes.SCRATCHPAD:
+      return { Icon: FileEdit, tileClassName: "bg-primary/10 text-primary" }
+    case StreamTypes.SYSTEM:
+      return { Icon: Bell, tileClassName: "bg-blue-500/10 text-blue-500" }
+    case StreamTypes.THREAD:
+      return { Icon: MessageSquareText, tileClassName: "bg-muted text-muted-foreground" }
+    case StreamTypes.DM:
+      return { Icon: User, tileClassName: "bg-muted text-muted-foreground" }
+    default:
+      return { Icon: MessageSquareText, tileClassName: "bg-muted text-muted-foreground" }
+  }
+}

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -639,11 +639,12 @@ function BoardPageInner({
             <h2
               key={row.key}
               className={cn(
-                "px-1 pb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground",
+                "flex items-center gap-3 px-1 pb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground",
                 row.first ? "pt-2" : "pt-6"
               )}
             >
-              {row.label}
+              <span className="shrink-0">{row.label}</span>
+              <span className="h-px flex-1 bg-border" aria-hidden />
             </h2>
           )
         }

--- a/apps/frontend/src/pages/board.tsx
+++ b/apps/frontend/src/pages/board.tsx
@@ -486,6 +486,8 @@ function BoardPageInner({
   const users = useWorkspaceUsers(workspaceId)
   const dmPeers = useWorkspaceDmPeers(workspaceId)
   const streamById = useMemo(() => new Map(streams.map((s) => [s.id, s])), [streams])
+  // Peer user id per DM stream — feeds the card's leading avatar (sidebar parity).
+  const dmPeerByStreamId = useMemo(() => new Map(dmPeers.map((p) => [p.streamId, p.userId])), [dmPeers])
   const sections = useMemo(() => groupByRecency(posts, activityById, Date.now()), [posts, activityById])
 
   // The board feed is virtualized (`virtua`): ~430 active cards each mount
@@ -582,14 +584,17 @@ function BoardPageInner({
   // Stable per workspace-cache change so the row memo below only recomputes when a
   // label input actually changes, not on every parent re-render.
   const labelsFor = useCallback(
-    (conversation: ConversationWithStaleness): { contextLabel: string; streamType: string | undefined } => {
+    (
+      conversation: ConversationWithStaleness
+    ): { contextLabel: string; streamType: string | undefined; dmPeerUserId: string | null } => {
       const streamName = resolveStreamName(conversation.streamId, { streams, users, dmPeers }, "generic")
       return {
         contextLabel: streamName ?? "Unknown stream",
         streamType: streamById.get(conversation.streamId)?.type,
+        dmPeerUserId: dmPeerByStreamId.get(conversation.streamId) ?? null,
       }
     },
-    [streams, users, dmPeers, streamById]
+    [streams, users, dmPeers, streamById, dmPeerByStreamId]
   )
 
   // Flat if-chain, not a nested ternary (INV-47 / no-nested-ternary).
@@ -663,7 +668,7 @@ function BoardPageInner({
             </div>
           )
         }
-        const { contextLabel, streamType } = labelsFor(row.post.conversation)
+        const { contextLabel, streamType, dmPeerUserId } = labelsFor(row.post.conversation)
         return (
           <div key={row.key} className="pb-3">
             <BoardCard
@@ -671,6 +676,7 @@ function BoardPageInner({
               post={row.post}
               contextLabel={contextLabel}
               streamType={streamType}
+              dmPeerUserId={dmPeerUserId}
               scrollerRef={scrollerRef}
               listRef={listRef}
             />


### PR DESCRIPTION
## Problem

The board reads flat — it's a digest, not the co-equal destination it's meant to be. Four verified causes:

- **No surface separation.** `--card` sits ~1% lightness off `--background` (light: 99% vs 98%) with no rest shadow. The 1px border is the only thing dividing a card from the page, so cards don't register as objects.
- **The title is buried.** `conversation.topicSummary` rendered `truncate text-sm font-medium` — same size as body text, weight-only distinction — and sat *below* the meta row. Every card led with its least interesting line (a tiny muted glyph + stream + timestamp locator).
- **No color, no differentiation.** The only color on the whole board was the 8px `bg-primary` unread dot. Nothing distinguished a channel from a scratchpad from a DM; recency section headers were muted uppercase text with no rule.
- **Whispery sub-topics.** Nested branches (`branch-rows.tsx`) rendered `↳ title` + a `border-border` rail — functionally there, visually part of the same flatness.

This is the LOOK pass only. No behavior, data, or layout-semantics change; the collapse model, sticky header (sm+), and resolved-stays-quiet ruling from #1280 are untouched.

## Solution

Spend the design budget where it buys the most: **typography hierarchy first, one restrained accent, real elevation.** All board-scoped — global tokens are untouched, so nothing outside the board shifts.

### How it works

1. **Title-led header** (`board-card.tsx`). When a topic exists, it's the card's headline: a `text-[15px] font-semibold` lead line, with the locator (tinted glyph · stream · time) demoted to a small `text-xs` line beneath. A message-led card (no topic — e.g. a scratchpad post) keeps the locator *as* the lead so it never grows a fake title. The two header shapes are a single `conversation.topicSummary ? … : …` branch; the shared chevron/unread-dot/panel/actions chrome is hoisted into JSX consts (`chevronToggle`, `unreadDot`, `headerActions`, `locatorLink`) so neither branch duplicates it.

2. **Leading visual matches the sidebar** (`lib/stream-visuals.ts` + `board-card.tsx`). The context glyph moves into a `rounded-md` tile whose glyph + tint come from the shared `streamTypeVisual(type)` — the same per-type mapping the sidebar row uses (channel `#` blue-on-muted, scratchpad gold, etc.). A **DM renders the peer avatar** over the tile (glyph as `AvatarFallback`), exactly like the sidebar. This is the only color added; the unread dot keeps the gold `--primary`. (First cut used board-only `--type-*` tokens; superseded — see the follow-up note below.)

3. **Cards read as objects** (`board-card.tsx`). A soft rest shadow on the card container lifts it off the page — shadow-only, so the header/row `bg-card` fills stay consistent (the header pins over scrolling messages and repaints `bg-card`; changing the fill would desync them). Light leans on the shadow; dark uses a deeper shadow (`dark:shadow-[…]`) since the fill delta reads weakly on the charcoal canvas.

4. **Sub-topics counted + branch styled.** `subtopicCount` (derived from `branchesByForkMessageId`, top-level groups only) shows as "· N sub-topics" in the locator line and the collapsed "N messages" pill. In `branch-rows.tsx`, the `↳` header gets `font-medium text-foreground/75` and the rails go from `border-border` to a more present neutral `border-muted-foreground/20–25` — no tint, keeping the whole color budget on the type tiles.

5. **Section rule** (`board.tsx`). Recency headers (Today / Yesterday / …) get a `flex-1` hairline (`h-px bg-border`) trailing the label, so the feed reads as sectioned instead of a wall.

### Key design decisions

**1. Shadow-only surface, not a lifted fill.** Round-1's mock lifted `--card` toward white. In light mode that's a ~1% gain (99%→100%) *and* would force a coordinated change across three `bg-card` sites (card, pinned-header fill, message-row surface) that deliberately match to cover scrolling content. The shadow does the real separation work at zero desync risk. If more pop is wanted, bumping the global `--card` is the follow-up lever (bigger blast radius — held off).

**2. Neutral branch rail, not tinted.** The mock tinted the branch rail with the channel hue. Shipped it neutral: the type tiles are then the *single* added color dimension, which is the more defensible answer to "don't make it a rainbow." The rail still gains presence via opacity, not hue.

**3. Resolved title uses a ternary, not appended classes.** `font-medium text-muted-foreground` (resolved) vs `font-semibold` (active) are selected by a ternary rather than conditionally appending `font-medium` — two font-weight utilities on one element resolve by stylesheet source order, not `cn()` arg order, so appending would be a latent bug. Resolved stays quiet: muted + `CircleCheck`, no strikethrough (Kris's ruling, #1280).

**4. INV-21 preserved.** The unread dot keeps its reserved fixed footprint; the rest shadow doesn't shift layout; the sticky-header stuck-elevation is unchanged.

### Follow-up: match the sidebar's leading visual (commit 2)

Kris off the staging env: "match the sidebar — for DMs show the Avatar." The board drew its own type-tinted tile; the sidebar draws a per-type glyph tile and, for DMs, the **peer avatar**. Unified them:

- New `lib/stream-visuals.ts` — `streamTypeVisual(type) → { Icon, tileClassName }`, the **single source of truth** for the per-type glyph + tile tint. The sidebar's `StreamItem.getAvatar()` (a private copy of this mapping) now calls it — behavior-preserving.
- `board-card.tsx` locator now uses `streamTypeVisual`, and a DM renders the peer avatar (`getActorAvatar(dmPeerUserId, "user").avatarUrl`) over the tile with the glyph as `AvatarFallback` — sidebar parity. The name already matched (both go through `resolveStreamName`, so channels are `#slug`).
- `board.tsx` resolves `dmPeerUserId` per card from the `dmPeers` cache and passes it down.
- The `--type-*` tokens from commit 1 are **removed** (INV-38) — superseded by the shared helper's sidebar-matched classes.

## New files

| File | Purpose |
| ---- | ------- |
| `apps/frontend/src/lib/stream-visuals.ts` | Shared `streamTypeVisual` — one source of truth for a stream type's glyph + tile tint, used by the sidebar row and the board card |

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/board/board-card.tsx` | Title-led / locator-led header split; leading visual via `streamTypeVisual` with DM peer avatar; `subtopicCount` in locator + collapse pill; card rest shadow; chevron/dot/actions hoisted to shared JSX |
| `apps/frontend/src/components/board/branch-rows.tsx` | Stronger sub-topic header (`font-medium text-foreground/75`); more present neutral rails (`border-muted-foreground/20–25`) |
| `apps/frontend/src/pages/board.tsx` | Hairline rule trailing recency section-header labels; resolve + pass `dmPeerUserId` per card |
| `apps/frontend/src/components/layout/sidebar/stream-item.tsx` | `getAvatar()` replaced by shared `streamTypeVisual` (behavior-preserving) |
| `apps/frontend/src/index.css` | (commit 1 added, commit 2 removed) `--type-*` tokens — net zero; no token change ships |

## Out of scope (deliberate)

- **No behavior change** — collapse model, sticky-header behavior, read/unread, branch grouping, virtualization all untouched. Purely visual.
- **Composer surfaces untouched** — a separate session is re-envisioning the composer as an overlay; restyling the current inline one would be wasted work.
- **Global `--card` fill** not bumped (see decision 1) — named as the follow-up if more surface pop is wanted after live review.
- **Live-app screenshots** not attached — an unseeded dev:test board is empty; the design was iterated against a token-faithful mock. This PR carries the `staging` label for a pixel-real pass on real data.

## Test plan

- [x] `apps/frontend` `tsc --noEmit` (via pre-commit full-monorepo typecheck) — clean, 0 errors
- [x] All app + package lints (via pre-commit) — clean
- [x] `bunx vitest run src/components/board/ src/components/layout/sidebar/stream-item.test.tsx` — **98 pass** (13 files). Board unread/resolved/collapse/branch behavior + sidebar row all green — the aria-labels the tests key on are preserved through the header refactor, and the sidebar's `getAvatar`→`streamTypeVisual` swap is behavior-preserving.
- [x] Reviewed off the `staging` per-PR env (mobile) — Kris confirmed the direction; commit 2 is the sidebar-match follow-up from that review.

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_
