### PR TITLE
docs(roadmap): backfill 6.4 (#1286); mark 7.2 claimed by local work

### DIFF
--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -58,11 +58,11 @@ Two concurrent efforts share primitives with this work; steps below reference th
 | 6.1  | Memo edit/archive endpoints + explorer UI                | ☑      | #1246 |
 | 6.2  | `save_memo` tool                                         | ☑      | #1260 |
 | 6.3  | Reflective capture at session completion                 | ☑      | #1273 |
-| 6.4  | `memoScope` (user/stream/workspace)                      | ☐      |       |
+| 6.4  | `memoScope` (user/stream/workspace)                      | ☑      | #1286 |
 | 6.5  | Retrieval feedback decay                                 | ☐      |       |
 | 6.6  | Agent-memo safety: read-time provenance + type allowlist | ☑      | #1277 |
 | 7.1  | Workspace persona config API + editor (partial: Ariadne) | ☑      | #1285 |
-| 7.2  | Persona picker UI                                        | ☐      |       |
+| 7.2  | Persona picker UI                                        | 🔒     | local |
 | 8.1  | Ambient classifier on settled conversations              | ☐      |       |
 | 8.2  | "Ariadne noticed" card + budget + toggle                 | ☐      |       |
 | 8.3  | Ambient precision eval                                   | ☐      |       |
@@ -677,6 +677,8 @@ Code-complete backend machinery (`applyBuiltInAgentPatch`, `agent_config_overrid
 **Goal:** choose the companion per stream; make first-party personas and external bots legible in one place.
 
 > The **workspace persona editor** half of this phase (the settings-page editor linked from the companion tab) shipped early with 7.1 (#1285) — see its Deviations block. What remains here is the per-stream persona _picker_ in `companion-tab.tsx`.
+
+> **🔒 Claimed locally (2026-07-12, Kris):** the persona editor is being revamped in a local working thread, and the persona roster/picker follows locally once the editor lands. **Do not pick this step up from a remote/parallel session** — coordinate with Kris first. Remove this note when the local work merges.
 
 **Shape:** `companion-tab.tsx` gains a persona select (streams already carry `companionPersonaId`) listing built-ins + workspace personas, plus a link to a small workspace-settings persona editor (create/edit per 7.1). External bots noted in the same tab via the existing `ExternalAgentIndicator` — one mental model: "who works in this stream."
 


### PR DESCRIPTION
## Problem

Two tracker drifts that would misdirect parallel sessions: 6.4 (memoScope) merged in #1286 without its status-table tick, and 7.2 (persona picker/roster) looks unclaimed while Kris is actively revamping the persona editor in a local thread with the roster planned to follow locally.

## Solution

Status table: 6.4 → ☑ #1286; 7.2 → 🔒 local. The 7.2 step section gains a dated claim note ("do not pick this up from a remote/parallel session; remove when the local work merges").

## Files changed

| File | Change |
| ---- | ------ |
| `docs/plans/ariadne-collaborator-roadmap.md` | 6.4 backfill; 7.2 lock note |

## Test plan

- [x] Pre-commit hooks (full monorepo lint + typecheck + OpenAPI check) — clean
- [ ] Docs-only; no runtime surface

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMwaTm3hFayoQj5o8k7Ga4)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786432299&installation_id=129946197&pr_number=1293&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1293&signature=87f87d5d91f46c086febdff07781801cd184752ed0912c4acbe3fbee38f0a3d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->