### PR TITLE
feat(delegations): close the copy-paste loop — lifecycle-aware prompt + Mark done

### DIFF
--- a/apps/backend/src/features/agents/tools/delegate-task-tool.ts
+++ b/apps/backend/src/features/agents/tools/delegate-task-tool.ts
@@ -41,7 +41,8 @@ Use \`delegate_task\` when the user describes work that is long-horizon, code-he
 
 - The \`brief\` is everything the executor gets. Write it self-contained: the executor has repo access but no Threa context. Include the goal, the background it needs, and explicit acceptance criteria ("done when …").
 - Link sources with \`contextRefs\` pointer URLs (\`shared-message:\`, \`memo:\`, \`attachment:\`) rather than inlining long quotes — the hand-off carries the pointers.
-- The delegation appears as a card in this stream that anyone can see, cancel, or copy as a ready-to-paste prompt; a local agent can also claim it programmatically. Report to the user that you've prepared the hand-off — don't promise to do the work yourself.
+- The delegation appears as a card in this stream that anyone can see, cancel, mark done, or copy as a ready-to-paste prompt; a local agent can also claim it programmatically. Report to the user that you've prepared the hand-off — don't promise to do the work yourself.
+- Set expectations honestly: the card does not run by itself. Tell the user it waits for someone with a local coding agent (or a Threa API key) to pick it up, and that they can mark it done from the card if the work happens outside the API.
 - Offer delegation when it fits; don't delegate trivia the user just wants answered in chat.`
 
 /**

--- a/apps/backend/src/features/delegations/handlers.ts
+++ b/apps/backend/src/features/delegations/handlers.ts
@@ -85,5 +85,35 @@ export function createDelegationHandlers({ pool, delegationService }: Dependenci
       // double-click is harmless.
       res.json({ cancelled: cancelled !== null })
     },
+
+    /**
+     * "Mark as done" from the card — closes the loop for work executed outside
+     * the API path (copy-paste into a local agent). Same access model and
+     * race-honest response shape as cancel.
+     */
+    async markDone(req: Request, res: Response) {
+      const userId = req.user!.id
+      const workspaceId = req.workspaceId!
+      const id = req.params.id!
+
+      const delegation = await delegationService.getById({ workspaceId, id })
+      if (!delegation) {
+        throw new HttpError("Delegation not found", { status: 404, code: "DELEGATION_NOT_FOUND" })
+      }
+
+      const access = await checkStreamAccess(pool, delegation.streamId, workspaceId, userId)
+      if (!access) {
+        throw new HttpError("Delegation not found", { status: 404, code: "DELEGATION_NOT_FOUND" })
+      }
+
+      const done = await delegationService.markDone({
+        workspaceId,
+        id,
+        streamId: delegation.streamId,
+        completedBy: { actorId: userId, actorType: AuthorTypes.USER },
+      })
+
+      res.json({ completed: done !== null })
+    },
   }
 }

--- a/apps/backend/src/features/delegations/repository.test.ts
+++ b/apps/backend/src/features/delegations/repository.test.ts
@@ -243,6 +243,30 @@ describe("DelegatedTaskRepository.markCancelled", () => {
   })
 })
 
+describe("DelegatedTaskRepository.markDone", () => {
+  afterEach(() => mock.restore())
+
+  it("CASes any non-terminal status → completed with no token, clearing the note", async () => {
+    const captured: Captured = { text: null, values: null }
+    const db = createQuerier(captured, [makeRow({ status: DelegationStatuses.COMPLETED })])
+
+    await DelegatedTaskRepository.markDone(db, { workspaceId: "ws_1", id: "dlg_1", streamId: "stream_1" })
+
+    expect(captured.values).toContain(DelegationStatuses.COMPLETED)
+    expect(captured.values).toContain(DelegationStatuses.OPEN)
+    expect(captured.values).toContain(DelegationStatuses.CLAIMED)
+    expect(captured.values).toContain(DelegationStatuses.RUNNING)
+    expect(captured.values).toContain("stream_1")
+    expect(captured.text).toContain("status_note = NULL")
+    expect(captured.text).not.toContain("claim_token_hash =")
+  })
+
+  it("returns null when the row already reached a terminal state", async () => {
+    const db = createQuerier({ text: null, values: null }, [])
+    expect(await DelegatedTaskRepository.markDone(db, { workspaceId: "ws_1", id: "dlg_1" })).toBeNull()
+  })
+})
+
 describe("DelegatedTaskRepository.listByStream", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/delegations/repository.ts
+++ b/apps/backend/src/features/delegations/repository.ts
@@ -321,6 +321,34 @@ export const DelegatedTaskRepository = {
   },
 
   /**
+   * CAS any non-terminal status → `completed`, no claim token — a person's
+   * "Mark as done" from the card, for work executed outside the API loop
+   * (copy-paste into a local agent, or just done by hand). Without this, the
+   * only affordance for finished paste-path work was Cancel, which lies.
+   * No result message is linked; the doer reports in chat like any human.
+   * Optionally stream-scoped like markCancelled. Returns `null` when already
+   * terminal (the mark-done lost the race).
+   */
+  async markDone(
+    db: Querier,
+    params: { workspaceId: string; id: string; streamId?: string }
+  ): Promise<DelegatedTask | null> {
+    const result = await db.query<DelegatedTaskRow>(sql`
+      UPDATE delegated_tasks SET
+        status = ${DelegationStatuses.COMPLETED},
+        status_note = NULL,
+        status_changed_at = NOW(),
+        updated_at = NOW()
+      WHERE id = ${params.id}
+        AND workspace_id = ${params.workspaceId}
+        AND (${params.streamId ?? null}::text IS NULL OR stream_id = ${params.streamId ?? null})
+        AND status IN (${DelegationStatuses.OPEN}, ${DelegationStatuses.CLAIMED}, ${DelegationStatuses.RUNNING})
+      RETURNING ${sql.raw(COLUMNS)}
+    `)
+    return result.rows[0] ? mapRow(result.rows[0]) : null
+  },
+
+  /**
    * CAS any non-terminal status → `cancelled` (a person's action from the card
    * — no claim token; cancelling out from under a claimed agent is deliberate,
    * its next token-guarded write no-ops). Optionally stream-scoped so the

--- a/apps/backend/src/features/delegations/service.test.ts
+++ b/apps/backend/src/features/delegations/service.test.ts
@@ -91,6 +91,52 @@ describe("DelegationService.create", () => {
   })
 })
 
+describe("DelegationService.markDone", () => {
+  afterEach(() => mock.restore())
+
+  it("appends a completed status patch attributed to the marking user", async () => {
+    stubTransaction()
+    spyOn(DelegatedTaskRepository, "markDone").mockResolvedValue(
+      fakeDelegation({ status: DelegationStatuses.COMPLETED })
+    )
+    const { insertEvent, insertOutbox } = stubEventAppend()
+
+    const done = await makeService().markDone({
+      workspaceId: "ws_1",
+      id: "dlg_1",
+      streamId: "stream_1",
+      completedBy: { actorId: "usr_kris", actorType: AuthorTypes.USER },
+    })
+
+    expect(done?.status).toBe(DelegationStatuses.COMPLETED)
+    expect(insertEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: "delegation:status_changed",
+        actorId: "usr_kris",
+        actorType: AuthorTypes.USER,
+        payload: expect.objectContaining({ delegationId: "dlg_1", status: DelegationStatuses.COMPLETED }),
+      })
+    )
+    expect(insertOutbox.mock.calls[0]?.[1]).toBe("stream:delegation_status_changed")
+  })
+
+  it("returns null (and appends nothing) when the mark-done lost the race", async () => {
+    stubTransaction()
+    spyOn(DelegatedTaskRepository, "markDone").mockResolvedValue(null)
+    const { insertEvent } = stubEventAppend()
+
+    const done = await makeService().markDone({
+      workspaceId: "ws_1",
+      id: "dlg_1",
+      completedBy: { actorId: "usr_kris", actorType: AuthorTypes.USER },
+    })
+
+    expect(done).toBeNull()
+    expect(insertEvent).not.toHaveBeenCalled()
+  })
+})
+
 describe("DelegationService.cancel", () => {
   afterEach(() => mock.restore())
 

--- a/apps/backend/src/features/delegations/service.ts
+++ b/apps/backend/src/features/delegations/service.ts
@@ -145,6 +145,31 @@ export class DelegationService {
   }
 
   /**
+   * A person's "Mark as done" from the card — the terminal transition for work
+   * executed outside the API loop (the copy-paste path). Same access model as
+   * cancel; the acting user is the event's actor. No result message is linked —
+   * the doer reports in chat like any human. Returns `null` when the delegation
+   * already reached a terminal state (the mark-done lost the race).
+   */
+  async markDone(params: {
+    workspaceId: string
+    id: string
+    streamId?: string
+    completedBy: { actorId: string; actorType: AuthorType }
+  }): Promise<DelegatedTask | null> {
+    return withTransaction(this.pool, async (client) => {
+      const done = await DelegatedTaskRepository.markDone(client, {
+        workspaceId: params.workspaceId,
+        id: params.id,
+        streamId: params.streamId,
+      })
+      if (!done) return null
+      await this.appendStatusEvent(client, done, params.completedBy)
+      return done
+    })
+  }
+
+  /**
    * Claim an open delegation for a local agent (the 5.3 claim endpoint's core).
    * Mints the claim token here — the cleartext goes back to the claimer once,
    * only its hash is stored (a DB read can never impersonate a claim).

--- a/apps/backend/src/routes.ts
+++ b/apps/backend/src/routes.ts
@@ -739,6 +739,7 @@ export function registerRoutes(app: Express, deps: Dependencies) {
 
   app.get("/api/workspaces/:workspaceId/delegations", ...authed, delegations.list)
   app.post("/api/workspaces/:workspaceId/delegations/:id/cancel", ...authed, delegations.cancel)
+  app.post("/api/workspaces/:workspaceId/delegations/:id/done", ...authed, delegations.markDone)
 
   // Drafts — centralized, local-first composer payloads that roam across the
   // author's devices. Private to the author; never timeline-broadcast.

--- a/apps/frontend/src/api/delegations.ts
+++ b/apps/frontend/src/api/delegations.ts
@@ -27,4 +27,13 @@ export const delegationsApi = {
   async cancel(workspaceId: string, id: string): Promise<{ cancelled: boolean }> {
     return api.post<{ cancelled: boolean }>(`/api/workspaces/${workspaceId}/delegations/${id}/cancel`, {})
   },
+
+  /**
+   * Mark a non-terminal delegation done — the close-the-loop affordance for
+   * work executed outside the API path (copy-paste into a local agent).
+   * Race-honest like cancel: `completed` is `false` when it was already terminal.
+   */
+  async markDone(workspaceId: string, id: string): Promise<{ completed: boolean }> {
+    return api.post<{ completed: boolean }>(`/api/workspaces/${workspaceId}/delegations/${id}/done`, {})
+  },
 }

--- a/apps/frontend/src/components/timeline/delegation-event.test.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.test.tsx
@@ -126,9 +126,42 @@ describe("DelegationEvent", () => {
     renderCard()
     await userEvent.click(screen.getByRole("button", { name: /Copy prompt/ }))
 
-    expect(writeText).toHaveBeenCalledWith(buildDelegationPrompt(CREATED_PAYLOAD))
+    expect(writeText).toHaveBeenCalledWith(
+      buildDelegationPrompt(CREATED_PAYLOAD, { workspaceId: "ws_1", origin: window.location.origin })
+    )
     await screen.findByRole("button", { name: "Prompt copied" })
     expect(success).not.toHaveBeenCalled()
+  })
+
+  it("marks the delegation done for paste-path work and relabels in place", async () => {
+    const markDone = vi.spyOn(delegationsApi, "markDone").mockResolvedValue({ completed: true })
+
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: "Mark done" }))
+
+    expect(markDone).toHaveBeenCalledWith("ws_1", "dlg_1")
+    await waitFor(() => expect(screen.getByText(/Ariadne · Completed/)).toBeInTheDocument())
+    expect(screen.getByRole("button", { name: /Done/ })).toHaveAttribute("aria-disabled", "true")
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument()
+  })
+
+  it("does not flip when mark-done lost the race; informs instead", async () => {
+    vi.spyOn(delegationsApi, "markDone").mockResolvedValue({ completed: false })
+    const info = vi.spyOn(toast, "info")
+
+    renderCard()
+    await userEvent.click(screen.getByRole("button", { name: "Mark done" }))
+
+    await waitFor(() => expect(info).toHaveBeenCalled())
+    expect(screen.getByText(/Ariadne · Open/)).toBeInTheDocument()
+  })
+
+  it("embeds the lifecycle breadcrumb (id + claim endpoint) in the compiled prompt", () => {
+    const prompt = buildDelegationPrompt(CREATED_PAYLOAD, { workspaceId: "ws_1", origin: "https://threa.test" })
+    expect(prompt).toContain("## Threa delegation lifecycle")
+    expect(prompt).toContain("https://threa.test/api/v1/workspaces/ws_1/delegations/dlg_1/claim")
+    expect(prompt).toContain("X-Threa-Callback-Token")
+    expect(prompt).toContain('press "Mark done"')
   })
 
   it("cancels via the API and flips to Cancelled for the clicking member", async () => {

--- a/apps/frontend/src/components/timeline/delegation-event.tsx
+++ b/apps/frontend/src/components/timeline/delegation-event.tsx
@@ -31,11 +31,41 @@ interface DelegationEventProps {
  * Compile the card's payload into one paste-ready prompt for a local agent —
  * the zero-tooling hand-off path (roadmap 5.2). Everything comes from the
  * `delegation:created` payload, so no fetch is needed.
+ *
+ * With `opts`, the prompt is self-contained for the lifecycle too: it carries
+ * the delegation id, the API breadcrumb (claim → token header → status →
+ * complete), and an honest note that context refs resolve only through Threa —
+ * so an agent WITH an API key knows exactly how to claim and report, and one
+ * without knows to ask instead of hallucinating (adversarial-review finding).
  */
-export function buildDelegationPrompt(payload: DelegationCreatedEventPayload): string {
+export function buildDelegationPrompt(
+  payload: DelegationCreatedEventPayload,
+  opts?: { workspaceId: string; origin: string }
+): string {
   const parts = [`# ${payload.title}`, "", payload.brief]
   if (payload.contextRefs.length > 0) {
     parts.push("", "## Threa context refs", ...payload.contextRefs.map((ref) => `- ${ref}`))
+  }
+  if (opts) {
+    const base = `${opts.origin}/api/v1/workspaces/${opts.workspaceId}/delegations/${payload.delegationId}`
+    parts.push(
+      "",
+      "## Threa delegation lifecycle",
+      `This task is tracked as delegation ${payload.delegationId}. If you have a Threa API key`,
+      `(created in Threa under Settings > API keys, scopes delegations:read + delegations:write),`,
+      `work it through the API so the card tracks your progress:`,
+      "",
+      `1. Claim: POST ${base}/claim with body {"claimedByLabel":"<who/what you are>"}.`,
+      `   The response carries the brief, the resolved context refs, and a claimToken (shown once, 15-minute lease).`,
+      `2. Send the token as an X-Threa-Callback-Token header on every later call:`,
+      `   POST ${base}/heartbeat (renew the lease), POST ${base}/status {"statusNote":"..."} (progress on the card),`,
+      `   then POST ${base}/complete {"resultMarkdown":"..."} or POST ${base}/fail {"errorMessage":"..."}.`,
+      `   Completing posts your result into the conversation.`,
+      "",
+      `Without API access: the context refs above are Threa-internal pointers you cannot resolve —`,
+      `ask the requester to paste their content, and when the work is finished tell them so they`,
+      `can press "Mark done" on the delegation card.`
+    )
   }
   return parts.join("\n")
 }
@@ -47,39 +77,46 @@ export function buildDelegationPrompt(payload: DelegationCreatedEventPayload): s
  * `delegation:status_changed` patch advances it via `statusPatch`.
  *
  * Copy prompt confirms in place by swapping the icon to a checkmark — same
- * footprint, no toast, no layout shift (INV-63/21). Cancel is a button (it
- * mutates — INV-40) shown only while non-terminal; "View result" is a link
+ * footprint, no toast, no layout shift (INV-63/21). Cancel and Mark done are
+ * buttons (they mutate — INV-40) shown only while non-terminal; Mark done
+ * closes the loop for work executed outside the API path (copy-paste), which
+ * previously had no honest terminal transition. "View result" is a link
  * (navigation — INV-40) shown when completed with a linked result message.
- * The status from `statusPatch` is authoritative; the local optimistic flip
- * only fast-paths the clicking member's own cancel.
+ * The status from `statusPatch` is authoritative; the local optimistic flips
+ * only fast-path the clicking member's own action.
  */
 export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: DelegationEventProps) {
   const { getActorName } = useActors(workspaceId)
   const payload = event.payload as DelegationCreatedEventPayload | undefined
   const [optimisticallyCancelled, setOptimisticallyCancelled] = useState(false)
+  const [optimisticallyDone, setOptimisticallyDone] = useState(false)
   const [cancelling, setCancelling] = useState(false)
+  const [markingDone, setMarkingDone] = useState(false)
   const [copyDone, setCopyDone] = useState(false)
   const [briefOpen, setBriefOpen] = useState(false)
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   if (!payload) return null
 
-  const status: DelegationStatus = optimisticallyCancelled
-    ? DelegationStatuses.CANCELLED
-    : (statusPatch?.status ?? DelegationStatuses.OPEN)
+  let status: DelegationStatus = statusPatch?.status ?? DelegationStatuses.OPEN
+  if (optimisticallyDone) status = DelegationStatuses.COMPLETED
+  else if (optimisticallyCancelled) status = DelegationStatuses.CANCELLED
   const terminal = DELEGATION_TERMINAL.has(status)
+  const optimisticFlip = optimisticallyCancelled || optimisticallyDone
   const actorName = getActorName(event.actorId, event.actorType)
 
   const metaParts = [`${actorName} · ${DELEGATION_STATUS_LABEL[status]}`]
-  if (statusPatch?.claimedByLabel && !optimisticallyCancelled) metaParts.push(statusPatch.claimedByLabel)
-  const statusNote = !optimisticallyCancelled ? statusPatch?.statusNote : null
+  if (statusPatch?.claimedByLabel && !optimisticFlip) metaParts.push(statusPatch.claimedByLabel)
+  const statusNote = !optimisticFlip ? statusPatch?.statusNote : null
   const resultMessageId =
     status === DelegationStatuses.COMPLETED ? (statusPatch?.resultMessageId ?? undefined) : undefined
+
+  const promptText = () => buildDelegationPrompt(payload, { workspaceId, origin: window.location.origin })
 
   async function handleCopy() {
     if (!payload) return
     try {
-      await navigator.clipboard.writeText(buildDelegationPrompt(payload))
+      await navigator.clipboard.writeText(promptText())
     } catch {
       toast.error("Couldn't copy the prompt")
       return
@@ -87,6 +124,23 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
     setCopyDone(true)
     if (copyResetRef.current) clearTimeout(copyResetRef.current)
     copyResetRef.current = setTimeout(() => setCopyDone(false), 1200)
+  }
+
+  async function handleMarkDone() {
+    if (!payload || markingDone || terminal) return
+    setMarkingDone(true)
+    try {
+      const { completed } = await delegationsApi.markDone(workspaceId, payload.delegationId)
+      if (completed) {
+        setOptimisticallyDone(true)
+      } else {
+        toast.info("This delegation already finished or was cancelled")
+      }
+    } catch {
+      toast.error("Couldn't mark the delegation done")
+    } finally {
+      setMarkingDone(false)
+    }
   }
 
   async function handleCancel() {
@@ -119,6 +173,14 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
   let cancelIcon: ReactNode = null
   if (cancelling) cancelIcon = <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
   else if (cancelled) cancelIcon = <Check className="h-3 w-3" aria-hidden="true" />
+
+  // Mark done relabels in place only for the clicker's OWN flip; an API/other
+  // completion already shows the Completed pill (and View result), so adding a
+  // disabled "Done" chip there would be noise.
+  const showDoneSlot = !terminal || optimisticallyDone
+  let doneIcon: ReactNode = null
+  if (markingDone) doneIcon = <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+  else if (optimisticallyDone) doneIcon = <Check className="h-3 w-3" aria-hidden="true" />
 
   return (
     <div className="px-3 sm:px-6 py-1.5">
@@ -176,6 +238,23 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
               )}
               Copy prompt
             </button>
+            {showDoneSlot && (
+              <button
+                type="button"
+                onClick={handleMarkDone}
+                aria-disabled={optimisticallyDone || markingDone}
+                aria-busy={markingDone}
+                aria-live="polite"
+                title="Close the loop for work done outside the API (e.g. a pasted prompt)"
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors",
+                  optimisticallyDone || markingDone ? "cursor-default" : "hover:bg-muted hover:text-foreground"
+                )}
+              >
+                {doneIcon}
+                {optimisticallyDone ? "Done" : "Mark done"}
+              </button>
+            )}
             {showCancelSlot && (
               <button
                 type="button"
@@ -215,10 +294,11 @@ export function DelegationEvent({ event, workspaceId, streamId, statusPatch }: D
             {/* The brief IS a prompt — show it as source text (mono, pre-wrap),
                 not rendered prose, so what you read is exactly what Copy ships. */}
             <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-foreground/80">
-              {buildDelegationPrompt(payload)}
+              {promptText()}
             </pre>
             <p className="mt-1.5 text-[11px] text-muted-foreground">
-              Paste this into your local agent (Claude Code, etc.) to run the task on your machine.
+              Paste this into your local agent (Claude Code, etc.). An agent with a Threa API key can claim the task and
+              update this card; otherwise press Mark done when the work is finished.
             </p>
           </div>
         )}

--- a/docs/plans/ariadne-collaborator-roadmap.md
+++ b/docs/plans/ariadne-collaborator-roadmap.md
@@ -513,6 +513,8 @@ The strategic bet: Threa is the shared-memory/coordination plane; the user's loc
 
 **Done when:** `threa-remote delegate <id>` (or equivalent) executes a delegation locally through the SDK runner and the card shows claimed → completed with the result linked — with zero delegation logic inside claude-code-remote itself.
 
+**Ruling from the adversarial UX review (2026-07-12, PR #1272 comment):** the runner's default delivery is **push over the existing bot-runtime websocket**, not polling — a connected claude-code-channel runtime already holds a live socket that receives bot invocations instantly, so delegation nudges ride the same channel at zero marginal request cost. HTTP polling of `GET /delegations` stays as the fallback for headless/cron runners only; the review's rate-limit math (60 req/min/key shared with lifecycle calls) puts a 15–30s floor on poll-based pickup, and every poll routes through the per-request-billed Cloudflare worker. Two contract improvements queued for the same step: **claim accepts a caller idempotency key** (a crash between claim-200 and persisting the single-shot token currently strands the task until TTL expiry), and consider a `since`/ETag on the list endpoint. Also from the review: port the delegation recipe to the public `/developers` docs — today the only working walkthrough is the internal `threa-public-api` skill, so no external user can complete the journey.
+
 ### 5.5 `@threa/mcp` server
 
 **Goal:** every local agent — not just ours — can pull Threa context and close delegations. One integration on our side instead of integrating everywhere.


### PR DESCRIPTION
## Problem

The adversarial UX review of the delegation feature (PR #1272 comment, five personas) converged on one wall all five hit: **the copy-paste path is a cul-de-sac**. The copied prompt carried no delegation id, no hint that a lifecycle API exists, and `memo:`/`shared-message:` pointer refs a local agent cannot resolve — so a pasted task either stalled or got done invisibly. And work executed outside the API had no honest terminal transition: the card's only mutating affordance was Cancel, so finished work either sat "Open" forever or got miscoded as Cancelled.

## Solution

Close the loop on the paste path; record the polling ruling for 5.4.

### How it works

1. **Lifecycle-aware Copy prompt.** `buildDelegationPrompt` (`delegation-event.tsx`) gains an optional `{workspaceId, origin}` and appends a `## Threa delegation lifecycle` section: the delegation id, the claim endpoint with the `claimedByLabel` body, the `X-Threa-Callback-Token` header contract for heartbeat/status/complete/fail, where keys come from (Settings → API keys, which scopes) — and an honest note that the context refs are Threa-internal pointers, so an agent without API access should ask for their content and report back for a manual Mark done instead of hallucinating. An agent WITH a key now knows exactly how to claim and drive the card; that was Kris's "is copy integrated with the status updating" question.
2. **Mark done.** New first-party endpoint `POST /api/workspaces/:wid/delegations/:id/done` (`delegations.markDone` handler — cancel's exact access model: `checkStreamAccess`, 404 hides existence, race-honest `{completed}`), over `DelegationService.markDone` → `DelegatedTaskRepository.markDone` (CAS any non-terminal → `completed`, no claim token, `status_note = NULL`, status event attributed to the acting user). The card grows a "Mark done" button beside Cancel (relabel-in-place with check + `aria-live` for the clicker's own flip; hidden on other terminals to avoid a redundant chip next to the Completed pill).
3. **Expectation-setting copy.** `delegate_task`'s promptBlock now tells the persona to say plainly that the card does not run itself and waits for someone with a local agent or API key; the card's expandable-prompt hint explains both paths.
4. **Roadmap ruling (5.4):** delegations are delivered over the **existing bot-runtime websocket** (connected claude-code-channel runtimes already receive bot invocations instantly); HTTP polling stays as headless fallback only — the review's rate-limit math (60 req/min/key shared with lifecycle calls) puts a 15–30s floor on poll pickup through the per-request-billed Cloudflare route. Claim idempotency key + `since`/ETag on list + porting the recipe to `/developers` are queued there too.

## Modified files

| File | Change |
| ---- | ------ |
| `apps/frontend/src/components/timeline/delegation-event.tsx` (+test) | Lifecycle section in the prompt, Mark done button, hint copy; 17 tests |
| `apps/frontend/src/api/delegations.ts` | `markDone` client |
| `apps/backend/src/features/delegations/{repository,service,handlers}.ts` (+tests) | `markDone` CAS + service txn + handler; SQL-capture + event-attribution tests |
| `apps/backend/src/routes.ts` | `POST /delegations/:id/done` |
| `apps/backend/src/features/agents/tools/delegate-task-tool.ts` | promptBlock expectation-setting |
| `docs/plans/ariadne-collaborator-roadmap.md` | 5.4 websocket-delivery ruling + queued contract improvements |

## Out of scope (deliberate)

- The 5.4 runner itself and the websocket delivery (ruling recorded, implementation is 5.4).
- Claim idempotency key and list `since`/ETag (queued with 5.4).
- `/developers` recipe port (separate docs PR).

## Test plan

- [x] Backend `bun test src/features/delegations src/features/agents/tools` — 40 pass (markDone CAS: non-terminal statuses + no token guard + note cleared; service event attribution; race-null)
- [x] Frontend `delegation-event.test.tsx` — 17 pass (mark-done flip + race-loss info + lifecycle breadcrumb content + existing suite); timeline+stream-context suites 507 pass
- [x] `tsc --noEmit` clean (backend, frontend)
- [ ] Live card verify on staging once deployed (`staging` label on)

---

🤖 _PR by [Claude Code](https://claude.com/claude-code)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/threahq/codesmith/threa/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786441808&installation_id=129946197&pr_number=1295&repository=threahq%2Fthrea&return_to=https%3A%2F%2Fgithub.com%2Fthreahq%2Fthrea%2Fpull%2F1295&signature=9053de4a62655411a7c10c321dbca7f8fb9f3eb8454d3bc9ffd4f886930038f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->